### PR TITLE
simple-engine: keep tool chat on the streaming execution path

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -146,7 +146,6 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_llm_model
             engine._loaded = True
-            engine._model.tokenizer.encode = MagicMock(return_value=[7, 8, 9])
             engine.stream_chat = fake_stream_chat  # type: ignore[method-assign]
 
             output = await engine.chat(
@@ -164,14 +163,11 @@ class TestSimpleEngineConcurrency:
             )
 
             assert output.text.startswith("<tool_call>")
-            assert output.tokens == [7, 8, 9]
+            assert output.tokens == []
             assert output.prompt_tokens == 11
             assert output.completion_tokens == 4
             assert output.finish_reason == "stop"
             mock_llm_model.chat.assert_not_called()
-            engine._model.tokenizer.encode.assert_called_once_with(
-                output.text, add_special_tokens=False
-            )
 
     @pytest.mark.anyio
     async def test_lock_serializes_stream_generate(self, mock_model):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -134,7 +134,7 @@ class TestSimpleEngineConcurrency:
                 finished=False,
             )
             yield MagicMock(
-                text="<|im_end|><tool_call>{\"name\":\"bash\",\"arguments\":{\"command\":\"pwd\"}}</tool_call>",
+                text='<|im_end|><tool_call>{"name":"bash","arguments":{"command":"pwd"}}</tool_call>',
                 tokens=[],
                 prompt_tokens=11,
                 completion_tokens=4,

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -11,6 +11,10 @@ class TestSimpleEngineConcurrency:
     """Test SimpleEngine lock behavior with concurrent requests."""
 
     @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @pytest.fixture
     def mock_model(self):
         """Create a mock model that tracks concurrent calls."""
         model = MagicMock()
@@ -65,7 +69,7 @@ class TestSimpleEngineConcurrency:
         model.chat = MagicMock(side_effect=chat_side_effect)
         return model
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lock_prevents_concurrent_generate(self, mock_model):
         """Test that the lock prevents concurrent generate calls."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -89,7 +93,7 @@ class TestSimpleEngineConcurrency:
                 "The lock is not working correctly."
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lock_prevents_concurrent_chat(self, mock_llm_model):
         """Test that the lock prevents concurrent chat calls."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -115,7 +119,61 @@ class TestSimpleEngineConcurrency:
                 "The lock is not working correctly."
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
+    async def test_chat_with_tools_aggregates_streaming_path(self, mock_llm_model):
+        """Tool-enabled non-stream chat should use the streaming path."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        async def fake_stream_chat(*args, **kwargs):
+            yield MagicMock(
+                text="partial",
+                tokens=[],
+                prompt_tokens=11,
+                completion_tokens=1,
+                finish_reason=None,
+                finished=False,
+            )
+            yield MagicMock(
+                text="<|im_end|><tool_call>{\"name\":\"bash\",\"arguments\":{\"command\":\"pwd\"}}</tool_call>",
+                tokens=[],
+                prompt_tokens=11,
+                completion_tokens=4,
+                finish_reason="stop",
+                finished=True,
+            )
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_llm_model
+            engine._loaded = True
+            engine._model.tokenizer.encode = MagicMock(return_value=[7, 8, 9])
+            engine.stream_chat = fake_stream_chat  # type: ignore[method-assign]
+
+            output = await engine.chat(
+                messages=[{"role": "user", "content": "run pwd"}],
+                max_tokens=16,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            assert output.text.startswith("<tool_call>")
+            assert output.tokens == [7, 8, 9]
+            assert output.prompt_tokens == 11
+            assert output.completion_tokens == 4
+            assert output.finish_reason == "stop"
+            mock_llm_model.chat.assert_not_called()
+            engine._model.tokenizer.encode.assert_called_once_with(
+                output.text, add_special_tokens=False
+            )
+
+    @pytest.mark.anyio
     async def test_lock_serializes_stream_generate(self, mock_model):
         """Test that stream_generate uses the same lock as other methods."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -178,7 +236,7 @@ class TestSimpleEngineConcurrency:
             result = await stream_task
             assert len(result) == 3, f"Expected 3 chunks, got {len(result)}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_engine_initialization_creates_lock(self):
         """Test that SimpleEngine creates a lock on initialization."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -189,7 +247,7 @@ class TestSimpleEngineConcurrency:
             assert hasattr(engine, "_generation_lock")
             assert isinstance(engine._generation_lock, asyncio.Lock)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requests_complete_in_order(self, mock_model):
         """Test that concurrent requests complete (may be in any order due to lock)."""
         from vllm_mlx.engine.simple import SimpleEngine

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -455,10 +455,6 @@ class SimpleEngine(BaseEngine):
             ):
                 final_output = output
             text = clean_output_text(final_output.text)
-            try:
-                tokens = self._model.tokenizer.encode(text, add_special_tokens=False)
-            except TypeError:
-                tokens = self._model.tokenizer.encode(text)
             return GenerationOutput(
                 text=text,
                 tokens=list(final_output.tokens),

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -461,7 +461,7 @@ class SimpleEngine(BaseEngine):
                 tokens = self._model.tokenizer.encode(text)
             return GenerationOutput(
                 text=text,
-                tokens=tokens,
+                tokens=list(final_output.tokens),
                 prompt_tokens=final_output.prompt_tokens,
                 completion_tokens=final_output.completion_tokens,
                 finish_reason=final_output.finish_reason,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -437,6 +437,36 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # mlx-lm non-streaming chat with tools can stall indefinitely on some
+        # local models, while the streaming path completes normally. Reuse the
+        # streaming implementation and aggregate its final state so both chat
+        # APIs share the same tool-capable execution path.
+        if tools and not self._is_mllm:
+            final_output = GenerationOutput(text="")
+            async for output in self.stream_chat(
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                images=images,
+                videos=videos,
+                **kwargs,
+            ):
+                final_output = output
+            text = clean_output_text(final_output.text)
+            try:
+                tokens = self._model.tokenizer.encode(text, add_special_tokens=False)
+            except TypeError:
+                tokens = self._model.tokenizer.encode(text)
+            return GenerationOutput(
+                text=text,
+                tokens=tokens,
+                prompt_tokens=final_output.prompt_tokens,
+                completion_tokens=final_output.completion_tokens,
+                finish_reason=final_output.finish_reason,
+            )
+
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
 


### PR DESCRIPTION
## Summary
Make tool-enabled non-stream `SimpleEngine.chat()` aggregate the existing streaming chat path instead of calling the separate blocking chat path.

## Why
On some local models, non-stream tool-enabled chat stalls while the streaming path completes normally. This change keeps one tool-capable execution path for simple-engine chat and still returns a normal non-stream `GenerationOutput`.

## What changed
- tool-enabled non-stream chat now aggregates `stream_chat()` output
- preserve the streamed token ids from the final output
- keep the streamed completion token count and final finish reason
- add regression coverage for the tool-chat path

## Status
- refreshed onto current upstream `main` (`b4fa030`) on 2026-04-09
- no logic changes beyond the base refresh

## Files to review
- `vllm_mlx/engine/simple.py`
- `tests/test_simple_engine.py`

## Validation
- `python -m pytest tests/test_simple_engine.py::TestSimpleEngineConcurrency::test_chat_with_tools_aggregates_streaming_path -q` -> `1 passed`
- note: the broader async `tests/test_simple_engine.py` run on current upstream depends on the separate harness refresh in `#226`
