### PR TITLE
fix: enable tool call parsing in streaming when reasoning parser is active

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1934,16 +1934,82 @@ async def stream_chat_completion(
                 # Skip this chunk (e.g., <think> token itself)
                 continue
 
+            # Phase 2: Tool call parsing on content from reasoning parser.
+            # Without this, tool XML passes through as plain content text
+            # when both --reasoning-parser and --tool-call-parser are set.
+            content = delta_msg.content
+            reasoning_part = delta_msg.reasoning
+
+            if tool_parser and content:
+                # Fast path: skip full parsing until '<' is seen
+                if not tool_markup_possible and "<" not in content:
+                    tool_accumulated_text += content
+                    # Fall through to normal chunk emission
+                else:
+                    if not tool_markup_possible:
+                        tool_markup_possible = True
+                    tool_previous = tool_accumulated_text
+                    tool_accumulated_text += content
+                    tool_result = tool_parser.extract_tool_calls_streaming(
+                        tool_previous, tool_accumulated_text, content
+                    )
+
+                    if tool_result is None:
+                        # Inside tool markup — suppress content,
+                        # emit reasoning only
+                        if reasoning_part:
+                            chunk = ChatCompletionChunk(
+                                id=response_id,
+                                model=request.model,
+                                choices=[
+                                    ChatCompletionChunkChoice(
+                                        delta=ChatCompletionChunkDelta(
+                                            reasoning=reasoning_part,
+                                        ),
+                                        finish_reason=None,
+                                    )
+                                ],
+                            )
+                            yield f"data: {chunk.model_dump_json()}\n\n"
+                        continue
+
+                    if "tool_calls" in tool_result:
+                        # Emit structured tool calls with reasoning
+                        tool_calls_detected = True
+                        chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=request.model,
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(
+                                        reasoning=reasoning_part,
+                                        tool_calls=tool_result["tool_calls"],
+                                    ),
+                                    finish_reason="tool_calls" if output.finished else None,
+                                )
+                            ],
+                            usage=get_usage(output) if output.finished else None,
+                        )
+                        yield f"data: {chunk.model_dump_json()}\n\n"
+                        continue
+
+                    # Normal content from tool parser
+                    content = tool_result.get("content", "")
+
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,
                 choices=[
                     ChatCompletionChunkChoice(
                         delta=ChatCompletionChunkDelta(
-                            content=delta_msg.content,
-                            reasoning=delta_msg.reasoning,
+                            content=content if content else None,
+                            reasoning=reasoning_part,
                         ),
-                        finish_reason=output.finish_reason if output.finished else None,
+                        finish_reason=(
+                            "tool_calls"
+                            if (output.finished and tool_calls_detected)
+                            else (output.finish_reason if output.finished else None)
+                        ),
                     )
                 ],
                 usage=get_usage(output) if output.finished else None,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1985,7 +1985,9 @@ async def stream_chat_completion(
                                         reasoning=reasoning_part,
                                         tool_calls=tool_result["tool_calls"],
                                     ),
-                                    finish_reason="tool_calls" if output.finished else None,
+                                    finish_reason=(
+                                        "tool_calls" if output.finished else None
+                                    ),
                                 )
                             ],
                             usage=get_usage(output) if output.finished else None,


### PR DESCRIPTION
## Problem

When both `--reasoning-parser` and `--tool-call-parser` are configured, **streaming tool calls are completely broken**. The reasoning parser branch in `stream_chat_completion()` yields chunks directly without ever passing content through the tool parser.

**Symptoms:**
- `tool_calls` is `null` in every SSE chunk
- Tool call XML (`<tool_call>`, `<function=...>`) appears as raw text in `content`
- `finish_reason` is `"stop"` instead of `"tool_calls"`
- Non-streaming works correctly

**Impact:** Every CLI agent using streaming (Claude Code, OpenCode, Roo, etc.) cannot execute tool calls when a reasoning parser is active. This affects all models that use both reasoning and tool calling: Qwen3, Qwen3.5, DeepSeek-R1 with tools, etc.

## Root Cause

In `stream_chat_completion()`, lines 1926-1952:

```python
if _reasoning_parser and delta_text:
    # ... reasoning extraction ...
    yield chunk  # <-- emits directly, NEVER runs tool parser
else:
    # ... tool parsing only runs HERE ...
```

The reasoning parser branch and tool parser branch are in opposite sides of an `if/else` — **mutually exclusive**. When `_reasoning_parser` is set, the `else` branch (containing all tool parsing logic) is never reached.

## Fix

After reasoning extraction produces `delta_msg.content`, pass that content through the tool parser before emitting the chunk. This creates a sequential pipeline matching upstream vLLM's architecture:

1. **Phase 1:** Reasoning extraction (separate thinking from content)
2. **Phase 2:** Tool call parsing on the content portion
3. **Phase 3:** Emit chunk with reasoning + structured `tool_calls`

Handles three tool parser states:
- **`None`** (inside XML markup): suppress content, still emit reasoning
- **`tool_calls` detected**: emit structured `tool_calls` with reasoning
- **Normal content**: pass through as before

The `else` branch (no reasoning parser) is unchanged.

## Testing

Tested on Apple Silicon (M2 Ultra, 128GB) with:
- **Model:** Qwen3.5-122B-A10B-5bit
- **Parsers:** `--tool-call-parser qwen3_xml --reasoning-parser qwen3`
- **Flags:** `--enable-auto-tool-choice --mllm`

### Before (broken)
```
tool_calls: null (all chunks)
content: "\n\n<tool_call>\n<function=write_file>..."
finish_reason: "stop"
```

### After (fixed)
```
tool_calls: [{"name": "write_file", "arguments": "{\"path\": \"hello.txt\", ...}"}]
content: null (tool XML consumed by parser)
finish_reason: "tool_calls"
```

Non-streaming regression test: still works correctly.

## Related

- Fixes #107
- Related: #93, #118, #127, #148 (all attempt to fix the same issue)
- Upstream vLLM uses the same sequential pipeline approach ([reasoning + tool calls docs](https://docs.vllm.ai/en/latest/examples/online_serving/openai_chat_completion_tool_calls_with_reasoning/))