### PR TITLE
Add MedGemma to MLLM detection patterns and fix the mllm flag

### DIFF
--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -65,6 +65,8 @@ MLLM_PATTERNS = [
     "PaliGemma",  # PaliGemma
     "gemma-3",
     "gemma3",  # Gemma 3 (multimodal)
+    "medgemma",
+    "MedGemma",  # MedGemma (medical multimodal with SigLIP vision encoder)
     "pixtral",
     "Pixtral",  # Pixtral
     "molmo",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -136,6 +136,7 @@ class BatchedEngine(BaseEngine):
         trust_remote_code: bool = True,
         scheduler_config: Optional[Any] = None,
         stream_interval: int = 1,
+        force_mllm: bool = False,
     ):
         """
         Initialize the batched engine.
@@ -145,12 +146,13 @@ class BatchedEngine(BaseEngine):
             trust_remote_code: Whether to trust remote code
             scheduler_config: Optional scheduler configuration
             stream_interval: Tokens to batch before streaming (1=every token)
+            force_mllm: Force loading as MLLM even if not auto-detected
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
-        self._is_mllm = is_mllm_model(model_name)
+        self._is_mllm = force_mllm or is_mllm_model(model_name)
 
         self._model = None
         self._processor = None  # For MLLM

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -31,6 +31,7 @@ class SimpleEngine(BaseEngine):
         model_name: str,
         trust_remote_code: bool = True,
         enable_cache: bool = True,
+        force_mllm: bool = False,
     ):
         """
         Initialize the simple engine.
@@ -39,11 +40,12 @@ class SimpleEngine(BaseEngine):
             model_name: HuggingFace model name or local path
             trust_remote_code: Whether to trust remote code
             enable_cache: Enable VLM cache for multimodal models
+            force_mllm: Force loading as MLLM even if not auto-detected
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._enable_cache = enable_cache
-        self._is_mllm = is_mllm_model(model_name)
+        self._is_mllm = force_mllm or is_mllm_model(model_name)
 
         self._model = None
         self._loaded = False

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1759,6 +1759,10 @@ class MLXMultimodalLM:
             "Idefics",
             "paligemma",
             "PaliGemma",
+            "gemma-3",
+            "gemma3",  # Gemma 3 (multimodal)
+            "medgemma",
+            "MedGemma",  # MedGemma (medical multimodal)
             "pixtral",
             "Pixtral",
             "molmo",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -259,19 +259,23 @@ def load_model(
     _default_max_tokens = max_tokens
     _model_name = model_name
 
+    if force_mllm:
+        logger.info("Force MLLM mode enabled via --mllm flag")
+
     if use_batching:
         logger.info(f"Loading model with BatchedEngine: {model_name}")
         _engine = BatchedEngine(
             model_name=model_name,
             scheduler_config=scheduler_config,
             stream_interval=stream_interval,
+            force_mllm=force_mllm,
         )
         # BatchedEngine will be started in lifespan (uvicorn's event loop)
         # Just log for now
-        logger.info(f"LLM model loaded (batched mode): {model_name}")
+        logger.info(f"Model loaded (batched mode): {model_name}")
     else:
         logger.info(f"Loading model with SimpleEngine: {model_name}")
-        _engine = SimpleEngine(model_name=model_name)
+        _engine = SimpleEngine(model_name=model_name, force_mllm=force_mllm)
         # Start SimpleEngine synchronously (no background loop)
         # Use new_event_loop() for Python 3.10+ compatibility (get_event_loop() is deprecated)
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
Fixes #21

## Summary

MedGemma models were not being recognized as multimodal because the pattern was missing from the detection list. Additionally, the `--mllm` flag was being ignored because `force_mllm` was never passed to the engines.

## Changes

Added `medgemma` to MLLM detection patterns in both `api/utils.py` and `models/mllm.py`. The `--mllm` CLI flag now properly passes `force_mllm` to SimpleEngine and BatchedEngine, allowing users to force MLLM mode for models not yet in the pattern list.

## Testing

All 389 tests pass. Verified that `mlx-community/medgemma-1.5-4b-it-bf16` is now correctly detected as MLLM.