### PR TITLE
Fix concurrency issues in continuous batching mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "mlx>=0.29.0",
-    "mlx-lm>=0.20.0",
+    "mlx-lm>=0.30.2",  # GLM-4 models require 0.30.2+
     "mlx-vlm>=0.1.0",  # VLM support
     "transformers>=4.40.0,<5.0.0",
     "tokenizers>=0.19.0",

--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -170,7 +170,7 @@ Solution:"""
             )
 
             # Update progress bar with accuracy
-            status = "✓" if correct else "✗"
+            status = "PASS" if correct else "FAIL"
             accuracy = correct_count / len(results)
             pbar.set_postfix({"acc": f"{accuracy:.1%}", "last": f"{status} {expected}"})
 
@@ -271,7 +271,7 @@ Solution:"""
                 )
 
                 # Update progress bar with accuracy
-                status = "✓" if correct else "✗"
+                status = "PASS" if correct else "FAIL"
                 accuracy = correct_count / len(results)
                 pbar.set_postfix(
                     {"acc": f"{accuracy:.1%}", "last": f"{status} {expected}"}

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for memory-aware prefix cache."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx.memory_cache import (
+    CacheStats,
+    MemoryAwarePrefixCache,
+    MemoryCacheConfig,
+    _CacheEntry,
+    _get_available_memory,
+    estimate_kv_cache_memory,
+)
+
+
+class TestMemoryCacheConfig:
+    """Tests for MemoryCacheConfig."""
+
+    def test_default_config(self):
+        config = MemoryCacheConfig()
+        assert config.max_memory_mb is None
+        assert config.max_memory_percent == 0.20
+        assert config.max_entries == 1000
+        assert config.enable_memory_tracking is True
+
+    def test_custom_config(self):
+        config = MemoryCacheConfig(
+            max_memory_mb=2048,
+            max_memory_percent=0.5,
+            max_entries=100,
+        )
+        assert config.max_memory_mb == 2048
+        assert config.max_memory_percent == 0.5
+        assert config.max_entries == 100
+
+    def test_invalid_memory_percent_zero(self):
+        with pytest.raises(ValueError, match="max_memory_percent"):
+            MemoryCacheConfig(max_memory_percent=0.0)
+
+    def test_invalid_memory_percent_negative(self):
+        with pytest.raises(ValueError, match="max_memory_percent"):
+            MemoryCacheConfig(max_memory_percent=-0.1)
+
+    def test_invalid_memory_percent_over_one(self):
+        with pytest.raises(ValueError, match="max_memory_percent"):
+            MemoryCacheConfig(max_memory_percent=1.5)
+
+    def test_invalid_max_entries(self):
+        with pytest.raises(ValueError, match="max_entries"):
+            MemoryCacheConfig(max_entries=0)
+
+    def test_compute_memory_limit_explicit(self):
+        config = MemoryCacheConfig(max_memory_mb=1024)
+        assert config.compute_memory_limit() == 1024 * 1024 * 1024
+
+    def test_compute_memory_limit_auto(self):
+        with patch(
+            "vllm_mlx.memory_cache._get_available_memory",
+            return_value=8 * 1024 * 1024 * 1024,  # 8GB
+        ):
+            config = MemoryCacheConfig(max_memory_percent=0.25)
+            limit = config.compute_memory_limit()
+            assert limit == 2 * 1024 * 1024 * 1024  # 25% of 8GB = 2GB
+
+    def test_compute_memory_limit_fallback(self):
+        with patch(
+            "vllm_mlx.memory_cache._get_available_memory",
+            return_value=0,  # Detection failed
+        ):
+            config = MemoryCacheConfig(max_memory_percent=0.25)
+            limit = config.compute_memory_limit()
+            # Fallback: 25% of 8GB = 2GB
+            assert limit == 2 * 1024 * 1024 * 1024
+
+
+class TestCacheStats:
+    """Tests for CacheStats."""
+
+    def test_initial_stats(self):
+        stats = CacheStats()
+        assert stats.hits == 0
+        assert stats.misses == 0
+        assert stats.hit_rate == 0.0
+
+    def test_hit_rate_calculation(self):
+        stats = CacheStats(hits=3, misses=1)
+        assert stats.hit_rate == 0.75
+
+    def test_hit_rate_no_queries(self):
+        stats = CacheStats(hits=0, misses=0)
+        assert stats.hit_rate == 0.0
+
+    def test_memory_utilization(self):
+        stats = CacheStats(
+            current_memory_bytes=500 * 1024 * 1024,
+            max_memory_bytes=1000 * 1024 * 1024,
+        )
+        assert stats.memory_utilization == 0.5
+
+    def test_to_dict(self):
+        stats = CacheStats(hits=10, misses=5, evictions=2)
+        d = stats.to_dict()
+        assert d["hits"] == 10
+        assert d["misses"] == 5
+        assert d["evictions"] == 2
+        assert "hit_rate" in d
+        assert "memory_utilization" in d
+
+
+class MockArray:
+    """Mock array with nbytes attribute."""
+
+    def __init__(self, nbytes: int):
+        self.nbytes = nbytes
+
+
+class MockKVCache:
+    """Mock KV cache with keys/values attributes."""
+
+    def __init__(self, key_bytes: int, value_bytes: int):
+        self.keys = MockArray(key_bytes)
+        self.values = MockArray(value_bytes)
+
+
+class MockStateCache:
+    """Mock cache with state property."""
+
+    def __init__(self, key_bytes: int, value_bytes: int):
+        self._keys = MockArray(key_bytes)
+        self._values = MockArray(value_bytes)
+
+    @property
+    def state(self):
+        return (self._keys, self._values)
+
+
+class TestEstimateKvCacheMemory:
+    """Tests for estimate_kv_cache_memory function."""
+
+    def test_empty_cache(self):
+        assert estimate_kv_cache_memory([]) == 0
+        assert estimate_kv_cache_memory(None) == 0
+
+    def test_cache_with_nbytes_attribute(self):
+        layer = MockKVCache(1000, 1000)
+        assert estimate_kv_cache_memory([layer]) == 2000
+
+    def test_cache_with_state_property(self):
+        layer = MockStateCache(500, 500)
+        assert estimate_kv_cache_memory([layer]) == 1000
+
+    def test_cache_with_dict_state(self):
+        keys = MockArray(300)
+        values = MockArray(300)
+        layer = {"state": (keys, values)}
+        assert estimate_kv_cache_memory([layer]) == 600
+
+    def test_multiple_layers(self):
+        layers = [MockKVCache(100, 100) for _ in range(4)]
+        assert estimate_kv_cache_memory(layers) == 800
+
+
+class TestCacheEntry:
+    """Tests for _CacheEntry."""
+
+    def test_create_entry(self):
+        cache = [MockKVCache(100, 100)]
+        entry = _CacheEntry.create([1, 2, 3], cache)
+        assert entry.tokens == (1, 2, 3)
+        assert entry.cache is cache
+        assert entry.memory_bytes == 200
+
+
+class TestMemoryAwarePrefixCache:
+    """Tests for MemoryAwarePrefixCache."""
+
+    @pytest.fixture
+    def model(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def small_cache(self, model):
+        """Cache with 1MB limit."""
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=10)
+        return MemoryAwarePrefixCache(model, config)
+
+    @pytest.fixture
+    def mock_kv_cache(self):
+        """Create a mock KV cache with known size."""
+
+        def _create(size_bytes: int):
+            return [MockKVCache(size_bytes // 2, size_bytes // 2)]
+
+        return _create
+
+    def test_initialization(self, model):
+        config = MemoryCacheConfig(max_memory_mb=100)
+        cache = MemoryAwarePrefixCache(model, config)
+        assert len(cache) == 0
+        assert cache.memory_limit_mb == 100.0
+
+    def test_store_and_fetch_exact_match(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3, 4, 5]
+        kv = mock_kv_cache(1000)
+
+        # Store
+        assert small_cache.store(tokens, kv) is True
+        assert len(small_cache) == 1
+
+        # Fetch exact match
+        result, remaining = small_cache.fetch(tokens)
+        assert result is kv  # Same reference, no copy
+        assert remaining == []
+
+    def test_fetch_prefix_match(self, small_cache, mock_kv_cache):
+        # Store shorter sequence
+        short_tokens = [1, 2, 3]
+        kv = mock_kv_cache(1000)
+        small_cache.store(short_tokens, kv)
+
+        # Fetch longer sequence that starts with cached prefix
+        long_tokens = [1, 2, 3, 4, 5, 6]
+        result, remaining = small_cache.fetch(long_tokens)
+
+        assert result is kv
+        assert remaining == [4, 5, 6]
+
+    def test_fetch_miss(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3]
+        kv = mock_kv_cache(1000)
+        small_cache.store(tokens, kv)
+
+        # Fetch completely different sequence
+        result, remaining = small_cache.fetch([7, 8, 9])
+        assert result is None
+        assert remaining == [7, 8, 9]
+
+    def test_lru_eviction_on_memory_pressure(self, model, mock_kv_cache):
+        # Create cache with 500KB limit
+        config = MemoryCacheConfig(max_memory_mb=0.5, max_entries=100)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        # Store entries that together exceed limit
+        # Each is ~200KB
+        for i in range(5):
+            tokens = list(range(i * 10, (i + 1) * 10))
+            kv = mock_kv_cache(200 * 1024)
+            cache.store(tokens, kv)
+
+        # Should have evicted older entries
+        assert cache.memory_usage_mb <= 0.5
+        stats = cache.get_stats()
+        assert stats["evictions"] > 0
+
+    def test_lru_order_updated_on_fetch(self, small_cache, mock_kv_cache):
+        # Store two entries
+        tokens1 = [1, 2, 3]
+        tokens2 = [4, 5, 6]
+        kv1 = mock_kv_cache(100 * 1024)
+        kv2 = mock_kv_cache(100 * 1024)
+
+        small_cache.store(tokens1, kv1)
+        small_cache.store(tokens2, kv2)
+
+        # Fetch first entry (moves it to end of LRU)
+        small_cache.fetch(tokens1)
+
+        # Now tokens2 should be evicted first if we need space
+        # Store a large entry to trigger eviction
+        big_kv = mock_kv_cache(900 * 1024)
+        small_cache.store([7, 8, 9], big_kv)
+
+        # tokens1 should still be there (was recently accessed)
+        # tokens2 should be evicted
+        assert tokens1 in small_cache or len(small_cache) == 1
+
+    def test_entry_too_large_rejected(self, small_cache, mock_kv_cache):
+        # Try to store entry larger than cache limit
+        tokens = [1, 2, 3]
+        huge_kv = mock_kv_cache(10 * 1024 * 1024)  # 10MB, limit is 1MB
+
+        result = small_cache.store(tokens, huge_kv)
+        assert result is False
+        assert len(small_cache) == 0
+
+    def test_store_empty_rejected(self, small_cache, mock_kv_cache):
+        assert small_cache.store([], mock_kv_cache(100)) is False
+        assert small_cache.store([1, 2, 3], []) is False
+        assert small_cache.store([1, 2, 3], None) is False
+
+    def test_remove_entry(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3]
+        kv = mock_kv_cache(1000)
+        small_cache.store(tokens, kv)
+        assert len(small_cache) == 1
+
+        assert small_cache.remove(tokens) is True
+        assert len(small_cache) == 0
+        assert small_cache.remove(tokens) is False  # Already removed
+
+    def test_clear(self, small_cache, mock_kv_cache):
+        for i in range(3):
+            small_cache.store([i], mock_kv_cache(1000))
+
+        assert len(small_cache) == 3
+        small_cache.clear()
+        assert len(small_cache) == 0
+        assert small_cache.memory_usage_mb == 0
+
+    def test_contains(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3]
+        assert tokens not in small_cache
+        small_cache.store(tokens, mock_kv_cache(1000))
+        assert tokens in small_cache
+
+    def test_stats_tracking(self, small_cache, mock_kv_cache):
+        tokens1 = [1, 2, 3]
+        tokens2 = [4, 5, 6]
+        kv = mock_kv_cache(1000)
+
+        small_cache.store(tokens1, kv)
+        small_cache.fetch(tokens1)  # Hit
+        small_cache.fetch(tokens2)  # Miss
+
+        stats = small_cache.get_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["entry_count"] == 1
+
+    def test_reset_stats(self, small_cache, mock_kv_cache):
+        small_cache.store([1, 2, 3], mock_kv_cache(1000))
+        small_cache.fetch([1, 2, 3])
+        small_cache.fetch([4, 5, 6])
+
+        small_cache.reset_stats()
+        stats = small_cache.get_stats()
+
+        # Stats reset but entry count preserved
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["entry_count"] == 1
+
+    def test_duplicate_store_updates_lru(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3]
+        kv = mock_kv_cache(1000)
+
+        small_cache.store(tokens, kv)
+        initial_len = len(small_cache)
+
+        # Store same tokens again
+        small_cache.store(tokens, kv)
+
+        # Should not create duplicate
+        assert len(small_cache) == initial_len
+
+    def test_max_entries_limit(self, model, mock_kv_cache):
+        # Create cache with low entry limit
+        config = MemoryCacheConfig(max_memory_mb=100, max_entries=3)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        # Store 5 entries (only 3 should remain)
+        for i in range(5):
+            cache.store([i], mock_kv_cache(100))
+
+        assert len(cache) <= 3
+
+
+class TestGetAvailableMemory:
+    """Tests for _get_available_memory helper."""
+
+    def test_with_psutil(self):
+        try:
+            from importlib.util import find_spec
+
+            if find_spec("psutil") is None:
+                pytest.skip("psutil not installed")
+            mem = _get_available_memory()
+            assert mem > 0
+        except ImportError:
+            pytest.skip("psutil not installed")
+
+    def test_without_psutil(self):
+        with patch.dict("sys.modules", {"psutil": None}):
+            # Should return 0 when psutil not available
+            # Note: This test may not work as expected due to import caching
+            pass

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -433,7 +433,7 @@ if __name__ == "__main__":
                     "MISS",
                     "MISS" if stats1["hits"] == 0 else "HIT",
                     f"{t1*1000:.1f}ms",
-                    "✓" if test1_pass else "✗",
+                    "PASS" if test1_pass else "FAIL",
                 ]
             )
 
@@ -466,7 +466,7 @@ if __name__ == "__main__":
                     "HIT",
                     "HIT" if stats2["hits"] > stats1["hits"] else "MISS",
                     f"{t2*1000:.1f}ms",
-                    "✓" if test2_pass else "✗",
+                    "PASS" if test2_pass else "FAIL",
                 ]
             )
 
@@ -501,7 +501,7 @@ if __name__ == "__main__":
                     "MISS",
                     "MISS" if stats3["misses"] > stats2["misses"] else "HIT",
                     f"{t3*1000:.1f}ms",
-                    "✓" if test3_pass else "✗",
+                    "PASS" if test3_pass else "FAIL",
                 ]
             )
 
@@ -539,9 +539,9 @@ if __name__ == "__main__":
 
             print("\n" + "=" * 70)
             if all_passed:
-                print("  ✓ ALL TESTS PASSED - Prefix cache working correctly!")
+                print("  [OK] ALL TESTS PASSED - Prefix cache working correctly")
             else:
-                print("  ✗ SOME TESTS FAILED - Check results above")
+                print("  [FAILED] SOME TESTS FAILED - Check results above")
             print("=" * 70)
 
     asyncio.run(run_cache_test())

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimpleEngine concurrency handling."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestSimpleEngineConcurrency:
+    """Test SimpleEngine lock behavior with concurrent requests."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Create a mock model that tracks concurrent calls."""
+        model = MagicMock()
+        model.tokenizer = MagicMock()
+        model.tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+
+        # Track concurrent executions
+        model._concurrent_count = 0
+        model._max_concurrent = 0
+
+        def generate_side_effect(**kwargs):
+            model._concurrent_count += 1
+            model._max_concurrent = max(model._max_concurrent, model._concurrent_count)
+            # Simulate some work
+            import time
+
+            time.sleep(0.05)
+            model._concurrent_count -= 1
+            result = MagicMock()
+            result.text = "test response"
+            result.tokens = [1, 2, 3]
+            result.finish_reason = "stop"
+            return result
+
+        model.generate = MagicMock(side_effect=generate_side_effect)
+        return model
+
+    @pytest.fixture
+    def mock_llm_model(self):
+        """Create a mock LLM model."""
+        model = MagicMock()
+        model.tokenizer = MagicMock()
+        model.tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+
+        # Track concurrent executions
+        model._concurrent_count = 0
+        model._max_concurrent = 0
+
+        def chat_side_effect(**kwargs):
+            model._concurrent_count += 1
+            model._max_concurrent = max(model._max_concurrent, model._concurrent_count)
+            import time
+
+            time.sleep(0.05)
+            model._concurrent_count -= 1
+            result = MagicMock()
+            result.text = "test response"
+            result.tokens = [1, 2, 3]
+            result.finish_reason = "stop"
+            return result
+
+        model.chat = MagicMock(side_effect=chat_side_effect)
+        return model
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_concurrent_generate(self, mock_model):
+        """Test that the lock prevents concurrent generate calls."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_model
+            engine._loaded = True
+
+            # Launch multiple concurrent generate calls
+            tasks = [
+                engine.generate(prompt=f"test prompt {i}", max_tokens=10)
+                for i in range(5)
+            ]
+
+            await asyncio.gather(*tasks)
+
+            # With the lock, max concurrent should be 1
+            assert mock_model._max_concurrent == 1, (
+                f"Expected max concurrent to be 1, but got {mock_model._max_concurrent}. "
+                "The lock is not working correctly."
+            )
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_concurrent_chat(self, mock_llm_model):
+        """Test that the lock prevents concurrent chat calls."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_llm_model
+            engine._loaded = True
+
+            # Launch multiple concurrent chat calls
+            tasks = [
+                engine.chat(
+                    messages=[{"role": "user", "content": f"test {i}"}], max_tokens=10
+                )
+                for i in range(5)
+            ]
+
+            await asyncio.gather(*tasks)
+
+            # With the lock, max concurrent should be 1
+            assert mock_llm_model._max_concurrent == 1, (
+                f"Expected max concurrent to be 1, but got {mock_llm_model._max_concurrent}. "
+                "The lock is not working correctly."
+            )
+
+    @pytest.mark.asyncio
+    async def test_lock_serializes_stream_generate(self, mock_model):
+        """Test that stream_generate uses the same lock as other methods."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        def stream_generate_side_effect(**kwargs):
+            # Yield a few chunks
+            for i in range(3):
+                chunk = MagicMock()
+                chunk.text = f"chunk{i}"
+                chunk.prompt_tokens = 5
+                chunk.finished = i == 2
+                chunk.finish_reason = "stop" if i == 2 else None
+                yield chunk
+
+        mock_model.stream_generate = MagicMock(side_effect=stream_generate_side_effect)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_model
+            engine._loaded = True
+
+            # Test that stream_generate acquires the lock
+            # by checking if it blocks when lock is already held
+            lock_acquired = asyncio.Event()
+            stream_started = asyncio.Event()
+
+            async def hold_lock():
+                async with engine._generation_lock:
+                    lock_acquired.set()
+                    # Wait until stream tries to start
+                    await asyncio.sleep(0.1)
+
+            async def try_stream():
+                # Wait for lock to be held
+                await lock_acquired.wait()
+                stream_started.set()
+                # This should block until hold_lock releases
+                result = []
+                async for chunk in engine.stream_generate(prompt="test", max_tokens=10):
+                    result.append(chunk)
+                return result
+
+            # Start both tasks
+            hold_task = asyncio.create_task(hold_lock())
+            stream_task = asyncio.create_task(try_stream())
+
+            # Wait a bit for stream to try to acquire lock
+            await asyncio.sleep(0.05)
+
+            # Stream should have started but be blocked on the lock
+            assert stream_started.is_set(), "Stream should have attempted to start"
+
+            # Stream task should not be done yet (blocked on lock)
+            assert not stream_task.done(), "Stream should be blocked waiting for lock"
+
+            # Let hold_lock finish
+            await hold_task
+
+            # Now stream should complete
+            result = await stream_task
+            assert len(result) == 3, f"Expected 3 chunks, got {len(result)}"
+
+    @pytest.mark.asyncio
+    async def test_engine_initialization_creates_lock(self):
+        """Test that SimpleEngine creates a lock on initialization."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+
+            assert hasattr(engine, "_generation_lock")
+            assert isinstance(engine._generation_lock, asyncio.Lock)
+
+    @pytest.mark.asyncio
+    async def test_requests_complete_in_order(self, mock_model):
+        """Test that concurrent requests complete (may be in any order due to lock)."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_model
+            engine._loaded = True
+
+            # Launch multiple concurrent generate calls
+            results = await asyncio.gather(
+                *[
+                    engine.generate(prompt=f"test prompt {i}", max_tokens=10)
+                    for i in range(3)
+                ]
+            )
+
+            # All requests should complete
+            assert len(results) == 3
+            for result in results:
+                assert result.text == "test response"

--- a/tests/test_vlm_cache.py
+++ b/tests/test_vlm_cache.py
@@ -674,7 +674,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t1:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit, "Expected cache miss"
@@ -695,7 +695,7 @@ if __name__ == "__main__":
                 "HIT",
                 "HIT" if hit else "MISS",
                 f"{t2:.2f}ms",
-                "✓" if hit else "✗",
+                "PASS" if hit else "FAIL",
             ]
         )
         assert hit, "Expected cache hit"
@@ -713,7 +713,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t3:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit, "Expected cache miss for different prompt"
@@ -743,7 +743,7 @@ if __name__ == "__main__":
                         "MISS",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if not hit else "✗",
+                        "PASS" if not hit else "FAIL",
                     ]
                 )
                 assert not hit
@@ -760,7 +760,7 @@ if __name__ == "__main__":
                         "HIT",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if hit else "✗",
+                        "PASS" if hit else "FAIL",
                     ]
                 )
                 assert hit
@@ -793,7 +793,7 @@ if __name__ == "__main__":
                         "MISS",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if not hit else "✗",
+                        "PASS" if not hit else "FAIL",
                     ]
                 )
                 assert not hit
@@ -810,7 +810,7 @@ if __name__ == "__main__":
                         "HIT",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if hit else "✗",
+                        "PASS" if hit else "FAIL",
                     ]
                 )
                 assert hit
@@ -845,7 +845,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit
@@ -866,7 +866,7 @@ if __name__ == "__main__":
                 "HIT",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if hit else "✗",
+                "PASS" if hit else "FAIL",
             ]
         )
         assert hit
@@ -883,7 +883,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit
@@ -900,7 +900,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit
@@ -920,7 +920,7 @@ if __name__ == "__main__":
                     "MISS",
                     "HIT" if hit else "MISS",
                     f"{t_ms:.2f}ms",
-                    "✓" if not hit else "✗",
+                    "PASS" if not hit else "FAIL",
                 ]
             )
             assert not hit
@@ -940,7 +940,7 @@ if __name__ == "__main__":
                     "HIT",
                     "HIT" if hit else "MISS",
                     f"{t_ms:.2f}ms",
-                    "✓" if hit else "✗",
+                    "PASS" if hit else "FAIL",
                 ]
             )
             assert hit
@@ -969,7 +969,7 @@ if __name__ == "__main__":
                         "MISS",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if not hit else "✗",
+                        "PASS" if not hit else "FAIL",
                     ]
                 )
                 assert not hit
@@ -989,7 +989,7 @@ if __name__ == "__main__":
                         "HIT",
                         "HIT" if hit else "MISS",
                         f"{t_ms:.2f}ms",
-                        "✓" if hit else "✗",
+                        "PASS" if hit else "FAIL",
                     ]
                 )
                 assert hit
@@ -1028,7 +1028,7 @@ if __name__ == "__main__":
                 "MISS",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if not hit else "✗",
+                "PASS" if not hit else "FAIL",
             ]
         )
         assert not hit
@@ -1043,7 +1043,7 @@ if __name__ == "__main__":
                 "HIT",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if hit else "✗",
+                "PASS" if hit else "FAIL",
             ]
         )
         assert hit
@@ -1058,7 +1058,7 @@ if __name__ == "__main__":
                 "HIT",
                 "HIT" if hit else "MISS",
                 f"{t_ms:.2f}ms",
-                "✓" if hit else "✗",
+                "PASS" if hit else "FAIL",
             ]
         )
         assert hit
@@ -1088,7 +1088,7 @@ if __name__ == "__main__":
             ],
         )
         print("\n" + "=" * 70)
-        print("  ✓ ALL TESTS PASSED - VLM cache working correctly!")
+        print("  [OK] ALL TESTS PASSED - VLM cache working correctly")
         print("=" * 70)
 
         # Cleanup temp files

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -72,6 +72,10 @@ def serve_command(args):
             completion_batch_size=args.completion_batch_size,
             enable_prefix_cache=enable_prefix_cache,
             prefix_cache_size=args.prefix_cache_size,
+            # Memory-aware cache options
+            use_memory_aware_cache=not args.no_memory_aware_cache,
+            cache_memory_mb=args.cache_memory_mb,
+            cache_memory_percent=args.cache_memory_percent,
             # Paged cache options
             use_paged_cache=args.use_paged_cache,
             paged_cache_block_size=args.paged_cache_block_size,
@@ -84,6 +88,15 @@ def serve_command(args):
             print(
                 f"Paged cache: block_size={args.paged_cache_block_size}, max_blocks={args.max_cache_blocks}"
             )
+        elif enable_prefix_cache and not args.no_memory_aware_cache:
+            cache_info = (
+                f"{args.cache_memory_mb}MB"
+                if args.cache_memory_mb
+                else f"{args.cache_memory_percent*100:.0f}% of RAM"
+            )
+            print(f"Memory-aware cache: {cache_info}")
+        elif enable_prefix_cache:
+            print(f"Prefix cache: max_entries={args.prefix_cache_size}")
     else:
         print("Mode: Simple (maximum throughput)")
 
@@ -123,6 +136,10 @@ def bench_command(args):
             completion_batch_size=args.completion_batch_size,
             enable_prefix_cache=enable_prefix_cache,
             prefix_cache_size=args.prefix_cache_size,
+            # Memory-aware cache options
+            use_memory_aware_cache=not args.no_memory_aware_cache,
+            cache_memory_mb=args.cache_memory_mb,
+            cache_memory_percent=args.cache_memory_percent,
             # Paged cache options
             use_paged_cache=args.use_paged_cache,
             paged_cache_block_size=args.paged_cache_block_size,
@@ -368,7 +385,25 @@ Examples:
         "--prefix-cache-size",
         type=int,
         default=100,
-        help="Max entries in prefix cache (default: 100)",
+        help="Max entries in prefix cache (default: 100, legacy mode only)",
+    )
+    # Memory-aware cache options (recommended for large models)
+    serve_parser.add_argument(
+        "--cache-memory-mb",
+        type=int,
+        default=None,
+        help="Cache memory limit in MB (default: auto-detect ~20%% of RAM)",
+    )
+    serve_parser.add_argument(
+        "--cache-memory-percent",
+        type=float,
+        default=0.20,
+        help="Fraction of available RAM for cache if auto-detecting (default: 0.20)",
+    )
+    serve_parser.add_argument(
+        "--no-memory-aware-cache",
+        action="store_true",
+        help="Disable memory-aware cache, use legacy entry-count based cache",
     )
     serve_parser.add_argument(
         "--stream-interval",
@@ -465,7 +500,25 @@ Examples:
         "--prefix-cache-size",
         type=int,
         default=100,
-        help="Max entries in prefix cache (default: 100)",
+        help="Max entries in prefix cache (default: 100, legacy mode only)",
+    )
+    # Memory-aware cache options (recommended for large models)
+    bench_parser.add_argument(
+        "--cache-memory-mb",
+        type=int,
+        default=None,
+        help="Cache memory limit in MB (default: auto-detect ~20%% of RAM)",
+    )
+    bench_parser.add_argument(
+        "--cache-memory-percent",
+        type=float,
+        default=0.20,
+        help="Fraction of available RAM for cache if auto-detecting (default: 0.20)",
+    )
+    bench_parser.add_argument(
+        "--no-memory-aware-cache",
+        action="store_true",
+        help="Disable memory-aware cache, use legacy entry-count based cache",
     )
     # Paged cache options (experimental)
     bench_parser.add_argument(

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Memory-aware prefix cache for vllm-mlx.
+
+This module provides a prefix cache implementation that tracks memory usage
+and evicts entries based on memory pressure rather than entry count.
+
+Key features:
+- Automatic memory limit detection based on available system RAM
+- Accurate memory tracking for MLX array caches
+- LRU eviction triggered by memory thresholds
+- No unnecessary deep copies (MLX arrays are immutable)
+
+Example:
+    config = MemoryCacheConfig(max_memory_percent=0.25)
+    cache = MemoryAwarePrefixCache(model, config)
+
+    # Fetch returns reference (no copy) - safe because MLX arrays are immutable
+    kv_cache, remaining = cache.fetch(tokens)
+
+    # Store tracks memory automatically
+    cache.store(tokens, kv_cache)
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Constants
+_BYTES_PER_MB = 1024 * 1024
+_DEFAULT_MEMORY_PERCENT = 0.20  # 20% of available RAM
+_MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
+_MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
+
+
+def _get_available_memory() -> int:
+    """
+    Get available system memory in bytes.
+
+    Returns:
+        Available memory in bytes, or 0 if detection fails.
+    """
+    try:
+        import psutil
+
+        return psutil.virtual_memory().available
+    except ImportError:
+        logger.warning("psutil not installed, using fallback memory limit")
+        return 0
+    except Exception as e:
+        logger.warning(f"Failed to detect available memory: {e}")
+        return 0
+
+
+def estimate_kv_cache_memory(cache: list[Any]) -> int:
+    """
+    Estimate memory usage of a KV cache in bytes.
+
+    This function inspects MLX arrays in the cache and calculates their
+    total memory footprint.
+
+    Args:
+        cache: List of layer cache objects, each containing keys/values tensors.
+
+    Returns:
+        Estimated memory usage in bytes.
+    """
+    if not cache:
+        return 0
+
+    total_bytes = 0
+
+    for layer_cache in cache:
+        # Handle different cache object types
+        # Check dict first since dicts have .keys() method that would match below
+        if isinstance(layer_cache, dict) and "state" in layer_cache:
+            # Extracted state dict
+            keys, values = layer_cache["state"]
+            if hasattr(keys, "nbytes"):
+                total_bytes += keys.nbytes
+            if hasattr(values, "nbytes"):
+                total_bytes += values.nbytes
+        elif hasattr(layer_cache, "state") and not isinstance(layer_cache, dict):
+            # Cache with state property returning (keys, values)
+            try:
+                keys, values = layer_cache.state
+                if hasattr(keys, "nbytes"):
+                    total_bytes += keys.nbytes
+                if hasattr(values, "nbytes"):
+                    total_bytes += values.nbytes
+            except (TypeError, ValueError):
+                pass
+        elif hasattr(layer_cache, "keys") and hasattr(layer_cache, "values"):
+            # Standard KVCache with keys/values attributes (not dict)
+            keys_attr = layer_cache.keys
+            values_attr = layer_cache.values
+            # Ensure these are arrays, not methods
+            if not callable(keys_attr) and hasattr(keys_attr, "nbytes"):
+                total_bytes += keys_attr.nbytes
+            if not callable(values_attr) and hasattr(values_attr, "nbytes"):
+                total_bytes += values_attr.nbytes
+
+    return total_bytes
+
+
+@dataclass(frozen=True)
+class MemoryCacheConfig:
+    """
+    Configuration for memory-aware prefix cache.
+
+    Attributes:
+        max_memory_mb: Maximum memory in MB. If None, auto-detects.
+        max_memory_percent: Fraction of available RAM to use (0.0-1.0).
+        max_entries: Hard limit on number of entries (safety net).
+        enable_memory_tracking: Whether to track per-entry memory.
+    """
+
+    max_memory_mb: int | None = None
+    max_memory_percent: float = _DEFAULT_MEMORY_PERCENT
+    max_entries: int = 1000  # Safety limit
+    enable_memory_tracking: bool = True
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.max_memory_percent <= 1.0:
+            raise ValueError(
+                f"max_memory_percent must be in (0, 1], got {self.max_memory_percent}"
+            )
+        if self.max_entries < 1:
+            raise ValueError(f"max_entries must be >= 1, got {self.max_entries}")
+
+    def compute_memory_limit(self) -> int:
+        """
+        Compute the memory limit in bytes.
+
+        Returns:
+            Memory limit in bytes.
+        """
+        if self.max_memory_mb is not None:
+            return self.max_memory_mb * _BYTES_PER_MB
+
+        available = _get_available_memory()
+        if available > 0:
+            limit = int(available * self.max_memory_percent)
+            return max(limit, _MIN_MEMORY_BYTES)
+
+        # Fallback: assume 8GB system, use configured percent
+        fallback_total = 8 * 1024 * _BYTES_PER_MB
+        return int(fallback_total * self.max_memory_percent)
+
+
+@dataclass
+class CacheStats:
+    """Statistics for cache performance monitoring."""
+
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    tokens_saved: int = 0
+    current_memory_bytes: int = 0
+    max_memory_bytes: int = 0
+    entry_count: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+    @property
+    def memory_utilization(self) -> float:
+        if self.max_memory_bytes == 0:
+            return 0.0
+        return self.current_memory_bytes / self.max_memory_bytes
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate": round(self.hit_rate, 4),
+            "evictions": self.evictions,
+            "tokens_saved": self.tokens_saved,
+            "current_memory_mb": round(self.current_memory_bytes / _BYTES_PER_MB, 2),
+            "max_memory_mb": round(self.max_memory_bytes / _BYTES_PER_MB, 2),
+            "memory_utilization": round(self.memory_utilization, 4),
+            "entry_count": self.entry_count,
+        }
+
+
+@dataclass
+class _CacheEntry:
+    """Internal cache entry with memory tracking."""
+
+    tokens: tuple[int, ...]
+    cache: list[Any]
+    memory_bytes: int
+
+    @classmethod
+    def create(cls, tokens: list[int], cache: list[Any]) -> _CacheEntry:
+        """Create a cache entry with memory estimation."""
+        memory = estimate_kv_cache_memory(cache)
+        return cls(
+            tokens=tuple(tokens),
+            cache=cache,
+            memory_bytes=memory,
+        )
+
+
+class MemoryAwarePrefixCache:
+    """
+    Prefix cache with memory-based eviction.
+
+    This cache tracks memory usage per entry and evicts based on memory
+    pressure rather than entry count. It uses LRU (Least Recently Used)
+    ordering for eviction decisions.
+
+    Key design decisions:
+    - No deep copies on fetch: MLX arrays are immutable, so sharing is safe
+    - Memory tracking per entry: Accurate accounting for eviction
+    - Auto-detection of available RAM: Adapts to different systems
+    - OrderedDict for O(1) LRU operations
+
+    Thread Safety:
+        This class is NOT thread-safe. Use external locking if needed.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        config: MemoryCacheConfig | None = None,
+    ) -> None:
+        """
+        Initialize the memory-aware prefix cache.
+
+        Args:
+            model: The MLX model (used for identification).
+            config: Cache configuration. Uses defaults if None.
+        """
+        self._model_id = id(model)
+        self._config = config or MemoryCacheConfig()
+
+        # OrderedDict maintains insertion order for LRU
+        # Key: tuple(tokens), Value: _CacheEntry
+        self._entries: OrderedDict[tuple[int, ...], _CacheEntry] = OrderedDict()
+
+        # Memory tracking
+        self._max_memory = self._config.compute_memory_limit()
+        self._current_memory = 0
+
+        # Statistics
+        self._stats = CacheStats(max_memory_bytes=self._max_memory)
+
+        logger.info(
+            f"MemoryAwarePrefixCache initialized: "
+            f"max_memory={self._max_memory / _BYTES_PER_MB:.1f}MB, "
+            f"max_entries={self._config.max_entries}"
+        )
+
+    def fetch(self, tokens: list[int]) -> tuple[list[Any] | None, list[int]]:
+        """
+        Find cached KV state for the given tokens.
+
+        This method searches for exact matches and prefix matches.
+        Returns the cached KV state directly (no copy) since MLX arrays
+        are immutable and safe to share.
+
+        Args:
+            tokens: Input token sequence.
+
+        Returns:
+            Tuple of (cache, remaining_tokens):
+            - cache: Cached KV state if found, None otherwise
+            - remaining_tokens: Tokens that still need processing
+        """
+        if not tokens:
+            self._stats.misses += 1
+            return None, tokens
+
+        tokens_key = tuple(tokens)
+
+        # Check for exact match
+        if tokens_key in self._entries:
+            entry = self._entries[tokens_key]
+            # Move to end (most recently used)
+            self._entries.move_to_end(tokens_key)
+            self._stats.hits += 1
+            self._stats.tokens_saved += len(tokens)
+            # Return reference directly - MLX arrays are immutable
+            return entry.cache, []
+
+        # Check for prefix matches (shorter cached sequences)
+        best_match: _CacheEntry | None = None
+        best_length = 0
+
+        for cached_key, entry in self._entries.items():
+            cached_len = len(cached_key)
+            # Check if cached sequence is a prefix of requested tokens
+            if (
+                cached_len < len(tokens)
+                and cached_len > best_length
+                and tokens_key[:cached_len] == cached_key
+            ):
+                best_match = entry
+                best_length = cached_len
+
+        if best_match is not None:
+            # Move matched entry to end (most recently used)
+            self._entries.move_to_end(best_match.tokens)
+            self._stats.hits += 1
+            self._stats.tokens_saved += best_length
+            remaining = tokens[best_length:]
+            return best_match.cache, remaining
+
+        self._stats.misses += 1
+        return None, tokens
+
+    def store(self, tokens: list[int], cache: list[Any]) -> bool:
+        """
+        Store KV cache for future reuse.
+
+        This method stores the cache reference directly (no copy) and
+        tracks memory usage. If memory limit is exceeded, LRU entries
+        are evicted until there's room.
+
+        Args:
+            tokens: Token sequence that was processed.
+            cache: The computed KV cache to store.
+
+        Returns:
+            True if stored successfully, False if rejected.
+        """
+        if not tokens or not cache:
+            return False
+
+        tokens_key = tuple(tokens)
+
+        # If already cached, just update LRU order
+        if tokens_key in self._entries:
+            self._entries.move_to_end(tokens_key)
+            return True
+
+        # Create entry and estimate memory
+        entry = _CacheEntry.create(tokens, cache)
+
+        # Check if single entry exceeds limit
+        if entry.memory_bytes > self._max_memory:
+            logger.warning(
+                f"Cache entry too large: {entry.memory_bytes / _BYTES_PER_MB:.1f}MB "
+                f"exceeds limit {self._max_memory / _BYTES_PER_MB:.1f}MB"
+            )
+            return False
+
+        # Evict until we have room
+        while (
+            self._current_memory + entry.memory_bytes > self._max_memory
+            or len(self._entries) >= self._config.max_entries
+        ) and self._entries:
+            self._evict_lru()
+
+        # Store entry
+        self._entries[tokens_key] = entry
+        self._current_memory += entry.memory_bytes
+        self._stats.entry_count = len(self._entries)
+        self._stats.current_memory_bytes = self._current_memory
+
+        logger.debug(
+            f"Stored cache: {len(tokens)} tokens, "
+            f"{entry.memory_bytes / _BYTES_PER_MB:.2f}MB, "
+            f"total={self._current_memory / _BYTES_PER_MB:.1f}MB"
+        )
+
+        return True
+
+    def _evict_lru(self) -> None:
+        """Evict the least recently used entry."""
+        if not self._entries:
+            return
+
+        # popitem(last=False) removes oldest entry (FIFO order = LRU)
+        tokens_key, entry = self._entries.popitem(last=False)
+        self._current_memory -= entry.memory_bytes
+        self._stats.evictions += 1
+        self._stats.entry_count = len(self._entries)
+        self._stats.current_memory_bytes = self._current_memory
+
+        logger.debug(
+            f"Evicted cache: {len(tokens_key)} tokens, "
+            f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
+        )
+
+    def remove(self, tokens: list[int]) -> bool:
+        """
+        Remove a specific cache entry.
+
+        Args:
+            tokens: Token sequence to remove.
+
+        Returns:
+            True if entry was found and removed.
+        """
+        tokens_key = tuple(tokens)
+        entry = self._entries.pop(tokens_key, None)
+        if entry is not None:
+            self._current_memory -= entry.memory_bytes
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
+            return True
+        return False
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._entries.clear()
+        self._current_memory = 0
+        self._stats = CacheStats(max_memory_bytes=self._max_memory)
+        logger.debug("Cache cleared")
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics."""
+        return self._stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset statistics while preserving cache contents."""
+        self._stats = CacheStats(
+            max_memory_bytes=self._max_memory,
+            current_memory_bytes=self._current_memory,
+            entry_count=len(self._entries),
+        )
+
+    @property
+    def memory_usage_mb(self) -> float:
+        """Current memory usage in MB."""
+        return self._current_memory / _BYTES_PER_MB
+
+    @property
+    def memory_limit_mb(self) -> float:
+        """Memory limit in MB."""
+        return self._max_memory / _BYTES_PER_MB
+
+    def __len__(self) -> int:
+        """Return number of cached entries."""
+        return len(self._entries)
+
+    def __contains__(self, tokens: list[int]) -> bool:
+        """Check if tokens are cached."""
+        return tuple(tokens) in self._entries


### PR DESCRIPTION
Fixes #16

## Changes

### 1. Metal crash fix
Added `asyncio.Lock` to serialize MLX operations in SimpleEngine. Metal command buffers don't handle concurrent access well, so we need to ensure only one generation runs at a time.

### 2. Memory leak fix  
Added memory-aware prefix cache that evicts based on actual memory usage instead of entry count.

**The problem:** The old prefix cache stored up to 100 KV cache entries. For large models like GLM-4.7-Flash, each entry can be hundreds of MB, quickly exhausting RAM.

**The solution:**
- New `MemoryAwarePrefixCache` class that tracks memory per entry
- Auto-detects available RAM (defaults to 20%)
- LRU eviction when memory limit is reached
- No deep copies (MLX arrays are immutable)

### 3. CLI options
New flags for cache control:
- `--cache-memory-mb` - Explicit limit in MB
- `--cache-memory-percent` - Fraction of RAM (default: 0.20)
- `--no-memory-aware-cache` - Use legacy entry-count cache

### 4. Dependencies
Updated mlx-lm requirement to >=0.30.2 for GLM-4 model support.

### 5. Code quality
Replaced emojis with text labels in test output for cleaner logs.

## Testing
- All 389 tests pass
- Tested with 10 concurrent requests - no Metal crashes
- Memory stays bounded during continuous batching