### PR TITLE
Fix chunked prefill crash with mlx-lm >= 0.31.0

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -392,6 +392,7 @@ def _install_chunked_prefill(
                         caches,
                         samplers,
                         logits_processors,
+                        *_extra,
                     ) = zip(*batch_prompts)
                     lengths = [len(p) for p in inputs_raw]
                     max_length = max(lengths)


### PR DESCRIPTION
## Summary

Fixes #155 — chunked prefill crashes with `mlx-lm >= 0.31.0` because `zip(*batch_prompts)` unpacking expects 6 tuple elements but now receives 7.

## Root Cause

mlx-lm PR [ml-explore/mlx-lm#911](https://github.com/ml-explore/mlx-lm/pull/911) ("Better caching in the server") added a `prompt_checkpoints` field to the prompt tuples returned by `BatchGenerator.unprocessed_prompts`. The hardcoded 6-variable unpacking in `scheduler.py:_chunked_next()` then fails with a `ValueError`.

## Fix

Add `*_extra` catch-all to the tuple unpacking:

```python
(
    uids,
    inputs_raw,
    max_tokens_list,
    caches,
    samplers,
    logits_processors,
    *_extra,                 # ← new: absorb extra fields from mlx-lm
) = zip(*batch_prompts)
```

This is:
- **Forward-compatible** — handles any future fields mlx-lm might add
- **Backward-compatible** — older mlx-lm versions that return 6 elements work fine (`*_extra` is empty)
- **Minimal** — 1 line added, no behavioral changes

## Testing

Tested on two Mac Studio Ultras (M2 Ultra, 192GB) with:
- `vllm-mlx==0.2.6`, `mlx-lm==0.31.1`, `mlx==0.31.1`
- Models: Qwen3.5-35B-A3B-8bit, Qwen3-14B
- `--continuous-batching` enabled
- 30 concurrent heavy requests (2048 max_tokens each) — all succeeded
- Aggregate throughput: ~416 tok/s across concurrent requests
- Stable over 48+ hours of continuous operation