### PR TITLE
fix: Don’t truncate base64 images before hashing

### DIFF
--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -466,7 +466,7 @@ def save_base64_image(base64_string: str) -> str:
     import hashlib
 
     # Hash the base64 string to check cache
-    image_hash = hashlib.md5(base64_string[:1000].encode()).hexdigest()
+    image_hash = hashlib.md5(base64_string.encode()).hexdigest()
 
     # Return cached path if available and file still exists
     if image_hash in _base64_image_cache:


### PR DESCRIPTION
Truncating the base64 string before hashing causes similar-but-not-the-same base64 JPGs to return the same hash, causing vllm-mlx to use the same cached image for all of them, resulting in duplicated and incorrect responses.

Fixes https://github.com/waybarrios/vllm-mlx/issues/197.