### PR TITLE
Upgrade torch and torchvision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Video processing for VLM
     "opencv-python>=4.8.0",
     # Vision processor (required for transformers AutoProcessor)
-    "torchvision>=0.21.0",
+    "torchvision>=0.23.0",
     # Resource monitoring
     "psutil>=5.9.0",
     # Server
@@ -75,7 +75,7 @@ vllm = [
 ]
 vision = [
     "torch>=2.8.0",
-    "torchvision>=0.21.0",
+    "torchvision>=0.23.0",
 ]
 # Audio dependencies for TTS/STT (mlx-audio)
 audio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ vllm = [
     "vllm>=0.4.0",
 ]
 vision = [
-    "torch>=2.3.0",
+    "torch>=2.8.0",
     "torchvision>=0.21.0",
 ]
 # Audio dependencies for TTS/STT (mlx-audio)


### PR DESCRIPTION
In PR 276 it was observed the lower bound of torch was lower than pip would resolve  it to. Since vllm-mlx advertises it should be run with python 3.10+, I upgraded the libraries as far as possible without compile errors. Attempting to upgrade torch to 2.9 and torchvision to 0.24, which are python 3.10+ led to dependency resolution errors so I went with the python 3.9 compatible versions listed on https://pypi.org/project/torchvision/ torch to 2.8 and torchvision to 0.21