### PR TITLE
fix: import Path in tokenizer utils

### DIFF
--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -9,6 +9,7 @@ directly from tokenizer.json.
 
 import json
 import logging
+from pathlib import Path
 
 from .chat_templates import DEFAULT_CHATML_TEMPLATE, NEMOTRON_CHAT_TEMPLATE
 


### PR DESCRIPTION
## Summary
- add the missing `Path` import in `vllm_mlx/utils/tokenizer.py`
- fix the red `main` CI run after #77 merged

## Verification
- `PYTHONPATH=/Users/David/code/vllm-mlx-tokenizer-import /opt/ai-runtime/venv-live/bin/python -m py_compile /Users/David/code/vllm-mlx-tokenizer-import/vllm_mlx/utils/tokenizer.py`
- `uvx ruff check /Users/David/code/vllm-mlx-tokenizer-import/vllm_mlx/utils/tokenizer.py --select E,F,W --ignore E402,E501,E731,F811,F841`
