### PR TITLE
fix: respect tool_choice="none" by excluding tools from template

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1421,8 +1421,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     if request.specprefill_keep_pct is not None:
         chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
-    # Add tools if provided
-    if request.tools:
+    # Add tools if provided (but skip if tool_choice="none")
+    # When tool_choice="none", models like Qwen2.5 and Llama 3.x still activate
+    # tool-calling if tools are present in the template context. To properly
+    # disable tool calling, we must not pass tools to the template at all.
+    if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
     if request.stream:


### PR DESCRIPTION
## Summary

Fixes #162

When `tool_choice` is set to `"none"`, models like Qwen2.5-Instruct and Llama 3.x-Instruct still activate their tool-calling behavior if tools are present in the chat template context. This causes:
- `finish_reason: "tool_calls"` instead of `"stop"`
- `content: null` with tool_calls containing empty `{}` arguments
- Model encoding output data as function names instead of text content

## Root Cause

The chat completions handler was passing `tools` to `chat_kwargs` without checking `tool_choice`. Even with `tool_choice="none"`, if tools were present in the request, they would be passed to `apply_chat_template()`. Qwen2.5 and Llama 3.x have tool-calling jinja templates that activate when a `tools` key is present — even an empty list triggers this behavior.

## Solution

Before adding tools to `chat_kwargs`, check if `tool_choice == "none"`. If so, skip adding tools entirely. This prevents the template from activating tool-calling mode.

```python
# Before
if request.tools:
    chat_kwargs["tools"] = convert_tools_for_template(request.tools)

# After
if request.tools and request.tool_choice != "none":
    chat_kwargs["tools"] = convert_tools_for_template(request.tools)
```

This matches the behavior of upstream vLLM's `--exclude-tools-when-tool-choice-none` flag.

## Test Plan

```bash
# Start server
vllm-mlx serve mlx-community/Qwen2.5-14B-Instruct-4bit --port 8080

# Test with tool_choice="none"
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/Qwen2.5-14B-Instruct-4bit",
    "messages": [{"role": "user", "content": "List 3 fruits as a JSON array"}],
    "tool_choice": "none",
    "tools": [],
    "max_tokens": 200
  }'

# Expected: finish_reason="stop", content contains JSON array, no tool_calls
# Before fix: finish_reason="tool_calls", content=null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)