### PR TITLE
[codex] fix(simple): cooperatively cancel specprefill workers

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -4,6 +4,7 @@
 import asyncio
 from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import pytest
 
 pytestmark = pytest.mark.anyio

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -373,3 +373,316 @@ class TestSimpleEngineConcurrency:
 
         assert output.text == ""
         assert output.finish_reason == "stop"
+
+    @pytest.mark.anyio
+    async def test_cancellation_does_not_release_lock_before_worker_finishes(
+        self, mock_llm_model
+    ):
+        """A cancelled blocking chat call must not overlap the next worker."""
+        from threading import Event, Lock
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        first_started = Event()
+        release_workers = Event()
+        call_count = 0
+        call_lock = Lock()
+
+        def chat_side_effect(**kwargs):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+                current_call = call_count
+                mock_llm_model._concurrent_count += 1
+                mock_llm_model._max_concurrent = max(
+                    mock_llm_model._max_concurrent,
+                    mock_llm_model._concurrent_count,
+                )
+                if current_call == 1:
+                    first_started.set()
+
+            try:
+                release_workers.wait(timeout=1.0)
+                result = MagicMock()
+                result.text = f"response-{current_call}"
+                result.tokens = [1, 2, 3]
+                result.finish_reason = "stop"
+                return result
+            finally:
+                with call_lock:
+                    mock_llm_model._concurrent_count -= 1
+
+        mock_llm_model.chat = MagicMock(side_effect=chat_side_effect)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_llm_model
+            engine._loaded = True
+
+            task1 = asyncio.create_task(
+                engine.chat(
+                    messages=[{"role": "user", "content": "first"}], max_tokens=8
+                )
+            )
+            await asyncio.to_thread(first_started.wait, 1.0)
+
+            task1.cancel()
+            task2 = asyncio.create_task(
+                engine.chat(
+                    messages=[{"role": "user", "content": "second"}], max_tokens=8
+                )
+            )
+
+            await asyncio.sleep(0.05)
+            release_workers.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task1
+            result2 = await task2
+
+            assert result2.text == "response-2"
+            assert mock_llm_model._max_concurrent == 1
+
+    @pytest.mark.anyio
+    async def test_specprefill_path_does_not_prelock_serialized_runner(self):
+        """SpecPrefill should let _run_blocking_serialized own the lock."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        async def fake_serialized(func, *args, **kwargs):
+            assert not engine._generation_lock.locked()
+            return []
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+            engine._model = MagicMock()
+            engine._model.model = MagicMock()
+            engine._model.tokenizer = MagicMock()
+            engine._draft_model = MagicMock()
+            engine._run_blocking_serialized = fake_serialized  # type: ignore[method-assign]
+
+            outputs = []
+            async for chunk in engine._stream_generate_specprefill(
+                prompt="hello",
+                tokens=[1, 2, 3, 4],
+                max_tokens=4,
+                temperature=0.7,
+                top_p=0.9,
+            ):
+                outputs.append(chunk)
+
+            assert len(outputs) == 1
+            assert outputs[0].finished
+            assert outputs[0].completion_tokens == 0
+
+    @pytest.mark.anyio
+    async def test_text_mtp_path_does_not_prelock_serialized_runner(self):
+        """Text-only MTP path should let _run_blocking_serialized own the lock."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        async def fake_serialized(func, *args, **kwargs):
+            assert not engine._generation_lock.locked()
+            return []
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=True):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+            engine._text_model = MagicMock()
+            engine._text_model.make_mtp_cache = MagicMock(return_value=[])
+            engine._text_tokenizer = MagicMock()
+            engine._text_tokenizer.apply_chat_template = MagicMock(return_value="hello")
+            engine._text_tokenizer.bos_token = None
+            engine._draft_model = None
+            engine._run_blocking_serialized = fake_serialized  # type: ignore[method-assign]
+
+            outputs = []
+            async for chunk in engine._stream_generate_text(
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=4,
+                temperature=0.7,
+                top_p=0.9,
+            ):
+                outputs.append(chunk)
+
+            assert len(outputs) == 1
+            assert outputs[0].finished
+            assert outputs[0].completion_tokens == 0
+
+    @pytest.mark.anyio
+    async def test_specprefill_threads_same_cancel_check_to_helpers(self):
+        """SpecPrefill worker should pass one cooperative cancel hook through both phases."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured = {}
+
+        def fake_score_tokens(*args, cancel_check=None, **kwargs):
+            captured["score"] = cancel_check
+            return mx.array([0.5], dtype=mx.float32)
+
+        def fake_sparse_prefill(*args, cancel_check=None, **kwargs):
+            captured["prefill"] = cancel_check
+            return mx.zeros((1, 1, 8), dtype=mx.float32)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+            engine._draft_model = MagicMock()
+            engine._model = MagicMock()
+            engine._model.model = MagicMock()
+            engine._model.tokenizer = MagicMock()
+            engine._model.tokenizer.decode = MagicMock(return_value="A")
+            engine._model.tokenizer.eos_token_id = 0
+
+            outputs = []
+            with (
+                patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+                patch(
+                    "mlx_lm.sample_utils.make_sampler",
+                    return_value=lambda logits: mx.array([0], dtype=mx.int32),
+                ),
+                patch(
+                    "vllm_mlx.specprefill.score_tokens", side_effect=fake_score_tokens
+                ),
+                patch(
+                    "vllm_mlx.specprefill.select_chunks",
+                    return_value=mx.array([0], dtype=mx.int32),
+                ),
+                patch(
+                    "vllm_mlx.specprefill.sparse_prefill",
+                    side_effect=fake_sparse_prefill,
+                ),
+                patch("vllm_mlx.specprefill.cleanup_rope"),
+            ):
+                async for chunk in engine._stream_generate_specprefill(
+                    prompt="hello",
+                    tokens=[1, 2, 3, 4],
+                    max_tokens=4,
+                    temperature=0.7,
+                    top_p=0.9,
+                ):
+                    outputs.append(chunk.new_text)
+
+        assert outputs == ["A"]
+        assert callable(captured["score"])
+        assert captured["score"] is captured["prefill"]
+
+    @pytest.mark.anyio
+    async def test_cancelling_specprefill_request_stops_during_scoring(self):
+        """Cancelling SpecPrefill should signal the blocking scorer and exit without output."""
+        import time
+        from threading import Event
+
+        from vllm_mlx.engine.simple import SimpleEngine, _SpecPrefillCancelled
+
+        score_started = Event()
+        score_cancelled = Event()
+
+        def fake_score_tokens(*args, cancel_check=None, **kwargs):
+            assert callable(cancel_check)
+            score_started.set()
+            while True:
+                try:
+                    cancel_check()
+                except _SpecPrefillCancelled:
+                    score_cancelled.set()
+                    raise
+                time.sleep(0.01)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+            engine._draft_model = MagicMock()
+            engine._model = MagicMock()
+            engine._model.model = MagicMock()
+            engine._model.tokenizer = MagicMock()
+
+            async def consume():
+                async for _chunk in engine._stream_generate_specprefill(
+                    prompt="hello",
+                    tokens=[1, 2, 3, 4],
+                    max_tokens=4,
+                    temperature=0.7,
+                    top_p=0.9,
+                ):
+                    pytest.fail("Cancelled SpecPrefill request should not emit output")
+
+            with (
+                patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+                patch(
+                    "vllm_mlx.specprefill.score_tokens",
+                    side_effect=fake_score_tokens,
+                ),
+                patch("vllm_mlx.specprefill.cleanup_rope"),
+            ):
+                task = asyncio.create_task(consume())
+                assert await asyncio.to_thread(score_started.wait, 1.0)
+                task.cancel()
+
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+        assert await asyncio.to_thread(score_cancelled.wait, 1.0)
+
+    @pytest.mark.anyio
+    async def test_cancelling_specprefill_request_stops_during_sparse_prefill(self):
+        """Cancelling SpecPrefill should signal the sparse-prefill loop and exit without output."""
+        import time
+        from threading import Event
+
+        from vllm_mlx.engine.simple import SimpleEngine, _SpecPrefillCancelled
+
+        prefill_started = Event()
+        prefill_cancelled = Event()
+
+        def fake_sparse_prefill(*args, cancel_check=None, **kwargs):
+            assert callable(cancel_check)
+            prefill_started.set()
+            while True:
+                try:
+                    cancel_check()
+                except _SpecPrefillCancelled:
+                    prefill_cancelled.set()
+                    raise
+                time.sleep(0.01)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+            engine._draft_model = MagicMock()
+            engine._model = MagicMock()
+            engine._model.model = MagicMock()
+            engine._model.tokenizer = MagicMock()
+
+            async def consume():
+                async for _chunk in engine._stream_generate_specprefill(
+                    prompt="hello",
+                    tokens=[1, 2, 3, 4],
+                    max_tokens=4,
+                    temperature=0.7,
+                    top_p=0.9,
+                ):
+                    pytest.fail("Cancelled SpecPrefill request should not emit output")
+
+            with (
+                patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+                patch(
+                    "vllm_mlx.specprefill.score_tokens",
+                    return_value=mx.array([0.5], dtype=mx.float32),
+                ),
+                patch(
+                    "vllm_mlx.specprefill.select_chunks",
+                    return_value=mx.array([0], dtype=mx.int32),
+                ),
+                patch(
+                    "vllm_mlx.specprefill.sparse_prefill",
+                    side_effect=fake_sparse_prefill,
+                ),
+                patch("vllm_mlx.specprefill.cleanup_rope"),
+            ):
+                task = asyncio.create_task(consume())
+                assert await asyncio.to_thread(prefill_started.wait, 1.0)
+                task.cancel()
+
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+        assert await asyncio.to_thread(prefill_cancelled.wait, 1.0)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -706,6 +706,8 @@ class SimpleEngine(BaseEngine):
         model, then generates autoregressively. Falls back to normal generation
         on any error.
         """
+        from threading import Event
+
         model = self._model.model
         tokenizer = self._model.tokenizer
         n_tokens = len(tokens)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -42,6 +42,10 @@ def _has_media_content(messages: list) -> bool:
     return False
 
 
+class _SpecPrefillCancelled(Exception):
+    """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
+
+
 class SimpleEngine(BaseEngine):
     """
     Simple engine for direct model calls.
@@ -228,7 +232,7 @@ class SimpleEngine(BaseEngine):
         self._system_kv_token_count = 0
         logger.info("SimpleEngine stopped")
 
-    async def _run_blocking_serialized(self, func, /, *args, **kwargs):
+    async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
         """Run a blocking MLX operation under the generation lock.
 
         Cancellation must not release the async lock before the worker thread
@@ -240,6 +244,14 @@ class SimpleEngine(BaseEngine):
             try:
                 return await asyncio.shield(task)
             except asyncio.CancelledError:
+                if on_cancel is not None:
+                    try:
+                        on_cancel()
+                    except Exception:
+                        logger.debug(
+                            "Blocking worker cancellation callback failed",
+                            exc_info=True,
+                        )
                 try:
                     await task
                 except BaseException:
@@ -697,10 +709,20 @@ class SimpleEngine(BaseEngine):
         model = self._model.model
         tokenizer = self._model.tokenizer
         n_tokens = len(tokens)
+        cancel_requested = Event()
+
+        def _request_cancel() -> None:
+            cancel_requested.set()
+
+        def _cancel_check() -> None:
+            if cancel_requested.is_set():
+                raise _SpecPrefillCancelled()
 
         def _run_all():
             try:
                 return _run_specprefill()
+            except _SpecPrefillCancelled:
+                raise
             except Exception as e:
                 logger.error("SpecPrefill failed, falling back to normal path: %s", e)
                 return _run_normal()
@@ -730,10 +752,12 @@ class SimpleEngine(BaseEngine):
                     self._draft_model,
                     tokens,
                     prefill_step_size=self._prefill_step_size,
+                    cancel_check=_cancel_check,
                 )
                 t_score = time.monotonic() - t0
 
                 # Phase 2: Select important chunks
+                _cancel_check()
                 effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
                 selected = select_chunks(importance, keep_pct=effective_keep)
                 n_selected = selected.shape[0]
@@ -746,6 +770,7 @@ class SimpleEngine(BaseEngine):
                     selected,
                     cache,
                     step_size=self._prefill_step_size,
+                    cancel_check=_cancel_check,
                 )
                 t_prefill = time.monotonic() - t0
 
@@ -762,6 +787,7 @@ class SimpleEngine(BaseEngine):
 
                 # Phase 4: Generate (simple autoregressive, no MTP)
                 sampler = make_sampler(temp=temperature, top_p=top_p)
+                _cancel_check()
                 eos_id = tokenizer.eos_token_id
                 y = sampler(logits[:, -1, :])
                 mx.eval(y)
@@ -771,6 +797,7 @@ class SimpleEngine(BaseEngine):
                 prev_decoded = ""
 
                 for _ in range(max_tokens):
+                    _cancel_check()
                     tok_id = y.item()
                     generated_ids.append(tok_id)
 
@@ -789,6 +816,7 @@ class SimpleEngine(BaseEngine):
                     if is_eos:
                         break
 
+                    _cancel_check()
                     logits = model(y.reshape(1, -1), cache=cache)
                     y = sampler(logits[:, -1, :])
                     mx.eval(y)
@@ -811,6 +839,7 @@ class SimpleEngine(BaseEngine):
                 stop=stop,
                 **kwargs,
             ):
+                _cancel_check()
                 new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
                 results.append(
                     SimpleNamespace(
@@ -820,7 +849,9 @@ class SimpleEngine(BaseEngine):
                 )
             return results
 
-        all_resps = await self._run_blocking_serialized(_run_all)
+        all_resps = await self._run_blocking_serialized(
+            _run_all, on_cancel=_request_cancel
+        )
 
         # Yield results as GenerationOutput
         accumulated_text = ""

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -155,32 +155,48 @@ def _unpatch_attention_capture(model, originals):
         _set_attn_module(model.layers[layer_idx], orig)
 
 
-def _prefill_draft(model, tokens, cache, step_size=2048):
+def _prefill_draft(model, tokens, cache, step_size=2048, cancel_check=None):
     """Prefill prompt tokens into cache. Returns logits from last token."""
     prompt = mx.array(tokens) if not isinstance(tokens, mx.array) else tokens
     n = len(tokens)
     processed = 0
     while n - processed > 1:
+        if cancel_check is not None:
+            cancel_check()
         chunk = min(step_size, n - processed - 1)
         model(prompt[processed : processed + chunk][None], cache=cache)
         mx.eval([c.state for c in cache])
         processed += chunk
         mx.clear_cache()
+    if cancel_check is not None:
+        cancel_check()
     logits = model(prompt[processed:][None], cache=cache)
     mx.eval(logits)
     return logits
 
 
-def _lookahead_decode(model, first_logits, cache, n_steps, temp=0.6, top_p=0.95):
+def _lookahead_decode(
+    model,
+    first_logits,
+    cache,
+    n_steps,
+    temp=0.6,
+    top_p=0.95,
+    cancel_check=None,
+):
     """Run n_steps autoregressive decode, returning generated token ids.
 
     Query vectors are captured by the monkey-patched attention layers.
     """
     sampler = make_sampler(temp=temp, top_p=top_p)
+    if cancel_check is not None:
+        cancel_check()
     y = sampler(first_logits[:, -1, :])
     mx.eval(y)
     generated = [y.item()]
     for _ in range(n_steps):
+        if cancel_check is not None:
+            cancel_check()
         logits = model(y.reshape(1, -1), cache=cache)
         y = sampler(logits[:, -1, :])
         mx.eval(y)
@@ -264,6 +280,7 @@ def score_tokens(
     top_p=0.95,
     prefill_step_size=2048,
     query_extractor=None,
+    cancel_check=None,
 ):
     """Score token importance using attention-based analysis on a draft model.
 
@@ -320,7 +337,13 @@ def score_tokens(
 
     # Phase 1: Prefill
     cache = make_prompt_cache(model)
-    logits = _prefill_draft(model, tokens, cache, step_size=prefill_step_size)
+    logits = _prefill_draft(
+        model,
+        tokens,
+        cache,
+        step_size=prefill_step_size,
+        cancel_check=cancel_check,
+    )
 
     # Phase 2: Lookahead decode with query capture
     query_buffer = [[] for _ in range(n_attn_layers)]
@@ -328,7 +351,15 @@ def score_tokens(
         model, query_buffer, query_extractor=query_extractor
     )
     try:
-        _lookahead_decode(model, logits, cache, n_lookahead, temp=temp, top_p=top_p)
+        _lookahead_decode(
+            model,
+            logits,
+            cache,
+            n_lookahead,
+            temp=temp,
+            top_p=top_p,
+            cancel_check=cancel_check,
+        )
         mx.eval(query_buffer)
     finally:
         _unpatch_attention_capture(model, patches)
@@ -338,6 +369,8 @@ def score_tokens(
     # compacted for Nemotron-H where only M/* layers have cache entries)
     layer_to_cache = _build_layer_to_cache_map(model)
     attn_caches = [cache[layer_to_cache[i]] for i in attn_indices]
+    if cancel_check is not None:
+        cancel_check()
     importance = _compute_importance(
         query_buffer,
         attn_caches,
@@ -606,7 +639,13 @@ def _build_layer_to_cache_map(model):
 
 
 def sparse_prefill(
-    model, tokens, selected_indices, cache, step_size=2048, position_offset=0
+    model,
+    tokens,
+    selected_indices,
+    cache,
+    step_size=2048,
+    position_offset=0,
+    cancel_check=None,
 ):
     """Prefill the model cache with selected tokens at their original positions.
 
@@ -692,6 +731,8 @@ def sparse_prefill(
         processed = 0
 
         while n - processed > 1:
+            if cancel_check is not None:
+                cancel_check()
             chunk = min(step_size, n - processed - 1)
             model(prompt[processed : processed + chunk][None], cache=cache)
             mx.eval([c.state for c in cache])
@@ -699,6 +740,8 @@ def sparse_prefill(
             mx.clear_cache()
 
         # Last token → logits
+        if cancel_check is not None:
+            cancel_check()
         logits = model(prompt[processed:][None], cache=cache)
         mx.eval(logits)
 


### PR DESCRIPTION
## Summary
- add cooperative cancellation to the SimpleEngine SpecPrefill worker path
- thread a single `cancel_check` hook through `_prefill_draft`, `score_tokens`, and `sparse_prefill`
- add regression coverage for scoring-time and sparse-prefill cancellation without changing the current `main` decode shape

## Why
`_run_blocking_serialized()` now keeps the async generation lock held until the worker thread actually finishes, but long-running SpecPrefill phases still need a cooperative exit path after request cancellation. Without that, cancelled SpecPrefill requests can keep burning CPU inside blocking scoring/prefill loops even though the request is already gone.

## Validation
- `black --fast --check vllm_mlx/engine/simple.py vllm_mlx/specprefill.py tests/test_simple_engine.py`
- `pytest -q tests/test_simple_engine.py`
