### PR TITLE
feat: repetition detector for degenerate token loops

### DIFF
--- a/tests/test_repetition_detector.py
+++ b/tests/test_repetition_detector.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the repetition detector in scheduler.py.
+"""
+
+from vllm_mlx.scheduler import _detect_repetition
+
+
+class TestDetectRepetition:
+    """Tests for _detect_repetition function."""
+
+    def test_no_repetition_normal_tokens(self):
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        assert _detect_repetition(tokens) is False
+
+    def test_single_token_repetition(self):
+        """8 identical tokens should trigger detection."""
+        tokens = [0, 0, 0, 0, 0, 0, 0, 0]
+        assert _detect_repetition(tokens) is True
+
+    def test_single_token_not_enough(self):
+        """7 identical tokens should NOT trigger (min_repeat=8)."""
+        tokens = [0, 0, 0, 0, 0, 0, 0]
+        assert _detect_repetition(tokens) is False
+
+    def test_single_token_at_tail(self):
+        """Repetition at the tail of a longer sequence."""
+        tokens = [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0]
+        assert _detect_repetition(tokens) is True
+
+    def test_two_token_pattern(self):
+        """Pattern of length 2 repeated 6 times = 12 tokens."""
+        tokens = [1, 2] * 6  # [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
+        assert _detect_repetition(tokens) is True
+
+    def test_two_token_not_enough_repeats(self):
+        """Pattern of length 2 repeated only 5 times should NOT trigger."""
+        tokens = [1, 2] * 5
+        assert _detect_repetition(tokens) is False
+
+    def test_three_token_pattern(self):
+        """Pattern of length 3 repeated 6 times = 18 tokens."""
+        tokens = [10, 20, 30] * 6
+        assert _detect_repetition(tokens) is True
+
+    def test_four_token_pattern(self):
+        """Pattern of length 4 repeated 6 times = 24 tokens."""
+        tokens = [1, 2, 3, 4] * 6
+        assert _detect_repetition(tokens) is True
+
+    def test_pattern_at_tail(self):
+        """Pattern repetition at the tail after normal tokens."""
+        prefix = [100, 200, 300, 400, 500]
+        repeating = [7, 8] * 6
+        tokens = prefix + repeating
+        assert _detect_repetition(tokens) is True
+
+    def test_empty_tokens(self):
+        assert _detect_repetition([]) is False
+
+    def test_short_tokens(self):
+        assert _detect_repetition([1, 2, 3]) is False
+
+    def test_almost_repetition(self):
+        """Almost repeating but one token is different."""
+        tokens = [0, 0, 0, 0, 0, 0, 0, 1]
+        assert _detect_repetition(tokens) is False
+
+    def test_custom_min_repeat(self):
+        """Custom min_repeat parameter."""
+        tokens = [5, 5, 5, 5]
+        assert _detect_repetition(tokens, min_repeat=4) is True
+        assert _detect_repetition(tokens, min_repeat=5) is False
+
+    def test_mixed_no_false_positive(self):
+        """Varied tokens should not trigger."""
+        tokens = list(range(32))
+        assert _detect_repetition(tokens) is False
+
+    def test_realistic_degenerate_output(self):
+        """Simulate realistic degenerate model output (token ID 0 = padding)."""
+        # Model starts generating, then degenerates
+        normal = [15234, 8821, 3309, 44, 2847]
+        degenerate = [0] * 10
+        tokens = normal + degenerate
+        assert _detect_repetition(tokens) is True


### PR DESCRIPTION
## Summary

- Adds a lightweight repetition detector to the scheduler that monitors the last 32 generated tokens per request
- Stops generation with `finish_reason="stop"` when degenerate patterns are detected:
  - Single-token repetition (8+ identical tokens, e.g. `0 0 0 0 0 0 0 0`)
  - Short sequence repetition (2-4 token patterns repeated 6+ times, e.g. `ab ab ab ab ab ab`)
- Ring buffer per UID with automatic cleanup on request finish/abort
- Zero overhead when no repetition occurs (simple list append + periodic check)

Split out from PR #53 per review feedback — this touches the scheduler hot path and is independent of the GPT-OSS reasoning parser.

## Test plan

- [x] 15 unit tests covering all detection patterns and edge cases (`tests/test_repetition_detector.py`)
- [ ] Manual testing with models known to produce degenerate output
- [ ] Verify no performance regression on normal generation

```bash
pytest tests/test_repetition_detector.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)