### PR TITLE
fix: strip billing header from Anthropic system prompt for prefix cache

### DIFF
--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -9,6 +9,7 @@ Handles translation of:
 """
 
 import json
+import re
 import uuid
 
 from .anthropic_models import (
@@ -60,6 +61,10 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
             system_text = "\n".join(parts)
         else:
             system_text = str(request.system)
+        # Strip per-request billing/tracking headers injected by some
+        # clients (e.g. Claude Code).  These contain a per-request hash
+        # that prevents prefix-cache reuse across turn boundaries.
+        system_text = re.sub(r"x-anthropic-billing-header:[^\n]*\n?", "", system_text)
         messages.append(Message(role="system", content=system_text))
 
     # Convert each message


### PR DESCRIPTION
## Summary

- Strip `x-anthropic-billing-header` from system prompt before tokenization to enable prefix cache reuse across turn boundaries

## Problem

Claude Code injects a billing/tracking header into the Anthropic Messages API system prompt:

```
x-anthropic-billing-header: cc_version=2.1.100.7b4; cc_entrypoint=cli; cch=eb6c6;
You are Claude Code...
```

The `cch=` hash **changes with every request**, causing token sequences to diverge at position ~40. This completely defeats prefix cache — every request requires full prefill of 60K+ tokens (~50 seconds on Gemma 4 26B-A4B).

## Fix

One-line regex strip in `anthropic_adapter.py` before the system text is passed to the chat template:

```python
system_text = re.sub(r"x-anthropic-billing-header:[^\n]*\n?", "", system_text)
```

## Result

| Metric | Before | After |
|--------|--------|-------|
| Prefix match | 40/60K tokens (0.07%) | 60K/60K tokens (99.9%) |
| Time per request | **50s** | **3.65s** |
| Throughput | 1.9 tok/s | **42.1 tok/s** |
| Speedup | — | **13.7x** |

## Test plan
- [x] Consecutive Claude Code Anthropic requests match 60K/60K tokens (prefix hit)
- [x] First request (cold cache): full prefill ~49s
- [x] Second request (warm cache): **3.65s** (only 34 new tokens to process)
- [x] Non-Anthropic (OpenAI) requests unaffected
- [x] Anthropic requests without billing header unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)