### PR TITLE
cli: expose harmony and gpt-oss tool parsers

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,6 +168,41 @@ class TestCompletionRequest:
         assert request.max_tokens is None  # uses _default_max_tokens when None
 
 
+class TestServeCli:
+    """Test serve CLI argument parsing."""
+
+    def test_tool_call_parser_accepts_harmony_aliases(self):
+        """GPT-OSS/Harmony parsers should be selectable from the serve CLI."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "harmony",
+            ]
+        )
+
+        assert args.command == "serve"
+        assert args.tool_call_parser == "harmony"
+        assert args.enable_auto_tool_choice is True
+
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "gpt-oss",
+            ]
+        )
+
+        assert args.tool_call_parser == "gpt-oss"
+
+
 # =============================================================================
 # Helper Function Tests
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -633,7 +633,8 @@ def bench_kv_cache_command(args):
     )
 
 
-def main():
+def create_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
         description="vllm-mlx: Apple Silicon MLX backend for vLLM",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -880,6 +881,8 @@ Examples:
             "qwen3_coder",
             "llama",
             "hermes",
+            "harmony",
+            "gpt-oss",
             "deepseek",
             "kimi",
             "granite",
@@ -893,7 +896,8 @@ Examples:
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, gemma4, kimi, granite, nemotron, xlam, functionary, glm47, minimax. "
+            "harmony, gpt-oss, deepseek, gemma4, kimi, granite, nemotron, "
+            "xlam, functionary, glm47, minimax. "
             "Required for --enable-auto-tool-choice."
         ),
     )
@@ -1113,6 +1117,12 @@ Examples:
         action="store_true",
         help="Download as multimodal model (broader file patterns)",
     )
+
+    return parser
+
+
+def main():
+    parser = create_parser()
     args = parser.parse_args()
 
     if args.command == "serve":


### PR DESCRIPTION
Supersedes #216 with the same functional diff rebased on current main.

Why this PR exists:
- I rebased the original branch locally and validated it cleanly.
- Direct maintainer push back to the original `computor-org` fork failed with 403 from this auth context, so the original PR could not be updated in place.

Scope:
- expose `harmony` and `gpt-oss` as valid `--tool-call-parser` choices in `vllm-mlx serve`
- factor parser construction into `create_parser()` so the serve CLI surface is unit-testable
- add regression coverage in `tests/test_server.py`

Local validation:
- `python -m py_compile vllm_mlx/cli.py tests/test_server.py`
- `python -m black --check --fast vllm_mlx/cli.py tests/test_server.py`
- `pytest -q tests/test_server.py`

Authorship note: this restack preserves the original implementation from #216; this PR exists only to unblock review/merge on a writable branch.
