### PR TITLE
Fix compatibility with mlx-lm 0.30.6 (MambaCache removal)

### DIFF
--- a/vllm_mlx/utils/mamba_cache.py
+++ b/vllm_mlx/utils/mamba_cache.py
@@ -15,10 +15,12 @@ import mlx.core as mx
 # MambaCache was removed in mlx-lm 0.30.6 - make import conditional
 try:
     from mlx_lm.models.cache import MambaCache
+
     HAS_MAMBA_CACHE = True
 except ImportError:
     # Fallback for mlx-lm >= 0.30.6 where MambaCache was removed
     from mlx_lm.models.cache import ArraysCache as MambaCache
+
     HAS_MAMBA_CACHE = False
 
 logger = logging.getLogger(__name__)
@@ -111,6 +113,7 @@ def patch_mlx_lm_for_mamba():
         RotatingKVCache,
         CacheList,
     )
+
     # MambaCache was removed in mlx-lm 0.30.6
     try:
         from mlx_lm.models.cache import MambaCache as OrigMambaCache


### PR DESCRIPTION
## Summary

- Make `MambaCache` import conditional with fallback to `ArraysCache` for mlx-lm >= 0.30.6
- Add `max_kv_size` parameter to `_patched_make_cache()` to match new mlx-lm 0.30.6 signature
- Support `BatchRotatingKVCache` fallback when `max_kv_size` is provided

## Background

mlx-lm 0.30.6 removed the `MambaCache` class from `mlx_lm.models.cache`, which causes vllm-mlx to fail with:

```
ImportError: cannot import name 'MambaCache' from 'mlx_lm.models.cache'
```

Additionally, the `_make_cache` function signature changed from `(model, left_padding)` to `(model, left_padding, max_kv_size)`.

## Test plan

- [x] Tested with mlx-lm 0.30.6 on GLM-4.7-Flash-MLX-8bit model
- [x] Server starts without errors
- [x] Chat completions work correctly
- [x] Backwards compatible with older mlx-lm versions (conditional import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)