### PR TITLE
fix(server): integrate tool call parser into reasoning parser streaming path

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the OpenAI-compatible API server."""
 
+import json
 import platform
 import sys
 
@@ -304,7 +305,7 @@ class TestRateLimiter:
         # First 3 requests should be allowed
         for i in range(3):
             allowed, retry_after = limiter.is_allowed("client1")
-            assert allowed is True, f"Request {i+1} should be allowed"
+            assert allowed is True, f"Request {i + 1} should be allowed"
             assert retry_after == 0
 
         # 4th request should be blocked
@@ -675,6 +676,225 @@ class TestRateLimiterHTTPResponse:
         # Now should be allowed again (old requests cleaned up)
         allowed, _ = limiter.is_allowed("test_client")
         assert allowed is True
+
+
+class TestStreamChatCompletion:
+    """Tests for streaming chat completion behavior."""
+
+    @pytest.mark.asyncio
+    async def test_reasoning_stream_emits_structured_tool_calls(self, monkeypatch):
+        """Tool markup after </think> should emit tool_calls chunks."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning import DeltaMessage
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                chunks = [
+                    GenerationOutput(text="", new_text="<think>", finished=False),
+                    GenerationOutput(text="", new_text="reasoning", finished=False),
+                    GenerationOutput(text="", new_text="</think>", finished=False),
+                    GenerationOutput(text="", new_text="<tool_call>", finished=False),
+                    GenerationOutput(
+                        text="", new_text='{"name":"search"}', finished=False
+                    ),
+                    GenerationOutput(
+                        text="",
+                        new_text="</tool_call>",
+                        finished=True,
+                        finish_reason="stop",
+                        prompt_tokens=7,
+                        completion_tokens=3,
+                    ),
+                ]
+                for chunk in chunks:
+                    yield chunk
+
+        class FakeReasoningParser:
+            def reset_state(self):
+                self._in_reasoning = False
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                if delta_text == "<think>":
+                    self._in_reasoning = True
+                    return None
+                if delta_text == "</think>":
+                    self._in_reasoning = False
+                    return None
+                if self._in_reasoning:
+                    return DeltaMessage(reasoning=delta_text)
+                return DeltaMessage(content=delta_text)
+
+        class FakeToolParser:
+            def reset(self):
+                pass
+
+            def extract_tool_calls_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                if "</tool_call>" in current_text:
+                    return {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {
+                                    "name": "search",
+                                    "arguments": '{"q":"weather"}',
+                                },
+                            }
+                        ]
+                    }
+                return None
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", True)
+        monkeypatch.setattr(server, "_tool_call_parser", "fake")
+        monkeypatch.setattr(server, "_tool_parser_instance", FakeToolParser())
+
+        request = ChatCompletionRequest(
+            model="request-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        tool_payloads = [
+            payload
+            for payload in payloads
+            if payload["choices"] and payload["choices"][0]["delta"].get("tool_calls")
+        ]
+
+        assert payloads[0]["choices"][0]["delta"]["role"] == "assistant"
+        assert payloads[1]["choices"][0]["delta"]["reasoning"] == "reasoning"
+        assert len(tool_payloads) == 1
+        assert (
+            tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["name"]
+            == "search"
+        )
+        assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+        assert tool_payloads[0]["usage"] == {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+        }
+
+    @pytest.mark.asyncio
+    async def test_reasoning_stream_skips_tool_parser_until_markup_appears(
+        self, monkeypatch
+    ):
+        """Plain post-reasoning content should stream normally on the fast path."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning import DeltaMessage
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                chunks = [
+                    GenerationOutput(text="", new_text="<think>", finished=False),
+                    GenerationOutput(text="", new_text="reasoning", finished=False),
+                    GenerationOutput(text="", new_text="</think>", finished=False),
+                    GenerationOutput(
+                        text="",
+                        new_text="final answer",
+                        finished=True,
+                        finish_reason="stop",
+                    ),
+                ]
+                for chunk in chunks:
+                    yield chunk
+
+        class FakeReasoningParser:
+            def reset_state(self):
+                self._in_reasoning = False
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                if delta_text == "<think>":
+                    self._in_reasoning = True
+                    return None
+                if delta_text == "</think>":
+                    self._in_reasoning = False
+                    return None
+                if self._in_reasoning:
+                    return DeltaMessage(reasoning=delta_text)
+                return DeltaMessage(content=delta_text)
+
+        class TrackingToolParser:
+            def __init__(self):
+                self.calls = []
+
+            def reset(self):
+                self.calls.clear()
+
+            def extract_tool_calls_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                self.calls.append((previous_text, current_text, delta_text))
+                return {"content": delta_text}
+
+        tool_parser = TrackingToolParser()
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", True)
+        monkeypatch.setattr(server, "_tool_call_parser", "fake")
+        monkeypatch.setattr(server, "_tool_parser_instance", tool_parser)
+
+        request = ChatCompletionRequest(
+            model="request-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        assert tool_parser.calls == []
+        assert payloads[1]["choices"][0]["delta"]["reasoning"] == "reasoning"
+        assert payloads[2]["choices"][0]["delta"]["content"] == "final answer"
+        assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 
 
 # =============================================================================

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2094,6 +2094,50 @@ async def stream_chat_completion(
                 # Skip this chunk (e.g., <think> token itself)
                 continue
 
+            # Run tool parser on content delta (post-reasoning text only).
+            # The reasoning parser suppresses <think> tokens, so tool calls
+            # only appear in delta_msg.content after </think> is emitted.
+            if tool_parser and delta_msg.content:
+                content_delta = delta_msg.content
+                if not tool_markup_possible and "<" not in content_delta:
+                    tool_accumulated_text += content_delta
+                else:
+                    if not tool_markup_possible:
+                        tool_markup_possible = True
+
+                    tool_previous = tool_accumulated_text
+                    tool_accumulated_text += content_delta
+                    tool_result = tool_parser.extract_tool_calls_streaming(
+                        tool_previous, tool_accumulated_text, content_delta
+                    )
+
+                    if tool_result is None:
+                        # Inside tool markup - suppress content
+                        continue
+
+                    if "tool_calls" in tool_result:
+                        tool_calls_detected = True
+                        tool_chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=request.model,
+                            choices=[
+                                ChatCompletionChunkChoice(
+                                    delta=ChatCompletionChunkDelta(
+                                        tool_calls=tool_result["tool_calls"]
+                                    ),
+                                    finish_reason=(
+                                        "tool_calls" if output.finished else None
+                                    ),
+                                )
+                            ],
+                            usage=get_usage(output) if output.finished else None,
+                        )
+                        yield f"data: {tool_chunk.model_dump_json()}\n\n"
+                        continue
+
+                    # Update content with what the tool parser returned
+                    delta_msg.content = tool_result.get("content", "") or None
+
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=_model_name,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2119,7 +2119,7 @@ async def stream_chat_completion(
                         tool_calls_detected = True
                         tool_chunk = ChatCompletionChunk(
                             id=response_id,
-                            model=request.model,
+                            model=_model_name,
                             choices=[
                                 ChatCompletionChunkChoice(
                                     delta=ChatCompletionChunkDelta(


### PR DESCRIPTION
Running Qwen 3.5 model results in printing tool calls as raw xml and not applying actual tools.

## Summary
- run the streaming tool-call parser in the reasoning-parser path after reasoning content has been stripped from streamed output
- suppress tool-call markup from normal content chunks and emit structured `tool_calls` chunks when parsed tool calls are detected
- preserve the `tool_calls` finish reason on the final streamed chunk when generation ends with parsed tool calls