### PR TITLE
Add missing pytz dependency for vllm-mlx-chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dependencies = [
     "mcp>=1.0.0",
     # JSON Schema validation for structured output
     "jsonschema>=4.0.0",
+    # pytz is required by gradio but not declared as a dependency
+    # See: https://github.com/waybarrios/vllm-mlx/issues/23
+    "pytz>=2024.1",
     # Note: mlx-audio moved to optional [audio] deps due to mlx-lm version conflict
     # See: https://github.com/waybarrios/vllm-mlx/issues/19
 ]


### PR DESCRIPTION
Gradio needs pytz but doesn't declare it as a dependency, causing `vllm-mlx-chat` to fail on fresh installs.

Tested on a clean venv and confirmed it works now.

Fixes #23