### PR TITLE
feat: add prompt prefix caching to SimpleEngine

### DIFF
--- a/tests/test_simple_engine_prefix_cache.py
+++ b/tests/test_simple_engine_prefix_cache.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimpleEngine prompt prefix caching."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_stream_chunks(texts, finish_on_last=True):
+    """Create mock stream_generate chunks."""
+    chunks = []
+    for i, text in enumerate(texts):
+        chunk = MagicMock()
+        chunk.text = text
+        chunk.finished = finish_on_last and (i == len(texts) - 1)
+        chunk.finish_reason = "stop" if chunk.finished else None
+        chunks.append(chunk)
+    return chunks
+
+
+@pytest.fixture
+def mock_model():
+    """Create a mock LLM model with tokenizer."""
+    model = MagicMock()
+    model.model = MagicMock()  # The underlying nn.Module for make_prompt_cache
+    model.tokenizer = MagicMock()
+    model.tokenizer.encode = MagicMock(return_value=[1, 2, 3, 4, 5])
+
+    chunks = _make_stream_chunks(["hello", " world"])
+    model.stream_generate = MagicMock(return_value=iter(chunks))
+    return model
+
+
+class TestPrefixCacheIntegration:
+    """Test prefix cache behavior in SimpleEngine.stream_generate."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_on_first_request(self, mock_model):
+        """First request should miss cache and create a fresh one."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False), \
+             patch("vllm_mlx.engine.simple.make_prompt_cache") as mock_make_cache:
+            mock_make_cache.return_value = [MagicMock()]
+
+            engine = SimpleEngine("test-model")
+            engine._model = mock_model
+            engine._loaded = True
+
+            results = []
+            async for chunk in engine.stream_generate(prompt="test", max_tokens=10):
+                results.append(chunk)
+
+            assert len(results) == 2
+            # make_prompt_cache should have been called (cache miss)
+            mock_make_cache.assert_called_once_with(mock_model.model)
+
+    @pytest.mark.asyncio
+    async def test_cache_disabled_when_size_zero(self, mock_model):
+        """prompt_cache_size=0 should disable caching entirely."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model", prompt_cache_size=0)
+            engine._model = mock_model
+            engine._loaded = True
+
+            assert engine._prompt_cache is None
+
+            results = []
+            async for chunk in engine.stream_generate(prompt="test", max_tokens=10):
+                results.append(chunk)
+
+            assert len(results) == 2
+            # stream_generate should have been called with the raw prompt string
+            call_kwargs = mock_model.stream_generate.call_args
+            assert call_kwargs.kwargs.get("prompt") == "test" or call_kwargs[1].get("prompt") == "test"
+            # No prompt_cache kwarg should be passed
+            assert "prompt_cache" not in (call_kwargs.kwargs or call_kwargs[1])
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_cache(self, mock_model):
+        """Stopping the engine should clear the prompt cache."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model", prompt_cache_size=10)
+            engine._model = mock_model
+            engine._loaded = True
+
+            old_cache = engine._prompt_cache
+            await engine.stop()
+            # Cache should be a new instance after stop
+            assert engine._prompt_cache is not old_cache
+
+    @pytest.mark.asyncio
+    async def test_configurable_cache_size(self):
+        """prompt_cache_size should be passed through to LRUPromptCache."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False), \
+             patch("vllm_mlx.engine.simple.LRUPromptCache") as mock_lru:
+            engine = SimpleEngine("test-model", prompt_cache_size=7)
+            mock_lru.assert_called_once_with(max_size=7)
+
+
+class TestBillingHeaderStripping:
+    """Test that x-anthropic- tracking headers are stripped from system blocks."""
+
+    def test_billing_header_stripped(self):
+        """System blocks starting with x-anthropic- should be dropped."""
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+        from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
+
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
+            system=[
+                {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.42; cch=abc123"},
+                {"type": "text", "text": "You are a helpful assistant."},
+            ],
+        )
+        result = anthropic_to_openai(req)
+        system_msg = result.messages[0]
+        assert system_msg.role == "system"
+        assert "x-anthropic" not in system_msg.content
+        assert system_msg.content == "You are a helpful assistant."
+
+    def test_non_anthropic_headers_preserved(self):
+        """System blocks not starting with x-anthropic- should be kept."""
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+        from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
+
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
+            system=[
+                {"type": "text", "text": "Be helpful."},
+                {"type": "text", "text": "Be concise."},
+            ],
+        )
+        result = anthropic_to_openai(req)
+        system_msg = result.messages[0]
+        assert system_msg.content == "Be helpful.\nBe concise."
+
+    def test_all_anthropic_headers_stripped(self):
+        """If ALL system blocks are x-anthropic-, system should be empty."""
+        from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+        from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
+
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
+            system=[
+                {"type": "text", "text": "x-anthropic-billing-header: cch=abc"},
+                {"type": "text", "text": "x-anthropic-other: foo"},
+            ],
+        )
+        result = anthropic_to_openai(req)
+        # System message should still exist but be empty
+        system_msg = result.messages[0]
+        assert system_msg.role == "system"
+        assert system_msg.content == ""

--- a/tests/test_simple_engine_prefix_cache.py
+++ b/tests/test_simple_engine_prefix_cache.py
@@ -39,8 +39,10 @@ class TestPrefixCacheIntegration:
         """First request should miss cache and create a fresh one."""
         from vllm_mlx.engine.simple import SimpleEngine
 
-        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False), \
-             patch("vllm_mlx.engine.simple.make_prompt_cache") as mock_make_cache:
+        with (
+            patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False),
+            patch("vllm_mlx.engine.simple.make_prompt_cache") as mock_make_cache,
+        ):
             mock_make_cache.return_value = [MagicMock()]
 
             engine = SimpleEngine("test-model")
@@ -74,7 +76,10 @@ class TestPrefixCacheIntegration:
             assert len(results) == 2
             # stream_generate should have been called with the raw prompt string
             call_kwargs = mock_model.stream_generate.call_args
-            assert call_kwargs.kwargs.get("prompt") == "test" or call_kwargs[1].get("prompt") == "test"
+            assert (
+                call_kwargs.kwargs.get("prompt") == "test"
+                or call_kwargs[1].get("prompt") == "test"
+            )
             # No prompt_cache kwarg should be passed
             assert "prompt_cache" not in (call_kwargs.kwargs or call_kwargs[1])
 
@@ -98,8 +103,10 @@ class TestPrefixCacheIntegration:
         """prompt_cache_size should be passed through to LRUPromptCache."""
         from vllm_mlx.engine.simple import SimpleEngine
 
-        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False), \
-             patch("vllm_mlx.engine.simple.LRUPromptCache") as mock_lru:
+        with (
+            patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False),
+            patch("vllm_mlx.engine.simple.LRUPromptCache") as mock_lru,
+        ):
             engine = SimpleEngine("test-model", prompt_cache_size=7)
             mock_lru.assert_called_once_with(max_size=7)
 
@@ -117,7 +124,10 @@ class TestBillingHeaderStripping:
             messages=[AnthropicMessage(role="user", content="hi")],
             max_tokens=100,
             system=[
-                {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.42; cch=abc123"},
+                {
+                    "type": "text",
+                    "text": "x-anthropic-billing-header: cc_version=2.1.42; cch=abc123",
+                },
                 {"type": "text", "text": "You are a helpful assistant."},
             ],
         )

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -54,7 +54,13 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
             parts = []
             for block in request.system:
                 if isinstance(block, dict) and block.get("type") == "text":
-                    parts.append(block.get("text", ""))
+                    text = block.get("text", "")
+                    # Strip per-request tracking headers injected by clients
+                    # (e.g. "x-anthropic-billing-header: ...cch=HASH").
+                    # These change every request and break prompt prefix caching.
+                    if text.startswith("x-anthropic-"):
+                        continue
+                    parts.append(text)
                 elif isinstance(block, str):
                     parts.append(block)
             system_text = "\n".join(parts)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -61,7 +61,11 @@ class SimpleEngine(BaseEngine):
 
         # LRU trie-based prompt prefix cache for KV reuse across requests
         self._prompt_cache_size = prompt_cache_size
-        self._prompt_cache = LRUPromptCache(max_size=prompt_cache_size) if prompt_cache_size > 0 else None
+        self._prompt_cache = (
+            LRUPromptCache(max_size=prompt_cache_size)
+            if prompt_cache_size > 0
+            else None
+        )
 
     @property
     def model_name(self) -> str:
@@ -220,7 +224,9 @@ class SimpleEngine(BaseEngine):
                 try:
                     cache_snapshot = copy.deepcopy(cache)
                 except Exception:
-                    logger.warning("Failed to snapshot prompt cache; skipping cache insert")
+                    logger.warning(
+                        "Failed to snapshot prompt cache; skipping cache insert"
+                    )
                     cache_snapshot = None
 
             accumulated_text = ""

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -171,23 +171,25 @@ class MLXLanguageModel:
 
     def stream_generate(
         self,
-        prompt: str,
+        prompt: "str | list[int]",
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        prompt_cache: "list | None" = None,
     ) -> Iterator[StreamingOutput]:
         """
         Stream text generation token by token.
 
         Args:
-            prompt: Input prompt text
+            prompt: Input prompt text or token IDs
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature (0 = greedy)
             top_p: Top-p (nucleus) sampling parameter
             repetition_penalty: Penalty for repeating tokens
             stop: List of stop sequences
+            prompt_cache: Optional KV cache from previous generation
 
         Yields:
             StreamingOutput for each generated token
@@ -203,12 +205,17 @@ class MLXLanguageModel:
         token_count = 0
         accumulated_text = ""
 
+        kwargs = {}
+        if prompt_cache is not None:
+            kwargs["prompt_cache"] = prompt_cache
+
         for response in stream_generate(
             self.model,
             self.tokenizer,
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
+            **kwargs,
         ):
             token_count += 1
             # response.text is the new token text (not accumulated)


### PR DESCRIPTION
## Summary

- Adds KV prefix caching to `SimpleEngine.stream_generate()` using mlx-lm's `LRUPromptCache` (trie-based prefix matching with LRU eviction)
- In agentic loops (e.g. Claude Code), successive requests share 90-99% of their prompt prefix, making prefill the bottleneck. This brings prompt eval from ~27s to ~1.8s on a 28k-token prompt (15-27x speedup on M4 Max)
- Strips `x-anthropic-` tracking headers from system blocks in the Anthropic adapter, since they contain per-request hashes that break prefix matching
- Configurable via `prompt_cache_size` parameter (default 10, 0 to disable)

## Implementation details

**`vllm_mlx/models/llm.py`**: Accept optional `prompt_cache` parameter in `stream_generate()` and pass it through to `mlx_lm.stream_generate()`. Also accept `list[int]` (token IDs) as prompt type, not just `str`.

**`vllm_mlx/engine/simple.py`**: 
- Tokenize prompt and look up nearest prefix in trie cache via `LRUPromptCache.fetch_nearest_cache()`
- Deep copy cache before generation (mlx-lm's `generate_step()` mutates the cache in place), with try/except fallback if deepcopy fails on MLX arrays
- Pass only the remaining (non-cached) tokens to the model along with the cached KV state
- After generation, store prompt-only KV state (excludes generated tokens, since the next request's representation of generated content may differ due to tool call formatting, system reminders, etc.)
- Cache is cleared on `stop()` to prevent stale KV state if the engine is recycled
- `prompt_cache_size` is configurable (default 10, 0 to disable caching entirely)

**`vllm_mlx/api/anthropic_adapter.py`**: Skip system content blocks starting with `x-anthropic-` (e.g. `x-anthropic-billing-header: cc_version=...; cch=HASH`). The `cch=` hash changes every request, causing prefix divergence at token ~33 and defeating the entire cache.

**`tests/test_simple_engine_prefix_cache.py`**: 7 new tests covering cache miss on first request, disabled cache (size=0), stop() cleanup, configurable size, billing header stripping, and edge cases.

## Test results (Claude Code agentic loop)

| Round | Tokens reused | Prompt eval time |
|-------|--------------|-----------------|
| 1 (cold) | 0/28457 (0%) | ~27s |
| 2 | 28457/29485 (96%) | ~1.8s |
| 3 | 29485/29650 (99%) | ~0.7s |
| 4 | 29650/29738 (99%) | ~1.4s |

## Test plan

- [x] 7 new unit tests (all passing)
- [x] Existing 50 tests unaffected (all passing)
- [x] Verify cold start (first request) works normally with 0% cache hit
- [x] Verify second request to same conversation shows high cache hit rate
- [x] Verify growing conversations maintain high reuse (96%+)
- [x] Verify `prompt_cache_size=0` disables caching cleanly
- [x] Verify `stop()` clears stale cache state


Generated with [Claude Code](https://claude.com/claude-code)