### PR TITLE
feat: add Gemma 4 tool call and reasoning parsers

### DIFF
--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -76,6 +76,7 @@ def list_parsers() -> list[str]:
 def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import DeepSeekR1ReasoningParser
+    from .gemma4_parser import Gemma4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
@@ -84,6 +85,7 @@ def _register_builtin_parsers():
     register_parser("deepseek_r1", DeepSeekR1ReasoningParser)
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
+    register_parser("gemma4", Gemma4ReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for Gemma 4 models.
+
+Gemma 4 uses channel-based tokens for reasoning:
+    <|channel>thought
+    [reasoning content]
+    <channel|>
+    [final content]
+
+The newline between the tag and content is optional — the model
+sometimes omits it before <channel|>.
+
+Unlike <think>/<​/think> which are single tokens, Gemma 4's tags span
+multiple tokens (e.g. <|channel> + thought), so the streaming parser
+uses stateful phase tracking instead of the base class text matching.
+"""
+
+from .base import DeltaMessage, ReasoningParser
+
+
+class Gemma4ReasoningParser(ReasoningParser):
+    """
+    Reasoning parser for Gemma 4 models.
+
+    Gemma 4 uses <|channel>thought / <channel|> tokens to denote reasoning.
+
+    Example:
+        Input: "<|channel>thought\\nLet me think...<channel|>The answer is 42."
+        Output: reasoning="Let me think...", content="The answer is 42."
+    """
+
+    START_TAG = "<|channel>thought"
+    END_TAG = "<channel|>"
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self._phase = "init"  # init -> reasoning -> content
+
+    def reset_state(self):
+        self._phase = "init"
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        implicit_think: bool = False,
+    ) -> tuple[str | None, str | None]:
+        """Extract reasoning from complete Gemma 4 output."""
+        if self.START_TAG in model_output and self.END_TAG in model_output:
+            _, _, after_start = model_output.partition(self.START_TAG)
+            reasoning, _, content = after_start.partition(self.END_TAG)
+            return reasoning.strip() or None, content.strip() or None
+
+        if self.START_TAG in model_output:
+            _, _, reasoning = model_output.partition(self.START_TAG)
+            return reasoning.strip() or None, None
+
+        if self.END_TAG in model_output:
+            reasoning, _, content = model_output.partition(self.END_TAG)
+            return reasoning.strip() or None, content.strip() or None
+
+        if implicit_think:
+            return model_output.strip() or None, None
+
+        return None, model_output
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        """
+        Extract reasoning from streaming deltas.
+
+        Uses stateful phase tracking because the start/end tags span
+        multiple MLX tokens (e.g. <|channel> and thought arrive separately).
+        """
+        # Phase: waiting for start tag to complete
+        if self._phase == "init":
+            if self.START_TAG in current_text:
+                # Start tag is now complete — switch to reasoning
+                self._phase = "reasoning"
+                # Emit any reasoning content after the start tag
+                after = current_text.partition(self.START_TAG)[2]
+                # Check if end tag also arrived in this chunk
+                if self.END_TAG in after:
+                    self._phase = "content"
+                    reasoning, _, content = after.partition(self.END_TAG)
+                    return DeltaMessage(
+                        reasoning=reasoning.lstrip("\n") or None,
+                        content=content.lstrip("\n") or None,
+                    )
+                text = after.lstrip("\n")
+                return DeltaMessage(reasoning=text) if text else None
+            # Still accumulating start tag — suppress output
+            # Check if current_text could be a prefix of the start tag
+            if self.START_TAG.startswith(current_text) or current_text.startswith("<"):
+                return None
+            # Not a thinking response — treat as plain content
+            return DeltaMessage(content=delta_text)
+
+        # Phase: inside reasoning, waiting for end tag
+        if self._phase == "reasoning":
+            if self.END_TAG in delta_text:
+                self._phase = "content"
+                reasoning, _, content = delta_text.partition(self.END_TAG)
+                return DeltaMessage(
+                    reasoning=reasoning or None,
+                    content=content.lstrip("\n") or None,
+                )
+            if self.END_TAG in current_text and self.END_TAG not in previous_text:
+                # End tag spans this delta boundary
+                self._phase = "content"
+                reasoning, _, content = current_text.partition(self.END_TAG)
+                # Only emit what's new (after previous_text's reasoning)
+                prev_reasoning = previous_text.partition(self.START_TAG)[2]
+                new_reasoning = reasoning[len(prev_reasoning):]
+                return DeltaMessage(
+                    reasoning=new_reasoning or None,
+                    content=content.lstrip("\n") or None,
+                )
+            return DeltaMessage(reasoning=delta_text)
+
+        # Phase: after end tag — pure content
+        return DeltaMessage(content=delta_text)

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -55,6 +55,7 @@ from .mistral_tool_parser import MistralToolParser
 from .nemotron_tool_parser import NemotronToolParser
 from .qwen_tool_parser import QwenToolParser
 from .xlam_tool_parser import xLAMToolParser
+from .gemma4_tool_parser import Gemma4ToolParser
 from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
 
@@ -75,6 +76,7 @@ __all__ = [
     "NemotronToolParser",
     "xLAMToolParser",
     "FunctionaryToolParser",
+    "Gemma4ToolParser",
     "Glm47ToolParser",
     "HarmonyToolParser",
 ]

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 4 tool call parser for vllm-mlx.
+
+Handles Gemma 4's tool calling format:
+- <|tool_call>call:function_name{param:<|"|>value<|"|>}<tool_call|>
+
+Supports Gemma 4 26B-A4B and similar models.
+"""
+
+import json
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParser,
+    ToolParserManager,
+)
+
+
+def generate_tool_id() -> str:
+    """Generate a unique tool call ID."""
+    return f"call_{uuid.uuid4().hex[:8]}"
+
+
+# Pattern to match Gemma 4 tool call format
+# <|tool_call>call:function_name{key:<|"|>value<|"|>, ...}<tool_call|>
+TOOL_CALL_PATTERN = re.compile(
+    r'<\|tool_call>call:([\w.-]+)\{(.*?)\}<tool_call\|>',
+    re.DOTALL
+)
+
+# Pattern to extract parameters: key:<|"|>value<|"|>
+PARAM_PATTERN = re.compile(
+    r'(\w+):<\|"\|>(.*?)<\|"\|>',
+    re.DOTALL
+)
+
+# Also handle the case where quotes are rendered as regular quotes
+PARAM_PATTERN_SIMPLE = re.compile(
+    r'(\w+):\s*"(.*?)"',
+    re.DOTALL
+)
+
+
+@ToolParserManager.register_module(["gemma4", "gemma-4"])
+class Gemma4ToolParser(ToolParser):
+    """Parser for Gemma 4's tool calling format."""
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from complete Gemma 4 output."""
+        tool_calls = []
+
+        # Also strip thinking/channel markers
+        text = model_output
+
+        matches = TOOL_CALL_PATTERN.findall(text)
+        for func_name, params_str in matches:
+            # Parse parameters
+            args = {}
+            for pattern in [PARAM_PATTERN, PARAM_PATTERN_SIMPLE]:
+                param_matches = pattern.findall(params_str)
+                for key, value in param_matches:
+                    args[key] = value
+
+            tool_calls.append({
+                "id": generate_tool_id(),
+                "name": func_name.strip(),
+                "arguments": json.dumps(args, ensure_ascii=False),
+            })
+
+        if tool_calls:
+            # Remove tool call markup from content
+            cleaned = TOOL_CALL_PATTERN.sub("", text).strip()
+            # Also remove thinking channel markers
+            cleaned = re.sub(r'<\|channel>thought\n.*?<channel\|>', '', cleaned, flags=re.DOTALL).strip()
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=cleaned or None,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Extract tool calls from streaming Gemma 4 output."""
+        # Check for tool call markers
+        if "<|tool_call>" not in current_text:
+            return {"content": delta_text}
+
+        # Check if tool call is complete (check current_text, not delta_text,
+        # because closing tag may span multiple tokens)
+        if "<tool_call|>" in current_text:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": i,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"],
+                            },
+                        }
+                        for i, tc in enumerate(result.tool_calls)
+                    ]
+                }
+
+        # Inside tool call markup — suppress output
+        return None


### PR DESCRIPTION
## Summary

Adds native Gemma 4 support for both tool calling and reasoning extraction.

- **Tool call parser** (`--tool-call-parser gemma4`): Parses Gemma 4's `<|tool_call>call:func{key:<|"|>value<|"|>}<tool_call|>` format. Supports hyphenated/dotted function names (e.g. `searxng-search`).
- **Reasoning parser** (`--reasoning-parser gemma4`): Extracts `<|channel>thought...<channel|>` tags into the `reasoning_content` API field. Stateful streaming parser handles tags that span multiple MLX tokens.

### Usage

```bash
vllm-mlx serve mlx-community/gemma-4-26b-a4b-it-4bit \
  --enable-auto-tool-choice \
  --tool-call-parser gemma4 \
  --reasoning-parser gemma4
```

### Files changed

| File | What |
|------|------|
| `vllm_mlx/tool_parsers/gemma4_tool_parser.py` | Tool call parser (new) |
| `vllm_mlx/tool_parsers/__init__.py` | Register import |
| `vllm_mlx/reasoning/gemma4_parser.py` | Reasoning parser (new) |
| `vllm_mlx/reasoning/__init__.py` | Register in builtin parsers |

### Test plan

- [x] Non-streaming tool calling with standard function names
- [x] Non-streaming tool calling with hyphenated names (e.g. `searxng-search`)
- [x] Streaming tool call extraction
- [x] Non-streaming reasoning extraction (`reasoning_content` populated, `content` clean)
- [x] Streaming reasoning extraction (no `<|channel>` tag leakage)
- [x] Tested on Apple M5 Max with `mlx-community/gemma-4-26b-a4b-it-4bit`

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)