### PR TITLE
fix: add missing return in load_model_with_fallback()

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -67,6 +67,8 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
             return _load_strict_false(model_name, tokenizer_config)
         raise
 
+    return model, tokenizer
+
 
 def _load_strict_false(model_name: str, tokenizer_config: dict = None):
     """Load model with strict=False to discard extra weights (e.g., vision tower, MTP)."""


### PR DESCRIPTION
## Summary

- `load_model_with_fallback()` in `vllm_mlx/utils/tokenizer.py` is missing a `return model, tokenizer` statement after the `try/except` block
- When `mlx_lm.load()` succeeds without raising a `ValueError` (no fallback path triggered), the function falls through and implicitly returns `None`
- The caller in `batched.py:257` then crashes with `TypeError: cannot unpack non-iterable NoneType object`

This affects models where `load()` succeeds on the first attempt, including `mlx-community/Qwen3-Coder-Next-4bit` with `trust_remote_code=True` (the default in `BatchedEngine`).

## Test plan

- [x] Verified the fix resolves the crash when serving `mlx-community/Qwen3-Coder-Next-4bit` with `--continuous-batching`
- [x] Confirmed inference works end-to-end after the fix (single and concurrent requests)
- [ ] Existing fallback paths (ValueError handlers) are unaffected — they already have explicit `return` statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)