### PR TITLE
fix: run MLLM prefill in thread executor to keep event loop responsive

### DIFF
--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -19,6 +19,7 @@ Architecture:
 """
 
 import asyncio
+import concurrent.futures
 import logging
 import time
 import uuid
@@ -634,14 +635,33 @@ class MLLMScheduler:
         logger.info("MLLM Scheduler stopped")
 
     async def _process_loop(self) -> None:
-        """Main async processing loop."""
+        """Main async processing loop.
+
+        Uses a thread pool executor for steps that involve prefill
+        (waiting requests or partial prefill in progress) so that the
+        event loop stays responsive for health checks and other HTTP
+        endpoints.  Decode-only steps are fast (<3 ms) and run inline.
+        """
+        _executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mllm-step"
+        )
+        loop = asyncio.get_running_loop()
+
         while self._running:
             try:
                 if self.has_requests():
-                    # Run one step
-                    self.step()
-                    # Yield to other tasks
-                    await asyncio.sleep(0)
+                    has_waiting = self.get_num_waiting() > 0
+                    has_partial = (
+                        self.batch_generator is not None
+                        and getattr(self.batch_generator, "_partial", None) is not None
+                    )
+                    needs_executor = has_waiting or has_partial
+
+                    if needs_executor:
+                        await loop.run_in_executor(_executor, self.step)
+                    else:
+                        self.step()
+                        await asyncio.sleep(0)
                 else:
                     # No work, wait a bit
                     await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary

- MLLM scheduler's `_process_loop()` was calling `self.step()` directly on the asyncio event loop, blocking all HTTP handlers (including `/health`) during prefill
- Apply the same hybrid executor pattern already used by `engine_core`: prefill-likely steps run via `run_in_executor`, decode-only steps remain inline
- This keeps `/health` and other endpoints responsive during long prefills

## Problem

When a large prompt arrives, prefill can block the event loop for several seconds. During this time, `/health` returns no response, causing monitoring dashboards to report the server as unavailable.

## Test plan

- [x] Start server with `--mllm --continuous-batching`
- [x] Send a long prompt request and simultaneously call `/health` — confirms 200 responses in ~65-73ms during active inference
- [x] Verify generation output is correct and streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)