### PR TITLE
feat: BatchedEngine — admission, MTP routing, cooperative SpecPrefill

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -178,6 +178,16 @@ def serve_command(args):
             print(f"Prefix cache: max_entries={args.prefix_cache_size}")
     else:
         print("Mode: Simple (maximum throughput)")
+        if args.enable_mtp:
+            print("MTP: enabled (native speculative decoding)")
+        if args.enable_mtp and getattr(args, "mllm", False):
+            print("MTP + MLLM: per-request routing (text-only → MTP, media → MLLM)")
+        if args.specprefill and args.specprefill_draft_model:
+            print(
+                f"SpecPrefill: enabled (draft={args.specprefill_draft_model}, "
+                f"threshold={args.specprefill_threshold}, "
+                f"keep={args.specprefill_keep_pct*100:.0f}%)"
+            )
 
     # Load model with unified server
     load_model(
@@ -187,6 +197,16 @@ def serve_command(args):
         stream_interval=args.stream_interval if args.continuous_batching else 1,
         max_tokens=args.max_tokens,
         force_mllm=args.mllm,
+        served_model_name=args.served_model_name,
+        mtp=args.enable_mtp,
+        prefill_step_size=args.prefill_step_size,
+        specprefill_enabled=args.specprefill,
+        specprefill_threshold=args.specprefill_threshold,
+        specprefill_keep_pct=args.specprefill_keep_pct,
+        specprefill_draft_model=args.specprefill_draft_model,
+        specprefill_chunk_size=args.specprefill_chunk_size,
+        scheduler_policy=args.scheduler_policy,
+        scheduler_headroom_gb=args.scheduler_headroom_gb,
     )
 
     # Start server
@@ -592,6 +612,12 @@ Examples:
     serve_parser = subparsers.add_parser("serve", help="Start OpenAI-compatible server")
     serve_parser.add_argument("model", type=str, help="Model to serve")
     serve_parser.add_argument(
+        "--served-model-name",
+        type=str,
+        default=None,
+        help="The model name used in the API. If not specified, the model argument is used.",
+    )
+    serve_parser.add_argument(
         "--host", type=str, default="0.0.0.0", help="Host to bind"
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
@@ -728,6 +754,67 @@ Examples:
         help="Skip MTP acceptance check for maximum speed. "
         "~5-10%% wrong tokens. Best for chat, not for code.",
     )
+    # Prefill step size
+    serve_parser.add_argument(
+        "--prefill-step-size",
+        type=int,
+        default=2048,
+        help="Chunk size for prompt prefill processing. Larger values use more memory "
+        "but can improve prefill throughput. (default: 2048)",
+    )
+    # SpecPrefill (attention-based sparse prefill using draft model)
+    serve_parser.add_argument(
+        "--specprefill",
+        action="store_true",
+        default=False,
+        help="Enable SpecPrefill: use a small draft model to score token importance, "
+        "then sparse-prefill only the important tokens on the target model. "
+        "Reduces TTFT on long prompts. Requires --specprefill-draft-model.",
+    )
+    serve_parser.add_argument(
+        "--specprefill-threshold",
+        type=int,
+        default=8192,
+        help="Minimum suffix tokens to trigger SpecPrefill (default: 8192). "
+        "Shorter prompts use full prefill (scoring overhead > savings).",
+    )
+    serve_parser.add_argument(
+        "--specprefill-keep-pct",
+        type=float,
+        default=0.3,
+        help="Fraction of tokens to keep during sparse prefill (default: 0.3). "
+        "Lower = faster prefill but more quality loss.",
+    )
+    serve_parser.add_argument(
+        "--specprefill-draft-model",
+        type=str,
+        default=None,
+        help="Path to small draft model for SpecPrefill importance scoring. "
+        "Must share the same tokenizer as the target model.",
+    )
+    serve_parser.add_argument(
+        "--specprefill-chunk-size",
+        type=int,
+        default=4096,
+        help="Tokens per draft scoring chunk before yielding to active requests (default: 4096). "
+        "Larger = faster scoring, less responsive interleaving. 0 = monolithic (no yielding).",
+    )
+    # Admission controller (memory-aware scheduling)
+    serve_parser.add_argument(
+        "--scheduler-policy",
+        type=str,
+        default="fifo",
+        choices=["fifo", "shortest_first", "priority"],
+        help="Request queue policy for admission control (default: fifo). "
+        "shortest_first: dequeue smallest prompt first (maximizes throughput). "
+        "priority: dequeue highest-priority request first.",
+    )
+    serve_parser.add_argument(
+        "--scheduler-headroom-gb",
+        type=float,
+        default=8.0,
+        help="Memory headroom in GB for admission control (default: 8.0)",
+    )
     # MCP options
     serve_parser.add_argument(
         "--mcp-config",
@@ -769,6 +856,8 @@ Examples:
             "mistral",
             "qwen",
             "qwen3_coder",
+            "qwen3_xml",
+            "qwen3.5",
             "llama",
             "hermes",
             "deepseek",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -11,15 +11,40 @@ MLLMBatchGenerator. MLLM models only initialise the MLLM scheduler (not the
 LLM engine), so text-only requests must also be routed through it.
 """
 
+import asyncio
 import logging
+import uuid
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Optional
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
+from ..message_utils import _normalize_messages
 from .base import BaseEngine, GenerationOutput
 
 logger = logging.getLogger(__name__)
+
+_MEDIA_TYPES = frozenset(
+    {
+        "image_url",
+        "video_url",
+        "audio_url",
+        "image",
+        "video",
+        "audio",
+    }
+)
+
+
+def _has_media_content(messages: list) -> bool:
+    """Check if any message contains media content (images, video, audio)."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in _MEDIA_TYPES:
+                    return True
+    return False
 
 
 def _extract_media_from_messages(messages: list[dict[str, Any]]) -> tuple:
@@ -137,6 +162,15 @@ class BatchedEngine(BaseEngine):
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,
+        mtp: bool = False,
+        prefill_step_size: int | None = None,
+        specprefill_enabled: bool = False,
+        specprefill_draft_model_path: str | None = None,
+        specprefill_threshold: int = 8192,
+        specprefill_keep_pct: float = 0.3,
+        specprefill_chunk_size: int = 4096,
+        scheduler_policy: str = "fifo",
+        scheduler_headroom_gb: float = 8.0,
     ):
         """
         Initialize the batched engine.
@@ -147,12 +181,37 @@ class BatchedEngine(BaseEngine):
             scheduler_config: Optional scheduler configuration
             stream_interval: Tokens to batch before streaming (1=every token)
             force_mllm: Force loading as MLLM even if not auto-detected
+            mtp: Enable MTP per-request routing (text-only → TextModel, media → MLLM)
+            prefill_step_size: Chunk size for prompt prefill (default 2048)
+            specprefill_enabled: Enable SpecPrefill sparse prefill
+            specprefill_draft_model_path: Draft model directory name under ~/ai-models/mlx_models/
+            specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default 8192)
+            specprefill_keep_pct: Fraction of tokens to keep (default 0.3)
+            specprefill_chunk_size: Draft scoring chunk size for cooperative scheduling
+                (default 4096). Set to 0 to disable cooperative mode (monolithic scoring).
+            scheduler_policy: Request queue policy for admission control (default: fifo)
+            scheduler_headroom_gb: Memory headroom in GB for admission control (default: 8.0)
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
         self._is_mllm = force_mllm or is_mllm_model(model_name)
+        self._mtp = mtp
+        self._prefill_step_size = prefill_step_size or 2048
+
+        # SpecPrefill configuration
+        self._specprefill_enabled = specprefill_enabled
+        self._specprefill_draft_model_path = specprefill_draft_model_path
+        self._specprefill_threshold = specprefill_threshold
+        self._specprefill_keep_pct = specprefill_keep_pct
+        self._specprefill_chunk_size = specprefill_chunk_size
+
+        # Admission controller (memory-aware scheduling)
+        self._scheduler_policy = scheduler_policy
+        self._scheduler_headroom_gb = scheduler_headroom_gb
+        self._admission: Optional["AdmissionController"] = None  # noqa: F821
+        self._draft_model = None
 
         self._model = None
         self._processor = None  # For MLLM
@@ -161,6 +220,109 @@ class BatchedEngine(BaseEngine):
         self._mllm_scheduler = None  # MLLMScheduler for MLLM
         self._mllm_instance = None  # MLXMultimodalLM instance
         self._loaded = False
+
+        # Per-request routing state (MLLM+MTP mode)
+        self._text_model = None
+        self._text_tokenizer = None
+        self._text_generation_lock = asyncio.Lock()
+        self._metal_lock = __import__(
+            "threading"
+        ).Lock()  # Serializes all Metal GPU access
+
+        # System prompt KV cache (reduces repeated prefill across requests)
+        # Protected by _system_kv_lock for thread-safe access — snapshot is
+        # written from background threads (via asyncio.to_thread) and read
+        # from the event loop thread.
+        import threading as _threading
+        self._system_kv_lock = _threading.Lock()
+        self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
+        self._system_kv_hash = None  # Hash of system prefix text
+        self._system_kv_token_count = 0  # Tokens in cached prefix
+
+    def _init_admission_controller(self, model_config) -> None:
+        """Create the admission controller from model config.
+
+        Extracts KV cache parameters from HuggingFace PretrainedConfig
+        (attribute access) or dict-style configs. VLM models nest the
+        language model config under ``text_config``.
+        """
+        from ..admission import AdmissionController, compute_kv_per_token
+
+        def _get(cfg, key, default):
+            """Read a config value from attr-based or dict-based config."""
+            if isinstance(cfg, dict):
+                return cfg.get(key, default)
+            return getattr(cfg, key, default)
+
+        # For VLM models, language model config is nested under text_config
+        text_cfg = _get(model_config, "text_config", None)
+        if text_cfg is not None:
+            cfg = text_cfg
+        else:
+            cfg = model_config
+
+        kv_per_token = compute_kv_per_token(
+            num_hidden_layers=_get(cfg, "num_hidden_layers", 32),
+            full_attention_interval=_get(cfg, "full_attention_interval", 1),
+            num_kv_heads=_get(cfg, "num_key_value_heads", 8),
+            head_dim=_get(cfg, "head_dim", 128),
+            hybrid_override_pattern=_get(cfg, "hybrid_override_pattern", None),
+        )
+
+        self._admission = AdmissionController(
+            kv_per_token=kv_per_token,
+            headroom_bytes=int(self._scheduler_headroom_gb * 1024**3),
+            policy=self._scheduler_policy,
+        )
+        logger.info(
+            "[admission] KV per token: %s bytes, headroom: %.1fGB",
+            f"{kv_per_token:,}",
+            self._scheduler_headroom_gb,
+        )
+
+    async def _metal_safe_mllm_loop(self) -> None:
+        """Process loop for MLLMScheduler that serializes with TextModel.
+
+        Replaces MLLMScheduler._process_loop when MTP routing is active.
+        Uses _metal_lock (threading.Lock) with non-blocking acquire so the
+        event loop is never blocked waiting for a background thread.
+
+        The TextModel path acquires _metal_lock in two places:
+          1. Cooperative specprefill chunks (outside _text_generation_lock)
+          2. Main generation (inside _text_generation_lock)
+        This loop tries to acquire the same lock. If the lock is held
+        (TextModel is running Metal), we yield and retry next iteration.
+        """
+        sched = self._mllm_scheduler
+        while sched._running:
+            try:
+                if sched.has_requests():
+                    acquired = self._metal_lock.acquire(blocking=False)
+                    if acquired:
+                        try:
+                            sched.step()
+                        finally:
+                            self._metal_lock.release()
+                        await asyncio.sleep(0)
+                    else:
+                        # TextModel holds the lock — yield and retry
+                        await asyncio.sleep(0.001)
+                else:
+                    await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                _mllm_errors = getattr(self, "_mllm_consecutive_errors", 0) + 1
+                self._mllm_consecutive_errors = _mllm_errors
+                logger.error(f"Error in Metal-safe MLLM loop ({_mllm_errors}x): {e}")
+                if _mllm_errors >= 10:
+                    logger.critical(
+                        "MLLM loop: %d consecutive errors, stopping loop", _mllm_errors
+                    )
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                self._mllm_consecutive_errors = 0
 
     @property
     def model_name(self) -> str:
@@ -235,11 +397,111 @@ class BatchedEngine(BaseEngine):
         )
         await self._mllm_scheduler.start()
 
+        # When MTP routing is active, both MLLMScheduler and TextModel access
+        # Metal. MLLMScheduler.step() runs synchronously on the event loop
+        # thread; TextModel runs via asyncio.to_thread. Without coordination,
+        # concurrent Metal access causes crashes (mlx#3216-class bugs).
+        # Fix: replace the scheduler's process loop with one that acquires
+        # _metal_lock around each step(), serializing with TextModel.
+        if self._mtp:
+            self._mllm_scheduler._running = False
+            if self._mllm_scheduler._processing_task:
+                self._mllm_scheduler._processing_task.cancel()
+                try:
+                    await self._mllm_scheduler._processing_task
+                except asyncio.CancelledError:
+                    pass
+            self._mllm_scheduler._running = True
+            self._mllm_scheduler._processing_task = asyncio.create_task(
+                self._metal_safe_mllm_loop()
+            )
+
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
             f"completion_batch={completion_batch_size}"
         )
+
+        # Initialize admission controller from config.json on disk
+        try:
+            import json
+            from pathlib import Path
+
+            config_path = Path(self._model_name) / "config.json"
+            if config_path.exists():
+                model_config = json.loads(config_path.read_text())
+                self._init_admission_controller(model_config)
+            else:
+                logger.info("[admission] No config.json found — admission disabled")
+        except Exception as e:
+            logger.warning(f"[admission] Failed to init: {e} — admission disabled")
+
+        # Build TextModel for MTP per-request routing (text-only → MTP, media → MLLM)
+        if self._mtp:
+            try:
+                from ..text_model_from_vlm import build_text_model
+
+                self._text_model = build_text_model(
+                    self._mllm_instance.model, self._model_name
+                )
+                if self._text_model is not None:
+                    # Get tokenizer from the MLLM instance (same model, shared tokenizer)
+                    self._text_tokenizer = self._mllm_instance.get_tokenizer()
+
+                    # Apply Qwen3.5 eos_token fix (matches SimpleEngine pattern)
+                    if "qwen3" in self._model_name.lower():
+                        self._text_tokenizer.eos_token = "<|im_end|>"
+                        self._text_tokenizer.eos_token_id = (
+                            self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
+                        )
+
+                    # Check if TextModel actually has MTP
+                    has_mtp = (
+                        hasattr(self._text_model, "mtp")
+                        and self._text_model.mtp is not None
+                    )
+                    if has_mtp:
+                        logger.info(
+                            "BatchedEngine MLLM+MTP routing: "
+                            "text-only → TextModel (MTP), media → MLLM"
+                        )
+                    else:
+                        logger.warning(
+                            "TextModel built but no MTP head — "
+                            "text-only won't use MTP"
+                        )
+                        self._text_model = None
+                        self._text_tokenizer = None
+            except Exception as e:
+                logger.error(f"MTP TextModel build failed: {e}")
+                self._text_model = None
+                self._text_tokenizer = None
+
+        # Load SpecPrefill draft model (for TextModel path — sparse cache
+        # is incompatible with MTP, so specprefill generates autoregressively)
+        if self._specprefill_enabled and self._specprefill_draft_model_path:
+            try:
+                from pathlib import Path
+
+                from mlx_lm import load as mlx_lm_load
+
+                draft_path = str(
+                    Path.home()
+                    / "ai-models"
+                    / "mlx_models"
+                    / self._specprefill_draft_model_path
+                )
+                self._draft_model, _ = mlx_lm_load(draft_path)
+                logger.info(
+                    "SpecPrefill draft model loaded: %s (threshold=%d, keep=%.0f%%)",
+                    self._specprefill_draft_model_path,
+                    self._specprefill_threshold,
+                    self._specprefill_keep_pct * 100,
+                )
+            except Exception as e:
+                logger.warning("Failed to load SpecPrefill draft model: %s", e)
+                self._specprefill_enabled = False
+                self._draft_model = None
 
     async def _start_llm(self) -> None:
         """Start the LLM engine with AsyncEngineCore."""
@@ -312,6 +574,44 @@ class BatchedEngine(BaseEngine):
 
         await self._engine.engine.start()
 
+        # Initialize admission controller from config.json on disk
+        # (mlx_lm models may not expose .config attribute)
+        try:
+            import json
+            from pathlib import Path
+
+            config_path = Path(self._model_name) / "config.json"
+            if config_path.exists():
+                model_config = json.loads(config_path.read_text())
+                self._init_admission_controller(model_config)
+            else:
+                logger.info("[admission] No config.json found — admission disabled")
+        except Exception as e:
+            logger.warning(f"[admission] Failed to init: {e} — admission disabled")
+
+        # Load SpecPrefill draft model (for LLM path)
+        if self._specprefill_enabled and self._specprefill_draft_model_path:
+            try:
+                from pathlib import Path
+
+                from mlx_lm import load as mlx_lm_load
+
+                draft_path = str(
+                    Path.home()
+                    / "ai-models"
+                    / "mlx_models"
+                    / self._specprefill_draft_model_path
+                )
+                self._draft_model, _ = mlx_lm_load(draft_path)
+                logger.info(
+                    "SpecPrefill draft model loaded (LLM path): %s",
+                    self._specprefill_draft_model_path,
+                )
+            except Exception as e:
+                logger.warning("Failed to load SpecPrefill draft model: %s", e)
+                self._specprefill_enabled = False
+                self._draft_model = None
+
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         if self._mllm_scheduler:
@@ -327,6 +627,13 @@ class BatchedEngine(BaseEngine):
         self._tokenizer = None
         self._processor = None
         self._mllm_instance = None
+        self._text_model = None
+        self._text_tokenizer = None
+        self._draft_model = None
+        self._system_kv_snapshot = None
+        self._system_kv_hash = None
+        self._system_kv_token_count = 0
+        self._admission = None
         self._loaded = False
         logger.info("BatchedEngine stopped")
 
@@ -423,6 +730,35 @@ class BatchedEngine(BaseEngine):
                 prepared.append(msg)
         return prepared
 
+    def _estimate_prompt_tokens(self, messages: list[dict[str, Any]]) -> int:
+        """Estimate token count from chat messages for admission control.
+
+        Uses the tokenizer when available, falls back to character-based
+        estimate (1 token per 4 characters).
+        """
+        # Concatenate message text for a rough estimate
+        text_parts = []
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                text_parts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, str):
+                        text_parts.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+        text = " ".join(text_parts)
+
+        tokenizer = self.tokenizer
+        if tokenizer is not None and hasattr(tokenizer, "encode"):
+            try:
+                return len(tokenizer.encode(text))
+            except Exception:
+                pass
+        # Fallback: ~4 chars per token
+        return len(text) // 4
+
     async def generate(
         self,
         prompt: str,
@@ -453,49 +789,62 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        if self._is_mllm and self._mllm_scheduler:
-            # Use MLLM scheduler for all requests when model is multimodal.
-            # MLLM models only initialise the _mllm_scheduler (not _engine),
-            # so text-only requests must also be routed here.
-            output = await self._mllm_scheduler.generate(
-                prompt=prompt,
-                images=images,
-                videos=videos,
+        # Admission control — estimate tokens from raw prompt
+        if self._admission is not None:
+            est_tokens = len(prompt) // 4  # rough estimate for raw prompts
+            try:
+                enc = getattr(self, "_text_tokenizer", None)
+                if enc:
+                    est_tokens = len(enc.encode(prompt))
+            except Exception:
+                pass
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, est_tokens)
+
+        try:
+            if self._is_mllm and self._mllm_scheduler:
+                output = await self._mllm_scheduler.generate(
+                    prompt=prompt,
+                    images=images,
+                    videos=videos,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                )
+
+                return GenerationOutput(
+                    text=clean_output_text(output.output_text),
+                    prompt_tokens=output.prompt_tokens,
+                    completion_tokens=output.completion_tokens,
+                    finish_reason=output.finish_reason,
+                )
+
+            # Use LLM engine for text-only (non-MLLM models)
+            from ..request import SamplingParams
+
+            sampling_params = SamplingParams(
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
+                stop=stop or [],
             )
 
+            output = await self._engine.generate(
+                prompt=prompt,
+                sampling_params=sampling_params,
+            )
+
+            text = clean_output_text(output.output_text)
+
             return GenerationOutput(
-                text=clean_output_text(output.output_text),
+                text=text,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
             )
-
-        # Use LLM engine for text-only (non-MLLM models)
-        from ..request import SamplingParams
-
-        sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            stop=stop or [],
-        )
-
-        output = await self._engine.generate(
-            prompt=prompt,
-            sampling_params=sampling_params,
-        )
-
-        text = clean_output_text(output.output_text)
-
-        return GenerationOutput(
-            text=text,
-            prompt_tokens=output.prompt_tokens,
-            completion_tokens=output.completion_tokens,
-            finish_reason=output.finish_reason,
-        )
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
 
     async def stream_generate(
         self,
@@ -527,56 +876,71 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        if self._is_mllm and self._mllm_scheduler:
-            # Use MLLM scheduler for all streaming when model is multimodal
-            request_id = await self._mllm_scheduler.add_request_async(
-                prompt=prompt,
-                images=images,
-                videos=videos,
+        # Admission control — estimate tokens from raw prompt
+        if self._admission is not None:
+            est_tokens = len(prompt) // 4
+            try:
+                enc = getattr(self, "_text_tokenizer", None)
+                if enc:
+                    est_tokens = len(enc.encode(prompt))
+            except Exception:
+                pass
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, est_tokens)
+
+        try:
+            if self._is_mllm and self._mllm_scheduler:
+                request_id = await self._mllm_scheduler.add_request_async(
+                    prompt=prompt,
+                    images=images,
+                    videos=videos,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                )
+
+                async for output in self._mllm_scheduler.stream_outputs(request_id):
+                    yield GenerationOutput(
+                        text=clean_output_text(output.output_text),
+                        new_text=output.new_text,
+                        prompt_tokens=output.prompt_tokens,
+                        completion_tokens=output.completion_tokens,
+                        finished=output.finished,
+                        finish_reason=output.finish_reason,
+                    )
+                return
+
+            # Use LLM engine for text-only
+            from ..request import SamplingParams
+
+            sampling_params = SamplingParams(
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
+                stop=stop or [],
             )
 
-            async for output in self._mllm_scheduler.stream_outputs(request_id):
+            prefix_boundary = kwargs.pop("prefix_boundary", 0)
+            request_id = await self._engine.add_request(
+                prompt=prompt,
+                sampling_params=sampling_params,
+                prefix_boundary=prefix_boundary,
+            )
+
+            async for output in self._engine.stream_outputs(request_id):
+                text = clean_output_text(output.output_text)
+
                 yield GenerationOutput(
-                    text=clean_output_text(output.output_text),
+                    text=text,
                     new_text=output.new_text,
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
                     finished=output.finished,
                     finish_reason=output.finish_reason,
                 )
-            return
-
-        # Use LLM engine for text-only
-        from ..request import SamplingParams
-
-        sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            stop=stop or [],
-        )
-
-        prefix_boundary = kwargs.pop("prefix_boundary", 0)
-        request_id = await self._engine.add_request(
-            prompt=prompt,
-            sampling_params=sampling_params,
-            prefix_boundary=prefix_boundary,
-        )
-
-        async for output in self._engine.stream_outputs(request_id):
-            text = clean_output_text(output.output_text)
-
-            yield GenerationOutput(
-                text=text,
-                new_text=output.new_text,
-                prompt_tokens=output.prompt_tokens,
-                completion_tokens=output.completion_tokens,
-                finished=output.finished,
-                finish_reason=output.finish_reason,
-            )
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
 
     async def chat(
         self,
@@ -612,31 +976,55 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        # Extract images/videos from messages (OpenAI multimodal format)
-        # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
-        all_images = (images or []) + extracted_images
-        all_videos = (videos or []) + extracted_videos
+        # Normalize messages before any path (developer->system, merge consecutive)
+        messages = _normalize_messages(messages)
 
-        # Convert tools for template
-        template_tools = convert_tools_for_template(tools) if tools else None
+        # Admission control — wait if memory is tight
+        admission_id = None
+        if self._admission is not None:
+            prompt_tokens = self._estimate_prompt_tokens(messages)
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, prompt_tokens)
 
-        # Apply chat template
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            num_images=len(all_images),
-        )
+        try:
+            # Per-request MTP routing: text-only → TextModel, media → MLLM
+            if self._text_model is not None and not _has_media_content(messages):
+                return await self._chat_text_model(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    tools=tools,
+                    **kwargs,
+                )
 
-        return await self.generate(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            images=all_images if all_images else None,
-            videos=all_videos if all_videos else None,
-            **kwargs,
-        )
+            # Extract images/videos from messages (OpenAI multimodal format)
+            _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+            all_images = (images or []) + extracted_images
+            all_videos = (videos or []) + extracted_videos
+
+            # Convert tools for template
+            template_tools = convert_tools_for_template(tools) if tools else None
+
+            # Apply chat template
+            prompt = self._apply_chat_template(
+                messages,
+                template_tools,
+                num_images=len(all_images),
+            )
+
+            return await self.generate(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                images=all_images if all_images else None,
+                videos=all_videos if all_videos else None,
+                **kwargs,
+            )
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
 
     def _compute_prefix_boundary(
         self, messages: list[dict[str, Any]], tools: list[dict] | None = None
@@ -723,37 +1111,716 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        # Extract images/videos from messages (OpenAI multimodal format)
-        # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
-        all_images = (images or []) + extracted_images
-        all_videos = (videos or []) + extracted_videos
+        # Normalize messages before any path (developer->system, merge consecutive)
+        messages = _normalize_messages(messages)
+
+        # Admission control — wait if memory is tight
+        admission_id = None
+        if self._admission is not None:
+            prompt_tokens = self._estimate_prompt_tokens(messages)
+            admission_id = str(uuid.uuid4())
+            await self._admission.wait_for_admission(admission_id, prompt_tokens)
+
+        try:
+            # Per-request MTP routing: text-only → TextModel, media → MLLM
+            if self._text_model is not None and not _has_media_content(messages):
+                async for output in self._stream_chat_text_model(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    tools=tools,
+                    **kwargs,
+                ):
+                    yield output
+                return
+
+            # Extract images/videos from messages (OpenAI multimodal format)
+            _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+            all_images = (images or []) + extracted_images
+            all_videos = (videos or []) + extracted_videos
+
+            # Convert tools for template
+            template_tools = convert_tools_for_template(tools) if tools else None
+
+            # Apply chat template
+            prompt = self._apply_chat_template(
+                messages,
+                template_tools,
+                num_images=len(all_images),
+            )
+
+            # Compute prefix boundary for cache
+            prefix_boundary = self._compute_prefix_boundary(messages, tools)
+            if prefix_boundary > 0:
+                kwargs["prefix_boundary"] = prefix_boundary
+
+            async for output in self.stream_generate(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                images=all_images if all_images else None,
+                videos=all_videos if all_videos else None,
+                **kwargs,
+            ):
+                yield output
+        finally:
+            if self._admission is not None:
+                self._admission.on_request_complete()
+
+    async def _chat_text_model(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> GenerationOutput:
+        """Non-streaming text-only generation via mlx_lm TextModel with MTP.
+
+        Collects all streaming output into a single GenerationOutput.
+        Used when MLLM+MTP routing is active and the request has no media.
+        """
+        logger.info("Text-only request → TextModel (MTP) [non-streaming]")
+        accumulated_text = ""
+        last_chunk = None
+        async for chunk in self._stream_chat_text_model(
+            messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            tools=tools,
+            **kwargs,
+        ):
+            accumulated_text = chunk.text
+            last_chunk = chunk
+        if last_chunk is not None:
+            return GenerationOutput(
+                text=accumulated_text,
+                prompt_tokens=last_chunk.prompt_tokens,
+                completion_tokens=last_chunk.completion_tokens,
+                finish_reason=last_chunk.finish_reason,
+            )
+        return GenerationOutput(text="", finish_reason="stop")
+
+    async def _stream_chat_text_model(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> AsyncIterator[GenerationOutput]:
+        """Streaming text-only generation via mlx_lm TextModel with MTP.
+
+        Used when MLLM+MTP routing is active and the request has no media.
+        Runs the full generation in a single thread to maintain Metal safety.
+
+        System prompt KV caching: on the first request, prefills system tokens
+        and snapshots backbone KV state. Subsequent requests with the same
+        system prompt restore the snapshot and only prefill the suffix tokens.
+
+        SpecPrefill: when a draft model is loaded and the prompt exceeds the
+        threshold, uses attention-based sparse prefill for faster TTFT.
+        Composes with system KV cache (sparse-prefill only the suffix when
+        cache hits). Falls back to normal path on any error.
+        """
+        import hashlib
+        import os
+
+        import mlx.core as mx
+        from mlx_lm import stream_generate as mlx_stream_generate
+        from mlx_lm.models.cache import make_prompt_cache
+        from mlx_lm.sample_utils import make_sampler
+
+        # Per-request specprefill overrides (from extra_body)
+        specprefill_override = kwargs.pop("specprefill", None)
+        specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
 
+        # Read enable_thinking from env (set by runtime_patches, consistent with MLLM path)
+        enable_thinking_env = os.environ.get("VLLM_MLX_ENABLE_THINKING", "true")
+        enable_thinking = enable_thinking_env.lower() in ("true", "1", "yes")
+
         # Apply chat template
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            num_images=len(all_images),
-        )
+        template_kwargs = {
+            "tokenize": False,
+            "add_generation_prompt": True,
+            "enable_thinking": enable_thinking,
+        }
+        if template_tools:
+            template_kwargs["tools"] = template_tools
 
-        # Compute prefix boundary for cache
-        prefix_boundary = self._compute_prefix_boundary(messages, tools)
-        if prefix_boundary > 0:
-            kwargs["prefix_boundary"] = prefix_boundary
+        try:
+            prompt = self._text_tokenizer.apply_chat_template(
+                messages, **template_kwargs
+            )
+        except TypeError:
+            # Template doesn't accept tools= or enable_thinking=
+            template_kwargs.pop("tools", None)
+            template_kwargs.pop("enable_thinking", None)
+            prompt = self._text_tokenizer.apply_chat_template(
+                messages, **template_kwargs
+            )
 
-        async for output in self.stream_generate(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            images=all_images if all_images else None,
-            videos=all_videos if all_videos else None,
-            **kwargs,
-        ):
-            yield output
+        # Build sampler
+        sampler = make_sampler(temp=temperature, top_p=top_p)
+        max_tokens = max_tokens or 4096
+
+        # --- System KV cache: find system prefix boundary ---
+        # ChatML (Qwen 3.5): everything before first <|im_start|>user is the system prefix
+        USER_MARKER = "<|im_start|>user"
+        marker_pos = prompt.find(USER_MARKER)
+        if marker_pos > 0:
+            system_prefix = prompt[:marker_pos]
+            suffix = prompt[marker_pos:]
+            prefix_hash = hashlib.sha256(system_prefix.encode()).hexdigest()[:16]
+        else:
+            system_prefix = None
+            suffix = prompt
+            prefix_hash = None
+
+        # Check for cache hit (lock protects against concurrent snapshot writes)
+        with self._system_kv_lock:
+            cache_hit = (
+                prefix_hash is not None
+                and prefix_hash == self._system_kv_hash
+                and self._system_kv_snapshot is not None
+            )
+            cached_token_count = self._system_kv_token_count if cache_hit else 0
+
+        if cache_hit:
+            logger.info(
+                "Text-only request → TextModel (MTP) [streaming, system KV cache HIT: "
+                "reusing %d cached tokens, hash=%s]",
+                cached_token_count,
+                prefix_hash,
+            )
+        else:
+            logger.info("Text-only request → TextModel (MTP) [streaming]")
+
+        prefill_step_size = self._prefill_step_size
+
+        # --- SpecPrefill decision ---
+        # Determine whether to use specprefill for this request.
+        # Must be decided before entering the generation lock so we can
+        # tokenize and check the threshold outside the critical section.
+        _SPECPREFILL_MAX_TOKENS = 196608
+        use_specprefill = False
+        if self._draft_model is not None:
+            if specprefill_override is True:
+                use_specprefill = True
+            elif specprefill_override is None and self._specprefill_enabled:
+                use_specprefill = True
+            # specprefill_override=False explicitly disables
+
+        # Tokenize to determine token count for specprefill threshold check.
+        # We need this for both specprefill and normal paths anyway.
+        sp_tokens = None  # tokens to score (suffix or full prompt)
+        sp_offset = 0  # position offset for sparse_prefill
+        sp_n_total = 0  # total prompt tokens (for logging / threshold)
+
+        if use_specprefill:
+            if cache_hit:
+                # Score only the suffix — system prefix is already cached
+                sp_tokens = self._text_tokenizer.encode(suffix)
+                sp_offset = self._system_kv_token_count
+                sp_n_total = sp_offset + len(sp_tokens)
+            else:
+                # Score the full prompt
+                sp_tokens = self._text_tokenizer.encode(prompt)
+                sp_offset = 0
+                sp_n_total = len(sp_tokens)
+
+            n_sp_tokens = len(sp_tokens)
+
+            # Threshold check (skip when force-enabled via per-request override)
+            if (
+                specprefill_override is not True
+                and n_sp_tokens <= self._specprefill_threshold
+            ):
+                use_specprefill = False
+
+            # Upper bound: cap to avoid draft model OOM
+            if use_specprefill and n_sp_tokens > _SPECPREFILL_MAX_TOKENS:
+                logger.warning(
+                    "SpecPrefill: prompt %d tokens exceeds max %d, "
+                    "falling back to normal path",
+                    n_sp_tokens,
+                    _SPECPREFILL_MAX_TOKENS,
+                )
+                use_specprefill = False
+
+        # --- Cooperative SpecPrefill: draft scoring OUTSIDE the lock ---
+        # When chunk_size > 0, draft scoring runs outside _text_generation_lock
+        # via ChunkedDraftScorer, yielding between chunks so active requests
+        # can generate tokens. The draft model is separate from the target
+        # model — no shared mutable state.
+        # When chunk_size == 0, the old monolithic path runs entirely under lock.
+        use_cooperative = use_specprefill and self._specprefill_chunk_size > 0
+        importance = None  # Pre-computed importance for cooperative path
+
+        if use_cooperative:
+            from ..cooperative_specprefill import ChunkedDraftScorer
+
+            scorer = ChunkedDraftScorer(
+                draft_model=self._draft_model,
+                tokens=sp_tokens,
+                chunk_size=self._specprefill_chunk_size,
+            )
+            def _locked_step():
+                with self._metal_lock:
+                    return scorer.step()
+
+            def _locked_finalize():
+                with self._metal_lock:
+                    return scorer.finalize()
+
+            try:
+                while scorer.is_scoring:
+                    await asyncio.to_thread(_locked_step)
+                    await asyncio.sleep(0)  # Yield to event loop
+
+                importance = await asyncio.to_thread(_locked_finalize)
+            except BaseException as e:
+                scorer.cleanup()
+                if isinstance(e, (asyncio.CancelledError, KeyboardInterrupt)):
+                    raise
+                logger.error(
+                    "SpecPrefill cooperative scoring failed, "
+                    "falling back to normal path: %s",
+                    e,
+                )
+                use_specprefill = False
+                use_cooperative = False
+                importance = None
+
+        # --- Selection + prefill + generation UNDER LOCK ---
+        async with self._text_generation_lock:
+
+            # Re-verify cache_hit under lock — another request may have
+            # changed the snapshot while we were waiting for the lock.
+            if cache_hit:
+                actual_hit = (
+                    prefix_hash is not None
+                    and prefix_hash == self._system_kv_hash
+                    and self._system_kv_snapshot is not None
+                )
+                if not actual_hit:
+                    logger.warning(
+                        "System KV cache invalidated while waiting for lock, "
+                        "falling back to cache miss path"
+                    )
+                    cache_hit = False
+
+            def _run_with_cache():
+                if use_specprefill and use_cooperative and importance is not None:
+                    try:
+                        return _run_specprefill_with_importance(importance)
+                    except Exception as e:
+                        logger.error(
+                            "SpecPrefill failed after scoring, "
+                            "falling back to normal path: %s",
+                            e,
+                        )
+                        # Fall through to normal path
+                elif use_specprefill and not use_cooperative:
+                    # Monolithic path (chunk_size=0): score + prefill under lock
+                    try:
+                        return _run_specprefill()
+                    except Exception as e:
+                        logger.error(
+                            "SpecPrefill failed, falling back to normal path: %s", e
+                        )
+                        # Fall through to normal path
+                if cache_hit:
+                    return _run_cache_hit()
+                else:
+                    return _run_cache_miss()
+
+            def _run_specprefill_with_importance(precomputed_importance):
+                """Select chunks, sparse prefill, generate with pre-scored importance.
+
+                Draft scoring has already been done outside the lock via
+                ChunkedDraftScorer. This function handles phases 2-4:
+                selection, sparse prefill, and autoregressive generation.
+
+                Composes with system KV cache: when cache_hit, restores the
+                system KV snapshot first, then sparse-prefills only the suffix
+                tokens with position_offset = system_kv_token_count.
+
+                Does NOT use MTP (sparse cache is incompatible with MTP
+                speculative decoding).
+                """
+                import time
+                from types import SimpleNamespace
+
+                from ..specprefill import (
+                    cleanup_rope,
+                    select_chunks,
+                    sparse_prefill,
+                )
+
+                # Build target cache (optionally restore system KV snapshot)
+                target_cache = make_prompt_cache(self._text_model)
+                if cache_hit:
+                    for layer_idx, snapshot_state in enumerate(
+                        self._system_kv_snapshot
+                    ):
+                        if layer_idx < len(target_cache):
+                            target_cache[layer_idx].state = snapshot_state
+                    mx.eval([c.state for c in target_cache if hasattr(c, "state")])
+
+                try:
+                    # Phase 2: Select important chunks
+                    effective_keep = (
+                        specprefill_keep_pct_override if specprefill_keep_pct_override is not None else self._specprefill_keep_pct
+                    )
+                    selected = select_chunks(
+                        precomputed_importance, keep_pct=effective_keep
+                    )
+                    n_selected = selected.shape[0]
+                    n_scored = len(sp_tokens)
+
+                    # Phase 3: Sparse prefill on target model
+                    t0 = time.monotonic()
+                    logits = sparse_prefill(
+                        self._text_model,
+                        sp_tokens,
+                        selected,
+                        target_cache,
+                        step_size=prefill_step_size,
+                        position_offset=sp_offset,
+                    )
+                    t_prefill = time.monotonic() - t0
+
+                    logger.info(
+                        "SpecPrefill (cooperative): "
+                        "sparse prefill %d/%d (keep=%.0f%%) in %.1fs "
+                        "(offset=%d, effective_keep=%.2f)",
+                        n_selected,
+                        n_scored,
+                        n_selected / n_scored * 100,
+                        t_prefill,
+                        sp_offset,
+                        effective_keep,
+                    )
+
+                    # Phase 4: Generate (simple autoregressive, no MTP)
+                    eos_id = self._text_tokenizer.eos_token_id
+                    y = sampler(logits[:, -1, :])
+                    mx.eval(y)
+
+                    results = []
+                    generated_ids = []
+                    prev_decoded = ""
+
+                    for _ in range(max_tokens):
+                        tok_id = y.item()
+                        generated_ids.append(tok_id)
+
+                        # Incremental text decode
+                        decoded = self._text_tokenizer.decode(generated_ids)
+                        new_text = decoded[len(prev_decoded) :]
+                        prev_decoded = decoded
+
+                        is_eos = tok_id == eos_id
+                        results.append(
+                            SimpleNamespace(
+                                text=new_text,
+                                finish_reason="stop" if is_eos else None,
+                            )
+                        )
+
+                        if is_eos:
+                            break
+
+                        # Next token
+                        logits = self._text_model(y.reshape(1, -1), cache=target_cache)
+                        y = sampler(logits[:, -1, :])
+                        mx.eval(y)
+
+                    return results, sp_n_total
+
+                finally:
+                    cleanup_rope(self._text_model)
+
+            def _run_specprefill():
+                """Monolithic: score tokens, sparse prefill, generate.
+
+                Used when cooperative mode is disabled (chunk_size=0).
+                Runs entirely under _text_generation_lock.
+
+                Composes with system KV cache: when cache_hit, restores the
+                system KV snapshot first, then sparse-prefills only the suffix
+                tokens with position_offset = system_kv_token_count.
+
+                Does NOT use MTP (sparse cache is incompatible with MTP
+                speculative decoding).
+                """
+                import time
+                from types import SimpleNamespace
+
+                from ..specprefill import (
+                    cleanup_rope,
+                    score_tokens,
+                    select_chunks,
+                    sparse_prefill,
+                )
+
+                # Build target cache (optionally restore system KV snapshot)
+                target_cache = make_prompt_cache(self._text_model)
+                if cache_hit:
+                    for layer_idx, snapshot_state in enumerate(
+                        self._system_kv_snapshot
+                    ):
+                        if layer_idx < len(target_cache):
+                            target_cache[layer_idx].state = snapshot_state
+                    mx.eval([c.state for c in target_cache if hasattr(c, "state")])
+
+                try:
+                    # Phase 1: Score with draft model
+                    t0 = time.monotonic()
+                    importance = score_tokens(
+                        self._draft_model,
+                        sp_tokens,
+                        prefill_step_size=prefill_step_size,
+                    )
+                    t_score = time.monotonic() - t0
+
+                    # Phase 2: Select important chunks
+                    effective_keep = (
+                        specprefill_keep_pct_override if specprefill_keep_pct_override is not None else self._specprefill_keep_pct
+                    )
+                    selected = select_chunks(importance, keep_pct=effective_keep)
+                    n_selected = selected.shape[0]
+                    n_scored = len(sp_tokens)
+
+                    # Phase 3: Sparse prefill on target model
+                    t0 = time.monotonic()
+                    logits = sparse_prefill(
+                        self._text_model,
+                        sp_tokens,
+                        selected,
+                        target_cache,
+                        step_size=prefill_step_size,
+                        position_offset=sp_offset,
+                    )
+                    t_prefill = time.monotonic() - t0
+
+                    logger.info(
+                        "SpecPrefill: scored %d tokens in %.1fs, "
+                        "sparse prefill %d/%d (keep=%.0f%%) in %.1fs "
+                        "(offset=%d, effective_keep=%.2f)",
+                        n_scored,
+                        t_score,
+                        n_selected,
+                        n_scored,
+                        n_selected / n_scored * 100,
+                        t_prefill,
+                        sp_offset,
+                        effective_keep,
+                    )
+
+                    # Phase 4: Generate (simple autoregressive, no MTP)
+                    eos_id = self._text_tokenizer.eos_token_id
+                    y = sampler(logits[:, -1, :])
+                    mx.eval(y)
+
+                    results = []
+                    generated_ids = []
+                    prev_decoded = ""
+
+                    for _ in range(max_tokens):
+                        tok_id = y.item()
+                        generated_ids.append(tok_id)
+
+                        # Incremental text decode
+                        decoded = self._text_tokenizer.decode(generated_ids)
+                        new_text = decoded[len(prev_decoded) :]
+                        prev_decoded = decoded
+
+                        is_eos = tok_id == eos_id
+                        results.append(
+                            SimpleNamespace(
+                                text=new_text,
+                                finish_reason="stop" if is_eos else None,
+                            )
+                        )
+
+                        if is_eos:
+                            break
+
+                        # Next token
+                        logits = self._text_model(y.reshape(1, -1), cache=target_cache)
+                        y = sampler(logits[:, -1, :])
+                        mx.eval(y)
+
+                    return results, sp_n_total
+
+                finally:
+                    cleanup_rope(self._text_model)
+
+            def _run_cache_hit():
+                """Restore system KV snapshot, prefill only suffix, generate."""
+                # Restore cached KV state into a fresh cache
+                restored_cache = make_prompt_cache(self._text_model)
+                for layer_idx, snapshot_state in enumerate(self._system_kv_snapshot):
+                    if layer_idx < len(restored_cache):
+                        restored_cache[layer_idx].state = snapshot_state
+                mx.eval([c.state for c in restored_cache if hasattr(c, "state")])
+
+                # Tokenize just the suffix and generate with the primed cache.
+                # stream_generate accepts mx.array prompt (skips tokenization)
+                # and prompt_cache is forwarded to mtp_generate_step.
+                suffix_tokens = self._text_tokenizer.encode(suffix)
+                suffix_array = mx.array(suffix_tokens)
+                n_suffix = len(suffix_tokens)
+
+                logger.info(
+                    "System KV cache HIT: prefilling %d suffix tokens "
+                    "(skipped %d cached tokens)",
+                    n_suffix,
+                    self._system_kv_token_count,
+                )
+
+                results = []
+                for resp in mlx_stream_generate(
+                    self._text_model,
+                    self._text_tokenizer,
+                    prompt=suffix_array,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    mtp=True,
+                    prompt_cache=restored_cache,
+                    prefill_step_size=prefill_step_size,
+                ):
+                    results.append(resp)
+                return results, self._system_kv_token_count + len(suffix_tokens)
+
+            def _run_cache_miss():
+                """Full prefill + generation, then snapshot system KV for next time."""
+                results = []
+                for resp in mlx_stream_generate(
+                    self._text_model,
+                    self._text_tokenizer,
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    mtp=True,
+                    prefill_step_size=prefill_step_size,
+                ):
+                    results.append(resp)
+
+                # Snapshot system KV for next request (if we found a system prefix)
+                if prefix_hash is not None and system_prefix is not None:
+                    try:
+                        _snapshot_system_kv()
+                    except Exception as e:
+                        logger.warning("Failed to snapshot system KV cache: %s", e)
+
+                # Get total prompt token count from generation response
+                prompt_tokens = 0
+                if results and hasattr(results[0], "prompt_tokens"):
+                    prompt_tokens = results[0].prompt_tokens
+                return results, prompt_tokens
+
+            def _snapshot_system_kv():
+                """Prefill just the system prefix on a fresh cache and save snapshot."""
+                snapshot_cache = make_prompt_cache(self._text_model)
+                prefix_tokens = self._text_tokenizer.encode(system_prefix)
+                prefix_ids = mx.array(prefix_tokens)
+
+                # Chunked prefill of system prefix
+                for i in range(0, prefix_ids.size, prefill_step_size):
+                    chunk = prefix_ids[i : i + prefill_step_size]
+                    self._text_model(chunk[None], cache=snapshot_cache)
+                    mx.eval([c.state for c in snapshot_cache if hasattr(c, "state")])
+
+                # Save snapshot: deep copy of each cache layer's state
+                new_snapshot = []
+                for c in snapshot_cache:
+                    state = c.state
+                    if isinstance(state, tuple) and len(state) == 2:
+                        # KVCache: (keys, values) — copy to detach from cache
+                        keys, values = state
+                        new_snapshot.append(
+                            (mx.array(keys), mx.array(values))
+                        )
+                    elif isinstance(state, list):
+                        # ArraysCache: list of arrays (Mamba/hybrid)
+                        new_snapshot.append(
+                            [mx.array(a) if a is not None else None for a in state]
+                        )
+                    else:
+                        # Unknown cache type — store as-is
+                        new_snapshot.append(state)
+
+                # Atomic update under lock — readers check these fields
+                # from the event loop thread (see cache_hit check).
+                with self._system_kv_lock:
+                    self._system_kv_snapshot = new_snapshot
+                    self._system_kv_token_count = len(prefix_tokens)
+                    self._system_kv_hash = prefix_hash
+
+                cache_bytes = 0
+                for entry in self._system_kv_snapshot:
+                    if isinstance(entry, tuple) and len(entry) == 2:
+                        cache_bytes += entry[0].nbytes + entry[1].nbytes
+                    elif isinstance(entry, list):
+                        cache_bytes += sum(a.nbytes for a in entry if a is not None)
+                logger.info(
+                    "System KV cache: stored %d-token snapshot " "(%.1f MB), hash=%s",
+                    len(prefix_tokens),
+                    cache_bytes / 1e6,
+                    prefix_hash,
+                )
+
+            def _locked_run_with_cache():
+                with self._metal_lock:
+                    return _run_with_cache()
+
+            result = await asyncio.to_thread(_locked_run_with_cache)
+            all_resps, prompt_token_count = result
+
+        # Yield results as GenerationOutput
+        accumulated_text = ""
+        token_count = 0
+        finished = False
+        for i, resp in enumerate(all_resps):
+            token_count += 1
+            new_text = resp.text if hasattr(resp, "text") else str(resp)
+            accumulated_text += new_text
+
+            is_last = i == len(all_resps) - 1
+            finished = is_last or token_count >= max_tokens
+
+            yield GenerationOutput(
+                text=accumulated_text,
+                new_text=new_text,
+                prompt_tokens=prompt_token_count,
+                completion_tokens=token_count,
+                finished=finished,
+                finish_reason="stop" if finished else None,
+            )
+
+            if finished:
+                break
+
+        if not finished:
+            yield GenerationOutput(
+                text=accumulated_text,
+                new_text="",
+                prompt_tokens=prompt_token_count,
+                completion_tokens=token_count,
+                finished=True,
+                finish_reason="length",
+            )
 
     def get_stats(self) -> dict[str, Any]:
         """Get engine statistics."""
@@ -778,6 +1845,31 @@ class BatchedEngine(BaseEngine):
                     stats[key] = mllm_stats[key]
         elif self._engine:
             stats.update(self._engine.get_stats())
+
+        # SpecPrefill stats
+        if self._draft_model is not None:
+            stats["specprefill"] = {
+                "enabled": self._specprefill_enabled,
+                "draft_model": self._specprefill_draft_model_path,
+                "threshold": self._specprefill_threshold,
+                "keep_pct": self._specprefill_keep_pct,
+                "chunk_size": self._specprefill_chunk_size,
+                "cooperative": self._specprefill_chunk_size > 0,
+            }
+
+        # System KV cache stats
+        if self._system_kv_snapshot is not None:
+            cache_bytes = 0
+            for entry in self._system_kv_snapshot:
+                if isinstance(entry, tuple) and len(entry) == 2:
+                    cache_bytes += entry[0].nbytes + entry[1].nbytes
+                elif isinstance(entry, list):
+                    cache_bytes += sum(a.nbytes for a in entry if a is not None)
+            stats["system_kv_cache"] = {
+                "tokens": self._system_kv_token_count,
+                "hash": self._system_kv_hash,
+                "memory_mb": round(cache_bytes / 1e6, 1),
+            }
 
         return stats
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2232,9 +2232,25 @@ class Scheduler:
         old_finished = self.finished_req_ids
         self.finished_req_ids = set()
 
-        # Periodically clear Metal cache to prevent memory accumulation
+        # Adaptive interval: scale inversely with concurrency to prevent
+        # Metal resource handle exhaustion under high-concurrency workloads.
+        active_seqs = len(self.running)
+        min_interval = max(4, self._clear_cache_interval // 4)
+        effective_interval = max(
+            min_interval, self._clear_cache_interval // max(1, active_seqs // 8)
+        )
+
         self._step_count += 1
-        if self._step_count % self._clear_cache_interval == 0:
+        if self._step_count % effective_interval == 0:
+            # Evaluate batch tokens to collapse lazy concatenation chains
+            if (
+                self.batch_generator is not None
+                and self.batch_generator.active_batch is not None
+                and hasattr(self.batch_generator.active_batch, "tokens")
+            ):
+                tokens = self.batch_generator.active_batch.tokens
+                if tokens:
+                    mx.eval(*tokens)
             mx.clear_cache()
 
         # Periodically log memory stats for monitoring

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -1,0 +1,742 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SpecPrefill: Attention-based sparse prefill for MLX.
+
+Full pipeline for reducing TTFT on long prompts:
+  Step 1 (score_tokens): Use a small draft model to identify important tokens
+  Step 2 (sparse_prefill): Prefill target model with only selected tokens,
+         preserving original positional encoding via manual RoPE
+
+Usage:
+    from specprefill import score_tokens, select_chunks, sparse_prefill, cleanup_rope
+
+    # 1. Score with draft model
+    importance = score_tokens(draft_model, tokens)
+
+    # 2. Select important token chunks
+    selected = select_chunks(importance, keep_pct=0.3)
+
+    # 3. Sparse prefill on target model
+    target_cache = make_prompt_cache(target_model)
+    logits = sparse_prefill(target_model, tokens, selected, target_cache)
+
+    # 4. Generate normally using target_cache...
+
+    # 5. Cleanup
+    cleanup_rope(target_model)
+
+Design notes:
+    - RoPE is relative: Q_m @ K_p^T depends only on (m - p). Selected keys stored
+      contiguously in the cache buffer with correct RoPE angles produce correct
+      attention during decode.
+    - After sparse prefill of N tokens from a total prompt of M, cache.offset = N
+      but decode RoPE needs position M. The _OffsetAdjustedRoPE adds (M - N) to
+      each RoPE offset call, so decode position = N + i + (M - N) = M + i.
+    - GatedDeltaNet (linear attention) layers process sparse tokens through their
+      conv/SSM state normally. This is lossy but acceptable per the SpecPrefill
+      paper — attention layers are the primary long-range mechanism.
+
+Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
+"""
+
+import math
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.sample_utils import make_sampler
+
+# ===========================================================================
+# Step 1: Token importance scoring (draft model)
+# ===========================================================================
+
+
+class _AttentionCapture:
+    """Wrapper that captures post-RoPE query vectors and delegates to original.
+
+    Installed on attention layers during lookahead decode to capture query
+    vectors for importance scoring. Supports multiple architectures via
+    query_extractor callback.
+    """
+
+    def __init__(self, original, buf_idx, query_buffer, query_extractor=None):
+        self._original = original
+        self._buf_idx = buf_idx
+        self._query_buffer = query_buffer
+        self._query_extractor = query_extractor or _qwen35_extract_queries
+
+    def __call__(self, x, mask=None, cache=None):
+        queries = self._query_extractor(self._original, x, cache)
+        self._query_buffer[self._buf_idx].append(queries)
+        return self._original(x, mask=mask, cache=cache)
+
+    def __getattr__(self, name):
+        return getattr(self._original, name)
+
+
+def _qwen35_extract_queries(attn, x, cache=None):
+    """Extract post-RoPE queries from Qwen3.5 attention (gate split + q_norm).
+
+    Qwen3.5 q_proj output is 2x wider: [queries, gate]. We split, normalize,
+    then apply RoPE.
+    """
+    B, L, D = x.shape
+    q_out = attn.q_proj(x)
+    queries, _gate = mx.split(
+        q_out.reshape(B, L, attn.num_attention_heads, -1), 2, axis=-1
+    )
+    queries = attn.q_norm(queries).transpose(0, 2, 1, 3)
+    if cache is not None:
+        queries = attn.rope(queries, offset=cache.offset)
+    else:
+        queries = attn.rope(queries)
+    return queries
+
+
+def _llama_extract_queries(attn, x, cache=None):
+    """Extract post-RoPE queries from standard transformer attention.
+
+    Standard architecture: q_proj → reshape → RoPE. No gate, no q_norm.
+    Works for Llama 3.x, Mistral, Gemma, GPT-OSS, and other GQA models.
+    """
+    B, L, D = x.shape
+    n_heads = getattr(
+        attn,
+        "num_attention_heads",
+        getattr(attn, "n_heads", getattr(attn, "num_heads", None)),
+    )
+    queries = attn.q_proj(x)
+    queries = queries.reshape(B, L, n_heads, -1).transpose(0, 2, 1, 3)
+    if cache is not None:
+        queries = attn.rope(queries, offset=cache.offset)
+    else:
+        queries = attn.rope(queries)
+    return queries
+
+
+def _nemotron_h_extract_queries(attn, x, cache=None):
+    """Extract queries from Nemotron-H attention (no RoPE, no gate, no q_norm).
+
+    Nemotron-H attention layers have NO positional encoding — RoPE is absent.
+    Positional modeling comes from Mamba2 layers. Attention is content-based only.
+    """
+    B, L, D = x.shape
+    queries = attn.q_proj(x).reshape(B, L, attn.num_heads, -1).transpose(0, 2, 1, 3)
+    # No RoPE to apply — queries are used as-is for content-based scoring
+    return queries
+
+
+def _patch_attention_for_capture(model, query_buffer, query_extractor=None):
+    """Replace attention modules on full-attention layers with capture wrappers.
+
+    Supports both `self_attn` (Qwen3.5/Llama/GPT-OSS) and `mixer`
+    (Nemotron-H block_type="*") attribute conventions.
+
+    Returns (originals, attn_layer_indices) for cleanup.
+    """
+    originals = []
+    attn_indices = []
+    for layer_idx, layer in _find_attention_layers(model):
+        buf_idx = len(attn_indices)
+        attn_indices.append(layer_idx)
+        orig = _get_attn_module(layer)
+        _set_attn_module(
+            layer,
+            _AttentionCapture(
+                orig, buf_idx, query_buffer, query_extractor=query_extractor
+            ),
+        )
+        originals.append((layer_idx, orig))
+    return originals, attn_indices
+
+
+def _unpatch_attention_capture(model, originals):
+    """Restore original attention modules after capture."""
+    for layer_idx, orig in originals:
+        _set_attn_module(model.layers[layer_idx], orig)
+
+
+def _prefill_draft(model, tokens, cache, step_size=2048):
+    """Prefill prompt tokens into cache. Returns logits from last token."""
+    prompt = mx.array(tokens) if not isinstance(tokens, mx.array) else tokens
+    n = len(tokens)
+    processed = 0
+    while n - processed > 1:
+        chunk = min(step_size, n - processed - 1)
+        model(prompt[processed : processed + chunk][None], cache=cache)
+        mx.eval([c.state for c in cache])
+        processed += chunk
+        mx.clear_cache()
+    logits = model(prompt[processed:][None], cache=cache)
+    mx.eval(logits)
+    return logits
+
+
+def _lookahead_decode(model, first_logits, cache, n_steps, temp=0.6, top_p=0.95):
+    """Run n_steps autoregressive decode, returning generated token ids.
+
+    Query vectors are captured by the monkey-patched attention layers.
+    """
+    sampler = make_sampler(temp=temp, top_p=top_p)
+    y = sampler(first_logits[:, -1, :])
+    mx.eval(y)
+    generated = [y.item()]
+    for _ in range(n_steps):
+        logits = model(y.reshape(1, -1), cache=cache)
+        y = sampler(logits[:, -1, :])
+        mx.eval(y)
+        generated.append(y.item())
+    return generated
+
+
+def _avg_pool1d(x, kernel_size):
+    """1D average pooling along last axis via prefix-sum.
+
+    Args:
+        x: (..., M) input
+        kernel_size: window size (odd for centered)
+
+    Returns:
+        (..., M) pooled (same size, zero-padded at edges)
+    """
+    if kernel_size <= 1:
+        return x
+    pad = kernel_size // 2
+    padded = mx.pad(x, [(0, 0)] * (x.ndim - 1) + [(pad, pad)])
+    zeros = mx.zeros(x.shape[:-1] + (1,), dtype=x.dtype)
+    prefix = mx.concatenate([zeros, mx.cumsum(padded, axis=-1)], axis=-1)
+    return (prefix[..., kernel_size:] - prefix[..., :-kernel_size]) / kernel_size
+
+
+def _compute_importance(
+    query_buffer, attn_caches, n_prompt, n_attn_heads, n_kv_heads, pool_kernel=13
+):
+    """Compute per-token importance from captured queries and cached keys.
+
+    Aggregation (SpecPrefill paper):
+      1. softmax(Q @ K^T / sqrt(d)) per head, per layer, per lookahead token
+      2. avg_pool1d smoothing
+      3. max across (layers × heads)
+      4. mean across lookahead tokens
+
+    Returns: (n_prompt,) importance scores.
+    """
+    heads_per_group = n_attn_heads // n_kv_heads
+    all_scores = []
+
+    for layer_i, captures in enumerate(query_buffer):
+        if not captures:
+            continue
+        cache = attn_caches[layer_i]
+        prompt_keys = cache.keys[..., :n_prompt, :]
+        # Skip layers with windowed/rotating caches that don't span
+        # the full prompt (e.g., GPT-OSS sliding_attention with 128-token window).
+        # These lack global context and would produce mismatched score shapes.
+        if prompt_keys.shape[-2] < n_prompt:
+            continue
+        head_dim = prompt_keys.shape[-1]
+        q_stack = mx.concatenate(captures, axis=2)
+        if heads_per_group > 1:
+            expanded_keys = mx.repeat(prompt_keys, heads_per_group, axis=1)
+        else:
+            expanded_keys = prompt_keys
+        scale = head_dim**-0.5
+        scores = (q_stack @ expanded_keys.transpose(0, 1, 3, 2)) * scale
+        weights = mx.softmax(scores.astype(mx.float32), axis=-1)
+        all_scores.append(weights.squeeze(0))
+
+    if not all_scores:
+        raise RuntimeError("No attention scores captured — check model/patching")
+
+    combined = mx.concatenate(all_scores, axis=0)
+    if pool_kernel and pool_kernel > 1:
+        combined = _avg_pool1d(combined, pool_kernel)
+    max_scores = mx.max(combined, axis=0)
+    importance = mx.mean(max_scores, axis=0)
+    return importance
+
+
+def score_tokens(
+    model,
+    tokens,
+    n_lookahead=8,
+    pool_kernel=13,
+    temp=0.6,
+    top_p=0.95,
+    prefill_step_size=2048,
+    query_extractor=None,
+):
+    """Score token importance using attention-based analysis on a draft model.
+
+    Runs the full scoring pipeline:
+      1. Prefill the draft model with all tokens
+      2. N lookahead decode steps, capturing query vectors from attention layers
+      3. Compute importance: Q_lookahead @ K_prompt^T, aggregated across heads/layers
+
+    The draft model's cache is created internally and discarded after scoring.
+
+    Args:
+        model: Draft model (small, fast — e.g. 4B)
+        tokens: list or mx.array of token IDs
+        n_lookahead: decode steps for query capture (default 8)
+        pool_kernel: smoothing kernel for avg_pool1d (default 13, 0=disable)
+        temp: sampling temperature for lookahead (default 0.6)
+        top_p: top-p for lookahead (default 0.95)
+        prefill_step_size: chunk size for draft prefill (default 2048)
+        query_extractor: function(attn, x, cache) → queries tensor.
+            Default: _qwen35_extract_queries. Use _llama_extract_queries for
+            standard Llama/Mistral/Gemma models.
+
+    Returns:
+        importance: (M,) mx.array of per-token importance scores
+    """
+    if isinstance(tokens, mx.array):
+        tokens = tokens.tolist()
+    n_prompt = len(tokens)
+
+    # Model topology — detect attribute names across architectures
+    attn_layers = _find_attention_layers(model)
+    n_attn_layers = len(attn_layers)
+    attn_obj = _get_attn_module(attn_layers[0][1])
+    # Attribute names vary: num_attention_heads (Qwen3.5), n_heads (Llama),
+    # num_heads (Nemotron-H)
+    n_attn_heads = getattr(
+        attn_obj,
+        "num_attention_heads",
+        getattr(attn_obj, "n_heads", getattr(attn_obj, "num_heads", None)),
+    )
+    n_kv_heads = getattr(
+        attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
+    )
+
+    # Auto-detect query extractor if not specified
+    if query_extractor is None:
+        if hasattr(attn_obj, "q_norm"):
+            query_extractor = _qwen35_extract_queries
+        elif not hasattr(attn_obj, "rope"):
+            # No RoPE attribute → Nemotron-H style (content-based attention)
+            query_extractor = _nemotron_h_extract_queries
+        else:
+            query_extractor = _llama_extract_queries
+
+    # Phase 1: Prefill
+    cache = make_prompt_cache(model)
+    logits = _prefill_draft(model, tokens, cache, step_size=prefill_step_size)
+
+    # Phase 2: Lookahead decode with query capture
+    query_buffer = [[] for _ in range(n_attn_layers)]
+    patches, attn_indices = _patch_attention_for_capture(
+        model, query_buffer, query_extractor=query_extractor
+    )
+    try:
+        _lookahead_decode(model, logits, cache, n_lookahead, temp=temp, top_p=top_p)
+        mx.eval(query_buffer)
+    finally:
+        _unpatch_attention_capture(model, patches)
+
+    # Phase 3: Compute importance
+    # Map layer indices to cache indices (identity for standard models,
+    # compacted for Nemotron-H where only M/* layers have cache entries)
+    layer_to_cache = _build_layer_to_cache_map(model)
+    attn_caches = [cache[layer_to_cache[i]] for i in attn_indices]
+    importance = _compute_importance(
+        query_buffer,
+        attn_caches,
+        n_prompt,
+        n_attn_heads,
+        n_kv_heads,
+        pool_kernel=pool_kernel if pool_kernel > 0 else None,
+    )
+    mx.eval(importance)
+
+    # Draft cache is no longer needed — let GC reclaim it
+    del cache, logits, query_buffer, attn_caches
+    mx.clear_cache()
+
+    return importance
+
+
+def select_chunks(importance, keep_pct=0.3, chunk_size=32):
+    """Select top-k% token chunks by average importance.
+
+    Args:
+        importance: (M,) per-token importance scores
+        keep_pct: fraction of chunks to keep (default 0.3)
+        chunk_size: tokens per chunk (default 32)
+
+    Returns:
+        sorted mx.array of kept token indices
+    """
+    M = importance.shape[0]
+    if keep_pct >= 1.0:
+        return mx.arange(M)
+
+    n_chunks = math.ceil(M / chunk_size)
+    keep_n = max(1, math.ceil(n_chunks * keep_pct))
+
+    chunk_scores = []
+    for i in range(n_chunks):
+        start = i * chunk_size
+        end = min(start + chunk_size, M)
+        chunk_scores.append(mx.mean(importance[start:end]).item())
+
+    top_chunks = sorted(range(n_chunks), key=lambda i: chunk_scores[i], reverse=True)[
+        :keep_n
+    ]
+    top_chunks.sort()
+
+    indices = []
+    for ci in top_chunks:
+        start = ci * chunk_size
+        end = min(start + chunk_size, M)
+        indices.extend(range(start, end))
+
+    return mx.array(indices)
+
+
+# ===========================================================================
+# Step 2: Sparse prefill with non-contiguous position IDs (target model)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Manual RoPE at arbitrary positions
+# ---------------------------------------------------------------------------
+
+
+def manual_rope(x, positions, dims, base=10000.0, scale=1.0):
+    """Apply RoPE at arbitrary (non-contiguous) positions.
+
+    Uses non-traditional (interleaved) layout matching Qwen3.5:
+    rotates first `dims` dimensions as pairs [0,half), [half,dims),
+    passes through [dims:] unchanged.
+
+    Args:
+        x: (B, n_heads, L, head_dim) input tensor
+        positions: (L,) position indices (can be non-contiguous)
+        dims: number of dimensions to rotate (head_dim * partial_rotary_factor)
+        base: RoPE base frequency (default 10000.0)
+        scale: position scale divisor (default 1.0, higher = compressed positions)
+
+    Returns:
+        (B, n_heads, L, head_dim) with RoPE applied
+    """
+    half = dims // 2
+    inv_freq = 1.0 / (base ** (mx.arange(0, dims, 2, dtype=mx.float32) / dims))
+    scaled_pos = positions.astype(mx.float32) / scale
+    angles = scaled_pos[:, None] * inv_freq[None, :]  # (L, half)
+    cos_a = mx.cos(angles)[None, None, :, :]  # (1, 1, L, half)
+    sin_a = mx.sin(angles)[None, None, :, :]
+    x_rot, x_pass = x[..., :dims], x[..., dims:]
+    x1, x2 = x_rot[..., :half], x_rot[..., half:]
+    rotated = mx.concatenate(
+        [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
+    )
+    return mx.concatenate([rotated, x_pass], axis=-1)
+
+
+def manual_rope_with_freqs(x, positions, dims, freqs, pre_scale=1.0):
+    """Apply RoPE at arbitrary positions using pre-computed frequencies.
+
+    For custom RoPE variants (Llama3, Yarn, SuScaled) that store _freqs.
+    """
+    half = dims // 2
+    inv_freq = (1.0 / freqs).astype(mx.float32)
+    angles = positions[:, None].astype(mx.float32) * inv_freq[None, :]
+    cos_a = mx.cos(angles)[None, None, :, :]
+    sin_a = mx.sin(angles)[None, None, :, :]
+    x_rot, x_pass = x[..., :dims], x[..., dims:]
+    if pre_scale != 1.0:
+        x_rot = pre_scale * x_rot
+    x1, x2 = x_rot[..., :half], x_rot[..., half:]
+    rotated = mx.concatenate(
+        [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
+    )
+    return mx.concatenate([rotated, x_pass], axis=-1)
+
+
+# ---------------------------------------------------------------------------
+# RoPE wrappers
+# ---------------------------------------------------------------------------
+
+
+class _PositionMappedRoPE:
+    """Wraps a RoPE module to apply rotation at non-contiguous positions.
+
+    Used during sparse prefill. The `offset` parameter from the cache tells us
+    which slice of the position array to use for the current chunk:
+        positions = all_positions[(offset - cache_start) : (offset - cache_start) + L]
+
+    When composing with a pre-populated cache (e.g., system KV cache), cache_start
+    is the initial cache offset so indexing into the position array is correct.
+    """
+
+    def __init__(self, original_rope, all_positions, cache_start=0):
+        self._original = original_rope
+        self._all_positions = all_positions
+        self._cache_start = cache_start
+        self._has_custom_freqs = hasattr(original_rope, "_freqs")
+
+        if self._has_custom_freqs:
+            self._freqs = original_rope._freqs
+            self._dims = _get_dims(original_rope)
+            self._pre_scale = _get_pre_scale(original_rope)
+        else:
+            # Standard nn.RoPE: attributes are dims, base, scale (no underscore)
+            self._dims = original_rope.dims
+            self._base = original_rope.base
+            self._scale = original_rope.scale
+
+    def __call__(self, x, offset=0):
+        L = x.shape[2]
+        idx = offset - self._cache_start
+        positions = self._all_positions[idx : idx + L]
+        if self._has_custom_freqs:
+            return manual_rope_with_freqs(
+                x, positions, self._dims, self._freqs, pre_scale=self._pre_scale
+            )
+        return manual_rope(x, positions, self._dims, base=self._base, scale=self._scale)
+
+
+class _OffsetAdjustedRoPE:
+    """Wraps a RoPE module to add a constant offset for decode after sparse prefill.
+
+    After sparse prefill of N tokens from a prompt of M total tokens:
+      cache.offset = N + i  (i = decode step)
+      desired RoPE position = M + i
+      adjustment = M - N
+
+    So: RoPE(x, offset = cache.offset + adjustment) = RoPE(x, M + i)
+    """
+
+    def __init__(self, original_rope, adjustment):
+        self._original = original_rope
+        self._adjustment = adjustment
+
+    def __call__(self, x, offset=0):
+        return self._original(x, offset=offset + self._adjustment)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_dims(rope_module):
+    """Extract rotary dimensions from any RoPE variant."""
+    for attr in ("_dims", "dim", "dims"):
+        if hasattr(rope_module, attr):
+            return getattr(rope_module, attr)
+    raise ValueError(f"Cannot determine dims from {type(rope_module)}")
+
+
+def _get_pre_scale(rope_module):
+    """Extract pre-scale factor from custom RoPE variants (SuScaled, Yarn)."""
+    if hasattr(rope_module, "mscale"):
+        return rope_module.mscale
+    if hasattr(rope_module, "_scale") and hasattr(rope_module, "dim"):
+        return rope_module._scale
+    return 1.0
+
+
+def _find_attention_layers(model):
+    """Find all full-attention layers across architectures.
+
+    Supports:
+      - Qwen3.5 / Llama / GPT-OSS: layers with `self_attn` attribute
+      - Nemotron-H: layers with `block_type == "*"` (attention blocks use `mixer`)
+
+    Returns list of (layer_idx, layer) tuples.
+    """
+    results = []
+    for idx, layer in enumerate(model.layers):
+        if hasattr(layer, "self_attn"):
+            results.append((idx, layer))
+        elif getattr(layer, "block_type", None) == "*":
+            results.append((idx, layer))
+    return results
+
+
+def _get_attn_module(layer):
+    """Get the attention module from a layer (self_attn or mixer)."""
+    if hasattr(layer, "self_attn"):
+        return layer.self_attn
+    if getattr(layer, "block_type", None) == "*":
+        return layer.mixer
+    return None
+
+
+def _set_attn_module(layer, module):
+    """Set the attention module on a layer (self_attn or mixer)."""
+    if hasattr(layer, "self_attn"):
+        layer.self_attn = module
+    elif getattr(layer, "block_type", None) == "*":
+        layer.mixer = module
+
+
+def _build_layer_to_cache_map(model):
+    """Build mapping from model layer index to cache index.
+
+    Standard models (Qwen3.5, Llama, GPT-OSS): one cache entry per layer,
+    so the mapping is identity (layer_idx → layer_idx).
+
+    Nemotron-H: only M (Mamba2) and * (attention) layers have cache entries.
+    MLP (-) and MoE (E) layers get no cache. The mapping is compacted.
+
+    Returns dict {layer_idx: cache_idx}.
+    """
+    has_block_type = any(hasattr(layer, "block_type") for layer in model.layers)
+    if not has_block_type:
+        # Standard model: identity mapping
+        return {i: i for i in range(len(model.layers))}
+
+    # Nemotron-H style: count cache entries for M/* layers
+    layer_to_cache = {}
+    cache_idx = 0
+    for layer_idx, layer in enumerate(model.layers):
+        bt = getattr(layer, "block_type", None)
+        if bt in ("M", "*"):
+            layer_to_cache[layer_idx] = cache_idx
+            cache_idx += 1
+    return layer_to_cache
+
+
+# ---------------------------------------------------------------------------
+# Core API — sparse prefill
+# ---------------------------------------------------------------------------
+
+
+def sparse_prefill(
+    model, tokens, selected_indices, cache, step_size=2048, position_offset=0
+):
+    """Prefill the model cache with selected tokens at their original positions.
+
+    Runs the model forward on only the selected tokens while preserving their
+    original positional encoding via manual RoPE. After this call, the cache
+    contains KV entries with correct RoPE positions, and attention layers have
+    _OffsetAdjustedRoPE installed for correct decode positioning.
+
+    Args:
+        model: Language model with .layers property (TextModel or VLM Model)
+        tokens: (M,) all prompt token IDs (mx.array or list)
+        selected_indices: (N,) sorted indices into tokens to keep (mx.array or list)
+        cache: list of KVCache/ArraysCache from make_prompt_cache()
+        step_size: chunk size for processing (default 2048)
+        position_offset: added to selected_indices for RoPE positions (default 0).
+            Use when the cache already has tokens from a prior prefill (e.g.,
+            system prompt KV cache with S tokens → position_offset=S).
+
+    Returns:
+        logits: (1, 1, vocab_size) from the last selected token
+
+    Side effects:
+        - Populates cache with KV for selected tokens
+        - Installs _OffsetAdjustedRoPE on attention layers for decode
+        - Call cleanup_rope(model) after generation to restore original RoPE
+    """
+    if not isinstance(tokens, mx.array):
+        tokens = mx.array(tokens)
+    if not isinstance(selected_indices, mx.array):
+        selected_indices = mx.array(selected_indices)
+
+    M = tokens.shape[0]
+
+    # Detect RotatingKVCache and ensure tail tokens are included.
+    # Models with sliding window attention (e.g., GPT-OSS) use RotatingKVCache
+    # which evicts old entries. We must include the last `max_size` positions
+    # so sliding window layers have valid recent context for decode.
+    max_rotating_size = 0
+    for c in cache:
+        if type(c).__name__ == "RotatingKVCache":
+            max_rotating_size = max(max_rotating_size, getattr(c, "max_size", 0))
+    if max_rotating_size > 0:
+        tail_start = max(0, M - max_rotating_size)
+        tail_indices = set(range(tail_start, M))
+        existing = set(selected_indices.tolist())
+        merged = sorted(existing | tail_indices)
+        selected_indices = mx.array(merged)
+
+    # RoPE positions: absolute positions accounting for any prefix
+    selected_positions = selected_indices.astype(mx.int32) + position_offset
+    selected_tokens = tokens[selected_indices]
+    N = selected_tokens.shape[0]
+
+    # Determine initial cache offset (non-zero when system KV cache is restored)
+    attn_layers = _find_attention_layers(model)
+    layer_to_cache = _build_layer_to_cache_map(model)
+    first_attn_layer_idx = attn_layers[0][0]
+    first_attn_cache_idx = layer_to_cache[first_attn_layer_idx]
+    cache_start = (
+        cache[first_attn_cache_idx].offset
+        if hasattr(cache[first_attn_cache_idx], "offset")
+        else 0
+    )
+
+    # Check if attention layers use RoPE (Nemotron-H has none)
+    first_attn = _get_attn_module(attn_layers[0][1])
+    has_rope = hasattr(first_attn, "rope")
+
+    # Patch RoPE on attention layers for position-mapped prefill
+    # (skipped for architectures without RoPE, e.g. Nemotron-H)
+    original_ropes = {}
+    if has_rope:
+        for layer_idx, layer in attn_layers:
+            attn = _get_attn_module(layer)
+            original_ropes[layer_idx] = attn.rope
+            attn.rope = _PositionMappedRoPE(
+                attn.rope, selected_positions, cache_start=cache_start
+            )
+
+    try:
+        prompt = selected_tokens
+        n = int(N)
+        processed = 0
+
+        while n - processed > 1:
+            chunk = min(step_size, n - processed - 1)
+            model(prompt[processed : processed + chunk][None], cache=cache)
+            mx.eval([c.state for c in cache])
+            processed += chunk
+            mx.clear_cache()
+
+        # Last token → logits
+        logits = model(prompt[processed:][None], cache=cache)
+        mx.eval(logits)
+
+    finally:
+        # Replace position-mapped RoPE with offset-adjusted RoPE for decode.
+        # Skipped for architectures without RoPE (e.g. Nemotron-H).
+        #
+        # Total prompt length = position_offset + M (prefix + current tokens).
+        # After prefill, cache offset = cache_start + N.
+        # Decode needs RoPE position = total_len + i, cache gives offset = cache_start + N + i.
+        # Adjustment = total_len - (cache_start + N) = position_offset + M - cache_start - N.
+        # When cache_start == position_offset (normal case): adjustment = M - N.
+        if has_rope:
+            total_prompt_len = position_offset + M
+            final_cache_offset = cache_start + N
+            adjustment = int(total_prompt_len) - int(final_cache_offset)
+            for layer_idx, layer in attn_layers:
+                attn = _get_attn_module(layer)
+                original = original_ropes[layer_idx]
+                if adjustment > 0:
+                    attn.rope = _OffsetAdjustedRoPE(original, adjustment)
+                else:
+                    attn.rope = original
+
+    return logits
+
+
+def cleanup_rope(model):
+    """Restore original RoPE on all attention layers.
+
+    Call this after generation is complete to remove _OffsetAdjustedRoPE
+    wrappers installed by sparse_prefill(). No-op for architectures
+    without RoPE (e.g. Nemotron-H).
+    """
+    for _, layer in _find_attention_layers(model):
+        attn = _get_attn_module(layer)
+        if attn is None or not hasattr(attn, "rope"):
+            continue
+        rope = attn.rope
+        if isinstance(rope, (_OffsetAdjustedRoPE, _PositionMappedRoPE)):
+            attn.rope = rope._original

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Construct an mlx_lm TextModel from mlx_vlm-loaded model weights.
+
+When mlx_vlm loads a model, it strips MTP weights in sanitize().
+This module builds a parallel mlx_lm TextModel that:
+1. Shares backbone + lm_head weights with the vlm model (zero-copy)
+2. Loads MTP weights from safetensors on disk
+3. Provides full mlx_lm API: return_hidden, n_confirmed, mtp_forward, make_mtp_cache
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.utils
+
+logger = logging.getLogger(__name__)
+
+
+def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
+    """Build an mlx_lm TextModel from a vlm-loaded model's weights.
+
+    Args:
+        vlm_model: The mlx_vlm-loaded model (has .language_model attribute)
+        model_path: Path to the model directory (contains config.json + safetensors)
+
+    Returns:
+        mlx_lm TextModel with MTP support, or None on failure.
+    """
+    if vlm_model is None:
+        return None
+
+    model_path = Path(model_path) if model_path else None
+    if model_path is None or not (model_path / "config.json").exists():
+        return None
+
+    try:
+        config = json.loads((model_path / "config.json").read_text())
+        text_config = config.get("text_config", config)
+
+        # Always import from qwen3_5 — TextModel and TextModelArgs handle both
+        # dense and MoE natively (MTPDecoderLayer auto-selects SparseMoeBlock
+        # when args.num_experts > 0). qwen3_5_moe.py does NOT export these.
+        from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+        # Build args with proper __post_init__ (handles partial_rotary_factor,
+        # rope_scaling, head_dim derivation)
+        args = TextModelArgs.from_dict(text_config)
+        text_model = TextModel(args)
+
+        # Collect all weights first: backbone from vlm + MTP from safetensors
+        vlm_lm = vlm_model.language_model
+        vlm_weights = mlx.utils.tree_flatten(vlm_lm.parameters())
+        mtp_weights = _load_mtp_weights(model_path)
+
+        all_weight_names = set(name for name, _ in vlm_weights)
+        all_weight_names.update(name for name, _ in mtp_weights)
+
+        # Quantize the TextModel skeleton to match source weights.
+        # Use a predicate that only quantizes layers that have .scales in source.
+        # This prevents quantizing layers like mtp.fc which are BF16.
+        quantization = text_config.get("quantization", config.get("quantization", None))
+        if quantization is not None:
+
+            def _class_predicate(path, module):
+                if not hasattr(module, "to_quantized"):
+                    return False
+                return f"{path}.scales" in all_weight_names
+
+            nn.quantize(
+                text_model,
+                group_size=quantization.get("group_size", 64),
+                bits=quantization.get("bits", 8),
+                class_predicate=_class_predicate,
+            )
+
+        # Transfer backbone + lm_head weights from vlm language_model (zero-copy).
+        # strict=False because TextModel has MTP params that vlm doesn't have yet.
+        text_model.load_weights(vlm_weights, strict=False)
+
+        logger.info(
+            "Transferred %d weight arrays from vlm language_model", len(vlm_weights)
+        )
+
+        # Load MTP weights from safetensors
+        if mtp_weights:
+            text_model.load_weights(mtp_weights, strict=False)
+            logger.info("Loaded %d MTP weights from safetensors", len(mtp_weights))
+        else:
+            logger.warning("No MTP weights found in %s", model_path.name)
+
+        # Verify MTP is functional
+        if hasattr(text_model, "mtp") and text_model.mtp is not None:
+            mx.eval(text_model.mtp.parameters())
+            logger.info(
+                "TextModel built with MTP support (%d layers)",
+                args.mtp_num_hidden_layers,
+            )
+        else:
+            logger.info("TextModel built without MTP (mtp_num_hidden_layers=0)")
+
+        return text_model
+
+    except ImportError as e:
+        logger.error("Cannot import mlx_lm TextModel (need PR #990): %s", e)
+        return None
+    except Exception as e:
+        logger.error("Failed to build TextModel from vlm: %s", e)
+        return None
+
+
+def _load_mtp_weights(model_path: Path) -> list[tuple[str, mx.array]]:
+    """Load MTP weights from safetensors, stripping the language_model. prefix.
+
+    mlx_vlm's sanitize() strips mtp.* keys during model loading,
+    but the weights are still on disk in the safetensors files.
+    """
+    index_file = model_path / "model.safetensors.index.json"
+    if not index_file.exists():
+        return []
+
+    index = json.loads(index_file.read_text())
+    weight_map = index.get("weight_map", {})
+
+    # Find MTP keys and their shard files
+    mtp_keys: dict[str, tuple[str, str]] = {}
+    for key, shard in weight_map.items():
+        if ".mtp." in key:
+            # Strip "language_model." prefix to match mlx_lm namespace
+            clean = (
+                key.replace("language_model.", "", 1)
+                if key.startswith("language_model.")
+                else key
+            )
+            mtp_keys[key] = (clean, shard)
+
+    if not mtp_keys:
+        return []
+
+    # Group by shard to minimize I/O
+    shards: dict[str, list[tuple[str, str]]] = {}
+    for orig, (clean, shard) in mtp_keys.items():
+        shards.setdefault(shard, []).append((orig, clean))
+
+    weights = []
+    for shard_file, key_pairs in shards.items():
+        shard_path = model_path / shard_file
+        if not shard_path.exists():
+            logger.warning("MTP shard not found: %s", shard_file)
+            continue
+        shard_data = mx.load(str(shard_path))
+        for orig, clean in key_pairs:
+            if orig in shard_data:
+                weights.append((clean, shard_data[orig]))
+
+    return weights


### PR DESCRIPTION
## Summary

Integrates the admission controller (#207), cooperative specprefill (#208), and MLLM+MTP per-request routing into the BatchedEngine for production multi-user serving on Apple Silicon.

**Depends on:** #207 (admission), #208 (cooperative specprefill), #165 (MLLM hybrid batching), #180 (SpecPrefill, merged)

## Key features

- **Admission gates** on all 4 public methods (`chat`, `stream_chat`, `generate`, `stream_generate`) with `try/finally` cleanup
- **MLLM+MTP routing**: text-only → mlx_lm TextModel with MTP, media → mlx_vlm MLLM
- **System KV cache**: prefix boundary detection + snapshot/restore (7x speedup on hits)
- **Cooperative specprefill**: draft scoring outside the generation lock
- **Thread-safe** snapshot access + stale cache-hit re-verification under lock
- CLI: `--scheduler-policy`, `--scheduler-headroom-gb`

## Files

- `vllm_mlx/engine/batched.py` — core integration (~1900 lines)
- `vllm_mlx/specprefill.py` — SpecPrefill scoring (builds on #180)
- `vllm_mlx/text_model_from_vlm.py` — zero-copy TextModel from VLM backbone
- `vllm_mlx/cli.py` — scheduler CLI flags
- `vllm_mlx/scheduler.py` — SchedulerConfig

## Status

Draft — running functional and quality validation across 2B/4B/35B/122B at context lengths up to 1M (YaRN). Test results incoming.