### PR TITLE
fix: handle 3D KV tensors in prefix cache

### DIFF
--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -816,6 +816,42 @@ class TestBlockAwarePrefixCache:
 
         assert cache.reconstruct_cache(prefix_table) is None
 
+    def test_reconstructs_3d_kv_prefix_cache(self):
+        from mlx_lm.models.cache import KVCache
+        import mlx.core as mx
+
+        from vllm_mlx.paged_cache import BlockTable, PagedCacheManager
+        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+        paged_manager = PagedCacheManager(block_size=4, max_blocks=10)
+        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
+
+        tokens = list(range(8))
+        kv_keys = mx.arange(2 * 8 * 3).reshape(2, 8, 3)
+        kv_values = mx.arange(1000, 1000 + (2 * 8 * 3)).reshape(2, 8, 3)
+        extracted = [
+            {
+                "state": (kv_keys, kv_values),
+                "meta_state": "",
+                "class_ref": KVCache,
+                "class_name": "KVCache",
+            }
+        ]
+
+        block_table = cache.store_cache("req-1", tokens, extracted)
+        prefix_table = BlockTable(
+            request_id="req-prefix",
+            block_ids=[block_table.block_ids[0]],
+            num_tokens=4,
+        )
+
+        reconstructed = cache.reconstruct_cache(prefix_table)
+
+        assert reconstructed is not None
+        assert isinstance(reconstructed[0], KVCache)
+        assert reconstructed[0].state[0].tolist() == kv_keys[:, :4, :].tolist()
+        assert reconstructed[0].state[1].tolist() == kv_values[:, :4, :].tolist()
+
     def test_deduplicated_terminal_uses_correct_recurrent_snapshot(self):
         """Deduplication must not leak recurrent state across sequences."""
         from mlx_lm.models.cache import ArraysCache, KVCache

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -658,7 +658,8 @@ class BlockAwarePrefixCache:
                 class_ref = layer_state.get("class_ref")
                 class_name = layer_state.get("class_name")
 
-                if self._can_concatenate_cache_state(state):
+                seq_axis = self._cache_state_seq_axis(state)
+                if seq_axis is not None:
                     state_slice = self._slice_concat_cache_state(
                         state, start_idx, end_idx
                     )
@@ -669,7 +670,7 @@ class BlockAwarePrefixCache:
                             "class_ref": class_ref,
                             "class_name": class_name,
                             "storage": "concat",
-                            "seq_axis": 2,
+                            "seq_axis": seq_axis,
                         }
                     )
                     continue
@@ -697,14 +698,28 @@ class BlockAwarePrefixCache:
             logger.warning(f"Failed to extract block tensor slice: {e}")
             return None
 
-    def _can_concatenate_cache_state(self, state: Any) -> bool:
-        """Return True when cache state can be concatenated block-by-block."""
+    def _cache_state_seq_axis(self, state: Any) -> Optional[int]:
+        """Return the sequence axis for cache states that support block concat."""
         if not isinstance(state, (list, tuple)) or not state:
-            return False
-        return all(
-            tensor is not None and hasattr(tensor, "shape") and len(tensor.shape) == 4
+            return None
+
+        ndims = {
+            len(tensor.shape)
             for tensor in state
-        )
+            if tensor is not None and hasattr(tensor, "shape")
+        }
+        if len(ndims) != 1:
+            return None
+
+        ndim = next(iter(ndims))
+        if ndim == 4:
+            return 2
+
+        # Qwen3.5-style KV caches use (heads, seq, dim).
+        if ndim == 3 and len(state) == 2:
+            return 1
+
+        return None
 
     def _slice_concat_cache_state(
         self,
@@ -713,7 +728,11 @@ class BlockAwarePrefixCache:
         end_idx: int,
     ) -> Tuple[Any, ...] | List[Any]:
         """Slice a sequence-backed cache state across the token axis."""
-        seq_len = state[0].shape[2]
+        seq_axis = self._cache_state_seq_axis(state)
+        if seq_axis is None:
+            raise ValueError("Cache state does not support sequence concatenation")
+
+        seq_len = state[0].shape[seq_axis]
         actual_end = min(end_idx, seq_len)
         if start_idx >= actual_end:
             raise ValueError(
@@ -722,7 +741,7 @@ class BlockAwarePrefixCache:
 
         def _slice_tensor(tensor: Any) -> Any:
             slices = [slice(None)] * len(tensor.shape)
-            slices[2] = slice(start_idx, actual_end)
+            slices[seq_axis] = slice(start_idx, actual_end)
             return tensor[tuple(slices)]
 
         sliced = [_slice_tensor(tensor) for tensor in state]
@@ -910,7 +929,7 @@ class BlockAwarePrefixCache:
                         cache = _KVCache()
                         cache.keys = keys
                         cache.values = values
-                        cache.offset = keys.shape[2]
+                        cache.offset = keys.shape[self._cache_state_seq_axis(state)]
                     else:
                         cache = cache_cls.from_state(state, meta_state)
                 else:
@@ -920,7 +939,10 @@ class BlockAwarePrefixCache:
                         return None
                     cache = KVCache()
                     cache.keys, cache.values = state
-                    cache.offset = cache.keys.shape[2]
+                    seq_axis = self._cache_state_seq_axis(state)
+                    if seq_axis is None:
+                        return None
+                    cache.offset = cache.keys.shape[seq_axis]
 
                 reconstructed_caches.append(cache)
 


### PR DESCRIPTION
Restack of #144 onto current `main`.

What changed:
- keep the existing 4D block-concat behavior intact
- add the missing 3D KV path for Qwen3.5-style `(heads, seq, dim)` caches
- store/use the correct sequence axis in block metadata
- fix reconstructed offset accounting for 3D states
- add a regression test that reconstructs a partial prefix from a 3D KV cache

Validation:
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr144-restack /opt/ai-runtime/venv-live/bin/python -m pytest /Users/David/code/vllm-mlx-pr144-restack/tests/test_paged_cache.py -q`
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr144-restack /opt/ai-runtime/venv-live/bin/python -m py_compile /Users/David/code/vllm-mlx-pr144-restack/vllm_mlx/prefix_cache.py /Users/David/code/vllm-mlx-pr144-restack/tests/test_paged_cache.py`
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr144-restack /opt/ai-runtime/venv-live/bin/python -m black --check --fast /Users/David/code/vllm-mlx-pr144-restack/vllm_mlx/prefix_cache.py /Users/David/code/vllm-mlx-pr144-restack/tests/test_paged_cache.py`

Fixes #142. Supersedes #144.