### PR TITLE
Add Qwen3.5 model support (text-only) and fix reasoning+tool streaming

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1934,77 +1934,16 @@ async def stream_chat_completion(
                 # Skip this chunk (e.g., <think> token itself)
                 continue
 
-            content_delta = delta_msg.content
-            reasoning_delta = delta_msg.reasoning
-
-            # Pipe content through tool parser when both are enabled
-            if tool_parser and content_delta:
-                if not tool_markup_possible and "<" not in content_delta:
-                    tool_accumulated_text += content_delta
-                else:
-                    if not tool_markup_possible:
-                        tool_markup_possible = True
-                    tool_previous = tool_accumulated_text
-                    tool_accumulated_text += content_delta
-                    tool_result = tool_parser.extract_tool_calls_streaming(
-                        tool_previous, tool_accumulated_text, content_delta
-                    )
-
-                    if tool_result is None:
-                        # Inside tool markup — suppress content but emit reasoning
-                        if reasoning_delta:
-                            chunk = ChatCompletionChunk(
-                                id=response_id,
-                                model=request.model,
-                                choices=[
-                                    ChatCompletionChunkChoice(
-                                        delta=ChatCompletionChunkDelta(
-                                            reasoning=reasoning_delta,
-                                        ),
-                                        finish_reason=None,
-                                    )
-                                ],
-                            )
-                            yield f"data: {chunk.model_dump_json()}\n\n"
-                        continue
-
-                    if "tool_calls" in tool_result:
-                        tool_calls_detected = True
-                        chunk = ChatCompletionChunk(
-                            id=response_id,
-                            model=request.model,
-                            choices=[
-                                ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        reasoning=reasoning_delta,
-                                        tool_calls=tool_result["tool_calls"],
-                                    ),
-                                    finish_reason=(
-                                        "tool_calls" if output.finished else None
-                                    ),
-                                )
-                            ],
-                            usage=get_usage(output) if output.finished else None,
-                        )
-                        yield f"data: {chunk.model_dump_json()}\n\n"
-                        continue
-
-                    content_delta = tool_result.get("content", "")
-
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
-                            content=content_delta if content_delta else None,
-                            reasoning=reasoning_delta,
+                            content=delta_msg.content,
+                            reasoning=delta_msg.reasoning,
                         ),
-                        finish_reason=(
-                            "tool_calls"
-                            if (output.finished and tool_calls_detected)
-                            else (output.finish_reason if output.finished else None)
-                        ),
+                        finish_reason=output.finish_reason if output.finished else None,
                     )
                 ],
                 usage=get_usage(output) if output.finished else None,

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -71,8 +71,6 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
 def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     """Load model with strict=False to discard extra weights (e.g., vision tower)."""
-    from pathlib import Path
-
     from mlx_lm.utils import load_model, load_tokenizer
 
     local_path = Path(model_name)
@@ -83,8 +81,12 @@ def _load_strict_false(model_name: str, tokenizer_config: dict = None):
 
         model_path = Path(snapshot_download(model_name))
 
-    model, _ = load_model(model_path, strict=False)
-    tokenizer = load_tokenizer(model_path, tokenizer_config or {})
+    model, config = load_model(model_path, strict=False)
+    tokenizer = load_tokenizer(
+        model_path,
+        tokenizer_config or {},
+        eos_token_ids=config.get("eos_token_id", None),
+    )
     return model, tokenizer
 
 


### PR DESCRIPTION
## Summary

- **Qwen3.5 text-only loading**: Adds a `strict=False` fallback in the tokenizer loader for models whose weight files contain extra parameters (e.g., vision tower weights). When mlx-lm rejects a model with "parameters not in model", the loader retries with `strict=False` to discard the unrecognized weights and load the model as text-only.
- **Fix streaming tool calls with reasoning parser**: The streaming code path had mutually exclusive branches for reasoning parsing and tool call parsing. When both `--reasoning-parser` and `--tool-call-parser` were enabled simultaneously, tool calls were never parsed during streaming — the raw XML markup (e.g., `<tool_call><function=bash>...</function></tool_call>`) leaked through as content. Now the reasoning parser's content output is piped through the tool parser before being emitted.
- **Dynamic memory pressure threshold**: The emergency memory pressure threshold was hardcoded at 200GB, which caused constant forced cache clears on high-memory systems running large models. It now dynamically queries Metal's `max_recommended_working_set_size` and sets the threshold to 85% of that value, scaling correctly with system RAM.

## Why text-only for Qwen3.5?

Qwen3.5 models (e.g., `Qwen3.5-397B-A17B`) are vision-text models that include a vision tower (SigLIP encoder). Loading them through the MLLM path (mlx-vlm) fails because:

1. mlx-vlm does not support the `qwen3_5_moe` architecture yet
2. Even if it did, the MoE layers produce `ArraysCache` instead of `KVCache`, which is incompatible with the MLLM batch generator's continuous batching (slicing, merging, and cache management all assume `KVCache`)

Loading via mlx-lm with `strict=False` discards the ~333 vision tower parameters and serves the model as text-only. This works well with continuous batching, prefix caching, reasoning, and tool calling.

## Files changed

- `vllm_mlx/utils/tokenizer.py` — Add `_load_strict_false()` and fallback for "parameters not in model" error
- `vllm_mlx/server.py` — Integrate tool call parsing into the reasoning parser streaming branch
- `vllm_mlx/engine_core.py` — Dynamic memory pressure threshold based on Metal device info

## Testing

Manually tested with:

```bash
vllm-mlx serve mlx-community/Qwen3.5-397B-A17B-4bit \
    --host 0.0.0.0 \
    --port 8081 \
    --max-num-seqs 5 \
    --cache-memory-percent 0.2 \
    --enable-prefix-cache \
    --reasoning-parser qwen3 \
    --enable-auto-tool-choice \
    --tool-call-parser qwen3_coder \
    --continuous-batching \
    --max-tokens 262144 \
    --served-model-name Qwen3.5-397B-A17B
```

Verified:
- Model loads successfully with vision tower weights discarded
- Reasoning (`<think>` blocks) extracted correctly
- Tool calls parsed correctly during streaming (multi-turn tool use works)
- No memory pressure warnings on 512GB unified memory system
- Prefix cache functional with continuous batching