### PR TITLE
fix: add missing return in load_model_with_fallback

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
When mlx_lm.load() succeeds on the happy path (no ValueError), the function falls through to implicit return None instead of returning the loaded (model, tokenizer) tuple.

This causes a TypeError in LLMModel.load():
  TypeError: cannot unpack non-iterable NoneType object

The bug only affects models that load successfully without needing the tokenizer or strict=False fallback paths (which do have return statements).