### PR TITLE
enable LCP and supersequence cache hits for hybrid models (Qwen3.5) 

### DIFF
--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -548,7 +548,7 @@ class MemoryAwarePrefixCache:
                     "[cache_fetch] supersequence match skipped: "
                     "non-trimmable cache layers (hybrid model)"
                 )
-            if excess > 0:
+            elif excess > 0:
                 trimmed_cache = _trim_cache_offset(best_super.cache, excess)
                 self._entries.move_to_end(best_super.tokens)
                 self._stats.hits += 1
@@ -623,28 +623,34 @@ class MemoryAwarePrefixCache:
         if best_lcp_entry is not None and best_lcp_length > 0:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
-        logger.debug(
+            logger.debug(
                 f"[cache_fetch] LCP candidate: lcp={best_lcp_length} "
                 f"entry_len={len(best_lcp_entry.tokens)} excess={excess} "
                 f"cache_layers={len(best_lcp_entry.cache)} "
                 f"layer_types={[type(lc).__name__ for lc in best_lcp_entry.cache[:3]]}"
-        )
-        trimmed_cache = _trim_cache_offset(best_lcp_entry.cache, excess)
-        self._entries.move_to_end(best_lcp_entry.tokens)
-        self._stats.hits += 1
-        self._stats.tokens_saved += best_lcp_length
-        remaining = tokens[best_lcp_length:]
-        logger.debug(
-            f"[cache_fetch] LCP hit: shared={best_lcp_length} "
-            f"trimmed={excess} remaining={len(remaining)}"
-        )
-        self._last_match_type = "lcp"
-        trimmed_cache = (
-            _dequantize_cache(trimmed_cache)
-            if self._config.kv_quantize
-            else trimmed_cache
-        )
-        return trimmed_cache, remaining
+            )
+
+            # _trim_cache_offset handles mixed layer types: it adjusts
+            # offset on trimmable layers (KVCache/QuantizedKVCache) and
+            # passes non-trimmable layers through unchanged. The remaining
+            # tokens are reprocessed in the forward pass, which updates
+            # all layer types including non-trimmable ones.
+            trimmed_cache = _trim_cache_offset(best_lcp_entry.cache, excess)
+            self._entries.move_to_end(best_lcp_entry.tokens)
+            self._stats.hits += 1
+            self._stats.tokens_saved += best_lcp_length
+            remaining = tokens[best_lcp_length:]
+            logger.debug(
+                f"[cache_fetch] LCP hit: shared={best_lcp_length} "
+                f"trimmed={excess} remaining={len(remaining)}"
+            )
+            self._last_match_type = "lcp"
+            trimmed_cache = (
+                _dequantize_cache(trimmed_cache)
+                if self._config.kv_quantize
+                else trimmed_cache
+            )
+            return trimmed_cache, remaining
 
         self._stats.misses += 1
         self._last_match_type = "miss"


### PR DESCRIPTION
I was able to get qwen code through the qwen CLI to actually get cache hits and not re-pre-fill entire conversation history every time. Got my full cycle TOK/sec from 2.5 -> 40. Please evaluate if I am not back-compatible to other important cases with this change but this did CONSIDERABLY improve my performance running qwen3.5 with a large context use. even if this is not robust enough for all cases and can not be merged, my fork will remain until a more targetted change allows qwen to succeed at cache hits (I was 100% miss before this). 

fix: enable LCP and supersequence cache hits for hybrid models (Qwen3.5) Hybrid models like Qwen3.5 mix KVCache (attention layers) and ArraysCache (Gated DeltaNet / linear attention layers). ArraysCache lacks offset and keys, so has_non_trimmable fired true and silently skipped both LCP and supersequence cache matches on every turn. _trim_cache_offset already handles ArraysCache correctly by passing those layers through unchanged — recurrent state doesn't need trimming. The guard was overly conservative. Removing it recovers 5k–50k token LCP hits per turn in agentic workloads on Qwen3.5, where turns share a long common prefix but diverge at the chat template boundary. Confirmed working on mlx-community/Qwen3.5-35B-A3B-4bit.
 Sonnet 4.6Extended