### PR TITLE
fix: replace manual decode loop with pipelined generation in SpecPrefill Phase 4

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -100,6 +100,58 @@ def test_model_stream_generate(small_model_name):
 
 
 @pytest.mark.slow
+def test_model_stream_generate_with_prompt_cache(small_model_name):
+    """Test streaming generation with pre-populated prompt_cache."""
+    pytest.importorskip("mlx_lm")
+    import mlx.core as mx
+    from mlx_lm.models.cache import make_prompt_cache
+
+    from vllm_mlx.models.llm import MLXLanguageModel
+
+    model = MLXLanguageModel(small_model_name)
+    model.load()
+
+    # Pre-populate cache by running a prefill
+    cache = make_prompt_cache(model.model)
+    tokens = model.tokenizer.encode("Hello")
+    model.model(mx.array([tokens]), cache=cache)
+    mx.eval([c.state for c in cache])
+
+    # Generate from a single token with the pre-populated cache
+    prompt_token = mx.array([tokens[-1]])
+    chunks = list(
+        model.stream_generate(
+            prompt=prompt_token,
+            max_tokens=10,
+            prompt_cache=cache,
+        )
+    )
+
+    assert len(chunks) > 0
+    assert any(chunk.finished for chunk in chunks)
+    # prompt_tokens should reflect the single-token prompt, not the full string
+    assert chunks[0].prompt_tokens == 1
+
+
+@pytest.mark.slow
+def test_model_stream_generate_with_list_prompt(small_model_name):
+    """Test streaming generation with list[int] prompt."""
+    pytest.importorskip("mlx_lm")
+
+    from vllm_mlx.models.llm import MLXLanguageModel
+
+    model = MLXLanguageModel(small_model_name)
+    model.load()
+
+    token_ids = model.tokenizer.encode("Hello")
+    chunks = list(model.stream_generate(prompt=token_ids, max_tokens=10))
+
+    assert len(chunks) > 0
+    assert any(chunk.finished for chunk in chunks)
+    assert chunks[0].prompt_tokens == len(token_ids)
+
+
+@pytest.mark.slow
 def test_model_chat(small_model_name):
     """Test chat interface."""
     pytest.importorskip("mlx_lm")

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1186,6 +1186,7 @@ class SimpleEngine(BaseEngine):
             from types import SimpleNamespace
 
             import mlx.core as mx
+            from mlx_lm import stream_generate as mlx_stream_generate
             from mlx_lm.models.cache import make_prompt_cache
             from mlx_lm.sample_utils import make_sampler
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -787,41 +787,37 @@ class SimpleEngine(BaseEngine):
                     t_prefill,
                 )
 
-                # Phase 4: Generate (simple autoregressive, no MTP)
+                # Phase 4: Generate via engine's standard pipelined path
                 sampler = make_sampler(temp=temperature, top_p=top_p)
                 _cancel_check()
+                first_token_id = sampler(logits[:, -1, :]).item()
+                first_text = tokenizer.decode([first_token_id])
                 eos_id = tokenizer.eos_token_id
-                y = sampler(logits[:, -1, :])
-                mx.eval(y)
 
-                results = []
-                generated_ids = []
-                prev_decoded = ""
-
-                for _ in range(max_tokens):
-                    _cancel_check()
-                    tok_id = y.item()
-                    generated_ids.append(tok_id)
-
-                    decoded = tokenizer.decode(generated_ids)
-                    new_text = decoded[len(prev_decoded) :]
-                    prev_decoded = decoded
-
-                    is_eos = tok_id == eos_id
-                    results.append(
-                        SimpleNamespace(
-                            text=new_text,
-                            finish_reason="stop" if is_eos else None,
-                        )
+                results = [
+                    SimpleNamespace(
+                        text=first_text,
+                        finish_reason="stop" if first_token_id == eos_id else None,
                     )
+                ]
 
-                    if is_eos:
-                        break
-
-                    _cancel_check()
-                    logits = model(y.reshape(1, -1), cache=cache)
-                    y = sampler(logits[:, -1, :])
-                    mx.eval(y)
+                if first_token_id != eos_id:
+                    for chunk in self._model.stream_generate(
+                        prompt=mx.array([first_token_id]),
+                        max_tokens=max_tokens - 1,
+                        temperature=temperature,
+                        top_p=top_p,
+                        stop=stop,
+                        prompt_cache=cache,
+                    ):
+                        _cancel_check()
+                        new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
+                        results.append(
+                            SimpleNamespace(
+                                text=new_text,
+                                finish_reason=getattr(chunk, "finish_reason", None),
+                            )
+                        )
 
                 return results
 
@@ -1250,39 +1246,28 @@ class SimpleEngine(BaseEngine):
                     effective_keep,
                 )
 
-                # Phase 4: Generate (simple autoregressive, no MTP)
+                # Phase 4: Generate via mlx_lm pipelined path (no MTP)
                 eos_id = self._text_tokenizer.eos_token_id
-                y = sampler(logits[:, -1, :])
-                mx.eval(y)
+                first_token_id = sampler(logits[:, -1, :]).item()
+                first_text = self._text_tokenizer.decode([first_token_id])
 
-                results = []
-                generated_ids = []
-                prev_decoded = ""
-
-                for _ in range(max_tokens):
-                    tok_id = y.item()
-                    generated_ids.append(tok_id)
-
-                    # Incremental text decode
-                    decoded = self._text_tokenizer.decode(generated_ids)
-                    new_text = decoded[len(prev_decoded) :]
-                    prev_decoded = decoded
-
-                    is_eos = tok_id == eos_id
-                    results.append(
-                        SimpleNamespace(
-                            text=new_text,
-                            finish_reason="stop" if is_eos else None,
-                        )
+                results = [
+                    SimpleNamespace(
+                        text=first_text,
+                        finish_reason="stop" if first_token_id == eos_id else None,
                     )
+                ]
 
-                    if is_eos:
-                        break
-
-                    # Next token
-                    logits = model(y.reshape(1, -1), cache=bc)
-                    y = sampler(logits[:, -1, :])
-                    mx.eval(y)
+                if first_token_id != eos_id:
+                    for resp in mlx_stream_generate(
+                        model,
+                        self._text_tokenizer,
+                        prompt=mx.array([first_token_id]),
+                        max_tokens=max_tokens - 1,
+                        sampler=sampler,
+                        prompt_cache=bc,
+                    ):
+                        results.append(resp)
 
                 return results
 

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -8,7 +8,7 @@ integrating with vLLM's model execution system.
 
 import logging
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Iterator, Union
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +214,7 @@ class MLXLanguageModel:
 
     def stream_generate(
         self,
-        prompt: str,
+        prompt: Union[str, "mx.array", list[int]],
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -224,13 +224,14 @@ class MLXLanguageModel:
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
         logits_processors: list | None = None,
+        prompt_cache=None,
         **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
         Stream text generation token by token.
 
         Args:
-            prompt: Input prompt text
+            prompt: Input prompt text, token array, or token id list
             max_tokens: Maximum number of tokens to generate
             temperature: Sampling temperature (0 = greedy)
             top_p: Top-p (nucleus) sampling parameter
@@ -239,6 +240,7 @@ class MLXLanguageModel:
             presence_penalty: Additive penalty for token presence
             repetition_penalty: Multiplicative penalty for repeating tokens
             stop: List of stop sequences
+            prompt_cache: Pre-populated KV cache (e.g. from SpecPrefill)
 
         Yields:
             StreamingOutput for each generated token
@@ -259,7 +261,10 @@ class MLXLanguageModel:
             all_processors = (logits_processors or []) + (penalty_processors or [])
 
         # Count prompt tokens once upfront
-        num_prompt_tokens = len(self.tokenizer.encode(prompt))
+        if isinstance(prompt, str):
+            num_prompt_tokens = len(self.tokenizer.encode(prompt))
+        else:
+            num_prompt_tokens = len(prompt)
 
         token_count = 0
         accumulated_text = ""
@@ -267,6 +272,8 @@ class MLXLanguageModel:
         mtp_kwargs = {}
         if self._mtp:
             mtp_kwargs["mtp"] = True
+        if prompt_cache is not None:
+            mtp_kwargs["prompt_cache"] = prompt_cache
 
         for response in stream_generate(
             self.model,

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -7,8 +7,12 @@ integrating with vLLM's model execution system.
 """
 
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator, Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    import mlx.core as mx
 
 logger = logging.getLogger(__name__)
 
@@ -98,11 +102,10 @@ class MLXLanguageModel:
             self._loaded = True
             logger.info(f"Model loaded successfully: {self.model_name}")
 
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
-                "mlx-lm is required for LLM inference. "
-                "Install with: pip install mlx-lm"
-            )
+                "mlx-lm is required for LLM inference. Install with: pip install mlx-lm"
+            ) from err
         except Exception as e:
             logger.error(f"Failed to load model: {e}")
             raise
@@ -266,7 +269,6 @@ class MLXLanguageModel:
         else:
             num_prompt_tokens = len(prompt)
 
-        token_count = 0
         accumulated_text = ""
 
         mtp_kwargs = {}
@@ -275,16 +277,18 @@ class MLXLanguageModel:
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache
 
-        for response in stream_generate(
-            self.model,
-            self.tokenizer,
-            prompt=prompt,
-            max_tokens=max_tokens,
-            sampler=sampler,
-            logits_processors=all_processors,
-            **mtp_kwargs,
+        for token_count, response in enumerate(
+            stream_generate(
+                self.model,
+                self.tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                logits_processors=all_processors,
+                **mtp_kwargs,
+            ),
+            start=1,
         ):
-            token_count += 1
             # response.text is the new token text (not accumulated)
             new_text = response.text
             accumulated_text += new_text


### PR DESCRIPTION
## Summary

Fixes #247. Try to make my first reviewed contribution here :)

SpecPrefill Phase 4 called `model()` + `mx.eval()` in a plain Python loop 
without `mx.async_eval` pipelining, causing the GPU to idle between steps 
(~0.3 tok/s vs 30+ tok/s normal decode).

- Extend `MLXLanguageModel.stream_generate()` to accept a `prompt_cache` 
  parameter and `mx.array`/`list[int]` prompt types, so SpecPrefill can 
  hand off the pre-populated sparse-prefill cache to the engine's standard 
  pipelined decode path
- Replace the manual decode loop in both SpecPrefill paths:
  - Non-MLLM: hand off to `self._model.stream_generate(prompt_cache=cache)`
  - MLLM text-only: hand off to `mlx_lm.stream_generate(prompt_cache=bc)` 
    (matching its normal path)
- First-token EOS check is preserved since `stream_generate` does not 
  validate whether the prompt itself is EOS

## Design decisions

### Handoff target: Model layer `self._model.stream_generate`

There are three layers that can drive decode: Engine layer 
(`SimpleEngine.stream_generate`), Model layer 
(`MLXLanguageModel.stream_generate`), and `mlx_lm.stream_generate` directly.

The Engine layer is not suitable because `_stream_generate_specprefill` already 
holds `self._generation_lock` (asyncio.Lock, non-reentrant) — calling back 
into `SimpleEngine.stream_generate` would deadlock. It would also re-run 
SpecPrefill eligibility checks and re-tokenize the prompt unnecessarily 
(though no infinite recursion: the single-token prompt falls below the 
threshold).

The Model layer (`self._model.stream_generate`) is the right fit. The 
non-MLLM normal decode path already calls it (line 362), so routing 
SpecPrefill Phase 4 through the same method maintains symmetry and reuses 
its stop sequence handling. For the MLLM text-only path, `self._text_model` 
is a raw `mlx_lm TextModel` (nn.Module built by `build_text_model`) with no 
`stream_generate` method, so it calls `mlx_lm.stream_generate` directly — 
again symmetric with the MLLM normal path (line 1090).

### Extending `MLXLanguageModel.stream_generate` interface

The Model layer originally only accepted `prompt: str` and had no way to 
pass a pre-populated cache. Two changes were needed:

1. **`prompt_cache` parameter**: forwarded via kwargs to 
   `mlx_lm.stream_generate`, which passes it through to `generate_step`. 
   When `prompt_cache` is not None, `generate_step` skips creating a new 
   cache and uses the provided one directly.
2. **`prompt` type broadened to `str | mx.array | list[int]`**: Phase 4 
   passes `mx.array([first_token_id])` as prompt. `mlx_lm.stream_generate` 
   already accepts all three types natively; the only adaptation needed was 
   gating `tokenizer.encode()` behind an `isinstance(prompt, str)` check 
   for the prompt token count.

## Test plan

- [x] Existing `test_model_stream_generate` still passes
- [x] New tests: `test_model_stream_generate_with_prompt_cache`, 
      `test_model_stream_generate_with_list_prompt`
- [x] End-to-end: SpecPrefill activated on 12k-token prompt, Phase 4 
      decode runs at normal speed