### PR TITLE
Add MTP speculative decoding for Qwen3.5 models

### DIFF
--- a/scripts/add_mtp_weights_qwen35.py
+++ b/scripts/add_mtp_weights_qwen35.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+Add MTP (Multi-Token Prediction) weights to an existing MLX Qwen3.5 model.
+
+This script:
+1. Fetches the safetensors index from the original BF16 HuggingFace model
+2. Identifies shards containing MTP weights (mtp.* keys)
+3. Downloads only those shards via curl -C -
+4. Extracts MTP weights
+5. For MoE models: stacks expert weights (256×) into switch_mlp format
+6. Applies norm shift (HF weight → MLX weight+1.0) for RMSNorm keys
+7. Quantizes to match the MLX model's quantization scheme
+8. Saves as mtp/weights.safetensors (subdirectory avoids mlx_vlm glob)
+
+Supports both:
+- MoE models (Qwen3.5-122B-A10B, 35B-A3B): 256 experts, sparse MTP attention
+- Dense models (Qwen3.5-27B): full MTP with k/v projections and norms
+
+Usage:
+    python add_mtp_weights_qwen35.py --mlx-model-path PATH --source-model MODEL
+
+Requirements:
+    pip install mlx
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Known model configurations
+MODEL_CONFIGS = {
+    "Qwen/Qwen3.5-122B-A10B": {
+        "num_experts": 256,
+        "hidden_size": 3072,
+        "is_moe": True,
+    },
+    "Qwen/Qwen3.5-35B-A3B": {
+        "num_experts": 256,
+        "hidden_size": 2048,
+        "is_moe": True,
+    },
+    "Qwen/Qwen3.5-27B": {
+        "num_experts": 0,
+        "hidden_size": 5120,
+        "is_moe": False,
+    },
+}
+
+
+def find_snapshot_dir(model_path: str) -> Path:
+    """Find the latest snapshot directory in HF cache structure."""
+    snapshots_dir = Path(model_path) / "snapshots"
+    if not snapshots_dir.exists():
+        if (Path(model_path) / "config.json").exists():
+            return Path(model_path)
+        raise FileNotFoundError(f"No snapshots found in {model_path}")
+    snapshots = sorted(snapshots_dir.iterdir(), key=lambda p: p.stat().st_mtime)
+    if not snapshots:
+        raise FileNotFoundError(f"No snapshots in {snapshots_dir}")
+    return snapshots[-1]
+
+
+def fetch_shard_index(source_model: str, download_dir: Path) -> dict:
+    """Fetch model.safetensors.index.json from HuggingFace."""
+    index_url = f"https://huggingface.co/{source_model}/resolve/main/model.safetensors.index.json"
+    index_path = download_dir / "source_index.json"
+
+    print(f"Fetching shard index from {source_model}...")
+    result = subprocess.run(
+        ["curl", "-L", "-C", "-", "-o", str(index_path), index_url],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to fetch index: return code {result.returncode}")
+
+    with open(index_path) as f:
+        return json.load(f)
+
+
+def identify_mtp_shards(index: dict) -> tuple[dict[str, str], set[str]]:
+    """Identify which shards contain MTP weights.
+
+    Returns:
+        Tuple of (mtp_key_to_shard mapping, set of shard filenames to download)
+    """
+    weight_map = index.get("weight_map", {})
+    mtp_keys = {}
+    shards_needed = set()
+
+    for key, shard in weight_map.items():
+        if key.startswith("mtp."):
+            mtp_keys[key] = shard
+            shards_needed.add(shard)
+
+    return mtp_keys, shards_needed
+
+
+def download_shards(
+    shards: set[str], source_model: str, download_dir: Path
+) -> dict[str, Path]:
+    """Download required shards using curl with resume support."""
+    shard_paths = {}
+    for shard_name in sorted(shards):
+        shard_url = f"https://huggingface.co/{source_model}/resolve/main/{shard_name}"
+        shard_path = download_dir / shard_name
+
+        if shard_path.exists():
+            size_gb = shard_path.stat().st_size / 1e9
+            print(f"  {shard_name}: exists ({size_gb:.2f} GB)")
+            shard_paths[shard_name] = shard_path
+            continue
+
+        print(f"  Downloading {shard_name}...")
+        result = subprocess.run(
+            ["curl", "-L", "-C", "-", "-o", str(shard_path), shard_url],
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Download failed for {shard_name}: code {result.returncode}"
+            )
+
+        size_gb = shard_path.stat().st_size / 1e9
+        print(f"  {shard_name}: {size_gb:.2f} GB")
+        shard_paths[shard_name] = shard_path
+
+    return shard_paths
+
+
+def extract_and_quantize_mtp_weights(
+    mtp_keys: dict[str, str],
+    shard_paths: dict[str, Path],
+    snapshot_dir: Path,
+    is_moe: bool,
+    num_experts: int,
+    no_quantize: bool = False,
+):
+    """Extract MTP weights from BF16 shards, optionally quantize, and save."""
+    import mlx.core as mx
+
+    mx.set_default_device(mx.cpu)
+
+    # Read MLX model's quantization config
+    config_path = snapshot_dir / "config.json"
+    with open(config_path) as f:
+        config = json.load(f)
+
+    text_config = config.get("text_config", config)
+    quant_config = text_config.get("quantization", config.get("quantization", {}))
+    bits = quant_config.get("bits", 4)
+    group_size = quant_config.get("group_size", 64)
+    if no_quantize:
+        print("MTP weights will be saved in BF16 (no quantization)")
+    else:
+        print(f"Target quantization: {bits}-bit, group_size={group_size}")
+
+    # Group MTP keys by shard for efficient I/O
+    shard_to_keys: dict[str, list[str]] = {}
+    for key, shard in mtp_keys.items():
+        shard_to_keys.setdefault(shard, []).append(key)
+
+    # Load all MTP weights
+    print(f"\nExtracting MTP weights from {len(shard_paths)} shards...")
+    all_mtp_weights: dict[str, mx.array] = {}
+
+    for shard_name, keys in sorted(shard_to_keys.items()):
+        shard_path = shard_paths[shard_name]
+        print(f"  Loading {shard_name} ({len(keys)} MTP keys)...")
+        shard_data = mx.load(str(shard_path))
+        for key in keys:
+            if key in shard_data:
+                all_mtp_weights[key] = shard_data[key]
+        del shard_data
+
+    print(f"Loaded {len(all_mtp_weights)} MTP weight tensors")
+
+    # Norm keys that need +1.0 shift (HF centered ~0 → MLX centered ~1)
+    norm_suffixes = (
+        ".input_layernorm.weight",
+        ".post_attention_layernorm.weight",
+        ".q_norm.weight",
+        ".k_norm.weight",
+        ".pre_fc_norm_hidden.weight",
+        ".pre_fc_norm_embedding.weight",
+        "mtp.norm.weight",
+    )
+
+    # Keys to keep as FP (not quantize)
+    skip_quantize_suffixes = (
+        ".input_layernorm.weight",
+        ".post_attention_layernorm.weight",
+        ".q_norm.weight",
+        ".k_norm.weight",
+        "mtp.fc.weight",
+        "mtp.norm.weight",
+        "mtp.pre_fc_norm_hidden.weight",
+        "mtp.pre_fc_norm_embedding.weight",
+        ".shared_expert_gate.weight",
+    )
+
+    def _quantize_one(key: str, weight: mx.array) -> dict[str, mx.array]:
+        """Quantize a single weight, apply norm adjustment."""
+        # Norm shift: +1.0 for RMSNorm weights
+        if any(key.endswith(s) for s in norm_suffixes) and weight.ndim == 1:
+            weight = weight + 1.0
+            mx.eval(weight)
+            print(f"  Norm shift: {key}")
+
+        if no_quantize:
+            print(f"  BF16: {key} {weight.shape}")
+            return {key: weight}
+        elif any(key.endswith(s) for s in skip_quantize_suffixes):
+            print(f"  Keep FP: {key} {weight.shape}")
+            return {key: weight}
+        elif weight.ndim >= 2 and weight.shape[-1] >= group_size:
+            q_w, q_s, q_b = mx.quantize(weight, group_size=group_size, bits=bits)
+            mx.eval(q_w, q_s, q_b)
+            print(f"  Quantize {bits}-bit: {key} {q_w.shape}")
+            return {
+                key: q_w,
+                key.replace(".weight", ".scales"): q_s,
+                key.replace(".weight", ".biases"): q_b,
+            }
+        else:
+            print(f"  Keep FP (small): {key} {weight.shape}")
+            return {key: weight}
+
+    quantized_weights: dict[str, mx.array] = {}
+
+    if is_moe and num_experts > 0:
+        # Stack expert weights ONE PROJECTION AT A TIME to minimize peak memory
+        for proj in ["up_proj", "down_proj", "gate_proj"]:
+            expert_keys = [
+                f"mtp.layers.0.mlp.experts.{e}.{proj}.weight"
+                for e in range(num_experts)
+            ]
+            if all(k in all_mtp_weights for k in expert_keys):
+                stacked = mx.stack([all_mtp_weights.pop(k) for k in expert_keys])
+                mx.eval(stacked)
+                stacked_key = f"mtp.layers.0.mlp.switch_mlp.{proj}.weight"
+                print(f"  Stacked {num_experts} experts for {proj}: {stacked.shape}")
+                quantized_weights.update(_quantize_one(stacked_key, stacked))
+                del stacked
+            else:
+                present = sum(1 for k in expert_keys if k in all_mtp_weights)
+                if present > 0:
+                    print(f"  WARNING: Only {present}/{num_experts} experts for {proj}")
+
+    # Quantize remaining non-expert weights
+    for key in sorted(all_mtp_weights.keys()):
+        weight = all_mtp_weights.pop(key)
+        quantized_weights.update(_quantize_one(key, weight))
+        del weight
+    del all_mtp_weights
+
+    # Save to mtp/ subdirectory (avoids mlx_vlm glob loading all *.safetensors)
+    mtp_output_dir = snapshot_dir / "mtp"
+    mtp_output_dir.mkdir(exist_ok=True)
+    mtp_output_file = mtp_output_dir / "weights.safetensors"
+    mode_str = "BF16" if no_quantize else "quantized"
+    print(
+        f"\nSaving {len(quantized_weights)} {mode_str} MTP weights to {mtp_output_file}"
+    )
+    mx.save_safetensors(str(mtp_output_file), quantized_weights)
+
+    total_bytes = sum(v.nbytes for v in quantized_weights.values())
+    print(f"MTP weights size: {total_bytes / 1e6:.1f} MB ({mode_str})")
+
+    return mtp_output_file, list(quantized_weights.keys())
+
+
+def update_model_index(snapshot_dir: Path, mtp_keys: list[str]):
+    """Update model.safetensors.index.json to include MTP weight keys."""
+    index_path = snapshot_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        print(f"WARNING: No index file found at {index_path}, skipping index update")
+        return
+
+    with open(index_path) as f:
+        index = json.load(f)
+
+    weight_map = index.get("weight_map", {})
+    for key in mtp_keys:
+        weight_map[key] = "model-mtp.safetensors"
+
+    index["weight_map"] = weight_map
+
+    with open(index_path, "w") as f:
+        json.dump(index, f, indent=2)
+
+    print(f"Updated {index_path} with {len(mtp_keys)} MTP weight entries")
+
+
+def update_config(snapshot_dir: Path):
+    """Update config.json to signal MTP availability.
+
+    For Qwen3.5, mtp_num_hidden_layers already exists in text_config.
+    We add num_nextn_predict_layers at top level for vllm-mlx compatibility.
+    """
+    config_path = snapshot_dir / "config.json"
+    with open(config_path) as f:
+        config = json.load(f)
+
+    text_config = config.get("text_config", config)
+    num_mtp = text_config.get("mtp_num_hidden_layers", 0)
+
+    if num_mtp > 0:
+        # Set num_nextn_predict_layers for vllm-mlx MTP detection
+        config["num_nextn_predict_layers"] = num_mtp
+        text_config["num_nextn_predict_layers"] = num_mtp
+        if "text_config" in config:
+            config["text_config"] = text_config
+
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+
+        print(f"Updated config: num_nextn_predict_layers={num_mtp}")
+    else:
+        print("WARNING: mtp_num_hidden_layers not found in config")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add MTP weights to MLX Qwen3.5 model")
+    parser.add_argument(
+        "--mlx-model-path",
+        type=str,
+        required=True,
+        help="Path to MLX model directory (HF cache or direct path)",
+    )
+    parser.add_argument(
+        "--source-model",
+        type=str,
+        required=True,
+        help="HuggingFace BF16 model to download MTP shards from (e.g., Qwen/Qwen3.5-122B-A10B)",
+    )
+    parser.add_argument(
+        "--download-dir",
+        type=str,
+        default=None,
+        help="Directory to download shards to (default: temp dir)",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Skip download (use existing shards in download-dir)",
+    )
+    parser.add_argument(
+        "--keep-shards",
+        action="store_true",
+        help="Don't delete downloaded BF16 shards after extraction",
+    )
+    parser.add_argument(
+        "--no-quantize",
+        action="store_true",
+        help="Save MTP weights in BF16 (no quantization). Required for correct MTP predictions.",
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("MTP Weight Addition for Qwen3.5 MLX Model")
+    print("=" * 60)
+
+    # Find snapshot directory
+    snapshot_dir = find_snapshot_dir(args.mlx_model_path)
+    print(f"\nMLX model snapshot: {snapshot_dir}")
+
+    # Read config
+    config_path = snapshot_dir / "config.json"
+    if not config_path.exists():
+        print(f"ERROR: No config.json found in {snapshot_dir}")
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    text_config = config.get("text_config", config)
+    model_type = text_config.get("model_type", config.get("model_type", "unknown"))
+    hidden_size = text_config.get("hidden_size", "?")
+    num_experts = text_config.get("num_experts", 0)
+    is_moe = num_experts > 0
+    mtp_layers = text_config.get("mtp_num_hidden_layers", 0)
+
+    print(f"Model type: {model_type}")
+    print(f"Hidden size: {hidden_size}")
+    print(f"Num experts: {num_experts} ({'MoE' if is_moe else 'Dense'})")
+    print(f"MTP layers: {mtp_layers}")
+
+    if mtp_layers == 0:
+        print("ERROR: Model has no MTP layers configured (mtp_num_hidden_layers=0)")
+        sys.exit(1)
+
+    # Check if MTP weights already exist
+    mtp_file = snapshot_dir / "mtp" / "weights.safetensors"
+    if mtp_file.exists():
+        size_mb = mtp_file.stat().st_size / 1e6
+        print(f"\nWARNING: mtp/weights.safetensors already exists ({size_mb:.1f} MB)")
+        print("Delete it first if you want to regenerate.")
+        sys.exit(0)
+
+    # Setup download directory
+    if args.download_dir:
+        download_dir = Path(args.download_dir)
+        download_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        download_dir = Path(tempfile.mkdtemp(prefix="qwen35_mtp_"))
+    print(f"\nDownload dir: {download_dir}")
+
+    # Fetch shard index and identify MTP shards
+    source_index = fetch_shard_index(args.source_model, download_dir)
+    mtp_key_map, shards_needed = identify_mtp_shards(source_index)
+
+    print(
+        f"\nFound {len(mtp_key_map)} MTP weight keys across {len(shards_needed)} shards:"
+    )
+    for shard in sorted(shards_needed):
+        count = sum(1 for v in mtp_key_map.values() if v == shard)
+        print(f"  {shard}: {count} keys")
+
+    # Download shards
+    if not args.skip_download:
+        print(f"\nDownloading {len(shards_needed)} shards...")
+        shard_paths = download_shards(shards_needed, args.source_model, download_dir)
+    else:
+        shard_paths = {}
+        for shard_name in shards_needed:
+            p = download_dir / shard_name
+            if p.exists():
+                shard_paths[shard_name] = p
+            else:
+                print(f"ERROR: Shard not found: {p}")
+                sys.exit(1)
+
+    # Extract, optionally quantize, and save MTP weights
+    mtp_file, mtp_weight_keys = extract_and_quantize_mtp_weights(
+        mtp_key_map,
+        shard_paths,
+        snapshot_dir,
+        is_moe,
+        num_experts,
+        no_quantize=args.no_quantize,
+    )
+
+    # NOTE: Do NOT update model.safetensors.index.json — mlx_vlm's glob
+    # would try to load MTP weights and fail with strict loading.
+    # MTP weights are loaded separately by inject_mtp_support().
+
+    # Update config
+    update_config(snapshot_dir)
+
+    # Cleanup downloaded shards
+    if not args.keep_shards and not args.skip_download:
+        print("\nCleaning up downloaded shards...")
+        for shard_path in shard_paths.values():
+            shard_path.unlink(missing_ok=True)
+            print(f"  Deleted {shard_path.name}")
+
+    print("\n" + "=" * 60)
+    print("SUCCESS! MTP weights added to MLX model.")
+    print("=" * 60)
+    print(f"\nMTP weight file: {mtp_file}")
+    print(f"Total MTP keys: {len(mtp_weight_keys)}")
+    print("\nTo use MTP, start the server with --enable-mtp:")
+    print(f"  vllm-mlx serve {args.mlx_model_path} --enable-mtp")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -137,6 +137,7 @@ class BatchedEngine(BaseEngine):
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,
+        gpu_memory_utilization: float = 0.90,
     ):
         """
         Initialize the batched engine.
@@ -147,11 +148,14 @@ class BatchedEngine(BaseEngine):
             scheduler_config: Optional scheduler configuration
             stream_interval: Tokens to batch before streaming (1=every token)
             force_mllm: Force loading as MLLM even if not auto-detected
+            gpu_memory_utilization: Fraction of device memory for Metal allocation
+                limit and emergency threshold (0.0-1.0, default 0.90)
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
+        self._gpu_memory_utilization = gpu_memory_utilization
         self._is_mllm = force_mllm or is_mllm_model(model_name)
 
         self._model = None
@@ -207,6 +211,10 @@ class BatchedEngine(BaseEngine):
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor
 
+        # Inject MTP support if enabled
+        if self._scheduler_config and self._scheduler_config.enable_mtp:
+            self._inject_mtp_mllm()
+
         # Create MLLM scheduler config with batch generator support
         if self._scheduler_config and hasattr(self._scheduler_config, "max_num_seqs"):
             max_num_seqs = self._scheduler_config.max_num_seqs
@@ -219,12 +227,20 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "completion_batch_size", 16
         )
 
+        cache_memory_mb = getattr(self._scheduler_config, "cache_memory_mb", None)
+        enable_mtp = (
+            self._scheduler_config.enable_mtp if self._scheduler_config else False
+        )
+        mtp_num_draft = getattr(self._scheduler_config, "mtp_num_draft_tokens", 1)
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,
             completion_batch_size=completion_batch_size,
             enable_vision_cache=True,
             vision_cache_size=100,
+            cache_memory_mb=cache_memory_mb,
+            enable_mtp=enable_mtp,
+            mtp_num_draft_tokens=mtp_num_draft,
         )
 
         # Create and start MLLM scheduler
@@ -240,6 +256,54 @@ class BatchedEngine(BaseEngine):
             f"max_num_seqs={max_num_seqs}, prefill_batch={prefill_batch_size}, "
             f"completion_batch={completion_batch_size}"
         )
+
+    def _inject_mtp_mllm(self) -> None:
+        """Inject MTP weights into the MLLM model's language_model."""
+        import json
+        from pathlib import Path
+
+        from mlx_lm.utils import _download
+
+        model = self._model
+        model_path = Path(_download(self._model_name))
+        config_path = model_path / "config.json"
+        if not config_path.exists():
+            logger.warning("[MTP-MLLM] No config.json found, skipping MTP")
+            return
+
+        with open(config_path) as f:
+            config = json.load(f)
+
+        text_config = config.get("text_config", config)
+        num_mtp = text_config.get("mtp_num_hidden_layers", 0)
+        if num_mtp == 0:
+            num_mtp = text_config.get(
+                "num_nextn_predict_layers",
+                config.get("num_nextn_predict_layers", 0),
+            )
+        if num_mtp == 0:
+            logger.info("[MTP-MLLM] No MTP layers in config, skipping")
+            return
+
+        # Navigate to text model
+        text_model = model
+        if hasattr(model, "language_model"):
+            text_model = model.language_model
+        if getattr(text_model, "mtp", None) is not None:
+            logger.info("[MTP-MLLM] Model already has MTP, skipping injection")
+            return
+
+        model_type = text_config.get("model_type", config.get("model_type", ""))
+        if "qwen3_5" in model_type:
+            from ..patches.qwen3_5_mtp import inject_mtp_support
+
+            ok = inject_mtp_support(model, model_path, config)
+            if ok:
+                logger.info("[MTP-MLLM] Qwen3.5 MTP injected successfully")
+            else:
+                logger.warning("[MTP-MLLM] Qwen3.5 MTP injection failed")
+        else:
+            logger.info(f"[MTP-MLLM] MTP not supported for model_type={model_type}")
 
     async def _start_llm(self) -> None:
         """Start the LLM engine with AsyncEngineCore."""
@@ -261,9 +325,10 @@ class BatchedEngine(BaseEngine):
 
         # Validate MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
+            from ..patches.qwen3_5_mtp import validate_mtp_support as validate_35
             from ..patches.qwen3_next_mtp import validate_mtp_support
 
-            if validate_mtp_support(self._model):
+            if validate_mtp_support(self._model) or validate_35(self._model):
                 logger.info("[MTP] Model validated for MTP speculative decoding")
             else:
                 logger.warning(
@@ -283,13 +348,14 @@ class BatchedEngine(BaseEngine):
                     device_info.get("memory_size", 0),
                 )
                 if max_recommended > 0:
-                    soft_limit = int(max_recommended * 0.90)
+                    soft_limit = int(max_recommended * self._gpu_memory_utilization)
                     mx.set_memory_limit(soft_limit)
                     mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                    pct = self._gpu_memory_utilization * 100
                     logger.info(
                         f"Metal memory limits set: "
                         f"allocation_limit={soft_limit / 1e9:.1f}GB "
-                        f"(90% of {max_recommended / 1e9:.1f}GB), "
+                        f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
                         f"cache_limit=32GB"
                     )
         except Exception as e:
@@ -301,6 +367,7 @@ class BatchedEngine(BaseEngine):
             model_name=self._model_name,
             scheduler_config=scheduler_config,
             stream_interval=self._stream_interval,
+            gpu_memory_utilization=self._gpu_memory_utilization,
         )
 
         # Create async engine
@@ -363,9 +430,13 @@ class BatchedEngine(BaseEngine):
             if self._is_mllm and num_images > 0:
                 messages = self._prepare_mllm_messages(messages)
 
+            # Disable thinking mode for coder models since it interferes
+            # with tool call parsing (tags leak as raw text).
+            enable_thinking = "coder" not in self._model_name.lower()
             template_kwargs = {
                 "tokenize": False,
                 "add_generation_prompt": True,
+                "enable_thinking": enable_thinking,
             }
             if tools:
                 template_kwargs["tools"] = tools
@@ -375,9 +446,10 @@ class BatchedEngine(BaseEngine):
                     messages, **template_kwargs
                 )
             except TypeError as e:
-                # Some templates don't accept 'tools'; retry without them.
+                # Some templates don't accept 'tools' or 'enable_thinking';
+                # retry without them.
                 logger.debug(f"Chat template TypeError, retrying without extras: {e}")
-                for key in ["tools"]:
+                for key in ["tools", "enable_thinking"]:
                     if key in template_kwargs:
                         del template_kwargs[key]
                 return template_applicator.apply_chat_template(
@@ -480,6 +552,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
         )
 
@@ -556,6 +629,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
         )
 
@@ -768,14 +842,26 @@ class BatchedEngine(BaseEngine):
         if self._mllm_scheduler:
             mllm_stats = self._mllm_scheduler.get_stats()
             stats["mllm_scheduler"] = mllm_stats
-            # Promote Metal memory stats to top-level for /v1/status
+            # Promote stats to top-level for /v1/status and monitoring
             for key in (
+                "running",
+                "num_running",
+                "num_waiting",
+                "num_requests_processed",
+                "total_prompt_tokens",
+                "total_completion_tokens",
                 "metal_active_memory_gb",
                 "metal_peak_memory_gb",
                 "metal_cache_memory_gb",
+                "memory_aware_cache",
+                "paged_cache",
+                "prefix_cache",
             ):
                 if key in mllm_stats:
                     stats[key] = mllm_stats[key]
+            # MLLM engine is always "running" once loaded
+            if "running" not in stats:
+                stats["running"] = self._loaded
         elif self._engine:
             stats.update(self._engine.get_stats())
 
@@ -783,8 +869,8 @@ class BatchedEngine(BaseEngine):
 
     def get_cache_stats(self) -> dict[str, Any] | None:
         """Get cache statistics."""
-        if self._mllm_scheduler and self._mllm_scheduler.vision_cache:
-            return self._mllm_scheduler.vision_cache.get_stats()
+        if self._mllm_scheduler and self._mllm_scheduler.batch_generator:
+            return self._mllm_scheduler.batch_generator.get_vision_cache_stats()
         elif self._engine:
             return self._engine.get_cache_stats()
         return None

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -139,17 +139,14 @@ class MLLMBatch:
         self.max_tokens.extend(other.max_tokens)
         self.requests.extend(other.requests)
 
-        # Extend cache - handle None and incompatible caches
+        # Extend cache - handle both BatchKVCache (.keys/.values) and
+        # ArraysCache (.cache list) from hybrid models like Qwen3.5
         for c, o in zip(self.cache, other.cache):
             if c is not None and o is not None and hasattr(c, "extend"):
                 try:
-                    # Only extend if both caches have valid keys
-                    if (
-                        hasattr(c, "keys")
-                        and c.keys is not None
-                        and hasattr(o, "keys")
-                        and o.keys is not None
-                    ):
+                    has_kv = hasattr(c, "keys") and c.keys is not None
+                    has_arrays = hasattr(c, "cache")
+                    if has_kv or has_arrays:
                         c.extend(o)
                 except Exception as e:
                     logger.warning(f"Failed to extend cache: {e}")
@@ -207,20 +204,26 @@ class MLLMBatchStats:
 
 def _make_batch_cache(model: nn.Module, left_padding: List[int]) -> List[Any]:
     """
-    Create batch-aware KV cache for the language model.
+    Create batch-aware cache for the language model.
+
+    Supports both KVCache (standard attention) and ArraysCache (hybrid
+    models like Qwen3.5 with GatedDeltaNet + attention layers).
 
     Args:
         model: The language model (model.language_model from VLM)
         left_padding: Padding amounts for left-padded prompts
 
     Returns:
-        List of BatchKVCache objects for each layer
+        List of batch cache objects for each layer
     """
-    from mlx_lm.models.cache import BatchKVCache, KVCache
+    from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
 
     def to_batch_cache(c):
         if isinstance(c, KVCache):
             return BatchKVCache(left_padding)
+        elif isinstance(c, ArraysCache):
+            # ArraysCache supports batching natively via merge/filter/extend
+            return c
         else:
             raise ValueError(f"{type(c)} does not yet support batching")
 
@@ -324,6 +327,11 @@ class MLLMBatchGenerator:
                 "MLLMBatchGenerator: Model does not have language_model, using model directly"
             )
 
+        # Patch Qwen3.5 attention for BatchKVCache compatibility
+        from .patches.qwen3_5_mllm import patch_qwen35_attention_for_batching
+
+        patch_qwen35_attention_for_batching()
+
         self.max_tokens = max_tokens
         self.stop_tokens = stop_tokens or set()
         self.sampler = sampler or (lambda x: mx.argmax(x, axis=-1))
@@ -339,6 +347,9 @@ class MLLMBatchGenerator:
 
         # Statistics
         self._stats = MLLMBatchStats()
+
+        # Error responses for requests that failed during preprocessing
+        self._pending_error_responses: List[MLLMBatchResponse] = []
 
         # Vision embedding cache for repeated images
         self.vision_cache = VisionEmbeddingCache(
@@ -613,23 +624,49 @@ class MLLMBatchGenerator:
 
         tic = time.perf_counter()
 
-        # Preprocess all requests
+        # Preprocess all requests (per-request error handling)
+        failed_requests = []
         for req in requests:
-            self._preprocess_request(req)
+            try:
+                self._preprocess_request(req)
+            except Exception as e:
+                logger.error(
+                    f"Failed to preprocess request {req.request_id}: "
+                    f"{type(e).__name__}: {e}"
+                )
+                failed_requests.append(req)
+
+        # Remove failed requests from batch and create error responses
+        if failed_requests:
+            for req in failed_requests:
+                requests.remove(req)
+                self._pending_error_responses.append(
+                    MLLMBatchResponse(
+                        uid=req.uid,
+                        request_id=req.request_id,
+                        token=0,
+                        logprobs=mx.zeros(1),
+                        finish_reason="error",
+                    )
+                )
+
+        if not requests:
+            # All requests failed
+            return None
 
         total_prompt_tokens = sum(
             req.input_ids.size if req.input_ids is not None else 1 for req in requests
         )
         self._stats.prompt_tokens += total_prompt_tokens
 
-        # Guard against excessive memory usage during cache merge.
-        # Each token in the batch requires KV entries across all layers.
+        # Log large prompts for monitoring (was previously a hard check that
+        # caused infinite retry loops when requests exceeded the limit).
         max_batch_tokens = self.prefill_step_size * len(requests)
         if total_prompt_tokens > max_batch_tokens:
-            raise ValueError(
-                f"Total prompt tokens ({total_prompt_tokens}) exceeds safe limit "
-                f"({max_batch_tokens}) for {len(requests)} requests. "
-                f"Reduce prompt length or batch size."
+            logger.warning(
+                f"Large batch prefill: {total_prompt_tokens} tokens "
+                f"(step_size={self.prefill_step_size}, requests={len(requests)}). "
+                f"Processing may be slow."
             )
 
         # Run vision encoding for each request with its own KVCache.
@@ -662,20 +699,9 @@ class MLLMBatchGenerator:
 
             per_request_caches.append(request_cache)
 
-        # Merge per-request KVCaches into a single BatchKVCache.
-        # KVCache.merge() creates a BatchKVCache with proper left-padding
-        # alignment, so all requests share a single batched cache for
-        # subsequent generation steps.
-        from mlx_lm.models.cache import KVCache
-
-        sample_cache = per_request_caches[0][0]
-        if not isinstance(sample_cache, KVCache):
-            raise ValueError(
-                f"MLLM continuous batching requires standard KVCache but got "
-                f"{type(sample_cache).__name__}. Disable --kv-cache-quantization "
-                f"when using multimodal models with --continuous-batching."
-            )
-
+        # Merge per-request caches into batched caches.
+        # Both KVCache.merge() and ArraysCache.merge() produce batch-aware
+        # caches that support filter/extend/extract for continuous batching.
         try:
             batch_cache = [
                 per_request_caches[0][layer_idx].merge(
@@ -684,8 +710,10 @@ class MLLMBatchGenerator:
                 for layer_idx in range(len(per_request_caches[0]))
             ]
         except Exception as e:
+            sample_type = type(per_request_caches[0][0]).__name__
             logger.error(
-                f"Failed to merge per-request KV caches: {type(e).__name__}: {e}"
+                f"Failed to merge per-request caches ({sample_type}): "
+                f"{type(e).__name__}: {e}"
             )
             raise
 
@@ -769,10 +797,16 @@ class MLLMBatchGenerator:
             self.active_batch = new_batch
             prompt_processing = True
 
+        # Collect any pending error responses (from failed preprocessing)
+        error_responses = []
+        if self._pending_error_responses:
+            error_responses = list(self._pending_error_responses)
+            self._pending_error_responses.clear()
+
         # Generate next token for active batch
         batch = self.active_batch
         if batch is None:
-            return []
+            return error_responses
 
         y, logprobs = batch.y, batch.logprobs
         batch.y, batch.logprobs = self._step(y[:, None], batch.cache)
@@ -841,7 +875,7 @@ class MLLMBatchGenerator:
                 self.active_batch = None
 
         self._stats.generation_tokens += len(responses)
-        return responses
+        return error_responses + responses
 
     def next(self) -> List[MLLMBatchResponse]:
         """
@@ -870,3 +904,312 @@ class MLLMBatchGenerator:
     def has_pending(self) -> bool:
         """Check if there are pending or active requests."""
         return bool(self.unprocessed_requests or self.active_batch)
+
+
+def install_mtp_mllm(
+    batch_gen: "MLLMBatchGenerator",
+    language_model: Any,
+    num_draft_tokens: int = 1,
+) -> None:
+    """Install MTP (Multi-Token Prediction) on an MLLMBatchGenerator.
+
+    Adapts the always-advance MTP strategy from scheduler._install_mtp
+    for the MLLM batched generation path. Handles hybrid model caches
+    (BatchKVCache for attention + ArraysCache for recurrent layers).
+
+    Flow per generation step:
+    1. Use skip_state logits/hidden OR run model forward -> sample primary
+    2. MTP head drafts one token
+    3. Verify [primary, draft] in one model call (always advances cache)
+    4. Accept: skip_state from pos 1, defer draft for next step emission
+       Reject: trim KV by 2 + restore RNN state + re-advance with primary
+    5. Draft is emitted in the NEXT generation step after primary
+    """
+    from .scheduler import make_sampler
+
+    _orig_step = batch_gen._step
+    _draft_sampler = make_sampler(temp=0.0)
+
+    # Skip state: stored logits + hidden from verify pass
+    _skip_state: list = [None]
+
+    # Deferred drafts keyed by UID
+    _deferred_drafts: Dict[int, dict] = {}
+
+    # MTP stats
+    _mtp_stats = {"accepted": 0, "rejected": 0, "errors": 0}
+
+    def _mtp_step(
+        input_tokens: mx.array, cache: List[Any]
+    ) -> Tuple[mx.array, List[mx.array]]:
+        """Extended _step with MTP always-advance strategy."""
+        batch_size = input_tokens.shape[0]
+
+        # Prefill guard: skip MTP for multi-token input or when no active batch
+        # Also skip MTP when batch has multiple active requests (MTP overhead
+        # hurts aggregate throughput in concurrent scenarios)
+        if (
+            input_tokens.shape[1] > 1
+            or batch_gen.active_batch is None
+            or len(batch_gen.active_batch) > 1
+        ):
+            _skip_state[0] = None
+            return _orig_step(input_tokens, cache)
+
+        # Check skip state
+        skip = _skip_state[0]
+        if skip is not None and skip["logits"].shape[0] != batch_size:
+            skip = None
+            _skip_state[0] = None
+
+        if skip is not None:
+            logits = skip["logits"]
+            hidden_states = skip["hidden"]
+            _skip_state[0] = None
+        else:
+            # Normal forward with return_hidden
+            model_output = language_model(input_tokens, cache=cache, return_hidden=True)
+            if isinstance(model_output, tuple):
+                logits, hidden_states = model_output
+            else:
+                return _orig_step(input_tokens, cache)
+            logits = logits[:, -1, :]
+
+        # Sample primary
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        primary_tokens = batch_gen.sampler(logprobs)
+
+        current_uids = list(batch_gen.active_batch.uids)
+
+        # MTP draft + always-advance verify
+        try:
+            draft_logits = language_model.mtp_forward(
+                hidden_states[:, -1:, :],
+                primary_tokens[:, None],
+                mtp_cache=None,
+            )
+            draft_logits = draft_logits[:, -1, :]
+            draft_logprobs = draft_logits - mx.logsumexp(
+                draft_logits, axis=-1, keepdims=True
+            )
+            draft_tokens = _draft_sampler(draft_logprobs)
+
+            # Snapshot RNN state for hybrid models
+            _rnn_snapshots = {}
+            for _ci, _c in enumerate(cache):
+                if not (hasattr(_c, "is_trimmable") and _c.is_trimmable()):
+                    if hasattr(_c, "state"):
+                        _rnn_snapshots[_ci] = [
+                            mx.array(s) if s is not None else None for s in _c.state
+                        ]
+
+            # Verify [primary, draft]
+            verify_input = mx.concatenate(
+                [primary_tokens[:, None], draft_tokens[:, None]], axis=1
+            )
+            verify_output = language_model(
+                verify_input, cache=cache, return_hidden=True
+            )
+            if isinstance(verify_output, tuple):
+                verify_logits, verify_hidden = verify_output
+            else:
+                verify_logits = verify_output
+                verify_hidden = None
+
+            # Verified mode: check if draft matches verify prediction
+            verify_pred = mx.argmax(verify_logits[:, 0, :], axis=-1)
+            mx.eval(verify_pred, draft_tokens)
+            pred_list = verify_pred.tolist()
+            draft_list = draft_tokens.tolist()
+            all_accepted = pred_list == draft_list
+
+            if all_accepted and verify_hidden is not None:
+                # ACCEPT
+                _skip_state[0] = {
+                    "logits": verify_logits[:, 1, :],
+                    "hidden": verify_hidden[:, -1:, :],
+                }
+                mx.async_eval(_skip_state[0]["logits"], _skip_state[0]["hidden"])
+                verify_lp = verify_logits[:, 0, :] - mx.logsumexp(
+                    verify_logits[:, 0, :], axis=-1, keepdims=True
+                )
+                for e in range(batch_size):
+                    uid = current_uids[e]
+                    _deferred_drafts[uid] = {
+                        "token": draft_list[e],
+                        "logprobs": verify_lp[e],
+                    }
+                _mtp_stats["accepted"] += 1
+
+            else:
+                # REJECT
+                if _rnn_snapshots:
+                    # Hybrid model: undo entire verify, re-advance with primary
+                    for c in cache:
+                        if (
+                            hasattr(c, "is_trimmable")
+                            and c.is_trimmable()
+                            and hasattr(c, "trim")
+                        ):
+                            c.trim(2)
+                    for _ci, _snap in _rnn_snapshots.items():
+                        cache[_ci].state = _snap
+                    rerun_out = language_model(
+                        primary_tokens[:, None],
+                        cache=cache,
+                        return_hidden=True,
+                    )
+                    if isinstance(rerun_out, tuple):
+                        rerun_logits, rerun_hidden = rerun_out
+                    else:
+                        rerun_logits = rerun_out
+                        rerun_hidden = None
+                    if rerun_hidden is not None:
+                        _skip_state[0] = {
+                            "logits": rerun_logits[:, -1, :],
+                            "hidden": rerun_hidden[:, -1:, :],
+                        }
+                        mx.async_eval(
+                            _skip_state[0]["logits"],
+                            _skip_state[0]["hidden"],
+                        )
+                    else:
+                        _skip_state[0] = None
+                else:
+                    # Pure attention model: simple trim
+                    for c in cache:
+                        if (
+                            hasattr(c, "is_trimmable")
+                            and c.is_trimmable()
+                            and hasattr(c, "trim")
+                        ):
+                            c.trim(1)
+                    if verify_hidden is not None:
+                        _skip_state[0] = {
+                            "logits": verify_logits[:, 0, :],
+                            "hidden": verify_hidden[:, 0:1, :],
+                        }
+                        mx.async_eval(
+                            _skip_state[0]["logits"],
+                            _skip_state[0]["hidden"],
+                        )
+                    else:
+                        _skip_state[0] = None
+                for uid in current_uids:
+                    _deferred_drafts.pop(uid, None)
+                _mtp_stats["rejected"] += 1
+
+        except Exception as e:
+            logger.warning(f"[MTP-MLLM] draft/verify failed: {e}")
+            _skip_state[0] = None
+            _mtp_stats["errors"] += 1
+
+        # Log MTP stats every 50 steps
+        total = _mtp_stats["accepted"] + _mtp_stats["rejected"] + _mtp_stats["errors"]
+        if total > 0 and total % 50 == 0:
+            acc = _mtp_stats["accepted"]
+            rej = _mtp_stats["rejected"]
+            err = _mtp_stats["errors"]
+            rate = acc / (acc + rej) * 100 if (acc + rej) > 0 else 0
+            logger.info(
+                f"[MTP-MLLM] stats: accepted={acc} rejected={rej} "
+                f"errors={err} acceptance={rate:.0f}%"
+            )
+
+        return primary_tokens, list(logprobs)
+
+    # Wrap _next to emit deferred MTP drafts
+    batch_gen._inner_next = batch_gen._next
+
+    def _mtp_next() -> List[MLLMBatchResponse]:
+        """Wrapper around _next that emits deferred MTP draft tokens."""
+        if batch_gen.active_batch is None:
+            _skip_state[0] = None
+            _deferred_drafts.clear()
+
+        # Save deferred drafts from previous step
+        prev_deferred: Dict[int, dict] = {}
+        if batch_gen.active_batch is not None:
+            for uid in batch_gen.active_batch.uids:
+                if uid in _deferred_drafts:
+                    prev_deferred[uid] = _deferred_drafts.pop(uid)
+
+        responses = batch_gen._inner_next()
+
+        if not prev_deferred or not responses:
+            return responses
+
+        # Augment responses with deferred drafts
+        augmented: List[MLLMBatchResponse] = []
+        draft_end_uids: set = set()
+
+        for r in responses:
+            uid = r.uid
+            augmented.append(r)
+
+            if r.finish_reason is not None:
+                _deferred_drafts.pop(uid, None)
+                prev_deferred.pop(uid, None)
+                continue
+
+            if uid in prev_deferred:
+                draft_info = prev_deferred.pop(uid)
+                draft_t = draft_info["token"]
+                draft_lp = draft_info["logprobs"]
+
+                if draft_t in batch_gen.stop_tokens:
+                    augmented.append(
+                        MLLMBatchResponse(
+                            uid=uid,
+                            request_id=r.request_id,
+                            token=draft_t,
+                            logprobs=draft_lp,
+                            finish_reason="stop",
+                        )
+                    )
+                    draft_end_uids.add(uid)
+                else:
+                    draft_finish = None
+                    batch = batch_gen.active_batch
+                    if batch is not None:
+                        for e, bu in enumerate(batch.uids):
+                            if bu == uid:
+                                batch.num_tokens[e] += 1
+                                batch.requests[e].output_tokens.append(draft_t)
+                                if batch.num_tokens[e] >= batch.max_tokens[e]:
+                                    draft_finish = "length"
+                                    draft_end_uids.add(uid)
+                                break
+
+                    augmented.append(
+                        MLLMBatchResponse(
+                            uid=uid,
+                            request_id=r.request_id,
+                            token=draft_t,
+                            logprobs=draft_lp,
+                            finish_reason=draft_finish,
+                        )
+                    )
+
+        # Remove sequences that finished due to draft tokens
+        if draft_end_uids and batch_gen.active_batch is not None:
+            keep = [
+                e
+                for e, u in enumerate(batch_gen.active_batch.uids)
+                if u not in draft_end_uids
+            ]
+            if keep:
+                batch_gen.active_batch.filter(keep)
+            else:
+                batch_gen.active_batch = None
+
+        return augmented
+
+    batch_gen._step = _mtp_step
+    batch_gen._next = _mtp_next
+
+    total = _mtp_stats
+    logger.info(
+        f"[MTP-MLLM] installed with num_draft_tokens={num_draft_tokens}, "
+        f"always-advance verified mode"
+    )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -35,7 +35,6 @@ from .mllm_batch_generator import (
     MLLMBatchRequest,
     MLLMBatchResponse,
 )
-from .mllm_cache import MLLMCacheManager
 from .multimodal_processor import MultimodalProcessor
 from .request import RequestOutput, RequestStatus, SamplingParams
 
@@ -62,8 +61,14 @@ class MLLMSchedulerConfig:
     default_max_tokens: int = 256
     # Default video FPS for frame extraction
     default_video_fps: float = 2.0
+    # KV cache memory limit (from --cache-memory-mb)
+    cache_memory_mb: Optional[int] = None
     # Maximum video frames
     max_video_frames: int = 128
+    # Enable MTP speculative decoding
+    enable_mtp: bool = False
+    # Number of draft tokens for MTP
+    mtp_num_draft_tokens: int = 1
 
 
 @dataclass
@@ -176,13 +181,6 @@ class MLLMScheduler:
             config=self.model_config,
         )
 
-        # Vision cache for repeated images
-        self.vision_cache: Optional[MLLMCacheManager] = None
-        if self.config.enable_vision_cache:
-            self.vision_cache = MLLMCacheManager(
-                max_entries=self.config.vision_cache_size
-            )
-
         # Get stop tokens from tokenizer
         self.stop_tokens = self._get_stop_tokens()
 
@@ -217,6 +215,10 @@ class MLLMScheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+
+        # Memory management: periodic mx.clear_cache() to free Metal buffers
+        self._step_count = 0
+        self._clear_cache_interval = 32
 
     def _get_stop_tokens(self) -> Set[int]:
         """Get stop token IDs from tokenizer."""
@@ -260,6 +262,18 @@ class MLLMScheduler:
                 completion_batch_size=self.config.completion_batch_size,
                 prefill_step_size=self.config.prefill_step_size,
             )
+
+            # Install MTP if enabled and language model supports it
+            if self.config.enable_mtp:
+                lm = self.batch_generator.language_model
+                if hasattr(lm, "mtp") and lm.mtp is not None:
+                    from .mllm_batch_generator import install_mtp_mllm
+
+                    install_mtp_mllm(
+                        self.batch_generator,
+                        lm,
+                        num_draft_tokens=self.config.mtp_num_draft_tokens,
+                    )
 
     # ========== Sync API (step-based) ==========
 
@@ -453,6 +467,27 @@ class MLLMScheduler:
             if request is None:
                 continue
 
+            # Handle error responses from failed preprocessing
+            if response.finish_reason == "error":
+                output = RequestOutput(
+                    request_id=request_id,
+                    new_token_ids=[],
+                    new_text="",
+                    output_token_ids=[],
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    finished=True,
+                    finish_reason="error",
+                )
+                request.status = RequestStatus.FINISHED_ABORTED
+                request.output_text = ""
+                request.finish_reason = "error"
+                finished_ids.add(request_id)
+                self.num_requests_processed += 1
+                logger.warning(f"Request {request_id} failed during preprocessing")
+                outputs.append(output)
+                continue
+
             # Append token to request
             request.output_tokens.append(response.token)
             request.num_output_tokens = len(request.output_tokens)
@@ -524,6 +559,9 @@ class MLLMScheduler:
             if request_id in self.running:
                 del self.running[request_id]
 
+            # Drain from requests dict to prevent linear memory growth
+            self.requests.pop(request_id, None)
+
             # Remove UID mappings
             if request_id in self.request_id_to_uid:
                 uid = self.request_id_to_uid[request_id]
@@ -534,6 +572,10 @@ class MLLMScheduler:
             # Track as finished
             self.finished_req_ids.add(request_id)
             self.requests.pop(request_id, None)
+
+        # Clear Metal buffer pool after cleanup to release memory
+        if finished_ids:
+            mx.clear_cache()
 
     def step(self) -> MLLMSchedulerOutput:
         """
@@ -594,6 +636,15 @@ class MLLMScheduler:
         # Clear finished tracking for next step
         self.finished_req_ids = set()
 
+        # Adaptive periodic Metal cache clearing (ported from LLM scheduler)
+        self._step_count += 1
+        active_seqs = len(self.running)
+        effective_interval = max(
+            8, self._clear_cache_interval // max(1, active_seqs // 4)
+        )
+        if self._step_count % effective_interval == 0:
+            mx.clear_cache()
+
         return output
 
     def get_request(self, request_id: str) -> Optional[MLLMRequest]:
@@ -649,7 +700,7 @@ class MLLMScheduler:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error(f"Error in MLLM process loop: {e}")
+                logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
                 await asyncio.sleep(0.1)
 
     async def add_request_async(
@@ -792,22 +843,55 @@ class MLLMScheduler:
         if self.batch_generator is not None:
             batch_stats = self.batch_generator.stats()
             stats["batch_generator"] = batch_stats.to_dict()
-            # Add vision embedding cache stats from batch generator
-            stats["vision_embedding_cache"] = (
-                self.batch_generator.get_vision_cache_stats()
-            )
-
-        if self.vision_cache:
-            stats["vision_cache"] = self.vision_cache.get_stats()
+            # Vision embedding cache stats from batch generator
+            vec_stats = self.batch_generator.get_vision_cache_stats()
+            stats["vision_embedding_cache"] = vec_stats
 
         # Include Metal memory stats
         try:
             if mx.metal.is_available():
-                stats["metal_active_memory_gb"] = round(mx.get_active_memory() / 1e9, 2)
-                stats["metal_peak_memory_gb"] = round(mx.get_peak_memory() / 1e9, 2)
-                stats["metal_cache_memory_gb"] = round(mx.get_cache_memory() / 1e9, 2)
+                active_gb = round(mx.get_active_memory() / 1e9, 2)
+                peak_gb = round(mx.get_peak_memory() / 1e9, 2)
+                cache_gb = round(mx.get_cache_memory() / 1e9, 2)
+                stats["metal_active_memory_gb"] = active_gb
+                stats["metal_peak_memory_gb"] = peak_gb
+                stats["metal_cache_memory_gb"] = cache_gb
         except Exception:
-            pass
+            active_gb = 0
+            cache_gb = 0
+
+        # Build KV cache stats for /v1/status and monitoring UI.
+        # Combine Metal KV cache memory with vision embedding cache hits.
+        max_mb = float(self.config.cache_memory_mb or 0)
+        current_mb = round(cache_gb * 1024, 2)
+        vec_stats = (
+            self.batch_generator.get_vision_cache_stats()
+            if self.batch_generator
+            else {}
+        )
+        hits = vec_stats.get("pixel_cache_hits", 0) + vec_stats.get(
+            "encoding_cache_hits", 0
+        )
+        misses = vec_stats.get("pixel_cache_misses", 0) + vec_stats.get(
+            "encoding_cache_misses", 0
+        )
+        total = hits + misses
+        entries = (
+            vec_stats.get("pixel_cache_size", 0)
+            + vec_stats.get("pixel_only_cache_size", 0)
+            + vec_stats.get("encoding_cache_size", 0)
+        )
+        stats["memory_aware_cache"] = {
+            "hits": hits,
+            "misses": misses,
+            "hit_rate": round(hits / total, 4) if total > 0 else 0.0,
+            "evictions": 0,
+            "tokens_saved": 0,
+            "current_memory_mb": current_mb,
+            "max_memory_mb": max_mb,
+            "memory_utilization": round(current_mb / max_mb, 4) if max_mb > 0 else 0.0,
+            "entry_count": entries,
+        }
 
         return stats
 

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Runtime MTP (Multi-Token Prediction) support for Qwen3.5 models.
+
+Qwen3.5 models may include a built-in MTP head that predicts token n+2
+from hidden states + token n+1.  MTP weights are added to the quantized
+MLX model via scripts/add_mtp_weights_qwen35.py.
+
+Since mlx_lm's qwen3_5.py does NOT define MTP module/methods, this
+module provides:
+  - inject_mtp_support(): dynamically creates MTP module, loads weights,
+    and monkey-patches the model class with return_hidden, mtp_forward,
+    and make_mtp_cache
+  - validate_mtp_support(): checks whether a loaded model has working MTP
+
+Supports both Dense (27B) and MoE (122B-A10B, 35B-A3B) architectures.
+
+The actual MTP scheduling logic lives in:
+  - vllm_mlx/scheduler.py  (_install_mtp, _mtp_step, _mtp_next)
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fixup_moe_mtp(mtp, inner_model, loaded_keys: set, mx) -> None:
+    """Fix missing weights in MoE MTP module.
+
+    MoE MTP checkpoints (122B, 35B) only contain: fc, q_proj, o_proj,
+    shared_expert.*, and per-expert weights.  Missing:
+    - k_proj, v_proj → zero out (attention becomes no-op)
+    - gate, shared_expert_gate → copy from main model's last full-attn layer
+    - norms → already at identity (weight=1.0), no action needed
+    """
+    import mlx.utils
+
+    mtp_layer = mtp.layers[0]
+
+    # Find last full-attention layer in main model for gate weights
+    last_fa_layer = None
+    for layer in reversed(inner_model.layers):
+        if not layer.is_linear:
+            last_fa_layer = layer
+            break
+
+    if last_fa_layer is None:
+        logger.warning("[MTP fixup] No full-attention layer found in main model")
+        return
+
+    # Copy expert routing gate if not in checkpoint
+    if "layers.0.mlp.gate.weight" not in loaded_keys:
+        src = getattr(last_fa_layer.mlp, "gate", None)
+        dst = getattr(mtp_layer.mlp, "gate", None)
+        if src is not None and dst is not None:
+            src_params = mlx.utils.tree_flatten(src.parameters())
+            dst.load_weights(src_params)
+            mx.eval(dst.parameters())
+            logger.info("[MTP fixup] Copied mlp.gate from main model last layer")
+
+    # Copy shared_expert_gate if not in checkpoint
+    if "layers.0.mlp.shared_expert_gate.weight" not in loaded_keys:
+        src = getattr(last_fa_layer.mlp, "shared_expert_gate", None)
+        dst = getattr(mtp_layer.mlp, "shared_expert_gate", None)
+        if src is not None and dst is not None:
+            src_params = mlx.utils.tree_flatten(src.parameters())
+            dst.load_weights(src_params)
+            mx.eval(dst.parameters())
+            logger.info(
+                "[MTP fixup] Copied shared_expert_gate from main model last layer"
+            )
+
+    # Zero out k_proj and v_proj → attention becomes no-op
+    attn = getattr(mtp_layer, "self_attn", None)
+    if attn is None:
+        return
+
+    for proj_name in ("k_proj", "v_proj"):
+        key = f"layers.0.self_attn.{proj_name}.weight"
+        if key not in loaded_keys:
+            proj = getattr(attn, proj_name, None)
+            if proj is None:
+                continue
+            # For quantized layers: zero scales+biases → dequantized = 0
+            if hasattr(proj, "scales"):
+                proj.scales = mx.zeros_like(proj.scales)
+                proj.biases = mx.zeros_like(proj.biases)
+            else:
+                proj.weight = mx.zeros_like(proj.weight)
+            mx.eval(proj.parameters())
+            logger.info(f"[MTP fixup] Zeroed {proj_name} (not in checkpoint)")
+
+
+def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
+    """Inject MTP module into a loaded Qwen3.5 model.
+
+    mlx_lm's qwen3_5.py does not define MTP layers, so we:
+    1. Create MTP module matching the weight structure
+    2. Quantize it to match the base model
+    3. Load MTP weights from model-mtp.safetensors
+    4. Monkey-patch Model with return_hidden, mtp_forward, make_mtp_cache
+
+    Args:
+        model: A model loaded via mlx_lm (strict=False, MTP weights ignored)
+        model_path: Path to model directory (contains model-mtp.safetensors)
+        config: Parsed config.json dict
+
+    Returns:
+        True if MTP was successfully injected, False otherwise.
+    """
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    # Navigate nested config: text_config for VLM wrappers
+    text_config = config.get("text_config", config)
+    num_mtp_layers = text_config.get("mtp_num_hidden_layers", 0)
+    if num_mtp_layers == 0:
+        # Fallback: check flat config for num_nextn_predict_layers
+        num_mtp_layers = text_config.get(
+            "num_nextn_predict_layers",
+            config.get("num_nextn_predict_layers", 0),
+        )
+    if num_mtp_layers == 0:
+        logger.info("[MTP inject] No MTP layers configured, skipping")
+        return False
+
+    model_path = Path(model_path)
+    # Look for MTP weights in mtp/ subdirectory first (avoids mlx_vlm glob),
+    # then fall back to model-mtp.safetensors in model dir.
+    mtp_file = model_path / "mtp" / "weights.safetensors"
+    if not mtp_file.exists():
+        mtp_file = model_path / "model-mtp.safetensors"
+    if not mtp_file.exists():
+        logger.warning(f"[MTP inject] MTP weights not found in {model_path}")
+        return False
+
+    # Get model args — navigate VLM wrapper if needed
+    # Model hierarchy: Model → language_model (TextModel) → model (Qwen3_5TextModel)
+    text_model = model
+    if hasattr(model, "language_model"):
+        text_model = model.language_model
+
+    args = text_model.args
+
+    # When loaded via mlx_vlm, args may be a TextConfig object missing fields
+    # that mlx_lm's TextModelArgs defines (rope_theta, partial_rotary_factor,
+    # rope_scaling, etc.). Build a proper TextModelArgs from the config dict.
+    from mlx_lm.models.qwen3_5 import TextModelArgs
+
+    if not isinstance(args, TextModelArgs):
+        logger.info("[MTP inject] Building TextModelArgs from config dict")
+        args = TextModelArgs.from_dict(text_config)
+
+    # Detect MoE vs Dense from args
+    num_experts = getattr(args, "num_experts", 0)
+    is_moe = num_experts > 0
+
+    # Import model components
+    from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+    from mlx_lm.models.cache import KVCache
+    from mlx_lm.models.qwen3_5 import DecoderLayer
+
+    logger.info(
+        f"[MTP inject] Creating MTP module ({num_mtp_layers} layers, "
+        f"{'MoE' if is_moe else 'Dense'})"
+    )
+
+    # MTP decoder uses full attention (not GatedDeltaNet).
+    # layer_idx = full_attention_interval - 1 ensures is_linear=False.
+    fa_idx = args.full_attention_interval - 1
+
+    class _MTPModule(nn.Module):
+        def __init__(self, args, n_layers):
+            super().__init__()
+            self.pre_fc_norm_hidden = nn.RMSNorm(
+                args.hidden_size, eps=args.rms_norm_eps
+            )
+            self.pre_fc_norm_embedding = nn.RMSNorm(
+                args.hidden_size, eps=args.rms_norm_eps
+            )
+            self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+            self.layers = [
+                DecoderLayer(args, layer_idx=fa_idx) for _ in range(n_layers)
+            ]
+            self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    mtp = _MTPModule(args, num_mtp_layers)
+
+    # --- Load MTP weights in BF16 (no quantization) ---
+    # MTP head is extremely sensitive to quantization — even 4-bit destroys
+    # prediction quality (0% acceptance).  Keep MTP in full precision.
+    # See: https://github.com/vllm-project/vllm/issues/36331
+    quant_config = text_config.get("quantization", config.get("quantization", {}))
+    bits = quant_config.get("bits", 4) if quant_config else 4
+    group_size = quant_config.get("group_size", 64) if quant_config else 64
+
+    logger.info(
+        f"[MTP inject] Loading weights from {mtp_file.name} (BF16, no quantization)"
+    )
+    raw = mx.load(str(mtp_file))
+    raw_mtp = {
+        k.removeprefix("mtp."): v for k, v in raw.items() if k.startswith("mtp.")
+    }
+    del raw
+
+    # Dequantize any quantized weight triplets (weight + scales + biases)
+    mtp_weights: dict[str, mx.array] = {}
+    processed = set()
+    for key in sorted(raw_mtp.keys()):
+        if key in processed:
+            continue
+        if key.endswith(".scales") or key.endswith(".biases"):
+            continue
+
+        scales_key = key.replace(".weight", ".scales")
+        biases_key = key.replace(".weight", ".biases")
+
+        if scales_key in raw_mtp and biases_key in raw_mtp:
+            # Quantized triplet → dequantize to BF16
+            dq = mx.dequantize(
+                raw_mtp[key],
+                raw_mtp[scales_key],
+                raw_mtp[biases_key],
+                group_size=group_size,
+                bits=bits,
+            )
+            mtp_weights[key] = dq
+            processed.update([key, scales_key, biases_key])
+        else:
+            # Already FP (norms, fc, shared_expert_gate)
+            mtp_weights[key] = raw_mtp[key]
+            processed.add(key)
+    del raw_mtp
+
+    mtp.load_weights(list(mtp_weights.items()), strict=False)
+    mx.eval(mtp.parameters())
+
+    dq_count = sum(1 for k in mtp_weights if not k.endswith((".scales", ".biases")))
+    has_quantized = any(k.endswith(".scales") for k in processed)
+    mode = "dequantized from quantized" if has_quantized else "native BF16"
+    logger.info(f"[MTP inject] Loaded {dq_count} MTP weight tensors ({mode})")
+
+    # --- Step 4: Fix missing MoE MTP weights ---
+    # MoE checkpoints lack: k_proj, v_proj, gate, shared_expert_gate, norms.
+    # Norms default to identity (weight=1.0) which is correct.
+    # k_proj/v_proj: zero out → attention becomes no-op, MLP does prediction.
+    # gate/shared_expert_gate: copy from main model's last full-attention layer.
+    if is_moe:
+        loaded_key_set = set(mtp_weights.keys())
+        _fixup_moe_mtp(mtp, text_model.model, loaded_key_set, mx)
+
+    # --- Attach MTP and monkey-patch model class ---
+    text_model.mtp = mtp
+
+    original_class = text_model.__class__
+
+    class _Qwen3_5MTP(original_class):
+        """Qwen3.5 with MTP support (injected at runtime)."""
+
+        def __call__(
+            self,
+            inputs,
+            cache=None,
+            return_hidden: bool = False,
+            input_embeddings=None,
+            **kwargs,
+        ):
+            inner = self.model
+            if input_embeddings is not None:
+                hidden_states = input_embeddings
+            else:
+                hidden_states = inner.embed_tokens(inputs)
+
+            if cache is None:
+                cache = [None] * len(inner.layers)
+
+            fa_mask = create_attention_mask(hidden_states, cache[inner.fa_idx])
+            ssm_mask = create_ssm_mask(hidden_states, cache[inner.ssm_idx])
+
+            for layer, c in zip(inner.layers, cache):
+                mask = ssm_mask if layer.is_linear else fa_mask
+                hidden_states = layer(hidden_states, mask=mask, cache=c)
+
+            normed = inner.norm(hidden_states)
+
+            if self.args.tie_word_embeddings:
+                out = inner.embed_tokens.as_linear(normed)
+            else:
+                out = self.lm_head(normed)
+
+            if return_hidden:
+                return out, normed  # post-norm hidden states (MTP expects post-norm)
+            return out
+
+        def mtp_forward(
+            self,
+            hidden_states,
+            next_token_ids,
+            cache=None,
+            mtp_cache=None,
+        ):
+            """Run MTP head: predict token n+2 from hidden states + token n+1."""
+            input_embeds = self.model.embed_tokens(next_token_ids)
+            e = self.mtp.pre_fc_norm_embedding(input_embeds)
+            h = self.mtp.pre_fc_norm_hidden(hidden_states)
+            x = self.mtp.fc(mx.concatenate([e, h], axis=-1))
+
+            layer = self.mtp.layers[0]
+            c = mtp_cache[0] if mtp_cache else None
+            mask = create_attention_mask(x, c)
+            x = layer(x, mask=mask, cache=c)
+
+            x = self.mtp.norm(x)
+
+            if self.args.tie_word_embeddings:
+                return self.model.embed_tokens.as_linear(x)
+            return self.lm_head(x)
+
+        def make_mtp_cache(self):
+            """Create KV cache for MTP layers."""
+            if self.mtp is None:
+                return None
+            return [KVCache() for _ in self.mtp.layers]
+
+    text_model.__class__ = _Qwen3_5MTP
+    logger.info("[MTP inject] Model class patched with MTP support")
+
+    # If we patched the inner language_model, also expose MTP on the outer Model
+    if hasattr(model, "language_model") and model.language_model is text_model:
+        model.mtp = mtp
+
+    return True
+
+
+def validate_mtp_support(model: Any) -> bool:
+    """Validate that a loaded model has working MTP support.
+
+    Checks:
+    1. model.mtp exists and is not None
+    2. model.mtp has layers with loaded weights
+    3. model has return_hidden support in __call__
+    4. model has mtp_forward method
+    5. model has make_mtp_cache method
+
+    Args:
+        model: A model loaded via mlx_lm.load()
+
+    Returns:
+        True if MTP is fully functional, False otherwise.
+    """
+    # Navigate to text model if VLM wrapper
+    text_model = model
+    if hasattr(model, "language_model"):
+        text_model = model.language_model
+
+    mtp = getattr(text_model, "mtp", None)
+    if mtp is None:
+        args = getattr(text_model, "args", None)
+        if args is not None:
+            num_mtp = getattr(args, "mtp_num_hidden_layers", 0)
+            if num_mtp == 0:
+                num_mtp = getattr(args, "num_nextn_predict_layers", 0)
+            if num_mtp > 0:
+                logger.warning(
+                    "[MTP] Model config has MTP layers=%d but model.mtp is None. "
+                    "Run scripts/add_mtp_weights_qwen35.py to add weights.",
+                    num_mtp,
+                )
+        return False
+
+    mtp_layers = getattr(mtp, "layers", [])
+    if not mtp_layers:
+        logger.warning("[MTP] model.mtp exists but has no layers.")
+        return False
+
+    import inspect
+
+    call_sig = inspect.signature(type(text_model).__call__)
+    if "return_hidden" not in call_sig.parameters:
+        logger.warning("[MTP] Model.__call__ does not accept return_hidden parameter.")
+        return False
+
+    if not hasattr(text_model, "mtp_forward") or not callable(text_model.mtp_forward):
+        logger.warning("[MTP] Model does not have mtp_forward() method.")
+        return False
+
+    if not hasattr(text_model, "make_mtp_cache") or not callable(
+        text_model.make_mtp_cache
+    ):
+        logger.warning("[MTP] Model does not have make_mtp_cache() method.")
+        return False
+
+    logger.info(
+        "[MTP] Qwen3.5 model has working MTP support: %d MTP layer(s)",
+        len(mtp_layers),
+    )
+    return True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -761,8 +761,7 @@ def _install_mtp(
                 log_accept_ratio = verify_at_d - draft_at_d
                 mx.eval(log_accept_ratio)
                 all_accepted = all(
-                    lar >= 0
-                    or math.log(random.random() or 1e-35) < lar
+                    lar >= 0 or math.log(random.random() or 1e-35) < lar
                     for lar in log_accept_ratio.tolist()
                 )
                 draft_list = draft_tokens.tolist()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -12,6 +12,8 @@ The scheduler follows vLLM's design with:
 """
 
 import logging
+import math
+import random
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
@@ -741,12 +743,29 @@ def _install_mtp(
                     _skip_state[0] = None
                 _mtp_stats["accepted"] += 1
             else:
-                # --- VERIFIED MODE: single eval + Python comparison ---
-                verify_pred = mx.argmax(verify_logits[:, 0, :], axis=-1)
-                mx.eval(verify_pred, draft_tokens)
-                pred_list = verify_pred.tolist()
+                # --- VERIFIED MODE: probabilistic acceptance ---
+                # Accept draft d with prob min(1, p_target(d)/q_draft(d)).
+                # At temp=0 both distributions peak at the same token,
+                # so this degenerates to exact match. At temp>0 it
+                # preserves the target distribution while accepting
+                # more drafts than argmax comparison.
+                verify_lp_check = verify_logits[:, 0, :] - mx.logsumexp(
+                    verify_logits[:, 0, :], axis=-1, keepdims=True
+                )
+                verify_at_d = mx.take_along_axis(
+                    verify_lp_check, draft_tokens[:, None], axis=-1
+                ).squeeze(-1)
+                draft_at_d = mx.take_along_axis(
+                    draft_logprobs, draft_tokens[:, None], axis=-1
+                ).squeeze(-1)
+                log_accept_ratio = verify_at_d - draft_at_d
+                mx.eval(log_accept_ratio)
+                all_accepted = all(
+                    lar >= 0
+                    or math.log(random.random() or 1e-35) < lar
+                    for lar in log_accept_ratio.tolist()
+                )
                 draft_list = draft_tokens.tolist()
-                all_accepted = pred_list == draft_list
 
                 if all_accepted and verify_hidden is not None:
                     # --- ACCEPT ---
@@ -755,14 +774,11 @@ def _install_mtp(
                         "hidden": verify_hidden[:, -1:, :],
                     }
                     mx.async_eval(_skip_state[0]["logits"], _skip_state[0]["hidden"])
-                    verify_lp = verify_logits[:, 0, :] - mx.logsumexp(
-                        verify_logits[:, 0, :], axis=-1, keepdims=True
-                    )
                     for e in range(batch_size):
                         uid = current_uids[e]
                         _deferred_drafts[uid] = {
                             "token": draft_list[e],
-                            "logprobs": verify_lp[e],
+                            "logprobs": verify_lp_check[e],
                         }
                     _mtp_stats["accepted"] += 1
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -542,6 +542,7 @@ def _install_mtp(
     model: Any,
     num_draft_tokens: int = 1,
     optimistic: bool = False,
+    greedy: bool = False,
 ) -> None:
     """
     Monkey-patch a BatchGenerator to use MTP (Multi-Token Prediction)
@@ -743,27 +744,34 @@ def _install_mtp(
                     _skip_state[0] = None
                 _mtp_stats["accepted"] += 1
             else:
-                # --- VERIFIED MODE: probabilistic acceptance ---
-                # Accept draft d with prob min(1, p_target(d)/q_draft(d)).
-                # At temp=0 both distributions peak at the same token,
-                # so this degenerates to exact match. At temp>0 it
-                # preserves the target distribution while accepting
-                # more drafts than argmax comparison.
+                # --- VERIFIED MODE ---
                 verify_lp_check = verify_logits[:, 0, :] - mx.logsumexp(
                     verify_logits[:, 0, :], axis=-1, keepdims=True
                 )
-                verify_at_d = mx.take_along_axis(
-                    verify_lp_check, draft_tokens[:, None], axis=-1
-                ).squeeze(-1)
-                draft_at_d = mx.take_along_axis(
-                    draft_logprobs, draft_tokens[:, None], axis=-1
-                ).squeeze(-1)
-                log_accept_ratio = verify_at_d - draft_at_d
-                mx.eval(log_accept_ratio)
-                all_accepted = all(
-                    lar >= 0 or math.log(random.random() or 1e-35) < lar
-                    for lar in log_accept_ratio.tolist()
-                )
+
+                if greedy:
+                    # Greedy (temp=0): exact-match verification.
+                    # Log-prob ratio can incorrectly accept wrong tokens
+                    # on poorly-calibrated models when the distribution
+                    # is a point mass.
+                    verify_pred = mx.argmax(verify_lp_check, axis=-1)
+                    mx.eval(verify_pred, draft_tokens)
+                    all_accepted = verify_pred.tolist() == draft_tokens.tolist()
+                else:
+                    # Stochastic (temp>0): probabilistic acceptance.
+                    # Accept draft d with prob min(1, p_target(d)/q_draft(d)).
+                    verify_at_d = mx.take_along_axis(
+                        verify_lp_check, draft_tokens[:, None], axis=-1
+                    ).squeeze(-1)
+                    draft_at_d = mx.take_along_axis(
+                        draft_logprobs, draft_tokens[:, None], axis=-1
+                    ).squeeze(-1)
+                    log_accept_ratio = verify_at_d - draft_at_d
+                    mx.eval(log_accept_ratio)
+                    all_accepted = all(
+                        lar >= 0 or math.log(random.random() or 1e-35) < lar
+                        for lar in log_accept_ratio.tolist()
+                    )
                 draft_list = draft_tokens.tolist()
 
                 if all_accepted and verify_hidden is not None:
@@ -1213,6 +1221,7 @@ class Scheduler:
                     model=self.model,
                     num_draft_tokens=self.config.mtp_num_draft_tokens,
                     optimistic=self.config.mtp_optimistic,
+                    greedy=sampling_params.temperature == 0.0,
                 )
             else:
                 logger.warning(

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -94,15 +94,27 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         else:
             logger.warning("No MTP weights found in %s", model_path.name)
 
-        # Verify MTP is functional
+        # Inject MTP if TextModel doesn't have native MTP support.
+        # mlx_lm's qwen3_5.TextModel strips MTP weights in sanitize(),
+        # so we inject MTP module + methods at runtime.
+        if not hasattr(text_model, "mtp") or text_model.mtp is None:
+            num_mtp = text_config.get("mtp_num_hidden_layers", 0)
+            if num_mtp == 0:
+                num_mtp = text_config.get("num_nextn_predict_layers", 0)
+            if num_mtp > 0:
+                from .patches.qwen3_5_mtp import inject_mtp_support
+
+                inject_mtp_support(text_model, model_path, config)
+
         if hasattr(text_model, "mtp") and text_model.mtp is not None:
             mx.eval(text_model.mtp.parameters())
-            logger.info(
-                "TextModel built with MTP support (%d layers)",
-                args.mtp_num_hidden_layers,
+            num_mtp = text_config.get(
+                "mtp_num_hidden_layers",
+                text_config.get("num_nextn_predict_layers", 0),
             )
+            logger.info("TextModel built with MTP support (%d layers)", num_mtp)
         else:
-            logger.info("TextModel built without MTP (mtp_num_hidden_layers=0)")
+            logger.info("TextModel built without MTP")
 
         return text_model
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -28,6 +28,27 @@ def _needs_tokenizer_fallback(model_name: str) -> bool:
     return any(pattern.lower() in model_lower for pattern in FALLBACK_MODELS)
 
 
+def _needs_strict_false(model_name: str) -> bool:
+    """Check if model needs strict=False loading (VLM models with extra weights).
+
+    VLM models (e.g., Qwen3.5) have vision_tower weights that don't match
+    the text-only model class.  Loading with strict=True fails and wastes
+    memory by loading all weights (~100 GB) before raising ValueError.
+    Detect these models up-front to avoid the double-load penalty.
+    """
+    from mlx_lm.utils import _download, load_config
+
+    try:
+        model_path = _download(model_name)
+        config = load_config(model_path)
+    except Exception:
+        return False
+    # VLM models have vision_config or text_config with a separate model_type
+    if "vision_config" in config and "text_config" in config:
+        return True
+    return False
+
+
 def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
     """
     Load model and tokenizer with fallback for non-standard tokenizers.
@@ -50,6 +71,15 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
         )
         return _load_with_tokenizer_fallback(model_name)
 
+    # VLM models (e.g., Qwen3.5) have extra vision weights that cause
+    # strict=True to fail.  Skip the first load attempt to avoid loading
+    # ~100 GB of weights twice (which can cause OOM on 256 GB systems).
+    if _needs_strict_false(model_name):
+        logger.info(
+            f"Model {model_name} detected as VLM, loading directly with strict=False"
+        )
+        return _load_strict_false(model_name, tokenizer_config)
+
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
     except ValueError as e:
@@ -59,42 +89,89 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
             return _load_with_tokenizer_fallback(model_name)
         # Fallback for models with extra weights (e.g., vision tower, MTP layers).
         # Retry with strict=False to discard extra weights.
-        if "parameters not in model" in str(e):
+        elif "parameters not in model" in str(e):
             logger.warning(
                 f"Extra parameters found (e.g., vision tower / MTP weights), "
                 f"retrying with strict=False: {e}"
             )
+            # Clear traceback references to free memory from the failed first load.
+            # Without this, large models (200GB+) cause OOM during retry because
+            # the traceback holds references to the first load's weight tensors.
+            e.__traceback__ = None
+            del e
+            import gc
+
+            gc.collect()
             return _load_strict_false(model_name, tokenizer_config)
-        raise
+        else:
+            raise
+
+    # After successful load, check if MTP weights exist but were stripped by sanitize()
+    _try_inject_mtp_post_load(model, model_name)
+    return model, tokenizer
 
 
 def _load_strict_false(model_name: str, tokenizer_config: dict = None):
-    """Load model with strict=False to discard extra weights (e.g., vision tower, MTP)."""
-    from mlx_lm.utils import load_model, load_tokenizer
+    """Load model with strict=False to discard extra weights.
 
-    local_path = Path(model_name)
-    if local_path.is_dir():
-        model_path = local_path
-    else:
-        from huggingface_hub import snapshot_download
+    Handles models with extra parameters that the text-only model class
+    doesn't define (e.g., vision tower weights in VLM models like Qwen3.5,
+    or MTP layers).  The model's own sanitize() handles key remapping
+    (e.g., language_model.* prefix), and strict=False silently drops
+    unmatched keys.
+    """
+    import mlx.core as mx
+    from mlx_lm.utils import _download, load_model, load_tokenizer
 
-        model_path = Path(snapshot_download(model_name))
-
+    model_path = _download(model_name)
     model, config = load_model(model_path, strict=False)
+
+    # Verify weights loaded correctly
+    from mlx.utils import tree_flatten
+
+    params = tree_flatten(model.parameters())
+    total_params = len(params)
+    zero_params = sum(1 for _, v in params if mx.all(v == 0).item())
+    logger.info(
+        f"[strict=False] Loaded {total_params} parameters, "
+        f"{zero_params} all-zero tensors"
+    )
+    # Spot-check embedding weights
+    if hasattr(model, "language_model"):
+        emb = model.language_model.model.embed_tokens.weight
+        logger.info(
+            f"[strict=False] embed_tokens: shape={emb.shape}, "
+            f"dtype={emb.dtype}, mean={mx.mean(emb.astype(mx.float32)).item():.4f}"
+        )
+
     tokenizer = load_tokenizer(
         model_path,
         tokenizer_config or {},
         eos_token_ids=config.get("eos_token_id", None),
     )
-    # Inject MTP support if model has MTP config + weights
     _try_inject_mtp(model, model_path, config)
     return model, tokenizer
 
 
 def _try_inject_mtp(model, model_path, config):
     """Inject MTP support if model has MTP config + weights."""
+    # Qwen3-Next: flat num_nextn_predict_layers
     if config.get("num_nextn_predict_layers", 0) > 0:
-        from ..patches.qwen3_next_mtp import inject_mtp_support
+        # Detect Qwen3.5 vs Qwen3-Next by checking text_config or model_type
+        text_config = config.get("text_config", config)
+        model_type = text_config.get("model_type", config.get("model_type", ""))
+        if "qwen3_5" in model_type:
+            from ..patches.qwen3_5_mtp import inject_mtp_support
+        else:
+            from ..patches.qwen3_next_mtp import inject_mtp_support
+        inject_mtp_support(model, model_path, config)
+        return
+
+    # Qwen3.5: mtp_num_hidden_layers in text_config
+    text_config = config.get("text_config", config)
+    num_mtp = text_config.get("mtp_num_hidden_layers", 0)
+    if num_mtp > 0:
+        from ..patches.qwen3_5_mtp import inject_mtp_support
 
         inject_mtp_support(model, model_path, config)
 
@@ -111,13 +188,21 @@ def _try_inject_mtp_post_load(model, model_name):
         return
     with open(config_path) as f:
         config = json.load(f)
-    # Also check text_config for nested configs
+    # Check for MTP in flat config and nested text_config
+    text_config = config.get("text_config", {})
     num_mtp = config.get("num_nextn_predict_layers", 0)
     if num_mtp == 0:
-        text_config = config.get("text_config", {})
         num_mtp = text_config.get("num_nextn_predict_layers", 0)
-    if num_mtp > 0 and getattr(model, "mtp", None) is None:
-        mtp_file = Path(model_path) / "model-mtp.safetensors"
+    if num_mtp == 0:
+        num_mtp = text_config.get("mtp_num_hidden_layers", 0)
+    # Also check mtp attribute on language_model for VLM wrappers
+    check_model = model
+    if hasattr(model, "language_model"):
+        check_model = model.language_model
+    if num_mtp > 0 and getattr(check_model, "mtp", None) is None:
+        mtp_file = Path(model_path) / "mtp" / "weights.safetensors"
+        if not mtp_file.exists():
+            mtp_file = Path(model_path) / "model-mtp.safetensors"
         if mtp_file.exists():
             logger.info(
                 f"[MTP] Found MTP config (layers={num_mtp}) and weights, injecting..."
@@ -126,7 +211,7 @@ def _try_inject_mtp_post_load(model, model_name):
         else:
             logger.info(
                 f"[MTP] Config has num_nextn_predict_layers={num_mtp} "
-                "but model-mtp.safetensors not found, skipping MTP."
+                "but MTP weights not found, skipping MTP."
             )
 
 


### PR DESCRIPTION
## Summary

- Adds runtime MTP (Multi-Token Prediction) support for Qwen3.5 Dense and MoE architectures (27B, 35B-A3B, 122B-A10B)
- Qwen3.5's built-in MTP head predicts token n+2 from hidden states + token n+1, enabling single-user speedup with 75-80% acceptance rate
- **MTP auto-disables when batch > 1** — no throughput penalty under concurrency
- Includes MTP weight extraction script for preparing BF16 weights from HuggingFace source models

## Benchmark Results

**Hardware:** Apple M3 Ultra, 256 GB unified memory
**Setup:** `--mllm --continuous-batching`, 300 tokens/request, same prompt
**MTP verified active** via process args and server logs

### Qwen3.5-35B-A3B-4bit (MoE, ~20 GB)

| Concurrency | Throughput (tok/s) | MTP status | Notes |
|-------------|-------------------|------------|-------|
| **1x** | **85.9** | Active | +18% vs baseline (73.7) |
| **8x** | **307.3** | Auto-skip | Matches no-MTP baseline (302.3) |

**MTP acceptance rate:** 79-80%

### Qwen3.5-122B-A10B-4bit (MoE, ~69 GB)

| Concurrency | No MTP (tok/s) | With MTP (tok/s) | Speedup |
|-------------|----------------|------------------|---------|
| **1x** (single-user) | 46.4 | **52.0** | **1.12x** |

**MTP acceptance rate:** 75-76%

### Qwen3.5-27B-4bit (Dense, ~16 GB)

| Concurrency | No MTP (tok/s) | With MTP (tok/s) | Speedup |
|-------------|----------------|------------------|---------|
| **1x** (single-user) | 30.1 | **35.9** | **1.19x** |

**MTP acceptance rate:** 78-80%
**Note:** Dense model (all 27B params active). Hybrid architecture (Gated DeltaNet + Full Attention). MTP weight extraction uses `--no-quantize` for BF16 (849 MB).

### How auto-skip works

MTP adds an extra `mtp_forward` pass per generation step that doesn't parallelize across batch items. With batch=1, the extra pass is worthwhile (~80% acceptance = fewer total steps). With batch>1, the overhead dominates and hurts aggregate throughput.

The fix is simple: `_mtp_step()` checks `len(batch_gen.active_batch)` and falls back to the standard `_step()` when there are multiple active requests. This gives the best of both worlds:
- **Single user:** MTP active → +12-19% faster
- **Concurrent users:** MTP skipped → full batching throughput preserved

### Feature Verification

| Feature | 35B (port 1238) | 122B (port 1237) | 27B (port 1240) |
|---------|-----------------|------------------|------------------|
| Single tool call | ✅ Correct | ✅ Correct | ✅ Correct |
| Multi tool call (parallel) | ✅ 2 tools parsed | ✅ 2 tools parsed | ✅ 2 tools parsed |
| Thinking/reasoning parsing | ✅ `reasoning_content` separated | ✅ `reasoning_content` separated | ✅ `reasoning_content` separated |
| `finish_reason` | ✅ `tool_calls` / `stop` | ✅ `tool_calls` / `stop` | ✅ `tool_calls` / `stop` |

## Details

### Runtime MTP injection (`vllm_mlx/patches/qwen3_5_mtp.py`)
Since `mlx_lm`'s `qwen3_5.py` does not define MTP layers, this module dynamically creates the MTP module, loads weights, and monkey-patches the model class with `return_hidden`, `mtp_forward`, and `make_mtp_cache` methods. Supports both Dense and MoE (SwitchMLP) variants.

**Critical implementation notes:**
- MTP concat order is `[embedding, hidden]` (not `[hidden, embedding]`) — fc weight first half corresponds to embedding columns
- MTP expects **post-norm** hidden states (after final RMSNorm), not pre-norm
- MTP weights must be native BF16 — dequantized 4-bit weights give 0% acceptance due to baked-in quantization error

### MLLM batched generation (`vllm_mlx/mllm_batch_generator.py`)
Implements always-advance verified MTP strategy for the MLLM batched path:
- `_mtp_step()`: forward with `return_hidden` → sample primary → MTP draft → verify → accept/reject
- `_mtp_next()`: emits deferred MTP draft tokens in subsequent generation steps
- **Auto-skip:** when `len(active_batch) > 1`, bypasses MTP and falls back to standard `_step()` — eliminates concurrent throughput penalty
- Handles hybrid model caches (BatchKVCache for attention + ArraysCache for recurrent GatedDeltaNet layers)
- RNN state snapshot/restore for correct recurrent state management

### MTP weight extraction (`scripts/add_mtp_weights_qwen35.py`)
- Downloads only MTP-containing shards from HuggingFace (not entire model)
- Stacks 256 expert weights into SwitchLinear `(num_experts, output, input)` format
- Applies RMSNorm +1.0 shift (HF centered at 0 → MLX centered at 1)
- `--no-quantize` flag for BF16 output (recommended for best acceptance rate)

### Model loading pipeline
- `tokenizer.py`: Extended MTP detection for `mtp_num_hidden_layers` in `text_config`
- `text_model_from_vlm.py`: Post-load MTP injection for VLM text models
- `batched.py`: MTP injection and validation for MLLM models

## Test plan

- [x] Qwen3.5-35B-A3B-4bit: 79-80% MTP acceptance, +18% single-user speedup
- [x] Qwen3.5-122B-A10B-4bit: 75-76% MTP acceptance, +12% single-user speedup
- [x] Qwen3.5-27B-4bit (Dense): 78-80% MTP acceptance, +19% single-user speedup (30.1 → 35.9 tok/s)
- [x] Auto-skip: 8x concurrent = 307 tok/s (matches no-MTP baseline 302 tok/s)
- [x] Tool calls (single + parallel) work correctly with MTP
- [x] Thinking/reasoning parsing works correctly with MTP
- [ ] Verify no regression when MTP weights are absent (graceful fallback)

## Usage

```bash
# 1. Extract MTP weights (run once per model)
python scripts/add_mtp_weights_qwen35.py \
  --mlx-model-path ~/.cache/huggingface/hub/models--mlx-community--Qwen3.5-35B-A3B-4bit/snapshots/... \
  --source-model Qwen/Qwen3.5-35B-A3B \
  --no-quantize

# 2. Serve with MTP enabled (auto-skips when batch > 1)
vllm-mlx serve mlx-community/Qwen3.5-35B-A3B-4bit \
  --enable-mtp \
  --mllm \
  --continuous-batching
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)