### PR TITLE
fix: map developer role to system before chat template

### DIFF
--- a/tests/test_normalize_roles.py
+++ b/tests/test_normalize_roles.py
@@ -1,0 +1,74 @@
+"""Tests for message role normalization."""
+
+
+class TestNormalizeMessageRoles:
+    """Test _normalize_message_roles helper."""
+
+    def test_developer_mapped_to_system(self):
+        """developer role should be mapped to system."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        messages = [
+            {"role": "developer", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = _normalize_message_roles(messages)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are a helpful assistant"
+        assert result[1]["role"] == "user"
+
+    def test_standard_roles_unchanged(self):
+        """system, user, assistant, tool roles should pass through unchanged."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "tool", "content": "result"},
+        ]
+        result = _normalize_message_roles(messages)
+        assert [m["role"] for m in result] == ["system", "user", "assistant", "tool"]
+
+    def test_empty_messages(self):
+        """Empty list should return empty list."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        assert _normalize_message_roles([]) == []
+
+    def test_does_not_mutate_input(self):
+        """Input list and dicts should not be modified."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        original = [{"role": "developer", "content": "test"}]
+        result = _normalize_message_roles(original)
+        assert original[0]["role"] == "developer"  # unchanged
+        assert result[0]["role"] == "system"  # mapped copy
+
+    def test_preserves_all_fields(self):
+        """All message fields besides role should be preserved."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        messages = [
+            {"role": "developer", "content": "test", "name": "dev", "extra": 42},
+        ]
+        result = _normalize_message_roles(messages)
+        assert result[0] == {
+            "role": "system",
+            "content": "test",
+            "name": "dev",
+            "extra": 42,
+        }
+
+    def test_multimodal_content_preserved(self):
+        """List content (multimodal) should be preserved as-is."""
+        from vllm_mlx.server import _normalize_message_roles
+
+        content = [
+            {"type": "text", "text": "Look at this"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+        ]
+        messages = [{"role": "developer", "content": content}]
+        result = _normalize_message_roles(messages)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] is content

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1326,12 +1326,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             messages.append(msg_dict)
         images, videos = [], []  # MLLM extracts these from messages
         logger.debug(f"MLLM: Processing {len(messages)} messages")
+        messages = _normalize_message_roles(messages)
     else:
         # For LLM, extract text, images, and videos separately
         messages, images, videos = extract_multimodal_content(
             request.messages,
             preserve_native_format=engine.preserve_native_tool_format,
         )
+        messages = _normalize_message_roles(messages)
 
     has_media = bool(images or videos)
 
@@ -1466,6 +1468,32 @@ def _inject_json_instruction(messages: list, instruction: str) -> list:
     return messages
 
 
+# Standard OpenAI roles. Roles outside this set get mapped.
+_ROLE_MAP = {"developer": "system"}
+
+
+def _normalize_message_roles(messages: list[dict]) -> list[dict]:
+    """Map non-standard message roles to standard ones.
+
+    The OpenAI Responses API uses ``developer`` instead of ``system``.
+    Chat templates only recognize system/user/assistant/tool, so unmapped
+    roles cause template failures and potential crashes.
+
+    Returns a new list with shallow-copied dicts where roles are remapped.
+    Does not mutate the input.
+    """
+    if not messages:
+        return messages
+    out = []
+    for msg in messages:
+        role = msg.get("role", "")
+        mapped = _ROLE_MAP.get(role)
+        if mapped is not None:
+            msg = {**msg, "role": mapped}
+        out.append(msg)
+    return out
+
+
 # =============================================================================
 # Anthropic Messages API Endpoints
 # =============================================================================
@@ -1529,6 +1557,7 @@ async def create_anthropic_message(
         openai_request.messages,
         preserve_native_format=engine.preserve_native_tool_format,
     )
+    messages = _normalize_message_roles(messages)
 
     chat_kwargs = {
         "max_tokens": openai_request.max_tokens or _default_max_tokens,
@@ -1686,6 +1715,7 @@ async def _stream_anthropic_messages(
         openai_request.messages,
         preserve_native_format=engine.preserve_native_tool_format,
     )
+    messages = _normalize_message_roles(messages)
 
     chat_kwargs = {
         "max_tokens": openai_request.max_tokens or _default_max_tokens,


### PR DESCRIPTION
## Summary
- Maps `developer` role → `system` before chat template application
- Prevents template failure and crash-prone fallback on unrecognized roles
- Applied in all 4 server paths (MLLM, LLM, Anthropic non-streaming, Anthropic streaming)

Fixes #137

## Test plan
- [x] `pytest tests/test_normalize_roles.py -v` — 6 unit tests for role mapping
- [x] `pytest tests/test_server.py -v` — 34 existing tests pass (no regressions)
- [ ] Manual: send request with `role: "developer"` — should work like `system`