### PR TITLE
feat: Add MiniMax-M2 tool call parser

### DIFF
--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -17,7 +17,8 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|"
     r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
     r"<\|channel\|>|<\|message\|>|<\|start\|>|<\|return\|>|<\|call\|>|<\|constrain\|>|"
-    r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]"
+    r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]|"
+    r"\[e~\[|\]~b\][a-z]*|\]~!b\["
 )
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -778,11 +778,12 @@ Examples:
             "xlam",
             "functionary",
             "glm47",
+            "minimax",
         ],
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47. "
+            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, minimax. "
             "Required for --enable-auto-tool-choice."
         ),
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1928,16 +1928,99 @@ async def stream_chat_completion(
                 # Skip this chunk (e.g., <think> token itself)
                 continue
 
+            content = delta_msg.content
+            reasoning = delta_msg.reasoning
+
+            # Some models (e.g. MiniMax) wrap tool calls in <think>
+            # blocks, so reasoning parser captures tool call XML as
+            # reasoning while content stays None.  Redirect reasoning
+            # to the content stream so the tool parser can handle it.
+            if tool_parser and reasoning and not content:
+                _check = tool_accumulated_text + reasoning
+                if (
+                    "<minimax:tool_call>" in _check
+                    or "<tool_call>" in _check
+                    or '<invoke name="' in _check
+                ):
+                    content = reasoning
+                    reasoning = None
+
+            # Tool call parsing on content portion
+            if tool_parser and content:
+                if not tool_markup_possible and "<" not in content:
+                    tool_accumulated_text += content
+                    # Suppress whitespace-only content when tools are active;
+                    # avoids emitting stray newlines before tool call XML.
+                    if not content.strip():
+                        continue
+                else:
+                    if not tool_markup_possible:
+                        tool_markup_possible = True
+                    tool_previous = tool_accumulated_text
+                    tool_accumulated_text += content
+                    tool_result = tool_parser.extract_tool_calls_streaming(
+                        tool_previous, tool_accumulated_text, content
+                    )
+
+                    if tool_result is None:
+                        # Inside tool markup - suppress content output
+                        if reasoning:
+                            # Still emit reasoning while buffering tool call
+                            chunk = ChatCompletionChunk(
+                                id=response_id,
+                                model=request.model,
+                                choices=[
+                                    ChatCompletionChunkChoice(
+                                        delta=ChatCompletionChunkDelta(
+                                            reasoning=reasoning,
+                                        ),
+                                        finish_reason=None,
+                                    )
+                                ],
+                                usage=None,
+                            )
+                            yield f"data: {chunk.model_dump_json()}\n\n"
+                        continue
+
+                    if "tool_calls" in tool_result:
+                        # Emit structured tool calls
+                        tool_calls_detected = True
+                        chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=request.model,
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(
+                                        tool_calls=tool_result["tool_calls"],
+                                        reasoning=reasoning,
+                                    ),
+                                    finish_reason=(
+                                        "tool_calls" if output.finished else None
+                                    ),
+                                )
+                            ],
+                            usage=get_usage(output) if output.finished else None,
+                        )
+                        yield f"data: {chunk.model_dump_json()}\n\n"
+                        continue
+
+                    # Normal content from tool parser
+                    content = tool_result.get("content", "")
+
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
-                            content=delta_msg.content,
-                            reasoning=delta_msg.reasoning,
+                            content=content if content else None,
+                            reasoning=reasoning,
                         ),
-                        finish_reason=output.finish_reason if output.finished else None,
+                        finish_reason=(
+                            "tool_calls"
+                            if (output.finished and tool_calls_detected)
+                            else (output.finish_reason if output.finished else None)
+                        ),
                     )
                 ],
                 usage=get_usage(output) if output.finished else None,

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -57,6 +57,7 @@ from .qwen_tool_parser import QwenToolParser
 from .xlam_tool_parser import xLAMToolParser
 from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
+from .minimax_tool_parser import MiniMaxToolParser
 
 __all__ = [
     # Base classes
@@ -77,4 +78,5 @@ __all__ = [
     "FunctionaryToolParser",
     "Glm47ToolParser",
     "HarmonyToolParser",
+    "MiniMaxToolParser",
 ]

--- a/vllm_mlx/tool_parsers/minimax_tool_parser.py
+++ b/vllm_mlx/tool_parsers/minimax_tool_parser.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MiniMax tool call parser for vllm-mlx.
+
+Parses the MiniMax-M2 native XML tool call format:
+<minimax:tool_call>
+<invoke name="tool-name">
+<parameter name="param-key">param-value</parameter>
+</invoke>
+</minimax:tool_call>
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module(["minimax", "minimax_m2"])
+class MiniMaxToolParser(ToolParser):
+    """
+    Parser for MiniMax-M2 tool call format.
+
+    Format:
+        <minimax:tool_call>
+        <invoke name="func_name">
+        <parameter name="key">value</parameter>
+        </invoke>
+        </minimax:tool_call>
+    """
+
+    TOOL_CALL_BLOCK = re.compile(
+        r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
+    )
+    INVOKE_PATTERN = re.compile(r'<invoke\s+name="([^"]+)">(.*?)</invoke>', re.DOTALL)
+    PARAM_PATTERN = re.compile(
+        r'<parameter\s+name="([^"]+)">(.*?)</parameter>', re.DOTALL
+    )
+    THINK_PATTERN = re.compile(r"<think>.*?</think>", re.DOTALL)
+
+    def _extract_invokes(self, text: str) -> list[dict[str, Any]]:
+        """Extract tool calls from invoke elements, with or without wrapper."""
+        tool_calls: list[dict[str, Any]] = []
+        invokes = self.INVOKE_PATTERN.findall(text)
+        for func_name, params_block in invokes:
+            params = self.PARAM_PATTERN.findall(params_block)
+            # Skip bare <invoke> tags without parameters (hallucinated junk)
+            if not params:
+                continue
+            arguments = {}
+            for p_name, p_value in params:
+                p_value = p_value.strip()
+                try:
+                    arguments[p_name] = json.loads(p_value)
+                except (json.JSONDecodeError, ValueError):
+                    arguments[p_name] = p_value
+
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": func_name.strip(),
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                }
+            )
+        return tool_calls
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        # Try wrapped format first: <minimax:tool_call>...<invoke>...</minimax:tool_call>
+        blocks = self.TOOL_CALL_BLOCK.findall(model_output)
+        if blocks:
+            tool_calls: list[dict[str, Any]] = []
+            for block in blocks:
+                tool_calls.extend(self._extract_invokes(block))
+
+            cleaned = self.TOOL_CALL_BLOCK.sub("", model_output).strip()
+            cleaned = self.THINK_PATTERN.sub("", cleaned).strip()
+            cleaned = re.sub(r"\[e~\[.*$", "", cleaned).strip()
+
+            return ExtractedToolCallInformation(
+                tools_called=bool(tool_calls),
+                tool_calls=tool_calls,
+                content=cleaned if cleaned else None,
+            )
+
+        # Fallback: bare <invoke> without <minimax:tool_call> wrapper
+        # (model sometimes emits tool calls inside <think> without wrapper)
+        tool_calls = self._extract_invokes(model_output)
+        if tool_calls:
+            # Strip matched invoke blocks and thinking from content
+            cleaned = self.INVOKE_PATTERN.sub("", model_output).strip()
+            cleaned = self.THINK_PATTERN.sub("", cleaned).strip()
+            cleaned = re.sub(r"\[e~\[.*$", "", cleaned).strip()
+            # Remove leftover closing tags
+            cleaned = cleaned.replace("</invoke>", "").strip()
+
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned if cleaned else None,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def _has_tool_start(self, text: str) -> bool:
+        """Check if text contains the start of a tool call block."""
+        return "<minimax:tool_call>" in text or (
+            '<invoke name="' in text and self.INVOKE_PATTERN.search(text) is not None
+        )
+
+    def _has_tool_end(self, current: str, previous: str) -> bool:
+        """Check if a tool call block just completed."""
+        # If wrapped format is used, only trigger on the wrapper closing tag
+        if "<minimax:tool_call>" in current:
+            return (
+                "</minimax:tool_call>" in current
+                and "</minimax:tool_call>" not in previous
+            )
+        # Bare invoke: </invoke> just appeared
+        if "</invoke>" in current and "</invoke>" not in previous:
+            return True
+        return False
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        # Not inside a tool call block yet — pass content through
+        if not self._has_tool_start(current_text):
+            return {"content": delta_text}
+
+        # Tool call block just completed
+        if self._has_tool_end(current_text, previous_text):
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        # Inside tool call block but not yet complete — suppress output
+        return None


### PR DESCRIPTION
## Summary

- Add `MiniMaxToolParser` for MiniMax-M2 models' native XML tool call format
- Integrate tool parser with reasoning parser path in streaming mode
- Strip MiniMax special tokens from output

## Details

MiniMax-M2 models use a custom XML-based tool call format distinct from other parsers. This PR adds:

1. **`minimax_tool_parser.py`** — Full parser with regex-based extraction of `<minimax:tool_call>` blocks, `<invoke>` elements, and `<parameter>` elements. Supports both non-streaming (`extract_tool_calls`) and streaming (`extract_tool_calls_streaming`) modes. Parameter values are auto-parsed as JSON when possible for proper typing.

2. **CLI integration** — `minimax` added to `--tool-call-parser` choices.

3. **Special token stripping** — MiniMax end-of-turn token `[e~[`, role markers `]~b]assistant` etc., and BOS token `]~!b[` are added to the global `SPECIAL_TOKENS_PATTERN` regex.

4. **Streaming: reasoning + tool parser integration** — MiniMax wraps tool calls inside `<think>` blocks, so when `--reasoning-parser` is enabled, the reasoning parser captures tool call XML as reasoning content. This PR adds detection of tool call markers in the reasoning stream and redirects them to the content stream for proper tool parser processing. This fixes streaming tool calls when both `--reasoning-parser` and `--tool-call-parser minimax` are used together.

## Changes

| File | Change |
|------|--------|
| `vllm_mlx/tool_parsers/minimax_tool_parser.py` | New parser for MiniMax XML format |
| `vllm_mlx/tool_parsers/__init__.py` | Import and register MiniMaxToolParser |
| `vllm_mlx/cli.py` | Add "minimax" to --tool-call-parser choices |
| `vllm_mlx/api/utils.py` | Add MiniMax special tokens to SPECIAL_TOKENS_PATTERN |
| `vllm_mlx/server.py` | Integrate tool parser within reasoning parser streaming path |

## Test plan

- [x] Tested with MiniMax-M2-5-REAP-39 (8-bit, 138GB MoE) on Apple M3 Ultra
- [x] Non-streaming tool calls parse correctly
- [x] Streaming tool calls: no XML leaking, proper `tool_calls` delta emission
- [x] Streaming with `--reasoning-parser deepseek_r1`: tool calls detected in reasoning and redirected
- [x] Streaming content (no tool call): reasoning/content split works correctly
- [x] Special tokens stripped from responses

## Usage

```bash
vllm-mlx serve <minimax-model> \
    --enable-auto-tool-choice \
    --tool-call-parser minimax \
    --reasoning-parser deepseek_r1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)