### PR TITLE
fix: forward tool definitions through MLLM code path

### DIFF
--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -276,6 +276,7 @@ class SimpleEngine(BaseEngine):
                     messages=messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
+                    tools=template_tools,
                     **kwargs,
                 )
                 text = clean_output_text(output.text)
@@ -351,6 +352,7 @@ class SimpleEngine(BaseEngine):
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
+                        tools=template_tools,
                         **kwargs,
                     )
                 )

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1152,12 +1152,19 @@ class MLXMultimodalLM:
             logger.info(
                 f"  Chat msg {i}: role={cm['role']}, content={content_preview}..."
             )
+
+        # Forward tools to chat template if provided (fix: MLLM path was dropping tools)
+        template_extra_kwargs = {}
+        if kwargs.get("tools"):
+            template_extra_kwargs["tools"] = kwargs["tools"]
+
         try:
             # Use get_chat_template directly since messages are already properly formatted
             formatted_prompt = get_chat_template(
                 self.processor,
                 chat_messages,
                 add_generation_prompt=True,
+                **template_extra_kwargs,
             )
         except Exception as e:
             logger.warning(
@@ -1504,12 +1511,18 @@ class MLXMultimodalLM:
             all_images.extend(frames)
 
         # Apply chat template directly - messages are already properly structured
+        # Forward tools to chat template if provided (fix: MLLM path was dropping tools)
+        template_extra_kwargs = {}
+        if kwargs.get("tools"):
+            template_extra_kwargs["tools"] = kwargs["tools"]
+
         try:
             # Use get_chat_template directly since messages are already properly formatted
             formatted_prompt = get_chat_template(
                 self.processor,
                 chat_messages,
                 add_generation_prompt=True,
+                **template_extra_kwargs,
             )
         except Exception as e:
             logger.warning(

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1153,10 +1153,11 @@ class MLXMultimodalLM:
                 f"  Chat msg {i}: role={cm['role']}, content={content_preview}..."
             )
 
-        # Forward tools to chat template if provided (fix: MLLM path was dropping tools)
+        # Pop tools so they don't leak into mlx_vlm.generate()/stream_generate()
+        tools = kwargs.pop("tools", None)
         template_extra_kwargs = {}
-        if kwargs.get("tools"):
-            template_extra_kwargs["tools"] = kwargs["tools"]
+        if tools:
+            template_extra_kwargs["tools"] = tools
 
         try:
             # Use get_chat_template directly since messages are already properly formatted
@@ -1511,10 +1512,11 @@ class MLXMultimodalLM:
             all_images.extend(frames)
 
         # Apply chat template directly - messages are already properly structured
-        # Forward tools to chat template if provided (fix: MLLM path was dropping tools)
+        # Pop tools so they don't leak into mlx_vlm.generate()/stream_generate()
+        tools = kwargs.pop("tools", None)
         template_extra_kwargs = {}
-        if kwargs.get("tools"):
-            template_extra_kwargs["tools"] = kwargs["tools"]
+        if tools:
+            template_extra_kwargs["tools"] = tools
 
         try:
             # Use get_chat_template directly since messages are already properly formatted


### PR DESCRIPTION
## Summary

The MLLM (multimodal) code path silently drops tool definitions, causing tool calling to be completely non-functional for models that require `--mllm` (e.g., Qwen 3.5 122B-A10B).

**Root cause:** Four locations in the MLLM path did not forward `tools` to the chat template, while the LLM (text-only) path handled them correctly.

### Changes

**`vllm_mlx/engine/simple.py`** (2 fixes):
- `chat()`: Pass `tools=template_tools` to `self._model.chat()` in the MLLM branch (matching the LLM branch on line 297)
- `stream_chat()`: Same fix for `self._model.stream_chat()` 

**`vllm_mlx/models/mllm.py`** (2 fixes):
- `chat()`: Forward `tools` from `kwargs` to `get_chat_template()` via `**template_extra_kwargs`
- `stream_chat()`: Same fix

### Evidence

Before fix: `prompt_tokens: 18` (tools not in prompt), `tool_calls: null`
After fix: `prompt_tokens: 283` (tools injected), `tool_calls: [{"function": {"name": "get_weather", "arguments": ...}}]`

### Reproduction

```bash
vllm-mlx serve <model> --mllm --tool-call-parser hermes --enable-auto-tool-choice

# This returns tool_calls: null before fix, correct tool call after
curl -X POST http://127.0.0.1:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"...","messages":[{"role":"user","content":"What is the weather?"}],
       "tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}],
       "tool_choice":"required"}'
```

Tested with Qwen 3.5 122B-A10B (5-bit MLX) on Mac Studio M2 Ultra.