### PR TITLE
fix: populate tokens field in BatchedEngine.generate()

### DIFF
--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for BatchedEngine generate() output."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestBatchedEngineGenerate:
+    """Test BatchedEngine.generate() output fields."""
+
+    def _make_engine(self):
+        """Create a BatchedEngine instance with loading bypassed."""
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=False):
+            engine = BatchedEngine("test-model")
+
+        engine._loaded = True
+        engine._is_mllm = False
+        return engine
+
+    def _make_mock_request_output(
+        self,
+        output_text="Paris",
+        output_token_ids=None,
+        prompt_tokens=10,
+        completion_tokens=3,
+        finish_reason="stop",
+    ):
+        """Build a mock RequestOutput (as returned by AsyncEngineCore)."""
+        mock = MagicMock()
+        mock.output_text = output_text
+        mock.output_token_ids = output_token_ids if output_token_ids is not None else [3681, 374, 279]
+        mock.prompt_tokens = prompt_tokens
+        mock.completion_tokens = completion_tokens
+        mock.finish_reason = finish_reason
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_tokens_field_is_populated(self):
+        """tokens should contain the output token IDs from AsyncEngineCore."""
+        engine = self._make_engine()
+        token_ids = [3681, 374, 279]
+        mock_output = self._make_mock_request_output(output_token_ids=token_ids)
+
+        mock_engine = MagicMock()
+        mock_engine.generate = AsyncMock(return_value=mock_output)
+        engine._engine = mock_engine
+
+        result = await engine.generate(prompt="What is the capital of France?", max_tokens=10)
+
+        assert result.tokens == token_ids
+
+    @pytest.mark.asyncio
+    async def test_tokens_field_empty_when_no_tokens_generated(self):
+        """tokens should be an empty list when output_token_ids is empty."""
+        engine = self._make_engine()
+        mock_output = self._make_mock_request_output(output_token_ids=[])
+
+        mock_engine = MagicMock()
+        mock_engine.generate = AsyncMock(return_value=mock_output)
+        engine._engine = mock_engine
+
+        result = await engine.generate(prompt="test", max_tokens=10)
+
+        assert result.tokens == []
+
+    @pytest.mark.asyncio
+    async def test_other_output_fields_still_populated(self):
+        """Existing fields (text, prompt_tokens, etc.) must remain correct."""
+        engine = self._make_engine()
+        mock_output = self._make_mock_request_output(
+            output_text="Paris",
+            output_token_ids=[3681],
+            prompt_tokens=7,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.generate = AsyncMock(return_value=mock_output)
+        engine._engine = mock_engine
+
+        result = await engine.generate(prompt="Capital of France?", max_tokens=5)
+
+        assert result.text == "Paris"
+        assert result.prompt_tokens == 7
+        assert result.completion_tokens == 1
+        assert result.finish_reason == "stop"

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -468,6 +468,7 @@ class BatchedEngine(BaseEngine):
 
             return GenerationOutput(
                 text=clean_output_text(output.output_text),
+                tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -492,6 +492,7 @@ class BatchedEngine(BaseEngine):
 
         return GenerationOutput(
             text=text,
+            tokens=output.output_token_ids,
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,


### PR DESCRIPTION
Encountered this while first investigating vllm-mlx for for RL training, I want to be able to see the tokens produced via BatchedEngine.generate. This PR was written exclusively with Claude so please let me know if you have any suggestions and I will implement them manually 😃. I also will try to implement and upstream any RL-related features that are missing.

Thank you for the project, it has been very useful!

The below is AI-generated:

## Summary

- `BatchedEngine.generate()` always returned `tokens=[]` despite `AsyncEngineCore` tracking `output_token_ids` per request
- The fix passes `output.output_token_ids` through to `GenerationOutput`
- Adds `tests/test_batched_engine.py` with three unit tests covering the `tokens` field and other output fields

## Root cause

In `engine/batched.py`, the `GenerationOutput` was constructed without the `tokens` field:

```python
# before
return GenerationOutput(
    text=text,
    prompt_tokens=output.prompt_tokens,
    completion_tokens=output.completion_tokens,
    finish_reason=output.finish_reason,
)

# after
return GenerationOutput(
    text=text,
    tokens=output.output_token_ids,
    prompt_tokens=output.prompt_tokens,
    completion_tokens=output.completion_tokens,
    finish_reason=output.finish_reason,
)
```

## Test plan
- [x] `test_tokens_field_is_populated` — verifies token IDs are forwarded correctly
- [x] `test_tokens_field_empty_when_no_tokens_generated` — verifies empty list is handled
- [x] `test_other_output_fields_still_populated` — verifies no regression on existing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)