### PR TITLE
Fix tokenizer fallback crash on local filesystem paths

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -63,13 +63,18 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
 def _load_with_tokenizer_fallback(model_name: str):
     """Load model with fallback tokenizer for non-standard models like Nemotron."""
-    from huggingface_hub import snapshot_download
     from mlx_lm.utils import load_model
 
     logger.info("Loading with tokenizer fallback...")
 
-    # Get model path
-    model_path = Path(snapshot_download(model_name))
+    # Get model path - use local path if it exists, otherwise download from Hub
+    local_path = Path(model_name)
+    if local_path.is_dir():
+        model_path = local_path
+    else:
+        from huggingface_hub import snapshot_download
+
+        model_path = Path(snapshot_download(model_name))
 
     # Load model
     model, _ = load_model(model_path)


### PR DESCRIPTION
## Summary

- Fixes `_load_with_tokenizer_fallback()` crashing with `HFValidationError` when `model_name` is a local directory path
- Checks if the path is a local directory before calling `snapshot_download()`, which only accepts Hub repo IDs
- Moves `huggingface_hub` import into the branch where it's actually needed

## Test plan

- [x] Verify `vllm-mlx serve /path/to/local/Nemotron-model` no longer crashes
- [x] Verify `vllm-mlx serve mlx-community/Nemotron-model` still works (Hub download path)

Closes #86