### PR TITLE
fix: guard tool parsing when no tools + trim RotatingKVCache after prefix restore

### DIFF
--- a/tests/test_specprefill_rotating_cache.py
+++ b/tests/test_specprefill_rotating_cache.py
@@ -82,3 +82,31 @@ def test_sparse_prefill_expands_tail_when_prompt_exceeds_window():
 
     flattened = [token for chunk in calls for row in chunk for token in row]
     assert flattened == [0, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_trim_rotating_caches_clamps_offset():
+    """Regression: offset > max_size after prefix restore must be clamped.
+
+    RotatingKVCache._update_in_place computes
+    ``new_size = min(step, max_size - prev)`` where prev = offset.
+    If offset > max_size the result is negative → crash.
+    _trim_rotating_caches must clamp offset after trimming buffers.
+    """
+    from mlx_lm.models.cache import RotatingKVCache
+
+    from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+    max_size = 4
+    cache = RotatingKVCache(max_size=max_size, keep=0)
+    # Simulate prefix-restored state: buffer larger than window, offset past max
+    cache.keys = mx.zeros((1, 1, 8, 4), dtype=mx.float32)
+    cache.values = mx.zeros((1, 1, 8, 4), dtype=mx.float32)
+    cache.offset = 8
+    cache._idx = 8
+
+    MLLMBatchGenerator._trim_rotating_caches([cache])
+
+    assert cache.keys.shape[2] == max_size
+    assert cache.values.shape[2] == max_size
+    assert cache._idx == max_size
+    assert cache.offset <= max_size

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -311,6 +311,7 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
                 tc.keys = None
                 tc.values = None
                 tc._idx = 0
+                tc.offset = 0
             elif entries_to_keep < old_size:
                 # Reorder to temporal order, keep the oldest entries
                 ordered_k = layer_cache._temporal_order(layer_cache.keys)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1588,7 +1588,12 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     )
 
     # Parse tool calls from output using configured parser
-    cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
+    # Skip tool parsing when request has no tools — otherwise the parser
+    # can misinterpret JSON output (e.g. response_format) as tool calls.
+    if request.tools:
+        cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
+    else:
+        cleaned_text, tool_calls = output.text, None
 
     # Extract reasoning content (strips channel tokens before JSON extraction)
     # Skip reasoning parser when enable_thinking=False (no think tags expected)
@@ -1847,10 +1852,13 @@ async def create_anthropic_message(
         f"Anthropic messages: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
-    # Parse tool calls
-    cleaned_text, tool_calls = _parse_tool_calls_with_parser(
-        output.text, openai_request
-    )
+    # Parse tool calls (skip when no tools to avoid misinterpreting output)
+    if openai_request.tools:
+        cleaned_text, tool_calls = _parse_tool_calls_with_parser(
+            output.text, openai_request
+        )
+    else:
+        cleaned_text, tool_calls = output.text, None
 
     # Extract reasoning if parser is configured
     reasoning_text = None


### PR DESCRIPTION
## Summary

- **Skip tool call parsing when request has no tools**: When `--tool-call-parser` is globally configured but a request defines no tools (e.g. `response_format` JSON mode), the parser could misinterpret JSON model output as tool calls. Added guard `if request.tools:` in both OpenAI and Anthropic endpoints.

- **Trim RotatingKVCache after prefix cache restore**: Models with sliding-window attention (e.g. Gemma 4, `sliding_window=1024`) crash with "Negative dimensions not allowed" when prefix cache restores KV state with offset exceeding `max_size`. Extracted `_trim_rotating_caches()` helper and call it after prefix-hit, exact-hit, and merge paths.

## Test plan

- [x] Verify JSON `response_format` requests return content (not tool_calls) when no tools defined
- [x] Verify tool calling still works when tools are defined
- [x] Verify sliding-window model (Gemma 4) handles prefix cache restore for prompts > 1024 tokens
- [x] Run existing CI test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)