### PR TITLE
fix: add missing return in load_model_with_fallback

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
## Summary

`load_model_with_fallback()` in `utils/tokenizer.py` is missing a `return` statement on the happy path. When `mlx_lm.load()` succeeds without raising a `ValueError`, the function falls through the `try` block and implicitly returns `None`.

This causes a `TypeError` in `MLXLanguageModel.load()`:

```
self.model, self.tokenizer = load_model_with_fallback(...)
TypeError: cannot unpack non-iterable NoneType object
```

**The fix is a single line** — adding `return model, tokenizer` after the successful `load()` call.

## How to reproduce

```python
import asyncio
from vllm_mlx.models.llm import MLXLanguageModel

async def test():
    m = MLXLanguageModel('mlx-community/Qwen3.5-35B-A3B-4bit', trust_remote_code=True)
    m.load()  # TypeError: cannot unpack non-iterable NoneType object

asyncio.run(test())
```

Note: the bug only manifests when called inside an async context (e.g., `asyncio.run()`), which is how the server starts the engine via `SimpleEngine.start()`. Direct calls outside async may work due to Python caching behaviour.

## Related issues

Fixes #252, #249

## Test

Verified with Qwen3.5-35B-A3B (4-bit and 8-bit) on Apple M5 Max. Server starts and serves requests successfully after the fix.