### PR TITLE
fix: add missing return in load_model_with_fallback

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
When mlx_lm.load() succeeds without raising ValueError, the function falls through without returning the (model, tokenizer) tuple, causing a TypeError in the caller ('cannot unpack non-iterable NoneType').

This affects any model that loads successfully on the first try (the common case). The ValueError catch paths all have returns, but the success path was missing one.