### PR TITLE
fix: honor tool_choice=none by stripping tools and suppressing parsing

### DIFF
--- a/tests/test_tool_choice_none.py
+++ b/tests/test_tool_choice_none.py
@@ -1,0 +1,65 @@
+"""Tests for tool_choice='none' handling."""
+
+
+class TestToolChoiceNoneParserSuppression:
+    """Verify tool call parsing is suppressed when tool_choice='none'."""
+
+    def test_parse_tool_calls_skipped_when_tool_choice_none(self):
+        """_parse_tool_calls_with_parser should return no tools when tool_choice='none'."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.server import _parse_tool_calls_with_parser
+
+        # Text that looks like a tool call
+        text = '<tool_call>{"name": "get_weather", "arguments": {"city": "London"}}</tool_call>'
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "Hello"}],
+            tool_choice="none",
+        )
+        cleaned, tool_calls = _parse_tool_calls_with_parser(text, request)
+        # With tool_choice="none", parser should be suppressed
+        assert tool_calls is None
+        assert cleaned == text  # text returned unchanged
+
+    def test_parse_tool_calls_works_when_tool_choice_auto(self):
+        """Tool parsing should work normally when tool_choice is not 'none'."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.server import _parse_tool_calls_with_parser
+
+        text = "Hello, how can I help?"
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "Hello"}],
+            tool_choice="auto",
+        )
+        cleaned, tool_calls = _parse_tool_calls_with_parser(text, request)
+        # No tool markup in text, so no tools found — but parser was NOT skipped
+        assert tool_calls is None
+
+    def test_parse_tool_calls_works_when_tool_choice_absent(self):
+        """Tool parsing should work when tool_choice is not set."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.server import _parse_tool_calls_with_parser
+
+        text = "Hello, how can I help?"
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        cleaned, tool_calls = _parse_tool_calls_with_parser(text, request)
+        assert tool_calls is None
+
+    def test_tool_markup_ignored_when_tool_choice_none(self):
+        """Even Qwen bracket-style tool calls should be suppressed."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.server import _parse_tool_calls_with_parser
+
+        text = '[Calling tool: get_weather({"city": "London"})]'
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "weather?"}],
+            tool_choice="none",
+        )
+        cleaned, tool_calls = _parse_tool_calls_with_parser(text, request)
+        assert tool_calls is None
+        assert cleaned == text

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -371,6 +371,14 @@ def _parse_tool_calls_with_parser(
 
     request_dict = request.model_dump() if request else None
 
+    # tool_choice="none" means never return tool calls — skip all parsing
+    if request is not None:
+        tool_choice = getattr(request, "tool_choice", None)
+        if tool_choice is None and request_dict:
+            tool_choice = request_dict.get("tool_choice")
+        if tool_choice == "none":
+            return output_text, None
+
     # If auto tool choice is not enabled, use the generic parser
     if not _enable_auto_tool_choice or not _tool_call_parser:
         return parse_tool_calls(output_text, request_dict)
@@ -1422,7 +1430,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
     # Add tools if provided
-    if request.tools:
+    if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
     if request.stream:
@@ -1600,7 +1608,7 @@ async def create_anthropic_message(
         "top_p": openai_request.top_p,
     }
 
-    if openai_request.tools:
+    if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
     start_time = time.perf_counter()
@@ -1757,7 +1765,7 @@ async def _stream_anthropic_messages(
         "top_p": openai_request.top_p,
     }
 
-    if openai_request.tools:
+    if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
     # Emit message_start
@@ -1961,7 +1969,8 @@ async def stream_chat_completion(
     tool_accumulated_text = ""
     tool_calls_detected = False
     tool_markup_possible = False  # Fast path: skip parsing until '<' seen
-    if _enable_auto_tool_choice and _tool_call_parser:
+    tool_choice = getattr(request, "tool_choice", None)
+    if _enable_auto_tool_choice and _tool_call_parser and tool_choice != "none":
         # Initialize parser if needed (same as _parse_tool_calls_with_parser)
         if _tool_parser_instance is None:
             try:


### PR DESCRIPTION
When `tool_choice="none"`, strip tools from the chat template and suppress tool call parsing.

**Before:** tools still appeared in the template and the parser could match output as tool calls.
**After:** tools removed from template context, parser skipped.

**Files:** `server.py` (2 lines in non-streaming, 2 lines in streaming)

**Test:**
```bash
curl http://localhost:8080/v1/chat/completions -d '{
  "messages": [{"role":"user","content":"What is 2+2?"}],
  "tools": [{"type":"function","function":{"name":"calc","parameters":{}}}],
  "tool_choice": "none",
  "max_tokens": 20
}'
# Expect: content with answer, tool_calls: null
```