### PR TITLE
Preserve raw chat output for reasoning parsing

### DIFF
--- a/tests/test_batched_engine_text_scheduler.py
+++ b/tests/test_batched_engine_text_scheduler.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused regressions for BatchedEngine raw-output handling."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.request import RequestOutput
+
+
+def _make_mllm_engine() -> BatchedEngine:
+    engine = BatchedEngine("dummy-model", force_mllm=True)
+    engine._loaded = True
+    return engine
+
+
+def test_generate_preserves_raw_output_for_mllm_scheduler():
+    async def _run():
+        engine = _make_mllm_engine()
+        engine._mllm_scheduler = AsyncMock()
+        engine._mllm_scheduler.generate.return_value = RequestOutput(
+            request_id="req-1",
+            output_text="<|channel>thought\nplan<channel|>Final answer",
+            prompt_tokens=9,
+            completion_tokens=3,
+            finished=True,
+            finish_reason="stop",
+        )
+
+        output = await engine.generate(prompt="hello", raw_output=True)
+
+        assert output.text == "<|channel>thought\nplan<channel|>Final answer"
+
+    asyncio.run(_run())
+
+
+def test_stream_generate_preserves_raw_output_for_mllm_scheduler():
+    async def _run():
+        engine = _make_mllm_engine()
+        engine._mllm_scheduler = MagicMock()
+        engine._mllm_scheduler.add_request_async = AsyncMock(return_value="req-1")
+
+        async def _stream_outputs(_request_id):
+            yield RequestOutput(
+                request_id="req-1",
+                output_text="<|channel>thought\n",
+                new_text="<|channel>thought\n",
+                prompt_tokens=4,
+                completion_tokens=1,
+                finished=False,
+            )
+            yield RequestOutput(
+                request_id="req-1",
+                output_text="<|channel>thought\nplan<channel|>Final answer",
+                new_text="plan<channel|>Final answer",
+                prompt_tokens=4,
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            )
+
+        engine._mllm_scheduler.stream_outputs = _stream_outputs
+
+        outputs = []
+        async for output in engine.stream_generate(prompt="hello", raw_output=True):
+            outputs.append((output.text, output.new_text))
+
+        assert outputs == [
+            ("<|channel>thought\n", "<|channel>thought\n"),
+            (
+                "<|channel>thought\nplan<channel|>Final answer",
+                "plan<channel|>Final answer",
+            ),
+        ]
+
+    asyncio.run(_run())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -178,10 +178,67 @@ class TestChatCompletionRawOutput:
             srv._engine = original_engine
             srv._model_name = original_model_name
             srv._reasoning_parser = original_reasoning_parser
+            # asyncio.run() closes its loop and leaves the default policy with
+            # _set_called=True and _loop=None. Any downstream test that calls
+            # asyncio.get_event_loop() would then raise
+            # "There is no current event loop in thread 'MainThread'".
+            # Install a fresh loop to keep subsequent tests in this file working.
+            asyncio.set_event_loop(asyncio.new_event_loop())
 
         msg = resp.choices[0].message
         assert msg.content == "Final answer"
         assert msg.reasoning == "plan"
+        assert mock_engine.chat.await_args.kwargs["raw_output"] is True
+
+
+class TestAnthropicMessagesRawOutput:
+    def test_anthropic_messages_requests_raw_output_for_tool_parsing(self):
+        """The /v1/messages non-streaming path must request raw engine output so
+        tool-call markers reach the parser, matching /v1/chat/completions parity.
+        """
+        import vllm_mlx.server as srv
+        from vllm_mlx.engine.base import GenerationOutput
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "anthropic-test-model"
+        mock_engine.is_mllm = False
+        mock_engine.preserve_native_tool_format = False
+        mock_engine.chat = AsyncMock(
+            return_value=GenerationOutput(
+                text="Hello from the model",
+                prompt_tokens=5,
+                completion_tokens=4,
+                finish_reason="stop",
+            )
+        )
+
+        original_engine = srv._engine
+        original_model_name = srv._model_name
+
+        srv._engine = mock_engine
+        srv._model_name = "anthropic-test-model"
+        try:
+
+            class _RawRequest:
+                async def is_disconnected(self):
+                    return False
+
+                async def json(self):
+                    return {
+                        "model": "anthropic-test-model",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "max_tokens": 16,
+                    }
+
+            resp = asyncio.run(srv.create_anthropic_message(_RawRequest()))
+        finally:
+            srv._engine = original_engine
+            srv._model_name = original_model_name
+            # asyncio.run() closes its loop; install a fresh one so subsequent
+            # tests using asyncio.get_event_loop() do not fail.
+            asyncio.set_event_loop(asyncio.new_event_loop())
+
+        assert resp is not None
         assert mock_engine.chat.await_args.kwargs["raw_output"] is True
 
 
@@ -675,9 +732,7 @@ class TestAPIKeyVerification:
 
             # Should raise HTTPException with 401
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
-                    server.verify_api_key(credentials)
-                )
+                asyncio.run(server.verify_api_key(credentials))
 
             assert exc_info.value.status_code == 401
             assert "Invalid API key" in str(exc_info.value.detail)
@@ -703,9 +758,7 @@ class TestAPIKeyVerification:
             )
 
             # Should not raise any exception
-            result = asyncio.get_event_loop().run_until_complete(
-                server.verify_api_key(credentials)
-            )
+            result = asyncio.run(server.verify_api_key(credentials))
             # verify_api_key returns True on success (no exception raised)
             assert result is True or result is None
         finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the OpenAI-compatible API server."""
 
+import asyncio
 import platform
 import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -101,6 +104,85 @@ class TestRequestModels:
             assert part.video_url["url"] == "https://example.com/video.mp4"
         else:
             assert part.video_url.url == "https://example.com/video.mp4"
+
+
+class TestChatCompletionRawOutput:
+    def test_chat_completion_requests_raw_output_for_reasoning_parser(self):
+        import vllm_mlx.server as srv
+        from vllm_mlx.engine.base import GenerationOutput
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "reasoning-test-model"
+        mock_engine.is_mllm = False
+        mock_engine.preserve_native_tool_format = False
+        mock_engine.chat = AsyncMock(
+            return_value=GenerationOutput(
+                text="<|channel>thought\nplan<channel|>Final answer",
+                prompt_tokens=7,
+                completion_tokens=3,
+                finish_reason="stop",
+            )
+        )
+
+        original_engine = srv._engine
+        original_model_name = srv._model_name
+        original_reasoning_parser = srv._reasoning_parser
+
+        class _FakeChannelParser:
+            def extract_reasoning(self, text):
+                prefix = "<|channel>thought\n"
+                end = "<channel|>"
+                if text.startswith(prefix) and end in text:
+                    reasoning_text, _, content = text[len(prefix) :].partition(end)
+                    return reasoning_text, content
+                return None, text
+
+        srv._engine = mock_engine
+        srv._model_name = "reasoning-test-model"
+        srv._reasoning_parser = _FakeChannelParser()
+        try:
+
+            class _Request(SimpleNamespace):
+                def model_dump(self):
+                    return dict(self.__dict__)
+
+            request = _Request(
+                model="reasoning-test-model",
+                messages=[srv.Message(role="user", content="hello")],
+                max_tokens=16,
+                temperature=0.7,
+                top_p=0.9,
+                top_k=0,
+                min_p=0.0,
+                presence_penalty=0.0,
+                repetition_penalty=1.0,
+                stop=None,
+                tools=None,
+                tool_choice=None,
+                stream=False,
+                stream_options=None,
+                response_format=None,
+                video_fps=None,
+                video_max_frames=None,
+                specprefill=None,
+                specprefill_keep_pct=None,
+                timeout=None,
+            )
+
+            class _RawRequest:
+                async def is_disconnected(self):
+                    return False
+
+            resp = asyncio.run(srv.create_chat_completion(request, _RawRequest()))
+        finally:
+            srv._engine = original_engine
+            srv._model_name = original_model_name
+            srv._reasoning_parser = original_reasoning_parser
+
+        msg = resp.choices[0].message
+        assert msg.content == "Final answer"
+        assert msg.reasoning == "plan"
+        assert mock_engine.chat.await_args.kwargs["raw_output"] is True
 
 
 class TestChatCompletionRequest:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -453,6 +453,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all requests when model is multimodal.
             # MLLM models only initialise the _mllm_scheduler (not _engine),
@@ -467,7 +469,11 @@ class BatchedEngine(BaseEngine):
             )
 
             return GenerationOutput(
-                text=clean_output_text(output.output_text),
+                text=(
+                    output.output_text
+                    if raw_output
+                    else clean_output_text(output.output_text)
+                ),
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
@@ -488,7 +494,9 @@ class BatchedEngine(BaseEngine):
             sampling_params=sampling_params,
         )
 
-        text = clean_output_text(output.output_text)
+        text = (
+            output.output_text if raw_output else clean_output_text(output.output_text)
+        )
 
         return GenerationOutput(
             text=text,
@@ -527,6 +535,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
             request_id = await self._mllm_scheduler.add_request_async(
@@ -540,8 +550,16 @@ class BatchedEngine(BaseEngine):
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
                 yield GenerationOutput(
-                    text=clean_output_text(output.output_text),
-                    new_text=output.new_text,
+                    text=(
+                        output.output_text
+                        if raw_output
+                        else clean_output_text(output.output_text)
+                    ),
+                    new_text=(
+                        output.new_text
+                        if raw_output
+                        else clean_output_text(output.new_text)
+                    ),
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
                     finished=output.finished,
@@ -567,11 +585,19 @@ class BatchedEngine(BaseEngine):
         )
 
         async for output in self._engine.stream_outputs(request_id):
-            text = clean_output_text(output.output_text)
+            text = (
+                output.output_text
+                if raw_output
+                else clean_output_text(output.output_text)
+            )
 
             yield GenerationOutput(
                 text=text,
-                new_text=output.new_text,
+                new_text=(
+                    output.new_text
+                    if raw_output
+                    else clean_output_text(output.new_text)
+                ),
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -437,6 +437,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
 
@@ -452,7 +454,7 @@ class SimpleEngine(BaseEngine):
                     tools=template_tools,
                     **kwargs,
                 )
-                text = clean_output_text(output.text)
+                text = output.text if raw_output else clean_output_text(output.text)
                 return GenerationOutput(
                     text=text,
                     prompt_tokens=output.prompt_tokens,
@@ -471,7 +473,7 @@ class SimpleEngine(BaseEngine):
                     tools=template_tools,
                     **kwargs,
                 )
-                text = clean_output_text(output.text)
+                text = output.text if raw_output else clean_output_text(output.text)
                 # Count prompt tokens from the full templated prompt
                 tokenizer = self._model.tokenizer
                 template_kwargs = {

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1606,6 +1606,11 @@ async def create_anthropic_message(
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
+    # Request raw output so tool-call markers are visible to the parser, mirroring
+    # the OpenAI /v1/chat/completions path. clean_output_text() is still applied
+    # to the final visible content below.
+    chat_kwargs["raw_output"] = True
+
     start_time = time.perf_counter()
     timeout = _default_timeout
 
@@ -1815,6 +1820,11 @@ async def _stream_anthropic_messages(
 
     if openai_request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+
+    # Request raw output so tool-call markers reach _parse_tool_calls_with_parser
+    # via accumulated_text. Streaming display still strips special tokens through
+    # SPECIAL_TOKENS_PATTERN below.
+    chat_kwargs["raw_output"] = True
 
     # Emit message_start
     message_start = {

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1426,6 +1426,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Add tools if provided
     if request.tools:
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
+    chat_kwargs["raw_output"] = True
 
     if request.stream:
         return StreamingResponse(
@@ -2014,6 +2015,7 @@ async def stream_chat_completion(
     """Stream chat completion response."""
     response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
     start_time = time.perf_counter()
+    kwargs["raw_output"] = True
 
     # Check if we should include usage in the final chunk
     include_usage = request.stream_options and request.stream_options.include_usage


### PR DESCRIPTION
## Summary

This fixes a server/engine contract bug for reasoning-capable chat paths.

Before this change, chat output could be cleaned inside the engine before the server reasoning parser ran. For models like Gemma 4, that turns raw output such as:

`<|channel>thought\n...<channel|>Final answer`

into partially-sanitized visible text before parsing. In practice, hidden reasoning can leak into `message.content`, and the server no longer has the original text it needs to split reasoning from final content correctly.

## Fix

- add `raw_output=True` on parser-aware server chat paths
- preserve raw output in `SimpleEngine.chat()`
- preserve raw output in `BatchedEngine.generate()` / `stream_generate()`
- keep cleanup on the server side after reasoning parsing instead of before it

## Why this matters

Gemma 4 was the clearest failure case because its hidden reasoning starts in a channel token format. Once that prefix is sanitized too early, the reasoning parser cannot reliably identify it as hidden reasoning anymore.

This change keeps the engine/server boundary clean:
- engine can still return cleaned output by default
- server can explicitly request raw output when it needs to run reasoning/tool parsing on the original text

## Tests

Added targeted regressions for:
- raw-output preservation in batched MLLM scheduler paths
- `/v1/chat/completions` requesting raw output and returning split reasoning/content correctly

Tested with:
- `tests/test_batched_engine_text_scheduler.py`
- `tests/test_server.py -k ChatCompletionRawOutput`
