### PR TITLE
fix: unpack prompt_checkpoints in _chunked_next for mlx-lm >= 0.31.0

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -392,6 +392,7 @@ def _install_chunked_prefill(
                         caches,
                         samplers,
                         logits_processors,
+                        _prompt_checkpoints,
                     ) = zip(*batch_prompts)
                     lengths = [len(p) for p in inputs_raw]
                     max_length = max(lengths)


### PR DESCRIPTION
## Summary

mlx-lm 0.31.0 added `prompt_checkpoints` as the 7th element in the `BatchGenerator.insert()` tuple. `_chunked_next` only unpacked 6 elements, causing `ValueError: too many values to unpack (expected 6)` when prefix cache triggers the chunked prefill path.

One-line fix: add `_prompt_checkpoints` to the `zip(*batch_prompts)` unpack.

Same class of bug as the `_process_prompts` tuple fix — different code path (`_chunked_next` bypasses `_process_prompts` entirely when prefix cache mid-prefill is active).

## Reproduction

1. Start server with `--enable-prefix-cache` and mlx-lm >= 0.31.0
2. Send any request with a prompt long enough to trigger chunked prefill
3. Server crashes with `ValueError: too many values to unpack (expected 6)`

## Test plan

- [ ] Start server with `--enable-prefix-cache --continuous-batching` on mlx-lm 0.31.x
- [ ] Send a request with >8K token prompt
- [ ] Verify no ValueError on chunked prefill path
- [ ] Verify prefix cache hit on subsequent request with same prefix

Fixes #178