### PR TITLE
feat(api): per-request SpecPrefill overrides on /v1/completions

### DIFF
--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -247,6 +247,10 @@ class CompletionRequest(BaseModel):
     repetition_penalty: float | None = None  # mlx-lm style (>1.0 penalizes)
     # Request timeout in seconds (None = use server default)
     timeout: float | None = None
+    # SpecPrefill: per-request enable/disable (None = server decides)
+    specprefill: bool | None = None
+    # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
+    specprefill_keep_pct: float | None = None
 
 
 class CompletionChoice(BaseModel):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1330,6 +1330,13 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             media_type="text/event-stream",
         )
 
+    # SpecPrefill: per-request overrides (mirrors /v1/chat/completions)
+    gen_kwargs = {}
+    if request.specprefill is not None:
+        gen_kwargs["specprefill"] = request.specprefill
+    if request.specprefill_keep_pct is not None:
+        gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+
     # Non-streaming response with timing and timeout
     start_time = time.perf_counter()
     timeout = request.timeout or _default_timeout
@@ -1346,6 +1353,10 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         }
         if comp_rep_penalty is not None:
             gen_kwargs["repetition_penalty"] = comp_rep_penalty
+        if request.specprefill is not None:
+            gen_kwargs["specprefill"] = request.specprefill
+        if request.specprefill_keep_pct is not None:
+            gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
         output = await _wait_with_disconnect(
             engine.generate(prompt=prompt, **gen_kwargs),
             raw_request,
@@ -2271,6 +2282,11 @@ async def stream_completion(
     }
     if repetition_penalty is not None:
         gen_kwargs["repetition_penalty"] = repetition_penalty
+    if request.specprefill is not None:
+        gen_kwargs["specprefill"] = request.specprefill
+    if request.specprefill_keep_pct is not None:
+        gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+
     async for output in engine.stream_generate(prompt=prompt, **gen_kwargs):
         data = {
             "id": f"cmpl-{uuid.uuid4().hex[:8]}",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1330,13 +1330,6 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             media_type="text/event-stream",
         )
 
-    # SpecPrefill: per-request overrides (mirrors /v1/chat/completions)
-    gen_kwargs = {}
-    if request.specprefill is not None:
-        gen_kwargs["specprefill"] = request.specprefill
-    if request.specprefill_keep_pct is not None:
-        gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
-
     # Non-streaming response with timing and timeout
     start_time = time.perf_counter()
     timeout = request.timeout or _default_timeout
@@ -1345,20 +1338,22 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     total_prompt_tokens = 0
 
     for i, prompt in enumerate(prompts):
-        gen_kwargs = {
+        generate_kwargs = {
+            "prompt": prompt,
             "max_tokens": request.max_tokens or _default_max_tokens,
             "temperature": _resolve_temperature(request.temperature),
             "top_p": _resolve_top_p(request.top_p),
             "stop": request.stop,
         }
         if comp_rep_penalty is not None:
-            gen_kwargs["repetition_penalty"] = comp_rep_penalty
+            generate_kwargs["repetition_penalty"] = comp_rep_penalty
         if request.specprefill is not None:
-            gen_kwargs["specprefill"] = request.specprefill
+            generate_kwargs["specprefill"] = request.specprefill
         if request.specprefill_keep_pct is not None:
-            gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+            generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+
         output = await _wait_with_disconnect(
-            engine.generate(prompt=prompt, **gen_kwargs),
+            engine.generate(**generate_kwargs),
             raw_request,
             timeout=timeout,
         )
@@ -2274,20 +2269,21 @@ async def stream_completion(
     repetition_penalty: float | None = None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
-    gen_kwargs = {
+    generate_kwargs = {
+        "prompt": prompt,
         "max_tokens": request.max_tokens or _default_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
         "stop": request.stop,
     }
     if repetition_penalty is not None:
-        gen_kwargs["repetition_penalty"] = repetition_penalty
+        generate_kwargs["repetition_penalty"] = repetition_penalty
     if request.specprefill is not None:
-        gen_kwargs["specprefill"] = request.specprefill
+        generate_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
-        gen_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+        generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
-    async for output in engine.stream_generate(prompt=prompt, **gen_kwargs):
+    async for output in engine.stream_generate(**generate_kwargs):
         data = {
             "id": f"cmpl-{uuid.uuid4().hex[:8]}",
             "object": "text_completion",


### PR DESCRIPTION
## Summary

/v1/chat/completions already accepts per-request `specprefill` and `specprefill_keep_pct` overrides and threads them into `engine.chat()`. /v1/completions does not. This PR wires the same two fields through to /v1/completions on both the non-streaming and streaming paths.

## Why

A SpecPrefill user with mixed /v1/chat/completions and /v1/completions traffic currently cannot opt individual /v1/completions requests into or out of SpecPrefill, and cannot tune `specprefill_keep_pct` per request on that endpoint. The server config is the only control. This closes that gap symmetrically against the existing chat endpoint.

## Changes

- `vllm_mlx/api/models.py`: add `specprefill: bool | None` and `specprefill_keep_pct: float | None` to `CompletionRequest`, matching the fields already on `ChatCompletionRequest`.
- `vllm_mlx/server.py::create_completion`: extract both and pass as `gen_kwargs` into `engine.generate()`, mirroring the pattern at `server.py:1421` in `create_chat_completion`.
- `vllm_mlx/server.py::stream_completion`: apply the same extraction so streaming clients have the same control.

Both new fields default to `None`, so existing behavior is unchanged for clients that don't set them. No schema changes to `ChatCompletionRequest`. No engine-side changes needed: `SimpleEngine.stream_generate` already pops `specprefill` and `specprefill_keep_pct` from kwargs (`simple.py:307-308`).

Total delta: +20 lines across 2 files.

## Test plan

- [ ] `POST /v1/completions` with `prompt` + `max_tokens` but no `specprefill` field still returns 200 with content (default behavior unchanged).
- [ ] `POST /v1/completions` with `{"specprefill": true}` engages SpecPrefill on an eligible SimpleEngine model (non-MLLM with `--specprefill-draft-model`).
- [ ] `POST /v1/completions` with `{"specprefill": false}` bypasses SpecPrefill on the same eligible model.
- [ ] `POST /v1/completions` with `{"specprefill_keep_pct": 0.2}` uses 20% keep instead of the server default.
- [ ] `POST /v1/completions` with `stream=true` respects all three per-request controls above.

I've verified the default-behavior case locally on a runtime whose `CompletionRequest` schema is a strict superset of this PR's changes. The minimal version in this branch is structurally a subset and should behave identically for the default path.