### PR TITLE
fix: pass size to ArraysCache in BatchMambaCache for Qwen3.5 hybrid models

### DIFF
--- a/vllm_mlx/utils/mamba_cache.py
+++ b/vllm_mlx/utils/mamba_cache.py
@@ -12,16 +12,11 @@ from typing import List, Optional
 
 import mlx.core as mx
 
-# MambaCache was removed in mlx-lm 0.30.6 - make import conditional
+# MambaCache was removed in mlx-lm 0.30.6, fall back to ArraysCache
 try:
     from mlx_lm.models.cache import MambaCache
-
-    HAS_MAMBA_CACHE = True
 except ImportError:
-    # Fallback for mlx-lm >= 0.30.6 where MambaCache was removed
     from mlx_lm.models.cache import ArraysCache as MambaCache
-
-    HAS_MAMBA_CACHE = False
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Fixes `--continuous-batching` mode crashing with Qwen3.5 models (hybrid Attention + Mamba/SSM architecture).

**Root cause:** `BatchMambaCache.__init__()` conditionally skips passing `size` to `ArraysCache.__init__()` when `HAS_MAMBA_CACHE=True`. Since `MambaCache` was removed in mlx-lm >= 0.30.6, the fallback assigns `ArraysCache` as `MambaCache`, but the `HAS_MAMBA_CACHE` flag becomes unreliable. `ArraysCache.__init__()` requires `size` as a positional argument, causing:

```
Engine loop error: ArraysCache.__init__() missing 1 required positional argument: 'size'
```

This error loops infinitely, making the server unresponsive.

The same issue exists in `BatchMambaCache.extract()`, which calls `MambaCache()` without `size`.

## Fix

Always pass `size` to `super().__init__()` — this is safe for both `ArraysCache` (requires it) and legacy `MambaCache` (accepts it). Remove the `HAS_MAMBA_CACHE` conditional branches that are no longer reliable.

## Impact

- **Before:** `--continuous-batching` with Qwen3.5 → infinite error loop, server hangs
- **After:** continuous batching + prefix cache works correctly

Tested on M1 Pro 32GB with `mlx-community/Qwen3.5-4B-4bit`:

| Request | Before (SimpleEngine, no cache) | After (BatchedEngine + prefix cache) |
|---------|--------------------------------|--------------------------------------|
| Cold    | 4.9s                           | 1.17s                                |
| Warm    | 4.9s (no cache)                | 1.08s (cache hit)                    |

## Context

Qwen3.5 uses a hybrid architecture where `model.make_cache()` returns a mix of `KVCache` (attention layers) and `ArraysCache` (Mamba/SSM layers). This is a known challenge:

- ml-explore/mlx-lm#980 — prefix cache fails for hybrid models
- QwenLM/Qwen3.5#37 — ArraysCache vs KVCache in hybrid architecture
- Related to #159 (continuous batching incompatible with ArraysCache)

## Test plan

- [x] `BatchGenerator` with Qwen3.5-4B-4bit no longer crashes
- [x] `--continuous-batching --enable-prefix-cache` serves requests correctly
- [x] Prefix cache provides ~2x speedup on repeated prompts
- [x] Tool calling (qwen3_coder parser) works with batched engine