### PR TITLE
feat: add --prefill-step-size CLI flag

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -172,11 +172,10 @@ def serve_command(args):
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
+            mllm_prefill_step_size=(
+                args.prefill_step_size if args.prefill_step_size > 0 else None
+            ),
         )
-
-        # Override prefill_step_size if explicitly set (0 = use engine default)
-        if args.prefill_step_size > 0:
-            scheduler_config.prefill_step_size = args.prefill_step_size
 
         print("Mode: Continuous batching (for multiple concurrent users)")
         if args.chunked_prefill_tokens > 0:
@@ -292,11 +291,10 @@ def bench_command(args):
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
+            mllm_prefill_step_size=(
+                args.prefill_step_size if args.prefill_step_size > 0 else None
+            ),
         )
-
-        # Override prefill_step_size if explicitly set (0 = use engine default)
-        if args.prefill_step_size > 0:
-            scheduler_config.prefill_step_size = args.prefill_step_size
 
         engine_config = EngineConfig(
             model_name=args.model,
@@ -681,7 +679,7 @@ Examples:
         "--prefill-step-size",
         type=int,
         default=0,
-        help="Max tokens per prefill forward pass (0=use engine default: 2048 for LLM, 1024 for MLLM)",
+        help="Override MLLM prefill-step guard (0=use MLLM default: 1024)",
     )
     serve_parser.add_argument(
         "--enable-prefix-cache",
@@ -997,7 +995,7 @@ Examples:
         "--prefill-step-size",
         type=int,
         default=0,
-        help="Max tokens per prefill forward pass (0=use engine default: 2048 for LLM, 1024 for MLLM)",
+        help="Override MLLM prefill-step guard (0=use MLLM default: 1024)",
     )
     bench_parser.add_argument(
         "--enable-prefix-cache",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -173,7 +173,7 @@ def serve_command(args):
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
             mllm_prefill_step_size=(
-                args.prefill_step_size if args.prefill_step_size > 0 else None
+                args.mllm_prefill_step_size if args.mllm_prefill_step_size > 0 else None
             ),
         )
 
@@ -291,9 +291,6 @@ def bench_command(args):
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
-            mllm_prefill_step_size=(
-                args.prefill_step_size if args.prefill_step_size > 0 else None
-            ),
         )
 
         engine_config = EngineConfig(
@@ -676,7 +673,7 @@ Examples:
         "--completion-batch-size", type=int, default=32, help="Completion batch size"
     )
     serve_parser.add_argument(
-        "--prefill-step-size",
+        "--mllm-prefill-step-size",
         type=int,
         default=0,
         help="Override MLLM prefill-step guard (0=use MLLM default: 1024)",
@@ -990,12 +987,6 @@ Examples:
     )
     bench_parser.add_argument(
         "--completion-batch-size", type=int, default=16, help="Completion batch size"
-    )
-    bench_parser.add_argument(
-        "--prefill-step-size",
-        type=int,
-        default=0,
-        help="Override MLLM prefill-step guard (0=use MLLM default: 1024)",
     )
     bench_parser.add_argument(
         "--enable-prefix-cache",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -174,6 +174,10 @@ def serve_command(args):
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
         )
 
+        # Override prefill_step_size if explicitly set (0 = use engine default)
+        if args.prefill_step_size > 0:
+            scheduler_config.prefill_step_size = args.prefill_step_size
+
         print("Mode: Continuous batching (for multiple concurrent users)")
         if args.chunked_prefill_tokens > 0:
             print(f"Chunked prefill: {args.chunked_prefill_tokens} tokens per step")
@@ -289,6 +293,11 @@ def bench_command(args):
             kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
             kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
         )
+
+        # Override prefill_step_size if explicitly set (0 = use engine default)
+        if args.prefill_step_size > 0:
+            scheduler_config.prefill_step_size = args.prefill_step_size
+
         engine_config = EngineConfig(
             model_name=args.model,
             scheduler_config=scheduler_config,
@@ -669,6 +678,12 @@ Examples:
         "--completion-batch-size", type=int, default=32, help="Completion batch size"
     )
     serve_parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=0,
+        help="Max tokens per prefill forward pass (0=use engine default: 2048 for LLM, 1024 for MLLM)",
+    )
+    serve_parser.add_argument(
         "--enable-prefix-cache",
         action="store_true",
         default=True,
@@ -977,6 +992,12 @@ Examples:
     )
     bench_parser.add_argument(
         "--completion-batch-size", type=int, default=16, help="Completion batch size"
+    )
+    bench_parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=0,
+        help="Max tokens per prefill forward pass (0=use engine default: 2048 for LLM, 1024 for MLLM)",
     )
     bench_parser.add_argument(
         "--enable-prefix-cache",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -237,6 +237,16 @@ class BatchedEngine(BaseEngine):
         kv_group_size = getattr(
             self._scheduler_config, "kv_cache_quantization_group_size", 64
         )
+
+        # Forward prefill_step_size only when explicitly overridden via CLI
+        # (i.e. differs from the SchedulerConfig dataclass default of 2048).
+        # Otherwise let MLLMSchedulerConfig use its own default (1024).
+        prefill_step_size = getattr(
+            self._scheduler_config, "prefill_step_size", None
+        )
+        mllm_extra = {}
+        if prefill_step_size is not None and prefill_step_size != 2048:
+            mllm_extra["prefill_step_size"] = prefill_step_size
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
@@ -249,6 +259,7 @@ class BatchedEngine(BaseEngine):
             kv_cache_quantization=kv_quant,
             kv_cache_quantization_bits=kv_bits,
             kv_cache_quantization_group_size=kv_group_size,
+            **mllm_extra,
         )
 
         # Create and start MLLM scheduler
@@ -262,7 +273,8 @@ class BatchedEngine(BaseEngine):
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
-            f"completion_batch={completion_batch_size}"
+            f"completion_batch={completion_batch_size}, "
+            f"prefill_step_size={mllm_config.prefill_step_size}"
         )
 
     def _inject_mtp_mllm(self) -> None:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -238,14 +238,13 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "kv_cache_quantization_group_size", 64
         )
 
-        # Forward prefill_step_size only when explicitly overridden via CLI
-        # (i.e. differs from the SchedulerConfig dataclass default of 2048).
-        # Otherwise let MLLMSchedulerConfig use its own default (1024).
+        # Forward MLLM prefill-step override only when explicitly configured.
+        # This keeps default behavior unchanged for MLLM (1024) unless set.
         prefill_step_size = getattr(
-            self._scheduler_config, "prefill_step_size", None
+            self._scheduler_config, "mllm_prefill_step_size", None
         )
         mllm_extra = {}
-        if prefill_step_size is not None and prefill_step_size != 2048:
+        if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -62,6 +62,8 @@ class SchedulerConfig:
     prefill_batch_size: int = 8
     completion_batch_size: int = 32
     prefill_step_size: int = 2048
+    # Optional override for MLLM prefill guard (None = use MLLM default).
+    mllm_prefill_step_size: Optional[int] = None
 
     # Prefix cache settings
     enable_prefix_cache: bool = True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -104,6 +104,10 @@ class SchedulerConfig:
     mtp_num_draft_tokens: int = 1  # Number of draft tokens from MTP head
     mtp_optimistic: bool = False  # Skip acceptance check for max speed
 
+    def __post_init__(self) -> None:
+        if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
+            raise ValueError("mllm_prefill_step_size must be > 0 when provided")
+
 
 @dataclass
 class SchedulerOutput:


### PR DESCRIPTION
## Summary

`MLLMSchedulerConfig.prefill_step_size` defaults to 1024 but isn't exposed as a
CLI argument. The MLLM batch generator enforces
`total_prompt_tokens <= prefill_step_size * batch_count`, so any single vision
request exceeding 1024 tokens fails with:

```
ValueError: Total prompt tokens (2289) exceeds safe limit (1024)
```

Since vision tokens alone typically exceed 1024 (images contribute ~1400+
tokens), this effectively blocks all MLLM inference under the default config.

## Fix

Add `--prefill-step-size` to both `serve` and `bench` commands. Default of `0`
means "use engine default" — 2048 for LLM, 1024 for MLLM — preserving existing
behavior. When set, the value flows through `SchedulerConfig` to both the LLM
scheduler and the MLLM scheduler.

Example usage:
```bash
vllm-mlx serve model-name --continuous-batching --prefill-step-size 16384
```

## Test

Tested with Qwen3-VL-32B-Instruct-8bit. Before this fix, vision requests fail
with the ValueError above. After passing `--prefill-step-size 16384`, they
complete successfully.