### PR TITLE
feat: native Qwen3-VL video support in MLLM mode

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,17 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for video support in MLLM chat/stream_chat."""
 
-import pytest
-
 from vllm_mlx.models.mllm import (
-    MLXMultimodalLM,
-    is_base64_video,
-    process_video_input,
-    smart_nframes,
     FRAME_FACTOR,
     MIN_FRAMES,
-    MAX_FRAMES,
-    DEFAULT_FPS,
+    MLXMultimodalLM,
+    is_base64_video,
+    smart_nframes,
 )
 
 
@@ -39,7 +34,9 @@ class TestSmartNframes:
     def test_result_always_even(self):
         for total in [5, 7, 11, 13, 100, 999]:
             result = smart_nframes(total, 30.0)
-            assert result % FRAME_FACTOR == 0, f"Odd frame count {result} for total={total}"
+            assert (
+                result % FRAME_FACTOR == 0
+            ), f"Odd frame count {result} for total={total}"
 
 
 class TestVideoUrlParsing:
@@ -75,7 +72,10 @@ class TestVideoUrlParsing:
             {
                 "role": "user",
                 "content": [
-                    {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/video.mp4"},
+                    },
                     {"type": "text", "text": "Describe this video"},
                 ],
             }
@@ -127,8 +127,14 @@ class TestVideoUrlParsing:
             {
                 "role": "user",
                 "content": [
-                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
-                    {"type": "video_url", "video_url": {"url": "https://example.com/vid.mp4"}},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/img.jpg"},
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/vid.mp4"},
+                    },
                     {"type": "text", "text": "Compare"},
                 ],
             }
@@ -155,8 +161,8 @@ class TestTranslateMessages:
         assert result[0]["content"] == "Hello"
 
     def test_video_url_translated(self):
-        import tempfile
         import os
+        import tempfile
 
         # Create a temp file to act as a "video"
         with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -20,9 +20,9 @@ import math
 import os
 import tempfile
 import threading
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator
 from urllib.parse import urlparse
 
 import numpy as np
@@ -729,9 +729,9 @@ class MLXMultimodalLM:
             self.config = load_config(self.model_name)
 
             self._loaded = True
-            self._video_native = hasattr(self.model.config, "video_token_id") or hasattr(
-                self.model.config, "video_token_index"
-            )
+            self._video_native = hasattr(
+                self.model.config, "video_token_id"
+            ) or hasattr(self.model.config, "video_token_index")
             logger.info(f"MLLM loaded successfully: {self.model_name}")
             if self._video_native:
                 logger.info("Native video pipeline enabled (temporal 3D conv + M-RoPE)")
@@ -919,7 +919,11 @@ class MLXMultimodalLM:
 
                 elif item_type == "image_url":
                     img_url = item.get("image_url", {})
-                    url = img_url.get("url", img_url) if isinstance(img_url, dict) else img_url
+                    url = (
+                        img_url.get("url", img_url)
+                        if isinstance(img_url, dict)
+                        else img_url
+                    )
                     # Resolve to local path for process_vision_info
                     local_path = process_image_input(url)
                     new_content.append({"type": "image", "image": local_path})
@@ -944,12 +948,14 @@ class MLXMultimodalLM:
 
                     # Resolve to local path
                     video_path = process_video_input(video_source)
-                    new_content.append({
-                        "type": "video",
-                        "video": video_path,
-                        "fps": video_fps,
-                        "max_frames": video_max_frames,
-                    })
+                    new_content.append(
+                        {
+                            "type": "video",
+                            "video": video_path,
+                            "fps": video_fps,
+                            "max_frames": video_max_frames,
+                        }
+                    )
 
                 else:
                     new_content.append(item)
@@ -1403,8 +1409,9 @@ class MLXMultimodalLM:
 
         # Prefix caching with vision embedding support
         # Following LMCache approach: cache vision embeddings to skip encoder on hit
-        from mlx_vlm.models import cache as vlm_cache
         import time
+
+        from mlx_vlm.models import cache as vlm_cache
 
         use_cache = kwargs.pop("use_cache", True)
         cache_entry = None
@@ -1523,6 +1530,7 @@ class MLXMultimodalLM:
         ):
             try:
                 import copy
+
                 import mlx.core as mx
 
                 # Get prompt token count (before generation)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -734,8 +734,7 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
 
         elapsed = time.perf_counter() - start_time
         logger.info(
-            f"Embeddings: {len(texts)} inputs, {prompt_tokens} tokens "
-            f"in {elapsed:.2f}s"
+            f"Embeddings: {len(texts)} inputs, {prompt_tokens} tokens in {elapsed:.2f}s"
         )
 
         # Build OpenAI-compatible response with ordered indices
@@ -756,8 +755,7 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
         raise HTTPException(
             status_code=503,
             detail=(
-                "mlx-embeddings not installed. "
-                "Install with: pip install mlx-embeddings"
+                "mlx-embeddings not installed. Install with: pip install mlx-embeddings"
             ),
         )
     except HTTPException:
@@ -1334,11 +1332,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         )
 
     has_media = bool(images or videos)
-    if engine.is_mllm:
-        # MLLM extracts media from messages internally, but request-level
-        # video params still need to reach chat() via chat_kwargs
-        if request.video_fps or request.video_max_frames:
-            has_media = True
+    if engine.is_mllm and (request.video_fps or request.video_max_frames):
+        # Video params need to reach chat() via chat_kwargs
+        has_media = True
 
     # Handle response_format - inject system prompt if needed
     response_format = request.response_format


### PR DESCRIPTION
## Summary

- Fix `video_url` content type being silently ignored in MLLM chat/stream_chat
- Fix video frame tokens not counted in prompt token reporting  
- Fix `has_media` always False for MLLM mode in server.py
- Add native video pipeline for Qwen3-VL family models (temporal 3D conv + M-RoPE + timestamp interleaving) using mlx-vlm's existing `process_vision_info` infrastructure

### Benchmarks (M-series, ZwZ-8B via mlx-vlm)

| Setting | Frames | video_grid_thw | Prompt tokens | Prefill | Gen speed |
|---------|--------|----------------|---------------|---------|-----------|
| 1 fps (4f) | 4 | [2, 36, 64] | 1,189 | ~3s | 23.9 tok/s |
| 2 fps (4f) | 4 | [2, 36, 64] | 1,200 | ~3s | 23.9 tok/s |
| 60 fps (354f) | 354 | [5, 36, 64] | 2,935 | ~12s | 5.7 tok/s |

Old approach (frames-as-images) produced ~32,666 prompt tokens for the same video.