### PR TITLE
fix: pass tools to chat template in MLLM path

### DIFF
--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -271,12 +271,16 @@ class SimpleEngine(BaseEngine):
             if self._is_mllm:
                 # For MLLM, use the chat method which handles images/videos
                 # Run in thread pool to allow asyncio timeout to work
+                # Pass tools for function calling support (same as LLM path)
+                mllm_kwargs = dict(kwargs)
+                if template_tools:
+                    mllm_kwargs["tools"] = template_tools
                 output = await asyncio.to_thread(
                     self._model.chat,
                     messages=messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
-                    **kwargs,
+                    **mllm_kwargs,
                 )
                 text = clean_output_text(output.text)
                 return GenerationOutput(
@@ -344,6 +348,11 @@ class SimpleEngine(BaseEngine):
             accumulated_text = ""
             token_count = 0
 
+            # Pass tools for function calling support (same as LLM path)
+            mllm_stream_kwargs = dict(kwargs)
+            if template_tools:
+                mllm_stream_kwargs["tools"] = template_tools
+
             # Run stream_chat in thread pool since it's synchronous
             def run_stream():
                 return list(
@@ -351,7 +360,7 @@ class SimpleEngine(BaseEngine):
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
-                        **kwargs,
+                        **mllm_stream_kwargs,
                     )
                 )
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1055,8 +1055,6 @@ class MLXMultimodalLM:
         videos = []
         chat_messages = []  # List of properly formatted messages for chat template
 
-        logger.info(f"MLLM.chat() called with {len(messages)} messages")
-
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content", "")
@@ -1147,17 +1145,18 @@ class MLXMultimodalLM:
         logger.info(
             f"Applying chat template with {len(chat_messages)} messages, {len(all_images)} images"
         )
-        for i, cm in enumerate(chat_messages):
-            content_preview = str(cm.get("content", ""))[:80]
-            logger.info(
-                f"  Chat msg {i}: role={cm['role']}, content={content_preview}..."
-            )
         try:
             # Use get_chat_template directly since messages are already properly formatted
+            # Pass tools through if provided (for function calling support)
+            template_kwargs = {}
+            tools = kwargs.get("tools")
+            if tools:
+                template_kwargs["tools"] = tools
             formatted_prompt = get_chat_template(
                 self.processor,
                 chat_messages,
                 add_generation_prompt=True,
+                **template_kwargs,
             )
         except Exception as e:
             logger.warning(
@@ -1506,10 +1505,16 @@ class MLXMultimodalLM:
         # Apply chat template directly - messages are already properly structured
         try:
             # Use get_chat_template directly since messages are already properly formatted
+            # Pass tools through if provided (for function calling support)
+            template_kwargs = {}
+            tools = kwargs.get("tools")
+            if tools:
+                template_kwargs["tools"] = tools
             formatted_prompt = get_chat_template(
                 self.processor,
                 chat_messages,
                 add_generation_prompt=True,
+                **template_kwargs,
             )
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
## Summary

- **Bug**: Models loaded with `--mllm` (e.g., Qwen3.5 which requires it due to `vision_tower` weights) silently dropped tool definitions from the prompt, making `--enable-auto-tool-choice --tool-call-parser` ineffective for MLLM models
- **Root cause**: `SimpleEngine.chat()`/`stream_chat()` MLLM branches did not pass `template_tools` to the model (only the LLM branch did), and `MLXMultimodalLM.chat()`/`stream_chat()` did not extract `tools` from `**kwargs` to forward to `get_chat_template()`
- **Fix**: Pass `template_tools` in the MLLM branch of `SimpleEngine`, and extract/forward `tools` in `MLXMultimodalLM`'s chat template calls

## Files Changed

- `vllm_mlx/engine/simple.py` — Pass `template_tools` to MLLM model in `chat()` and `stream_chat()`
- `vllm_mlx/models/mllm.py` — Extract `tools` from `**kwargs` and pass to `get_chat_template()` in `chat()` and `stream_chat()`

## Test plan

- [x] Tested with `Qwen3.5-4B-8bit` — single tool call works, multi-tool parallel calls work
- [x] Tested with `Qwen3.5-9B-MLX-8bit` — single and multi-tool calls work
- [x] Verified `prompt_tokens` increases when tools are provided (284 with tools vs 29 without)
- [x] Verified `finish_reason: "tool_calls"` and proper OpenAI wire format output
- [x] Confirmed `qwen3_coder` parser correctly translates `<function=name><parameter=key>value</parameter></function>` to OpenAI `tool_calls` JSON

## Reproduction

```bash
# Before fix: tools silently dropped, model responds with text
vllm-mlx serve mlx-community/Qwen3.5-4B-8bit --mllm \
  --enable-auto-tool-choice --tool-call-parser qwen3_coder

# prompt_tokens: 29, tool_calls: null

# After fix: tools properly injected, model makes tool calls
# Same command, same model — now works correctly
# prompt_tokens: 284, tool_calls: [{...}], finish_reason: "tool_calls"
```

