### PR TITLE
fix: add missing return in load_model_with_fallback

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
## Summary
- `load_model_with_fallback()` in `vllm_mlx/utils/tokenizer.py` is missing a `return` statement after the successful `mlx_lm.load()` call
- When `load()` succeeds without raising `ValueError`, the function falls through the try/except and implicitly returns `None`
- The caller (`MLXLanguageModel.load()`) then crashes with `TypeError: cannot unpack non-iterable NoneType object`
- This affects **all models** that load successfully on the first try (i.e. most models that don't need the Nemotron/vision fallback paths)

## Fix
One line: `return model, tokenizer` after the successful `load()` call.

## Test plan
- [x] Verified `vllm-mlx serve mlx-community/Mistral-Small-3.2-24B-Instruct-2506-4bit` starts successfully
- [x] Verified `vllm-mlx serve mlx-community/Qwen3.5-9B-4bit` starts successfully
- [x] Both models previously crashed with the NoneType error on v0.2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)