### PR TITLE
test: make Python 3.13 async suite pass and cover it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -64,6 +64,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+
+      - name: Verify async test plugin
+        run: python -c "import pytest_asyncio"
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -98,19 +101,24 @@ jobs:
 
   test-apple-silicon:
     runs-on: macos-14
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install project and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[vision]"
-          pip install pytest pytest-asyncio
+          pip install -e ".[dev,vision]"
+
+      - name: Verify async test plugin
+        run: python -c "import pytest_asyncio"
 
       - name: Verify Apple Silicon
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+          pip install pytest pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
 
       - name: Verify async test plugin
-        run: python -c "import pytest_asyncio"
+        run: python -c "import anyio"
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -118,7 +118,7 @@ jobs:
           pip install -e ".[dev,vision]"
 
       - name: Verify async test plugin
-        run: python -c "import pytest_asyncio"
+        run: python -c "import anyio"
 
       - name: Verify Apple Silicon
         run: |

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -18,8 +18,29 @@ pip install -e ".[dev]"
 ### Running Tests
 
 ```bash
-# Run all tests
-pytest tests/
+# Pure-Python test subset (matches the Ubuntu CI job)
+pip install -e ".[dev]"
+pytest \
+  tests/test_mcp_security.py \
+  tests/test_structured_output.py \
+  tests/test_reasoning_parser.py \
+  tests/test_tool_parsers.py \
+  tests/test_streaming_json_encoder.py \
+  tests/test_native_tool_format.py \
+  tests/test_memory_cache.py \
+  tests/test_prefix_cache.py \
+  tests/test_mllm_cache.py \
+  tests/test_api_models.py \
+  tests/test_api_utils.py \
+  tests/test_request.py \
+  tests/test_anthropic_models.py \
+  tests/test_anthropic_adapter.py \
+  tests/test_harmony_parsers.py \
+  -v --tb=short -m "not slow and not integration"
+
+# Full Apple Silicon suite (requires macOS on Apple Silicon with MLX)
+pip install -e ".[dev,vision]"
+pytest tests/ -v --tb=short -m "not slow and not integration"
 
 # Run specific test file
 pytest tests/test_paged_cache.py -v
@@ -27,6 +48,14 @@ pytest tests/test_paged_cache.py -v
 # Run with coverage
 pytest --cov=vllm_mlx tests/
 ```
+
+The full suite is intentionally split in CI:
+
+- The Ubuntu matrix runs the pure-Python subset only.
+- The Apple Silicon job runs MLX-dependent tests that require macOS on ARM.
+
+If you are running tests locally outside the documented `.[dev]` environment, async tests
+will fail because `pytest-asyncio` is a dev dependency rather than a runtime dependency.
 
 ### Code Style
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -54,8 +54,8 @@ The full suite is intentionally split in CI:
 - The Ubuntu matrix runs the pure-Python subset only.
 - The Apple Silicon job runs MLX-dependent tests that require macOS on ARM.
 
-If you are running tests locally outside the documented `.[dev]` environment, async tests
-will fail because `pytest-asyncio` is a dev dependency rather than a runtime dependency.
+Async tests run through `anyio` on the asyncio backend. If you are running tests locally,
+use the documented dev environment so the test dependencies match CI.
 
 ### Code Style
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -18,29 +18,8 @@ pip install -e ".[dev]"
 ### Running Tests
 
 ```bash
-# Pure-Python test subset (matches the Ubuntu CI job)
-pip install -e ".[dev]"
-pytest \
-  tests/test_mcp_security.py \
-  tests/test_structured_output.py \
-  tests/test_reasoning_parser.py \
-  tests/test_tool_parsers.py \
-  tests/test_streaming_json_encoder.py \
-  tests/test_native_tool_format.py \
-  tests/test_memory_cache.py \
-  tests/test_prefix_cache.py \
-  tests/test_mllm_cache.py \
-  tests/test_api_models.py \
-  tests/test_api_utils.py \
-  tests/test_request.py \
-  tests/test_anthropic_models.py \
-  tests/test_anthropic_adapter.py \
-  tests/test_harmony_parsers.py \
-  -v --tb=short -m "not slow and not integration"
-
-# Full Apple Silicon suite (requires macOS on Apple Silicon with MLX)
-pip install -e ".[dev,vision]"
-pytest tests/ -v --tb=short -m "not slow and not integration"
+# Run all tests
+pytest tests/
 
 # Run specific test file
 pytest tests/test_paged_cache.py -v
@@ -48,14 +27,6 @@ pytest tests/test_paged_cache.py -v
 # Run with coverage
 pytest --cov=vllm_mlx tests/
 ```
-
-The full suite is intentionally split in CI:
-
-- The Ubuntu matrix runs the pure-Python subset only.
-- The Apple Silicon job runs MLX-dependent tests that require macOS on ARM.
-
-Async tests run through `anyio` on the asyncio backend. If you are running tests locally,
-use the documented dev environment so the test dependencies match CI.
 
 ### Code Style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "anyio>=4.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
@@ -134,4 +135,3 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,12 @@
 import pytest
 
 
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Run anyio tests on asyncio consistently across environments."""
+    return "asyncio"
+
+
 def pytest_addoption(parser):
     """Add custom command line options."""
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,9 @@ def pytest_collection_modifyitems(config, items):
 def server_url(request):
     """Get server URL from command line."""
     return request.config.getoption("--server-url")
+
+
+@pytest.fixture(params=["asyncio"])
+def anyio_backend(request):
+    """Run anyio-marked tests on asyncio only (trio is not installed)."""
+    return request.param

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -432,7 +432,7 @@ class TestSchedulerIntegration:
         assert len(finished) == len(prompts), f"Only {len(finished)} requests finished"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 class TestEngineAsync:
     """Async tests for the engine."""
 

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -37,7 +37,7 @@ def sampling_params():
 class TestDeterministicSingleRequest:
     """Test single request determinism."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_same_prompt_same_output(self, model_and_tokenizer, sampling_params):
         """Same prompt should produce same output with temp=0."""
         from vllm_mlx import AsyncEngineCore, EngineConfig, SchedulerConfig
@@ -68,7 +68,7 @@ class TestDeterministicSingleRequest:
         assert len(outputs) == 3
         assert outputs[0] == outputs[1] == outputs[2], f"Outputs differ: {outputs}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_token_streaming_order(self, model_and_tokenizer, sampling_params):
         """Tokens should stream in order."""
         from vllm_mlx import AsyncEngineCore
@@ -94,7 +94,7 @@ class TestDeterministicSingleRequest:
 class TestDeterministicConcurrentRequests:
     """Test concurrent request handling with determinism."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_concurrent_same_prompt(self, model_and_tokenizer):
         """Multiple concurrent requests with same prompt should get same output."""
         from vllm_mlx import (
@@ -137,7 +137,7 @@ class TestDeterministicConcurrentRequests:
             # All should be the same
             assert all(r == results[0] for r in results), f"Outputs differ: {results}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_concurrent_different_prompts(self, model_and_tokenizer):
         """Different prompts should get different (but deterministic) outputs."""
         from vllm_mlx import (
@@ -191,7 +191,7 @@ class TestDeterministicConcurrentRequests:
 class TestBatchingPerformance:
     """Test that batching improves throughput."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_batched_faster_than_sequential(self, model_and_tokenizer):
         """Batched requests should be faster than sequential."""
         from vllm_mlx import (
@@ -274,7 +274,7 @@ class TestBatchingPerformance:
 class TestRequestManagement:
     """Test request lifecycle management."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request(self, model_and_tokenizer):
         """Test aborting a request mid-generation."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -304,7 +304,7 @@ class TestRequestManagement:
             stats = engine.get_stats()
             assert stats["active_requests"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_engine_stats(self, model_and_tokenizer):
         """Test engine statistics tracking."""
         from vllm_mlx import (
@@ -343,7 +343,7 @@ class TestRequestManagement:
 class TestSchedulerPolicy:
     """Test scheduler policies."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fcfs_ordering(self, model_and_tokenizer):
         """Test that FCFS policy processes requests in order."""
         from vllm_mlx import (
@@ -396,7 +396,7 @@ class TestSchedulerPolicy:
 class TestEdgeCases:
     """Test edge cases and error handling."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_prompt(self, model_and_tokenizer):
         """Test handling of empty prompt."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -414,7 +414,7 @@ class TestEdgeCases:
                     assert out.finished
                     break
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_very_short_max_tokens(self, model_and_tokenizer):
         """Test with max_tokens=1."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -436,7 +436,7 @@ class TestEdgeCases:
             # Should generate exactly 1 token
             assert token_count == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_multiple_start_stop(self, model_and_tokenizer):
         """Test starting and stopping engine multiple times."""
         from vllm_mlx import AsyncEngineCore, SamplingParams

--- a/tests/test_continuous_batching.py
+++ b/tests/test_continuous_batching.py
@@ -53,7 +53,7 @@ class TestContinuousBatchingBasic:
         assert config.completion_batch_size == 32
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 class TestContinuousBatchingIntegration:
     """Integration tests requiring actual model loading."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -593,9 +593,7 @@ class TestAPIKeyVerification:
 
             # Should raise HTTPException with 401
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
-                    server.verify_api_key(credentials)
-                )
+                asyncio.run(server.verify_api_key(credentials))
 
             assert exc_info.value.status_code == 401
             assert "Invalid API key" in str(exc_info.value.detail)
@@ -621,9 +619,7 @@ class TestAPIKeyVerification:
             )
 
             # Should not raise any exception
-            result = asyncio.get_event_loop().run_until_complete(
-                server.verify_api_key(credentials)
-            )
+            result = asyncio.run(server.verify_api_key(credentials))
             # verify_api_key returns True on success (no exception raised)
             assert result is True or result is None
         finally:

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -65,7 +65,7 @@ class TestSimpleEngineConcurrency:
         model.chat = MagicMock(side_effect=chat_side_effect)
         return model
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lock_prevents_concurrent_generate(self, mock_model):
         """Test that the lock prevents concurrent generate calls."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -89,7 +89,7 @@ class TestSimpleEngineConcurrency:
                 "The lock is not working correctly."
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lock_prevents_concurrent_chat(self, mock_llm_model):
         """Test that the lock prevents concurrent chat calls."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -115,7 +115,7 @@ class TestSimpleEngineConcurrency:
                 "The lock is not working correctly."
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lock_serializes_stream_generate(self, mock_model):
         """Test that stream_generate uses the same lock as other methods."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -178,7 +178,7 @@ class TestSimpleEngineConcurrency:
             result = await stream_task
             assert len(result) == 3, f"Expected 3 chunks, got {len(result)}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_engine_initialization_creates_lock(self):
         """Test that SimpleEngine creates a lock on initialization."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -189,7 +189,7 @@ class TestSimpleEngineConcurrency:
             assert hasattr(engine, "_generation_lock")
             assert isinstance(engine._generation_lock, asyncio.Lock)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requests_complete_in_order(self, mock_model):
         """Test that concurrent requests complete (may be in any order due to lock)."""
         from vllm_mlx.engine.simple import SimpleEngine

--- a/tests/test_streaming_latency.py
+++ b/tests/test_streaming_latency.py
@@ -206,7 +206,7 @@ async def run_benchmark(
             print(f"Throughput: {throughput:.1f} tokens/sec")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_output_collector():
     """Unit test for RequestOutputCollector."""
     import sys


### PR DESCRIPTION
## Summary
Fix Python 3.13 test execution and add real 3.13 coverage to the project test jobs.

## Changes
- standardize async tests on `anyio` with the asyncio backend
- replace Python 3.13-fragile `asyncio.get_event_loop().run_until_complete(...)` with `asyncio.run(...)`
- remove dead `asyncio_mode = "auto"` config (pytest-asyncio reference after its removal)
- add `anyio>=4.0` as explicit dev dependency
- add Python 3.13 to the Ubuntu test matrix and the Apple Silicon MLX job

## Status
- refreshed onto current upstream `main` (`b4fa030`) on 2026-04-09
- no logic changes beyond the base refresh

## Validation
- `python -m pytest tests/ -q --timeout=120` -> `1020 passed, 2 failed, 9 skipped, 20 deselected`
- the two failures are throughput assertions in `tests/test_batching_deterministic.py::TestBatchingPerformance::test_batched_faster_than_sequential[asyncio]` and `tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_batching_improves_throughput[asyncio]`
- the async-harness changes themselves are exercising correctly; these failures are performance thresholds, not event-loop/plugin failures
