### PR TITLE
fix(mllm_scheduler): add adaptive periodic cache clearing

### DIFF
--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -205,6 +205,10 @@ class MLLMScheduler:
         self._running = False
         self._processing_task: Optional[asyncio.Task] = None
 
+        # Memory management: periodic mx.clear_cache() to free Metal buffer pool
+        self._step_count = 0
+        self._clear_cache_interval = 32
+
         # Statistics
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
@@ -549,6 +553,18 @@ class MLLMScheduler:
                 self._cleanup_finished(finished_ids)
                 if finished_ids:
                     mx.clear_cache()
+
+        # Adaptive periodic cache clear: scale inversely with concurrency
+        # to prevent Metal buffer pool growth during long generations
+        active_seqs = len(self.running)
+        min_interval = max(4, self._clear_cache_interval // 4)
+        effective_interval = max(
+            min_interval, self._clear_cache_interval // max(1, active_seqs // 8)
+        )
+
+        self._step_count += 1
+        if self._step_count % effective_interval == 0:
+            mx.clear_cache()
 
         # Clear finished tracking for next step
         self.finished_req_ids = set()


### PR DESCRIPTION
### Summary
- Add adaptive, step-based `mx.clear_cache()` to `MLLMScheduler.step()`
- Clear periodically even when no requests complete
- Use the same concurrency-scaled interval strategy as the LLM `Scheduler`

### Context

Follow-up to #154 and @waybarrios' [suggestion](https://github.com/waybarrios/vllm-mlx/pull/154#issuecomment-4048492199).

`MLLMScheduler` currently clears the Metal buffer pool only when requests finish. That covers cleanup at completion time, but long multimodal generations can run for many scheduler steps without completions and freed memory can accumulate in the MLX Metal buffer pool.

The LLM `Scheduler` already addresses this with adaptive periodic cache clearing. This change ports that interval logic to the MLLM path: increment a step counter and call `mx.clear_cache()` every N steps, with N decreasing as concurrency rises.

The existing clear on finish behavior remains in place. This change adds a second cleanup path for long running generations that stay active across many scheduler steps.
