### PR TITLE
True token-by-token streaming for MLLM path

### DIFF
--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -340,24 +340,39 @@ class SimpleEngine(BaseEngine):
 
         # Build prompt using tokenizer
         if self._is_mllm:
-            # For MLLM, use stream_chat which yields tokens incrementally
-            accumulated_text = ""
-            token_count = 0
+            # For MLLM, stream tokens via queue so clients see output
+            # as it's generated rather than waiting for completion.
+            import queue
 
-            # Run stream_chat in thread pool since it's synchronous
+            chunk_queue: queue.Queue = queue.Queue()
+            _DONE = object()
+
             def run_stream():
-                return list(
-                    self._model.stream_chat(
+                try:
+                    for chunk in self._model.stream_chat(
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
                         **kwargs,
-                    )
-                )
+                    ):
+                        chunk_queue.put(chunk)
+                except Exception as e:
+                    chunk_queue.put(e)
+                finally:
+                    chunk_queue.put(_DONE)
 
-            chunks = await asyncio.to_thread(run_stream)
+            loop = asyncio.get_event_loop()
+            loop.run_in_executor(None, run_stream)
 
-            for chunk in chunks:
+            accumulated_text = ""
+            token_count = 0
+            while True:
+                chunk = await asyncio.to_thread(chunk_queue.get)
+                if chunk is _DONE:
+                    break
+                if isinstance(chunk, Exception):
+                    raise chunk
+
                 token_count += 1
                 new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
                 accumulated_text += new_text


### PR DESCRIPTION
## Summary

The MLLM path in `stream_chat()` currently collects ALL tokens via `list(self._model.stream_chat(...))` before yielding any chunks to the client. On large models (122B), this means ~50s of silence followed by the entire response at once.

This PR replaces the collect-all-then-yield pattern with a `queue.Queue`-based bridge between the mlx_vlm generation thread and the async generator, so tokens are yielded as they're produced.

## Changes

- `simple.py`: Replace `list()` collection + `asyncio.to_thread(run_stream)` with `run_in_executor` + `queue.Queue` consumer loop
- Error propagation: exceptions from the generation thread are re-raised in the async context
- Completion signal: sentinel object marks end of generation

## Before/After

| | Before | After |
|--|--------|-------|
| Time to first visible token | ~50s (full generation) | ~90s (prefill) + first token |
| Streaming behavior | Fake (batch then yield) | Real (yield as generated) |

## Test plan

- [ ] MLLM streaming produces identical output
- [ ] Error handling works (model errors surface correctly)
- [ ] No resource leaks (queue + thread cleanup)
- [ ] Text-only (non-MLLM) path unaffected