### PR TITLE
fix: check trim method existence before calling

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -769,7 +769,7 @@ def _install_mtp(
                         # (both P and D) for all cache types, then
                         # re-advance with just P for a consistent state.
                         for c in prompt_cache:
-                            if hasattr(c, "is_trimmable") and c.is_trimmable():
+                            if hasattr(c, "is_trimmable") and c.is_trimmable() and hasattr(c, "trim"):
                                 c.trim(2)
                         for _ci, _snap in _rnn_snapshots.items():
                             prompt_cache[_ci].state = _snap
@@ -799,7 +799,7 @@ def _install_mtp(
                     else:
                         # Pure attention model: simple trim(1) is enough.
                         for c in prompt_cache:
-                            if hasattr(c, "is_trimmable") and c.is_trimmable():
+                            if hasattr(c, "is_trimmable") and c.is_trimmable() and hasattr(c, "trim"):
                                 c.trim(1)
                         if verify_hidden is not None:
                             _skip_state[0] = {


### PR DESCRIPTION
Fixes AttributeError when ArraysCache.is_trimmable() returns True but the trim() method doesn't exist.

## Problem
- Issue #145: ArraysCache 'trim' AttributeError on perfect cache hits
- The code checks `is_trimmable()` but doesn't verify that `trim()` exists before calling it

## Solution
Added `hasattr(c, "trim")` check before calling `c.trim()` in scheduler.py:
- Line 772: added check before `c.trim(2)`
- Line 802: added check before `c.trim(1)`

This prevents the AttributeError when dealing with cache objects that have `is_trimmable()` but not `trim()`. 

Closes #145