### PR TITLE
Add Metal memory stats to MLLMScheduler

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -754,7 +754,16 @@ class BatchedEngine(BaseEngine):
         }
 
         if self._mllm_scheduler:
-            stats["mllm_scheduler"] = self._mllm_scheduler.get_stats()
+            mllm_stats = self._mllm_scheduler.get_stats()
+            stats["mllm_scheduler"] = mllm_stats
+            # Promote Metal memory stats to top-level for /v1/status
+            for key in (
+                "metal_active_memory_gb",
+                "metal_peak_memory_gb",
+                "metal_cache_memory_gb",
+            ):
+                if key in mllm_stats:
+                    stats[key] = mllm_stats[key]
         elif self._engine:
             stats.update(self._engine.get_stats())
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -415,12 +415,25 @@ class SimpleEngine(BaseEngine):
 
     def get_stats(self) -> dict[str, Any]:
         """Get engine statistics."""
-        return {
+        stats = {
             "engine_type": "simple",
             "model_name": self._model_name,
             "is_mllm": self._is_mllm,
             "loaded": self._loaded,
         }
+
+        # Include Metal memory stats
+        try:
+            import mlx.core as mx
+
+            if mx.metal.is_available():
+                stats["metal_active_memory_gb"] = round(mx.get_active_memory() / 1e9, 2)
+                stats["metal_peak_memory_gb"] = round(mx.get_peak_memory() / 1e9, 2)
+                stats["metal_cache_memory_gb"] = round(mx.get_cache_memory() / 1e9, 2)
+        except Exception:
+            pass
+
+        return stats
 
     def get_cache_stats(self) -> dict[str, Any] | None:
         """Get cache statistics (for MLLM models)."""

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -26,15 +26,16 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 
+import mlx.core as mx
 
 from .mllm_batch_generator import (
     MLLMBatchGenerator,
     MLLMBatchRequest,
     MLLMBatchResponse,
 )
+from .mllm_cache import MLLMCacheManager
 from .multimodal_processor import MultimodalProcessor
 from .request import RequestOutput, RequestStatus, SamplingParams
-from .mllm_cache import MLLMCacheManager
 
 logger = logging.getLogger(__name__)
 
@@ -752,6 +753,15 @@ class MLLMScheduler:
 
         if self.vision_cache:
             stats["vision_cache"] = self.vision_cache.get_stats()
+
+        # Include Metal memory stats
+        try:
+            if mx.metal.is_available():
+                stats["metal_active_memory_gb"] = round(mx.get_active_memory() / 1e9, 2)
+                stats["metal_peak_memory_gb"] = round(mx.get_peak_memory() / 1e9, 2)
+                stats["metal_cache_memory_gb"] = round(mx.get_cache_memory() / 1e9, 2)
+        except Exception:
+            pass
 
         return stats
 


### PR DESCRIPTION
## Summary
- `MLLMScheduler.get_stats()` was missing Metal memory metrics (`metal_active_memory_gb`, `metal_peak_memory_gb`, `metal_cache_memory_gb`) that the regular `Scheduler` already reports (scheduler.py:1818-1822)
- `SimpleEngine.get_stats()` was also missing Metal memory metrics entirely
- `BatchedEngine.get_stats()` nested MLLM scheduler stats under a `mllm_scheduler` key, but `/v1/status` looks for `metal_*` at top-level — so Metal stats were always `null` for vision models even after the scheduler fix
- All three issues together caused monitoring dashboards to show no Metal memory data for vision models (e.g. Qwen3-VL on BatchedEngine)

## Changes
1. **`mllm_scheduler.py`** — Added `import mlx.core as mx` and Metal memory stats block to `get_stats()` (identical to `scheduler.py:1818-1822`)
2. **`engine/simple.py`** — Added Metal memory stats to `SimpleEngine.get_stats()`
3. **`engine/batched.py`** — Promote `metal_*_memory_gb` keys from nested `mllm_scheduler` dict to top-level, so `/v1/status` can find them (consistent with how non-MLLM stats are merged via `update()`)

## Test plan
- [x] Verify `curl http://localhost:1236/v1/status` returns non-null `metal.active_memory_gb`, `metal.peak_memory_gb`, `metal.cache_memory_gb` for an MLLM model (Qwen3-VL-8B — confirmed 5.76 GB)
- [ ] Verify no regression on regular LLM scheduler stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)