### PR TITLE
Add MiniMax M2.1 tool call parser

### DIFF
--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -63,6 +63,7 @@ Use `--tool-call-parser` to select a parser for your model family:
 | `xlam` | | Salesforce xLAM | JSON with `tool_calls` array |
 | `functionary` | `meetkai` | MeetKai Functionary | Multiple function blocks |
 | `glm47` | `glm4` | GLM-4.7, GLM-4.7-Flash | `<tool_call>` with `<arg_key>`/`<arg_value>` XML |
+| `minimax` | `minimax_m2` | MiniMax M2.1 | `<minimax:tool_call>` with `<invoke>`/`<parameter>` XML |
 
 ## Model Examples
 
@@ -126,6 +127,14 @@ vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
   --enable-auto-tool-choice --tool-call-parser glm47
 ```
 
+### MiniMax M2.1
+
+```bash
+# MiniMax M2.1
+vllm-mlx serve mlx-community/MiniMax-M2.1-40k-4bit \
+  --enable-auto-tool-choice --tool-call-parser minimax
+```
+
 ### Kimi K2
 
 ```bash
@@ -155,9 +164,10 @@ The auto parser tries formats in this order:
 1. Mistral (`[TOOL_CALLS]`)
 2. Qwen bracket (`[Calling tool:]`)
 3. Nemotron (`<tool_call><function=...><parameter=...>`)
-4. Qwen/Hermes XML (`<tool_call>{...}</tool_call>`)
-5. Llama (`<function=name>{...}</function>`)
-6. Raw JSON
+4. MiniMax (`<minimax:tool_call><invoke>...</invoke></minimax:tool_call>`)
+5. Qwen/Hermes XML (`<tool_call>{...}</tool_call>`)
+6. Llama (`<function=name>{...}</function>`)
+7. Raw JSON
 
 ## Streaming Tool Calls
 

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -16,6 +16,7 @@ from vllm_mlx.tool_parsers import (
     HermesToolParser,
     KimiToolParser,
     LlamaToolParser,
+    MiniMaxToolParser,
     MistralToolParser,
     NemotronToolParser,
     QwenToolParser,
@@ -37,6 +38,7 @@ class TestNativeToolFormatCapability:
             FunctionaryToolParser,
             KimiToolParser,
             HermesToolParser,
+            MiniMaxToolParser,
         ]
         for parser_cls in native_parsers:
             assert (
@@ -73,6 +75,7 @@ class TestNativeToolFormatCapability:
             "functionary",
             "kimi",
             "hermes",
+            "minimax",
         ]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert (

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -564,11 +564,12 @@ Examples:
             "xlam",
             "functionary",
             "glm47",
+            "minimax",
         ],
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47. "
+            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, minimax. "
             "Required for --enable-auto-tool-choice."
         ),
     )

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -18,6 +18,7 @@ Available parsers:
 - xlam: Salesforce xLAM models
 - functionary/meetkai: MeetKai Functionary models
 - glm47/glm4: GLM-4.7 and GLM-4.7-Flash models
+- minimax/minimax_m2: MiniMax M2.1 models
 - harmony/gpt-oss: GPT-OSS models (Harmony format with channels)
 
 Usage:
@@ -56,6 +57,7 @@ from .nemotron_tool_parser import NemotronToolParser
 from .qwen_tool_parser import QwenToolParser
 from .xlam_tool_parser import xLAMToolParser
 from .glm47_tool_parser import Glm47ToolParser
+from .minimax_tool_parser import MiniMaxToolParser
 from .harmony_tool_parser import HarmonyToolParser
 
 __all__ = [
@@ -76,5 +78,6 @@ __all__ = [
     "xLAMToolParser",
     "FunctionaryToolParser",
     "Glm47ToolParser",
+    "MiniMaxToolParser",
     "HarmonyToolParser",
 ]

--- a/vllm_mlx/tool_parsers/minimax_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minimax_tool_parser.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MiniMax M2.1 tool call parser for vllm-mlx.
+
+Handles MiniMax M2.1 style tool calling format with XML tags:
+<minimax:tool_call>
+<invoke name="func_name">
+<parameter name="param">value</parameter>
+</invoke>
+</minimax:tool_call>
+
+Based on the GLM-4.7 parser pattern.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["minimax", "minimax_m2"])
+class MiniMaxToolParser(ToolParser):
+    """
+    Tool call parser for MiniMax M2.1 models.
+
+    Supports MiniMax tool call format:
+    <minimax:tool_call>
+    <invoke name="function_name">
+    <parameter name="param1">value1</parameter>
+    <parameter name="param2">value2</parameter>
+    </invoke>
+    </minimax:tool_call>
+
+    Multiple invocations can appear in a single <minimax:tool_call> block.
+
+    Used when --enable-auto-tool-choice --tool-call-parser minimax are set.
+    """
+
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
+    # Match entire tool call block
+    TOOL_CALL_PATTERN = re.compile(
+        r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
+    )
+
+    # Match individual invoke blocks with function name
+    INVOKE_PATTERN = re.compile(r'<invoke name="([^"]+)"\s*>(.*?)</invoke>', re.DOTALL)
+
+    # Match parameter key-value pairs
+    PARAM_PATTERN = re.compile(
+        r'<parameter name="([^"]+)"\s*>(.*?)</parameter>', re.DOTALL
+    )
+
+    def _deserialize(self, value: str) -> Any:
+        """Convert string value to appropriate Python type.
+
+        Uses json.loads for type coercion, falls back to raw string.
+        """
+        value = value.strip()
+
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+
+    def _get_tool_names(self, request: dict[str, Any] | None) -> set[str]:
+        """Extract valid tool names from the request."""
+        if not request or "tools" not in request:
+            return set()
+        return {
+            t.get("function", {}).get("name", "")
+            for t in request.get("tools", [])
+            if isinstance(t, dict)
+        }
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete MiniMax M2.1 model response.
+        """
+        tool_calls = []
+
+        # Strip think tags using the base class method
+        cleaned_text = self.strip_think_tags(model_output)
+
+        # Get valid tool names for validation
+        valid_names = self._get_tool_names(request)
+
+        # Find all <minimax:tool_call> blocks
+        tc_blocks = self.TOOL_CALL_PATTERN.findall(cleaned_text)
+
+        for block in tc_blocks:
+            # Find all <invoke> elements within the block
+            invoke_matches = self.INVOKE_PATTERN.findall(block)
+
+            for func_name, params_section in invoke_matches:
+                func_name = func_name.strip()
+                if not func_name:
+                    continue
+
+                # Validate tool name against available tools if provided
+                if valid_names and func_name not in valid_names:
+                    continue
+
+                # Parse parameters
+                arguments = {}
+                param_matches = self.PARAM_PATTERN.findall(params_section)
+                for param_name, param_value in param_matches:
+                    key = param_name.strip()
+                    value = self._deserialize(param_value)
+                    if key:
+                        arguments[key] = value
+
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": json.dumps(arguments, ensure_ascii=False),
+                    }
+                )
+
+        # When tool calls are found, don't return reasoning text as content
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=None,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=cleaned_text
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Extract tool calls from streaming MiniMax M2.1 model output.
+        """
+        # Skip thinking content in streaming
+        if "<think>" in current_text and "</think>" not in current_text:
+            return None
+
+        # Once <minimax:tool_call> is detected, buffer until it closes.
+        if "<minimax:tool_call>" in current_text:
+            if "</minimax:tool_call>" in delta_text:
+                result = self.extract_tool_calls(current_text, request)
+                if result.tools_called:
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": i,
+                                "id": tc["id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tc["name"],
+                                    "arguments": tc["arguments"],
+                                },
+                            }
+                            for i, tc in enumerate(result.tool_calls)
+                        ]
+                    }
+            return None
+
+        # No tool call detected yet; strip think tags and emit content
+        clean_delta = self.strip_think_tags(delta_text)
+        if clean_delta:
+            return {"content": clean_delta}
+        return None


### PR DESCRIPTION
## Summary

- Add `MiniMaxToolParser` for MiniMax M2.1 models using XML-based `<minimax:tool_call>`/`<invoke>`/`<parameter>` format
- Integrate MiniMax detection into `AutoToolParser` (step 3.5 between Nemotron and Qwen/Hermes XML)
- Add `--tool-call-parser minimax` CLI option with `minimax_m2` alias
- Full streaming support, native tool format (`SUPPORTS_NATIVE_TOOL_FORMAT = True`), and `<think>` tag handling
- 9 dedicated parser tests + streaming test + native format tests (84/84 passing)

Closes https://github.com/waybarrios/vllm-mlx/issues/35

## Test plan

- [x] `pytest tests/test_tool_parsers.py tests/test_native_tool_format.py -v` — 84/84 passed
- [x] `uvx black vllm_mlx/ tests/` — clean
- [x] `uvx ruff check vllm_mlx/tool_parsers/minimax_tool_parser.py` — all checks passed
- [ ] Manual test with MiniMax M2.1 model (requires model access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)