### PR TITLE
batch generator crashes with prompt_progress_callback on mlx-lm 0.31.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vllm-mlx"
-version = "0.2.7"
+version = "0.2.8"
 description = "vLLM-like inference for Apple Silicon - GPU-accelerated Text, Image, Video & Audio on Mac"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1256,15 +1256,25 @@ class Scheduler:
             prefill_batch_size=self.config.prefill_batch_size,
             completion_batch_size=self.config.completion_batch_size,
             prefill_step_size=self.config.prefill_step_size,
-            prompt_progress_callback=_prefill_progress,
         )
+        # Set callback as attribute — used by _install_chunked_prefill
+        # monkey-patch. Not a BatchGenerator constructor parameter.
+        bg.prompt_progress_callback = _prefill_progress
 
         # Install chunked prefill when explicitly configured OR when
         # memory-aware cache is active (needed for prefix_boundary saves
         # in agentic multi-turn workloads with hybrid Mamba+Transformer models).
         chunked_budget = self.config.chunked_prefill_tokens
         need_chunked = chunked_budget > 0 or self.memory_aware_cache is not None
-        if need_chunked:
+
+        # The chunked prefill monkey-patch relies on BatchGenerator internals
+        # (_process_prompts, active_batch, _step, etc.) that were refactored
+        # in mlx-lm 0.31.x.  Skip gracefully when the required API is absent.
+        chunked_compatible = hasattr(bg, "_process_prompts") and hasattr(
+            bg, "active_batch"
+        )
+
+        if need_chunked and chunked_compatible:
             if chunked_budget <= 0:
                 # No explicit budget — use a very large value so normal
                 # prompts pass through unchanged.  Prefix boundary splits
@@ -1286,6 +1296,12 @@ class Scheduler:
                 pending_abort_ids=self._pending_abort_ids,
                 uid_to_request_id=self.uid_to_request_id,
                 requests=self.requests,
+            )
+        elif need_chunked and not chunked_compatible:
+            logger.warning(
+                "Chunked prefill disabled: mlx-lm BatchGenerator lacks required "
+                "internals (_process_prompts, active_batch). Upgrade mlx-lm or "
+                "check compatibility."
             )
 
         # Install MTP if the model supports it
@@ -2334,8 +2350,15 @@ class Scheduler:
 
                 # Run generation step if we have running requests
                 if self.batch_generator is not None and self.running:
-                    responses = self.batch_generator.next()
+                    result = self.batch_generator.next()
                     output.has_work = True
+
+                    # mlx-lm >=0.31.x returns (prompt_responses, generation_responses);
+                    # older versions returned a flat list.
+                    if isinstance(result, tuple):
+                        responses = result[1]  # generation_responses only
+                    else:
+                        responses = result
 
                     if responses:
                         outputs, finished_ids = self._process_batch_responses(responses)
@@ -2403,6 +2426,7 @@ class Scheduler:
             # Evaluate batch tokens to collapse lazy concatenation chains
             if (
                 self.batch_generator is not None
+                and hasattr(self.batch_generator, "active_batch")
                 and self.batch_generator.active_batch is not None
                 and hasattr(self.batch_generator.active_batch, "tokens")
             ):


### PR DESCRIPTION
## Problem

Reported in #293 — after the backport in f61d34e, running `vllm-mlx bench` or `vllm-mlx serve` with batching enabled crashes immediately on mlx-lm 0.31.x (the latest release).

This affects all users on v0.2.7 installed via `pip` or `uv`.

### Error 1: `prompt_progress_callback` not a constructor parameter

```
TypeError: BatchGenerator.__init__() got an unexpected keyword argument 'prompt_progress_callback'
```

```
  File ".../vllm_mlx/scheduler.py", line 1252, in _create_batch_generator
    bg = BatchGenerator(
         ^^^^^^^^^^^^^^^
TypeError: BatchGenerator.__init__() got an unexpected keyword argument 'prompt_progress_callback'
```

### Error 2: `_process_prompts` removed in mlx-lm 0.31.x

```
AttributeError: 'BatchGenerator' object has no attribute '_process_prompts'
```

The `_install_chunked_prefill` monkey-patch relies on internal BatchGenerator APIs (`_process_prompts`, `active_batch`, `_step`) that were refactored in mlx-lm 0.31.x.

### Error 3: `next()` return format changed

```
AttributeError: 'list' object has no attribute 'uid'
```

`BatchGenerator.next()` now returns a `(prompt_responses, generation_responses)` tuple instead of a flat list. The scheduler was iterating over the tuple and trying to access `.uid` on a list.

### Error 4: `active_batch` no longer exists

```
AttributeError: 'BatchGenerator' object has no attribute 'active_batch'
```

The periodic cache eval in `step()` references `self.batch_generator.active_batch` without checking if it exists.

## Root cause

The backport commit f61d34e was written against a version of `mlx-lm` with different internal APIs than the released 0.31.x series. No released version of `mlx-lm` (up to 0.31.2) has these internal methods/attributes.

## Fix

Three changes in `scheduler.py`:

**1. Set `prompt_progress_callback` as an instance attribute instead of constructor argument**

The callback is only consumed by the `_install_chunked_prefill` monkey-patch (lines 343, 566), not by BatchGenerator itself.

```diff
         bg = BatchGenerator(
             ...
-            prompt_progress_callback=_prefill_progress,
         )
+        bg.prompt_progress_callback = _prefill_progress
```

**2. Guard `_install_chunked_prefill` with a compatibility check**

Skip the monkey-patch gracefully when the required BatchGenerator internals are absent, and log a warning:

```python
chunked_compatible = hasattr(bg, "_process_prompts") and hasattr(bg, "active_batch")

if need_chunked and chunked_compatible:
    _install_chunked_prefill(...)
elif need_chunked and not chunked_compatible:
    logger.warning("Chunked prefill disabled: mlx-lm BatchGenerator lacks ...")
```

**3. Handle `next()` return format change**

```diff
-                    responses = self.batch_generator.next()
+                    result = self.batch_generator.next()
+                    # mlx-lm >=0.31.x returns (prompt_responses, generation_responses)
+                    if isinstance(result, tuple):
+                        responses = result[1]
+                    else:
+                        responses = result
```

**4. Add `hasattr` guard for `active_batch`**

```diff
             if (
                 self.batch_generator is not None
+                and hasattr(self.batch_generator, "active_batch")
                 and self.batch_generator.active_batch is not None
```

## Test results

```
tests/test_batching.py         — 22 passed
tests/test_memory_stability.py — 15 passed
======================= 37 passed, 2 deselected in 3.29s =======================
```

## Smoke test: `vllm-mlx bench` (Llama-3.2-1B-Instruct-4bit)

Fresh conda environment with `mlx-lm==0.31.2`:

```
$ vllm-mlx bench mlx-community/Llama-3.2-1B-Instruct-4bit --max-tokens 100 --num-prompts 10

Chunked prefill disabled: mlx-lm BatchGenerator lacks required internals
(_process_prompts, active_batch). Upgrade mlx-lm or check compatibility.

Loading model: mlx-community/Llama-3.2-1B-Instruct-4bit

Running benchmark with 10 prompts, max_tokens=100
--------------------------------------------------

Results:
  Total time: 2.38s
  Prompts: 10
  Prompts/second: 4.19
  Total prompt tokens: 80
  Total completion tokens: 960
  Total tokens: 1040
  Tokens/second: 402.52
  Throughput: 436.06 tok/s
```

## Test plan

- [x] `pytest tests/test_batching.py` — all chunked prefill tests pass
- [x] `pytest tests/test_memory_stability.py` — all BatchGenerator lifecycle tests pass
- [x] Verified `BatchGenerator.__init__` signature in fresh `mlx-lm==0.31.2` install (conda env)
- [x] `vllm-mlx bench mlx-community/Llama-3.2-1B-Instruct-4bit` — 10 prompts, 960 tokens, 0 errors

## Notes

- Chunked prefill is disabled as a degradation (not a crash) on mlx-lm 0.31.x. When mlx-lm adds back compatible internals or a public chunked prefill API, the guard will automatically re-enable it.
- MTP (`_install_mtp`) also references removed internals (`_step`) but is disabled by default (`enable_mtp: bool = False`), so it's not part of this fix.

Closes #293