### PR TITLE
Token-level JSON schema constrained decoding

### DIFF
--- a/vllm_mlx/json_logits_processor.py
+++ b/vllm_mlx/json_logits_processor.py
@@ -1,0 +1,107 @@
+"""JSON schema constrained decoding via outlines-core.
+
+Provides a logits processor that masks tokens to guarantee valid JSON output
+conforming to a given JSON schema. Uses outlines-core's regex-based guide
+built from the JSON schema.
+
+Requires: pip install outlines-core
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from outlines_core import Guide, Index, Vocabulary
+    from outlines_core.json_schema import build_regex_from_schema
+
+    HAS_OUTLINES = True
+except ImportError:
+    HAS_OUTLINES = False
+
+
+def _build_vocabulary(tokenizer) -> "Vocabulary":
+    """Build outlines-core Vocabulary from a HuggingFace tokenizer."""
+    eos_id = tokenizer.eos_token_id
+    vocab_map = {}
+    for token_str, token_id in tokenizer.get_vocab().items():
+        if token_id == eos_id:
+            continue
+        vocab_map.setdefault(token_str, []).append(token_id)
+    return Vocabulary(eos_id, vocab_map)
+
+
+def build_json_logits_processor(schema, tokenizer):
+    """Build a logits processor that constrains output to valid JSON.
+
+    Args:
+        schema: JSON schema as dict or string.
+        tokenizer: HuggingFace tokenizer with get_vocab() and eos_token_id.
+
+    Returns:
+        A callable (tokens, logits) -> logits suitable for mlx-lm's
+        logits_processors parameter, or None if outlines-core is not installed.
+    """
+    if not HAS_OUTLINES:
+        logger.warning(
+            "outlines-core not installed, JSON schema constraint disabled. "
+            "Install with: pip install outlines-core"
+        )
+        return None
+
+    if isinstance(schema, dict):
+        schema = json.dumps(schema)
+
+    try:
+        regex = build_regex_from_schema(schema)
+    except Exception as e:
+        logger.warning("Failed to build regex from JSON schema: %s", e)
+        return None
+
+    try:
+        vocab = _build_vocabulary(tokenizer)
+        index = Index(regex, vocab)
+        guide = Guide(index)
+    except Exception as e:
+        logger.warning("Failed to build constrained decoding guide: %s", e)
+        return None
+
+    logger.info("JSON schema constraint active (regex length: %d)", len(regex))
+
+    import mlx.core as mx
+
+    class JsonSchemaProcessor:
+        """Stateful logits processor that tracks the guide state."""
+
+        def __init__(self, guide):
+            self._guide = guide
+            self._started = False
+
+        def __call__(self, tokens, logits):
+            # Advance guide with the last generated token
+            if self._started and len(tokens) > 0:
+                last_token = tokens[-1].item()
+                try:
+                    self._guide.advance(last_token)
+                except Exception:
+                    # Token not in guide's allowed set — shouldn't happen
+                    # if processor was applied, but fail gracefully
+                    logger.warning("Guide advance failed for token %d", last_token)
+                    return logits
+            self._started = True
+
+            allowed = self._guide.get_tokens()
+            if not allowed:
+                return logits
+
+            mask = mx.full(logits.shape, float("-inf"))
+            allowed_list = list(allowed)
+            # Set allowed positions to 0 (logits + 0 = unchanged, logits + -inf = masked)
+            for idx in allowed_list:
+                if idx < logits.shape[-1]:
+                    mask[idx] = 0.0
+
+            return logits + mask
+
+    return JsonSchemaProcessor(guide)

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -177,6 +177,7 @@ class MLXLanguageModel:
         top_p: float = 0.9,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list | None = None,
     ) -> Iterator[StreamingOutput]:
         """
         Stream text generation token by token.
@@ -203,12 +204,18 @@ class MLXLanguageModel:
         token_count = 0
         accumulated_text = ""
 
-        for response in stream_generate(
-            self.model,
-            self.tokenizer,
+        gen_kwargs = dict(
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
+        )
+        if logits_processors:
+            gen_kwargs["logits_processors"] = logits_processors
+
+        for response in stream_generate(
+            self.model,
+            self.tokenizer,
+            **gen_kwargs,
         ):
             token_count += 1
             # response.text is the new token text (not accumulated)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1350,6 +1350,21 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         "top_p": _resolve_top_p(request.top_p),
     }
 
+    # Build JSON schema logits processor for constrained decoding
+    if (
+        response_format
+        and isinstance(response_format, dict)
+        and response_format.get("type") == "json_schema"
+        and not engine.is_mllm
+    ):
+        schema = response_format.get("json_schema", {}).get("schema")
+        if schema:
+            from .json_logits_processor import build_json_logits_processor
+
+            processor = build_json_logits_processor(schema, engine.tokenizer)
+            if processor:
+                chat_kwargs["logits_processors"] = [processor]
+
     # Add multimodal content
     if has_media:
         chat_kwargs["images"] = images if images else None


### PR DESCRIPTION
## Summary

Adds token-level constrained decoding that **guarantees** valid JSON output conforming to a given schema. Uses [outlines-core](https://github.com/dottxt-ai/outlines-core)'s regex-based finite state machine to mask disallowed tokens at each generation step.

This replaces the current prompt-injection approach (which achieves ~30% schema conformance per #133) with deterministic enforcement at the logits level.

## How it works

1. `response_format: {"type": "json_schema", "json_schema": {"schema": {...}}}` triggers the processor
2. `outlines-core` converts the JSON schema → regex → finite state automaton → token-level guide
3. At each generation step, the guide provides the set of allowed token IDs
4. All other tokens are masked to `-inf` before sampling
5. The guide advances with each sampled token, tracking position in the schema

## Changes

- **New:** `vllm_mlx/json_logits_processor.py` — `JsonSchemaProcessor` class (~100 lines)
- `models/llm.py`: Accept and pass `logits_processors` to `mlx_lm.stream_generate()`
- `server.py`: Build processor from `response_format.json_schema` when present

## Design decisions

- **Optional dependency:** `outlines-core` is not required. Falls back to prompt-only mode with a warning.
- **LLM-only:** MLLM path excluded (mlx_vlm generate doesn't support logits processors)
- **Graceful fallback:** Any guide construction failure → warning + no constraint (never crashes)
- **Stateful:** The processor tracks its position in the JSON schema FSM across tokens

## Requires

```bash
pip install outlines-core
```

## Test plan

- [ ] Simple schema (name + age) produces valid JSON 100% of the time
- [ ] Complex nested schemas work
- [ ] No constraint when outlines-core not installed
- [ ] No constraint on MLLM path
- [ ] Performance: measure overhead of guide.get_tokens() per step

Addresses #133.