### PR TITLE
feat: full sampling parameter support (top_k, min_p, presence_penalty, repetition_penalty)

### DIFF
--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -158,6 +158,10 @@ class ChatCompletionRequest(BaseModel):
     messages: list[Message]
     temperature: float | None = None
     top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    repetition_penalty: float | None = None
     max_tokens: int | None = None
     stream: bool = False
     stream_options: StreamOptions | None = (
@@ -240,6 +244,10 @@ class CompletionRequest(BaseModel):
     prompt: str | list[str]
     temperature: float | None = None
     top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    repetition_penalty: float | None = None
     max_tokens: int | None = None
     stream: bool = False
     stop: list[str] | None = None

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -111,6 +111,8 @@ class MLXLanguageModel:
         self,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
     ):
         """Create a sampler for text generation."""
         from mlx_lm.sample_utils import make_sampler
@@ -118,7 +120,25 @@ class MLXLanguageModel:
         return make_sampler(
             temp=temperature,
             top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
         )
+
+    def _create_logits_processors(
+        self,
+        presence_penalty: float = 0.0,
+        repetition_penalty: float = 1.0,
+    ):
+        """Create logits processors for penalty-based sampling."""
+        from mlx_lm.sample_utils import make_logits_processors
+
+        processors = make_logits_processors(
+            repetition_penalty=(
+                repetition_penalty if repetition_penalty != 1.0 else None
+            ),
+            presence_penalty=presence_penalty if presence_penalty != 0.0 else None,
+        )
+        return processors if processors else None
 
     def generate(
         self,
@@ -126,8 +146,12 @@ class MLXLanguageModel:
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        presence_penalty: float = 0.0,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        **kwargs,
     ) -> GenerationOutput:
         """
         Generate text from a prompt.
@@ -137,7 +161,10 @@ class MLXLanguageModel:
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature (0 = greedy)
             top_p: Top-p (nucleus) sampling parameter
-            repetition_penalty: Penalty for repeating tokens
+            top_k: Top-k sampling (0 = disabled)
+            min_p: Minimum probability threshold
+            presence_penalty: Additive penalty for token presence
+            repetition_penalty: Multiplicative penalty for repeating tokens
             stop: List of stop sequences
 
         Returns:
@@ -148,8 +175,11 @@ class MLXLanguageModel:
 
         from mlx_lm import generate
 
-        # Create sampler with parameters
-        sampler = self._create_sampler(temperature, top_p)
+        # Create sampler and logits processors with full Unsloth params
+        sampler = self._create_sampler(temperature, top_p, top_k, min_p)
+        logits_processors = self._create_logits_processors(
+            presence_penalty, repetition_penalty
+        )
 
         # Generate text
         output_text = generate(
@@ -158,6 +188,7 @@ class MLXLanguageModel:
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
+            logits_processors=logits_processors,
             verbose=False,
         )
 
@@ -179,8 +210,13 @@ class MLXLanguageModel:
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        presence_penalty: float = 0.0,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list | None = None,
+        **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
         Stream text generation token by token.
@@ -190,7 +226,10 @@ class MLXLanguageModel:
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature (0 = greedy)
             top_p: Top-p (nucleus) sampling parameter
-            repetition_penalty: Penalty for repeating tokens
+            top_k: Top-k sampling (0 = disabled)
+            min_p: Minimum probability threshold
+            presence_penalty: Additive penalty for token presence
+            repetition_penalty: Multiplicative penalty for repeating tokens
             stop: List of stop sequences
 
         Yields:
@@ -201,8 +240,15 @@ class MLXLanguageModel:
 
         from mlx_lm import stream_generate
 
-        # Create sampler with parameters
-        sampler = self._create_sampler(temperature, top_p)
+        # Create sampler and logits processors with full Unsloth params
+        sampler = self._create_sampler(temperature, top_p, top_k, min_p)
+        penalty_processors = self._create_logits_processors(
+            presence_penalty, repetition_penalty
+        )
+        # Merge any externally-provided logits_processors with penalty processors
+        all_processors = None
+        if penalty_processors or logits_processors:
+            all_processors = (logits_processors or []) + (penalty_processors or [])
 
         # Count prompt tokens once upfront
         num_prompt_tokens = len(self.tokenizer.encode(prompt))
@@ -220,6 +266,7 @@ class MLXLanguageModel:
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
+            logits_processors=all_processors,
             **mtp_kwargs,
         ):
             token_count += 1

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1310,6 +1310,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     logger.info(
         f"[REQUEST] POST /v1/completions stream={request.stream} "
         f"max_tokens={request.max_tokens} temp={request.temperature} "
+        f"top_p={request.top_p} top_k={request.top_k} min_p={request.min_p} "
+        f"presence_penalty={request.presence_penalty} "
+        f"repetition_penalty={request.repetition_penalty} "
         f"prompt_chars={prompt_len} prompt_preview={prompt_preview!r}"
     )
 
@@ -1342,6 +1345,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             "max_tokens": request.max_tokens or _default_max_tokens,
             "temperature": _resolve_temperature(request.temperature),
             "top_p": _resolve_top_p(request.top_p),
+            "top_k": request.top_k or 0,
+            "min_p": request.min_p or 0.0,
+            "presence_penalty": request.presence_penalty or 0.0,
             "stop": request.stop,
         }
         if comp_rep_penalty is not None:
@@ -1447,7 +1453,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     logger.info(
         f"[REQUEST] POST /v1/chat/completions stream={request.stream} "
         f"model={request.model!r} max_tokens={request.max_tokens} "
-        f"temp={request.temperature} msgs={n_msgs} roles={msg_roles} "
+        f"temp={request.temperature} top_p={request.top_p} "
+        f"top_k={request.top_k} min_p={request.min_p} "
+        f"presence_penalty={request.presence_penalty} "
+        f"repetition_penalty={request.repetition_penalty} "
+        f"msgs={n_msgs} roles={msg_roles} "
         f"total_chars={total_chars} tools={n_tools} "
         f"response_format={request.response_format}"
     )
@@ -1513,6 +1523,10 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         "max_tokens": request.max_tokens or _default_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
+        "top_k": request.top_k or 0,
+        "min_p": request.min_p or 0.0,
+        "presence_penalty": request.presence_penalty or 0.0,
+        "repetition_penalty": request.repetition_penalty or 1.0,
     }
     if rep_penalty is not None:
         chat_kwargs["repetition_penalty"] = rep_penalty
@@ -1795,6 +1809,10 @@ async def create_anthropic_message(
         "max_tokens": openai_request.max_tokens or _default_max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
+        "top_k": openai_request.top_k or 0,
+        "min_p": openai_request.min_p or 0.0,
+        "presence_penalty": openai_request.presence_penalty or 0.0,
+        "repetition_penalty": openai_request.repetition_penalty or 1.0,
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -2038,6 +2056,10 @@ async def _stream_anthropic_messages(
         "max_tokens": openai_request.max_tokens or _default_max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
+        "top_k": openai_request.top_k or 0,
+        "min_p": openai_request.min_p or 0.0,
+        "presence_penalty": openai_request.presence_penalty or 0.0,
+        "repetition_penalty": openai_request.repetition_penalty or 1.0,
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -2267,6 +2289,9 @@ async def stream_completion(
         "max_tokens": request.max_tokens or _default_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
+        "top_k": request.top_k or 0,
+        "min_p": request.min_p or 0.0,
+        "presence_penalty": request.presence_penalty or 0.0,
         "stop": request.stop,
     }
     if repetition_penalty is not None:


### PR DESCRIPTION
## Summary

Pass all OpenAI-compatible sampling parameters through to mlx-lm's `make_sampler` and `make_logits_processors`. Previously only `temperature`, `top_p`, and `max_tokens` reached the engine — `top_k`, `min_p`, `presence_penalty`, and `repetition_penalty` were silently dropped.

## Changes

- **api/models.py**: Add `top_k`, `min_p`, `presence_penalty`, `repetition_penalty` to `ChatCompletionRequest` and `CompletionRequest`
- **request.py**: Add `presence_penalty` to `SamplingParams` dataclass
- **server.py**: Extract and pass all params in every code path (6 locations), log all params on request
- **models/llm.py**: Build sampler with `top_k`/`min_p`, build `logits_processors` for `presence_penalty`/`repetition_penalty`
- **engine/simple.py**: Fix `enable_thinking` to read `VLLM_MLX_ENABLE_THINKING` env var instead of hardcoding based on model name

## Motivation

Qwen 3.5 requires [specific sampling profiles](https://unsloth.ai/docs/models/qwen3.5) with all 7 parameters set. Without `presence_penalty`, accuracy drops to near-zero on evals. Without `top_k=20`, sampling doesn't match the model's training distribution.

## Test plan

- [x] All 4 Unsloth Qwen 3.5 profiles tested on 122B model
- [x] All 7 params logged in server stderr for every request
- [x] `presence_penalty=1.5` works without crash (requires mlx-lm MTP fix, separate PR)
- [x] `enable_thinking` toggle via env var verified (on/off)
- [x] Black + ruff clean