### PR TITLE
Security hardening: fix auth bypass, SSRF, MCP vulnerabilities (issue #68)

### DIFF
--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -184,39 +184,37 @@ class TestVideoFrameExtraction:
 class TestImageProcessing:
     """Test image processing functions."""
 
-    def test_process_image_input_local_file(self, test_image_path):
-        """Test processing local image file."""
+    def test_process_image_input_local_file_rejected(self, test_image_path):
+        """Test that local file paths are rejected (path traversal prevention)."""
         from vllm_mlx.models.mllm import process_image_input
 
-        result = process_image_input(test_image_path)
-        assert result == test_image_path
+        with pytest.raises(ValueError):
+            process_image_input(test_image_path)
 
-    def test_process_image_input_dict_format(self, test_image_path):
-        """Test processing image in dict format."""
+    def test_process_image_input_dict_local_file_rejected(self, test_image_path):
+        """Test that local file paths in dict format are rejected."""
         from vllm_mlx.models.mllm import process_image_input
 
-        # OpenAI format
-        result = process_image_input({"url": test_image_path})
-        assert Path(result).exists()
+        with pytest.raises(ValueError):
+            process_image_input({"url": test_image_path})
 
 
 class TestVideoProcessing:
     """Test video processing functions."""
 
-    def test_process_video_input_local_file(self, test_video_path):
-        """Test processing local video file."""
+    def test_process_video_input_local_file_rejected(self, test_video_path):
+        """Test that local file paths are rejected (path traversal prevention)."""
         from vllm_mlx.models.mllm import process_video_input
 
-        result = process_video_input(test_video_path)
-        assert result == test_video_path
+        with pytest.raises(ValueError):
+            process_video_input(test_video_path)
 
-    def test_process_video_input_dict_format(self, test_video_path):
-        """Test processing video in dict format."""
+    def test_process_video_input_dict_local_file_rejected(self, test_video_path):
+        """Test that local file paths in dict format are rejected."""
         from vllm_mlx.models.mllm import process_video_input
 
-        # OpenAI format
-        result = process_video_input({"url": test_video_path})
-        assert Path(result).exists()
+        with pytest.raises(ValueError):
+            process_video_input({"url": test_video_path})
 
     def test_process_video_input_empty_raises(self):
         """Test that empty input raises error."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -133,7 +133,7 @@ class BatchedEngine(BaseEngine):
     def __init__(
         self,
         model_name: str,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -52,7 +52,7 @@ class SimpleEngine(BaseEngine):
     def __init__(
         self,
         model_name: str,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         enable_cache: bool = True,
         force_mllm: bool = False,
         mtp: bool = False,

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 # Default config search paths
 CONFIG_SEARCH_PATHS = [
-    "./mcp.json",
-    "./mcp.yaml",
     "~/.config/vllm-mlx/mcp.json",
     "~/.config/vllm-mlx/mcp.yaml",
 ]

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -43,8 +43,7 @@ class MCPServerConfig:
     enabled: bool = True
     timeout: float = 30.0
 
-    # Security options
-    skip_security_validation: bool = False  # WARNING: Only for development!
+    # Security options removed: skip_security_validation was a bypass risk
 
     def __post_init__(self):
         """Validate configuration."""
@@ -67,16 +66,7 @@ class MCPServerConfig:
 
     def _validate_security(self) -> None:
         """Validate security of the configuration."""
-        from .security import validate_mcp_server_config, MCPSecurityError
-
-        if self.skip_security_validation:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                f"MCP server '{self.name}': Security validation SKIPPED. "
-                f"This is dangerous and should only be used in development!"
-            )
-            return
+        from .security import MCPSecurityError, validate_mcp_server_config
 
         try:
             validate_mcp_server_config(

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -48,6 +48,9 @@ class RequestStatus(enum.IntEnum):
         return None
 
 
+MAX_TOKENS_LIMIT = 131072  # 128K hard upper bound
+
+
 @dataclass
 class SamplingParams:
     """Sampling parameters for text generation."""
@@ -66,6 +69,8 @@ class SamplingParams:
             self.stop = []
         if self.stop_token_ids is None:
             self.stop_token_ids = []
+        if self.max_tokens > MAX_TOKENS_LIMIT:
+            self.max_tokens = MAX_TOKENS_LIMIT
 
 
 @dataclass

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -260,6 +260,8 @@ class RateLimiter:
         self.window_size = 60.0  # 1 minute window
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._last_cleanup = time.time()
+        self._cleanup_interval = 300  # 5 minutes
 
     def is_allowed(self, client_id: str) -> tuple[bool, int]:
         """
@@ -275,6 +277,17 @@ class RateLimiter:
         window_start = current_time - self.window_size
 
         with self._lock:
+            # Periodic cleanup of stale clients
+            if current_time - self._last_cleanup > self._cleanup_interval:
+                self._last_cleanup = current_time
+                stale = [
+                    k
+                    for k, v in self._requests.items()
+                    if not v or max(v) < window_start
+                ]
+                for k in stale:
+                    del self._requests[k]
+
             # Clean old requests outside window
             self._requests[client_id] = [
                 t for t in self._requests[client_id] if t > window_start
@@ -294,6 +307,10 @@ class RateLimiter:
 
 # Global rate limiter (disabled by default)
 _rate_limiter = RateLimiter(requests_per_minute=60, enabled=False)
+
+# Audio/TTS limits
+MAX_AUDIO_UPLOAD_SIZE = 100 * 1024 * 1024  # 100MB
+MAX_TTS_INPUT_LENGTH = 10_000  # characters
 
 
 async def check_rate_limit(request: Request):
@@ -490,6 +507,7 @@ def load_model(
     specprefill_threshold: int = 8192,
     specprefill_keep_pct: float = 0.3,
     specprefill_draft_model: str = None,
+    trust_remote_code: bool = False,
 ):
     """
     Load a model (auto-detects MLLM vs LLM).
@@ -507,6 +525,7 @@ def load_model(
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
+        trust_remote_code: Allow execution of custom code from model repos
     """
     global _engine, _model_name, _model_path, _default_max_tokens, _tool_parser_instance
 
@@ -523,6 +542,7 @@ def load_model(
         logger.info(f"Loading model with BatchedEngine: {model_name}")
         _engine = BatchedEngine(
             model_name=model_name,
+            trust_remote_code=trust_remote_code,
             scheduler_config=scheduler_config,
             stream_interval=stream_interval,
             force_mllm=force_mllm,
@@ -534,6 +554,7 @@ def load_model(
         logger.info(f"Loading model with SimpleEngine: {model_name}")
         _engine = SimpleEngine(
             model_name=model_name,
+            trust_remote_code=trust_remote_code,
             force_mllm=force_mllm,
             mtp=mtp,
             prefill_step_size=prefill_step_size,
@@ -601,7 +622,7 @@ async def health():
     }
 
 
-@app.get("/v1/status")
+@app.get("/v1/status", dependencies=[Depends(verify_api_key)])
 async def status():
     """Real-time status with per-request details for debugging and monitoring."""
     if _engine is None:
@@ -631,7 +652,7 @@ async def status():
     }
 
 
-@app.get("/v1/cache/stats")
+@app.get("/v1/cache/stats", dependencies=[Depends(verify_api_key)])
 async def cache_stats():
     """Get cache statistics for debugging and monitoring."""
     try:
@@ -650,7 +671,7 @@ async def cache_stats():
         return {"error": "Cache stats not available (mlx_vlm not loaded)"}
 
 
-@app.delete("/v1/cache")
+@app.delete("/v1/cache", dependencies=[Depends(verify_api_key)])
 async def clear_cache():
     """Clear all caches."""
     try:
@@ -802,8 +823,8 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Embedding generation failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Embedding generation failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 # =============================================================================
@@ -860,6 +881,24 @@ async def execute_mcp_tool(request: MCPExecuteRequest) -> MCPExecuteResponse:
             status_code=503, detail="MCP not configured. Start server with --mcp-config"
         )
 
+    # Validate through sandbox before execution
+    from .mcp.security import MCPSecurityError, get_sandbox
+
+    sandbox = get_sandbox()
+    try:
+        # Extract server name from tool_name (format: server__tool)
+        parts = request.tool_name.split("__", 1)
+        server_name = parts[0] if len(parts) > 1 else "unknown"
+        tool_name = parts[1] if len(parts) > 1 else request.tool_name
+
+        sandbox.validate_tool_execution(
+            tool_name=tool_name,
+            server_name=server_name,
+            arguments=request.arguments or {},
+        )
+    except MCPSecurityError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     result = await _mcp_manager.execute_tool(
         request.tool_name,
         request.arguments,
@@ -912,16 +951,26 @@ async def create_transcription(
             "parakeet": "mlx-community/parakeet-tdt-0.6b-v2",
             "parakeet-v3": "mlx-community/parakeet-tdt-0.6b-v3",
         }
-        model_name = model_map.get(model, model)
+        model_name = model_map.get(model)
+        if model_name is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown STT model '{model}'. Available: {list(model_map.keys())}",
+            )
 
         # Load engine if needed
         if _stt_engine is None or _stt_engine.model_name != model_name:
             _stt_engine = STTEngine(model_name)
             _stt_engine.load()
 
-        # Save uploaded file temporarily
+        # Save uploaded file temporarily (with size limit)
+        content = await file.read()
+        if len(content) > MAX_AUDIO_UPLOAD_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Audio file too large (max {MAX_AUDIO_UPLOAD_SIZE // 1024 // 1024}MB)",
+            )
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
-            content = await file.read()
             tmp.write(content)
             tmp_path = tmp.name
 
@@ -945,8 +994,8 @@ async def create_transcription(
             detail="mlx-audio not installed. Install with: pip install mlx-audio",
         )
     except Exception as e:
-        logger.error(f"Transcription failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Transcription failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.post("/v1/audio/speech", dependencies=[Depends(verify_api_key)])
@@ -968,6 +1017,13 @@ async def create_speech(
     """
     global _tts_engine
 
+    # Validate TTS input length
+    if len(input) > MAX_TTS_INPUT_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"TTS input too long (max {MAX_TTS_INPUT_LENGTH} chars)",
+        )
+
     try:
         from .audio.tts import TTSEngine  # Lazy import - optional feature
 
@@ -980,7 +1036,12 @@ async def create_speech(
             "vibevoice": "mlx-community/VibeVoice-Realtime-0.5B-4bit",
             "voxcpm": "mlx-community/VoxCPM1.5",
         }
-        model_name = model_map.get(model, model)
+        model_name = model_map.get(model)
+        if model_name is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown TTS model '{model}'. Available: {list(model_map.keys())}",
+            )
 
         # Load engine if needed
         if _tts_engine is None or _tts_engine.model_name != model_name:
@@ -1001,8 +1062,8 @@ async def create_speech(
             detail="mlx-audio not installed. Install with: pip install mlx-audio",
         )
     except Exception as e:
-        logger.error(f"TTS generation failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"TTS generation failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/v1/audio/voices", dependencies=[Depends(verify_api_key)])
@@ -1518,7 +1579,10 @@ def _inject_json_instruction(messages: list, instruction: str) -> list:
 # =============================================================================
 
 
-@app.post("/v1/messages")
+@app.post(
+    "/v1/messages",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
 async def create_anthropic_message(
     request: Request,
 ):
@@ -1645,7 +1709,10 @@ async def create_anthropic_message(
     )
 
 
-@app.post("/v1/messages/count_tokens")
+@app.post(
+    "/v1/messages/count_tokens",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
 async def count_anthropic_tokens(request: Request):
     """
     Count tokens for an Anthropic Messages API request.
@@ -2195,8 +2262,8 @@ Examples:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="Host to bind to",
+        default="127.0.0.1",
+        help="Host to bind to (default: 127.0.0.1; use 0.0.0.0 to expose to network)",
     )
     parser.add_argument(
         "--port",
@@ -2276,6 +2343,11 @@ Examples:
         default=None,
         help="Default top_p for generation when not specified in request",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow execution of custom code from HuggingFace model repos (security risk, use only with trusted models)",
+    )
 
     args = parser.parse_args()
 
@@ -2296,6 +2368,13 @@ Examples:
             f"Rate limiting enabled: {args.rate_limit} requests/minute per client"
         )
 
+    # Warn about network exposure without auth
+    if args.host == "0.0.0.0" and not args.api_key:
+        logger.warning(
+            "Server binding to 0.0.0.0 (all interfaces) without --api-key. "
+            "This exposes the server to the network without authentication."
+        )
+
     # Security summary at startup
     logger.info("=" * 60)
     logger.info("SECURITY CONFIGURATION")
@@ -2309,6 +2388,7 @@ Examples:
     else:
         logger.warning("  Rate limiting: DISABLED - Use --rate-limit to enable")
     logger.info(f"  Request timeout: {args.timeout}s")
+    logger.info(f"  Trust remote code: {args.trust_remote_code}")
     logger.info("=" * 60)
 
     # Set MCP config for lifespan
@@ -2333,6 +2413,7 @@ Examples:
         use_batching=args.continuous_batching,
         max_tokens=args.max_tokens,
         force_mllm=args.mllm,
+        trust_remote_code=args.trust_remote_code,
     )
 
     # Start server


### PR DESCRIPTION
## Summary

Comprehensive security hardening addressing 17 of the 25 vulnerabilities identified in #68. This PR fixes all actionable items in a single commit.

### CRITICAL fixes:
- **Auth bypass on Anthropic endpoints**: Added `verify_api_key` + `check_rate_limit` dependencies to `/v1/messages`, `/v1/messages/count_tokens`, `/v1/status`, `/v1/cache/stats`, `/v1/cache`
- **MCP `skip_security_validation` bypass**: Removed the field entirely from `MCPServerConfig` — security validation always runs
- **SSRF via URL fetching**: Added `_validate_url_safety()` that blocks private IPs, localhost, link-local, and cloud metadata endpoints before `download_image()`/`download_video()`

### HIGH fixes:
- **Path traversal in multimodal input**: Removed `Path.exists()` local file checks from `process_image_input()`/`process_video_input()` — API only accepts URLs and base64
- **`trust_remote_code=True` default**: Changed to `False` in `SimpleEngine`, `BatchedEngine`, and `MLXMultimodalLM`; added `--trust-remote-code` CLI flag for explicit opt-in
- **`/v1/mcp/execute` sandbox bypass**: Now routes through `ToolSandbox.validate_tool_execution()` before executing
- **MCP `allow_unsafe` bypass**: Removed `allow_unsafe` parameter and all bypass code from `MCPCommandValidator`
- **MCP regex bypass**: Added newline/CR detection and `${}` expansion patterns to dangerous command/arg patterns; added interpreter argument validation (`-c`, `-e`, `--eval`)

### MEDIUM fixes:
- **No audio file size limit**: Added 100MB upload limit
- **No TTS text length limit**: Added 10K character limit
- **Default bind to 0.0.0.0**: Changed to `127.0.0.1` with warning when `0.0.0.0` used without `--api-key`
- **No max_tokens upper bound**: Added 128K cap in `SamplingParams.__post_init__()`
- **MCP config from CWD**: Removed `./mcp.json` and `./mcp.yaml` from search paths (only `~/.config/` now)
- **High-risk MCP tools only warned**: Changed `_check_high_risk_tool()` to raise `MCPSecurityError` instead of just logging
- **Arbitrary model loading for STT/TTS**: Reject unknown models instead of passing through to HuggingFace

### LOW fixes:
- **Rate limiter unbounded growth**: Added periodic GC of stale clients (every 5 minutes)
- **Exception details leaked**: Replaced `detail=str(e)` with `"Internal server error"` in 500 responses

### NOT included (separate PRs):
- Log injection (#12) — moderate refactoring scope
- Race condition in global STT/TTS engines (#14) — requires architectural change
- MD5 cache collision (#15), disk cache integrity (#17), TOCTOU (#22), hash truncation (#23), thread safety (#24) — separate concerns
- Spoofed User-Agent (#25) — informational

## Test plan

- [ ] Verify `/v1/messages` returns 401 without API key when `--api-key` is set
- [ ] Verify SSRF protection blocks `http://169.254.169.254/` and `http://localhost/`
- [ ] Verify local file paths are rejected by `process_image_input()`
- [ ] Verify `MCPServerConfig(skip_security_validation=True)` raises `TypeError`
- [ ] Verify `--trust-remote-code` flag is required for models needing it
- [ ] Run `uvx black vllm_mlx/` — passes
- [ ] Run existing test suite

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)