### PR TITLE
Fix token metrics in streaming, and improve token tracking

### DIFF
--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -336,3 +336,4 @@ class ChatCompletionChunk(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
     choices: List[ChatCompletionChunkChoice]
+    usage: Usage | None = None


### PR DESCRIPTION
Come across a few issues while testing token metrics in streaming responses, added fixes and improvements:
- Add optional usage field to ChatCompletionChunk for token metrics
- Refactor SimpleEngine.stream_generate() to properly track prompt/completion tokens
- Fix JSON serialization in streaming responses by handling None values
- Add get_usage() helper for consistent token metric extraction
- Include prompt_tokens in all non-streaming responses
- Improve logging to show breakdown of prompt vs completion tokens