### PR TITLE
tokenizer: return successful mlx-lm load result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
             tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \
+            tests/test_tokenizer_utils.py \
             tests/test_paged_cache.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \

--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -33,13 +33,16 @@ class TestLoadModelWithFallback:
         fake_model = object()
         fake_tokenizer = object()
 
-        with patch(
-            "mlx_lm.load",
-            side_effect=ValueError("Tokenizer class Foo does not exist"),
-        ), patch(
-            "vllm_mlx.utils.tokenizer._load_with_tokenizer_fallback",
-            return_value=(fake_model, fake_tokenizer),
-        ) as fallback:
+        with (
+            patch(
+                "mlx_lm.load",
+                side_effect=ValueError("Tokenizer class Foo does not exist"),
+            ),
+            patch(
+                "vllm_mlx.utils.tokenizer._load_with_tokenizer_fallback",
+                return_value=(fake_model, fake_tokenizer),
+            ) as fallback,
+        ):
             model, tokenizer = load_model_with_fallback("example/model")
 
         fallback.assert_called_once_with("example/model")

--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tokenizer utility helpers."""
+
+import platform
+import sys
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
+
+
+class TestLoadModelWithFallback:
+    def test_returns_successful_load_result(self):
+        from vllm_mlx.utils.tokenizer import load_model_with_fallback
+
+        fake_model = object()
+        fake_tokenizer = object()
+
+        with patch("mlx_lm.load", return_value=(fake_model, fake_tokenizer)) as load:
+            model, tokenizer = load_model_with_fallback("mlx-community/Qwen3.5-4B")
+
+        load.assert_called_once()
+        assert model is fake_model
+        assert tokenizer is fake_tokenizer
+
+    def test_uses_tokenizer_fallback_for_tokenizer_errors(self):
+        from vllm_mlx.utils.tokenizer import load_model_with_fallback
+
+        fake_model = object()
+        fake_tokenizer = object()
+
+        with patch(
+            "mlx_lm.load",
+            side_effect=ValueError("Tokenizer class Foo does not exist"),
+        ), patch(
+            "vllm_mlx.utils.tokenizer._load_with_tokenizer_fallback",
+            return_value=(fake_model, fake_tokenizer),
+        ) as fallback:
+            model, tokenizer = load_model_with_fallback("example/model")
+
+        fallback.assert_called_once_with("example/model")
+        assert model is fake_model
+        assert tokenizer is fake_tokenizer

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
## Summary
- fix `load_model_with_fallback()` so a successful `mlx_lm.load()` returns `(model, tokenizer)` instead of falling through as `None`
- add a regression test for the successful return path
- run the tokenizer regression in Apple Silicon CI

## Status
- refreshed onto current upstream `main` (`b4fa030`) on 2026-04-09
- no logic changes beyond the base refresh

## Main files
- `vllm_mlx/utils/tokenizer.py`
- `tests/test_tokenizer_utils.py`
- `.github/workflows/ci.yml`

## Reviewer focus
Small user-visible startup fix. This overlaps with `#243`; this PR keeps the regression test with the fix.

## Validation
- `python -m pytest tests/test_tokenizer_utils.py -q` -> `2 passed`
