### PR TITLE
Enable tool calling for MLLM/VLM chat paths by passing tools and tool_choice into chat templates

### DIFF
--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -45,6 +45,24 @@ if response.choices[0].message.tool_calls:
         print(f"Arguments: {tc.function.arguments}")
 ```
 
+## MLLM / VLM Tool Calling (I7)
+
+Tool calling now runs through both text (LLM) and multimodal (MLLM/VLM) chat paths.
+
+For VLM models, start the server in MLLM mode and keep parser flags enabled:
+
+```bash
+vllm-mlx serve <vlm-model-id> \
+  --mllm \
+  --enable-auto-tool-choice \
+  --tool-call-parser auto
+```
+
+Notes:
+- `tools` and `tool_choice` are passed into the MLLM chat-template path.
+- Structured `tool_calls` are still parser/model-format dependent.
+- `tool_choice` is best-effort: templates that do not support it fall back safely.
+
 ## Supported Parsers
 
 Use `--tool-call-parser` to select a parser for your model family:

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -211,3 +211,141 @@ class TestSimpleEngineConcurrency:
             assert len(results) == 3
             for result in results:
                 assert result.text == "test response"
+
+
+class TestSimpleEngineToolChoicePassthrough:
+    """Test tool/tool_choice propagation for LLM and MLLM paths."""
+
+    @pytest.mark.asyncio
+    async def test_mllm_chat_passes_tools_and_tool_choice(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        model = MagicMock()
+        model.chat = MagicMock(
+            return_value=MagicMock(
+                text='<tool_call>{"name":"search_files","arguments":{"q":"x"}}</tool_call>',
+                prompt_tokens=12,
+                completion_tokens=4,
+                finish_reason="stop",
+            )
+        )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "description": "Search files",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                        "required": ["q"],
+                    },
+                },
+            }
+        ]
+        tool_choice = {"type": "function", "function": {"name": "search_files"}}
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=True):
+            engine = SimpleEngine("test-mllm")
+            engine._model = model
+            engine._loaded = True
+
+            await engine.chat(
+                messages=[{"role": "user", "content": "Find X"}],
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=32,
+            )
+
+            _, kwargs = model.chat.call_args
+            assert kwargs["tools"] == tools
+            assert kwargs["tool_choice"] == tool_choice
+
+    @pytest.mark.asyncio
+    async def test_mllm_stream_chat_passes_tools_and_tool_choice(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        chunk1 = MagicMock()
+        chunk1.text = "<tool_call>"
+        chunk1.finish_reason = None
+        chunk1.prompt_tokens = 8
+        chunk2 = MagicMock()
+        chunk2.text = "</tool_call>"
+        chunk2.finish_reason = "stop"
+        chunk2.prompt_tokens = 8
+
+        model = MagicMock()
+        model.stream_chat = MagicMock(return_value=iter([chunk1, chunk2]))
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "description": "Search files",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        tool_choice = "required"
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=True):
+            engine = SimpleEngine("test-mllm")
+            engine._model = model
+            engine._loaded = True
+
+            outputs = []
+            async for output in engine.stream_chat(
+                messages=[{"role": "user", "content": "Find X"}],
+                tools=tools,
+                tool_choice=tool_choice,
+                max_tokens=16,
+            ):
+                outputs.append(output)
+
+            assert outputs
+            _, kwargs = model.stream_chat.call_args
+            assert kwargs["tools"] == tools
+            assert kwargs["tool_choice"] == tool_choice
+
+    @pytest.mark.asyncio
+    async def test_llm_chat_does_not_leak_tool_choice_to_model_call(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        model = MagicMock()
+        model.tokenizer = MagicMock()
+        model.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        model.chat = MagicMock(
+            return_value=MagicMock(
+                text="ok",
+                tokens=[1, 2],
+                finish_reason="stop",
+            )
+        )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "description": "Search files",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-llm")
+            engine._model = model
+            engine._loaded = True
+
+            await engine.chat(
+                messages=[{"role": "user", "content": "Find X"}],
+                tools=tools,
+                tool_choice="required",
+                max_tokens=16,
+            )
+
+            _, chat_kwargs = model.chat.call_args
+            assert "tool_choice" not in chat_kwargs

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -266,6 +266,7 @@ class SimpleEngine(BaseEngine):
 
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
+        template_tool_choice = kwargs.pop("tool_choice", None)
 
         async with self._generation_lock:
             if self._is_mllm:
@@ -276,6 +277,8 @@ class SimpleEngine(BaseEngine):
                     messages=messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
+                    tools=template_tools,
+                    tool_choice=template_tool_choice,
                     **kwargs,
                 )
                 text = clean_output_text(output.text)
@@ -337,6 +340,7 @@ class SimpleEngine(BaseEngine):
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
+        template_tool_choice = kwargs.pop("tool_choice", None)
 
         # Build prompt using tokenizer
         if self._is_mllm:
@@ -351,6 +355,8 @@ class SimpleEngine(BaseEngine):
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
+                        tools=template_tools,
+                        tool_choice=template_tool_choice,
                         **kwargs,
                     )
                 )
@@ -390,12 +396,14 @@ class SimpleEngine(BaseEngine):
             }
             if template_tools:
                 template_kwargs["tools"] = template_tools
+            if template_tool_choice is not None:
+                template_kwargs["tool_choice"] = template_tool_choice
 
             try:
                 prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
             except TypeError:
                 # Some templates don't support all kwargs
-                for key in ["tools", "enable_thinking"]:
+                for key in ["tools", "tool_choice", "enable_thinking"]:
                     if key in template_kwargs:
                         del template_kwargs[key]
                 prompt = tokenizer.apply_chat_template(messages, **template_kwargs)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1362,6 +1362,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Add tools if provided
     if request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
+        if request.tool_choice is not None:
+            chat_kwargs["tool_choice"] = request.tool_choice
 
     if request.stream:
         return StreamingResponse(
@@ -1538,6 +1540,8 @@ async def create_anthropic_message(
 
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        if openai_request.tool_choice is not None:
+            chat_kwargs["tool_choice"] = openai_request.tool_choice
 
     start_time = time.perf_counter()
     timeout = _default_timeout
@@ -1695,6 +1699,8 @@ async def _stream_anthropic_messages(
 
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+        if openai_request.tool_choice is not None:
+            chat_kwargs["tool_choice"] = openai_request.tool_choice
 
     # Emit message_start
     message_start = {


### PR DESCRIPTION
## VLM/MLLM Tool Calling Support

### Problem
Multimodal models served with `--mllm` accepted `tools` in API payloads,
but tool metadata was not consistently passed into MLLM chat-template paths.
This left many VLM requests without structured `tool_calls` output even when
parser flags were enabled.

### Fix
Pass `tools` and `tool_choice` through MLLM chat/template paths in both engines:

- `SimpleEngine`
  - forwards `tools` + `tool_choice` in MLLM `chat` and `stream_chat`
  - keeps LLM behavior safe by not leaking unsupported kwargs to model calls
- `BatchedEngine`
  - `_apply_chat_template` now accepts `tool_choice`
  - propagates `tool_choice` through prompt/prefix-boundary flows
- `MLXMultimodalLM`
  - includes `tools` + `tool_choice` in chat-template invocation with safe fallback
- `server.py`
  - propagates `tool_choice` when `tools` are supplied

### Validation
- Added regression tests for tool/tool_choice passthrough and LLM guard behavior
  in `tests/test_simple_engine.py`.
- Added docs updates for MLLM/VLM tool-calling usage.

### Usage
```bash
vllm-mlx serve <vlm-model-id> \
  --mllm \
  --enable-auto-tool-choice \
  --tool-call-parser auto
```

### Notes
`tool_choice` support is best-effort: templates that don't support `tool_choice`
fall back cleanly without raising template errors.
