### PR TITLE
feat: Gemma 4 tool call + reasoning parser

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -778,11 +778,12 @@ Examples:
             "xlam",
             "functionary",
             "glm47",
+            "gemma4",
         ],
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47. "
+            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47, gemma4. "
             "Required for --enable-auto-tool-choice."
         ),
     )

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -85,6 +85,10 @@ def _register_builtin_parsers():
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
 
+    from .gemma4_parser import Gemma4ReasoningParser
+
+    register_parser("gemma4", Gemma4ReasoningParser)
+
 
 # Register built-in parsers on module load
 _register_builtin_parsers()

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 4 reasoning parser for vllm-mlx.
+
+Handles Gemma 4's channel-based thinking format:
+    <|channel>thought
+    ...reasoning content...
+    <channel|>
+    Final answer content
+
+The thinking channel is activated when <|think|> appears in the system prompt.
+"""
+
+from .base import DeltaMessage, ReasoningParser
+
+START_TOKEN = "<|channel>thought\n"
+END_TOKEN = "<channel|>"
+
+
+class Gemma4ReasoningParser(ReasoningParser):
+    """
+    Reasoning parser for Gemma 4 models.
+
+    Extracts reasoning from <|channel>thought ... <channel|> blocks.
+    """
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self._in_reasoning = False
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+    ) -> tuple[str | None, str | None]:
+        text = model_output
+
+        # Case 1: Both markers present
+        if START_TOKEN in text and END_TOKEN in text:
+            _, _, after_start = text.partition(START_TOKEN)
+            reasoning, _, content = after_start.partition(END_TOKEN)
+            return reasoning.strip() or None, content.strip() or None
+
+        # Case 2: Only start (reasoning still in progress or truncated)
+        if START_TOKEN in text:
+            _, _, reasoning = text.partition(START_TOKEN)
+            return reasoning.strip() or None, None
+
+        # Case 3: Only end (start was in prompt/previous turn)
+        if END_TOKEN in text:
+            reasoning, _, content = text.partition(END_TOKEN)
+            return reasoning.strip() or None, content.strip() or None
+
+        # Case 4: No markers — pure content
+        return None, text.strip() or None
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        had_start = START_TOKEN in previous_text
+        has_start = START_TOKEN in current_text
+        had_end = END_TOKEN in previous_text
+        has_end = END_TOKEN in current_text
+
+        # Transition: start token just appeared
+        if has_start and not had_start:
+            # Everything after start is reasoning; suppress the marker
+            _, _, after = current_text.partition(START_TOKEN)
+            if after:
+                return DeltaMessage(reasoning=after)
+            return None  # suppress the marker itself
+
+        # In reasoning phase (start seen, end not yet)
+        if has_start and not has_end:
+            # Check if delta contains partial end token — buffer it
+            if "<channel" in delta_text or "channel|>" in delta_text:
+                return None  # buffer partial end markers
+            return DeltaMessage(reasoning=delta_text)
+
+        # Transition: end token just appeared
+        if has_end and not had_end:
+            # Split: reasoning before end, content after
+            before_end, _, after_end = current_text.partition(END_TOKEN)
+            if START_TOKEN in before_end:
+                _, _, reasoning_part = before_end.partition(START_TOKEN)
+            else:
+                reasoning_part = before_end
+
+            # Only emit the new content after the end marker
+            prev_after_end = ""
+            if END_TOKEN in previous_text:
+                _, _, prev_after_end = previous_text.partition(END_TOKEN)
+            new_content = after_end[len(prev_after_end):]
+            if new_content:
+                return DeltaMessage(content=new_content)
+            return DeltaMessage(content="")  # signal transition
+
+        # Post-reasoning: both markers seen
+        if has_start and has_end:
+            return DeltaMessage(content=delta_text)
+
+        # No markers at all — pure content
+        return DeltaMessage(content=delta_text)
+
+    def reset_state(self):
+        self._in_reasoning = False

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -92,7 +92,7 @@ class Gemma4ReasoningParser(ReasoningParser):
             prev_after_end = ""
             if END_TOKEN in previous_text:
                 _, _, prev_after_end = previous_text.partition(END_TOKEN)
-            new_content = after_end[len(prev_after_end):]
+            new_content = after_end[len(prev_after_end) :]
             if new_content:
                 return DeltaMessage(content=new_content)
             return DeltaMessage(content="")  # signal transition

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -49,40 +49,40 @@ def _parse_gemma4_params(param_str: str) -> dict:
     current = []
     pairs = []
     for ch in s:
-        if ch == PLACEHOLDER[0] and s[len(current):].startswith(PLACEHOLDER):
+        if ch == PLACEHOLDER[0] and s[len(current) :].startswith(PLACEHOLDER):
             in_string = not in_string
             current.append(ch)
-        elif ch == '{' and not in_string:
+        elif ch == "{" and not in_string:
             depth += 1
             current.append(ch)
-        elif ch == '}' and not in_string:
+        elif ch == "}" and not in_string:
             depth -= 1
             current.append(ch)
-        elif ch == ',' and depth == 0 and not in_string:
-            pairs.append(''.join(current).strip())
+        elif ch == "," and depth == 0 and not in_string:
+            pairs.append("".join(current).strip())
             current = []
         else:
             current.append(ch)
     if current:
-        pairs.append(''.join(current).strip())
+        pairs.append("".join(current).strip())
 
     for pair in pairs:
-        if ':' not in pair:
+        if ":" not in pair:
             continue
-        key, _, val = pair.partition(':')
+        key, _, val = pair.partition(":")
         key = key.strip()
         val = val.strip()
 
         # Restore escaped quotes and extract string value
-        val = val.replace(PLACEHOLDER, '')
+        val = val.replace(PLACEHOLDER, "")
         if not val:
             val = val  # empty string
         # Try numeric/bool conversion
-        elif val.lower() == 'true':
+        elif val.lower() == "true":
             val = True
-        elif val.lower() == 'false':
+        elif val.lower() == "false":
             val = False
-        elif val.lower() == 'null':
+        elif val.lower() == "null":
             val = None
         else:
             try:
@@ -99,7 +99,7 @@ def _parse_gemma4_params(param_str: str) -> dict:
 
 # Pattern: <|tool_call>call:function_name{params}<tool_call|>
 GEMMA4_TOOL_PATTERN = re.compile(
-    r'<\|tool_call>call:(\w+)\{(.*?)\}<tool_call\|>',
+    r"<\|tool_call>call:(\w+)\{(.*?)\}<tool_call\|>",
     re.DOTALL,
 )
 
@@ -129,11 +129,13 @@ class Gemma4ToolParser(ToolParser):
             param_str = match.group(2)
             arguments = _parse_gemma4_params(param_str)
 
-            tool_calls.append({
-                "id": _generate_tool_id(),
-                "name": func_name,
-                "arguments": json.dumps(arguments),
-            })
+            tool_calls.append(
+                {
+                    "id": _generate_tool_id(),
+                    "name": func_name,
+                    "arguments": json.dumps(arguments),
+                }
+            )
             cleaned_text = cleaned_text.replace(match.group(0), "").strip()
 
         return ExtractedToolCallInformation(
@@ -147,22 +149,34 @@ class Gemma4ToolParser(ToolParser):
         previous_text: str,
         current_text: str,
         delta: str,
-        previous_token_ids: Sequence[int],
-        current_token_ids: Sequence[int],
-        delta_token_ids: Sequence[int],
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
         request: dict[str, Any] | None = None,
-    ) -> ExtractedToolCallInformation:
-        # Check if we have a complete tool call in current_text
+    ) -> dict[str, Any] | None:
+        # Complete tool call found — extract and return formatted dict
         if "<tool_call|>" in current_text:
-            return self.extract_tool_calls(current_text, request)
+            result = self.extract_tool_calls(current_text, request)
+            if result.tools_called and result.tool_calls:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+            return {"content": result.content or ""}
 
-        # If we see the start marker, signal that a tool call is in progress
+        # Start marker seen — suppress content (tool call in progress)
         if GEMMA4_TOOL_START in current_text:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=None, content=None
-            )
+            return None
 
-        # No tool call markers — pass through as content
-        return ExtractedToolCallInformation(
-            tools_called=False, tool_calls=None, content=delta
-        )
+        # No markers — pass through as content
+        return {"content": delta}

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 4 tool call parser for vllm-mlx.
+
+Handles Gemma 4's native tool calling format:
+    <|tool_call>call:function_name{param:<|"|>value<|"|>,param2:42}<tool_call|>
+
+The <|"|> tokens are Gemma 4's escaped string delimiters within tool calls.
+Parameters use a custom key:value format (not JSON).
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def _generate_tool_id() -> str:
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+def _parse_gemma4_params(param_str: str) -> dict:
+    """Parse Gemma 4's key:value parameter format into a dict.
+
+    Handles:
+        city:<|"|>San Francisco<|"|>
+        count:42
+        flag:true
+        nested:{a:<|"|>b<|"|>}
+    """
+    result = {}
+    if not param_str or not param_str.strip():
+        return result
+
+    # Replace escaped quotes with placeholder for parsing
+    PLACEHOLDER = "\x00QUOTE\x00"
+    s = param_str.replace('<|"|>', PLACEHOLDER)
+
+    # Split on top-level commas (not inside braces or strings)
+    depth = 0
+    in_string = False
+    current = []
+    pairs = []
+    for ch in s:
+        if ch == PLACEHOLDER[0] and s[len(current):].startswith(PLACEHOLDER):
+            in_string = not in_string
+            current.append(ch)
+        elif ch == '{' and not in_string:
+            depth += 1
+            current.append(ch)
+        elif ch == '}' and not in_string:
+            depth -= 1
+            current.append(ch)
+        elif ch == ',' and depth == 0 and not in_string:
+            pairs.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        pairs.append(''.join(current).strip())
+
+    for pair in pairs:
+        if ':' not in pair:
+            continue
+        key, _, val = pair.partition(':')
+        key = key.strip()
+        val = val.strip()
+
+        # Restore escaped quotes and extract string value
+        val = val.replace(PLACEHOLDER, '')
+        if not val:
+            val = val  # empty string
+        # Try numeric/bool conversion
+        elif val.lower() == 'true':
+            val = True
+        elif val.lower() == 'false':
+            val = False
+        elif val.lower() == 'null':
+            val = None
+        else:
+            try:
+                val = int(val)
+            except ValueError:
+                try:
+                    val = float(val)
+                except ValueError:
+                    pass  # keep as string
+
+        result[key] = val
+    return result
+
+
+# Pattern: <|tool_call>call:function_name{params}<tool_call|>
+GEMMA4_TOOL_PATTERN = re.compile(
+    r'<\|tool_call>call:(\w+)\{(.*?)\}<tool_call\|>',
+    re.DOTALL,
+)
+
+# Streaming: detect start of tool call
+GEMMA4_TOOL_START = "<|tool_call>"
+
+
+@ToolParserManager.register_module(["gemma4"])
+class Gemma4ToolParser(ToolParser):
+    """
+    Tool call parser for Gemma 4 models.
+
+    Handles the native format:
+        <|tool_call>call:function_name{key:<|"|>value<|"|>}<tool_call|>
+    """
+
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        tool_calls = []
+        cleaned_text = model_output
+
+        for match in GEMMA4_TOOL_PATTERN.finditer(model_output):
+            func_name = match.group(1)
+            param_str = match.group(2)
+            arguments = _parse_gemma4_params(param_str)
+
+            tool_calls.append({
+                "id": _generate_tool_id(),
+                "name": func_name,
+                "arguments": json.dumps(arguments),
+            })
+            cleaned_text = cleaned_text.replace(match.group(0), "").strip()
+
+        return ExtractedToolCallInformation(
+            tools_called=len(tool_calls) > 0,
+            tool_calls=tool_calls if tool_calls else None,
+            content=cleaned_text if cleaned_text else None,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: dict[str, Any] | None = None,
+    ) -> ExtractedToolCallInformation:
+        # Check if we have a complete tool call in current_text
+        if "<tool_call|>" in current_text:
+            return self.extract_tool_calls(current_text, request)
+
+        # If we see the start marker, signal that a tool call is in progress
+        if GEMMA4_TOOL_START in current_text:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=None, content=None
+            )
+
+        # No tool call markers — pass through as content
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=None, content=delta
+        )


### PR DESCRIPTION
## Summary
- Gemma 4 tool call parser: parses `<|tool_call>call:name{params}<tool_call|>` with `<|"|>` string escaping
- Gemma 4 reasoning parser: extracts `<|channel>thought...<channel|>` blocks into `reasoning_content`
- Registered as `--tool-call-parser gemma4` and `--reasoning-parser gemma4`
- CLI choices updated

Addresses the server-side equivalent of ml-explore/mlx-lm#1096 (Gemma 4 native tool calls not parsed).

## Details

**Tool parser** (`tool_parsers/gemma4_tool_parser.py`):
- Regex extracts function name and parameter block from `<|tool_call>call:name{...}<tool_call|>`
- Handles `<|"|>` escaped string values, numeric/boolean coercion
- Arguments serialized to JSON string for OpenAI API compatibility
- Streaming support with start-marker detection

**Reasoning parser** (`reasoning/gemma4_parser.py`):
- Splits `<|channel>thought\n...reasoning...<channel|>` from final answer
- Non-streaming: returns `(reasoning, content)` tuple
- Streaming: tracks channel boundaries, emits reasoning deltas then content deltas

## Test plan
- [x] Non-streaming: `tool_calls` field populated with correct function name + JSON arguments
- [x] Non-streaming: `reasoning_content` separated from `content`, both present
- [x] Streaming: SSE chunks flow correctly
- [x] Concurrent: 3 simultaneous requests with BatchedEngine
- [x] Thinking + tools: model produces empty think channel then tool call (correct behavior)
- [x] Parser standalone unit tests pass