### PR TITLE
Add mid-batch extend for text-only MLLM requests

### DIFF
--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -757,6 +757,8 @@ class MLLMBatchGenerator:
         # merged into a single BatchKVCache. Merging into an active batch
         # mid-generation would cause shape mismatches in attention layers,
         # so queued requests wait until the current batch finishes.
+        # Exception: text-only requests can be extended into an active batch
+        # via the elif branch below (they skip vision encoding entirely).
         if num_active == 0:
             requests = self.unprocessed_requests[: self.completion_batch_size]
 
@@ -768,6 +770,23 @@ class MLLMBatchGenerator:
             self.unprocessed_requests = self.unprocessed_requests[len(requests) :]
             self.active_batch = new_batch
             prompt_processing = True
+
+        # Mid-batch extend: text-only requests can join an active batch
+        # without vision encoding (no shape mismatch risk).
+        elif self.unprocessed_requests:
+            text_only = [
+                r for r in self.unprocessed_requests if not r.images and not r.videos
+            ][: self.completion_batch_size]
+
+            if text_only:
+                new_batch = self._process_prompts(text_only)
+                processed_uids = {r.uid for r in text_only}
+                self.unprocessed_requests = [
+                    r for r in self.unprocessed_requests if r.uid not in processed_uids
+                ]
+                if new_batch is not None:
+                    batch.extend(new_batch)
+                prompt_processing = True
 
         # Generate next token for active batch
         batch = self.active_batch


### PR DESCRIPTION
## Summary

- **MLLM batch generator** previously only started new batches when `num_active == 0`, serializing all concurrent requests. A short text-only request had to wait for a long request to finish generating all its tokens.
- Now **text-only requests** (no images/videos) can join an active batch mid-generation via `MLLMBatch.extend()`. Multimodal requests still wait for batch completion due to vision encoding shape constraints.
- This leverages the existing `MLLMBatch.extend()` method and `BatchKVCache.extend()` — no new infrastructure needed.

### Before
```
Request 1 (long):  |===prefill===|=========generation (2000 tokens)=========|
Request 2 (short): |                    waiting...                           |===prefill+gen===|
```

### After
```
Request 1 (long):  |===prefill===|=========generation (2000 tokens)=========|
Request 2 (short):        |==prefill+gen==| done!
```

### Tested on Qwen3.5-35B-A3B (--mllm --continuous-batching)
- Long request: 53.8s (2000 max_tokens)
- Short request: 1.0s (joined mid-batch, finished 48.8s earlier)
- Both outputs correct, no artifacts

## Test plan

- [x] Concurrent text-only requests: short request joins active batch and finishes independently
- [x] Output correctness: both requests produce coherent text
- [ ] Multimodal requests still wait for `num_active == 0` (no regression)
- [ ] Edge case: `_process_prompts` returns `None` (handled, no extend called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)