### PR TITLE
fix: skip RNN snapshots in MTP optimistic mode to prevent memory leak

### DIFF
--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -800,12 +800,13 @@ def _install_mtp(
             # RNN snapshot, then re-advance with just P so both cache
             # types end up consistent at [..., P].
             _rnn_snapshots = {}
-            for _ci, _c in enumerate(prompt_cache):
-                if not (hasattr(_c, "is_trimmable") and _c.is_trimmable()):
-                    if hasattr(_c, "state"):
-                        _rnn_snapshots[_ci] = [
-                            s.copy() if s is not None else None for s in _c.state
-                        ]
+            if not optimistic:
+                for _ci, _c in enumerate(prompt_cache):
+                    if not (hasattr(_c, "is_trimmable") and _c.is_trimmable()):
+                        if hasattr(_c, "state"):
+                            _rnn_snapshots[_ci] = [
+                                s.copy() if s is not None else None for s in _c.state
+                            ]
 
             verify_input = mx.concatenate(
                 [primary_tokens[:, None], draft_tokens[:, None]], axis=1


### PR DESCRIPTION
## Summary

In the MTP always-advance decode path, every step copies all recurrent layer states (GatedDeltaNet SSM) for potential rollback on draft token rejection. In optimistic mode, rejection never happens — the copies are pure waste that causes a memory leak.

## Root Cause

Each SSM state is `[1, 64, 128, 128]` float32 = ~4 MB. With 36 linear attention layers (e.g., Qwen3.5-122B-A10B), that's ~147 MB of `.copy()` graph nodes per step. The lazy copies hold references to pre-verify Metal buffers, preventing the allocator from freeing them. With GPU pipeline depth of 2-3 steps, this creates 300-450 MB of memory pressure that grows during long generations.

## Observed Impact

On M2 Ultra 128GB with Qwen3.5-122B-A10B (5-bit, ~82 GB weights):
- Memory grows ~2 GB per 256 decode steps
- After ~4000 steps: active=108.7 GB, peak=119.4 GB → Metal OOM crash
- Server log: `[METAL] Command buffer execution failed: Insufficient Memory`

## Changes

1. Gate the RNN snapshot loop with `if not optimistic:` — snapshots are only needed for the verified reject path
2. Include `batch.tokens` in `mx.async_eval` to collapse the token history concatenation chain

## Test plan

- [ ] Run 4000+ token generation with `--enable-mtp` on a hybrid model (Qwen3.5)
- [ ] Verify memory stays flat during decode (should not grow ~2 GB/256 steps)
- [ ] Verify MTP verified mode still works (snapshots still taken when `optimistic=False`)
- [ ] Monitor with `[Metal memory]` log lines