### PR TITLE
Add GLM-4 reasoning parser and fix think tag / prefix cache bugs

### DIFF
--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -297,6 +297,136 @@ class TestSchedulerIntegration:
         assert default_config.prefix_cache_size == 100
 
 
+class TestTrimRotatingCaches:
+    """Regression tests for _trim_rotating_caches offset clamp."""
+
+    def test_offset_clamped_to_max_size(self):
+        """Restored cache with offset > max_size must be clamped.
+
+        Without clamping, RotatingKVCache._update_in_place computes
+        ``new_size = min(step, max_size - prev)`` which goes negative
+        when ``prev = offset % max_size`` exceeds max_size after trim.
+        """
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        # Simulate a RotatingKVCache with offset far beyond max_size
+        # (happens when prefix cache stores long-generation state)
+        rc = RotatingKVCache(max_size=128, keep=0)
+        rc.offset = 500  # Way beyond max_size
+        rc.keys = mx.zeros((1, 4, 128, 64))  # Full buffer at max_size
+        rc.values = mx.zeros((1, 4, 128, 64))
+        rc._idx = 128
+
+        # Also include a regular KVCache (should be unaffected)
+        kv = KVCache()
+        kv.offset = 200
+        kv.keys = mx.zeros((1, 4, 200, 64))
+        kv.values = mx.zeros((1, 4, 200, 64))
+
+        cache_list = [rc, kv]
+        MLLMBatchGenerator._trim_rotating_caches(cache_list)
+
+        # RotatingKVCache offset must be clamped to max_size
+        assert rc.offset <= rc.max_size
+        assert rc.offset == 128
+
+        # KVCache should be untouched
+        assert kv.offset == 200
+
+    def test_empty_rotating_cache_offset_reset(self):
+        """RotatingKVCache with keys=None should get offset reset to 0."""
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        rc = RotatingKVCache(max_size=128, keep=0)
+        rc.offset = 500
+        rc.keys = None
+        rc.values = None
+
+        MLLMBatchGenerator._trim_rotating_caches([rc])
+        assert rc.offset == 0
+
+
+class TestCopyPrefixCache:
+    """Tests for _copy_prefix_cache preventing mutation of stored entries."""
+
+    def test_copy_prevents_offset_mutation(self):
+        """Modifying copied cache offset should not affect original."""
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        KVCache = mlx_lm_cache.KVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        original = KVCache()
+        original.offset = 100
+
+        copies = MLLMBatchGenerator._copy_prefix_cache([original])
+        copies[0].offset = 999
+
+        assert original.offset == 100
+
+    def test_copy_rotating_prevents_idx_mutation(self):
+        """Modifying copied RotatingKVCache _idx should not affect original."""
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        original = RotatingKVCache(max_size=128, keep=0)
+        original.offset = 50
+        original._idx = 50
+        original.keys = mx.zeros((1, 4, 50, 64))
+        original.values = mx.zeros((1, 4, 50, 64))
+
+        copies = MLLMBatchGenerator._copy_prefix_cache([original])
+        copies[0].offset = 999
+        copies[0]._idx = 999
+
+        assert original.offset == 50
+        assert original._idx == 50
+
+
+class TestHasEmptyRotatingCache:
+    """Tests for _has_empty_rotating_cache detection."""
+
+    def test_detects_empty_rotating_cache(self):
+        """Should return True when any RotatingKVCache has keys=None."""
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv = KVCache()
+        rc = RotatingKVCache(max_size=128, keep=0)
+        rc.keys = None
+
+        assert MLLMBatchGenerator._has_empty_rotating_cache([kv, rc]) is True
+
+    def test_returns_false_when_all_populated(self):
+        """Should return False when all caches have data."""
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv = KVCache()
+        rc = RotatingKVCache(max_size=128, keep=0)
+        rc.keys = mx.zeros((1, 4, 50, 64))
+
+        assert MLLMBatchGenerator._has_empty_rotating_cache([kv, rc]) is False
+
+
 if __name__ == "__main__":
     # Verbose standalone test with real model
     import argparse

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -1186,3 +1186,135 @@ class TestGemma4Parser:
         full_reasoning = "".join(reasoning_parts)
         assert "very long reasoning process" in full_reasoning
         assert len(content_parts) == 0
+
+
+class TestGlm4Parser:
+    """Tests for the GLM-4 reasoning parser."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a fresh GLM-4 parser for each test."""
+        return get_parser("glm4")()
+
+    def test_registry_includes_glm4(self):
+        """glm4 should be in the parser registry."""
+        assert "glm4" in list_parsers()
+
+    # Non-streaming tests
+
+    def test_extract_with_both_tags(self, parser):
+        """Should extract reasoning when both tags present."""
+        output = "<think>Let me analyze this</think>The answer is 42."
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "Let me analyze this"
+        assert content == "The answer is 42."
+
+    def test_no_tags_returns_content(self, parser):
+        """GLM-4 without tags = normal content (not reasoning)."""
+        output = "Just a regular response."
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning is None
+        assert content == output
+
+    def test_implicit_mode(self, parser):
+        """Only closing tag (think injected by agent)."""
+        output = "reasoning text</think>content text"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "reasoning text"
+        assert content == "content text"
+
+    def test_strips_box_tags(self, parser):
+        """GLM-4.6V box container tags should be stripped."""
+        output = "<|begin_of_box|>Paris<|end_of_box|>"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning is None
+        assert content == "Paris"
+
+    def test_strips_box_tags_with_thinking(self, parser):
+        """Box tags should be stripped from reasoning output too."""
+        output = "<think><|begin_of_box|>analysis</think><|begin_of_box|>answer<|end_of_box|>"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "analysis"
+        assert content == "answer"
+
+    # Streaming tests
+
+    def test_streaming_no_tags_emits_content(self, parser):
+        """GLM-4 streaming without tags should emit content (not reasoning)."""
+        parser.reset_state()
+        result = parser.extract_reasoning_streaming("", "Hello", "Hello")
+        assert result is not None
+        assert result.content == "Hello"
+        assert result.reasoning is None
+
+    def test_streaming_with_thinking(self, parser):
+        """Test streaming with think tags."""
+        parser.reset_state()
+
+        tokens = ["<think>", "analyze", "</think>", "answer"]
+        accumulated = ""
+        reasoning_parts = []
+        content_parts = []
+
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result:
+                if result.reasoning:
+                    reasoning_parts.append(result.reasoning)
+                if result.content:
+                    content_parts.append(result.content)
+
+        assert "analyze" in "".join(reasoning_parts)
+        assert "answer" in "".join(content_parts)
+
+    def test_streaming_strips_box_tags(self, parser):
+        """Box tags should be stripped from streaming deltas."""
+        parser.reset_state()
+
+        tokens = ["<|begin_of_box|>", "Paris", "<|end_of_box|>"]
+        accumulated = ""
+        content_parts = []
+
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result and result.content:
+                content_parts.append(result.content)
+
+        full = "".join(content_parts)
+        assert "Paris" in full
+        assert "<|begin_of_box|>" not in full
+        assert "<|end_of_box|>" not in full
+
+    def test_streaming_box_tag_returns_none(self, parser):
+        """A delta that is purely a box tag should return None."""
+        parser.reset_state()
+        result = parser.extract_reasoning_streaming(
+            "", "<|begin_of_box|>", "<|begin_of_box|>"
+        )
+        assert result is None
+
+
+class TestDuplicateThinkEndTag:
+    """Test duplicate </think> stripping in BaseThinkingReasoningParser."""
+
+    @pytest.fixture(params=["qwen3", "deepseek_r1", "glm4"])
+    def parser(self, request):
+        return get_parser(request.param)()
+
+    def test_duplicate_end_tag_stripped(self, parser):
+        """Extra </think> after reasoning should be stripped from content."""
+        output = "<think>reasoning</think></think>content"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "reasoning"
+        assert content == "content"
+
+    def test_triple_end_tag_stripped(self, parser):
+        """Multiple extra </think> tags should all be stripped."""
+        output = "<think>reasoning</think></think></think>content"
+        reasoning, content = parser.extract_reasoning(output)
+        assert reasoning == "reasoning"
+        assert content == "content"

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -184,7 +184,10 @@ class TestSimpleEngineConcurrency:
                 ],
             )
 
-            assert output.text == '{"name":"bash","arguments":{"command":"pwd"}}'
+            assert (
+                output.text
+                == '<tool_call>{"name":"bash","arguments":{"command":"pwd"}}</tool_call>'
+            )
             assert output.tokens == [7, 8, 9]
             assert output.prompt_tokens == 11
             assert output.completion_tokens == 4

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -22,7 +22,7 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|channel\|>|<\|message\|>|<\|start\|>|<\|return\|>|<\|call\|>|<\|constrain\|>|"
     r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]|"
     r"\[e~\[|\]~b\][a-z]*|\]~!b\[|"
-    r"</?tool_call>|</?tool_call_reasoning>"
+    r"</?tool_call_reasoning>"
 )
 
 

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -775,6 +775,79 @@ class MLLMBatchGenerator:
             f"({processing_time:.2f}s)"
         )
 
+    @staticmethod
+    def _copy_prefix_cache(cache_list):
+        """Create shallow copies of cache objects to prevent mutation of stored prefix cache.
+
+        MLX arrays are immutable and safe to share, but cache objects have mutable
+        Python attributes (offset, _idx) that get modified by update_and_fetch().
+        Without copying, the stored prefix cache entry is corrupted after each use.
+        """
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        copies = []
+        for c in cache_list:
+            if isinstance(c, RotatingKVCache):
+                new_c = RotatingKVCache(c.max_size, c.keep)
+                new_c.step = c.step
+                new_c.keys = c.keys
+                new_c.values = c.values
+                new_c.offset = c.offset
+                new_c._idx = c._idx
+                copies.append(new_c)
+            elif isinstance(c, KVCache):
+                new_c = KVCache()
+                new_c.step = c.step
+                new_c.keys = c.keys
+                new_c.values = c.values
+                new_c.offset = c.offset
+                copies.append(new_c)
+            else:
+                copies.append(c)
+        return copies
+
+    @staticmethod
+    def _has_empty_rotating_cache(cache_list):
+        """Check if any RotatingKVCache layer has no data (keys=None).
+
+        This happens when prefix cache stores a long response where all
+        sliding-window entries were trimmed (entries_to_keep=0).
+        Using such a cache produces garbage — fall through to full prefill.
+        """
+        from mlx_lm.models.cache import RotatingKVCache
+
+        for c in cache_list:
+            if isinstance(c, RotatingKVCache) and c.keys is None:
+                return True
+        return False
+
+    @staticmethod
+    def _trim_rotating_caches(cache_list):
+        """Trim RotatingKVCache buffers restored from prefix cache.
+
+        Prefix cache stores the full KV state (offset may exceed max_size for
+        sliding-window layers).  RotatingKVCache._update_in_place computes
+        ``new_size = min(step, max_size - prev)`` which goes negative when
+        ``prev > max_size``, crashing with "Negative dimensions not allowed".
+
+        Trimming the buffer to max_size and clamping offset/idx prevents this.
+        """
+        from mlx_lm.models.cache import RotatingKVCache
+
+        for layer_cache in cache_list:
+            if not isinstance(layer_cache, RotatingKVCache):
+                continue
+            if layer_cache.keys is None:
+                layer_cache.offset = 0
+                continue
+            buf_len = layer_cache.keys.shape[2]
+            if buf_len > layer_cache.max_size:
+                trim_size = buf_len - layer_cache.max_size
+                layer_cache.keys = layer_cache._trim(trim_size, layer_cache.keys)
+                layer_cache.values = layer_cache._trim(trim_size, layer_cache.values)
+                layer_cache._idx = layer_cache.max_size
+            layer_cache.offset = min(layer_cache.offset, layer_cache.max_size)
+
     def _run_chunked_text_prefill(
         self, request: MLLMBatchRequest, cache: List[Any]
     ) -> mx.array:
@@ -1001,9 +1074,22 @@ class MLLMBatchGenerator:
                             cached_kv = None
                             remaining_ids = None
 
+                # Detect empty RotatingKVCache in cached entry — if any sliding-window
+                # layer has keys=None (all entries trimmed), the cache is unusable.
+                # Fall through to full prefill instead of producing garbage.
+                if cached_kv is not None and self._has_empty_rotating_cache(cached_kv):
+                    logger.warning(
+                        f"Prefix cache hit for {req.request_id} has empty "
+                        f"RotatingKVCache layers — falling through to full prefill"
+                    )
+                    cached_kv = None
+                    remaining_ids = None
+
                 if cached_kv is not None and remaining_ids:
-                    # Prefix/LCP match — run language model on remaining tokens
-                    request_cache = cached_kv
+                    # Prefix/LCP match — run language model on remaining tokens.
+                    # Copy cache to prevent mutation of stored prefix cache entry.
+                    request_cache = self._copy_prefix_cache(cached_kv)
+                    self._trim_rotating_caches(request_cache)
                     remaining = mx.array(remaining_ids)[None, :]
                     cached_count = len(input_ids_list) - len(remaining_ids)
                     total_tokens = len(input_ids_list)
@@ -1081,7 +1167,9 @@ class MLLMBatchGenerator:
                     # but we still need logits for the last token.
                     # fetch() with trim-by-1 store always returns remaining=[last_token].
                     # If we get here (empty remaining), re-run on last token.
-                    request_cache = cached_kv
+                    # Copy cache to prevent mutation of stored prefix cache entry.
+                    request_cache = self._copy_prefix_cache(cached_kv)
+                    self._trim_rotating_caches(request_cache)
                     last_token = req.input_ids[:, -1:]
                     total_tokens = len(input_ids_list)
                     self._prefill_progress[req.request_id] = (
@@ -1173,19 +1261,10 @@ class MLLMBatchGenerator:
         from mlx_lm.models.cache import RotatingKVCache
 
         for rc in per_request_caches:
+            self._trim_rotating_caches(rc)
             for layer_cache in rc:
                 if isinstance(layer_cache, RotatingKVCache):
                     if layer_cache.keys is not None:
-                        buf_len = layer_cache.keys.shape[2]
-                        if buf_len > layer_cache.max_size:
-                            trim_size = buf_len - layer_cache.max_size
-                            layer_cache.keys = layer_cache._trim(
-                                trim_size, layer_cache.keys
-                            )
-                            layer_cache.values = layer_cache._trim(
-                                trim_size, layer_cache.values
-                            )
-                            layer_cache._idx = layer_cache.max_size
                         # Normalize wrapped rotating cache for merge:
                         # after rotation _idx wraps around but merge()
                         # expects _idx == actual buffer size.

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -77,6 +77,7 @@ def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import DeepSeekR1ReasoningParser
     from .gemma4_parser import Gemma4ReasoningParser
+    from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
@@ -86,6 +87,7 @@ def _register_builtin_parsers():
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("gemma4", Gemma4ReasoningParser)
+    register_parser("glm4", Glm4ReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for GLM-4 models (GLM-4.5-Air, GLM-4.6V, GLM-4.7, etc.).
+
+GLM-4 uses <think>...</think> tags for reasoning content, same as Qwen3.
+However, unlike Qwen3, GLM-4 does NOT inject <think> in the prompt —
+the model decides autonomously whether to reason.
+
+This means:
+- Output without tags = normal response (no reasoning)
+- Output with tags = reasoning + content
+
+This is the opposite of Qwen3 where no tags = pure reasoning (because
+<think> was injected in the prompt and the model hit max_tokens).
+
+GLM-4.6V also wraps responses in <|begin_of_box|>...<|end_of_box|> container
+tags which must be stripped before returning content.
+"""
+
+from .base import DeltaMessage
+from .think_parser import BaseThinkingReasoningParser
+
+_BOX_START = "<|begin_of_box|>"
+_BOX_END = "<|end_of_box|>"
+
+
+class Glm4ReasoningParser(BaseThinkingReasoningParser):
+    """
+    Reasoning parser for GLM-4 models.
+
+    GLM-4 uses <think>...</think> tokens to denote reasoning text.
+    Unlike Qwen3, the template does NOT inject <think> in the prompt,
+    so output without tags is a normal response (not truncated reasoning).
+
+    Supports three scenarios:
+    1. Both tags in output: <think>reasoning</think>content
+    2. Only closing tag (think in prompt): reasoning</think>content
+    3. No tags: pure content (NOT reasoning)
+
+    Example (with thinking):
+        Input: "<think>Let me analyze...</think>The answer is 42."
+        Output: reasoning="Let me analyze...", content="The answer is 42."
+
+    Example (no thinking):
+        Input: "The answer is 42."
+        Output: reasoning=None, content="The answer is 42."
+    """
+
+    @property
+    def start_token(self) -> str:
+        return "<think>"
+
+    @property
+    def end_token(self) -> str:
+        return "</think>"
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+    ) -> tuple[str | None, str | None]:
+        cleaned = model_output.replace(_BOX_START, "").replace(_BOX_END, "")
+        return super().extract_reasoning(cleaned)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        """
+        Extract reasoning from streaming delta.
+
+        Overrides base class pre_think behavior: when no tags have been seen,
+        emit delta as content (not reasoning). GLM-4 doesn't inject <think>
+        in the prompt, so early tokens without tags are normal content.
+
+        Once <think> is seen, delegates to base class state machine.
+        """
+        # Strip GLM-4.6V box container tags (special tokens, always whole)
+        delta_text = delta_text.replace(_BOX_START, "").replace(_BOX_END, "")
+        if not delta_text:
+            return None
+
+        start_tok = self.start_token
+        end_tok = self.end_token
+
+        # In pre_think phase: check if we should treat as content
+        if self._phase == "pre_think":
+            # If start tag appeared, transition to thinking via base class
+            if start_tok in current_text:
+                return super().extract_reasoning_streaming(
+                    previous_text, current_text, delta_text
+                )
+
+            # If end tag appeared without start (implicit mode from agent)
+            if end_tok in current_text:
+                return super().extract_reasoning_streaming(
+                    previous_text, current_text, delta_text
+                )
+
+            # No tags yet — GLM-4 doesn't inject <think>, so this is content
+            return DeltaMessage(content=delta_text)
+
+        # In thinking or content phase, delegate to base class
+        return super().extract_reasoning_streaming(
+            previous_text, current_text, delta_text
+        )

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -84,11 +84,16 @@ class BaseThinkingReasoningParser(ReasoningParser):
         if self.start_token in text and self.end_token in text:
             _, _, after_start = text.partition(self.start_token)
             reasoning, _, content = after_start.partition(self.end_token)
+            # Strip duplicate end tokens (some models generate <think></think></think>)
+            while content.lstrip().startswith(self.end_token):
+                content = content.lstrip()[len(self.end_token) :]
             return reasoning.strip() or None, content.strip() or None
 
         # Case 2: Only closing tag (think was injected in prompt)
         if self.end_token in text:
             reasoning, _, content = text.partition(self.end_token)
+            while content.lstrip().startswith(self.end_token):
+                content = content.lstrip()[len(self.end_token) :]
             return reasoning.strip() or None, content.strip() or None
 
         # Case 3: Only start tag (incomplete reasoning, no end yet)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -805,6 +805,9 @@ def _install_mtp(
             # and on reject: trim KV by 2 (remove both P and D), restore
             # RNN snapshot, then re-advance with just P so both cache
             # types end up consistent at [..., P].
+            # Skip RNN snapshots in optimistic mode — it never rejects,
+            # so the copies are wasted (~147 MB/step of lazy graph nodes
+            # that prevent pre-verify Metal buffers from being freed).
             _rnn_snapshots = {}
             if not optimistic:
                 for _ci, _c in enumerate(prompt_cache):
@@ -1350,12 +1353,19 @@ class Scheduler:
                 return
 
             prompt_tokens = list(request.prompt_token_ids)
+            # Trim cache by 1 so the stored KV has offset = N-1.
+            # On exact fetch the scheduler sends the last prompt token
+            # for reprocessing (lines 1872-1877).  Without this trim
+            # the last token would be placed at position N instead of N-1.
+            from .memory_cache import _trim_cache_offset
+
+            trimmed_cache = _trim_cache_offset(extracted_cache, 1)
             _t0 = _time.monotonic()
             # evict_prefixes=False: keep mid-prefill boundary entries so
             # that future requests with the same prefix but different
             # suffix get a prefix cache hit (critical for agentic multi-turn).
             stored = self.memory_aware_cache.store(
-                prompt_tokens, extracted_cache, evict_prefixes=False
+                prompt_tokens, trimmed_cache, evict_prefixes=False
             )
             _dt = _time.monotonic() - _t0
             if stored:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1590,14 +1590,20 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Parse tool calls from output using configured parser
     cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
 
-    # Extract reasoning content FIRST (strips channel tokens before JSON extraction)
+    # Extract reasoning content (strips channel tokens before JSON extraction)
     # Skip reasoning parser when enable_thinking=False (no think tags expected)
     reasoning_text = None
-    if _reasoning_parser and not tool_calls and request.enable_thinking is not False:
-        text_to_parse = cleaned_text or output.text
-        reasoning_text, cleaned_text = _reasoning_parser.extract_reasoning(
+    if _reasoning_parser and request.enable_thinking is not False:
+        # Always use original output.text for reasoning extraction so
+        # <think> content is preserved even when tool calls are present.
+        text_to_parse = output.text
+        reasoning_text, remaining_text = _reasoning_parser.extract_reasoning(
             text_to_parse
         )
+        # Only update cleaned_text from reasoning parser when no tool calls
+        # (tool parser already set cleaned_text appropriately)
+        if not tool_calls:
+            cleaned_text = remaining_text
 
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:


### PR DESCRIPTION
## Summary

- **Add `Glm4ReasoningParser`** (`--reasoning-parser glm4`) for GLM-4 models (GLM-4.5-Air, GLM-4.7) that use `<think>...</think>` tags but don't inject `<think>` in the prompt. Unlike Qwen3 where no tags = truncated reasoning, GLM-4 no tags = normal content. Streaming override emits pre-think deltas as content.
- **Fix duplicate `</think>` tag** in `BaseThinkingReasoningParser`: some models generate `<think></think></think>` with an extra closing tag that leaked into content.
- **Fix reasoning extraction with tool calls**: always parse reasoning from original `output.text` so `<think>` content is preserved even when tool calls are present.
- **Remove `<tool_call>` from `SPECIAL_TOKENS_PATTERN`**: these are structural tags used by GLM-4's tool calling format (`--tool-call-parser glm47`) and must not be stripped.
- **Fix prefix cache corruption on exact match**: trim stored cache by 1 in `_prompt_cache_save` so the last prompt token is reprocessed at the correct position on cache hit.
- **Fix prefix cache exact/prefix match with empty RotatingKVCache**: when stored cache has sliding-window layers with `keys=None` (all entries trimmed after long generation exceeding `sliding_window`), detect this and fall through to full prefill instead of producing garbage that causes client-visible hangs.
- **Fix prefix cache mutation corruption**: `fetch()` returns the same Python objects stored in the cache. `update_and_fetch()` mutates mutable attributes (`offset`, `_idx`) on these objects, corrupting the stored entry for future fetches. Fix: shallow-copy cache objects before use (`_copy_prefix_cache`), sharing immutable MLX arrays but with independent mutable state.
- **Extract `_trim_rotating_caches()` helper**: consolidates RotatingKVCache buffer trimming after prefix cache restore (previously inline in merge path).

## Test plan

- [x] Basic text generation (reasoning + content correctly separated)
- [x] Tool calling with reasoning (`tool_calls` + `reasoning_content` in response)
- [x] Streaming (reasoning chunks → content chunks transition)
- [x] Prefix cache exact hit (identical output on repeated prompts)
- [x] KV cache quantization Q8 (no degradation)
- [x] Verified Qwen3.5-122B (MLLM path) unaffected by scheduler.py fix
- [x] Gemma 4 json_schema repeat request: no longer hangs (empty RotatingKVCache detected, falls through to full prefill)
- [x] Prefix cache entries not corrupted after fetch (copy prevents mutation)

Tested with GLM-4.5-Air (106B/12B MoE, mixed 6/8-bit) and Gemma 4 26B-A4B (26B/4B MoE, mixed 6/8-bit) on Apple M3 Ultra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)