### PR TITLE
fix: MLLM continuous batching — system prompt, routing, and KV cache

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -336,8 +336,10 @@ class BatchedEngine(BaseEngine):
         # For MLLM models, the processor handles special vision tokens.
         # For text-only models, the tokenizer is sufficient.
         template_applicator = None
-        if self._is_mllm and self._processor and hasattr(
-            self._processor, "apply_chat_template"
+        if (
+            self._is_mllm
+            and self._processor
+            and hasattr(self._processor, "apply_chat_template")
         ):
             template_applicator = self._processor
         elif hasattr(self.tokenizer, "apply_chat_template"):

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -618,8 +618,7 @@ class MLLMBatchGenerator:
             self._preprocess_request(req)
 
         total_prompt_tokens = sum(
-            req.input_ids.size if req.input_ids is not None else 1
-            for req in requests
+            req.input_ids.size if req.input_ids is not None else 1 for req in requests
         )
         self._stats.prompt_tokens += total_prompt_tokens
 


### PR DESCRIPTION
## Summary

Fixes three related bugs that caused multimodal models (e.g. Qwen2.5-VL, Qwen3-VL) to produce garbage output when running with `--continuous-batching`:

- **Chat template drops conversation history**: `_apply_chat_template` used `mlx_vlm.prompt_utils.apply_chat_template` which only extracted the last user message text, discarding system prompts and all prior turns. Fixed by using the processor/tokenizer's `apply_chat_template` with the full message list.
- **MLLM text-only requests crash**: `generate()` and `stream_generate()` only routed to `_mllm_scheduler` when images/videos were present, but `_engine` is `None` for MLLM models. Fixed by routing all requests through `_mllm_scheduler` when the model is multimodal.
- **KV cache not transferred from VLM prefill**: `_run_vision_encoding` was called without a cache argument, so prefill KV state was discarded. The code then tried to copy state via `BatchKVCache.insert_single` which doesn't exist. Fixed by passing per-request `KVCache` objects to the VLM forward pass, then merging them into a `BatchKVCache` via `KVCache.merge()`.

## Details

### Bug 1: Chat template (`batched.py`)
The MLLM path called `mlx_vlm.prompt_utils.apply_chat_template(processor, config, text_prompt)` with only the extracted last-user-message text. This function is designed for single-turn VLM inference and doesn't accept a messages list. The fix uses `processor.apply_chat_template(messages, ...)` (the HuggingFace standard) which preserves system prompts, assistant turns, and multi-turn history. Also removed hardcoded `enable_thinking=True` which isn't supported by all model templates.

### Bug 2: MLLM routing (`batched.py`)
For MLLM models, only `_mllm_scheduler` is initialised (not `_engine`). The condition `if self._is_mllm and self._mllm_scheduler and (images or videos)` meant text-only chat requests fell through to `self._engine.add_request()` which is `None`, causing an `AttributeError`. Removed the `(images or videos)` guard so all requests route through the MLLM scheduler when the model is multimodal.

### Bug 3: KV cache (`mllm_batch_generator.py`)
`_process_prompts` created an empty `BatchKVCache` upfront, ran VLM encoding without passing any cache, then attempted to extract KV state from the model's internal layer caches. This failed because (a) the VLM discards its internal cache after the forward pass without a `cache=` argument, and (b) `BatchKVCache` doesn't have an `insert_single` method. The fix:
1. Creates a per-request `KVCache` (from `mlx_lm.models.cache.make_prompt_cache`)
2. Passes it to `_run_vision_encoding(req, cache=request_cache)` — the VLM model's `__call__` passes `cache=` through to `self.language_model()`
3. After all requests are prefilled, merges per-request caches via `KVCache.merge()` → `BatchKVCache` with proper left-padding alignment

## Test plan

Tested on Mac Studio M3 Ultra (96GB):

- [x] `Qwen2.5-VL-32B-Instruct-4bit` with `--continuous-batching` — correct output
- [x] `Qwen3-VL-30B-A3B-Instruct-4bit` with `--continuous-batching` — correct output
- [x] System prompt retention (e.g. "Always mention TAN15 policy" → model follows instruction)
- [x] Multi-turn conversation history (e.g. "My name is Chris" → "What is my name?" → "Chris")
- [x] Concurrent request batching (3 simultaneous requests, all correct, <1.5s total)
- [x] Text-only requests to MLLM models (no crash, correct output)

🤖 Generated with [Claude Code](https://claude.ai/code)