### PR TITLE
fix: strip tools from template when tool_choice="none"

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1359,8 +1359,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         if request.video_max_frames:
             chat_kwargs["video_max_frames"] = request.video_max_frames
 
-    # Add tools if provided
-    if request.tools:
+    # Add tools if provided — strip when tool_choice="none" to prevent
+    # chat templates from activating tool-call tokens (fixes #162)
+    if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
     if request.stream:
@@ -1536,7 +1537,7 @@ async def create_anthropic_message(
         "top_p": openai_request.top_p,
     }
 
-    if openai_request.tools:
+    if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
     start_time = time.perf_counter()
@@ -1693,7 +1694,7 @@ async def _stream_anthropic_messages(
         "top_p": openai_request.top_p,
     }
 
-    if openai_request.tools:
+    if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
     # Emit message_start


### PR DESCRIPTION
## Summary

Fixes #162 — `tool_choice: "none"` is ignored, model still generates `tool_calls` with empty `{}` arguments.

### Root cause

All three code paths (streaming chat, non-streaming chat, Anthropic streaming) pass `tools` to the chat template regardless of `tool_choice`. Qwen 3.5 and Llama 3.x templates activate tool-call token branches when any `tools` key is present — even an empty list.

### Fix

Add `and request.tool_choice != "none"` to the three `if request.tools:` checks before `convert_tools_for_template()`. When `tool_choice="none"`, tools are not passed to the template, so the model generates normal text content.

This matches upstream vLLM's `--exclude-tools-when-tool-choice-none` flag behavior.

### Test plan

- [x] Verified all 3 code paths are patched (streaming, non-streaming, Anthropic)
- [ ] Manual test with `tool_choice: "none"` and `tools: []` — expect `finish_reason: "stop"` with text content