### PR TITLE
feat: per-request thinking/reasoning control

### DIFF
--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -174,6 +174,10 @@ class ChatCompletionRequest(BaseModel):
     video_max_frames: int | None = None
     # Request timeout in seconds (None = use server default)
     timeout: float | None = None
+    # Thinking/reasoning control (OpenAI-compatible)
+    reasoning_effort: str | None = None  # "low", "medium", "high", "none"
+    # vLLM-compatible chat_template_kwargs pass-through
+    chat_template_kwargs: dict | None = None
 
 
 class AssistantMessage(BaseModel):

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -391,6 +391,16 @@ class SimpleEngine(BaseEngine):
             if template_tools:
                 template_kwargs["tools"] = template_tools
 
+            # Apply per-request chat_template_kwargs override
+            chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
+            if chat_template_kwargs:
+                template_kwargs.update(chat_template_kwargs)
+
+            # Map reasoning_effort to enable_thinking
+            reasoning_effort = kwargs.pop("reasoning_effort", None)
+            if reasoning_effort is not None:
+                template_kwargs["enable_thinking"] = reasoning_effort != "none"
+
             try:
                 prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
             except TypeError:


### PR DESCRIPTION
## Summary

- Adds `reasoning_effort` and `chat_template_kwargs` parameters to `ChatCompletionRequest`
- `reasoning_effort` maps to `enable_thinking` in chat template kwargs (`"none"` → `false`, others → `true`)
- When `reasoning_effort="none"`, the reasoning parser is skipped entirely (both streaming and non-streaming)
- `chat_template_kwargs` provides a generic pass-through for arbitrary template parameters (vLLM-compatible)
- Graceful fallback when the chat template doesn't support `enable_thinking` (TypeError → retry without it)

## Motivation

Models like Qwen3 have `enable_thinking` in their chat template, but the server sets it globally. Clients cannot control thinking/reasoning on a per-request basis. This is needed for:
- Disabling thinking for simple queries (faster responses, lower token usage)
- OpenAI API compatibility (`reasoning_effort` parameter)
- vLLM compatibility (`chat_template_kwargs` pass-through)

## API Usage

```bash
# Disable thinking for this request
curl http://localhost:8000/v1/chat/completions \
  -d '{"model":"...","messages":[...],"reasoning_effort":"none"}'

# Enable thinking explicitly
curl http://localhost:8000/v1/chat/completions \
  -d '{"model":"...","messages":[...],"reasoning_effort":"high"}'

# Pass arbitrary template kwargs
curl http://localhost:8000/v1/chat/completions \
  -d '{"model":"...","messages":[...],"chat_template_kwargs":{"enable_thinking":false}}'
```

## Changed files

| File | Change |
|------|--------|
| `vllm_mlx/api/models.py` | +2 fields: `reasoning_effort`, `chat_template_kwargs` |
| `vllm_mlx/server.py` | Pass kwargs to engine, skip reasoning parser on `"none"` |
| `vllm_mlx/engine/batched.py` | `apply_chat_template()` accepts and merges kwargs |
| `vllm_mlx/engine/simple.py` | Same for SimpleEngine |
| `vllm_mlx/models/llm.py` | Same for MLXLanguageModel |

## Test plan

- [ ] `uvx black --check vllm_mlx/` passes
- [ ] `uvx ruff check vllm_mlx/` has no new errors
- [ ] Server starts with `--enable-mtp`
- [ ] `reasoning_effort="none"` skips thinking output
- [ ] `reasoning_effort="high"` includes thinking output
- [ ] `chat_template_kwargs={"enable_thinking": false}` works
- [ ] Streaming and non-streaming paths both handle the new params
- [ ] Models without `enable_thinking` in template work (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)