### PR TITLE
cli: expose harmony and gpt-oss tool parsers

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,41 @@ class TestCompletionRequest:
         assert request.max_tokens is None  # uses _default_max_tokens when None
 
 
+class TestServeCli:
+    """Test serve CLI argument parsing."""
+
+    def test_tool_call_parser_accepts_harmony_aliases(self):
+        """GPT-OSS/Harmony parsers should be selectable from the serve CLI."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "harmony",
+            ]
+        )
+
+        assert args.command == "serve"
+        assert args.tool_call_parser == "harmony"
+        assert args.enable_auto_tool_choice is True
+
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "gpt-oss",
+            ]
+        )
+
+        assert args.tool_call_parser == "gpt-oss"
+
+
 # =============================================================================
 # Helper Function Tests
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -593,7 +593,8 @@ def bench_kv_cache_command(args):
     )
 
 
-def main():
+def create_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
         description="vllm-mlx: Apple Silicon MLX backend for vLLM",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -832,6 +833,8 @@ Examples:
             "qwen3_coder",
             "llama",
             "hermes",
+            "harmony",
+            "gpt-oss",
             "deepseek",
             "kimi",
             "granite",
@@ -843,7 +846,8 @@ Examples:
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47. "
+            "harmony, gpt-oss, deepseek, kimi, granite, nemotron, xlam, "
+            "functionary, glm47. "
             "Required for --enable-auto-tool-choice."
         ),
     )
@@ -1022,6 +1026,12 @@ Examples:
         default=64,
         help="Quantization group size (default: 64)",
     )
+
+    return parser
+
+
+def main():
+    parser = create_parser()
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- expose `harmony` and `gpt-oss` as valid `--tool-call-parser` values in `vllm-mlx serve`
- factor CLI parser construction so the flag surface is unit-testable
- add regression coverage for the serve CLI choices

## Status
- refreshed onto current upstream `main` (`b4fa030`) on 2026-04-09
- no logic changes beyond the base refresh

## Main files
- `vllm_mlx/cli.py`
- `tests/test_server.py`

## Reviewer focus
This is a CLI-surface fix only. The parser implementations already exist; the gap is that the serve CLI does not currently expose them consistently through `--tool-call-parser`.

## Validation
- `python -m pytest tests/test_server.py -q` -> `35 passed, 3 deselected`
