### PR TITLE
fix: use exclude_none=True in MLLM message serialization

### DIFF
--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1072,11 +1072,12 @@ class MLXMultimodalLM:
                         msg_text += item
                         continue
 
-                    # Convert Pydantic models to dicts
+                    # Convert Pydantic models to dicts, excluding None fields
+                    # to avoid null keys like image_url: null on text parts
                     if hasattr(item, "model_dump"):
-                        item = item.model_dump()
+                        item = item.model_dump(exclude_none=True)
                     elif hasattr(item, "dict"):
-                        item = item.dict()
+                        item = {k: v for k, v in item.dict().items() if v is not None}
 
                     if isinstance(item, dict):
                         item_type = item.get("type", "")
@@ -1432,11 +1433,12 @@ class MLXMultimodalLM:
                         msg_text += item
                         continue
 
-                    # Convert Pydantic models to dicts
+                    # Convert Pydantic models to dicts, excluding None fields
+                    # to avoid null keys like image_url: null on text parts
                     if hasattr(item, "model_dump"):
-                        item = item.model_dump()
+                        item = item.model_dump(exclude_none=True)
                     elif hasattr(item, "dict"):
-                        item = item.dict()
+                        item = {k: v for k, v in item.dict().items() if v is not None}
 
                     if isinstance(item, dict):
                         item_type = item.get("type", "")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1313,10 +1313,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # For MLLM models, keep original messages with embedded images
     # (MLLM.chat() extracts images from message content internally)
     if engine.is_mllm:
-        # Convert Pydantic messages to dicts preserving full content
+        # Convert Pydantic messages to dicts, excluding None fields
+        # to prevent chat templates from misinterpreting key presence
+        # (e.g. image_url: null on text parts triggers Qwen3-VL crash)
         messages = []
         for msg in request.messages:
-            msg_dict = msg.model_dump(exclude_none=True) if hasattr(msg, "model_dump") else dict(msg)
+            if hasattr(msg, "model_dump"):
+                msg_dict = msg.model_dump(exclude_none=True)
+            else:
+                raw = dict(msg)
+                msg_dict = {k: v for k, v in raw.items() if v is not None}
             messages.append(msg_dict)
         images, videos = [], []  # MLLM extracts these from messages
         logger.debug(f"MLLM: Processing {len(messages)} messages")


### PR DESCRIPTION
## Summary

Fixes the MLLM message serialization side of #100.

`msg.model_dump()` includes every field even when `None`, producing keys like
`image_url: null` on text `ContentPart`s. Qwen3-VL's chat template checks
`'image_url' in content` (key presence, not truthiness), so text parts with
`image_url: null` are misinterpreted as image parts, causing crashes.

## Fix

`model_dump()` → `model_dump(exclude_none=True)` in the MLLM message
serialization path (`server.py`, line 1319).

Note: this addresses the request serialization side. #100 also describes null
values in API responses (`tool_calls: null`, `reasoning_content: null`) which
would need a separate fix in the response serialization path.

## Test

Tested with Qwen3-VL-32B-Instruct-8bit. Before this fix, multi-part messages
with text and images crash. After, they work correctly.