### PR TITLE
feat: add Gemma 4 tool call parser

### DIFF
--- a/tests/test_gemma4_openai_format.py
+++ b/tests/test_gemma4_openai_format.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test: verify Gemma 4 tool calls produce valid OpenAI API responses.
+
+Claude Code (and other OpenAI-compatible clients) expect:
+- response.choices[0].message.tool_calls[0].type == "function"
+- response.choices[0].message.tool_calls[0].function.name == "read_file"
+- response.choices[0].message.tool_calls[0].function.arguments == '{"path":"/tmp/test.py"}'
+- response.choices[0].message.content is None (not empty string)
+- response.choices[0].finish_reason == "tool_calls"
+
+This test verifies the FULL pipeline from parser output → server wrapping → JSON response,
+not just the parser in isolation.
+"""
+
+import json
+
+import pytest
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    FunctionCall,
+    ToolCall,
+    Usage,
+)
+from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
+
+
+def _build_response_from_parser(parser_output, model_name="gemma-4-27b-it"):
+    """Simulate what server.py does at lines 1494-1511 to build the HTTP response."""
+    if parser_output.tools_called:
+        tool_calls = [
+            ToolCall(
+                id=tc.get("id", "call_test"),
+                type="function",
+                function=FunctionCall(
+                    name=tc["name"],
+                    arguments=tc["arguments"],
+                ),
+            )
+            for tc in parser_output.tool_calls
+        ]
+        content = parser_output.content if parser_output.content else None
+        finish_reason = "tool_calls"
+    else:
+        tool_calls = None
+        content = parser_output.content
+        finish_reason = "stop"
+
+    return ChatCompletionResponse(
+        model=model_name,
+        choices=[
+            ChatCompletionChoice(
+                message=AssistantMessage(
+                    content=content,
+                    tool_calls=tool_calls,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+class TestGemma4OpenAIFormat:
+    """Verify the full response matches what Claude Code expects."""
+
+    def setup_method(self):
+        self.parser = Gemma4ToolParser()
+
+    def test_tool_call_response_has_correct_structure(self):
+        """The JSON response must have the exact OpenAI structure."""
+        output = '<|tool_call>call:read_file{path:<|"|>/tmp/test.py<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        response = _build_response_from_parser(result)
+
+        # Serialize to JSON (this is what goes over the wire)
+        data = json.loads(response.model_dump_json(exclude_none=True))
+
+        choice = data["choices"][0]
+        msg = choice["message"]
+
+        # finish_reason must be "tool_calls" not "stop"
+        assert choice["finish_reason"] == "tool_calls"
+
+        # content must be absent or null when tool_calls present
+        assert msg.get("content") is None
+
+        # tool_calls must be a list
+        assert isinstance(msg["tool_calls"], list)
+        assert len(msg["tool_calls"]) == 1
+
+        tc = msg["tool_calls"][0]
+
+        # type must be "function"
+        assert tc["type"] == "function"
+
+        # id must be present and non-empty
+        assert tc["id"]
+        assert isinstance(tc["id"], str)
+
+        # function.name must be the function name
+        assert tc["function"]["name"] == "read_file"
+
+        # function.arguments must be a JSON string (not a dict!)
+        assert isinstance(tc["function"]["arguments"], str)
+        args = json.loads(tc["function"]["arguments"])
+        assert args == {"path": "/tmp/test.py"}
+
+    def test_multiple_tool_calls_response(self):
+        """Multiple tool calls in one response."""
+        output = (
+            "<|tool_call>"
+            'call:read_file{path:<|"|>/a.py<|"|>}'
+            'call:read_file{path:<|"|>/b.py<|"|>}'
+            "<tool_call|>"
+        )
+        result = self.parser.extract_tool_calls(output)
+        response = _build_response_from_parser(result)
+        data = json.loads(response.model_dump_json(exclude_none=True))
+
+        tcs = data["choices"][0]["message"]["tool_calls"]
+        assert len(tcs) == 2
+        assert tcs[0]["function"]["name"] == "read_file"
+        assert tcs[1]["function"]["name"] == "read_file"
+        # Each must have a unique id
+        assert tcs[0]["id"] != tcs[1]["id"]
+
+    def test_content_before_tool_call_preserved(self):
+        """Text before the tool call goes in content field."""
+        output = 'Let me check that.\n<|tool_call>call:read_file{path:<|"|>/tmp/x<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        response = _build_response_from_parser(result)
+        data = json.loads(response.model_dump_json(exclude_none=True))
+
+        msg = data["choices"][0]["message"]
+        assert msg["content"] == "Let me check that."
+        assert len(msg["tool_calls"]) == 1
+
+    def test_no_tool_call_response(self):
+        """Plain text response has no tool_calls field."""
+        output = "The answer is 42."
+        result = self.parser.extract_tool_calls(output)
+        response = _build_response_from_parser(result)
+        data = json.loads(response.model_dump_json(exclude_none=True))
+
+        msg = data["choices"][0]["message"]
+        assert msg["content"] == "The answer is 42."
+        assert "tool_calls" not in msg  # excluded by exclude_none
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    def test_complex_arguments_serialize_correctly(self):
+        """Nested objects and arrays must survive JSON round-trip."""
+        output = '<|tool_call>call:configure{settings:{enabled:true,tags:[<|"|>a<|"|>,<|"|>b<|"|>]}}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        response = _build_response_from_parser(result)
+        data = json.loads(response.model_dump_json(exclude_none=True))
+
+        tc = data["choices"][0]["message"]["tool_calls"][0]
+        args = json.loads(tc["function"]["arguments"])
+        assert args == {"settings": {"enabled": True, "tags": ["a", "b"]}}

--- a/tests/test_gemma4_openai_format.py
+++ b/tests/test_gemma4_openai_format.py
@@ -14,8 +14,6 @@ not just the parser in isolation.
 
 import json
 
-import pytest
-
 from vllm_mlx.api.models import (
     AssistantMessage,
     ChatCompletionChoice,

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Gemma 4 tool call parser."""
+
+import json
+
+import pytest
+
+from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
+
+
+class TestGemma4ToolParserExtract:
+    """Test extract_tool_calls on complete model output."""
+
+    def setup_method(self):
+        self.parser = Gemma4ToolParser()
+
+    def test_single_tool_call_string_arg(self):
+        output = '<|tool_call>call:read_file{path:<|"|>/tmp/foo.py<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc["name"] == "read_file"
+        args = json.loads(tc["arguments"])
+        assert args == {"path": "/tmp/foo.py"}
+        assert result.content is None
+
+    def test_single_tool_call_numeric_arg(self):
+        output = "<|tool_call>call:search{limit:10,verbose:false}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"limit": 10, "verbose": False}
+
+    def test_mixed_types(self):
+        output = '<|tool_call>call:search{query:<|"|>hello world<|"|>,limit:10,verbose:false}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"query": "hello world", "limit": 10, "verbose": False}
+
+    def test_nested_object(self):
+        output = '<|tool_call>call:configure{settings:{enabled:true,name:<|"|>test<|"|>}}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"settings": {"enabled": True, "name": "test"}}
+
+    def test_array_argument(self):
+        output = '<|tool_call>call:tag{items:[<|"|>foo<|"|>,<|"|>bar<|"|>]}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"items": ["foo", "bar"]}
+
+    def test_multiple_tool_calls_in_one_block(self):
+        output = (
+            "<|tool_call>"
+            'call:glob{pattern:<|"|>README*.md<|"|>}'
+            'call:glob{pattern:<|"|>CONTRIBUTING.md<|"|>}'
+            "<tool_call|>"
+        )
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        args0 = json.loads(result.tool_calls[0]["arguments"])
+        args1 = json.loads(result.tool_calls[1]["arguments"])
+        assert args0 == {"pattern": "README*.md"}
+        assert args1 == {"pattern": "CONTRIBUTING.md"}
+
+    def test_content_before_tool_call(self):
+        output = 'Let me read that file for you.\n<|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert result.content == "Let me read that file for you."
+        assert len(result.tool_calls) == 1
+
+    def test_no_tool_calls(self):
+        output = "Hello, how can I help you today?"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is False
+        assert result.tool_calls == []
+        assert result.content == output
+
+    def test_empty_tool_call_block(self):
+        output = "<|tool_call><tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is False
+        assert result.tool_calls == []
+
+    def test_tool_call_id_generated(self):
+        output = '<|tool_call>call:read_file{path:<|"|>/tmp/a<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        tc = result.tool_calls[0]
+        assert "id" in tc
+        assert tc["id"].startswith("call_")
+
+    def test_string_with_special_chars(self):
+        output = '<|tool_call>call:write{content:<|"|>line1\\nline2<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["content"] == "line1\\nline2"
+
+    def test_deeply_nested_objects(self):
+        output = "<|tool_call>call:update{a:{b:{c:1,d:true}}}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"a": {"b": {"c": 1, "d": True}}}
+
+    def test_null_value(self):
+        output = "<|tool_call>call:clear{target:null}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"target": None}
+
+    def test_unicode_emoji_in_args(self):
+        output = '<|tool_call>call:search{query:<|"|>hello world \U0001f30d \u4f60\u597d<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"query": "hello world \U0001f30d \u4f60\u597d"}
+
+    def test_braces_inside_string_value(self):
+        output = '<|tool_call>call:run{code:<|"|>if (x) { return y; }<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"code": "if (x) { return y; }"}
+
+    def test_quoted_keys(self):
+        output = '<|tool_call>call:read{<|"|>path<|"|>:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"path": "/tmp/foo"}
+
+    def test_think_tags_stripped(self):
+        output = '<think>Let me think about this...</think><|tool_call>call:search{query:<|"|>test<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -144,6 +144,31 @@ class TestGemma4ToolParserExtract:
         assert result.tools_called is True
         assert len(result.tool_calls) == 1
 
+    def test_missing_end_delimiter(self):
+        """Unclosed tool call block still parses (server fallback path)."""
+        output = '<|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"path": "/tmp/foo"}
+
+    def test_string_with_colon(self):
+        """String containing colon pattern must not be corrupted by bare-key quoting."""
+        output = '<|tool_call>call:connect{url:<|"|>host:8080<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"url": "host:8080"}
+
+    def test_string_with_newline_and_quote(self):
+        """Real newline and double quote inside string values are JSON-escaped."""
+        output = '<|tool_call>call:write{text:<|"|>line1\nline2 said "hello"<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"text": 'line1\nline2 said "hello"'}
+
 
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -143,3 +143,73 @@ class TestGemma4ToolParserExtract:
         result = self.parser.extract_tool_calls(output)
         assert result.tools_called is True
         assert len(result.tool_calls) == 1
+
+
+class TestGemma4ToolParserStreaming:
+    """Test streaming tool call extraction."""
+
+    def setup_method(self):
+        self.parser = Gemma4ToolParser()
+        self.parser.reset()
+
+    def test_streaming_no_tool_call(self):
+        """Normal text passes through as content."""
+        result = self.parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="Hello",
+            delta_text="Hello",
+        )
+        assert result == {"content": "Hello"}
+
+    def test_streaming_suppresses_during_tool_call(self):
+        """Returns None while inside tool call block (buffering)."""
+        r1 = self.parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="Sure. ",
+            delta_text="Sure. ",
+        )
+        assert r1 == {"content": "Sure. "}
+
+        r2 = self.parser.extract_tool_calls_streaming(
+            previous_text="Sure. ",
+            current_text="Sure. <|tool_call>call:read",
+            delta_text="<|tool_call>call:read",
+        )
+        assert r2 is None
+
+        r3 = self.parser.extract_tool_calls_streaming(
+            previous_text="Sure. <|tool_call>call:read",
+            current_text='Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}',
+            delta_text='_file{path:<|"|>/tmp/foo<|"|>}',
+        )
+        assert r3 is None
+
+    def test_streaming_emits_on_close(self):
+        """Emits structured tool_calls when end delimiter arrives."""
+        full_text = 'Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls_streaming(
+            previous_text='Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}',
+            current_text=full_text,
+            delta_text="<tool_call|>",
+        )
+        assert result is not None
+        assert "tool_calls" in result
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["function"]["name"] == "read_file"
+        assert tc["type"] == "function"
+        assert tc["index"] == 0
+
+
+class TestGemma4Registration:
+    """Test parser registration and flags."""
+
+    def test_registered_in_manager(self):
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        parser_cls = ToolParserManager.get_tool_parser("gemma4")
+        assert parser_cls is Gemma4ToolParser
+
+    def test_native_format_false(self):
+        assert Gemma4ToolParser.SUPPORTS_NATIVE_TOOL_FORMAT is False
+        assert Gemma4ToolParser.supports_native_format() is False

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -3,8 +3,6 @@
 
 import json
 
-import pytest
-
 from vllm_mlx.tool_parsers.gemma4_tool_parser import Gemma4ToolParser
 
 

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -209,7 +209,9 @@ class TestGemma4ToolParserStreaming:
 
     def test_streaming_emits_on_close(self):
         """Emits structured tool_calls when end delimiter arrives."""
-        full_text = 'Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        full_text = (
+            'Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        )
         result = self.parser.extract_tool_calls_streaming(
             previous_text='Sure. <|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}',
             current_text=full_text,

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -12,6 +12,7 @@ from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
     FunctionaryToolParser,
+    Gemma4ToolParser,
     GraniteToolParser,
     HermesToolParser,
     KimiToolParser,
@@ -53,6 +54,7 @@ class TestNativeToolFormatCapability:
             NemotronToolParser,
             xLAMToolParser,
             AutoToolParser,
+            Gemma4ToolParser,
         ]
         for parser_cls in non_native_parsers:
             assert (

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -9,6 +9,7 @@ from vllm_mlx.tool_parsers import (
     AutoToolParser,
     DeepSeekToolParser,
     FunctionaryToolParser,
+    Gemma4ToolParser,
     GraniteToolParser,
     HermesToolParser,
     KimiToolParser,
@@ -39,6 +40,7 @@ class TestToolParserManager:
             "nemotron",
             "xlam",
             "functionary",
+            "gemma4",
         ]
         for p in expected:
             assert p in parsers, f"Parser '{p}' not found"
@@ -68,6 +70,7 @@ class TestToolParserManager:
             ("meetkai", FunctionaryToolParser),
             ("hermes", HermesToolParser),
             ("nous", HermesToolParser),
+            ("gemma4", Gemma4ToolParser),
         ]
         for name, expected_cls in test_cases:
             parser_cls = ToolParserManager.get_tool_parser(name)

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -121,6 +121,7 @@ _TOOL_CALL_TAGS = [
     ("<minimax:tool_call>", "</minimax:tool_call>"),
     ("<tool_call>", "</tool_call>"),
     ("<function=", "</function>"),
+    ("<|tool_call>", "<tool_call|>"),
     ("[TOOL_CALL]", "[/TOOL_CALL]"),
     ("[Calling tool", "]\n"),  # Qwen3 bracket-style: [Calling tool: func({...})]\n
 ]

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2293,7 +2293,7 @@ async def stream_chat_completion(
         tool_parser
         and tool_accumulated_text
         and not tool_calls_detected
-        and "<tool_call>" in tool_accumulated_text
+        and ("<tool_call>" in tool_accumulated_text or "<|tool_call>" in tool_accumulated_text)
     ):
         result = tool_parser.extract_tool_calls(tool_accumulated_text)
         if result.tools_called:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2293,7 +2293,10 @@ async def stream_chat_completion(
         tool_parser
         and tool_accumulated_text
         and not tool_calls_detected
-        and ("<tool_call>" in tool_accumulated_text or "<|tool_call>" in tool_accumulated_text)
+        and (
+            "<tool_call>" in tool_accumulated_text
+            or "<|tool_call>" in tool_accumulated_text
+        )
     ):
         result = tool_parser.extract_tool_calls(tool_accumulated_text)
         if result.tools_called:

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -19,6 +19,7 @@ Available parsers:
 - functionary/meetkai: MeetKai Functionary models
 - glm47/glm4: GLM-4.7 and GLM-4.7-Flash models
 - harmony/gpt-oss: GPT-OSS models (Harmony format with channels)
+- gemma4: Google Gemma 4 models (<|tool_call>call:name{} format)
 
 Usage:
     from vllm_mlx.tool_parsers import ToolParserManager
@@ -57,6 +58,7 @@ from .qwen_tool_parser import QwenToolParser
 from .xlam_tool_parser import xLAMToolParser
 from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
+from .gemma4_tool_parser import Gemma4ToolParser
 
 __all__ = [
     # Base classes
@@ -77,4 +79,5 @@ __all__ = [
     "FunctionaryToolParser",
     "Glm47ToolParser",
     "HarmonyToolParser",
+    "Gemma4ToolParser",
 ]

--- a/vllm_mlx/tool_parsers/auto_tool_parser.py
+++ b/vllm_mlx/tool_parsers/auto_tool_parser.py
@@ -16,6 +16,7 @@ from .abstract_tool_parser import (
     ToolParser,
     ToolParserManager,
 )
+from .gemma4_tool_parser import Gemma4ToolParser
 
 
 def generate_tool_id() -> str:
@@ -29,12 +30,13 @@ class AutoToolParser(ToolParser):
     Auto-detecting tool call parser.
 
     Tries multiple formats in order:
-    1. Mistral: [TOOL_CALLS] ...
-    2. Qwen bracket: [Calling tool: func_name({...})]
-    3. Qwen/Hermes XML: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
-    4. Llama: <function=name>{"arg": "value"}</function>
-    5. Nemotron: <tool_call><function=name>...</function></tool_call>
-    6. Raw JSON: {"name": "...", "arguments": {...}}
+    1. Gemma 4: <|tool_call>call:name{...}<tool_call|>
+    2. Mistral: [TOOL_CALLS] ...
+    3. Qwen bracket: [Calling tool: func_name({...})]
+    4. Qwen/Hermes XML: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+    5. Llama: <function=name>{"arg": "value"}</function>
+    6. Nemotron: <tool_call><function=name>...</function></tool_call>
+    7. Raw JSON: {"name": "...", "arguments": {...}}
 
     This is the default parser when no specific parser is selected.
     """
@@ -63,7 +65,14 @@ class AutoToolParser(ToolParser):
         tool_calls: list[dict[str, Any]] = []
         cleaned_text = model_output
 
-        # 1. Try Mistral format
+        # 1. Try Gemma 4 format (most distinctive marker)
+        if "<|tool_call>" in model_output:
+            gemma_parser = Gemma4ToolParser()
+            result = gemma_parser.extract_tool_calls(model_output, request)
+            if result.tools_called:
+                return result
+
+        # 2. Try Mistral format
         if self.MISTRAL_TOKEN in model_output:
             parts = model_output.split(self.MISTRAL_TOKEN)
             content = parts[0].strip()
@@ -327,6 +336,7 @@ class AutoToolParser(ToolParser):
         """
         # Check for any tool call markers
         markers = [
+            "<|tool_call>",
             self.MISTRAL_TOKEN,
             "[Calling tool:",
             "<tool_call>",
@@ -339,7 +349,7 @@ class AutoToolParser(ToolParser):
             return {"content": delta_text}
 
         # Check for completion markers
-        end_markers = ["</tool_call>", "</function>", ")]"]
+        end_markers = ["<tool_call|>", "</tool_call>", "</function>", ")]"]
         if any(m in delta_text for m in end_markers):
             result = self.extract_tool_calls(current_text)
             if result.tools_called:

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -43,7 +43,7 @@ _STRING_DELIM_RE = re.compile(r'<\|"\|>(.*?)<\|"\|>', re.DOTALL)
 _CALL_PREFIX = re.compile(r"call:(\w+)\s*\{")
 
 # Pattern to quote bare keys: word followed by : at start or after , or {
-_BARE_KEY = re.compile(r'(?<=[{,])\s*(\w+)\s*:')
+_BARE_KEY = re.compile(r"(?<=[{,])\s*(\w+)\s*:")
 
 # Max arg block length to prevent runaway parsing on malformed input (1 MB)
 _MAX_ARG_BLOCK_LEN = 1_048_576

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 4 tool call parser for vllm-mlx.
+
+Handles Gemma 4's native tool call format:
+  <|tool_call>call:func_name{<|"|>key<|"|>: <|"|>value<|"|>, num: 42}<tool_call|>
+
+Gemma 4 uses special tokens instead of JSON:
+- <|tool_call> / <tool_call|> delimit tool call blocks
+- <|"|> replaces " for string values
+- Keys are unquoted bare identifiers
+- Multiple call:name{...} can appear in a single block
+
+Reference: mlx-lm PR #1105, vllm PR #38837
+"""
+
+import json
+import logging
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+logger = logging.getLogger(__name__)
+
+# Delimiters
+TOOL_CALL_START = "<|tool_call>"
+TOOL_CALL_END = "<tool_call|>"
+
+# Placeholder token used during <|"|> extraction. Matches \x00 + digits + \x00.
+_PLACEHOLDER_RE = re.compile(r"\x00(\d+)\x00")
+
+# Pattern to extract <|"|>-delimited strings (non-greedy, supports multiline)
+_STRING_DELIM_RE = re.compile(r'<\|"\|>(.*?)<\|"\|>', re.DOTALL)
+
+# Pattern to match call:name followed by a { (we extract balanced braces manually)
+_CALL_PREFIX = re.compile(r"call:(\w+)\s*\{")
+
+# Pattern to quote bare keys: word followed by : at start or after , or {
+_BARE_KEY = re.compile(r'(?<=[{,])\s*(\w+)\s*:')
+
+# Max arg block length to prevent runaway parsing on malformed input (1 MB)
+_MAX_ARG_BLOCK_LEN = 1_048_576
+
+
+def _find_balanced_brace(text: str, start: int) -> int:
+    """Find the index of the closing } that balances the { at `start`.
+
+    Before counting braces, <|"|>-delimited strings are conceptually opaque --
+    we skip over <|"|>...<|"|> regions so that braces inside string values
+    (e.g. code snippets) don't affect depth counting.
+
+    Args:
+        text: The string to search (may contain <|"|> tokens)
+        start: Index of the opening {
+
+    Returns:
+        Index of the matching } in the ORIGINAL text, or -1 if not found
+    """
+    if len(text) - start > _MAX_ARG_BLOCK_LEN:
+        return -1
+
+    depth = 0
+    i = start
+    in_string = False
+    while i < len(text):
+        if text.startswith('<|"|>', i):
+            in_string = not in_string
+            i += 5
+            continue
+        if not in_string:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    return -1
+
+
+def _gemma4_args_to_json(text: str) -> str:
+    """Convert Gemma 4 tool call args to valid JSON.
+
+    Three-step conversion (ORDER MATTERS):
+    1. Extract <|"|>-delimited strings into numbered \\x00N\\x00 placeholders.
+       This protects string contents from step 2's bare-key quoting -- without
+       this, a string value like "key: value" would be corrupted.
+    2. Quote bare keys (word: -> "word":) now that strings are safe.
+    3. Restore placeholders as properly JSON-escaped strings via json.dumps().
+       Uses a single re.sub pass (O(len(text))) instead of per-placeholder replace.
+    """
+    strings: list[str] = []
+
+    def _capture(m: re.Match) -> str:
+        strings.append(m.group(1))
+        return f"\x00{len(strings) - 1}\x00"
+
+    # Step 1: Extract <|"|>-delimited strings
+    text = _STRING_DELIM_RE.sub(_capture, text)
+
+    # Step 2: Quote bare keys
+    text = _BARE_KEY.sub(r'"\1":', text)
+
+    # Step 3: Restore captured strings as properly escaped JSON strings
+    def _restore(m: re.Match) -> str:
+        idx = int(m.group(1))
+        return json.dumps(strings[idx]) if idx < len(strings) else m.group(0)
+
+    text = _PLACEHOLDER_RE.sub(_restore, text)
+
+    return text
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+@ToolParserManager.register_module("gemma4")
+class Gemma4ToolParser(ToolParser):
+    """
+    Tool call parser for Gemma 4 models.
+
+    Parses: <|tool_call>call:func{<|"|>key<|"|>: <|"|>val<|"|>}<tool_call|>
+
+    Used when --enable-auto-tool-choice --tool-call-parser gemma4 are set.
+    """
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from a complete Gemma 4 model response."""
+        cleaned = self.strip_think_tags(model_output)
+
+        start_idx = cleaned.find(TOOL_CALL_START)
+        if start_idx == -1:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        content_before = cleaned[:start_idx].strip() or None
+
+        block_start = start_idx + len(TOOL_CALL_START)
+        end_idx = cleaned.find(TOOL_CALL_END, block_start)
+        if end_idx == -1:
+            block = cleaned[block_start:]
+        else:
+            block = cleaned[block_start:end_idx]
+
+        tool_calls: list[dict[str, Any]] = []
+
+        pos = 0
+        while pos < len(block):
+            m = _CALL_PREFIX.search(block, pos)
+            if not m:
+                break
+
+            func_name = m.group(1)
+            brace_start = m.end() - 1
+
+            brace_end = _find_balanced_brace(block, brace_start)
+            if brace_end == -1:
+                pos = m.end()
+                continue
+
+            args_raw = block[brace_start : brace_end + 1]
+            try:
+                args_json = _gemma4_args_to_json(args_raw)
+                json.loads(args_json)
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": func_name,
+                        "arguments": args_json,
+                    }
+                )
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.warning(
+                    f"Gemma 4 tool parser: failed to parse args for "
+                    f"call:{func_name}: {e}"
+                )
+
+            pos = brace_end + 1
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content_before,
+            )
+        else:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Extract tool calls from streaming Gemma 4 model output."""
+        has_start = TOOL_CALL_START in current_text
+
+        if not has_start:
+            return {"content": delta_text}
+
+        if TOOL_CALL_END in delta_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        return None


### PR DESCRIPTION
## Summary

- Adds `gemma4_tool_parser.py` — parses Gemma 4's `<|tool_call>call:name{<|"|>key<|"|>:val}<tool_call|>` format into OpenAI-compatible `tool_calls`
- Handles nested objects, arrays, unicode, braces in strings, quoted keys, multiple calls per block, think tags
- Registers as `--tool-call-parser gemma4`
- Adds streaming filter tags for `<|tool_call>`/`<tool_call|>`
- 30 tests including OpenAI format integration tests verifying exact Claude Code compatibility

## Usage

```bash
vllm-mlx serve google/gemma-4-27b-it \
  --enable-auto-tool-choice --tool-call-parser gemma4
```

## Test plan

- [x] 30 unit/integration tests passing
- [x] OpenAI format verified (content=null, finish_reason=tool_calls, function.arguments as JSON string)
- [ ] End-to-end with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)