### PR TITLE
Tool calling support

### DIFF
--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -1,0 +1,213 @@
+# Tool Calling
+
+vllm-mlx supports OpenAI-compatible tool calling (function calling) with automatic parsing for many popular model families.
+
+## Quick Start
+
+Enable tool calling by adding the `--enable-auto-tool-choice` flag when starting the server:
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+Then use tools with the standard OpenAI API:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+# Check for tool calls
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"Function: {tc.function.name}")
+        print(f"Arguments: {tc.function.arguments}")
+```
+
+## Supported Parsers
+
+Use `--tool-call-parser` to select a parser for your model family:
+
+| Parser | Models | Format |
+|--------|--------|--------|
+| `auto` | Any model | Auto-detects format (default) |
+| `mistral` | Mistral, Devstral | `[TOOL_CALLS]` token |
+| `qwen` | Qwen, Qwen3 | `<tool_call>` XML or `[Calling tool:]` |
+| `llama` | Llama 3.x, 4.x | `<function=name>` tags |
+| `hermes` | Hermes, NousResearch | `<tool_call>` XML |
+| `deepseek` | DeepSeek V3, R1 | Unicode delimiters |
+| `kimi` | Kimi K2, Moonshot | `<\|tool_call_begin\|>` tokens |
+| `granite` | IBM Granite 3.x, 4.x | `<\|tool_call\|>` or `<tool_call>` |
+| `nemotron` | NVIDIA Nemotron | `<parameter=name>` tags |
+| `xlam` | Salesforce xLAM | JSON with `tool_calls` array |
+| `functionary` | MeetKai Functionary | Multiple function blocks |
+
+## Model Examples
+
+### Mistral / Devstral
+
+```bash
+# Devstral Small (optimized for coding and tool use)
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Mistral Instruct
+vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+### Qwen
+
+```bash
+# Qwen3
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser qwen
+```
+
+### Llama
+
+```bash
+# Llama 3.2
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser llama
+```
+
+### DeepSeek
+
+```bash
+# DeepSeek V3
+vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
+  --enable-auto-tool-choice --tool-call-parser deepseek
+```
+
+### IBM Granite
+
+```bash
+# Granite 4.0
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+```
+
+### NVIDIA Nemotron
+
+```bash
+# Nemotron 3 Nano
+vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
+  --enable-auto-tool-choice --tool-call-parser nemotron
+```
+
+## Auto Parser
+
+If you're not sure which parser to use, the `auto` parser tries to detect the format automatically:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser auto
+```
+
+The auto parser tries formats in this order:
+1. Mistral (`[TOOL_CALLS]`)
+2. Qwen bracket (`[Calling tool:]`)
+3. Nemotron (`<tool_call><function=...><parameter=...>`)
+4. Qwen/Hermes XML (`<tool_call>{...}</tool_call>`)
+5. Llama (`<function=name>{...}</function>`)
+6. Raw JSON
+
+## Streaming Tool Calls
+
+Tool calls work with streaming. The tool call information is sent when the model finishes generating:
+
+```python
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's 25 * 17?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Calculate math expressions",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string"}
+                },
+                "required": ["expression"]
+            }
+        }
+    }],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.tool_calls:
+        for tc in chunk.choices[0].delta.tool_calls:
+            print(f"Tool call: {tc.function.name}({tc.function.arguments})")
+```
+
+## Handling Tool Results
+
+After receiving a tool call, execute the function and send the result back:
+
+```python
+import json
+
+# First request - model decides to call a tool
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=[weather_tool]
+)
+
+# Get the tool call
+tool_call = response.choices[0].message.tool_calls[0]
+tool_call_id = tool_call.id
+function_name = tool_call.function.name
+arguments = json.loads(tool_call.function.arguments)
+
+# Execute the function (your implementation)
+result = get_weather(**arguments)  # {"temperature": 22, "condition": "sunny"}
+
+# Send result back to model
+response = client.chat.completions.create(
+    model="default",
+    messages=[
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {"role": "assistant", "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": tool_call_id, "content": json.dumps(result)}
+    ],
+    tools=[weather_tool]
+)
+
+print(response.choices[0].message.content)
+# "The weather in Tokyo is sunny with a temperature of 22°C."
+```
+
+## CLI Reference
+
+| Option | Description |
+|--------|-------------|
+| `--enable-auto-tool-choice` | Enable automatic tool calling |
+| `--tool-call-parser` | Select parser (`auto`, `mistral`, `qwen`, `llama`, etc.) |
+
+See [CLI Reference](../reference/cli.md) for all options.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,6 +38,9 @@ vllm-mlx serve <model> [options]
 | `--paged-cache-block-size` | Tokens per cache block | 64 |
 | `--max-cache-blocks` | Maximum cache blocks | 1000 |
 | `--max-num-seqs` | Max concurrent sequences | 256 |
+| `--reasoning-parser` | Parser for reasoning models (`qwen3`, `deepseek_r1`) | None |
+| `--enable-auto-tool-choice` | Enable automatic tool calling | False |
+| `--tool-call-parser` | Tool call parser (`auto`, `mistral`, `qwen`, `llama`, `deepseek`, `granite`, `nemotron`, etc.) | None |
 
 ### Examples
 
@@ -64,6 +67,20 @@ vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
 
 # Multimodal model
 vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Reasoning model (separates thinking from answer)
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek reasoning model
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+
+# Tool calling with Mistral/Devstral
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Tool calling with Granite
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
 
 # With API key authentication
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -1,0 +1,682 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Comprehensive tests for tool call parsers."""
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers import (
+    AutoToolParser,
+    DeepSeekToolParser,
+    FunctionaryToolParser,
+    GraniteToolParser,
+    HermesToolParser,
+    KimiToolParser,
+    LlamaToolParser,
+    MistralToolParser,
+    NemotronToolParser,
+    QwenToolParser,
+    ToolParserManager,
+    xLAMToolParser,
+)
+
+
+class TestToolParserManager:
+    """Test the ToolParserManager registry."""
+
+    def test_list_registered(self):
+        """Test that all expected parsers are registered."""
+        parsers = ToolParserManager.list_registered()
+        expected = [
+            "auto",
+            "mistral",
+            "qwen",
+            "llama",
+            "hermes",
+            "deepseek",
+            "kimi",
+            "granite",
+            "nemotron",
+            "xlam",
+            "functionary",
+        ]
+        for p in expected:
+            assert p in parsers, f"Parser '{p}' not found"
+
+    def test_get_tool_parser_by_name(self):
+        """Test getting parsers by name."""
+        test_cases = [
+            ("mistral", MistralToolParser),
+            ("qwen", QwenToolParser),
+            ("qwen3", QwenToolParser),
+            ("llama", LlamaToolParser),
+            ("llama3", LlamaToolParser),
+            ("llama4", LlamaToolParser),
+            ("auto", AutoToolParser),
+            ("deepseek", DeepSeekToolParser),
+            ("deepseek_v3", DeepSeekToolParser),
+            ("deepseek_r1", DeepSeekToolParser),
+            ("kimi", KimiToolParser),
+            ("kimi_k2", KimiToolParser),
+            ("moonshot", KimiToolParser),
+            ("granite", GraniteToolParser),
+            ("granite3", GraniteToolParser),
+            ("nemotron", NemotronToolParser),
+            ("nemotron3", NemotronToolParser),
+            ("xlam", xLAMToolParser),
+            ("functionary", FunctionaryToolParser),
+            ("meetkai", FunctionaryToolParser),
+            ("hermes", HermesToolParser),
+            ("nous", HermesToolParser),
+        ]
+        for name, expected_cls in test_cases:
+            parser_cls = ToolParserManager.get_tool_parser(name)
+            assert parser_cls == expected_cls, f"Parser '{name}' returned wrong class"
+
+    def test_get_unknown_parser_raises(self):
+        """Test that unknown parser raises KeyError."""
+        with pytest.raises(KeyError):
+            ToolParserManager.get_tool_parser("unknown_parser")
+
+    def test_parser_instantiation(self):
+        """Test that all parsers can be instantiated without tokenizer."""
+        for name in [
+            "auto",
+            "mistral",
+            "qwen",
+            "llama",
+            "hermes",
+            "deepseek",
+            "kimi",
+            "granite",
+            "nemotron",
+            "xlam",
+            "functionary",
+        ]:
+            parser_cls = ToolParserManager.get_tool_parser(name)
+            parser = parser_cls()  # Should not raise
+            assert parser is not None
+
+
+class TestMistralToolParser:
+    """Test the Mistral tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return MistralToolParser()
+
+    def test_old_format_single(self, parser):
+        """Test parsing old Mistral format with single tool call."""
+        text = '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Paris"}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["city"] == "Paris"
+
+    def test_old_format_multiple(self, parser):
+        """Test parsing old Mistral format with multiple tool calls."""
+        text = '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Paris"}}, {"name": "get_time", "arguments": {"timezone": "UTC"}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert result.tool_calls[1]["name"] == "get_time"
+
+    def test_new_format(self, parser):
+        """Test parsing new Mistral format."""
+        text = '[TOOL_CALLS]get_weather{"city": "London"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_no_tool_call(self, parser):
+        """Test that regular text is not parsed as tool call."""
+        text = "Hello, how can I help you today?"
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.content == text
+
+    def test_content_with_tool_call(self, parser):
+        """Test content before tool call is preserved."""
+        text = 'Let me check the weather for you.[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.content == "Let me check the weather for you."
+
+
+class TestQwenToolParser:
+    """Test the Qwen tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return QwenToolParser()
+
+    def test_xml_format(self, parser):
+        """Test parsing Qwen XML format."""
+        text = '<tool_call>{"name": "calculate", "arguments": {"x": 1, "y": 2}}</tool_call>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "calculate"
+
+    def test_bracket_format(self, parser):
+        """Test parsing Qwen bracket format (Qwen3 style)."""
+        text = '[Calling tool: add({"a": 5, "b": 3})]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "add"
+
+    def test_multiple_xml_calls(self, parser):
+        """Test multiple XML tool calls."""
+        text = '<tool_call>{"name": "func1", "arguments": {}}</tool_call><tool_call>{"name": "func2", "arguments": {}}</tool_call>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "I can help you with that question."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestLlamaToolParser:
+    """Test the Llama tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return LlamaToolParser()
+
+    def test_function_format(self, parser):
+        """Test parsing Llama function format."""
+        text = '<function=multiply>{"x": 3, "y": 4}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "multiply"
+
+    def test_multiple_functions(self, parser):
+        """Test parsing multiple function calls."""
+        text = '<function=add>{"a": 1}</function><function=multiply>{"x": 3}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0]["name"] == "add"
+        assert result.tool_calls[1]["name"] == "multiply"
+
+    def test_content_with_function(self, parser):
+        """Test content before function call."""
+        text = 'Computing result<function=calc>{"n": 5}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.content == "Computing result"
+
+
+class TestHermesToolParser:
+    """Test the Hermes tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return HermesToolParser()
+
+    def test_tool_call_format(self, parser):
+        """Test parsing Hermes format."""
+        text = (
+            '<tool_call>{"name": "search", "arguments": {"query": "test"}}</tool_call>'
+        )
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_with_reasoning(self, parser):
+        """Test with reasoning block."""
+        text = '<tool_call_reasoning>I need to search for this</tool_call_reasoning><tool_call>{"name": "search", "arguments": {}}</tool_call>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert "Reasoning" in (result.content or "")
+
+
+class TestDeepSeekToolParser:
+    """Test the DeepSeek tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return DeepSeekToolParser()
+
+    def test_deepseek_format(self, parser):
+        """Test parsing DeepSeek V3 format."""
+        text = """<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"city": "Tokyo"}
+```<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜>"""
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_multiple_calls(self, parser):
+        """Test multiple DeepSeek tool calls."""
+        text = """<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>func1
+```json
+{"a": 1}
+```<｜tool▁call▁end｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>func2
+```json
+{"b": 2}
+```<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜>"""
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+    def test_content_before_tools(self, parser):
+        """Test content before tool calls is preserved."""
+        text = """Let me help you with that.<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>search
+```json
+{}
+```<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜>"""
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.content == "Let me help you with that."
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "Here is my response without any tool calls."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestKimiToolParser:
+    """Test the Kimi tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return KimiToolParser()
+
+    def test_kimi_format(self, parser):
+        """Test parsing Kimi K2 format."""
+        text = """<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"city": "Beijing"}<|tool_call_end|>
+<|tool_calls_section_end|>"""
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_simple_function_name(self, parser):
+        """Test with simple function name (no functions. prefix)."""
+        text = (
+            "<|tool_call_begin|>search:0<|tool_call_argument_begin|>{}<|tool_call_end|>"
+        )
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "I'll answer your question directly."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestGraniteToolParser:
+    """Test the Granite tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return GraniteToolParser()
+
+    def test_granite_30_format(self, parser):
+        """Test parsing Granite 3.0 format."""
+        text = (
+            '<|tool_call|>[{"name": "calculate", "arguments": {"expression": "2+2"}}]'
+        )
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "calculate"
+
+    def test_granite_31_format(self, parser):
+        """Test parsing Granite 3.1 format."""
+        text = '<tool_call>[{"name": "search", "arguments": {"query": "test"}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_multiple_calls(self, parser):
+        """Test multiple tool calls."""
+        text = '<|tool_call|>[{"name": "func1", "arguments": {}}, {"name": "func2", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "The answer is 42."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestNemotronToolParser:
+    """Test the Nemotron tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return NemotronToolParser()
+
+    def test_parameter_format(self, parser):
+        """Test parsing Nemotron parameter format."""
+        text = "<tool_call><function=get_weather><parameter=city>Paris</parameter><parameter=units>celsius</parameter></function></tool_call>"
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["city"] == "Paris"
+        assert args["units"] == "celsius"
+
+    def test_json_format(self, parser):
+        """Test parsing Nemotron with JSON arguments."""
+        text = '<tool_call><function=calculate>{"expression": "2*3"}</function></tool_call>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "calculate"
+
+    def test_multiple_calls(self, parser):
+        """Test multiple Nemotron tool calls."""
+        text = "<tool_call><function=func1><parameter=a>1</parameter></function></tool_call><tool_call><function=func2><parameter=b>2</parameter></function></tool_call>"
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "Here is the information you requested."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestXLAMToolParser:
+    """Test the xLAM tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return xLAMToolParser()
+
+    def test_json_array(self, parser):
+        """Test parsing JSON array format."""
+        text = '[{"name": "search", "arguments": {"query": "AI"}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_code_block(self, parser):
+        """Test parsing markdown code block."""
+        text = '```json\n[{"name": "calculate", "arguments": {"x": 5}}]\n```'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "calculate"
+
+    def test_after_think(self, parser):
+        """Test parsing after </think> tag."""
+        text = (
+            '<think>Let me search for this</think>[{"name": "search", "arguments": {}}]'
+        )
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_tool_calls_tag(self, parser):
+        """Test [TOOL_CALLS] tag format."""
+        text = '[TOOL_CALLS][{"name": "func", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "I don't need to use any tools for this."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestFunctionaryToolParser:
+    """Test the Functionary tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return FunctionaryToolParser()
+
+    def test_recipient_format(self, parser):
+        """Test parsing Functionary v3 recipient format."""
+        text = '<|from|>assistant\n<|recipient|>get_weather\n<|content|>{"city": "NYC"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_weather"
+
+    def test_function_format(self, parser):
+        """Test parsing function format."""
+        text = '<function=search>{"query": "test"}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_json_array(self, parser):
+        """Test parsing JSON array."""
+        text = '[{"name": "func1", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "Let me explain that to you."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestAutoToolParser:
+    """Test the auto-detecting tool parser."""
+
+    @pytest.fixture
+    def parser(self):
+        return AutoToolParser()
+
+    def test_detects_mistral(self, parser):
+        """Test auto detection of Mistral format."""
+        text = '[TOOL_CALLS] [{"name": "search", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_detects_qwen_xml(self, parser):
+        """Test auto detection of Qwen XML format."""
+        text = '<tool_call>{"name": "calculate", "arguments": {}}</tool_call>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "calculate"
+
+    def test_detects_qwen_bracket(self, parser):
+        """Test auto detection of Qwen bracket format."""
+        text = '[Calling tool: add({"a": 1})]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "add"
+
+    def test_detects_llama(self, parser):
+        """Test auto detection of Llama format."""
+        text = '<function=multiply>{"x": 2}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "multiply"
+
+    def test_detects_nemotron(self, parser):
+        """Test auto detection of Nemotron format."""
+        text = "<tool_call><function=search><parameter=q>test</parameter></function></tool_call>"
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "search"
+
+    def test_detects_raw_json(self, parser):
+        """Test auto detection of raw JSON format."""
+        text = '{"name": "test_func", "arguments": {"key": "value"}}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "test_func"
+
+    def test_no_tool_call(self, parser):
+        """Test text without tool calls."""
+        text = "This is just a regular response."
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_empty_input(self):
+        """Test with empty input."""
+        parsers = [
+            MistralToolParser(),
+            QwenToolParser(),
+            LlamaToolParser(),
+            DeepSeekToolParser(),
+            AutoToolParser(),
+        ]
+        for parser in parsers:
+            result = parser.extract_tool_calls("")
+            assert not result.tools_called
+
+    def test_malformed_json(self):
+        """Test with malformed JSON."""
+        parser = MistralToolParser()
+        text = '[TOOL_CALLS] [{"name": "func", "arguments": {invalid json}]'
+        result = parser.extract_tool_calls(text)
+        # Should not crash, may or may not parse
+
+    def test_nested_arguments(self):
+        """Test with deeply nested arguments."""
+        parser = AutoToolParser()
+        args = {"level1": {"level2": {"level3": [1, 2, 3]}}}
+        text = f'{{"name": "complex", "arguments": {json.dumps(args)}}}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        parsed_args = json.loads(result.tool_calls[0]["arguments"])
+        assert parsed_args["level1"]["level2"]["level3"] == [1, 2, 3]
+
+    def test_unicode_in_arguments(self):
+        """Test with unicode characters in arguments."""
+        parser = MistralToolParser()
+        text = '[TOOL_CALLS] [{"name": "translate", "arguments": {"text": "日本語"}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["text"] == "日本語"
+
+    def test_special_characters_in_name(self):
+        """Test function names with special characters."""
+        parser = LlamaToolParser()
+        text = '<function=get_user_info>{"user_id": 123}</function>'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert result.tool_calls[0]["name"] == "get_user_info"
+
+    def test_tool_call_id_uniqueness(self):
+        """Test that each tool call gets a unique ID."""
+        parser = MistralToolParser()
+        text = '[TOOL_CALLS] [{"name": "func1", "arguments": {}}, {"name": "func2", "arguments": {}}]'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        ids = [tc["id"] for tc in result.tool_calls]
+        assert len(ids) == len(set(ids)), "Tool call IDs should be unique"
+
+
+class TestStreamingParsing:
+    """Test streaming tool call parsing."""
+
+    def test_mistral_streaming(self):
+        """Test Mistral streaming parsing."""
+        parser = MistralToolParser()
+
+        # Simulate streaming
+        result1 = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="Let me",
+            delta_text="Let me",
+        )
+        assert result1 == {"content": "Let me"}
+
+        result2 = parser.extract_tool_calls_streaming(
+            previous_text="Let me",
+            current_text="Let me[TOOL_CALLS]",
+            delta_text="[TOOL_CALLS]",
+        )
+        # Should start tool call parsing
+
+    def test_auto_streaming(self):
+        """Test auto parser streaming."""
+        parser = AutoToolParser()
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="Hello world",
+            delta_text="Hello world",
+        )
+        assert result == {"content": "Hello world"}

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tool call parsers for vllm-mlx.
+
+This module provides tool call parsing functionality for various model formats.
+Inspired by vLLM's tool parser architecture but simplified for MLX backend.
+
+Available parsers:
+- auto: Auto-detecting parser that tries all formats (default)
+- mistral: Mistral models ([TOOL_CALLS] format)
+- qwen/qwen3: Qwen models (<tool_call> and [Calling tool:] formats)
+- llama/llama3/llama4: Llama models (<function=name> format)
+- hermes/nous: Hermes/NousResearch models
+- deepseek/deepseek_v3/deepseek_r1: DeepSeek models (unicode tokens)
+- kimi/kimi_k2/moonshot: Kimi/Moonshot models
+- granite/granite3: IBM Granite models
+- nemotron/nemotron3: NVIDIA Nemotron models
+- xlam: Salesforce xLAM models
+- functionary/meetkai: MeetKai Functionary models
+
+Usage:
+    from vllm_mlx.tool_parsers import ToolParserManager
+
+    # Get a parser by name
+    parser_cls = ToolParserManager.get_tool_parser("mistral")
+    parser = parser_cls(tokenizer)
+
+    # Parse tool calls
+    result = parser.extract_tool_calls(model_output)
+    if result.tools_called:
+        for tc in result.tool_calls:
+            print(f"Tool: {tc['name']}, Args: {tc['arguments']}")
+
+    # List available parsers
+    print(ToolParserManager.list_registered())
+"""
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+# Import parsers to register them
+from .auto_tool_parser import AutoToolParser
+from .deepseek_tool_parser import DeepSeekToolParser
+from .functionary_tool_parser import FunctionaryToolParser
+from .granite_tool_parser import GraniteToolParser
+from .hermes_tool_parser import HermesToolParser
+from .kimi_tool_parser import KimiToolParser
+from .llama_tool_parser import LlamaToolParser
+from .mistral_tool_parser import MistralToolParser
+from .nemotron_tool_parser import NemotronToolParser
+from .qwen_tool_parser import QwenToolParser
+from .xlam_tool_parser import xLAMToolParser
+
+__all__ = [
+    # Base classes
+    "ToolParser",
+    "ToolParserManager",
+    "ExtractedToolCallInformation",
+    # Specific parsers
+    "AutoToolParser",
+    "MistralToolParser",
+    "QwenToolParser",
+    "LlamaToolParser",
+    "HermesToolParser",
+    "DeepSeekToolParser",
+    "KimiToolParser",
+    "GraniteToolParser",
+    "NemotronToolParser",
+    "xLAMToolParser",
+    "FunctionaryToolParser",
+]

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Abstract tool parser base class and manager for vllm-mlx.
+
+Inspired by vLLM's tool parser architecture but simplified for MLX backend.
+"""
+
+import importlib
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Any
+
+from transformers import PreTrainedTokenizerBase
+
+
+@dataclass
+class ExtractedToolCallInformation:
+    """Information extracted from model output about tool calls."""
+
+    tools_called: bool
+    """Whether any tool calls were detected."""
+
+    tool_calls: list[dict[str, Any]]
+    """List of tool calls with 'name' and 'arguments' fields."""
+
+    content: str | None = None
+    """Any content that wasn't part of tool calls."""
+
+
+class ToolParser(ABC):
+    """
+    Abstract base class for tool call parsers.
+
+    Each parser implementation handles a specific model's tool calling format.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase | None = None):
+        """
+        Initialize the tool parser.
+
+        Args:
+            tokenizer: The tokenizer for the model (optional, some parsers need it)
+        """
+        self.model_tokenizer = tokenizer
+        # State for streaming parsing
+        self.current_tool_id: int = -1
+        self.prev_tool_call_arr: list[dict] = []
+
+    @cached_property
+    def vocab(self) -> dict[str, int]:
+        """Get the tokenizer vocabulary."""
+        if self.model_tokenizer is None:
+            return {}
+        return self.model_tokenizer.get_vocab()
+
+    @abstractmethod
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete model response.
+
+        Args:
+            model_output: The complete model output string
+            request: Optional request context (for tool definitions, etc.)
+
+        Returns:
+            ExtractedToolCallInformation with parsed tool calls
+        """
+        raise NotImplementedError
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming model output.
+
+        Override this method for streaming support. Default implementation
+        returns None (no streaming support).
+
+        Args:
+            previous_text: Text before this delta
+            current_text: Complete text so far
+            delta_text: New text in this chunk
+            previous_token_ids: Token IDs before this delta
+            current_token_ids: All token IDs so far
+            delta_token_ids: New token IDs in this chunk
+            request: Optional request context
+
+        Returns:
+            Delta message dict with content and/or tool_calls, or None
+        """
+        return None
+
+    def reset(self) -> None:
+        """Reset parser state for a new request."""
+        self.current_tool_id = -1
+        self.prev_tool_call_arr = []
+
+
+class ToolParserManager:
+    """
+    Central registry for ToolParser implementations.
+
+    Supports both eager and lazy registration of tool parsers.
+    """
+
+    tool_parsers: dict[str, type[ToolParser]] = {}
+    lazy_parsers: dict[str, tuple[str, str]] = {}  # name -> (module_path, class_name)
+
+    @classmethod
+    def get_tool_parser(cls, name: str) -> type[ToolParser]:
+        """
+        Retrieve a registered ToolParser class by name.
+
+        Args:
+            name: Parser name (e.g., 'mistral', 'qwen', 'llama')
+
+        Returns:
+            The ToolParser class
+
+        Raises:
+            KeyError: If parser not found
+        """
+        if name in cls.tool_parsers:
+            return cls.tool_parsers[name]
+
+        if name in cls.lazy_parsers:
+            return cls._load_lazy_parser(name)
+
+        raise KeyError(
+            f"Tool parser '{name}' not found. "
+            f"Available parsers: {cls.list_registered()}"
+        )
+
+    @classmethod
+    def _load_lazy_parser(cls, name: str) -> type[ToolParser]:
+        """Import and register a lazily loaded parser."""
+        module_path, class_name = cls.lazy_parsers[name]
+        try:
+            mod = importlib.import_module(module_path)
+            parser_cls = getattr(mod, class_name)
+            if not issubclass(parser_cls, ToolParser):
+                raise TypeError(
+                    f"{class_name} in {module_path} is not a ToolParser subclass."
+                )
+            cls.tool_parsers[name] = parser_cls
+            return parser_cls
+        except Exception as e:
+            raise ImportError(
+                f"Failed to import tool parser '{name}' from {module_path}: {e}"
+            ) from e
+
+    @classmethod
+    def register_module(
+        cls,
+        name: str | list[str],
+        module: type[ToolParser] | None = None,
+        force: bool = True,
+    ) -> type[ToolParser] | None:
+        """
+        Register a ToolParser class.
+
+        Can be used as a decorator or direct call.
+
+        Usage:
+            @ToolParserManager.register_module("my_parser")
+            class MyToolParser(ToolParser):
+                ...
+
+            # Or direct registration:
+            ToolParserManager.register_module("my_parser", MyToolParser)
+        """
+        names = [name] if isinstance(name, str) else name
+
+        if module is not None:
+            # Direct registration
+            if not issubclass(module, ToolParser):
+                raise TypeError(
+                    f"module must be subclass of ToolParser, got {type(module)}"
+                )
+            for n in names:
+                if not force and n in cls.tool_parsers:
+                    raise KeyError(f"Parser '{n}' is already registered")
+                cls.tool_parsers[n] = module
+            return module
+
+        # Decorator usage
+        def decorator(parser_cls: type[ToolParser]) -> type[ToolParser]:
+            for n in names:
+                if not force and n in cls.tool_parsers:
+                    raise KeyError(f"Parser '{n}' is already registered")
+                cls.tool_parsers[n] = parser_cls
+            return parser_cls
+
+        return decorator  # type: ignore
+
+    @classmethod
+    def register_lazy_module(cls, name: str, module_path: str, class_name: str) -> None:
+        """
+        Register a lazy module mapping for deferred loading.
+
+        Args:
+            name: Parser name to register
+            module_path: Full module path (e.g., 'vllm_mlx.tool_parsers.mistral')
+            class_name: Class name within the module
+        """
+        cls.lazy_parsers[name] = (module_path, class_name)
+
+    @classmethod
+    def list_registered(cls) -> list[str]:
+        """Return names of all registered tool parsers."""
+        return sorted(set(cls.tool_parsers.keys()) | set(cls.lazy_parsers.keys()))

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Auto-detecting tool call parser for vllm-mlx.
+
+Automatically detects and parses tool calls from various model formats.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["auto", "generic"])
+class AutoToolParser(ToolParser):
+    """
+    Auto-detecting tool call parser.
+
+    Tries multiple formats in order:
+    1. Mistral: [TOOL_CALLS] ...
+    2. Qwen bracket: [Calling tool: func_name({...})]
+    3. Qwen/Hermes XML: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+    4. Llama: <function=name>{"arg": "value"}</function>
+    5. Nemotron: <tool_call><function=name>...</function></tool_call>
+    6. Raw JSON: {"name": "...", "arguments": {...}}
+
+    This is the default parser when no specific parser is selected.
+    """
+
+    # Patterns for different formats
+    MISTRAL_TOKEN = "[TOOL_CALLS]"
+
+    QWEN_BRACKET_PATTERN = re.compile(
+        r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]", re.DOTALL
+    )
+    QWEN_XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+    LLAMA_PATTERN = re.compile(r"<function=([^>]+)>(\{.*?\})</function>", re.DOTALL)
+    NEMOTRON_PATTERN = re.compile(
+        r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>", re.DOTALL
+    )
+    NEMOTRON_PARAM_PATTERN = re.compile(
+        r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>", re.DOTALL
+    )
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls by trying all known formats.
+        """
+        tool_calls: list[dict[str, Any]] = []
+        cleaned_text = model_output
+
+        # 1. Try Mistral format
+        if self.MISTRAL_TOKEN in model_output:
+            parts = model_output.split(self.MISTRAL_TOKEN)
+            content = parts[0].strip()
+            raw_tool_calls = parts[1:]
+
+            for raw in raw_tool_calls:
+                raw = raw.strip()
+                if not raw:
+                    continue
+
+                # New Mistral format: func_name{"args"}
+                if not raw.startswith("[") and "{" in raw:
+                    end_name = raw.find("{")
+                    name = raw[:end_name].strip()
+                    args = raw[end_name:]
+                    if name:
+                        tool_calls.append(
+                            {"id": generate_tool_id(), "name": name, "arguments": args}
+                        )
+                    continue
+
+                # Old Mistral format: [{"name": "...", "arguments": {...}}]
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, list):
+                        for item in parsed:
+                            if isinstance(item, dict) and "name" in item:
+                                args = item.get("arguments", {})
+                                tool_calls.append(
+                                    {
+                                        "id": generate_tool_id(),
+                                        "name": item["name"],
+                                        "arguments": (
+                                            json.dumps(args, ensure_ascii=False)
+                                            if isinstance(args, dict)
+                                            else str(args)
+                                        ),
+                                    }
+                                )
+                except json.JSONDecodeError:
+                    pass
+
+            if tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=content if content else None,
+                )
+
+        # 2. Try Qwen bracket pattern
+        bracket_matches = self.QWEN_BRACKET_PATTERN.findall(model_output)
+        for name, args_str in bracket_matches:
+            try:
+                arguments = json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": (
+                            json.dumps(arguments, ensure_ascii=False)
+                            if isinstance(arguments, dict)
+                            else str(arguments)
+                        ),
+                    }
+                )
+            except json.JSONDecodeError:
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": args_str,
+                    }
+                )
+
+        if bracket_matches:
+            cleaned_text = self.QWEN_BRACKET_PATTERN.sub("", cleaned_text).strip()
+
+        # 3. Try Nemotron pattern (before Qwen XML as it's more specific)
+        nemotron_matches = self.NEMOTRON_PATTERN.findall(cleaned_text)
+        for name, params_block in nemotron_matches:
+            params = self.NEMOTRON_PARAM_PATTERN.findall(params_block)
+            arguments = {p_name.strip(): p_value.strip() for p_name, p_value in params}
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": name.strip(),
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                }
+            )
+
+        if nemotron_matches:
+            cleaned_text = self.NEMOTRON_PATTERN.sub("", cleaned_text).strip()
+
+        # 4. Try Qwen/Hermes XML pattern
+        xml_matches = self.QWEN_XML_PATTERN.findall(cleaned_text)
+        for match in xml_matches:
+            try:
+                data = json.loads(match)
+                name = data.get("name", "")
+                arguments = data.get("arguments", {})
+                if name:
+                    tool_calls.append(
+                        {
+                            "id": generate_tool_id(),
+                            "name": name,
+                            "arguments": (
+                                json.dumps(arguments, ensure_ascii=False)
+                                if isinstance(arguments, dict)
+                                else str(arguments)
+                            ),
+                        }
+                    )
+            except json.JSONDecodeError:
+                continue
+
+        if xml_matches:
+            cleaned_text = self.QWEN_XML_PATTERN.sub("", cleaned_text).strip()
+
+        # 5. Try Llama pattern
+        llama_matches = self.LLAMA_PATTERN.findall(cleaned_text)
+        for name, args_str in llama_matches:
+            try:
+                arguments = json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": (
+                            json.dumps(arguments, ensure_ascii=False)
+                            if isinstance(arguments, dict)
+                            else str(arguments)
+                        ),
+                    }
+                )
+            except json.JSONDecodeError:
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": args_str,
+                    }
+                )
+
+        if llama_matches:
+            cleaned_text = self.LLAMA_PATTERN.sub("", cleaned_text).strip()
+
+        # 6. Fallback: Try raw JSON
+        if not tool_calls:
+            raw_calls = self._parse_raw_json_tool_calls(cleaned_text)
+            if raw_calls:
+                tool_calls.extend(raw_calls)
+                cleaned_text = ""
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def _parse_raw_json_tool_calls(self, text: str) -> list[dict[str, Any]]:
+        """
+        Parse raw JSON tool calls from text.
+
+        Handles:
+        - Single JSON object: {"name": "func", "arguments": {...}}
+        - JSON array: [{...}, {...}]
+        """
+        if not text:
+            return []
+
+        text = text.strip()
+        tool_calls = []
+
+        # Try JSON array first
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    for item in parsed:
+                        if isinstance(item, dict):
+                            # Support "name" and "type" fields (Granite)
+                            func_name = item.get("name") or item.get("type")
+                            if func_name:
+                                args = item.get("arguments", {})
+                                tool_calls.append(
+                                    {
+                                        "id": generate_tool_id(),
+                                        "name": func_name,
+                                        "arguments": (
+                                            json.dumps(args, ensure_ascii=False)
+                                            if isinstance(args, dict)
+                                            else str(args)
+                                        ),
+                                    }
+                                )
+                    return tool_calls
+            except json.JSONDecodeError:
+                pass
+
+        # Find JSON objects with balanced braces
+        depth = 0
+        start = None
+
+        for i, char in enumerate(text):
+            if char == "{":
+                if depth == 0:
+                    start = i
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth < 0:
+                    # Reset on unbalanced braces
+                    depth = 0
+                    start = None
+                    continue
+                if depth == 0 and start is not None:
+                    json_str = text[start : i + 1]
+                    try:
+                        obj = json.loads(json_str)
+                        if isinstance(obj, dict):
+                            # Support both "name" and "type" fields
+                            func_name = obj.get("name") or obj.get("type")
+                            if func_name:
+                                args = obj.get("arguments", {})
+                                tool_calls.append(
+                                    {
+                                        "id": generate_tool_id(),
+                                        "name": func_name,
+                                        "arguments": (
+                                            json.dumps(args, ensure_ascii=False)
+                                            if isinstance(args, dict)
+                                            else str(args)
+                                        ),
+                                    }
+                                )
+                    except json.JSONDecodeError:
+                        pass
+                    start = None
+
+        return tool_calls
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming model output.
+
+        Uses simple heuristics to detect when a tool call might be complete.
+        """
+        # Check for any tool call markers
+        markers = [
+            self.MISTRAL_TOKEN,
+            "[Calling tool:",
+            "<tool_call>",
+            "<function=",
+        ]
+
+        has_marker = any(m in current_text for m in markers)
+
+        if not has_marker:
+            return {"content": delta_text}
+
+        # Check for completion markers
+        end_markers = ["</tool_call>", "</function>", ")]"]
+        if any(m in delta_text for m in end_markers):
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/deepseek_tool_parser.py
+++ b/vllm_mlx/tool_parsers/deepseek_tool_parser.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeepSeek tool call parser for vllm-mlx.
+
+Handles DeepSeek V3 and R1 tool calling formats:
+- <｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜> wrapper
+- <｜tool▁call▁begin｜>function<｜tool▁sep｜>name
+  ```json
+  {...}
+  ```<｜tool▁call▁end｜>
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["deepseek", "deepseek_v3", "deepseek_r1"])
+class DeepSeekToolParser(ToolParser):
+    """
+    Tool call parser for DeepSeek V3 and R1 models.
+
+    Supports DeepSeek's tool call format with special unicode tokens:
+    <｜tool▁calls▁begin｜>
+    <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+    ```json
+    {"city": "Paris"}
+    ```<｜tool▁call▁end｜>
+    <｜tool▁calls▁end｜>
+
+    Used when --enable-auto-tool-choice --tool-call-parser deepseek are set.
+    """
+
+    # Special DeepSeek tokens (unicode)
+    TOOL_CALLS_START = "<｜tool▁calls▁begin｜>"
+    TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
+    TOOL_CALL_START = "<｜tool▁call▁begin｜>"
+    TOOL_CALL_END = "<｜tool▁call▁end｜>"
+    TOOL_SEP = "<｜tool▁sep｜>"
+
+    # Pattern to match individual tool calls
+    TOOL_CALL_PATTERN = re.compile(
+        r"<｜tool▁call▁begin｜>(?P<type>.*?)<｜tool▁sep｜>(?P<name>.*?)\n```json\n(?P<args>.*?)\n```<｜tool▁call▁end｜>",
+        re.DOTALL,
+    )
+
+    # Alternative pattern without type
+    TOOL_CALL_SIMPLE_PATTERN = re.compile(
+        r"<｜tool▁call▁begin｜>(?P<name>.*?)\n```json\n(?P<args>.*?)\n```<｜tool▁call▁end｜>",
+        re.DOTALL,
+    )
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from DeepSeek model output.
+        """
+        # Check for tool calls marker
+        if self.TOOL_CALLS_START not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        tool_calls = []
+
+        # Extract content before tool calls
+        content_end = model_output.find(self.TOOL_CALLS_START)
+        content = model_output[:content_end].strip() if content_end > 0 else None
+
+        # Try full pattern with type first
+        matches = self.TOOL_CALL_PATTERN.findall(model_output)
+        for match in matches:
+            tool_type, func_name, func_args = match
+            try:
+                # Validate JSON
+                json.loads(func_args)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": func_args.strip(),
+                    }
+                )
+            except json.JSONDecodeError:
+                # Keep raw arguments
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": func_args.strip(),
+                    }
+                )
+
+        # Try simple pattern if no matches
+        if not tool_calls:
+            simple_matches = self.TOOL_CALL_SIMPLE_PATTERN.findall(model_output)
+            for match in simple_matches:
+                func_name, func_args = match
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": func_args.strip(),
+                    }
+                )
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming DeepSeek model output.
+        """
+        if self.TOOL_CALLS_START not in current_text:
+            return {"content": delta_text}
+
+        # If we see the end marker, parse the complete output
+        if self.TOOL_CALL_END in delta_text or self.TOOL_CALLS_END in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/functionary_tool_parser.py
+++ b/vllm_mlx/tool_parsers/functionary_tool_parser.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Functionary tool call parser for vllm-mlx.
+
+Handles MeetKai Functionary models' tool calling format.
+Similar to OpenAI function calling with JSON arguments.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["functionary", "meetkai"])
+class FunctionaryToolParser(ToolParser):
+    """
+    Tool call parser for MeetKai Functionary models.
+
+    Supports Functionary's tool call format similar to OpenAI:
+    - Uses special tokens to mark tool calls
+    - Arguments are JSON strings
+
+    Formats supported:
+    - <|from|>assistant\n<|recipient|>func_name\n<|content|>{"args": ...}
+    - <function=name>{"args": ...}</function>
+
+    Used when --enable-auto-tool-choice --tool-call-parser functionary are set.
+    """
+
+    # Functionary v3 format
+    RECIPIENT_PATTERN = re.compile(
+        r"<\|recipient\|>\s*(\w+)\s*\n<\|content\|>\s*(\{.*?\})(?=<\||$)",
+        re.DOTALL,
+    )
+
+    # Alternative function format
+    FUNCTION_PATTERN = re.compile(
+        r"<function=([^>]+)>(\{.*?\})</function>",
+        re.DOTALL,
+    )
+
+    # OpenAI-style JSON array
+    JSON_ARRAY_PATTERN = re.compile(r"^\s*\[.*\]\s*$", re.DOTALL)
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from Functionary model output.
+        """
+        tool_calls = []
+        cleaned_text = model_output
+
+        # Try recipient pattern (Functionary v3)
+        recipient_matches = self.RECIPIENT_PATTERN.findall(model_output)
+        for func_name, args_str in recipient_matches:
+            if func_name.lower() in ["all", "user"]:
+                continue  # Skip non-function recipients
+            try:
+                json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": args_str,
+                    }
+                )
+            except json.JSONDecodeError:
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": args_str,
+                    }
+                )
+
+        if recipient_matches:
+            cleaned_text = self.RECIPIENT_PATTERN.sub("", cleaned_text)
+            cleaned_text = re.sub(r"<\|from\|>assistant\s*", "", cleaned_text).strip()
+
+        # Try function pattern
+        function_matches = self.FUNCTION_PATTERN.findall(cleaned_text)
+        for func_name, args_str in function_matches:
+            try:
+                json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": args_str,
+                    }
+                )
+            except json.JSONDecodeError:
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": args_str,
+                    }
+                )
+
+        if function_matches:
+            cleaned_text = self.FUNCTION_PATTERN.sub("", cleaned_text).strip()
+
+        # Try JSON array format
+        if not tool_calls and self.JSON_ARRAY_PATTERN.match(model_output.strip()):
+            try:
+                parsed = json.loads(model_output.strip())
+                if isinstance(parsed, list):
+                    for call in parsed:
+                        if isinstance(call, dict) and "name" in call:
+                            args = call.get("arguments", {})
+                            tool_calls.append(
+                                {
+                                    "id": generate_tool_id(),
+                                    "name": call["name"],
+                                    "arguments": (
+                                        json.dumps(args, ensure_ascii=False)
+                                        if isinstance(args, dict)
+                                        else str(args)
+                                    ),
+                                }
+                            )
+                    cleaned_text = None
+            except json.JSONDecodeError:
+                pass
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Functionary model output.
+        """
+        markers = ["<|recipient|>", "<function=", "["]
+        has_marker = any(m in current_text for m in markers)
+
+        if not has_marker:
+            return {"content": delta_text}
+
+        end_markers = ["<|content|>", "</function>", "]"]
+        if any(m in delta_text for m in end_markers):
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/granite_tool_parser.py
+++ b/vllm_mlx/tool_parsers/granite_tool_parser.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Granite tool call parser for vllm-mlx.
+
+Handles IBM Granite models' tool calling format:
+- <|tool_call|> or <tool_call> followed by JSON array
+- [{"name": "func", "arguments": {...}}]
+"""
+
+import json
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["granite", "granite3"])
+class GraniteToolParser(ToolParser):
+    """
+    Tool call parser for IBM Granite models.
+
+    Supports Granite's tool call format:
+    <|tool_call|>[{"name": "get_weather", "arguments": {"city": "Paris"}}]
+
+    Or Granite 3.1:
+    <tool_call>[{"name": "get_weather", "arguments": {"city": "Paris"}}]
+
+    Used when --enable-auto-tool-choice --tool-call-parser granite are set.
+    """
+
+    BOT_TOKEN = "<|tool_call|>"
+    BOT_STRING = "<tool_call>"
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from Granite model output.
+        """
+        stripped = model_output.strip()
+
+        # Remove tool call markers
+        if stripped.startswith(self.BOT_TOKEN):
+            stripped = stripped[len(self.BOT_TOKEN) :].lstrip()
+        elif stripped.startswith(self.BOT_STRING):
+            stripped = stripped[len(self.BOT_STRING) :].lstrip()
+
+        # Check if it starts with JSON array
+        if not stripped or stripped[0] != "[":
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        try:
+            raw_calls = json.loads(stripped)
+            if not isinstance(raw_calls, list):
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
+
+            tool_calls = []
+            for call in raw_calls:
+                if isinstance(call, dict):
+                    # Granite uses "name" or "type" for function name
+                    func_name = call.get("name") or call.get("type")
+                    if func_name:
+                        args = call.get("arguments", {})
+                        tool_calls.append(
+                            {
+                                "id": generate_tool_id(),
+                                "name": func_name,
+                                "arguments": (
+                                    json.dumps(args, ensure_ascii=False)
+                                    if isinstance(args, dict)
+                                    else str(args)
+                                ),
+                            }
+                        )
+
+            if tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=tool_calls,
+                    content=None,
+                )
+
+        except json.JSONDecodeError:
+            pass
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Granite model output.
+        """
+        stripped = current_text.strip()
+        has_marker = stripped.startswith(self.BOT_TOKEN) or stripped.startswith(
+            self.BOT_STRING
+        )
+
+        if not has_marker:
+            return {"content": delta_text}
+
+        # Try to parse when we have a complete JSON array
+        if "]" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/hermes_tool_parser.py
+++ b/vllm_mlx/tool_parsers/hermes_tool_parser.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Hermes/Nous tool call parser for vllm-mlx.
+
+Handles Hermes-style tool calling format used by NousResearch models.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["hermes", "nous"])
+class HermesToolParser(ToolParser):
+    """
+    Tool call parser for Hermes/Nous models.
+
+    Supports Hermes tool call format:
+    - <tool_call>{"name": "func", "arguments": {...}}</tool_call>
+    - Sometimes with additional reasoning in <tool_call_reasoning>
+
+    Used when --enable-auto-tool-choice --tool-call-parser hermes are set.
+    """
+
+    TOOL_CALL_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+    REASONING_PATTERN = re.compile(
+        r"<tool_call_reasoning>(.*?)</tool_call_reasoning>", re.DOTALL
+    )
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete Hermes model response.
+        """
+        tool_calls = []
+        cleaned_text = model_output
+
+        # Remove reasoning tags first (keep for content)
+        reasoning_matches = self.REASONING_PATTERN.findall(model_output)
+        cleaned_text = self.REASONING_PATTERN.sub("", cleaned_text)
+
+        # Parse tool calls
+        matches = self.TOOL_CALL_PATTERN.findall(cleaned_text)
+        for match in matches:
+            try:
+                data = json.loads(match)
+                name = data.get("name", "")
+                arguments = data.get("arguments", {})
+                if name:
+                    tool_calls.append(
+                        {
+                            "id": generate_tool_id(),
+                            "name": name,
+                            "arguments": (
+                                json.dumps(arguments, ensure_ascii=False)
+                                if isinstance(arguments, dict)
+                                else str(arguments)
+                            ),
+                        }
+                    )
+            except json.JSONDecodeError:
+                continue
+
+        if matches:
+            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text).strip()
+
+        # Include reasoning in content if present
+        if reasoning_matches:
+            reasoning_text = " ".join(reasoning_matches)
+            if cleaned_text:
+                cleaned_text = f"{cleaned_text}\n\n(Reasoning: {reasoning_text})"
+            else:
+                cleaned_text = f"(Reasoning: {reasoning_text})"
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Hermes model output.
+        """
+        if "<tool_call>" not in current_text:
+            return {"content": delta_text}
+
+        if "</tool_call>" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/kimi_tool_parser.py
+++ b/vllm_mlx/tool_parsers/kimi_tool_parser.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Kimi/Moonshot tool call parser for vllm-mlx.
+
+Handles Kimi K2 and related models' tool calling format:
+- <|tool_calls_section_begin|>...<|tool_calls_section_end|>
+- <|tool_call_begin|>func_name:0<|tool_call_argument_begin|>{...}<|tool_call_end|>
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["kimi", "kimi_k2", "moonshot"])
+class KimiToolParser(ToolParser):
+    """
+    Tool call parser for Kimi K2 and Moonshot models.
+
+    Supports Kimi's tool call format:
+    <|tool_calls_section_begin|>
+    <|tool_call_begin|>func:0<|tool_call_argument_begin|>{...}<|tool_call_end|>
+    <|tool_calls_section_end|>
+
+    Used when --enable-auto-tool-choice --tool-call-parser kimi are set.
+    """
+
+    # Kimi tokens
+    TOOL_CALLS_START = "<|tool_calls_section_begin|>"
+    TOOL_CALLS_START_ALT = "<|tool_call_section_begin|>"  # Singular variant
+    TOOL_CALLS_END = "<|tool_calls_section_end|>"
+    TOOL_CALLS_END_ALT = "<|tool_call_section_end|>"
+    TOOL_CALL_START = "<|tool_call_begin|>"
+    TOOL_CALL_END = "<|tool_call_end|>"
+    TOOL_ARG_START = "<|tool_call_argument_begin|>"
+
+    # Pattern to match individual tool calls
+    TOOL_CALL_PATTERN = re.compile(
+        r"<\|tool_call_begin\|>\s*(?P<func_id>[^<]+?)(?::\d+)?\s*<\|tool_call_argument_begin\|>\s*(?P<args>.*?)\s*<\|tool_call_end\|>",
+        re.DOTALL,
+    )
+
+    def _has_tool_section(self, text: str) -> bool:
+        """Check if text contains tool section markers."""
+        return (
+            self.TOOL_CALLS_START in text
+            or self.TOOL_CALLS_START_ALT in text
+            or self.TOOL_CALL_START in text
+        )
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from Kimi model output.
+        """
+        if not self._has_tool_section(model_output):
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        tool_calls = []
+
+        # Extract content before tool calls
+        content = None
+        for marker in [self.TOOL_CALLS_START, self.TOOL_CALLS_START_ALT]:
+            if marker in model_output:
+                idx = model_output.find(marker)
+                content = model_output[:idx].strip() if idx > 0 else None
+                break
+
+        # Find all tool calls
+        matches = self.TOOL_CALL_PATTERN.findall(model_output)
+        for match in matches:
+            func_id, func_args = match
+            # func_id format: functions.get_weather:0 or get_weather:0
+            func_name = func_id.split(":")[-2] if ":" in func_id else func_id
+            func_name = func_name.split(".")[-1]  # Remove 'functions.' prefix
+
+            try:
+                # Validate JSON
+                json.loads(func_args)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": func_args.strip(),
+                    }
+                )
+            except json.JSONDecodeError:
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name.strip(),
+                        "arguments": func_args.strip(),
+                    }
+                )
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Kimi model output.
+        """
+        if not self._has_tool_section(current_text):
+            return {"content": delta_text}
+
+        if self.TOOL_CALL_END in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/llama_tool_parser.py
+++ b/vllm_mlx/tool_parsers/llama_tool_parser.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Llama tool call parser for vllm-mlx.
+
+Handles Llama's tool calling format:
+- XML style: <function=name>{"arg": "value"}</function>
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["llama", "llama3", "llama4"])
+class LlamaToolParser(ToolParser):
+    """
+    Tool call parser for Llama models.
+
+    Supports Llama tool call format:
+    - <function=name>{"arg": "value"}</function>
+
+    Used when --enable-auto-tool-choice --tool-call-parser llama are set.
+    """
+
+    # Pattern for Llama-style: <function=name>{"json"}</function>
+    FUNCTION_PATTERN = re.compile(r"<function=([^>]+)>(\{.*?\})</function>", re.DOTALL)
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete Llama model response.
+        """
+        tool_calls = []
+        cleaned_text = model_output
+
+        matches = self.FUNCTION_PATTERN.findall(model_output)
+        for name, args_str in matches:
+            try:
+                arguments = json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": (
+                            json.dumps(arguments, ensure_ascii=False)
+                            if isinstance(arguments, dict)
+                            else str(arguments)
+                        ),
+                    }
+                )
+            except json.JSONDecodeError:
+                # Keep the raw arguments string
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": args_str,
+                    }
+                )
+
+        if matches:
+            cleaned_text = self.FUNCTION_PATTERN.sub("", cleaned_text).strip()
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Llama model output.
+        """
+        # Check for tool call markers
+        if "<function=" not in current_text:
+            return {"content": delta_text}
+
+        # If we detect end of function, parse
+        if "</function>" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Mistral tool call parser for vllm-mlx.
+
+Handles Mistral's tool calling format:
+- Format: [TOOL_CALLS] [{"name": "func", "arguments": {...}}]
+- Or newer: [TOOL_CALLS]func_name{"arg": "value"}
+
+Used with models like Mistral-7B-Instruct, Devstral, etc.
+"""
+
+import json
+import re
+from collections.abc import Sequence
+from random import choices
+from string import ascii_letters, digits
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+ALPHANUMERIC = ascii_letters + digits
+
+
+def generate_mistral_tool_id() -> str:
+    """
+    Generate a random Mistral-compatible tool call ID.
+
+    Mistral Tool Call IDs must be alphanumeric with a length of 9.
+    """
+    return "".join(choices(ALPHANUMERIC, k=9))
+
+
+@ToolParserManager.register_module("mistral")
+class MistralToolParser(ToolParser):
+    """
+    Tool call parser for Mistral models.
+
+    Supports both old and new Mistral tool call formats:
+    - Old (< v11): [TOOL_CALLS] [{"name": "add", "arguments": {"a": 1, "b": 2}}]
+    - New (>= v11): [TOOL_CALLS]add{"a": 1, "b": 2}
+
+    Used when --enable-auto-tool-choice --tool-call-parser mistral are set.
+    """
+
+    BOT_TOKEN = "[TOOL_CALLS]"
+    TOOL_CALL_REGEX = re.compile(r"\[{.*}\]", re.DOTALL)
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self.bot_token_id = self.vocab.get(self.BOT_TOKEN) if self.vocab else None
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete Mistral model response.
+
+        Args:
+            model_output: The complete model output string
+            request: Optional request context
+
+        Returns:
+            ExtractedToolCallInformation with parsed tool calls
+        """
+        # If the tool call token is not present, return as text response
+        if self.BOT_TOKEN not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        content_and_raw_tool_calls = model_output.split(self.BOT_TOKEN)
+        content = content_and_raw_tool_calls[0].strip()
+        raw_tool_calls = content_and_raw_tool_calls[1:]
+
+        tool_calls = []
+
+        for raw_tool_call in raw_tool_calls:
+            raw_tool_call = raw_tool_call.strip()
+            if not raw_tool_call:
+                continue
+
+            # Try new format first: func_name{"arg": "value"}
+            if not raw_tool_call.startswith("[") and "{" in raw_tool_call:
+                end_name = raw_tool_call.find("{")
+                tool_name = raw_tool_call[:end_name].strip()
+                args_str = raw_tool_call[end_name:]
+
+                if tool_name:
+                    tool_calls.append(
+                        {
+                            "id": generate_mistral_tool_id(),
+                            "name": tool_name,
+                            "arguments": args_str,
+                        }
+                    )
+                continue
+
+            # Try old format: [{"name": "func", "arguments": {...}}]
+            try:
+                parsed = json.loads(raw_tool_call)
+                if isinstance(parsed, list):
+                    for item in parsed:
+                        if isinstance(item, dict) and "name" in item:
+                            args = item.get("arguments", {})
+                            tool_calls.append(
+                                {
+                                    "id": generate_mistral_tool_id(),
+                                    "name": item["name"],
+                                    "arguments": (
+                                        json.dumps(args, ensure_ascii=False)
+                                        if isinstance(args, dict)
+                                        else str(args)
+                                    ),
+                                }
+                            )
+                continue
+            except json.JSONDecodeError:
+                pass
+
+            # Fallback: try regex to extract JSON array
+            try:
+                match = self.TOOL_CALL_REGEX.search(raw_tool_call)
+                if match:
+                    parsed = json.loads(match.group(0))
+                    if isinstance(parsed, list):
+                        for item in parsed:
+                            if isinstance(item, dict) and "name" in item:
+                                args = item.get("arguments", {})
+                                tool_calls.append(
+                                    {
+                                        "id": generate_mistral_tool_id(),
+                                        "name": item["name"],
+                                        "arguments": (
+                                            json.dumps(args, ensure_ascii=False)
+                                            if isinstance(args, dict)
+                                            else str(args)
+                                        ),
+                                    }
+                                )
+            except (json.JSONDecodeError, AttributeError):
+                # If all parsing fails, treat as content
+                if raw_tool_call:
+                    content = (
+                        (content + " " + raw_tool_call).strip()
+                        if content
+                        else raw_tool_call
+                    )
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content if content else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Mistral model output.
+
+        For streaming, we detect when [TOOL_CALLS] appears and start
+        accumulating tool call data.
+        """
+        # Check if tool call token is in current output
+        if self.BOT_TOKEN not in current_text:
+            # Not a tool call yet, return content delta
+            return {"content": delta_text}
+
+        # Tool call detected
+        if self.BOT_TOKEN in delta_text:
+            # This delta contains the start of tool calls
+            parts = delta_text.split(self.BOT_TOKEN)
+            content_part = parts[0]
+            tool_part = self.BOT_TOKEN.join(parts[1:])
+
+            result: dict[str, Any] = {}
+            if content_part:
+                result["content"] = content_part
+
+            # Start tracking tool call
+            self.current_tool_id += 1
+
+            if tool_part:
+                # Try to parse the tool part
+                tool_delta = self._parse_streaming_tool_delta(tool_part)
+                if tool_delta:
+                    result["tool_calls"] = [
+                        {
+                            "index": self.current_tool_id,
+                            "id": generate_mistral_tool_id(),
+                            "type": "function",
+                            "function": tool_delta,
+                        }
+                    ]
+
+            return result if result else None
+
+        # We're in the middle of a tool call
+        if self.current_tool_id >= 0:
+            tool_delta = self._parse_streaming_tool_delta(delta_text)
+            if tool_delta:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": self.current_tool_id,
+                            "type": "function",
+                            "function": tool_delta,
+                        }
+                    ]
+                }
+
+        return None
+
+    def _parse_streaming_tool_delta(self, text: str) -> dict[str, str] | None:
+        """Parse a streaming delta for tool call information."""
+        if not text:
+            return None
+
+        result: dict[str, str] = {}
+
+        # Check for function name (before {)
+        if "{" in text:
+            name_part = text[: text.find("{")]
+            args_part = text[text.find("{") :]
+            if name_part.strip():
+                result["name"] = name_part.strip()
+            if args_part:
+                result["arguments"] = args_part
+        else:
+            # Could be name or arguments continuation
+            if text.strip() and not text.startswith(("{", "}", "[", "]", ",")):
+                result["name"] = text.strip()
+            else:
+                result["arguments"] = text
+
+        return result if result else None

--- a/vllm_mlx/tool_parsers/nemotron_tool_parser.py
+++ b/vllm_mlx/tool_parsers/nemotron_tool_parser.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Nemotron tool call parser for vllm-mlx.
+
+Handles NVIDIA Nemotron models' tool calling format:
+- <tool_call><function=name><parameter=p>v</parameter></function></tool_call>
+
+Supports Nemotron-3-Nano-30B-A3B and similar models.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["nemotron", "nemotron3"])
+class NemotronToolParser(ToolParser):
+    """
+    Tool call parser for NVIDIA Nemotron models.
+
+    Supports Nemotron's tool call format:
+    <tool_call><function=get_weather><parameter=city>Paris</parameter></function></tool_call>
+
+    Also supports JSON arguments:
+    <tool_call><function=get_weather>{"city": "Paris"}</function></tool_call>
+
+    Used when --enable-auto-tool-choice --tool-call-parser nemotron are set.
+    """
+
+    # Pattern for Nemotron-style with parameters
+    TOOL_CALL_PATTERN = re.compile(
+        r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
+        re.DOTALL,
+    )
+
+    # Pattern to extract parameters
+    PARAM_PATTERN = re.compile(
+        r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
+        re.DOTALL,
+    )
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from Nemotron model output.
+        """
+        if "<tool_call>" not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        tool_calls = []
+        cleaned_text = model_output
+
+        matches = self.TOOL_CALL_PATTERN.findall(model_output)
+        for func_name, content in matches:
+            func_name = func_name.strip()
+
+            # Try to parse content as JSON first
+            content = content.strip()
+            if content.startswith("{"):
+                try:
+                    json.loads(content)
+                    tool_calls.append(
+                        {
+                            "id": generate_tool_id(),
+                            "name": func_name,
+                            "arguments": content,
+                        }
+                    )
+                    continue
+                except json.JSONDecodeError:
+                    pass
+
+            # Parse parameter tags
+            params = self.PARAM_PATTERN.findall(content)
+            if params:
+                arguments = {}
+                for param_name, param_value in params:
+                    # Try to parse value as JSON (for nested objects)
+                    try:
+                        arguments[param_name.strip()] = json.loads(param_value.strip())
+                    except json.JSONDecodeError:
+                        arguments[param_name.strip()] = param_value.strip()
+
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": json.dumps(arguments, ensure_ascii=False),
+                    }
+                )
+            elif content:
+                # Raw content without parameter tags
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": content,
+                    }
+                )
+
+        # Clean the text
+        if matches:
+            cleaned_text = self.TOOL_CALL_PATTERN.sub("", cleaned_text).strip()
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Nemotron model output.
+        """
+        if "<tool_call>" not in current_text:
+            return {"content": delta_text}
+
+        if "</tool_call>" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen tool call parser for vllm-mlx.
+
+Handles Qwen's tool calling formats:
+- XML style: <tool_call>{"name": "func", "arguments": {...}}</tool_call>
+- Bracket style: [Calling tool: func_name({"arg": "value"})]
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["qwen", "qwen3"])
+class QwenToolParser(ToolParser):
+    """
+    Tool call parser for Qwen models.
+
+    Supports multiple Qwen tool call formats:
+    - XML: <tool_call>{"name": "func", "arguments": {...}}</tool_call>
+    - Bracket: [Calling tool: func_name({"arg": "value"})]
+
+    Used when --enable-auto-tool-choice --tool-call-parser qwen are set.
+    """
+
+    # Pattern for XML-style: <tool_call>{"json"}</tool_call>
+    XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+
+    # Pattern for bracket-style: [Calling tool: func_name({...})]
+    BRACKET_PATTERN = re.compile(r"\[Calling tool:\s*(\w+)\((\{.*?\})\)\]", re.DOTALL)
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete Qwen model response.
+        """
+        tool_calls = []
+        cleaned_text = model_output
+
+        # Try bracket pattern first (Qwen3 style)
+        bracket_matches = self.BRACKET_PATTERN.findall(model_output)
+        for name, args_str in bracket_matches:
+            try:
+                arguments = json.loads(args_str)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name.strip(),
+                        "arguments": (
+                            json.dumps(arguments, ensure_ascii=False)
+                            if isinstance(arguments, dict)
+                            else str(arguments)
+                        ),
+                    }
+                )
+            except json.JSONDecodeError:
+                continue
+
+        if bracket_matches:
+            cleaned_text = self.BRACKET_PATTERN.sub("", cleaned_text).strip()
+
+        # Try XML pattern (traditional Qwen style)
+        xml_matches = self.XML_PATTERN.findall(cleaned_text)
+        for match in xml_matches:
+            try:
+                data = json.loads(match)
+                name = data.get("name", "")
+                arguments = data.get("arguments", {})
+                if name:
+                    tool_calls.append(
+                        {
+                            "id": generate_tool_id(),
+                            "name": name,
+                            "arguments": (
+                                json.dumps(arguments, ensure_ascii=False)
+                                if isinstance(arguments, dict)
+                                else str(arguments)
+                            ),
+                        }
+                    )
+            except json.JSONDecodeError:
+                continue
+
+        if xml_matches:
+            cleaned_text = self.XML_PATTERN.sub("", cleaned_text).strip()
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned_text if cleaned_text else None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming Qwen model output.
+        """
+        # Check for tool call markers
+        has_tool_marker = (
+            "<tool_call>" in current_text or "[Calling tool:" in current_text
+        )
+
+        if not has_tool_marker:
+            return {"content": delta_text}
+
+        # If we're in a tool call, accumulate and parse at the end
+        # For simplicity, return None during accumulation
+        if "</tool_call>" in delta_text or ")]" in delta_text:
+            # Tool call complete, parse the whole thing
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None

--- a/vllm_mlx/tool_parsers/xlam_tool_parser.py
+++ b/vllm_mlx/tool_parsers/xlam_tool_parser.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+xLAM tool call parser for vllm-mlx.
+
+Handles Salesforce xLAM models' tool calling format which supports:
+- JSON arrays of tool calls
+- Tool calls in markdown code blocks
+- Tool calls after </think> reasoning blocks
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module("xlam")
+class xLAMToolParser(ToolParser):
+    """
+    Tool call parser for Salesforce xLAM models.
+
+    Supports multiple formats:
+    - JSON array: [{"name": "func", "arguments": {...}}]
+    - Markdown code blocks: ```json [...] ```
+    - After thinking: </think>[...]
+
+    Used when --enable-auto-tool-choice --tool-call-parser xlam are set.
+    """
+
+    # Patterns for extracting JSON
+    CODE_BLOCK_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
+    THINKING_PATTERN = re.compile(r"</think>\s*([\s\S]*)")
+    TOOL_CALLS_TAG_PATTERN = re.compile(r"\[TOOL_CALLS\]([\s\S]*?)(?:\n|$)")
+
+    def _try_extract_json(self, text: str) -> tuple[str | None, list | None]:
+        """
+        Try to extract JSON tool calls from text.
+
+        Returns:
+            Tuple of (content, tool_calls_list)
+        """
+        # Try markdown code blocks
+        for pattern in [
+            self.CODE_BLOCK_PATTERN,
+            self.TOOL_CALLS_TAG_PATTERN,
+        ]:
+            matches = pattern.findall(text)
+            for match in matches:
+                try:
+                    parsed = json.loads(match.strip())
+                    if isinstance(parsed, list):
+                        content = pattern.sub("", text).strip()
+                        return content if content else None, parsed
+                except json.JSONDecodeError:
+                    continue
+
+        # Try after </think> tag
+        thinking_match = self.THINKING_PATTERN.search(text)
+        if thinking_match:
+            after_think = thinking_match.group(1).strip()
+            try:
+                parsed = json.loads(after_think)
+                if isinstance(parsed, list):
+                    content = text[: thinking_match.start() + len("</think>")].strip()
+                    return content if content else None, parsed
+            except json.JSONDecodeError:
+                pass
+
+        # Try entire text as JSON array
+        text = text.strip()
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    return None, parsed
+            except json.JSONDecodeError:
+                pass
+
+        return text, None
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from xLAM model output.
+        """
+        content, tool_calls_data = self._try_extract_json(model_output)
+
+        if not tool_calls_data:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=content or model_output
+            )
+
+        tool_calls = []
+        for call in tool_calls_data:
+            if isinstance(call, dict) and "name" in call:
+                args = call.get("arguments", call.get("parameters", {}))
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": call["name"],
+                        "arguments": (
+                            json.dumps(args, ensure_ascii=False)
+                            if isinstance(args, dict)
+                            else str(args)
+                        ),
+                    }
+                )
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming xLAM model output.
+        """
+        # Check for any indicators of tool calls
+        markers = ["```", "[TOOL_CALLS]", "</think>"]
+        has_marker = any(m in current_text for m in markers)
+
+        # Also check for JSON array start
+        stripped = current_text.strip()
+        if stripped.startswith("[") and "{" in stripped:
+            has_marker = True
+
+        if not has_marker:
+            return {"content": delta_text}
+
+        # Try to parse when we see completion markers
+        if "]" in delta_text or "```" in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None


### PR DESCRIPTION
Implemented the tool call parser flags from #25

## What's new

Two new CLI options:
- `--enable-auto-tool-choice` 
- `--tool-call-parser <parser>`

## Example

```bash
vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
  --enable-auto-tool-choice --tool-call-parser mistral
```

## Parsing example

When Granite outputs:
```
<|tool_call|>[{"arguments": {"expression": "25 * 17"}, "type": "calculator"}]
```

The parser extracts:
```python
{
    "id": "call_a1b2c3d4",
    "name": "calculator", 
    "arguments": "{\"expression\": \"25 * 17\"}"
}
```

## Parsers

mistral, qwen, llama, deepseek, granite, nemotron, kimi, xlam, functionary, auto

## Tests

```
$ pytest tests/test_tool_parsers.py -v
...
57 passed in 0.42s
```

Tested with granite-4.0-tiny and nemotron-3-nano.

Fixes #25