### PR TITLE
fix: normalize messages in BatchedEngine before chat template

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
+from ..message_utils import _normalize_messages
 from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
@@ -612,6 +613,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        messages = _normalize_messages(messages)
+
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
@@ -722,6 +725,8 @@ class BatchedEngine(BaseEngine):
         """
         if not self._loaded:
             await self.start()
+
+        messages = _normalize_messages(messages)
 
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, is_mllm_model
+from ..message_utils import _normalize_messages
 from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
@@ -434,6 +435,8 @@ class SimpleEngine(BaseEngine):
         Returns:
             GenerationOutput with assistant response
         """
+        messages = _normalize_messages(messages)
+
         if not self._loaded:
             await self.start()
 
@@ -506,6 +509,8 @@ class SimpleEngine(BaseEngine):
         Yields:
             GenerationOutput with incremental text
         """
+        messages = _normalize_messages(messages)
+
         if not self._loaded:
             await self.start()
 

--- a/vllm_mlx/message_utils.py
+++ b/vllm_mlx/message_utils.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Message normalization utilities.
+
+ALL engine paths that call ``apply_chat_template`` MUST normalize messages
+first.  Qwen 3.5 templates reject:
+
+  - ``developer`` role (must be mapped to ``system``)
+  - system messages anywhere other than position [0]
+  - consecutive messages with the same role
+
+Without normalization, multi-turn agent sessions crash on template
+application.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_messages(messages: list[dict]) -> list[dict]:
+    """Normalize chat messages for safe chat-template application.
+
+    Performs three transformations in order:
+
+    1. **Role mapping** -- ``developer`` role is mapped to ``system``.
+    2. **System hoisting** -- all system messages are moved to position [0],
+       concatenated with ``\\n\\n`` in their original relative order.
+    3. **Consecutive merge** -- adjacent messages with the same role are
+       merged (content joined with ``\\n\\n``).
+
+    Args:
+        messages: List of chat message dicts (each with at least ``role``
+            and ``content`` keys).
+
+    Returns:
+        A new list of normalized message dicts.  The input list is not
+        modified.
+    """
+    if not messages:
+        return messages
+
+    # --- 1. Map developer -> system ---
+    mapped: list[dict] = []
+    for msg in messages:
+        role = msg.get("role", "")
+        if role == "developer":
+            mapped.append({**msg, "role": "system"})
+        else:
+            mapped.append(msg)
+
+    # --- 2. Hoist system messages to position [0] ---
+    system_parts: list[str] = []
+    non_system: list[dict] = []
+    for msg in mapped:
+        if msg.get("role") == "system":
+            content = msg.get("content", "")
+            if isinstance(content, str) and content:
+                system_parts.append(content)
+            elif isinstance(content, list):
+                # Handle structured content (list of parts)
+                text_parts = []
+                for part in content:
+                    if isinstance(part, str):
+                        text_parts.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                text = "\n\n".join(p for p in text_parts if p)
+                if text:
+                    system_parts.append(text)
+        else:
+            non_system.append(msg)
+
+    hoisted: list[dict] = []
+    if system_parts:
+        hoisted.append({"role": "system", "content": "\n\n".join(system_parts)})
+    hoisted.extend(non_system)
+
+    # --- 3. Merge consecutive same-role messages ---
+    merged: list[dict] = []
+    for msg in hoisted:
+        if merged and merged[-1].get("role") == msg.get("role"):
+            prev_content = merged[-1].get("content", "")
+            cur_content = msg.get("content", "")
+            # Only merge when both are plain strings
+            if isinstance(prev_content, str) and isinstance(cur_content, str):
+                merged[-1] = {
+                    **merged[-1],
+                    "content": prev_content + "\n\n" + cur_content,
+                }
+            else:
+                # Cannot safely merge structured content; keep separate
+                merged.append(msg)
+        else:
+            merged.append(msg)
+
+    if len(merged) != len(messages):
+        logger.debug(
+            "Normalized messages: %d -> %d (hoisted system, merged consecutive)",
+            len(messages),
+            len(merged),
+        )
+
+    return merged


### PR DESCRIPTION
## Summary
- Add `_normalize_messages()` to shared `message_utils.py` module
- Call it in `BatchedEngine.chat()`, `BatchedEngine.stream_chat()`, `SimpleEngine.chat()`, `SimpleEngine.stream_chat()`

## Problem
BatchedEngine passes messages directly to `_apply_chat_template()` without normalization. Qwen 3.5 chat templates reject:
- `developer` role (must be mapped to `system`)
- Consecutive same-role messages (must be merged)
- System messages not at position [0] (must be hoisted)

This causes multi-turn agent sessions (Claude Code, OpenCode, etc.) to crash on template application when using continuous batching.

SimpleEngine also lacked normalization in some paths.

## Changes
- New: `vllm_mlx/message_utils.py` — shared `_normalize_messages()` function
- Modified: `engine/simple.py` — import and call in `chat()` and `stream_chat()`
- Modified: `engine/batched.py` — import and call in `chat()` and `stream_chat()`

## Test plan
- [ ] Multi-turn chat with `developer` role → mapped to system, no template error
- [ ] Consecutive same-role messages → merged with `\n\n` separator
- [ ] System message not at position [0] → hoisted to front
- [ ] Verify both SimpleEngine and BatchedEngine paths