### PR TITLE
chat: forward chat_template_kwargs on simple-engine paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
             tests/test_mllm_cache.py \
             tests/test_optimizations.py \
             tests/test_simple_engine.py \
+            tests/test_chat_template_kwargs.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \
             -v --tb=short \

--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for chat template kwargs forwarding."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import vllm_mlx.server as srv
+from vllm_mlx.engine.base import GenerationOutput
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_chat_completion_request_preserves_chat_template_kwargs():
+    request = srv.ChatCompletionRequest(
+        model="test-model",
+        messages=[srv.Message(role="user", content="Hello")],
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert request.chat_template_kwargs == {"enable_thinking": False}
+
+
+def test_batched_engine_applies_chat_template_kwargs():
+    with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=False):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine("test-model")
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.apply_chat_template.return_value = "prompt"
+
+        prompt = engine._apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+        assert prompt == "prompt"
+        engine._tokenizer.apply_chat_template.assert_called_once()
+        assert (
+            engine._tokenizer.apply_chat_template.call_args.kwargs["enable_thinking"]
+            is False
+        )
+
+
+def test_chat_completion_endpoint_forwards_chat_template_kwargs():
+    captured = {}
+
+    class FakeEngine:
+        model_name = "test-model"
+        is_mllm = False
+        preserve_native_tool_format = False
+
+        async def chat(self, messages, **kwargs):
+            captured["messages"] = messages
+            captured["kwargs"] = kwargs
+            return GenerationOutput(
+                text="ORBIT",
+                prompt_tokens=4,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+
+    client = TestClient(srv.app)
+    original_engine = srv._engine
+    original_model_name = srv._model_name
+    srv._engine = FakeEngine()
+    srv._model_name = "test-model"
+    try:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Reply with ORBIT."}],
+                "max_tokens": 8,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+    finally:
+        srv._engine = original_engine
+        srv._model_name = original_model_name
+
+    assert response.status_code == 200
+    assert captured["kwargs"]["chat_template_kwargs"] == {"enable_thinking": False}
+    assert response.json()["choices"][0]["message"]["content"] == "ORBIT"
+
+
+def test_llm_chat_applies_chat_template_kwargs_before_generate():
+    from vllm_mlx.models.llm import MLXLanguageModel
+
+    model = MLXLanguageModel.__new__(MLXLanguageModel)
+    model._loaded = True
+    model.tokenizer = MagicMock()
+    model.tokenizer.apply_chat_template.return_value = "prompt"
+    model.generate = MagicMock(return_value="ok")
+
+    result = model.chat(
+        [{"role": "user", "content": "Hello"}],
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert result == "ok"
+    model.tokenizer.apply_chat_template.assert_called_once()
+    assert (
+        model.tokenizer.apply_chat_template.call_args.kwargs["enable_thinking"] is False
+    )
+    model.generate.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_simple_engine_mllm_chat_forwards_chat_template_kwargs():
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=True):
+        engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._is_mllm = True
+        engine._model = MagicMock()
+        engine._model.chat = MagicMock(
+            return_value=SimpleNamespace(
+                text="OK",
+                prompt_tokens=5,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+        )
+
+        await engine.chat(
+            [{"role": "user", "content": "Hello"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+        assert engine._model.chat.call_args.kwargs["chat_template_kwargs"] == {
+            "enable_thinking": False
+        }
+
+
+@pytest.mark.anyio
+async def test_simple_engine_stream_generate_text_applies_chat_template_kwargs():
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=True):
+        engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._is_mllm = True
+        engine._text_tokenizer = MagicMock()
+        engine._text_tokenizer.apply_chat_template.return_value = "prompt"
+        engine._text_model = MagicMock()
+        engine._text_model.model = MagicMock()
+
+        with (
+            patch("mlx_lm.stream_generate", return_value=iter(())),
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch("mlx_lm.sample_utils.make_sampler", return_value=object()),
+        ):
+            chunks = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    [{"role": "user", "content": "Hello"}],
+                    max_tokens=8,
+                    temperature=0.7,
+                    top_p=0.9,
+                    chat_template_kwargs={"enable_thinking": False},
+                )
+            ]
+
+        assert chunks
+        engine._text_tokenizer.apply_chat_template.assert_called_once()
+        assert (
+            engine._text_tokenizer.apply_chat_template.call_args.kwargs[
+                "enable_thinking"
+            ]
+            is False
+        )

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -11,6 +11,7 @@ These models define the request and response schemas for:
 
 import time
 import uuid
+from typing import Any
 
 from pydantic import AliasChoices, BaseModel, Field
 
@@ -173,6 +174,8 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict | None = None  # "auto", "none", or specific tool
     # Structured output
     response_format: ResponseFormat | dict | None = None
+    # Extra kwargs forwarded to tokenizer.apply_chat_template
+    chat_template_kwargs: dict[str, Any] | None = None
     # MLLM-specific parameters
     video_fps: float | None = None
     video_max_frames: int | None = None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -423,6 +423,7 @@ class BatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         num_images: int = 0,
+        chat_template_kwargs: dict[str, Any] | None = None,
         enable_thinking: bool | None = None,
     ) -> str:
         """Apply chat template to messages.
@@ -460,7 +461,9 @@ class BatchedEngine(BaseEngine):
                 "add_generation_prompt": True,
                 "enable_thinking": enable_thinking,
             }
-            if tools:
+            if chat_template_kwargs:
+                template_kwargs.update(chat_template_kwargs)
+            if tools and "tools" not in template_kwargs:
                 template_kwargs["tools"] = tools
 
             try:
@@ -468,12 +471,14 @@ class BatchedEngine(BaseEngine):
                     messages, **template_kwargs
                 )
             except TypeError as e:
-                # Some templates don't accept 'tools' or 'enable_thinking';
-                # retry without them.
+                # Some templates don't accept extra kwargs; retry without them.
                 logger.debug(f"Chat template TypeError, retrying without extras: {e}")
-                for key in ["tools", "enable_thinking"]:
-                    if key in template_kwargs:
-                        del template_kwargs[key]
+                for key in [
+                    "tools",
+                    "enable_thinking",
+                    *(chat_template_kwargs or {}).keys(),
+                ]:
+                    template_kwargs.pop(key, None)
                 return template_applicator.apply_chat_template(
                     messages, **template_kwargs
                 )
@@ -736,6 +741,7 @@ class BatchedEngine(BaseEngine):
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
 
         # Per-request enable_thinking override
         enable_thinking = kwargs.pop("enable_thinking", None)
@@ -745,6 +751,7 @@ class BatchedEngine(BaseEngine):
             messages,
             template_tools,
             num_images=len(all_images),
+            chat_template_kwargs=chat_template_kwargs,
             enable_thinking=enable_thinking,
         )
 
@@ -759,7 +766,10 @@ class BatchedEngine(BaseEngine):
         )
 
     def _compute_prefix_boundary(
-        self, messages: list[dict[str, Any]], tools: list[dict] | None = None
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
     ) -> int:
         """Compute token count for the shared prefix across message variations.
 
@@ -781,7 +791,11 @@ class BatchedEngine(BaseEngine):
             template_tools = convert_tools_for_template(tools) if tools else None
 
             # Tokenize the real prompt
-            real_prompt = self._apply_chat_template(messages, template_tools)
+            real_prompt = self._apply_chat_template(
+                messages,
+                template_tools,
+                chat_template_kwargs=chat_template_kwargs,
+            )
 
             # Build a dummy variant with different last user content
             dummy_messages = list(messages)
@@ -789,7 +803,11 @@ class BatchedEngine(BaseEngine):
                 **messages[last_user_idx],
                 "content": "XXXXXXXXXX",
             }
-            dummy_prompt = self._apply_chat_template(dummy_messages, template_tools)
+            dummy_prompt = self._apply_chat_template(
+                dummy_messages,
+                template_tools,
+                chat_template_kwargs=chat_template_kwargs,
+            )
 
             tokenizer = self.tokenizer
             if hasattr(tokenizer, "tokenizer"):
@@ -851,6 +869,7 @@ class BatchedEngine(BaseEngine):
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
 
         # Per-request enable_thinking override
         enable_thinking = kwargs.pop("enable_thinking", None)
@@ -860,11 +879,16 @@ class BatchedEngine(BaseEngine):
             messages,
             template_tools,
             num_images=len(all_images),
+            chat_template_kwargs=chat_template_kwargs,
             enable_thinking=enable_thinking,
         )
 
         # Compute prefix boundary for cache
-        prefix_boundary = self._compute_prefix_boundary(messages, tools)
+        prefix_boundary = self._compute_prefix_boundary(
+            messages,
+            tools,
+            chat_template_kwargs=chat_template_kwargs,
+        )
         if prefix_boundary > 0:
             kwargs["prefix_boundary"] = prefix_boundary
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -482,6 +482,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+
         # mlx-lm non-streaming chat with tools can stall indefinitely on some
         # local models, while the streaming path completes normally. Reuse the
         # streaming implementation and aggregate its final state so both chat
@@ -496,6 +498,7 @@ class SimpleEngine(BaseEngine):
                 tools=tools,
                 images=images,
                 videos=videos,
+                chat_template_kwargs=chat_template_kwargs,
                 **kwargs,
             ):
                 final_output = output
@@ -512,6 +515,8 @@ class SimpleEngine(BaseEngine):
         template_tools = convert_tools_for_template(tools) if tools else None
 
         if self._is_mllm:
+            if chat_template_kwargs:
+                kwargs["chat_template_kwargs"] = chat_template_kwargs
             output = await self._run_blocking_serialized(
                 self._model.chat,
                 messages=messages,
@@ -535,6 +540,7 @@ class SimpleEngine(BaseEngine):
                 temperature=temperature,
                 top_p=top_p,
                 tools=template_tools,
+                chat_template_kwargs=chat_template_kwargs,
                 **kwargs,
             )
             text = clean_output_text(output.text)
@@ -587,6 +593,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
 
@@ -597,6 +605,8 @@ class SimpleEngine(BaseEngine):
             and not _has_media_content(messages)
         ):
             logger.info("Text-only request → LLM path (MTP=True)")
+            if chat_template_kwargs:
+                kwargs["chat_template_kwargs"] = chat_template_kwargs
             async for chunk in self._stream_generate_text(
                 messages,
                 max_tokens,
@@ -620,13 +630,16 @@ class SimpleEngine(BaseEngine):
 
             # Run stream_chat in thread pool since it's synchronous
             def run_stream():
+                local_kwargs = dict(kwargs)
+                if chat_template_kwargs:
+                    local_kwargs["chat_template_kwargs"] = chat_template_kwargs
                 return list(
                     self._model.stream_chat(
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
                         tools=template_tools,
-                        **kwargs,
+                        **local_kwargs,
                     )
                 )
 
@@ -664,6 +677,8 @@ class SimpleEngine(BaseEngine):
                 "add_generation_prompt": True,
                 "enable_thinking": enable_thinking,
             }
+            if chat_template_kwargs:
+                template_kwargs.update(chat_template_kwargs)
             if template_tools:
                 template_kwargs["tools"] = template_tools
 
@@ -671,7 +686,7 @@ class SimpleEngine(BaseEngine):
                 prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
             except TypeError:
                 # Some templates don't support all kwargs
-                for key in ["tools", "enable_thinking"]:
+                for key in ["tools", "enable_thinking", *chat_template_kwargs.keys()]:
                     if key in template_kwargs:
                         del template_kwargs[key]
                 prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
@@ -909,6 +924,7 @@ class SimpleEngine(BaseEngine):
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct = kwargs.pop("specprefill_keep_pct", None)
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
 
         # Per-request enable_thinking override; fall back to env var / default True.
         enable_thinking = kwargs.pop("enable_thinking", None)
@@ -922,6 +938,7 @@ class SimpleEngine(BaseEngine):
             "add_generation_prompt": True,
             "enable_thinking": enable_thinking,
         }
+        template_kwargs.update(chat_template_kwargs)
         if tools:
             template_kwargs["tools"] = tools
 

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -324,6 +324,7 @@ class MLXLanguageModel:
         temperature: float = 0.7,
         top_p: float = 0.9,
         tools: list | None = None,
+        chat_template_kwargs: dict | None = None,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -354,6 +355,8 @@ class MLXLanguageModel:
             # Add tools if provided and supported
             if tools:
                 template_kwargs["tools"] = tools
+            if chat_template_kwargs:
+                template_kwargs.update(chat_template_kwargs)
 
             try:
                 prompt = self.tokenizer.apply_chat_template(
@@ -361,8 +364,10 @@ class MLXLanguageModel:
                     **template_kwargs,
                 )
             except TypeError:
-                # Tokenizer doesn't support tools parameter
-                del template_kwargs["tools"]
+                # Tokenizer doesn't support all requested template kwargs
+                template_kwargs.pop("tools", None)
+                for key in (chat_template_kwargs or {}).keys():
+                    template_kwargs.pop(key, None)
                 prompt = self.tokenizer.apply_chat_template(
                     messages,
                     **template_kwargs,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1714,6 +1714,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         chat_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
         chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+    if request.chat_template_kwargs:
+        chat_kwargs["chat_template_kwargs"] = dict(request.chat_template_kwargs)
 
     # Enable/disable thinking mode per request
     if request.enable_thinking is not None:


### PR DESCRIPTION
## Summary
Honor `chat_template_kwargs` on the simple-engine paths that still ignored it and run the regression coverage in Apple Silicon CI.

## Why
Before this branch, `chat_template_kwargs` was only reliably honored on the batched path and the plain LLM chat path. Simple-engine multimodal chat, multimodal stream chat, and the text-only MTP route still dropped the field.

## What changed
- forward `chat_template_kwargs` through simple-engine multimodal `chat()`
- forward `chat_template_kwargs` through simple-engine multimodal `stream_chat()`
- forward `chat_template_kwargs` into `_stream_generate_text()` for the text-only MTP route
- include `tests/test_chat_template_kwargs.py` in Apple Silicon CI

## Status
- refreshed onto current upstream `main` (`b4fa030`) on 2026-04-09
- no logic changes beyond the base refresh

## Files to review
- `vllm_mlx/engine/simple.py`
- `.github/workflows/ci.yml`
- `tests/test_chat_template_kwargs.py`

## Validation
- `python -m pytest tests/test_chat_template_kwargs.py -q` -> `6 passed`
- note: the older `tests/test_simple_engine.py` validation command now depends on the separate async-harness refresh in `#226` on current upstream, so I kept validation scoped to this PR's dedicated regression file here
