### PR TITLE
fix: bump mlx-lm minimum to 0.31.0 for hybrid model batching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "mlx>=0.29.0",
-    "mlx-lm>=0.30.5",  # GLM-4 models require 0.30.5+ (new attention layers)
+    "mlx-lm>=0.31.0",  # 0.31+ required for ArraysCache native batching (hybrid models)
     "mlx-vlm>=0.1.0",  # VLM support
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",


### PR DESCRIPTION
## Summary
Bump the `mlx-lm` minimum version from `>=0.30.5` to `>=0.31.0`.

## Why
`ArraysCache` gained native batching support (`extract`, `merge`, `filter`, `prepare`) in mlx-lm 0.31.0. Older versions crash with `ArraysCache.__init__() missing 1 required positional argument: 'size'` when continuous batching encounters hybrid models like Qwen3.5 that mix KVCache and ArraysCache layers.

The `ensure_mamba_support()` monkey-patch is already correctly disabled since these methods are native. The only missing piece was the version floor in `pyproject.toml`.

## Reproduction
```bash
# With mlx-lm < 0.31.0:
vllm-mlx serve mlx-community/Qwen3.5-35B-A3B-6bit --continuous-batching True
# ERROR: ArraysCache.__init__() missing 1 required positional argument: 'size'
```

## Verification
```bash
python -c "from mlx_lm.models.cache import ArraysCache; print(hasattr(ArraysCache, 'extract'), hasattr(ArraysCache, 'merge'))"
# True True (on 0.31.0+)
```

## Files
- `pyproject.toml`

Fixes computor-org/vllm-mlx#11
Related: waybarrios/vllm-mlx#160, waybarrios/vllm-mlx#159