### PR TITLE
feat: memory-aware admission controller for multi-user serving

### DIFF
--- a/tests/smoke_test_specdec.py
+++ b/tests/smoke_test_specdec.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Smoke test for speculative decoding with real models.
+
+Usage: python tests/smoke_test_specdec.py
+
+Uses Qwen3.5-35B-A3B-8bit as target, Qwen3.5-4B-4bit as draft.
+Tests the SimpleEngine path (mlx_lm.stream_generate with draft_model).
+"""
+
+import os
+import sys
+import time
+
+# Add project to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+TARGET = os.path.expanduser("~/ai-models/mlx_models/Qwen3.5-35B-A3B-8bit")
+DRAFT = os.path.expanduser("~/ai-models/mlx_models/Qwen3.5-4B-4bit")
+PROMPT = "What is the capital of France? Answer in one sentence."
+MAX_TOKENS = 64
+NUM_DRAFT = 3
+
+
+def test_without_draft():
+    """Baseline: generate without speculative decoding."""
+    from mlx_lm import load, stream_generate
+
+    print("=" * 60)
+    print("Loading target model (no draft)...")
+    model, tokenizer = load(TARGET)
+    print(f"Target loaded. Generating {MAX_TOKENS} tokens...")
+
+    tokens = []
+    t0 = time.perf_counter()
+    for resp in stream_generate(model, tokenizer, prompt=PROMPT, max_tokens=MAX_TOKENS):
+        tokens.append(resp.token)
+    elapsed = time.perf_counter() - t0
+    text = tokenizer.decode(tokens)
+    print(f"Output ({len(tokens)} tokens, {len(tokens)/elapsed:.1f} tok/s):")
+    print(f"  {text}")
+    print()
+    return len(tokens), elapsed
+
+
+def test_with_draft():
+    """Speculative: generate with draft model."""
+    from mlx_lm import load, stream_generate
+
+    print("=" * 60)
+    print("Loading target + draft model...")
+    model, tokenizer = load(TARGET)
+    draft_model, _ = load(DRAFT)
+
+    # Verify vocab match — walk model structure to find embed_tokens
+    def _get_vocab_size(m):
+        for attr in ["model", "language_model"]:
+            sub = getattr(m, attr, None)
+            if sub is not None:
+                et = getattr(sub, "embed_tokens", None)
+                if et is not None:
+                    return et.weight.shape[0]
+        return None
+
+    target_vocab = _get_vocab_size(model)
+    draft_vocab = _get_vocab_size(draft_model)
+    print(f"Target vocab: {target_vocab}, Draft vocab: {draft_vocab}")
+    if target_vocab and draft_vocab:
+        assert target_vocab == draft_vocab, "Vocab size mismatch!"
+
+    print(f"Generating {MAX_TOKENS} tokens with num_draft_tokens={NUM_DRAFT}...")
+
+    tokens = []
+    from_draft_count = 0
+    t0 = time.perf_counter()
+    for resp in stream_generate(
+        model,
+        tokenizer,
+        prompt=PROMPT,
+        max_tokens=MAX_TOKENS,
+        draft_model=draft_model,
+        num_draft_tokens=NUM_DRAFT,
+    ):
+        tokens.append(resp.token)
+        if resp.from_draft:
+            from_draft_count += 1
+    elapsed = time.perf_counter() - t0
+
+    text = tokenizer.decode(tokens)
+    accept_rate = from_draft_count / len(tokens) * 100 if tokens else 0
+    print(f"Output ({len(tokens)} tokens, {len(tokens)/elapsed:.1f} tok/s):")
+    print(f"  {text}")
+    print(f"Draft acceptance: {from_draft_count}/{len(tokens)} ({accept_rate:.0f}%)")
+    print()
+    return len(tokens), elapsed
+
+
+if __name__ == "__main__":
+    print("Speculative Decoding Smoke Test")
+    print("Target:", TARGET)
+    print("Draft:", DRAFT)
+    print()
+
+    n1, t1 = test_without_draft()
+    # Clear model from memory
+    import gc
+    import mlx.core as mx
+
+    gc.collect()
+    mx.clear_cache()
+
+    n2, t2 = test_with_draft()
+
+    print("=" * 60)
+    print("RESULTS:")
+    print(f"  Without draft: {n1} tokens in {t1:.2f}s ({n1/t1:.1f} tok/s)")
+    print(f"  With draft:    {n2} tokens in {t2:.2f}s ({n2/t2:.1f} tok/s)")
+    if t1 > 0 and t2 > 0:
+        speedup = (n1 / t1) / (n2 / t2) if n2 / t2 > 0 else 0
+        print(f"  Speedup: {1/speedup:.2f}x" if speedup > 0 else "  N/A")

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -308,3 +308,77 @@ def test_admission_wait_cleans_up_on_cancellation():
             assert "req-cancel" not in controller._wait_events
 
         asyncio.get_event_loop().run_until_complete(simulate_cancel())
+
+
+def test_admission_controller_eviction_callback():
+    """When queue is non-empty and memory tight, evict prefix cache."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+
+        eviction_count = []
+
+        def mock_evict():
+            eviction_count.append(1)
+            # Simulate freeing memory by reducing active
+            mock_mx.get_active_memory.return_value = 50 * 1024**3
+            return True  # True = evicted something
+
+        controller.set_eviction_callback(mock_evict)
+
+        # Queue a request (not enough memory)
+        controller.try_admit("req-1", prompt_tokens=1000)
+        assert controller.queue_length == 1
+
+        # check_queue should call eviction, then admit
+        ready = controller.check_queue()
+        assert len(eviction_count) > 0  # Eviction was called
+        assert len(ready) == 1  # Request was admitted after eviction
+        assert ready[0].request_id == "req-1"
+
+
+def test_admission_controller_eviction_no_callback():
+    """Without eviction callback, check_queue just waits."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+        controller.try_admit("req-1", prompt_tokens=1000)
+        ready = controller.check_queue()
+        assert len(ready) == 0  # Can't admit, no eviction callback
+
+
+def test_admission_controller_eviction_exhausted():
+    """If eviction can't free enough memory, request stays queued."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+
+        def mock_evict_nothing():
+            return False  # Nothing to evict
+
+        controller.set_eviction_callback(mock_evict_nothing)
+        controller.try_admit("req-1", prompt_tokens=1000)
+        ready = controller.check_queue()
+        assert len(ready) == 0  # Still can't admit
+        assert controller.queue_length == 1

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -46,10 +46,11 @@ def test_memory_monitor_free_memory():
         mock_mx.device_info.return_value = {
             "max_recommended_working_set_size": 120 * 1024**3
         }
-        mock_mx.get_active_memory.return_value = 90 * 1024**3
+        mock_mx.get_active_memory.return_value = 80 * 1024**3
+        mock_mx.get_cache_memory.return_value = 10 * 1024**3
         monitor = MemoryMonitor()
         free = monitor.free_memory()
-        assert free == 30 * 1024**3  # 120 - 90
+        assert free == 30 * 1024**3  # 120 - 80 - 10
 
 
 def test_memory_monitor_can_admit():
@@ -58,7 +59,8 @@ def test_memory_monitor_can_admit():
         mock_mx.device_info.return_value = {
             "max_recommended_working_set_size": 120 * 1024**3
         }
-        mock_mx.get_active_memory.return_value = 100 * 1024**3
+        mock_mx.get_active_memory.return_value = 95 * 1024**3
+        mock_mx.get_cache_memory.return_value = 5 * 1024**3
         monitor = MemoryMonitor(headroom_bytes=8 * 1024**3)
         # 20 GB free, 8 GB headroom, 5 GB prefill = 20 >= 13 → admit
         assert monitor.can_admit(prefill_bytes=5 * 1024**3) is True

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-from vllm_mlx.admission import compute_kv_per_token
+from unittest.mock import patch
+
+from vllm_mlx.admission import MemoryMonitor, QueuedRequest, RequestQueue, compute_kv_per_token
 
 
 def test_kv_per_token_qwen35_35b():
@@ -36,3 +38,29 @@ def test_kv_per_token_dense_model():
         dtype_bytes=2,
     )
     assert result == 32 * 8 * 128 * 2 * 2  # 131_072
+
+
+def test_memory_monitor_free_memory():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 90 * 1024**3
+        monitor = MemoryMonitor()
+        free = monitor.free_memory()
+        assert free == 30 * 1024**3  # 120 - 90
+
+
+def test_memory_monitor_can_admit():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 100 * 1024**3
+        monitor = MemoryMonitor(headroom_bytes=8 * 1024**3)
+        # 20 GB free, 8 GB headroom, 5 GB prefill = 20 >= 13 → admit
+        assert monitor.can_admit(prefill_bytes=5 * 1024**3) is True
+        # 20 GB free, 8 GB headroom, 15 GB prefill = 20 < 23 → reject
+        assert monitor.can_admit(prefill_bytes=15 * 1024**3) is False

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -159,3 +159,46 @@ def test_admission_controller_drain_queue():
         assert len(ready) == 1
         assert ready[0].request_id == "req-1"
         assert controller.queue_length == 0
+
+
+def test_admission_controller_fifo_no_bypass():
+    """Small requests must queue behind large ones even if they'd fit."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 112 * 1024**3  # 8 GB free
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+        )
+        # Large request can't fit (~3.8GB prefill + 8GB headroom > 8GB free)
+        admitted1, pos1 = controller.try_admit("req-large", prompt_tokens=200_000)
+        assert admitted1 is False
+        assert pos1 == 0
+        # Small request WOULD fit (20KB + 8GB < 8GB is false, but even if
+        # memory freed later, FIFO requires it to queue behind the large one)
+        admitted2, pos2 = controller.try_admit("req-small", prompt_tokens=1)
+        assert admitted2 is False
+        assert pos2 == 1
+
+
+def test_admission_controller_cancel():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+        )
+        controller.try_admit("req-1", prompt_tokens=1000)
+        assert controller.queue_length == 1
+        assert controller.cancel("req-1") is True
+        assert controller.queue_length == 0
+        assert controller.cancel("nonexistent") is False

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+from vllm_mlx.admission import compute_kv_per_token
+
+
+def test_kv_per_token_qwen35_35b():
+    """Qwen3.5-35B: 10 attn layers, 2 KV heads, 256 head_dim, bfloat16."""
+    result = compute_kv_per_token(
+        num_hidden_layers=40,
+        full_attention_interval=4,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_bytes=2,
+    )
+    assert result == 20_480  # 10 * 2 * 256 * 2 * 2
+
+
+def test_kv_per_token_qwen35_122b():
+    """Qwen3.5-122B: 12 attn layers, 2 KV heads, 256 head_dim, bfloat16."""
+    result = compute_kv_per_token(
+        num_hidden_layers=48,
+        full_attention_interval=4,
+        num_kv_heads=2,
+        head_dim=256,
+        dtype_bytes=2,
+    )
+    assert result == 24_576  # 12 * 2 * 256 * 2 * 2
+
+
+def test_kv_per_token_dense_model():
+    """Dense model (no interval): all layers are attention."""
+    result = compute_kv_per_token(
+        num_hidden_layers=32,
+        full_attention_interval=1,
+        num_kv_heads=8,
+        head_dim=128,
+        dtype_bytes=2,
+    )
+    assert result == 32 * 8 * 128 * 2 * 2  # 131_072

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
+import time
 
 from unittest.mock import patch
 
@@ -45,6 +46,31 @@ def test_kv_per_token_dense_model():
         dtype_bytes=2,
     )
     assert result == 32 * 8 * 128 * 2 * 2  # 131_072
+
+
+def test_kv_per_token_nemotron_h_hybrid_pattern():
+    """Nemotron-H: 8 attention layers from hybrid_override_pattern, not 88."""
+    pattern = "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME"
+    result = compute_kv_per_token(
+        num_hidden_layers=88,
+        full_attention_interval=1,  # default — would give 88 without pattern
+        num_kv_heads=2,
+        head_dim=128,
+        dtype_bytes=2,
+        hybrid_override_pattern=pattern,
+    )
+    # 8 attention layers (count of '*' in pattern), not 88
+    assert result == 8 * 2 * 128 * 2 * 2  # 8,192
+    # Without pattern, it would be 88 * 2 * 128 * 2 * 2 = 90,112 (11x overestimate)
+    wrong = compute_kv_per_token(
+        num_hidden_layers=88,
+        full_attention_interval=1,
+        num_kv_heads=2,
+        head_dim=128,
+        dtype_bytes=2,
+    )
+    assert wrong == 90_112
+    assert wrong / result == 11.0
 
 
 def test_memory_monitor_free_memory():
@@ -382,3 +408,146 @@ def test_admission_controller_eviction_exhausted():
         ready = controller.check_queue()
         assert len(ready) == 0  # Still can't admit
         assert controller.queue_length == 1
+
+
+# =====================================================================
+# Phase B3: Queue policy tests
+# =====================================================================
+
+
+def test_request_queue_shortest_first_basic():
+    """shortest_first dequeues smallest prompt first."""
+    q = RequestQueue(policy="shortest_first")
+    q.enqueue("req-large", prompt_tokens=100_000)
+    q.enqueue("req-small", prompt_tokens=1_000)
+    q.enqueue("req-medium", prompt_tokens=50_000)
+    assert q.dequeue().request_id == "req-small"
+    assert q.dequeue().request_id == "req-medium"
+    assert q.dequeue().request_id == "req-large"
+    assert q.is_empty()
+
+
+def test_request_queue_shortest_first_tiebreak_fifo():
+    """shortest_first breaks ties by enqueue order."""
+    q = RequestQueue(policy="shortest_first")
+    q.enqueue("req-a", prompt_tokens=1000)
+    q.enqueue("req-b", prompt_tokens=1000)
+    q.enqueue("req-c", prompt_tokens=1000)
+    assert q.dequeue().request_id == "req-a"
+    assert q.dequeue().request_id == "req-b"
+    assert q.dequeue().request_id == "req-c"
+
+
+def test_request_queue_shortest_first_starvation_guard():
+    """Requests waiting past starvation_timeout_s get dequeued first."""
+    q = RequestQueue(policy="shortest_first", starvation_timeout_s=60.0)
+    q.enqueue("req-large", prompt_tokens=100_000)
+    q.enqueue("req-small", prompt_tokens=1_000)
+    # Simulate req-large has been waiting 120s (past 60s timeout)
+    q._queue[0].enqueued_at = time.time() - 120.0
+    # Starved request gets effective_tokens=0, dequeued before req-small
+    assert q.dequeue().request_id == "req-large"
+    assert q.dequeue().request_id == "req-small"
+
+
+def test_request_queue_shortest_first_peek():
+    """peek() returns the same entry that dequeue() would."""
+    q = RequestQueue(policy="shortest_first")
+    q.enqueue("req-large", prompt_tokens=100_000)
+    q.enqueue("req-small", prompt_tokens=1_000)
+    peeked = q.peek()
+    assert peeked.request_id == "req-small"
+    dequeued = q.dequeue()
+    assert dequeued.request_id == "req-small"
+
+
+def test_request_queue_priority_basic():
+    """priority dequeues highest priority first."""
+    q = RequestQueue(policy="priority")
+    q.enqueue("req-low", prompt_tokens=1000, priority=0)
+    q.enqueue("req-high", prompt_tokens=1000, priority=10)
+    q.enqueue("req-mid", prompt_tokens=1000, priority=5)
+    assert q.dequeue().request_id == "req-high"
+    assert q.dequeue().request_id == "req-mid"
+    assert q.dequeue().request_id == "req-low"
+
+
+def test_request_queue_priority_tiebreak_fifo():
+    """Same-priority requests ordered FIFO."""
+    q = RequestQueue(policy="priority")
+    q.enqueue("req-a", prompt_tokens=1000, priority=5)
+    q.enqueue("req-b", prompt_tokens=1000, priority=5)
+    q.enqueue("req-c", prompt_tokens=1000, priority=5)
+    assert q.dequeue().request_id == "req-a"
+    assert q.dequeue().request_id == "req-b"
+    assert q.dequeue().request_id == "req-c"
+
+
+def test_request_queue_invalid_policy():
+    """Invalid policy raises ValueError."""
+    import pytest
+
+    with pytest.raises(ValueError, match="Unsupported policy"):
+        RequestQueue(policy="round_robin")
+
+
+def test_admission_controller_shortest_first_admits_small():
+    """shortest_first admits a small request even when a large one can't fit."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        # 10 GB free (just enough for small, not large)
+        mock_mx.get_active_memory.return_value = 110 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+            policy="shortest_first",
+        )
+        # Both queued (neither fits when first checked — queue is empty so
+        # try_admit checks memory directly)
+        # Large: 200K * 20KB = 4GB prefill + 8GB headroom = 12GB > 10GB free → queue
+        admitted1, _ = controller.try_admit("req-large", prompt_tokens=200_000)
+        assert admitted1 is False
+        # Small: 100 * 20KB ≈ 2MB + 8GB headroom < 10GB → would fit, but
+        # queue is non-empty so it joins the queue
+        admitted2, _ = controller.try_admit("req-small", prompt_tokens=100)
+        assert admitted2 is False
+        assert controller.queue_length == 2
+
+        # Now memory frees to 20GB — shortest_first admits small first
+        mock_mx.get_active_memory.return_value = 100 * 1024**3
+        ready = controller.on_request_complete()
+        # Both should be admittable now, but small is dequeued first
+        assert len(ready) >= 1
+        assert ready[0].request_id == "req-small"
+
+
+def test_admission_controller_priority_order():
+    """priority policy admits highest-priority request first."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+            policy="priority",
+        )
+        controller.try_admit("req-low", prompt_tokens=1000, priority=0)
+        controller.try_admit("req-high", prompt_tokens=1000, priority=10)
+        controller.try_admit("req-mid", prompt_tokens=1000, priority=5)
+        assert controller.queue_length == 3
+
+        # Free memory — highest priority dequeued first
+        mock_mx.get_active_memory.return_value = 50 * 1024**3
+        ready = controller.on_request_complete()
+        assert len(ready) == 3
+        assert ready[0].request_id == "req-high"
+        assert ready[1].request_id == "req-mid"
+        assert ready[2].request_id == "req-low"

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from unittest.mock import patch
 
-from vllm_mlx.admission import MemoryMonitor, QueuedRequest, RequestQueue, compute_kv_per_token
+from vllm_mlx.admission import MemoryMonitor, RequestQueue, compute_kv_per_token
 
 
 def test_kv_per_token_qwen35_35b():
@@ -64,3 +64,33 @@ def test_memory_monitor_can_admit():
         assert monitor.can_admit(prefill_bytes=5 * 1024**3) is True
         # 20 GB free, 8 GB headroom, 15 GB prefill = 20 < 23 → reject
         assert monitor.can_admit(prefill_bytes=15 * 1024**3) is False
+
+
+def test_request_queue_fifo():
+    q = RequestQueue(policy="fifo")
+    q.enqueue("req-1", prompt_tokens=1000)
+    q.enqueue("req-2", prompt_tokens=500)
+    q.enqueue("req-3", prompt_tokens=2000)
+    # FIFO: order of insertion
+    assert q.peek().request_id == "req-1"
+    assert q.dequeue().request_id == "req-1"
+    assert q.dequeue().request_id == "req-2"
+    assert q.dequeue().request_id == "req-3"
+    assert q.is_empty()
+
+
+def test_request_queue_length():
+    q = RequestQueue(policy="fifo")
+    assert len(q) == 0
+    q.enqueue("req-1", prompt_tokens=100)
+    assert len(q) == 1
+    q.dequeue()
+    assert len(q) == 0
+
+
+def test_request_queue_cancel():
+    q = RequestQueue(policy="fifo")
+    q.enqueue("req-1", prompt_tokens=100)
+    q.enqueue("req-2", prompt_tokens=200)
+    q.cancel("req-1")
+    assert q.dequeue().request_id == "req-2"

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from unittest.mock import patch
 
-from vllm_mlx.admission import MemoryMonitor, RequestQueue, compute_kv_per_token
+from vllm_mlx.admission import (
+    AdmissionController,
+    MemoryMonitor,
+    RequestQueue,
+    compute_kv_per_token,
+)
 
 
 def test_kv_per_token_qwen35_35b():
@@ -96,3 +101,61 @@ def test_request_queue_cancel():
     q.enqueue("req-2", prompt_tokens=200)
     q.cancel("req-1")
     assert q.dequeue().request_id == "req-2"
+
+
+def test_admission_controller_admit_when_room():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 50 * 1024**3  # 70 GB free
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+        )
+        admitted, position = controller.try_admit("req-1", prompt_tokens=10_000)
+        assert admitted is True
+        assert position is None
+
+
+def test_admission_controller_queue_when_full():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3  # 5 GB free
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+        )
+        # 10K tokens * 20KB = 200MB prefill. 5GB free < 200MB + 8GB → queue
+        admitted, position = controller.try_admit("req-1", prompt_tokens=10_000)
+        assert admitted is False
+        assert position == 0
+
+
+def test_admission_controller_drain_queue():
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        # Start full
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480,
+            headroom_bytes=8 * 1024**3,
+        )
+        controller.try_admit("req-1", prompt_tokens=1000)
+        assert controller.queue_length == 1
+        # Memory freed
+        mock_mx.get_active_memory.return_value = 50 * 1024**3
+        ready = controller.check_queue()
+        assert len(ready) == 1
+        assert ready[0].request_id == "req-1"
+        assert controller.queue_length == 0

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -278,3 +278,33 @@ def test_admission_controller_cancel_wakes_waiter():
         assert controller.cancel("req-1") is True
         assert event.is_set()
         assert "req-1" not in controller._wait_events
+
+
+def test_admission_wait_cleans_up_on_cancellation():
+    """Verify CancelledError during wait cleans up queue and events."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+
+        async def simulate_cancel():
+            task = asyncio.create_task(
+                controller.wait_for_admission("req-cancel", prompt_tokens=1000)
+            )
+            await asyncio.sleep(0)  # Let it reach the await event.wait()
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            # Queue and events should be cleaned up
+            assert controller.queue_length == 0
+            assert "req-cancel" not in controller._wait_events
+
+        asyncio.get_event_loop().run_until_complete(simulate_cancel())

--- a/tests/test_admission.py
+++ b/tests/test_admission.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
+
 from unittest.mock import patch
 
 from vllm_mlx.admission import (
@@ -202,3 +204,77 @@ def test_admission_controller_cancel():
         assert controller.cancel("req-1") is True
         assert controller.queue_length == 0
         assert controller.cancel("nonexistent") is False
+
+
+def test_admission_controller_wait_for_admission():
+    """Test async wait — admitted immediately when room."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 50 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+        # Should return immediately — plenty of memory
+        asyncio.get_event_loop().run_until_complete(
+            controller.wait_for_admission("req-1", prompt_tokens=100)
+        )
+        assert controller.queue_length == 0
+
+
+def test_admission_controller_on_request_complete():
+    """Test that completing a request releases queued ones."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+
+        # Queue a request (not enough memory)
+        admitted, pos = controller.try_admit("req-1", prompt_tokens=1000)
+        assert admitted is False
+
+        # Set up wait event manually
+        event = asyncio.Event()
+        controller._wait_events["req-1"] = event
+
+        # Free memory and signal completion
+        mock_mx.get_active_memory.return_value = 50 * 1024**3
+        ready = controller.on_request_complete()
+        assert len(ready) == 1
+        assert ready[0].request_id == "req-1"
+        assert event.is_set()  # Waiter was signaled
+
+
+def test_admission_controller_cancel_wakes_waiter():
+    """Test that cancelling a queued request wakes up its waiter."""
+    with patch("vllm_mlx.admission.mx") as mock_mx:
+        mock_mx.metal.is_available.return_value = True
+        mock_mx.device_info.return_value = {
+            "max_recommended_working_set_size": 120 * 1024**3
+        }
+        mock_mx.get_active_memory.return_value = 115 * 1024**3
+        mock_mx.get_cache_memory.return_value = 0
+        controller = AdmissionController(
+            kv_per_token=20_480, headroom_bytes=8 * 1024**3
+        )
+
+        # Queue a request
+        controller.try_admit("req-1", prompt_tokens=1000)
+
+        # Set up wait event
+        event = asyncio.Event()
+        controller._wait_events["req-1"] = event
+
+        # Cancel should wake the waiter
+        assert controller.cancel("req-1") is True
+        assert event.is_set()
+        assert "req-1" not in controller._wait_events

--- a/tests/test_cooperative_specprefill.py
+++ b/tests/test_cooperative_specprefill.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import MagicMock
+
+from vllm_mlx.cooperative_specprefill import ChunkedDraftScorer
+
+
+def test_chunked_scorer_initial_state():
+    """Scorer starts with correct initial state."""
+    scorer = ChunkedDraftScorer(
+        draft_model=MagicMock(),
+        tokens=list(range(10000)),
+        chunk_size=4096,
+    )
+    assert scorer.is_scoring
+    assert not scorer.is_done
+    assert scorer.chunks_remaining > 0
+    assert scorer.tokens_processed == 0
+
+
+def test_chunked_scorer_chunks_remaining():
+    """Chunks remaining computed correctly."""
+    scorer = ChunkedDraftScorer(
+        draft_model=MagicMock(),
+        tokens=list(range(10000)),
+        chunk_size=4096,
+    )
+    # 10000 tokens, chunk_size=4096: (9999 processable) / 4096 = 3 chunks
+    assert scorer.chunks_remaining >= 2
+
+
+def test_chunked_scorer_small_prompt():
+    """Prompt smaller than chunk_size: still works."""
+    scorer = ChunkedDraftScorer(
+        draft_model=MagicMock(),
+        tokens=list(range(100)),
+        chunk_size=4096,
+    )
+    assert scorer.chunks_remaining >= 1
+
+
+def test_chunked_scorer_cleanup_frees_resources():
+    """cleanup() frees cache and intermediates."""
+    scorer = ChunkedDraftScorer(
+        draft_model=MagicMock(),
+        tokens=list(range(100)),
+        chunk_size=50,
+    )
+    # Simulate partial state
+    scorer._cache = MagicMock()
+    scorer._logits = MagicMock()
+    scorer.cleanup()
+    assert scorer._cache is None
+    assert scorer._logits is None
+
+
+def test_chunked_scorer_finalize_before_done_raises():
+    """finalize() raises if scoring not complete."""
+    scorer = ChunkedDraftScorer(
+        draft_model=MagicMock(),
+        tokens=list(range(10000)),
+        chunk_size=4096,
+    )
+    import pytest
+
+    with pytest.raises(RuntimeError, match="Cannot finalize"):
+        scorer.finalize()

--- a/tests/test_speculative_decoding.py
+++ b/tests/test_speculative_decoding.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for speculative decoding with a separate draft model (SimpleEngine path)."""
+
+import pytest
+
+try:
+    import mlx.core as mx  # noqa: F401
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI args
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgs:
+    def test_draft_model_arg_parsing(self):
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--draft-model", type=str, default=None)
+        parser.add_argument("--num-draft-tokens", type=int, default=3)
+
+        args = parser.parse_args(
+            ["--draft-model", "/path/to/model", "--num-draft-tokens", "5"]
+        )
+        assert args.draft_model == "/path/to/model"
+        assert args.num_draft_tokens == 5
+
+    def test_default_num_draft_tokens(self):
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--num-draft-tokens", type=int, default=3)
+
+        args = parser.parse_args([])
+        assert args.num_draft_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: SimpleEngine draft model
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleEngineDraftModel:
+    def test_draft_model_params_stored(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine(
+            model_name="test-model",
+            draft_model_path="/path/to/draft",
+            num_draft_tokens=5,
+        )
+        assert engine._draft_model_path == "/path/to/draft"
+        assert engine._num_draft_tokens == 5
+
+    def test_no_draft_model_by_default(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine(model_name="test-model")
+        assert engine._draft_model_path is None
+        assert engine._num_draft_tokens == 3
+
+
+class TestMLXLanguageModelDraftModel:
+    def test_draft_model_params_stored(self):
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        model = MLXLanguageModel(
+            model_name="test-model",
+            draft_model_path="/path/to/draft",
+            num_draft_tokens=5,
+        )
+        assert model._draft_model_path == "/path/to/draft"
+        assert model._num_draft_tokens == 5
+        assert model.draft_model is None
+
+    def test_no_draft_model_by_default(self):
+        from vllm_mlx.models.llm import MLXLanguageModel
+
+        model = MLXLanguageModel(model_name="test-model")
+        assert model._draft_model_path is None
+        assert model.draft_model is None

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -25,6 +25,7 @@ def compute_kv_per_token(
     num_kv_heads: int,
     head_dim: int,
     dtype_bytes: int = 2,
+    hybrid_override_pattern: Optional[str] = None,
 ) -> int:
     """Compute KV cache bytes per token for this model.
 
@@ -39,13 +40,21 @@ def compute_kv_per_token(
         num_kv_heads: Number of KV attention heads.
         head_dim: Dimension per head.
         dtype_bytes: Bytes per element (2 for bfloat16, 1 for int8 quantized).
+        hybrid_override_pattern: Layer-type string from config.json (e.g.
+            Nemotron-H "MEMEMEM*E..."). '*' = attention, 'M' = Mamba,
+            'E' = MoE, '-' = MLP.  When provided, attention layers are
+            counted directly from the pattern instead of using
+            full_attention_interval.
 
     Returns:
         Bytes of KV cache consumed per token.
     """
-    if full_attention_interval <= 0:
-        full_attention_interval = 1
-    attention_layers = num_hidden_layers // full_attention_interval
+    if hybrid_override_pattern:
+        attention_layers = hybrid_override_pattern.count("*")
+    else:
+        if full_attention_interval <= 0:
+            full_attention_interval = 1
+        attention_layers = num_hidden_layers // full_attention_interval
     return attention_layers * num_kv_heads * head_dim * 2 * dtype_bytes  # 2 = K + V
 
 
@@ -75,45 +84,127 @@ class MemoryMonitor:
         return self.free_memory() >= prefill_bytes + self.headroom_bytes
 
 
+_VALID_POLICIES = ("fifo", "shortest_first", "priority")
+
+
 @dataclass
 class QueuedRequest:
     request_id: str
     prompt_tokens: int
+    priority: int = 0  # Higher = more important (only used by "priority" policy)
     enqueued_at: float = field(default_factory=time.time)
 
 
 class RequestQueue:
-    """Request queue with configurable ordering policy."""
+    """Request queue with configurable ordering policy.
 
-    def __init__(self, policy: str = "fifo"):
-        if policy != "fifo":
+    Policies:
+        fifo: First-in-first-out. Fair, prevents starvation. Head-of-line
+            blocking: a large request at the front blocks smaller ones behind it.
+        shortest_first: Dequeue the request with the fewest prompt tokens.
+            Maximizes throughput by clearing short requests first. Starvation
+            guard: requests waiting longer than ``starvation_timeout_s`` are
+            promoted to highest priority.
+        priority: Dequeue the request with the highest ``priority`` value.
+            Same-priority requests are ordered FIFO (by enqueue time).
+    """
+
+    def __init__(self, policy: str = "fifo", starvation_timeout_s: float = 120.0):
+        if policy not in _VALID_POLICIES:
             raise ValueError(
-                f"Unsupported policy: {policy!r}. Only 'fifo' is implemented."
+                f"Unsupported policy: {policy!r}. "
+                f"Valid policies: {', '.join(_VALID_POLICIES)}"
             )
         self._policy = policy
+        self._starvation_timeout_s = starvation_timeout_s
         self._queue: deque[QueuedRequest] = deque()
 
-    def enqueue(self, request_id: str, prompt_tokens: int) -> int:
+    @property
+    def policy(self) -> str:
+        return self._policy
+
+    def enqueue(self, request_id: str, prompt_tokens: int, priority: int = 0) -> int:
         """Add request to queue. Returns position (0-indexed)."""
-        entry = QueuedRequest(request_id=request_id, prompt_tokens=prompt_tokens)
+        entry = QueuedRequest(
+            request_id=request_id, prompt_tokens=prompt_tokens, priority=priority
+        )
         self._queue.append(entry)
         position = len(self._queue) - 1
         logger.info(
-            f"[queue] {request_id} queued at position {position} ({prompt_tokens} tokens)"
+            f"[queue] {request_id} queued at position {position} "
+            f"({prompt_tokens} tokens, priority={priority})"
         )
         return position
 
     def peek(self) -> Optional[QueuedRequest]:
-        """Return next request without removing it."""
+        """Return the next request that would be dequeued, without removing it."""
         if not self._queue:
             return None
-        return self._queue[0]
+        if self._policy == "fifo":
+            return self._queue[0]
+        return self._select_next()
 
     def dequeue(self) -> Optional[QueuedRequest]:
         """Remove and return next request per policy."""
         if not self._queue:
             return None
-        return self._queue.popleft()
+        if self._policy == "fifo":
+            return self._queue.popleft()
+        entry = self._select_next()
+        if entry is not None:
+            self._queue.remove(entry)
+        return entry
+
+    def _select_next(self) -> Optional[QueuedRequest]:
+        """Select the next request to dequeue based on policy.
+
+        For shortest_first: pick the request with fewest prompt_tokens.
+        Starvation guard: any request waiting longer than starvation_timeout_s
+        is treated as having 0 tokens (highest priority to dequeue).
+
+        For priority: pick the request with highest priority value.
+        Ties broken by earliest enqueue time (FIFO within same priority).
+        """
+        if not self._queue:
+            return None
+
+        now = time.time()
+
+        if self._policy == "shortest_first":
+            best = None
+            for entry in self._queue:
+                waited = now - entry.enqueued_at
+                starved = waited >= self._starvation_timeout_s
+                # Starved requests get effective size 0 (dequeue first)
+                effective_tokens = 0 if starved else entry.prompt_tokens
+                if best is None:
+                    best = (entry, effective_tokens, entry.enqueued_at)
+                else:
+                    _, best_tokens, best_time = best
+                    # Prefer fewer tokens; break ties by earlier enqueue
+                    if effective_tokens < best_tokens or (
+                        effective_tokens == best_tokens
+                        and entry.enqueued_at < best_time
+                    ):
+                        best = (entry, effective_tokens, entry.enqueued_at)
+            return best[0] if best else None
+
+        elif self._policy == "priority":
+            best = None
+            for entry in self._queue:
+                if best is None:
+                    best = entry
+                elif entry.priority > best.priority:
+                    best = entry
+                elif (
+                    entry.priority == best.priority
+                    and entry.enqueued_at < best.enqueued_at
+                ):
+                    best = entry
+            return best
+
+        # Fallback (shouldn't reach here — FIFO handled in dequeue)
+        return self._queue[0]
 
     def cancel(self, request_id: str) -> bool:
         """Remove a request from the queue. Returns True if found."""
@@ -151,7 +242,7 @@ class AdmissionController:
         self._eviction_callback: Optional[callable] = None
 
     def try_admit(
-        self, request_id: str, prompt_tokens: int
+        self, request_id: str, prompt_tokens: int, priority: int = 0
     ) -> Tuple[bool, Optional[int]]:
         """Try to admit a request for immediate processing.
 
@@ -160,8 +251,9 @@ class AdmissionController:
             (False, queue_position) if queued.
         """
         # FIFO: if anything is already waiting, join the queue regardless of memory.
+        # (shortest_first and priority also respect queue — no cutting the line)
         if not self._queue.is_empty():
-            position = self._queue.enqueue(request_id, prompt_tokens)
+            position = self._queue.enqueue(request_id, prompt_tokens, priority)
             return False, position
         prefill_bytes = prompt_tokens * self.kv_per_token
         if self._monitor.can_admit(prefill_bytes):
@@ -171,7 +263,7 @@ class AdmissionController:
                 f"{self._monitor.free_memory() / 1e9:.1f} GB free)"
             )
             return True, None
-        position = self._queue.enqueue(request_id, prompt_tokens)
+        position = self._queue.enqueue(request_id, prompt_tokens, priority)
         return False, position
 
     def set_eviction_callback(self, callback) -> None:
@@ -186,34 +278,69 @@ class AdmissionController:
         """Check if queued requests can now be admitted.
 
         Called after a request completes or memory is freed.
-        If an eviction callback is registered and the front-of-queue request
-        can't fit, the callback is invoked once to free prefix cache memory,
-        then admission is re-checked. If the callback returns False (nothing
-        left to evict), the loop stops.
+
+        Policy behavior:
+            fifo: Only admit the front of the queue. Never skips.
+            shortest_first: Admit the smallest request that fits, even if
+                it's not at the front. Starved requests (past timeout) are
+                treated as smallest.
+            priority: Admit the highest-priority request that fits. Ties
+                broken by FIFO order.
+
+        If an eviction callback is registered and the selected request can't
+        fit, the callback is invoked to free prefix cache memory.
+
         Returns list of newly-admittable requests.
         """
         ready = []
-        while not self._queue.is_empty():
-            entry = self._queue.peek()
-            prefill_bytes = entry.prompt_tokens * self.kv_per_token
-            if self._monitor.can_admit(prefill_bytes):
-                ready.append(self._queue.dequeue())
-                logger.info(
-                    f"[admit] {entry.request_id} DEQUEUED → admitted "
-                    f"(waited {time.time() - entry.enqueued_at:.1f}s)"
-                )
-            else:
-                # FIFO: do not skip the front to admit smaller requests behind it.
-                # Prevents starvation of large requests.
-                # Try evicting prefix cache to make room.
-                if self._eviction_callback is not None and self._eviction_callback():
-                    continue  # Re-check after eviction freed memory
-                break  # No eviction possible or nothing left to evict
+
+        if self._queue._policy == "fifo":
+            # FIFO: strict head-of-line. Never skip the front.
+            while not self._queue.is_empty():
+                entry = self._queue.peek()
+                prefill_bytes = entry.prompt_tokens * self.kv_per_token
+                if self._monitor.can_admit(prefill_bytes):
+                    ready.append(self._queue.dequeue())
+                    logger.info(
+                        f"[admit] {entry.request_id} DEQUEUED → admitted "
+                        f"(waited {time.time() - entry.enqueued_at:.1f}s)"
+                    )
+                else:
+                    if (
+                        self._eviction_callback is not None
+                        and self._eviction_callback()
+                    ):
+                        continue
+                    break
+        else:
+            # shortest_first / priority: scan for best admittable request
+            while not self._queue.is_empty():
+                candidate = self._queue.peek()  # Policy-ordered best
+                prefill_bytes = candidate.prompt_tokens * self.kv_per_token
+                if self._monitor.can_admit(prefill_bytes):
+                    self._queue.dequeue()
+                    ready.append(candidate)
+                    logger.info(
+                        f"[admit] {candidate.request_id} DEQUEUED → admitted "
+                        f"(waited {time.time() - candidate.enqueued_at:.1f}s, "
+                        f"policy={self._queue._policy})"
+                    )
+                else:
+                    # Best candidate doesn't fit. Try eviction once.
+                    if (
+                        self._eviction_callback is not None
+                        and self._eviction_callback()
+                    ):
+                        continue
+                    break
+
         return ready
 
-    async def wait_for_admission(self, request_id: str, prompt_tokens: int) -> None:
+    async def wait_for_admission(
+        self, request_id: str, prompt_tokens: int, priority: int = 0
+    ) -> None:
         """Block until this request can be admitted. Returns immediately if room."""
-        admitted, position = self.try_admit(request_id, prompt_tokens)
+        admitted, position = self.try_admit(request_id, prompt_tokens, priority)
         if admitted:
             return
         event = asyncio.Event()

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -148,6 +148,7 @@ class AdmissionController:
         self._monitor = MemoryMonitor(headroom_bytes=headroom_bytes)
         self._queue = RequestQueue(policy=policy)
         self._wait_events: dict[str, asyncio.Event] = {}
+        self._eviction_callback: Optional[callable] = None
 
     def try_admit(
         self, request_id: str, prompt_tokens: int
@@ -173,10 +174,22 @@ class AdmissionController:
         position = self._queue.enqueue(request_id, prompt_tokens)
         return False, position
 
+    def set_eviction_callback(self, callback) -> None:
+        """Set a callback to evict prefix cache entries under memory pressure.
+
+        The callback should return True if it evicted something, False if
+        there's nothing left to evict.
+        """
+        self._eviction_callback = callback
+
     def check_queue(self) -> List[QueuedRequest]:
         """Check if queued requests can now be admitted.
 
         Called after a request completes or memory is freed.
+        If an eviction callback is registered and the front-of-queue request
+        can't fit, the callback is invoked once to free prefix cache memory,
+        then admission is re-checked. If the callback returns False (nothing
+        left to evict), the loop stops.
         Returns list of newly-admittable requests.
         """
         ready = []
@@ -192,7 +205,10 @@ class AdmissionController:
             else:
                 # FIFO: do not skip the front to admit smaller requests behind it.
                 # Prevents starvation of large requests.
-                break
+                # Try evicting prefix cache to make room.
+                if self._eviction_callback is not None and self._eviction_callback():
+                    continue  # Re-check after eviction freed memory
+                break  # No eviction possible or nothing left to evict
         return ready
 
     async def wait_for_admission(self, request_id: str, prompt_tokens: int) -> None:

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -7,6 +7,8 @@ Once a request starts generating, it runs to completion.
 The admission controller only decides WHEN to start.
 """
 
+import mlx.core as mx
+
 
 def compute_kv_per_token(
     num_hidden_layers: int,
@@ -36,3 +38,28 @@ def compute_kv_per_token(
         full_attention_interval = 1
     attention_layers = num_hidden_layers // full_attention_interval
     return attention_layers * num_kv_heads * head_dim * 2 * dtype_bytes  # 2 = K + V
+
+
+class MemoryMonitor:
+    """Reads actual Metal memory to make admission decisions.
+
+    Uses mx.get_active_memory() — real GPU allocations, not estimates.
+    """
+
+    def __init__(self, headroom_bytes: int = 8 * 1024**3):
+        self.headroom_bytes = headroom_bytes
+        if mx.metal.is_available():
+            info = mx.device_info()
+            self._device_usable = info["max_recommended_working_set_size"]
+        else:
+            self._device_usable = 0
+
+    def free_memory(self) -> int:
+        """Return bytes of free GPU-usable memory."""
+        if not mx.metal.is_available():
+            return 0
+        return self._device_usable - mx.get_active_memory()
+
+    def can_admit(self, prefill_bytes: int) -> bool:
+        """Can we admit a request that needs prefill_bytes of KV cache?"""
+        return self.free_memory() >= prefill_bytes + self.headroom_bytes

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -51,7 +51,8 @@ def compute_kv_per_token(
 class MemoryMonitor:
     """Reads actual Metal memory to make admission decisions.
 
-    Uses mx.get_active_memory() — real GPU allocations, not estimates.
+    Uses mx.get_active_memory() + mx.get_cache_memory() for true GPU
+    memory usage, not just live tensors.
     """
 
     def __init__(self, headroom_bytes: int = 8 * 1024**3):
@@ -66,7 +67,7 @@ class MemoryMonitor:
         """Return bytes of free GPU-usable memory."""
         if not mx.metal.is_available():
             return 0
-        return self._device_usable - mx.get_active_memory()
+        return self._device_usable - mx.get_active_memory() - mx.get_cache_memory()
 
     def can_admit(self, prefill_bytes: int) -> bool:
         """Can we admit a request that needs prefill_bytes of KV cache?"""
@@ -84,6 +85,10 @@ class RequestQueue:
     """Request queue with configurable ordering policy."""
 
     def __init__(self, policy: str = "fifo"):
+        if policy != "fifo":
+            raise ValueError(
+                f"Unsupported policy: {policy!r}. Only 'fifo' is implemented."
+            )
         self._policy = policy
         self._queue: deque[QueuedRequest] = deque()
 

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Memory-aware admission controller for multi-user inference.
+
+Core principle: Load affects latency, never quality.
+Once a request starts generating, it runs to completion.
+The admission controller only decides WHEN to start.
+"""
+
+
+def compute_kv_per_token(
+    num_hidden_layers: int,
+    full_attention_interval: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype_bytes: int = 2,
+) -> int:
+    """Compute KV cache bytes per token for this model.
+
+    Only full attention layers contribute to KV cache.
+    Linear attention (GatedDeltaNet) layers use fixed-size
+    SSM state regardless of context length.
+
+    Args:
+        num_hidden_layers: Total layer count.
+        full_attention_interval: Every Nth layer is full attention.
+            1 = all attention (dense), 4 = 25% attention (Qwen3.5).
+        num_kv_heads: Number of KV attention heads.
+        head_dim: Dimension per head.
+        dtype_bytes: Bytes per element (2 for bfloat16, 1 for int8 quantized).
+
+    Returns:
+        Bytes of KV cache consumed per token.
+    """
+    if full_attention_interval <= 0:
+        full_attention_interval = 1
+    attention_layers = num_hidden_layers // full_attention_interval
+    return attention_layers * num_kv_heads * head_dim * 2 * dtype_bytes  # 2 = K + V

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -11,7 +11,7 @@ import logging
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import mlx.core as mx
 
@@ -127,3 +127,70 @@ class RequestQueue:
 
     def __len__(self) -> int:
         return len(self._queue)
+
+
+class AdmissionController:
+    """Flow control for multi-user inference.
+
+    Core principle: Load affects latency, never quality.
+    Decides WHEN to start requests. Once started, a request
+    runs to completion at full quality.
+    """
+
+    def __init__(
+        self,
+        kv_per_token: int,
+        headroom_bytes: int = 8 * 1024**3,
+        policy: str = "fifo",
+    ):
+        self.kv_per_token = kv_per_token
+        self.monitor = MemoryMonitor(headroom_bytes=headroom_bytes)
+        self.queue = RequestQueue(policy=policy)
+
+    def try_admit(
+        self, request_id: str, prompt_tokens: int
+    ) -> Tuple[bool, Optional[int]]:
+        """Try to admit a request for immediate processing.
+
+        Returns:
+            (True, None) if admitted.
+            (False, queue_position) if queued.
+        """
+        prefill_bytes = prompt_tokens * self.kv_per_token
+        if self.monitor.can_admit(prefill_bytes):
+            logger.info(
+                f"[admit] {request_id} ADMITTED ({prompt_tokens} tokens, "
+                f"{prefill_bytes / 1e6:.0f} MB prefill, "
+                f"{self.monitor.free_memory() / 1e9:.1f} GB free)"
+            )
+            return True, None
+        position = self.queue.enqueue(request_id, prompt_tokens)
+        return False, position
+
+    def check_queue(self) -> List[QueuedRequest]:
+        """Check if queued requests can now be admitted.
+
+        Called after a request completes or memory is freed.
+        Returns list of newly-admittable requests.
+        """
+        ready = []
+        while not self.queue.is_empty():
+            entry = self.queue.peek()
+            prefill_bytes = entry.prompt_tokens * self.kv_per_token
+            if self.monitor.can_admit(prefill_bytes):
+                ready.append(self.queue.dequeue())
+                logger.info(
+                    f"[admit] {entry.request_id} DEQUEUED → admitted "
+                    f"(waited {time.time() - entry.enqueued_at:.1f}s)"
+                )
+            else:
+                break  # If front of queue can't fit, nothing behind it can either (FIFO)
+        return ready
+
+    def cancel(self, request_id: str) -> bool:
+        """Cancel a queued request."""
+        return self.queue.cancel(request_id)
+
+    @property
+    def queue_length(self) -> int:
+        return len(self.queue)

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -144,8 +144,8 @@ class AdmissionController:
         policy: str = "fifo",
     ):
         self.kv_per_token = kv_per_token
-        self.monitor = MemoryMonitor(headroom_bytes=headroom_bytes)
-        self.queue = RequestQueue(policy=policy)
+        self._monitor = MemoryMonitor(headroom_bytes=headroom_bytes)
+        self._queue = RequestQueue(policy=policy)
 
     def try_admit(
         self, request_id: str, prompt_tokens: int
@@ -156,15 +156,19 @@ class AdmissionController:
             (True, None) if admitted.
             (False, queue_position) if queued.
         """
+        # FIFO: if anything is already waiting, join the queue regardless of memory.
+        if not self._queue.is_empty():
+            position = self._queue.enqueue(request_id, prompt_tokens)
+            return False, position
         prefill_bytes = prompt_tokens * self.kv_per_token
-        if self.monitor.can_admit(prefill_bytes):
+        if self._monitor.can_admit(prefill_bytes):
             logger.info(
                 f"[admit] {request_id} ADMITTED ({prompt_tokens} tokens, "
                 f"{prefill_bytes / 1e6:.0f} MB prefill, "
-                f"{self.monitor.free_memory() / 1e9:.1f} GB free)"
+                f"{self._monitor.free_memory() / 1e9:.1f} GB free)"
             )
             return True, None
-        position = self.queue.enqueue(request_id, prompt_tokens)
+        position = self._queue.enqueue(request_id, prompt_tokens)
         return False, position
 
     def check_queue(self) -> List[QueuedRequest]:
@@ -174,23 +178,25 @@ class AdmissionController:
         Returns list of newly-admittable requests.
         """
         ready = []
-        while not self.queue.is_empty():
-            entry = self.queue.peek()
+        while not self._queue.is_empty():
+            entry = self._queue.peek()
             prefill_bytes = entry.prompt_tokens * self.kv_per_token
-            if self.monitor.can_admit(prefill_bytes):
-                ready.append(self.queue.dequeue())
+            if self._monitor.can_admit(prefill_bytes):
+                ready.append(self._queue.dequeue())
                 logger.info(
                     f"[admit] {entry.request_id} DEQUEUED → admitted "
                     f"(waited {time.time() - entry.enqueued_at:.1f}s)"
                 )
             else:
-                break  # If front of queue can't fit, nothing behind it can either (FIFO)
+                # FIFO: do not skip the front to admit smaller requests behind it.
+                # Prevents starvation of large requests.
+                break
         return ready
 
     def cancel(self, request_id: str) -> bool:
         """Cancel a queued request."""
-        return self.queue.cancel(request_id)
+        return self._queue.cancel(request_id)
 
     @property
     def queue_length(self) -> int:
-        return len(self.queue)
+        return len(self._queue)

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -7,6 +7,7 @@ Once a request starts generating, it runs to completion.
 The admission controller only decides WHEN to start.
 """
 
+import asyncio
 import logging
 import time
 from collections import deque
@@ -146,6 +147,7 @@ class AdmissionController:
         self.kv_per_token = kv_per_token
         self._monitor = MemoryMonitor(headroom_bytes=headroom_bytes)
         self._queue = RequestQueue(policy=policy)
+        self._wait_events: dict[str, asyncio.Event] = {}
 
     def try_admit(
         self, request_id: str, prompt_tokens: int
@@ -193,9 +195,33 @@ class AdmissionController:
                 break
         return ready
 
+    async def wait_for_admission(self, request_id: str, prompt_tokens: int) -> None:
+        """Block until this request can be admitted. Returns immediately if room."""
+        admitted, position = self.try_admit(request_id, prompt_tokens)
+        if admitted:
+            return
+        event = asyncio.Event()
+        self._wait_events[request_id] = event
+        logger.info(f"[admit] {request_id} waiting for admission (position {position})")
+        await event.wait()
+        self._wait_events.pop(request_id, None)
+
+    def on_request_complete(self) -> List[QueuedRequest]:
+        """Called when a request completes. Drains queue and signals waiters."""
+        ready = self.check_queue()
+        for entry in ready:
+            event = self._wait_events.get(entry.request_id)
+            if event:
+                event.set()
+        return ready
+
     def cancel(self, request_id: str) -> bool:
-        """Cancel a queued request."""
-        return self._queue.cancel(request_id)
+        """Cancel a queued request and wake up its waiter."""
+        result = self._queue.cancel(request_id)
+        event = self._wait_events.pop(request_id, None)
+        if event:
+            event.set()  # Wake up waiter so it can clean up
+        return result
 
     @property
     def queue_length(self) -> int:

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -203,7 +203,12 @@ class AdmissionController:
         event = asyncio.Event()
         self._wait_events[request_id] = event
         logger.info(f"[admit] {request_id} waiting for admission (position {position})")
-        await event.wait()
+        try:
+            await event.wait()
+        except asyncio.CancelledError:
+            self._queue.cancel(request_id)
+            self._wait_events.pop(request_id, None)
+            raise
         self._wait_events.pop(request_id, None)
 
     def on_request_complete(self) -> List[QueuedRequest]:

--- a/vllm_mlx/admission.py
+++ b/vllm_mlx/admission.py
@@ -7,7 +7,15 @@ Once a request starts generating, it runs to completion.
 The admission controller only decides WHEN to start.
 """
 
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Optional
+
 import mlx.core as mx
+
+logger = logging.getLogger(__name__)
 
 
 def compute_kv_per_token(
@@ -63,3 +71,54 @@ class MemoryMonitor:
     def can_admit(self, prefill_bytes: int) -> bool:
         """Can we admit a request that needs prefill_bytes of KV cache?"""
         return self.free_memory() >= prefill_bytes + self.headroom_bytes
+
+
+@dataclass
+class QueuedRequest:
+    request_id: str
+    prompt_tokens: int
+    enqueued_at: float = field(default_factory=time.time)
+
+
+class RequestQueue:
+    """Request queue with configurable ordering policy."""
+
+    def __init__(self, policy: str = "fifo"):
+        self._policy = policy
+        self._queue: deque[QueuedRequest] = deque()
+
+    def enqueue(self, request_id: str, prompt_tokens: int) -> int:
+        """Add request to queue. Returns position (0-indexed)."""
+        entry = QueuedRequest(request_id=request_id, prompt_tokens=prompt_tokens)
+        self._queue.append(entry)
+        position = len(self._queue) - 1
+        logger.info(
+            f"[queue] {request_id} queued at position {position} ({prompt_tokens} tokens)"
+        )
+        return position
+
+    def peek(self) -> Optional[QueuedRequest]:
+        """Return next request without removing it."""
+        if not self._queue:
+            return None
+        return self._queue[0]
+
+    def dequeue(self) -> Optional[QueuedRequest]:
+        """Remove and return next request per policy."""
+        if not self._queue:
+            return None
+        return self._queue.popleft()
+
+    def cancel(self, request_id: str) -> bool:
+        """Remove a request from the queue. Returns True if found."""
+        for i, entry in enumerate(self._queue):
+            if entry.request_id == request_id:
+                del self._queue[i]
+                return True
+        return False
+
+    def is_empty(self) -> bool:
+        return len(self._queue) == 0
+
+    def __len__(self) -> int:
+        return len(self._queue)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -804,8 +804,10 @@ Examples:
         "--scheduler-policy",
         type=str,
         default="fifo",
-        choices=["fifo"],
-        help="Request queue policy for admission control (default: fifo)",
+        choices=["fifo", "shortest_first", "priority"],
+        help="Request queue policy for admission control (default: fifo). "
+        "shortest_first: dequeue smallest prompt first (maximizes throughput). "
+        "priority: dequeue highest-priority request first.",
     )
     serve_parser.add_argument(
         "--scheduler-headroom-gb",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -204,6 +204,8 @@ def serve_command(args):
         specprefill_threshold=args.specprefill_threshold,
         specprefill_keep_pct=args.specprefill_keep_pct,
         specprefill_draft_model=args.specprefill_draft_model,
+        scheduler_policy=args.scheduler_policy,
+        scheduler_headroom_gb=args.scheduler_headroom_gb,
     )
 
     # Start server
@@ -788,6 +790,20 @@ Examples:
         default=None,
         help="Path to small draft model for SpecPrefill importance scoring. "
         "Must share the same tokenizer as the target model.",
+    )
+    # Admission controller (memory-aware scheduling)
+    serve_parser.add_argument(
+        "--scheduler-policy",
+        type=str,
+        default="fifo",
+        choices=["fifo"],
+        help="Request queue policy for admission control (default: fifo)",
+    )
+    serve_parser.add_argument(
+        "--scheduler-headroom-gb",
+        type=float,
+        default=8.0,
+        help="Memory headroom in GB for admission control (default: 8.0)",
     )
     # MCP options
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -204,6 +204,7 @@ def serve_command(args):
         specprefill_threshold=args.specprefill_threshold,
         specprefill_keep_pct=args.specprefill_keep_pct,
         specprefill_draft_model=args.specprefill_draft_model,
+        specprefill_chunk_size=args.specprefill_chunk_size,
         scheduler_policy=args.scheduler_policy,
         scheduler_headroom_gb=args.scheduler_headroom_gb,
     )
@@ -790,6 +791,13 @@ Examples:
         default=None,
         help="Path to small draft model for SpecPrefill importance scoring. "
         "Must share the same tokenizer as the target model.",
+    )
+    serve_parser.add_argument(
+        "--specprefill-chunk-size",
+        type=int,
+        default=4096,
+        help="Tokens per draft scoring chunk before yielding to active requests (default: 4096). "
+        "Larger = faster scoring, less responsive interleaving. 0 = monolithic (no yielding).",
     )
     # Admission controller (memory-aware scheduling)
     serve_parser.add_argument(

--- a/vllm_mlx/cooperative_specprefill.py
+++ b/vllm_mlx/cooperative_specprefill.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Cooperative SpecPrefill — chunked draft model scoring with yield points.
+
+Draft scoring (the slowest phase) is broken into chunks. Between chunks,
+the caller yields to the event loop so active requests can generate tokens.
+Selection + sparse prefill + generation run monolithically after scoring.
+
+The draft model is separate from the target model — no shared mutable state
+(RoPE, cache). Safe to interleave draft scoring with target generation.
+"""
+
+import logging
+import math
+import time
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkedDraftScorer:
+    """Break draft model token scoring into chunks for cooperative scheduling.
+
+    Usage:
+        scorer = ChunkedDraftScorer(draft_model, tokens, chunk_size=4096)
+        while scorer.is_scoring:
+            scorer.step()       # Process one chunk of draft prefill
+            await asyncio.sleep(0)  # Yield to event loop
+        importance = scorer.finalize()  # Lookahead + importance (fast)
+    """
+
+    def __init__(
+        self,
+        draft_model,
+        tokens,
+        chunk_size: int = 4096,
+        prefill_step_size: int = 2048,
+        n_lookahead: int = 8,
+        pool_kernel: int = 13,
+        temp: float = 0.6,
+        top_p: float = 0.95,
+        query_extractor=None,
+    ):
+        self._model = draft_model
+        self._tokens = tokens if isinstance(tokens, list) else tokens.tolist()
+        self._chunk_size = chunk_size
+        self._prefill_step_size = prefill_step_size
+        self._n_lookahead = n_lookahead
+        self._pool_kernel = pool_kernel
+        self._temp = temp
+        self._top_p = top_p
+        self._query_extractor = query_extractor
+
+        # State
+        self._cache = None
+        self._processed = 0
+        self._logits = None
+        self._done_scoring = False
+        self._importance = None
+        self._t_start = time.monotonic()
+
+    @property
+    def is_scoring(self) -> bool:
+        """True while draft prefill chunks remain."""
+        return not self._done_scoring
+
+    @property
+    def is_done(self) -> bool:
+        """True after finalize() completes."""
+        return self._importance is not None
+
+    @property
+    def tokens_processed(self) -> int:
+        return self._processed
+
+    @property
+    def chunks_remaining(self) -> int:
+        n = len(self._tokens)
+        remaining = n - self._processed
+        if remaining <= 1:
+            return 0
+        return math.ceil((remaining - 1) / self._chunk_size)
+
+    def step(self) -> bool:
+        """Process one chunk of draft prefill. Returns True if more chunks remain."""
+        from mlx_lm.models.cache import make_prompt_cache
+
+        if self._done_scoring:
+            return False
+
+        # Initialize cache on first step
+        if self._cache is None:
+            self._cache = make_prompt_cache(self._model)
+
+        prompt = mx.array(self._tokens)
+        n = len(self._tokens)
+        remaining = n - self._processed
+
+        if remaining > 1:
+            chunk = min(self._chunk_size, remaining - 1)
+            self._model(
+                prompt[self._processed : self._processed + chunk][None],
+                cache=self._cache,
+            )
+            mx.eval([c.state for c in self._cache])
+            self._processed += chunk
+            mx.clear_cache()
+            return (n - self._processed) > 1  # More chunks?
+        else:
+            # Last token — get logits
+            self._logits = self._model(
+                prompt[self._processed :][None], cache=self._cache
+            )
+            mx.eval(self._logits)
+            self._processed = n
+            self._done_scoring = True
+            return False
+
+    def finalize(self):
+        """Run lookahead decode + importance computation. Returns importance scores.
+
+        This is fast (~100ms) — no yield needed. Must be called after
+        all scoring chunks are processed (is_scoring == False).
+        """
+        if not self._done_scoring:
+            raise RuntimeError("Cannot finalize before scoring is complete")
+        if self._importance is not None:
+            return self._importance
+
+        from .specprefill import (
+            _build_layer_to_cache_map,
+            _compute_importance,
+            _find_attention_layers,
+            _get_attn_module,
+            _llama_extract_queries,
+            _lookahead_decode,
+            _nemotron_h_extract_queries,
+            _patch_attention_for_capture,
+            _qwen35_extract_queries,
+            _unpatch_attention_capture,
+        )
+
+        attn_layers = _find_attention_layers(self._model)
+        n_attn_layers = len(attn_layers)
+        attn_obj = _get_attn_module(attn_layers[0][1])
+        n_attn_heads = getattr(
+            attn_obj,
+            "num_attention_heads",
+            getattr(attn_obj, "n_heads", getattr(attn_obj, "num_heads", None)),
+        )
+        n_kv_heads = getattr(
+            attn_obj,
+            "num_key_value_heads",
+            getattr(attn_obj, "n_kv_heads", None),
+        )
+
+        # Auto-detect query extractor
+        qe = self._query_extractor
+        if qe is None:
+            if hasattr(attn_obj, "q_norm"):
+                qe = _qwen35_extract_queries
+            elif not hasattr(attn_obj, "rope"):
+                qe = _nemotron_h_extract_queries
+            else:
+                qe = _llama_extract_queries
+
+        # Lookahead decode with query capture
+        query_buffer = [[] for _ in range(n_attn_layers)]
+        patches, attn_indices = _patch_attention_for_capture(
+            self._model,
+            query_buffer,
+            query_extractor=qe,
+        )
+        try:
+            _lookahead_decode(
+                self._model,
+                self._logits,
+                self._cache,
+                self._n_lookahead,
+                temp=self._temp,
+                top_p=self._top_p,
+            )
+            mx.eval(query_buffer)
+        finally:
+            _unpatch_attention_capture(self._model, patches)
+
+        # Compute importance
+        layer_to_cache = _build_layer_to_cache_map(self._model)
+        attn_caches = [self._cache[layer_to_cache[i]] for i in attn_indices]
+        self._importance = _compute_importance(
+            query_buffer,
+            attn_caches,
+            len(self._tokens),
+            n_attn_heads,
+            n_kv_heads,
+            pool_kernel=self._pool_kernel if self._pool_kernel > 0 else None,
+        )
+        mx.eval(self._importance)
+
+        t_total = time.monotonic() - self._t_start
+        logger.info(
+            "ChunkedDraftScorer: scored %d tokens in %.1fs (%d chunks of %d)",
+            len(self._tokens),
+            t_total,
+            math.ceil(len(self._tokens) / self._chunk_size),
+            self._chunk_size,
+        )
+
+        # Free draft resources
+        del self._cache, self._logits
+        self._cache = None
+        self._logits = None
+        mx.clear_cache()
+
+        return self._importance
+
+    def cleanup(self):
+        """Clean up on cancellation. Frees draft cache and intermediates."""
+        if self._cache is not None:
+            del self._cache
+            self._cache = None
+        if self._logits is not None:
+            del self._logits
+            self._logits = None
+        if self._importance is not None:
+            del self._importance
+            self._importance = None
+        mx.clear_cache()

--- a/vllm_mlx/cooperative_specprefill.py
+++ b/vllm_mlx/cooperative_specprefill.py
@@ -54,6 +54,7 @@ class ChunkedDraftScorer:
 
         # State
         self._cache = None
+        self._prompt = mx.array(self._tokens)  # Create once, reuse in step()
         self._processed = 0
         self._logits = None
         self._done_scoring = False
@@ -93,14 +94,13 @@ class ChunkedDraftScorer:
         if self._cache is None:
             self._cache = make_prompt_cache(self._model)
 
-        prompt = mx.array(self._tokens)
         n = len(self._tokens)
         remaining = n - self._processed
 
         if remaining > 1:
             chunk = min(self._chunk_size, remaining - 1)
             self._model(
-                prompt[self._processed : self._processed + chunk][None],
+                self._prompt[self._processed : self._processed + chunk][None],
                 cache=self._cache,
             )
             mx.eval([c.state for c in self._cache])
@@ -110,7 +110,7 @@ class ChunkedDraftScorer:
         else:
             # Last token — get logits
             self._logits = self._model(
-                prompt[self._processed :][None], cache=self._cache
+                self._prompt[self._processed :][None], cache=self._cache
             )
             mx.eval(self._logits)
             self._processed = n
@@ -208,9 +208,10 @@ class ChunkedDraftScorer:
         )
 
         # Free draft resources
-        del self._cache, self._logits
+        del self._cache, self._logits, self._prompt
         self._cache = None
         self._logits = None
+        self._prompt = None
         mx.clear_cache()
 
         return self._importance
@@ -220,6 +221,9 @@ class ChunkedDraftScorer:
         if self._cache is not None:
             del self._cache
             self._cache = None
+        if self._prompt is not None:
+            del self._prompt
+            self._prompt = None
         if self._logits is not None:
             del self._logits
             self._logits = None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -13,8 +13,9 @@ LLM engine), so text-only requests must also be routed through it.
 
 import asyncio
 import logging
+import uuid
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Optional
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
@@ -167,6 +168,8 @@ class BatchedEngine(BaseEngine):
         specprefill_draft_model_path: str | None = None,
         specprefill_threshold: int = 8192,
         specprefill_keep_pct: float = 0.3,
+        scheduler_policy: str = "fifo",
+        scheduler_headroom_gb: float = 8.0,
     ):
         """
         Initialize the batched engine.
@@ -183,6 +186,8 @@ class BatchedEngine(BaseEngine):
             specprefill_draft_model_path: Draft model directory name under ~/ai-models/mlx_models/
             specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default 8192)
             specprefill_keep_pct: Fraction of tokens to keep (default 0.3)
+            scheduler_policy: Request queue policy for admission control (default: fifo)
+            scheduler_headroom_gb: Memory headroom in GB for admission control (default: 8.0)
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
@@ -197,6 +202,11 @@ class BatchedEngine(BaseEngine):
         self._specprefill_draft_model_path = specprefill_draft_model_path
         self._specprefill_threshold = specprefill_threshold
         self._specprefill_keep_pct = specprefill_keep_pct
+
+        # Admission controller (memory-aware scheduling)
+        self._scheduler_policy = scheduler_policy
+        self._scheduler_headroom_gb = scheduler_headroom_gb
+        self._admission: Optional["AdmissionController"] = None  # noqa: F821
         self._specprefill_lock = asyncio.Lock()
         self._draft_model = None
 
@@ -217,6 +227,46 @@ class BatchedEngine(BaseEngine):
         self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
         self._system_kv_hash = None  # Hash of system prefix text
         self._system_kv_token_count = 0  # Tokens in cached prefix
+
+    def _init_admission_controller(self, model_config) -> None:
+        """Create the admission controller from model config.
+
+        Extracts KV cache parameters from HuggingFace PretrainedConfig
+        (attribute access) or dict-style configs. VLM models nest the
+        language model config under ``text_config``.
+        """
+        from ..admission import AdmissionController, compute_kv_per_token
+
+        def _get(cfg, key, default):
+            """Read a config value from attr-based or dict-based config."""
+            if isinstance(cfg, dict):
+                return cfg.get(key, default)
+            return getattr(cfg, key, default)
+
+        # For VLM models, language model config is nested under text_config
+        text_cfg = _get(model_config, "text_config", None)
+        if text_cfg is not None:
+            cfg = text_cfg
+        else:
+            cfg = model_config
+
+        kv_per_token = compute_kv_per_token(
+            num_hidden_layers=_get(cfg, "num_hidden_layers", 32),
+            full_attention_interval=_get(cfg, "full_attention_interval", 1),
+            num_kv_heads=_get(cfg, "num_key_value_heads", 8),
+            head_dim=_get(cfg, "head_dim", 128),
+        )
+
+        self._admission = AdmissionController(
+            kv_per_token=kv_per_token,
+            headroom_bytes=int(self._scheduler_headroom_gb * 1024**3),
+            policy=self._scheduler_policy,
+        )
+        logger.info(
+            "[admission] KV per token: %s bytes, headroom: %.1fGB",
+            f"{kv_per_token:,}",
+            self._scheduler_headroom_gb,
+        )
 
     @property
     def model_name(self) -> str:
@@ -296,6 +346,11 @@ class BatchedEngine(BaseEngine):
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
             f"completion_batch={completion_batch_size}"
         )
+
+        # Initialize admission controller from MLLM model config
+        mllm_config = getattr(self._mllm_instance, "config", None)
+        if mllm_config is not None:
+            self._init_admission_controller(mllm_config)
 
         # Build TextModel for MTP per-request routing (text-only → MTP, media → MLLM)
         if self._mtp:
@@ -435,6 +490,11 @@ class BatchedEngine(BaseEngine):
 
         await self._engine.engine.start()
 
+        # Initialize admission controller from LLM model config
+        model_config = getattr(self._model, "config", None)
+        if model_config is not None:
+            self._init_admission_controller(model_config)
+
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         if self._mllm_scheduler:
@@ -456,6 +516,7 @@ class BatchedEngine(BaseEngine):
         self._system_kv_snapshot = None
         self._system_kv_hash = None
         self._system_kv_token_count = 0
+        self._admission = None
         self._loaded = False
         logger.info("BatchedEngine stopped")
 
@@ -551,6 +612,35 @@ class BatchedEngine(BaseEngine):
             else:
                 prepared.append(msg)
         return prepared
+
+    def _estimate_prompt_tokens(self, messages: list[dict[str, Any]]) -> int:
+        """Estimate token count from chat messages for admission control.
+
+        Uses the tokenizer when available, falls back to character-based
+        estimate (1 token per 4 characters).
+        """
+        # Concatenate message text for a rough estimate
+        text_parts = []
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                text_parts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, str):
+                        text_parts.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+        text = " ".join(text_parts)
+
+        tokenizer = self.tokenizer
+        if tokenizer is not None and hasattr(tokenizer, "encode"):
+            try:
+                return len(tokenizer.encode(text))
+            except Exception:
+                pass
+        # Fallback: ~4 chars per token
+        return len(text) // 4
 
     async def generate(
         self,
@@ -744,42 +834,52 @@ class BatchedEngine(BaseEngine):
         # Normalize messages before any path (developer->system, merge consecutive)
         messages = _normalize_messages(messages)
 
-        # Per-request MTP routing: text-only → TextModel, media → MLLM
-        if self._text_model is not None and not _has_media_content(messages):
-            return await self._chat_text_model(
+        # Admission control — wait if memory is tight
+        admission_id = None
+        if self._admission is not None:
+            prompt_tokens = self._estimate_prompt_tokens(messages)
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, prompt_tokens)
+
+        try:
+            # Per-request MTP routing: text-only → TextModel, media → MLLM
+            if self._text_model is not None and not _has_media_content(messages):
+                return await self._chat_text_model(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    tools=tools,
+                    **kwargs,
+                )
+
+            # Extract images/videos from messages (OpenAI multimodal format)
+            _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+            all_images = (images or []) + extracted_images
+            all_videos = (videos or []) + extracted_videos
+
+            # Convert tools for template
+            template_tools = convert_tools_for_template(tools) if tools else None
+
+            # Apply chat template
+            prompt = self._apply_chat_template(
                 messages,
+                template_tools,
+                num_images=len(all_images),
+            )
+
+            return await self.generate(
+                prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
-                tools=tools,
+                images=all_images if all_images else None,
+                videos=all_videos if all_videos else None,
                 **kwargs,
             )
-
-        # Extract images/videos from messages (OpenAI multimodal format)
-        # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
-        all_images = (images or []) + extracted_images
-        all_videos = (videos or []) + extracted_videos
-
-        # Convert tools for template
-        template_tools = convert_tools_for_template(tools) if tools else None
-
-        # Apply chat template
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            num_images=len(all_images),
-        )
-
-        return await self.generate(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            images=all_images if all_images else None,
-            videos=all_videos if all_videos else None,
-            **kwargs,
-        )
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
 
     def _compute_prefix_boundary(
         self, messages: list[dict[str, Any]], tools: list[dict] | None = None
@@ -869,50 +969,60 @@ class BatchedEngine(BaseEngine):
         # Normalize messages before any path (developer->system, merge consecutive)
         messages = _normalize_messages(messages)
 
-        # Per-request MTP routing: text-only → TextModel, media → MLLM
-        if self._text_model is not None and not _has_media_content(messages):
-            async for output in self._stream_chat_text_model(
+        # Admission control — wait if memory is tight
+        admission_id = None
+        if self._admission is not None:
+            prompt_tokens = self._estimate_prompt_tokens(messages)
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, prompt_tokens)
+
+        try:
+            # Per-request MTP routing: text-only → TextModel, media → MLLM
+            if self._text_model is not None and not _has_media_content(messages):
+                async for output in self._stream_chat_text_model(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    tools=tools,
+                    **kwargs,
+                ):
+                    yield output
+                return
+
+            # Extract images/videos from messages (OpenAI multimodal format)
+            _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+            all_images = (images or []) + extracted_images
+            all_videos = (videos or []) + extracted_videos
+
+            # Convert tools for template
+            template_tools = convert_tools_for_template(tools) if tools else None
+
+            # Apply chat template
+            prompt = self._apply_chat_template(
                 messages,
+                template_tools,
+                num_images=len(all_images),
+            )
+
+            # Compute prefix boundary for cache
+            prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            if prefix_boundary > 0:
+                kwargs["prefix_boundary"] = prefix_boundary
+
+            async for output in self.stream_generate(
+                prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
-                tools=tools,
+                images=all_images if all_images else None,
+                videos=all_videos if all_videos else None,
                 **kwargs,
             ):
                 yield output
-            return
-
-        # Extract images/videos from messages (OpenAI multimodal format)
-        # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
-        all_images = (images or []) + extracted_images
-        all_videos = (videos or []) + extracted_videos
-
-        # Convert tools for template
-        template_tools = convert_tools_for_template(tools) if tools else None
-
-        # Apply chat template
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            num_images=len(all_images),
-        )
-
-        # Compute prefix boundary for cache
-        prefix_boundary = self._compute_prefix_boundary(messages, tools)
-        if prefix_boundary > 0:
-            kwargs["prefix_boundary"] = prefix_boundary
-
-        async for output in self.stream_generate(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            images=all_images if all_images else None,
-            videos=all_videos if all_videos else None,
-            **kwargs,
-        ):
-            yield output
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
 
     async def _chat_text_model(
         self,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -211,7 +211,6 @@ class BatchedEngine(BaseEngine):
         self._scheduler_policy = scheduler_policy
         self._scheduler_headroom_gb = scheduler_headroom_gb
         self._admission: Optional["AdmissionController"] = None  # noqa: F821
-        self._specprefill_lock = asyncio.Lock()
         self._draft_model = None
 
         self._model = None
@@ -226,7 +225,9 @@ class BatchedEngine(BaseEngine):
         self._text_model = None
         self._text_tokenizer = None
         self._text_generation_lock = asyncio.Lock()
-        self._metal_lock = __import__("threading").Lock()  # Serializes all Metal GPU access
+        self._metal_lock = __import__(
+            "threading"
+        ).Lock()  # Serializes all Metal GPU access
 
         # System prompt KV cache (reduces repeated prefill across requests)
         self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
@@ -260,6 +261,7 @@ class BatchedEngine(BaseEngine):
             full_attention_interval=_get(cfg, "full_attention_interval", 1),
             num_kv_heads=_get(cfg, "num_key_value_heads", 8),
             head_dim=_get(cfg, "head_dim", 128),
+            hybrid_override_pattern=_get(cfg, "hybrid_override_pattern", None),
         )
 
         self._admission = AdmissionController(
@@ -272,6 +274,41 @@ class BatchedEngine(BaseEngine):
             f"{kv_per_token:,}",
             self._scheduler_headroom_gb,
         )
+
+    async def _metal_safe_mllm_loop(self) -> None:
+        """Process loop for MLLMScheduler that serializes with TextModel.
+
+        Replaces MLLMScheduler._process_loop when MTP routing is active.
+        Uses _metal_lock (threading.Lock) with non-blocking acquire so the
+        event loop is never blocked waiting for a background thread.
+
+        The TextModel path acquires _metal_lock in two places:
+          1. Cooperative specprefill chunks (outside _text_generation_lock)
+          2. Main generation (inside _text_generation_lock)
+        This loop tries to acquire the same lock. If the lock is held
+        (TextModel is running Metal), we yield and retry next iteration.
+        """
+        sched = self._mllm_scheduler
+        while sched._running:
+            try:
+                if sched.has_requests():
+                    acquired = self._metal_lock.acquire(blocking=False)
+                    if acquired:
+                        try:
+                            sched.step()
+                        finally:
+                            self._metal_lock.release()
+                        await asyncio.sleep(0)
+                    else:
+                        # TextModel holds the lock — yield and retry
+                        await asyncio.sleep(0.001)
+                else:
+                    await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in Metal-safe MLLM loop: {e}")
+                await asyncio.sleep(0.1)
 
     @property
     def model_name(self) -> str:
@@ -345,6 +382,25 @@ class BatchedEngine(BaseEngine):
             config=mllm_config,
         )
         await self._mllm_scheduler.start()
+
+        # When MTP routing is active, both MLLMScheduler and TextModel access
+        # Metal. MLLMScheduler.step() runs synchronously on the event loop
+        # thread; TextModel runs via asyncio.to_thread. Without coordination,
+        # concurrent Metal access causes crashes (mlx#3216-class bugs).
+        # Fix: replace the scheduler's process loop with one that acquires
+        # _metal_lock around each step(), serializing with TextModel.
+        if self._mtp:
+            self._mllm_scheduler._running = False
+            if self._mllm_scheduler._processing_task:
+                self._mllm_scheduler._processing_task.cancel()
+                try:
+                    await self._mllm_scheduler._processing_task
+                except asyncio.CancelledError:
+                    pass
+            self._mllm_scheduler._running = True
+            self._mllm_scheduler._processing_task = asyncio.create_task(
+                self._metal_safe_mllm_loop()
+            )
 
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
@@ -1276,14 +1332,18 @@ class BatchedEngine(BaseEngine):
             )
             try:
                 while scorer.is_scoring:
+
                     def _locked_step():
                         with self._metal_lock:
                             return scorer.step()
+
                     await asyncio.to_thread(_locked_step)
                     await asyncio.sleep(0)  # Yield to event loop
+
                 def _locked_finalize():
                     with self._metal_lock:
                         return scorer.finalize()
+
                 importance = await asyncio.to_thread(_locked_finalize)
             except Exception as e:
                 scorer.cleanup()
@@ -1661,6 +1721,7 @@ class BatchedEngine(BaseEngine):
             def _locked_run_with_cache():
                 with self._metal_lock:
                     return _run_with_cache()
+
             result = await asyncio.to_thread(_locked_run_with_cache)
             all_resps, prompt_token_count = result
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -168,6 +168,7 @@ class BatchedEngine(BaseEngine):
         specprefill_draft_model_path: str | None = None,
         specprefill_threshold: int = 8192,
         specprefill_keep_pct: float = 0.3,
+        specprefill_chunk_size: int = 4096,
         scheduler_policy: str = "fifo",
         scheduler_headroom_gb: float = 8.0,
     ):
@@ -186,6 +187,8 @@ class BatchedEngine(BaseEngine):
             specprefill_draft_model_path: Draft model directory name under ~/ai-models/mlx_models/
             specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default 8192)
             specprefill_keep_pct: Fraction of tokens to keep (default 0.3)
+            specprefill_chunk_size: Draft scoring chunk size for cooperative scheduling
+                (default 4096). Set to 0 to disable cooperative mode (monolithic scoring).
             scheduler_policy: Request queue policy for admission control (default: fifo)
             scheduler_headroom_gb: Memory headroom in GB for admission control (default: 8.0)
         """
@@ -202,6 +205,7 @@ class BatchedEngine(BaseEngine):
         self._specprefill_draft_model_path = specprefill_draft_model_path
         self._specprefill_threshold = specprefill_threshold
         self._specprefill_keep_pct = specprefill_keep_pct
+        self._specprefill_chunk_size = specprefill_chunk_size
 
         # Admission controller (memory-aware scheduling)
         self._scheduler_policy = scheduler_policy
@@ -1228,11 +1232,56 @@ class BatchedEngine(BaseEngine):
                 )
                 use_specprefill = False
 
-        # Run under generation lock, all tokens in single thread (Metal safety)
+        # --- Cooperative SpecPrefill: draft scoring OUTSIDE the lock ---
+        # When chunk_size > 0, draft scoring runs outside _text_generation_lock
+        # via ChunkedDraftScorer, yielding between chunks so active requests
+        # can generate tokens. The draft model is separate from the target
+        # model — no shared mutable state.
+        # When chunk_size == 0, the old monolithic path runs entirely under lock.
+        use_cooperative = use_specprefill and self._specprefill_chunk_size > 0
+        importance = None  # Pre-computed importance for cooperative path
+
+        if use_cooperative:
+            from ..cooperative_specprefill import ChunkedDraftScorer
+
+            scorer = ChunkedDraftScorer(
+                draft_model=self._draft_model,
+                tokens=sp_tokens,
+                chunk_size=self._specprefill_chunk_size,
+                prefill_step_size=prefill_step_size,
+            )
+            try:
+                while scorer.is_scoring:
+                    await asyncio.to_thread(scorer.step)
+                    await asyncio.sleep(0)  # Yield to event loop
+                importance = await asyncio.to_thread(scorer.finalize)
+            except Exception as e:
+                scorer.cleanup()
+                logger.error(
+                    "SpecPrefill cooperative scoring failed, "
+                    "falling back to normal path: %s",
+                    e,
+                )
+                use_specprefill = False
+                use_cooperative = False
+                importance = None
+
+        # --- Selection + prefill + generation UNDER LOCK ---
         async with self._text_generation_lock:
 
             def _run_with_cache():
-                if use_specprefill:
+                if use_specprefill and use_cooperative and importance is not None:
+                    try:
+                        return _run_specprefill_with_importance(importance)
+                    except Exception as e:
+                        logger.error(
+                            "SpecPrefill failed after scoring, "
+                            "falling back to normal path: %s",
+                            e,
+                        )
+                        # Fall through to normal path
+                elif use_specprefill and not use_cooperative:
+                    # Monolithic path (chunk_size=0): score + prefill under lock
                     try:
                         return _run_specprefill()
                     except Exception as e:
@@ -1245,8 +1294,118 @@ class BatchedEngine(BaseEngine):
                 else:
                     return _run_cache_miss()
 
+            def _run_specprefill_with_importance(precomputed_importance):
+                """Select chunks, sparse prefill, generate with pre-scored importance.
+
+                Draft scoring has already been done outside the lock via
+                ChunkedDraftScorer. This function handles phases 2-4:
+                selection, sparse prefill, and autoregressive generation.
+
+                Composes with system KV cache: when cache_hit, restores the
+                system KV snapshot first, then sparse-prefills only the suffix
+                tokens with position_offset = system_kv_token_count.
+
+                Does NOT use MTP (sparse cache is incompatible with MTP
+                speculative decoding).
+                """
+                import time
+                from types import SimpleNamespace
+
+                from ..specprefill import (
+                    cleanup_rope,
+                    select_chunks,
+                    sparse_prefill,
+                )
+
+                # Build target cache (optionally restore system KV snapshot)
+                target_cache = make_prompt_cache(self._text_model)
+                if cache_hit:
+                    for layer_idx, snapshot_state in enumerate(
+                        self._system_kv_snapshot
+                    ):
+                        if layer_idx < len(target_cache):
+                            target_cache[layer_idx].state = snapshot_state
+                    mx.eval([c.state for c in target_cache if hasattr(c, "state")])
+
+                try:
+                    # Phase 2: Select important chunks
+                    effective_keep = (
+                        specprefill_keep_pct_override or self._specprefill_keep_pct
+                    )
+                    selected = select_chunks(
+                        precomputed_importance, keep_pct=effective_keep
+                    )
+                    n_selected = selected.shape[0]
+                    n_scored = len(sp_tokens)
+
+                    # Phase 3: Sparse prefill on target model
+                    t0 = time.monotonic()
+                    logits = sparse_prefill(
+                        self._text_model,
+                        sp_tokens,
+                        selected,
+                        target_cache,
+                        step_size=prefill_step_size,
+                        position_offset=sp_offset,
+                    )
+                    t_prefill = time.monotonic() - t0
+
+                    logger.info(
+                        "SpecPrefill (cooperative): "
+                        "sparse prefill %d/%d (keep=%.0f%%) in %.1fs "
+                        "(offset=%d, effective_keep=%.2f)",
+                        n_selected,
+                        n_scored,
+                        n_selected / n_scored * 100,
+                        t_prefill,
+                        sp_offset,
+                        effective_keep,
+                    )
+
+                    # Phase 4: Generate (simple autoregressive, no MTP)
+                    eos_id = self._text_tokenizer.eos_token_id
+                    y = sampler(logits[:, -1, :])
+                    mx.eval(y)
+
+                    results = []
+                    generated_ids = []
+                    prev_decoded = ""
+
+                    for _ in range(max_tokens):
+                        tok_id = y.item()
+                        generated_ids.append(tok_id)
+
+                        # Incremental text decode
+                        decoded = self._text_tokenizer.decode(generated_ids)
+                        new_text = decoded[len(prev_decoded) :]
+                        prev_decoded = decoded
+
+                        is_eos = tok_id == eos_id
+                        results.append(
+                            SimpleNamespace(
+                                text=new_text,
+                                finish_reason="stop" if is_eos else None,
+                            )
+                        )
+
+                        if is_eos:
+                            break
+
+                        # Next token
+                        logits = self._text_model(y.reshape(1, -1), cache=target_cache)
+                        y = sampler(logits[:, -1, :])
+                        mx.eval(y)
+
+                    return results, sp_n_total
+
+                finally:
+                    cleanup_rope(self._text_model)
+
             def _run_specprefill():
-                """Score tokens, sparse prefill, generate autoregressively.
+                """Monolithic: score tokens, sparse prefill, generate.
+
+                Used when cooperative mode is disabled (chunk_size=0).
+                Runs entirely under _text_generation_lock.
 
                 Composes with system KV cache: when cache_hit, restores the
                 system KV snapshot first, then sparse-prefills only the suffix
@@ -1537,6 +1696,8 @@ class BatchedEngine(BaseEngine):
                 "draft_model": self._specprefill_draft_model_path,
                 "threshold": self._specprefill_threshold,
                 "keep_pct": self._specprefill_keep_pct,
+                "chunk_size": self._specprefill_chunk_size,
+                "cooperative": self._specprefill_chunk_size > 0,
             }
 
         # System KV cache stats

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -226,6 +226,7 @@ class BatchedEngine(BaseEngine):
         self._text_model = None
         self._text_tokenizer = None
         self._text_generation_lock = asyncio.Lock()
+        self._metal_lock = __import__("threading").Lock()  # Serializes all Metal GPU access
 
         # System prompt KV cache (reduces repeated prefill across requests)
         self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
@@ -1275,9 +1276,15 @@ class BatchedEngine(BaseEngine):
             )
             try:
                 while scorer.is_scoring:
-                    await asyncio.to_thread(scorer.step)
+                    def _locked_step():
+                        with self._metal_lock:
+                            return scorer.step()
+                    await asyncio.to_thread(_locked_step)
                     await asyncio.sleep(0)  # Yield to event loop
-                importance = await asyncio.to_thread(scorer.finalize)
+                def _locked_finalize():
+                    with self._metal_lock:
+                        return scorer.finalize()
+                importance = await asyncio.to_thread(_locked_finalize)
             except Exception as e:
                 scorer.cleanup()
                 logger.error(
@@ -1651,7 +1658,10 @@ class BatchedEngine(BaseEngine):
                     prefix_hash,
                 )
 
-            result = await asyncio.to_thread(_run_with_cache)
+            def _locked_run_with_cache():
+                with self._metal_lock:
+                    return _run_with_cache()
+            result = await asyncio.to_thread(_locked_run_with_cache)
             all_resps, prompt_token_count = result
 
         # Yield results as GenerationOutput

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -11,15 +11,39 @@ MLLMBatchGenerator. MLLM models only initialise the MLLM scheduler (not the
 LLM engine), so text-only requests must also be routed through it.
 """
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
+from ..message_utils import _normalize_messages
 from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
+
+_MEDIA_TYPES = frozenset(
+    {
+        "image_url",
+        "video_url",
+        "audio_url",
+        "image",
+        "video",
+        "audio",
+    }
+)
+
+
+def _has_media_content(messages: list) -> bool:
+    """Check if any message contains media content (images, video, audio)."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in _MEDIA_TYPES:
+                    return True
+    return False
 
 
 def _extract_media_from_messages(messages: list[dict[str, Any]]) -> tuple:
@@ -137,6 +161,12 @@ class BatchedEngine(BaseEngine):
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,
+        mtp: bool = False,
+        prefill_step_size: int | None = None,
+        specprefill_enabled: bool = False,
+        specprefill_draft_model_path: str | None = None,
+        specprefill_threshold: int = 8192,
+        specprefill_keep_pct: float = 0.3,
     ):
         """
         Initialize the batched engine.
@@ -147,12 +177,28 @@ class BatchedEngine(BaseEngine):
             scheduler_config: Optional scheduler configuration
             stream_interval: Tokens to batch before streaming (1=every token)
             force_mllm: Force loading as MLLM even if not auto-detected
+            mtp: Enable MTP per-request routing (text-only → TextModel, media → MLLM)
+            prefill_step_size: Chunk size for prompt prefill (default 2048)
+            specprefill_enabled: Enable SpecPrefill sparse prefill
+            specprefill_draft_model_path: Draft model directory name under ~/ai-models/mlx_models/
+            specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default 8192)
+            specprefill_keep_pct: Fraction of tokens to keep (default 0.3)
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
         self._is_mllm = force_mllm or is_mllm_model(model_name)
+        self._mtp = mtp
+        self._prefill_step_size = prefill_step_size or 2048
+
+        # SpecPrefill configuration
+        self._specprefill_enabled = specprefill_enabled
+        self._specprefill_draft_model_path = specprefill_draft_model_path
+        self._specprefill_threshold = specprefill_threshold
+        self._specprefill_keep_pct = specprefill_keep_pct
+        self._specprefill_lock = asyncio.Lock()
+        self._draft_model = None
 
         self._model = None
         self._processor = None  # For MLLM
@@ -161,6 +207,16 @@ class BatchedEngine(BaseEngine):
         self._mllm_scheduler = None  # MLLMScheduler for MLLM
         self._mllm_instance = None  # MLXMultimodalLM instance
         self._loaded = False
+
+        # Per-request routing state (MLLM+MTP mode)
+        self._text_model = None
+        self._text_tokenizer = None
+        self._text_generation_lock = asyncio.Lock()
+
+        # System prompt KV cache (reduces repeated prefill across requests)
+        self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
+        self._system_kv_hash = None  # Hash of system prefix text
+        self._system_kv_token_count = 0  # Tokens in cached prefix
 
     @property
     def model_name(self) -> str:
@@ -240,6 +296,73 @@ class BatchedEngine(BaseEngine):
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
             f"completion_batch={completion_batch_size}"
         )
+
+        # Build TextModel for MTP per-request routing (text-only → MTP, media → MLLM)
+        if self._mtp:
+            try:
+                from ..text_model_from_vlm import build_text_model
+
+                self._text_model = build_text_model(
+                    self._mllm_instance.model, self._model_name
+                )
+                if self._text_model is not None:
+                    # Get tokenizer from the MLLM instance (same model, shared tokenizer)
+                    self._text_tokenizer = self._mllm_instance.get_tokenizer()
+
+                    # Apply Qwen3.5 eos_token fix (matches SimpleEngine pattern)
+                    if "qwen3" in self._model_name.lower():
+                        self._text_tokenizer.eos_token = "<|im_end|>"
+                        self._text_tokenizer.eos_token_id = (
+                            self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
+                        )
+
+                    # Check if TextModel actually has MTP
+                    has_mtp = (
+                        hasattr(self._text_model, "mtp")
+                        and self._text_model.mtp is not None
+                    )
+                    if has_mtp:
+                        logger.info(
+                            "BatchedEngine MLLM+MTP routing: "
+                            "text-only → TextModel (MTP), media → MLLM"
+                        )
+                    else:
+                        logger.warning(
+                            "TextModel built but no MTP head — "
+                            "text-only won't use MTP"
+                        )
+                        self._text_model = None
+                        self._text_tokenizer = None
+            except Exception as e:
+                logger.error(f"MTP TextModel build failed: {e}")
+                self._text_model = None
+                self._text_tokenizer = None
+
+        # Load SpecPrefill draft model (for TextModel path — sparse cache
+        # is incompatible with MTP, so specprefill generates autoregressively)
+        if self._specprefill_enabled and self._specprefill_draft_model_path:
+            try:
+                from pathlib import Path
+
+                from mlx_lm import load as mlx_lm_load
+
+                draft_path = str(
+                    Path.home()
+                    / "ai-models"
+                    / "mlx_models"
+                    / self._specprefill_draft_model_path
+                )
+                self._draft_model, _ = mlx_lm_load(draft_path)
+                logger.info(
+                    "SpecPrefill draft model loaded: %s (threshold=%d, keep=%.0f%%)",
+                    self._specprefill_draft_model_path,
+                    self._specprefill_threshold,
+                    self._specprefill_keep_pct * 100,
+                )
+            except Exception as e:
+                logger.warning("Failed to load SpecPrefill draft model: %s", e)
+                self._specprefill_enabled = False
+                self._draft_model = None
 
     async def _start_llm(self) -> None:
         """Start the LLM engine with AsyncEngineCore."""
@@ -327,6 +450,12 @@ class BatchedEngine(BaseEngine):
         self._tokenizer = None
         self._processor = None
         self._mllm_instance = None
+        self._text_model = None
+        self._text_tokenizer = None
+        self._draft_model = None
+        self._system_kv_snapshot = None
+        self._system_kv_hash = None
+        self._system_kv_token_count = 0
         self._loaded = False
         logger.info("BatchedEngine stopped")
 
@@ -612,6 +741,20 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # Normalize messages before any path (developer->system, merge consecutive)
+        messages = _normalize_messages(messages)
+
+        # Per-request MTP routing: text-only → TextModel, media → MLLM
+        if self._text_model is not None and not _has_media_content(messages):
+            return await self._chat_text_model(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                **kwargs,
+            )
+
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
@@ -723,6 +866,22 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # Normalize messages before any path (developer->system, merge consecutive)
+        messages = _normalize_messages(messages)
+
+        # Per-request MTP routing: text-only → TextModel, media → MLLM
+        if self._text_model is not None and not _has_media_content(messages):
+            async for output in self._stream_chat_text_model(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                **kwargs,
+            ):
+                yield output
+            return
+
         # Extract images/videos from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
@@ -755,6 +914,469 @@ class BatchedEngine(BaseEngine):
         ):
             yield output
 
+    async def _chat_text_model(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> GenerationOutput:
+        """Non-streaming text-only generation via mlx_lm TextModel with MTP.
+
+        Collects all streaming output into a single GenerationOutput.
+        Used when MLLM+MTP routing is active and the request has no media.
+        """
+        logger.info("Text-only request → TextModel (MTP) [non-streaming]")
+        accumulated_text = ""
+        last_chunk = None
+        async for chunk in self._stream_chat_text_model(
+            messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            tools=tools,
+            **kwargs,
+        ):
+            accumulated_text = chunk.text
+            last_chunk = chunk
+        if last_chunk is not None:
+            return GenerationOutput(
+                text=accumulated_text,
+                prompt_tokens=last_chunk.prompt_tokens,
+                completion_tokens=last_chunk.completion_tokens,
+                finish_reason=last_chunk.finish_reason,
+            )
+        return GenerationOutput(text="", finish_reason="stop")
+
+    async def _stream_chat_text_model(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> AsyncIterator[GenerationOutput]:
+        """Streaming text-only generation via mlx_lm TextModel with MTP.
+
+        Used when MLLM+MTP routing is active and the request has no media.
+        Runs the full generation in a single thread to maintain Metal safety.
+
+        System prompt KV caching: on the first request, prefills system tokens
+        and snapshots backbone KV state. Subsequent requests with the same
+        system prompt restore the snapshot and only prefill the suffix tokens.
+
+        SpecPrefill: when a draft model is loaded and the prompt exceeds the
+        threshold, uses attention-based sparse prefill for faster TTFT.
+        Composes with system KV cache (sparse-prefill only the suffix when
+        cache hits). Falls back to normal path on any error.
+        """
+        import hashlib
+        import os
+
+        import mlx.core as mx
+        from mlx_lm import stream_generate as mlx_stream_generate
+        from mlx_lm.models.cache import make_prompt_cache
+        from mlx_lm.sample_utils import make_sampler
+
+        # Per-request specprefill overrides (from extra_body)
+        specprefill_override = kwargs.pop("specprefill", None)
+        specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
+
+        # Convert tools for template
+        template_tools = convert_tools_for_template(tools) if tools else None
+
+        # Read enable_thinking from env (set by runtime_patches, consistent with MLLM path)
+        enable_thinking_env = os.environ.get("VLLM_MLX_ENABLE_THINKING", "true")
+        enable_thinking = enable_thinking_env.lower() in ("true", "1", "yes")
+
+        # Apply chat template
+        template_kwargs = {
+            "tokenize": False,
+            "add_generation_prompt": True,
+            "enable_thinking": enable_thinking,
+        }
+        if template_tools:
+            template_kwargs["tools"] = template_tools
+
+        try:
+            prompt = self._text_tokenizer.apply_chat_template(
+                messages, **template_kwargs
+            )
+        except TypeError:
+            # Template doesn't accept tools= or enable_thinking=
+            template_kwargs.pop("tools", None)
+            template_kwargs.pop("enable_thinking", None)
+            prompt = self._text_tokenizer.apply_chat_template(
+                messages, **template_kwargs
+            )
+
+        # Build sampler
+        sampler = make_sampler(temp=temperature, top_p=top_p)
+        max_tokens = max_tokens or 4096
+
+        # --- System KV cache: find system prefix boundary ---
+        # ChatML (Qwen 3.5): everything before first <|im_start|>user is the system prefix
+        USER_MARKER = "<|im_start|>user"
+        marker_pos = prompt.find(USER_MARKER)
+        if marker_pos > 0:
+            system_prefix = prompt[:marker_pos]
+            suffix = prompt[marker_pos:]
+            prefix_hash = hashlib.sha256(system_prefix.encode()).hexdigest()[:16]
+        else:
+            system_prefix = None
+            suffix = prompt
+            prefix_hash = None
+
+        # Check for cache hit
+        cache_hit = (
+            prefix_hash is not None
+            and prefix_hash == self._system_kv_hash
+            and self._system_kv_snapshot is not None
+        )
+
+        if cache_hit:
+            logger.info(
+                "Text-only request → TextModel (MTP) [streaming, system KV cache HIT: "
+                "reusing %d cached tokens, hash=%s]",
+                self._system_kv_token_count,
+                prefix_hash,
+            )
+        else:
+            logger.info("Text-only request → TextModel (MTP) [streaming]")
+
+        prefill_step_size = self._prefill_step_size
+
+        # --- SpecPrefill decision ---
+        # Determine whether to use specprefill for this request.
+        # Must be decided before entering the generation lock so we can
+        # tokenize and check the threshold outside the critical section.
+        _SPECPREFILL_MAX_TOKENS = 196608
+        use_specprefill = False
+        if self._draft_model is not None:
+            if specprefill_override is True:
+                use_specprefill = True
+            elif specprefill_override is None and self._specprefill_enabled:
+                use_specprefill = True
+            # specprefill_override=False explicitly disables
+
+        # Tokenize to determine token count for specprefill threshold check.
+        # We need this for both specprefill and normal paths anyway.
+        sp_tokens = None  # tokens to score (suffix or full prompt)
+        sp_offset = 0  # position offset for sparse_prefill
+        sp_n_total = 0  # total prompt tokens (for logging / threshold)
+
+        if use_specprefill:
+            if cache_hit:
+                # Score only the suffix — system prefix is already cached
+                sp_tokens = self._text_tokenizer.encode(suffix)
+                sp_offset = self._system_kv_token_count
+                sp_n_total = sp_offset + len(sp_tokens)
+            else:
+                # Score the full prompt
+                sp_tokens = self._text_tokenizer.encode(prompt)
+                sp_offset = 0
+                sp_n_total = len(sp_tokens)
+
+            n_sp_tokens = len(sp_tokens)
+
+            # Threshold check (skip when force-enabled via per-request override)
+            if (
+                specprefill_override is not True
+                and n_sp_tokens <= self._specprefill_threshold
+            ):
+                use_specprefill = False
+
+            # Upper bound: cap to avoid draft model OOM
+            if use_specprefill and n_sp_tokens > _SPECPREFILL_MAX_TOKENS:
+                logger.warning(
+                    "SpecPrefill: prompt %d tokens exceeds max %d, "
+                    "falling back to normal path",
+                    n_sp_tokens,
+                    _SPECPREFILL_MAX_TOKENS,
+                )
+                use_specprefill = False
+
+        # Run under generation lock, all tokens in single thread (Metal safety)
+        async with self._text_generation_lock:
+
+            def _run_with_cache():
+                if use_specprefill:
+                    try:
+                        return _run_specprefill()
+                    except Exception as e:
+                        logger.error(
+                            "SpecPrefill failed, falling back to normal path: %s", e
+                        )
+                        # Fall through to normal path
+                if cache_hit:
+                    return _run_cache_hit()
+                else:
+                    return _run_cache_miss()
+
+            def _run_specprefill():
+                """Score tokens, sparse prefill, generate autoregressively.
+
+                Composes with system KV cache: when cache_hit, restores the
+                system KV snapshot first, then sparse-prefills only the suffix
+                tokens with position_offset = system_kv_token_count.
+
+                Does NOT use MTP (sparse cache is incompatible with MTP
+                speculative decoding).
+                """
+                import time
+                from types import SimpleNamespace
+
+                from ..specprefill import (
+                    cleanup_rope,
+                    score_tokens,
+                    select_chunks,
+                    sparse_prefill,
+                )
+
+                # Build target cache (optionally restore system KV snapshot)
+                target_cache = make_prompt_cache(self._text_model)
+                if cache_hit:
+                    for layer_idx, snapshot_state in enumerate(
+                        self._system_kv_snapshot
+                    ):
+                        if layer_idx < len(target_cache):
+                            target_cache[layer_idx].state = snapshot_state
+                    mx.eval([c.state for c in target_cache if hasattr(c, "state")])
+
+                try:
+                    # Phase 1: Score with draft model
+                    t0 = time.monotonic()
+                    importance = score_tokens(
+                        self._draft_model,
+                        sp_tokens,
+                        prefill_step_size=prefill_step_size,
+                    )
+                    t_score = time.monotonic() - t0
+
+                    # Phase 2: Select important chunks
+                    effective_keep = (
+                        specprefill_keep_pct_override or self._specprefill_keep_pct
+                    )
+                    selected = select_chunks(importance, keep_pct=effective_keep)
+                    n_selected = selected.shape[0]
+                    n_scored = len(sp_tokens)
+
+                    # Phase 3: Sparse prefill on target model
+                    t0 = time.monotonic()
+                    logits = sparse_prefill(
+                        self._text_model,
+                        sp_tokens,
+                        selected,
+                        target_cache,
+                        step_size=prefill_step_size,
+                        position_offset=sp_offset,
+                    )
+                    t_prefill = time.monotonic() - t0
+
+                    logger.info(
+                        "SpecPrefill: scored %d tokens in %.1fs, "
+                        "sparse prefill %d/%d (keep=%.0f%%) in %.1fs "
+                        "(offset=%d, effective_keep=%.2f)",
+                        n_scored,
+                        t_score,
+                        n_selected,
+                        n_scored,
+                        n_selected / n_scored * 100,
+                        t_prefill,
+                        sp_offset,
+                        effective_keep,
+                    )
+
+                    # Phase 4: Generate (simple autoregressive, no MTP)
+                    eos_id = self._text_tokenizer.eos_token_id
+                    y = sampler(logits[:, -1, :])
+                    mx.eval(y)
+
+                    results = []
+                    generated_ids = []
+                    prev_decoded = ""
+
+                    for _ in range(max_tokens):
+                        tok_id = y.item()
+                        generated_ids.append(tok_id)
+
+                        # Incremental text decode
+                        decoded = self._text_tokenizer.decode(generated_ids)
+                        new_text = decoded[len(prev_decoded) :]
+                        prev_decoded = decoded
+
+                        is_eos = tok_id == eos_id
+                        results.append(
+                            SimpleNamespace(
+                                text=new_text,
+                                finish_reason="stop" if is_eos else None,
+                            )
+                        )
+
+                        if is_eos:
+                            break
+
+                        # Next token
+                        logits = self._text_model(y.reshape(1, -1), cache=target_cache)
+                        y = sampler(logits[:, -1, :])
+                        mx.eval(y)
+
+                    return results, sp_n_total
+
+                finally:
+                    cleanup_rope(self._text_model)
+
+            def _run_cache_hit():
+                """Restore system KV snapshot, prefill only suffix, generate."""
+                # Restore cached KV state into a fresh cache
+                restored_cache = make_prompt_cache(self._text_model)
+                for layer_idx, snapshot_state in enumerate(self._system_kv_snapshot):
+                    if layer_idx < len(restored_cache):
+                        restored_cache[layer_idx].state = snapshot_state
+                mx.eval([c.state for c in restored_cache if hasattr(c, "state")])
+
+                # Tokenize just the suffix and generate with the primed cache.
+                # stream_generate accepts mx.array prompt (skips tokenization)
+                # and prompt_cache is forwarded to mtp_generate_step.
+                suffix_tokens = self._text_tokenizer.encode(suffix)
+                suffix_array = mx.array(suffix_tokens)
+                n_suffix = len(suffix_tokens)
+
+                logger.info(
+                    "System KV cache HIT: prefilling %d suffix tokens "
+                    "(skipped %d cached tokens)",
+                    n_suffix,
+                    self._system_kv_token_count,
+                )
+
+                results = []
+                for resp in mlx_stream_generate(
+                    self._text_model,
+                    self._text_tokenizer,
+                    prompt=suffix_array,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    mtp=True,
+                    prompt_cache=restored_cache,
+                    prefill_step_size=prefill_step_size,
+                ):
+                    results.append(resp)
+                return results, self._system_kv_token_count + len(suffix_tokens)
+
+            def _run_cache_miss():
+                """Full prefill + generation, then snapshot system KV for next time."""
+                results = []
+                for resp in mlx_stream_generate(
+                    self._text_model,
+                    self._text_tokenizer,
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    mtp=True,
+                    prefill_step_size=prefill_step_size,
+                ):
+                    results.append(resp)
+
+                # Snapshot system KV for next request (if we found a system prefix)
+                if prefix_hash is not None and system_prefix is not None:
+                    try:
+                        _snapshot_system_kv()
+                    except Exception as e:
+                        logger.warning("Failed to snapshot system KV cache: %s", e)
+
+                # Get total prompt token count from generation response
+                prompt_tokens = 0
+                if results and hasattr(results[0], "prompt_tokens"):
+                    prompt_tokens = results[0].prompt_tokens
+                return results, prompt_tokens
+
+            def _snapshot_system_kv():
+                """Prefill just the system prefix on a fresh cache and save snapshot."""
+                snapshot_cache = make_prompt_cache(self._text_model)
+                prefix_tokens = self._text_tokenizer.encode(system_prefix)
+                prefix_ids = mx.array(prefix_tokens)
+
+                # Chunked prefill of system prefix
+                for i in range(0, prefix_ids.size, prefill_step_size):
+                    chunk = prefix_ids[i : i + prefill_step_size]
+                    self._text_model(chunk[None], cache=snapshot_cache)
+                    mx.eval([c.state for c in snapshot_cache if hasattr(c, "state")])
+
+                # Save snapshot: deep copy of each cache layer's state
+                self._system_kv_snapshot = []
+                for c in snapshot_cache:
+                    state = c.state
+                    if isinstance(state, tuple) and len(state) == 2:
+                        # KVCache: (keys, values) — copy to detach from cache
+                        keys, values = state
+                        self._system_kv_snapshot.append(
+                            (mx.array(keys), mx.array(values))
+                        )
+                    elif isinstance(state, list):
+                        # ArraysCache: list of arrays (Mamba/hybrid)
+                        self._system_kv_snapshot.append(
+                            [mx.array(a) if a is not None else None for a in state]
+                        )
+                    else:
+                        # Unknown cache type — store as-is
+                        self._system_kv_snapshot.append(state)
+
+                self._system_kv_token_count = len(prefix_tokens)
+                self._system_kv_hash = prefix_hash
+
+                cache_bytes = 0
+                for entry in self._system_kv_snapshot:
+                    if isinstance(entry, tuple) and len(entry) == 2:
+                        cache_bytes += entry[0].nbytes + entry[1].nbytes
+                    elif isinstance(entry, list):
+                        cache_bytes += sum(a.nbytes for a in entry if a is not None)
+                logger.info(
+                    "System KV cache: stored %d-token snapshot " "(%.1f MB), hash=%s",
+                    len(prefix_tokens),
+                    cache_bytes / 1e6,
+                    prefix_hash,
+                )
+
+            result = await asyncio.to_thread(_run_with_cache)
+            all_resps, prompt_token_count = result
+
+        # Yield results as GenerationOutput
+        accumulated_text = ""
+        token_count = 0
+        finished = False
+        for i, resp in enumerate(all_resps):
+            token_count += 1
+            new_text = resp.text if hasattr(resp, "text") else str(resp)
+            accumulated_text += new_text
+
+            is_last = i == len(all_resps) - 1
+            finished = is_last or token_count >= max_tokens
+
+            yield GenerationOutput(
+                text=accumulated_text,
+                new_text=new_text,
+                prompt_tokens=prompt_token_count,
+                completion_tokens=token_count,
+                finished=finished,
+                finish_reason="stop" if finished else None,
+            )
+
+            if finished:
+                break
+
+        if not finished:
+            yield GenerationOutput(
+                text=accumulated_text,
+                new_text="",
+                prompt_tokens=prompt_token_count,
+                completion_tokens=token_count,
+                finished=True,
+                finish_reason="length",
+            )
+
     def get_stats(self) -> dict[str, Any]:
         """Get engine statistics."""
         stats = {
@@ -778,6 +1400,29 @@ class BatchedEngine(BaseEngine):
                     stats[key] = mllm_stats[key]
         elif self._engine:
             stats.update(self._engine.get_stats())
+
+        # SpecPrefill stats
+        if self._draft_model is not None:
+            stats["specprefill"] = {
+                "enabled": self._specprefill_enabled,
+                "draft_model": self._specprefill_draft_model_path,
+                "threshold": self._specprefill_threshold,
+                "keep_pct": self._specprefill_keep_pct,
+            }
+
+        # System KV cache stats
+        if self._system_kv_snapshot is not None:
+            cache_bytes = 0
+            for entry in self._system_kv_snapshot:
+                if isinstance(entry, tuple) and len(entry) == 2:
+                    cache_bytes += entry[0].nbytes + entry[1].nbytes
+                elif isinstance(entry, list):
+                    cache_bytes += sum(a.nbytes for a in entry if a is not None)
+            stats["system_kv_cache"] = {
+                "tokens": self._system_kv_token_count,
+                "hash": self._system_kv_hash,
+                "memory_mb": round(cache_bytes / 1e6, 1),
+            }
 
         return stats
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -347,10 +347,19 @@ class BatchedEngine(BaseEngine):
             f"completion_batch={completion_batch_size}"
         )
 
-        # Initialize admission controller from MLLM model config
-        mllm_config = getattr(self._mllm_instance, "config", None)
-        if mllm_config is not None:
-            self._init_admission_controller(mllm_config)
+        # Initialize admission controller from config.json on disk
+        try:
+            import json
+            from pathlib import Path
+
+            config_path = Path(self._model_name) / "config.json"
+            if config_path.exists():
+                model_config = json.loads(config_path.read_text())
+                self._init_admission_controller(model_config)
+            else:
+                logger.info("[admission] No config.json found — admission disabled")
+        except Exception as e:
+            logger.warning(f"[admission] Failed to init: {e} — admission disabled")
 
         # Build TextModel for MTP per-request routing (text-only → MTP, media → MLLM)
         if self._mtp:
@@ -490,10 +499,20 @@ class BatchedEngine(BaseEngine):
 
         await self._engine.engine.start()
 
-        # Initialize admission controller from LLM model config
-        model_config = getattr(self._model, "config", None)
-        if model_config is not None:
-            self._init_admission_controller(model_config)
+        # Initialize admission controller from config.json on disk
+        # (mlx_lm models may not expose .config attribute)
+        try:
+            import json
+            from pathlib import Path
+
+            config_path = Path(self._model_name) / "config.json"
+            if config_path.exists():
+                model_config = json.loads(config_path.read_text())
+                self._init_admission_controller(model_config)
+            else:
+                logger.info("[admission] No config.json found — admission disabled")
+        except Exception as e:
+            logger.warning(f"[admission] Failed to init: {e} — admission disabled")
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -518,6 +518,29 @@ class BatchedEngine(BaseEngine):
         except Exception as e:
             logger.warning(f"[admission] Failed to init: {e} — admission disabled")
 
+        # Load SpecPrefill draft model (for LLM path)
+        if self._specprefill_enabled and self._specprefill_draft_model_path:
+            try:
+                from pathlib import Path
+
+                from mlx_lm import load as mlx_lm_load
+
+                draft_path = str(
+                    Path.home()
+                    / "ai-models"
+                    / "mlx_models"
+                    / self._specprefill_draft_model_path
+                )
+                self._draft_model, _ = mlx_lm_load(draft_path)
+                logger.info(
+                    "SpecPrefill draft model loaded (LLM path): %s",
+                    self._specprefill_draft_model_path,
+                )
+            except Exception as e:
+                logger.warning("Failed to load SpecPrefill draft model: %s", e)
+                self._specprefill_enabled = False
+                self._draft_model = None
+
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         if self._mllm_scheduler:

--- a/vllm_mlx/message_utils.py
+++ b/vllm_mlx/message_utils.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared message normalization utilities.
+
+Provides ``_normalize_messages()`` which maps non-standard roles, merges
+consecutive same-role messages, and hoists system messages to position [0].
+Used by both SimpleEngine and BatchedEngine before ``apply_chat_template``.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_messages(messages: list[dict]) -> list[dict]:
+    """Normalize message roles and merge consecutive same-role messages.
+
+    1. Maps non-standard roles to standard ones (e.g. ``developer`` -> ``system``).
+    2. Merges consecutive same-role messages to satisfy chat template constraints
+       (Qwen 3.5, Llama, etc. require alternating roles).
+
+    Only merges when both messages have string content. Messages with list
+    content (multimodal) are left as-is to preserve image/video attachments.
+    """
+    _ROLE_MAP = {"developer": "system"}
+
+    if not messages:
+        return messages
+
+    merged = [messages[0].copy()]
+    if merged[0]["role"] in _ROLE_MAP:
+        merged[0]["role"] = _ROLE_MAP[merged[0]["role"]]
+    for msg in messages[1:]:
+        prev = merged[-1]
+        role = _ROLE_MAP.get(msg["role"], msg["role"])
+        if (
+            role == prev["role"]
+            and isinstance(prev.get("content"), str)
+            and isinstance(msg.get("content"), str)
+        ):
+            prev["content"] = prev["content"] + "\n\n" + msg["content"]
+            logger.debug(
+                f"Merged consecutive {role} messages "
+                f"({len(prev['content'])} chars total)"
+            )
+        else:
+            copy = msg.copy()
+            copy["role"] = role
+            merged.append(copy)
+
+    # Hoist system messages to position [0] and merge them.
+    # Many CLIs (OpenCode, Qwen Code, Kilo) send system messages mid-conversation;
+    # the Qwen 3.5 chat template rejects any system message not at position [0].
+    system_msgs = [m for m in merged if m["role"] == "system"]
+    non_system = [m for m in merged if m["role"] != "system"]
+    if system_msgs and (len(system_msgs) > 1 or merged[0]["role"] != "system"):
+        # Combine all system message content (string only) into one
+        parts = []
+        for m in system_msgs:
+            c = m.get("content")
+            if isinstance(c, str):
+                parts.append(c)
+            elif isinstance(c, list):
+                # Multimodal system message — extract text parts
+                for part in c:
+                    if isinstance(part, str):
+                        parts.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        parts.append(part.get("text", ""))
+        if parts:
+            combined_system = {"role": "system", "content": "\n\n".join(parts)}
+            merged = [combined_system] + non_system
+            logger.info(
+                f"Hoisted {len(system_msgs)} system message(s) to position [0] "
+                f"({len(combined_system['content'])} chars)"
+            )
+        else:
+            # No string content — just move the first system msg to front
+            merged = system_msgs[:1] + non_system
+            logger.info("Hoisted system message to position [0]")
+
+    merged_count = len(messages) - len(merged)
+    if merged_count:
+        logger.info(f"Normalized messages: merged {len(messages)} -> {len(merged)}")
+
+    return merged

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -490,6 +490,7 @@ def load_model(
     specprefill_threshold: int = 8192,
     specprefill_keep_pct: float = 0.3,
     specprefill_draft_model: str = None,
+    specprefill_chunk_size: int = 4096,
     scheduler_policy: str = "fifo",
     scheduler_headroom_gb: float = 8.0,
 ):
@@ -509,6 +510,7 @@ def load_model(
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
+        specprefill_chunk_size: Draft scoring chunk size for cooperative scheduling (default: 4096)
         scheduler_policy: Request queue policy for admission control (default: fifo)
         scheduler_headroom_gb: Memory headroom in GB for admission control (default: 8.0)
     """
@@ -530,6 +532,11 @@ def load_model(
             scheduler_config=scheduler_config,
             stream_interval=stream_interval,
             force_mllm=force_mllm,
+            specprefill_enabled=specprefill_enabled,
+            specprefill_threshold=specprefill_threshold,
+            specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_draft_model_path=specprefill_draft_model,
+            specprefill_chunk_size=specprefill_chunk_size,
             scheduler_policy=scheduler_policy,
             scheduler_headroom_gb=scheduler_headroom_gb,
         )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -490,6 +490,8 @@ def load_model(
     specprefill_threshold: int = 8192,
     specprefill_keep_pct: float = 0.3,
     specprefill_draft_model: str = None,
+    scheduler_policy: str = "fifo",
+    scheduler_headroom_gb: float = 8.0,
 ):
     """
     Load a model (auto-detects MLLM vs LLM).
@@ -507,6 +509,8 @@ def load_model(
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
+        scheduler_policy: Request queue policy for admission control (default: fifo)
+        scheduler_headroom_gb: Memory headroom in GB for admission control (default: 8.0)
     """
     global _engine, _model_name, _model_path, _default_max_tokens, _tool_parser_instance
 
@@ -526,6 +530,8 @@ def load_model(
             scheduler_config=scheduler_config,
             stream_interval=stream_interval,
             force_mllm=force_mllm,
+            scheduler_policy=scheduler_policy,
+            scheduler_headroom_gb=scheduler_headroom_gb,
         )
         # BatchedEngine will be started in lifespan (uvicorn's event loop)
         # Just log for now


### PR DESCRIPTION
## Summary

- Memory-aware admission controller that gates requests before engine submission
- Reads actual Metal GPU memory (`mx.get_active_memory()` + `mx.get_cache_memory()`) for admission decisions
- FIFO request queue with fairness enforcement (small requests can't bypass large queued ones)
- Async wait/signal pattern for queued requests with CancelledError cleanup
- Prefix cache eviction callback when queue is non-empty and memory is tight
- `kv_per_token` computed from model config (supports hybrid MoE with `full_attention_interval`)
- CLI args: `--scheduler-policy fifo --scheduler-headroom-gb 8`
- Backward compatible: no config = defaults, single-user behavior unchanged

Depends on #203 (BatchedEngine parity).

## New files

- `vllm_mlx/admission.py` — AdmissionController, MemoryMonitor, RequestQueue, compute_kv_per_token
- `tests/test_admission.py` — 20 unit tests

## Test plan

- [x] 20 unit tests (admission logic, FIFO fairness, async wait, cancellation, eviction)
- [x] Standalone Metal memory test (real `mx.get_active_memory()`)
- [x] kv_per_token verified against real model configs (24KB for 122B, 20KB for 35B)
- [x] E2E: server boot with scheduler args, request admitted (8GB headroom)
- [x] E2E: request queued under artificial memory pressure (100GB headroom)
- [x] Backward compat: production 122B running with no `scheduler` in mode.json