### PR TITLE
fix: compatibility with mlx-lm 0.31.x (prompt_checkpoints tuple)

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -404,7 +404,7 @@ def _install_chunked_prefill(
 
                     if not is_cached:
                         padded = _left_pad_prompts(inputs_raw, max_length=max_length)
-                        prompt_cache = _make_cache(self.model, padding, None)
+                        prompt_cache = _make_cache(self.model, padding, self.max_kv_size)
                     else:
                         last_inputs = mx.array([p[-1:] for p in inputs_raw])
                         padded = _right_pad_prompts(inputs_raw, max_length=max_length)


### PR DESCRIPTION
## Summary

mlx-lm 0.31.0 added `prompt_checkpoints` support, changing the `BatchGenerator.insert()` tuple from 6 elements to 7. This causes `ValueError: too many values to unpack (expected 6)` in `_chunked_next` when processing any request.

## Changes

- `scheduler.py` ~line 395: unpack 7 values instead of 6 (add `_prompt_checkpoints`)
- `scheduler.py` ~line 406: pass `max_kv_size=None` to `_make_cache()` (signature changed in mlx-lm 0.31.0 to require 3 positional args)

## Error Before Fix

```
File "vllm_mlx/scheduler.py", line 388, in _chunked_next
    (
ValueError: too many values to unpack (expected 6)
```

## Tested On

- Mac Mini M4 Pro 64GB, macOS 26.3
- mlx-lm 0.31.0
- mlx 0.31.1 / mlx-metal 0.31.1
- transformers 5.3.0
- Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit
- Running as an OpenClaw backend with the blockops1 proxy

## Related

- Same root cause as [jundot/omlx#110](https://github.com/jundot/omlx/issues/110), fixed in [omlx PR#126](https://github.com/jundot/omlx/pull/126)