### PR TITLE
simple-engine: keep tool chat on the streaming execution path

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -147,7 +147,6 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_llm_model
             engine._loaded = True
-            engine._model.tokenizer.encode = MagicMock(return_value=[7, 8, 9])
             engine.stream_chat = fake_stream_chat  # type: ignore[method-assign]
 
             output = await engine.chat(
@@ -165,14 +164,11 @@ class TestSimpleEngineConcurrency:
             )
 
             assert output.text.startswith("<tool_call>")
-            assert output.tokens == [7, 8, 9]
+            assert output.tokens == []
             assert output.prompt_tokens == 11
             assert output.completion_tokens == 4
             assert output.finish_reason == "stop"
             mock_llm_model.chat.assert_not_called()
-            engine._model.tokenizer.encode.assert_called_once_with(
-                output.text, add_special_tokens=False
-            )
 
     @pytest.mark.anyio
     async def test_lock_serializes_stream_generate(self, mock_model):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -13,6 +13,10 @@ class TestSimpleEngineConcurrency:
     """Test SimpleEngine lock behavior with concurrent requests."""
 
     @pytest.fixture
+    def anyio_backend(self):
+        return "asyncio"
+
+    @pytest.fixture
     def mock_model(self):
         """Create a mock model that tracks concurrent calls."""
         model = MagicMock()
@@ -115,6 +119,59 @@ class TestSimpleEngineConcurrency:
             assert mock_llm_model._max_concurrent == 1, (
                 f"Expected max concurrent to be 1, but got {mock_llm_model._max_concurrent}. "
                 "The lock is not working correctly."
+            )
+
+    async def test_chat_with_tools_aggregates_streaming_path(self, mock_llm_model):
+        """Tool-enabled non-stream chat should use the streaming path."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        async def fake_stream_chat(*args, **kwargs):
+            yield MagicMock(
+                text="partial",
+                tokens=[],
+                prompt_tokens=11,
+                completion_tokens=1,
+                finish_reason=None,
+                finished=False,
+            )
+            yield MagicMock(
+                text="<|im_end|><tool_call>{\"name\":\"bash\",\"arguments\":{\"command\":\"pwd\"}}</tool_call>",
+                tokens=[],
+                prompt_tokens=11,
+                completion_tokens=4,
+                finish_reason="stop",
+                finished=True,
+            )
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = mock_llm_model
+            engine._loaded = True
+            engine._model.tokenizer.encode = MagicMock(return_value=[7, 8, 9])
+            engine.stream_chat = fake_stream_chat  # type: ignore[method-assign]
+
+            output = await engine.chat(
+                messages=[{"role": "user", "content": "run pwd"}],
+                max_tokens=16,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            assert output.text.startswith("<tool_call>")
+            assert output.tokens == [7, 8, 9]
+            assert output.prompt_tokens == 11
+            assert output.completion_tokens == 4
+            assert output.finish_reason == "stop"
+            mock_llm_model.chat.assert_not_called()
+            engine._model.tokenizer.encode.assert_called_once_with(
+                output.text, add_special_tokens=False
             )
 
     @pytest.mark.anyio

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -135,7 +135,7 @@ class TestSimpleEngineConcurrency:
                 finished=False,
             )
             yield MagicMock(
-                text="<|im_end|><tool_call>{\"name\":\"bash\",\"arguments\":{\"command\":\"pwd\"}}</tool_call>",
+                text='<|im_end|><tool_call>{"name":"bash","arguments":{"command":"pwd"}}</tool_call>',
                 tokens=[],
                 prompt_tokens=11,
                 completion_tokens=4,

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -128,7 +128,7 @@ class TestSimpleEngineConcurrency:
         async def fake_stream_chat(*args, **kwargs):
             yield MagicMock(
                 text="partial",
-                tokens=[],
+                tokens=[1],
                 prompt_tokens=11,
                 completion_tokens=1,
                 finish_reason=None,
@@ -136,7 +136,7 @@ class TestSimpleEngineConcurrency:
             )
             yield MagicMock(
                 text='<|im_end|><tool_call>{"name":"bash","arguments":{"command":"pwd"}}</tool_call>',
-                tokens=[],
+                tokens=[7, 8, 9],
                 prompt_tokens=11,
                 completion_tokens=4,
                 finish_reason="stop",
@@ -163,8 +163,8 @@ class TestSimpleEngineConcurrency:
                 ],
             )
 
-            assert output.text.startswith("<tool_call>")
-            assert output.tokens == []
+            assert output.text == '{"name":"bash","arguments":{"command":"pwd"}}'
+            assert output.tokens == [7, 8, 9]
             assert output.prompt_tokens == 11
             assert output.completion_tokens == 4
             assert output.finish_reason == "stop"

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -453,6 +453,36 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # mlx-lm non-streaming chat with tools can stall indefinitely on some
+        # local models, while the streaming path completes normally. Reuse the
+        # streaming implementation and aggregate its final state so both chat
+        # APIs share the same tool-capable execution path.
+        if tools and not self._is_mllm:
+            final_output = GenerationOutput(text="")
+            async for output in self.stream_chat(
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                images=images,
+                videos=videos,
+                **kwargs,
+            ):
+                final_output = output
+            text = clean_output_text(final_output.text)
+            try:
+                tokens = self._model.tokenizer.encode(text, add_special_tokens=False)
+            except TypeError:
+                tokens = self._model.tokenizer.encode(text)
+            return GenerationOutput(
+                text=text,
+                tokens=tokens,
+                prompt_tokens=final_output.prompt_tokens,
+                completion_tokens=final_output.completion_tokens,
+                finish_reason=final_output.finish_reason,
+            )
+
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -477,7 +477,7 @@ class SimpleEngine(BaseEngine):
                 tokens = self._model.tokenizer.encode(text)
             return GenerationOutput(
                 text=text,
-                tokens=tokens,
+                tokens=list(final_output.tokens),
                 prompt_tokens=final_output.prompt_tokens,
                 completion_tokens=final_output.completion_tokens,
                 finish_reason=final_output.finish_reason,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -471,10 +471,6 @@ class SimpleEngine(BaseEngine):
             ):
                 final_output = output
             text = clean_output_text(final_output.text)
-            try:
-                tokens = self._model.tokenizer.encode(text, add_special_tokens=False)
-            except TypeError:
-                tokens = self._model.tokenizer.encode(text)
             return GenerationOutput(
                 text=text,
                 tokens=list(final_output.tokens),


### PR DESCRIPTION
Supersedes #222 with the same functional change rebased on current main.

Why this PR exists:
- I rebased the original branch locally and validated it cleanly.
- Direct maintainer push back to the original computor-org fork is not available from this auth context, so the original PR could not be updated in place.

Scope:
- route tool-enabled non-stream SimpleEngine.chat() through the streaming chat path
- preserve streamed token ids and final finish_reason/completion accounting
- carry the regression coverage in tests/test_simple_engine.py on top of current main

Local validation:
- python -m py_compile vllm_mlx/engine/simple.py tests/test_simple_engine.py
- python -m black --check --fast vllm_mlx/engine/simple.py tests/test_simple_engine.py
- pytest -q tests/test_simple_engine.py

Authorship note: this restack preserves the original implementation from #222; the only local adjustment was aligning the regression assertion with current main's cleaned tool-call text behavior.