### PR TITLE
fix: integrate tool call parsing with reasoning parser in streaming mode

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1934,6 +1934,59 @@ async def stream_chat_completion(
                 # Skip this chunk (e.g., <think> token itself)
                 continue
 
+            # Check if tool call markup appears in reasoning or content.
+            # Some models (e.g. Qwen3-Coder) emit <tool_call> directly
+            # inside reasoning without a </think> transition, so we need to
+            # intercept tool call tokens regardless of which field they land in.
+            effective_text = delta_msg.content or delta_msg.reasoning or ""
+            if tool_parser and effective_text:
+                if not tool_markup_possible and "<" not in effective_text:
+                    tool_accumulated_text += effective_text
+                    # No tool markup yet — emit the delta as-is
+                else:
+                    if not tool_markup_possible:
+                        tool_markup_possible = True
+                    tool_previous = tool_accumulated_text
+                    tool_accumulated_text += effective_text
+                    tool_result = tool_parser.extract_tool_calls_streaming(
+                        tool_previous, tool_accumulated_text, effective_text,
+                    )
+
+                    if tool_result is None:
+                        # Inside tool markup — suppress output entirely
+                        continue
+
+                    if "tool_calls" in tool_result:
+                        # Emit structured tool calls instead of reasoning/content
+                        tool_calls_detected = True
+                        chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=request.model,
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(
+                                        tool_calls=tool_result["tool_calls"]
+                                    ),
+                                    finish_reason=(
+                                        "tool_calls" if output.finished else None
+                                    ),
+                                )
+                            ],
+                            usage=get_usage(output) if output.finished else None,
+                        )
+                        yield f"data: {chunk.model_dump_json()}\n\n"
+                        continue
+
+                    # Tool parser returned content (not a tool call) — use it
+                    tool_content = tool_result.get("content", "")
+                    if tool_content:
+                        if delta_msg.reasoning:
+                            delta_msg.reasoning = tool_content
+                            delta_msg.content = None
+                        else:
+                            delta_msg.content = tool_content
+                            delta_msg.reasoning = None
+
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,


### PR DESCRIPTION
## Problem

When both `--reasoning-parser` and `--tool-call-parser` are enabled, the reasoning parser branch in `stream_chat_completion` consumes all streaming tokens without routing them through the tool call parser. This causes `<tool_call>` XML markup to be emitted as raw text in the `reasoning` or `content` fields instead of being parsed into structured `tool_calls` in the response.

This affects models like **Qwen3-Coder** that emit tool calls directly inside reasoning blocks without a clean `</think>` transition.

## Fix

The fix integrates tool call detection into the reasoning parser's streaming branch:

1. After the reasoning parser processes each delta, the effective text (whether `content` or `reasoning`) is also fed through the tool call parser
2. If tool markup is detected, the output is suppressed until the full tool call is parsed
3. When a complete tool call is found, it's emitted as a structured `tool_calls` chunk with `finish_reason: "tool_calls"`
4. Non-tool-call content continues to flow through the reasoning parser's normal path

## Testing

Tested with:
- **Model**: Qwen3-Coder-Next-8bit
- **Flags**: `--reasoning-parser qwen3 --tool-call-parser qwen3_coder --continuous-batching`
- **Load**: 4 concurrent agents (CoPaw, OpenCode) over ~200 requests
- **Result**: All requests returned structured tool calls correctly; zero errors