### PR TITLE
fix(specprefill): avoid dense tail expansion within cache window

### DIFF
--- a/tests/test_specprefill_rotating_cache.py
+++ b/tests/test_specprefill_rotating_cache.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for RotatingKVCache handling in sparse_prefill."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+class _FakeAttention:
+    def __init__(self):
+        self.num_heads = 1
+        self.q_proj = lambda x: x
+
+
+class _FakeLayer:
+    def __init__(self):
+        self.block_type = "*"
+        self.mixer = _FakeAttention()
+
+
+class _FakeModel:
+    def __init__(self):
+        self.layers = [_FakeLayer()]
+        self.calls: list[list[int]] = []
+
+    def __call__(self, x, cache=None):
+        self.calls.append(x.tolist())
+        logits = mx.zeros((1, x.shape[1], 8), dtype=mx.float32)
+        return logits
+
+
+class RotatingKVCache:
+    def __init__(self, max_size: int, keep: int = 0):
+        self.max_size = max_size
+        self.keep = keep
+        self.offset = 0
+        self.state = mx.array([0], dtype=mx.float32)
+
+
+def _run_sparse_prefill(total_tokens: int, selected_indices: list[int], max_size: int):
+    from vllm_mlx.specprefill import sparse_prefill
+
+    model = _FakeModel()
+    tokens = list(range(total_tokens))
+    cache = [RotatingKVCache(max_size=max_size, keep=0)]
+    sparse_prefill(
+        model,
+        tokens,
+        selected_indices,
+        cache,
+        step_size=64,
+    )
+    return model.calls
+
+
+def test_sparse_prefill_does_not_expand_tail_when_prompt_fits_window():
+    calls = _run_sparse_prefill(
+        total_tokens=6,
+        selected_indices=[0, 2, 4],
+        max_size=8,
+    )
+
+    flattened = [token for chunk in calls for row in chunk for token in row]
+    assert flattened == [0, 2, 4]
+
+
+def test_sparse_prefill_expands_tail_when_prompt_exceeds_window():
+    calls = _run_sparse_prefill(
+        total_tokens=10,
+        selected_indices=[0, 2],
+        max_size=8,
+    )
+
+    flattened = [token for chunk in calls for row in chunk for token in row]
+    assert flattened == [0, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -640,15 +640,15 @@ def sparse_prefill(
 
     M = tokens.shape[0]
 
-    # Detect RotatingKVCache and ensure tail tokens are included.
-    # Models with sliding window attention (e.g., GPT-OSS) use RotatingKVCache
-    # which evicts old entries. We must include the last `max_size` positions
-    # so sliding window layers have valid recent context for decode.
+    # Detect RotatingKVCache and ensure tail tokens are included only when the
+    # prompt actually exceeds the live cache window. If the full prompt still
+    # fits inside ``max_size`` there is no eviction yet, so forcing the entire
+    # tail back in would collapse sparse prefill into dense work.
     max_rotating_size = 0
     for c in cache:
         if type(c).__name__ == "RotatingKVCache":
             max_rotating_size = max(max_rotating_size, getattr(c, "max_size", 0))
-    if max_rotating_size > 0:
+    if max_rotating_size > 0 and M > max_rotating_size:
         tail_start = max(0, M - max_rotating_size)
         tail_indices = set(range(tail_start, M))
         existing = set(selected_indices.tolist())


### PR DESCRIPTION
## Summary
- avoid forcing full-tail inclusion for `RotatingKVCache` when the prompt still fits inside the cache window
- add a regression test that pins the no-eviction vs eviction boundary

## Why
On the Nemotron 120B live runtime path we cap unbounded attention caches with `max_kv_size=65536`, which means the SpecPrefill target cache is a `RotatingKVCache` even for prompts that still fit entirely inside the window. The previous sparse-prefill logic treated any `RotatingKVCache` as if eviction were already active and unioned in the full `max_size` tail. At 64K this effectively collapsed sparse prefill back into dense target work.

## Validation
- `pytest tests/test_specprefill_rotating_cache.py -q`
- `black --check --fast vllm_mlx/specprefill.py tests/test_specprefill_rotating_cache.py`
- `python -m py_compile vllm_mlx/specprefill.py tests/test_specprefill_rotating_cache.py`

Live runtime evidence from the promoted stack:
- Nemotron 64K clean cold rerun before fix: dense `271.98s`, sparse `395.37s`
- Nemotron 64K clean cold rerun after fix: dense `277.89s`, sparse `143.90s`
- Nemotron 16K clean cold rerun after fix: dense `68.48s`, sparse `36.26s`
- recall stayed correct in all fixed runs
