### PR TITLE
test: use anyio in async regression slice

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -790,7 +790,7 @@ class TestSchedulerIntegration:
         assert len(finished) == len(prompts), f"Only {len(finished)} requests finished"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 class TestEngineAsync:
     """Async tests for the engine."""
 

--- a/tests/test_batching_deterministic.py
+++ b/tests/test_batching_deterministic.py
@@ -37,7 +37,7 @@ def sampling_params():
 class TestDeterministicSingleRequest:
     """Test single request determinism."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_same_prompt_same_output(self, model_and_tokenizer, sampling_params):
         """Same prompt should produce same output with temp=0."""
         from vllm_mlx import AsyncEngineCore, EngineConfig, SchedulerConfig
@@ -68,7 +68,7 @@ class TestDeterministicSingleRequest:
         assert len(outputs) == 3
         assert outputs[0] == outputs[1] == outputs[2], f"Outputs differ: {outputs}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_token_streaming_order(self, model_and_tokenizer, sampling_params):
         """Tokens should stream in order."""
         from vllm_mlx import AsyncEngineCore
@@ -94,7 +94,7 @@ class TestDeterministicSingleRequest:
 class TestDeterministicConcurrentRequests:
     """Test concurrent request handling with determinism."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_concurrent_same_prompt(self, model_and_tokenizer):
         """Multiple concurrent requests with same prompt should get same output."""
         from vllm_mlx import (
@@ -137,7 +137,7 @@ class TestDeterministicConcurrentRequests:
             # All should be the same
             assert all(r == results[0] for r in results), f"Outputs differ: {results}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_concurrent_different_prompts(self, model_and_tokenizer):
         """Different prompts should get different (but deterministic) outputs."""
         from vllm_mlx import (
@@ -191,7 +191,7 @@ class TestDeterministicConcurrentRequests:
 class TestBatchingPerformance:
     """Test that batching improves throughput."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_batched_faster_than_sequential(self, model_and_tokenizer):
         """Batched requests should be faster than sequential."""
         from vllm_mlx import (
@@ -274,7 +274,7 @@ class TestBatchingPerformance:
 class TestRequestManagement:
     """Test request lifecycle management."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request(self, model_and_tokenizer):
         """Test aborting a request mid-generation."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -304,7 +304,7 @@ class TestRequestManagement:
             stats = engine.get_stats()
             assert stats["active_requests"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_engine_stats(self, model_and_tokenizer):
         """Test engine statistics tracking."""
         from vllm_mlx import (
@@ -343,7 +343,7 @@ class TestRequestManagement:
 class TestSchedulerPolicy:
     """Test scheduler policies."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fcfs_ordering(self, model_and_tokenizer):
         """Test that FCFS policy processes requests in order."""
         from vllm_mlx import (
@@ -396,7 +396,7 @@ class TestSchedulerPolicy:
 class TestEdgeCases:
     """Test edge cases and error handling."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_prompt(self, model_and_tokenizer):
         """Test handling of empty prompt."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -414,7 +414,7 @@ class TestEdgeCases:
                     assert out.finished
                     break
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_very_short_max_tokens(self, model_and_tokenizer):
         """Test with max_tokens=1."""
         from vllm_mlx import AsyncEngineCore, SamplingParams
@@ -436,7 +436,7 @@ class TestEdgeCases:
             # Should generate exactly 1 token
             assert token_count == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_multiple_start_stop(self, model_and_tokenizer):
         """Test starting and stopping engine multiple times."""
         from vllm_mlx import AsyncEngineCore, SamplingParams

--- a/tests/test_continuous_batching.py
+++ b/tests/test_continuous_batching.py
@@ -53,7 +53,7 @@ class TestContinuousBatchingBasic:
         assert config.completion_batch_size == 32
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 class TestContinuousBatchingIntegration:
     """Integration tests requiring actual model loading."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -629,9 +629,7 @@ class TestAPIKeyVerification:
 
             # Should raise HTTPException with 401
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
-                    server.verify_api_key(credentials)
-                )
+                asyncio.run(server.verify_api_key(credentials))
 
             assert exc_info.value.status_code == 401
             assert "Invalid API key" in str(exc_info.value.detail)
@@ -657,9 +655,7 @@ class TestAPIKeyVerification:
             )
 
             # Should not raise any exception
-            result = asyncio.get_event_loop().run_until_complete(
-                server.verify_api_key(credentials)
-            )
+            result = asyncio.run(server.verify_api_key(credentials))
             # verify_api_key returns True on success (no exception raised)
             assert result is True or result is None
         finally:
@@ -716,7 +712,7 @@ class TestRateLimiterHTTPResponse:
 class TestStreamChatCompletion:
     """Tests for streaming chat completion behavior."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reasoning_stream_emits_structured_tool_calls(self, monkeypatch):
         """Tool markup after </think> should emit tool_calls chunks."""
         from vllm_mlx.engine.base import GenerationOutput
@@ -837,7 +833,7 @@ class TestStreamChatCompletion:
             "total_tokens": 10,
         }
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reasoning_stream_skips_tool_parser_until_markup_appears(
         self, monkeypatch
     ):

--- a/tests/test_streaming_latency.py
+++ b/tests/test_streaming_latency.py
@@ -206,7 +206,7 @@ async def run_benchmark(
             print(f"Throughput: {throughput:.1f} tokens/sec")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_output_collector():
     """Unit test for RequestOutputCollector."""
     import sys


### PR DESCRIPTION
Derived from the current-main restack work for #226, but limited to the pushable test-side cleanup.

Changes:
- convert the current async regression slice to `@pytest.mark.anyio`
- replace `asyncio.get_event_loop().run_until_complete(...)` with `asyncio.run(...)` in the API key tests

Why split this out:
- I also prepared the Python 3.13 CI matrix/workflow changes locally, but this auth context cannot push workflow-file updates (`.github/workflows/ci.yml`) because GitHub requires `workflow` scope for OAuth-app pushes.
- This PR lands the tested Python-side compatibility cleanup now, without waiting on that auth limitation.

Local validation:
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr226-async-tests /opt/ai-runtime/venv-live/bin/python -m pytest /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_server.py -q -k "verify_api_key or reasoning_stream"`
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr226-async-tests /opt/ai-runtime/venv-live/bin/python -m pytest /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_batching.py -q -k TestEngineAsync`
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr226-async-tests /opt/ai-runtime/venv-live/bin/python -m pytest /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_streaming_latency.py -q -k test_output_collector`
- `PYTHONPATH=/Users/David/code/vllm-mlx-pr226-async-tests /opt/ai-runtime/venv-live/bin/python -m black --check --fast /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_batching.py /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_batching_deterministic.py /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_continuous_batching.py /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_server.py /Users/David/code/vllm-mlx-pr226-async-tests/tests/test_streaming_latency.py`

Related to #226.