### PR TITLE
fix(cli): change model from positional arg to --model flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ pip install -e .
 
 ```bash
 # Simple mode (single user, max throughput)
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
 # Continuous batching (multiple users)
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
 
 # With API key authentication
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --api-key your-secret-key
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --api-key your-secret-key
 ```
 
 ### Use with OpenAI SDK
@@ -117,7 +117,7 @@ See [Anthropic Messages API docs](docs/guides/server.md#anthropic-messages-api) 
 ### Multimodal (Images & Video)
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 ```
 
 ```python
@@ -168,7 +168,7 @@ Extract the thinking process from reasoning models like Qwen3 and DeepSeek-R1:
 
 ```bash
 # Start server with reasoning parser
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 ```
 
 ```python
@@ -194,7 +194,7 @@ Generate text embeddings for semantic search, RAG, and similarity:
 
 ```bash
 # Start server with an embedding model pre-loaded
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
 ```
 
 ```python
@@ -305,7 +305,7 @@ vllm-mlx includes native support for Gemma 3 vision models. Gemma 3 is automatic
 
 ```bash
 # Start server with Gemma 3
-vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
+vllm-mlx serve --model mlx-community/gemma-3-27b-it-4bit --port 8000
 
 # Verify it loaded as MLLM (not LLM)
 curl http://localhost:8000/health
@@ -345,13 +345,13 @@ def make_cache(self):
 
 ```bash
 # Default (~10K max context)
-vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
+vllm-mlx serve --model mlx-community/gemma-3-27b-it-4bit --port 8000
 
 # Extended context (~40K max)
-GEMMA3_SLIDING_WINDOW=8192 vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
+GEMMA3_SLIDING_WINDOW=8192 vllm-mlx serve --model mlx-community/gemma-3-27b-it-4bit --port 8000
 
 # Maximum context (~50K max)
-GEMMA3_SLIDING_WINDOW=0 vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
+GEMMA3_SLIDING_WINDOW=0 vllm-mlx serve --model mlx-community/gemma-3-27b-it-4bit --port 8000
 ```
 
 **Benchmark Results (M4 Max 128GB):**

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -85,5 +85,5 @@ huggingface-cli login
 
 Use a smaller quantized model:
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
+vllm-mlx serve --model mlx-community/Llama-3.2-1B-Instruct-4bit
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,10 +6,10 @@ Start the server:
 
 ```bash
 # Simple mode - maximum throughput for single user
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
 # Continuous batching - for multiple concurrent users
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
 ```
 
 Use with OpenAI Python SDK:
@@ -64,7 +64,7 @@ Opens a web interface at http://localhost:7860
 For image/video understanding, use a VLM model:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 ```
 
 ```python
@@ -86,7 +86,7 @@ response = client.chat.completions.create(
 Separate the model's thinking process from the final answer:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 ```
 
 ```python
@@ -102,7 +102,7 @@ print(response.choices[0].message.content)  # Final answer
 Generate text embeddings for semantic search and RAG:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
 ```
 
 ```python
@@ -117,7 +117,7 @@ response = client.embeddings.create(
 Enable function calling with any supported model:
 
 ```bash
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice --tool-call-parser mistral
 ```
 

--- a/docs/guides/continuous-batching.md
+++ b/docs/guides/continuous-batching.md
@@ -5,7 +5,7 @@ Continuous batching enables higher throughput when serving multiple concurrent u
 ## Enabling Continuous Batching
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit --continuous-batching
 ```
 
 ## With Paged Cache
@@ -13,7 +13,7 @@ vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
 For memory-efficient prefix sharing:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
 ```
 
 ## How It Works
@@ -67,10 +67,10 @@ Control token delivery with `--stream-interval`:
 
 ```bash
 # Every token (smoothest)
-vllm-mlx serve model --continuous-batching --stream-interval 1
+vllm-mlx serve --model model --continuous-batching --stream-interval 1
 
 # Batch tokens (better for high-latency)
-vllm-mlx serve model --continuous-batching --stream-interval 5
+vllm-mlx serve --model model --continuous-batching --stream-interval 5
 ```
 
 | Value | Behavior |
@@ -85,13 +85,13 @@ For large models, the prefix cache can consume significant memory. The memory-aw
 
 ```bash
 # Auto-detect (uses 20% of available RAM)
-vllm-mlx serve model --continuous-batching
+vllm-mlx serve --model model --continuous-batching
 
 # Explicit limit
-vllm-mlx serve model --continuous-batching --cache-memory-mb 2048
+vllm-mlx serve --model model --continuous-batching --cache-memory-mb 2048
 
 # Custom percentage
-vllm-mlx serve model --continuous-batching --cache-memory-percent 0.10
+vllm-mlx serve --model model --continuous-batching --cache-memory-percent 0.10
 ```
 
 | Option | Description |
@@ -167,7 +167,7 @@ python tests/test_prefix_cache.py
 ## Production Setup
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching \
   --use-paged-cache \
   --port 8000

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -14,7 +14,7 @@ pip install mlx-embeddings>=0.0.5
 
 ```bash
 # Pre-load a specific embedding model at startup
-vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+vllm-mlx serve --model my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
 ```
 
 If you don't use `--embedding-model`, the embedding model is loaded lazily on the first request.
@@ -78,7 +78,7 @@ By default, the embedding model is loaded on the first `/v1/embeddings` request.
 Use `--embedding-model` to load a model at startup. When this flag is set, only that specific model can be used for embeddings:
 
 ```bash
-vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+vllm-mlx serve --model my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
 ```
 
 Requesting a different model will return a 400 error.

--- a/docs/guides/mcp-tools.md
+++ b/docs/guides/mcp-tools.md
@@ -52,10 +52,10 @@ Create `mcp.json`:
 
 ```bash
 # Simple mode
-vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
 
 # Continuous batching
-vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
 ```
 
 ### 3. Verify MCP Status

--- a/docs/guides/multimodal.md
+++ b/docs/guides/multimodal.md
@@ -17,7 +17,7 @@ vllm-mlx supports vision-language models for image and video understanding.
 ## Starting a Multimodal Server
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 ```
 
 Models with "VL", "Vision", or "mllm" in the name are auto-detected as multimodal.
@@ -252,10 +252,10 @@ The cache uses content-based hashing (similar to LMCache) to identify identical 
 
 ```bash
 # Enable with default settings (512 MB max)
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
 
 # With custom memory limit
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit \
     --enable-mllm-cache \
     --mllm-cache-max-mb 1024
 ```

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -24,10 +24,10 @@ Without reasoning parsing, you get the raw output with the tags included. With r
 
 ```bash
 # For Qwen3 models
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 
 # For DeepSeek-R1 models
-vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+vllm-mlx serve --model mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
 ```
 
 ### API Response Format
@@ -116,7 +116,7 @@ For Qwen3 models that use explicit `<think>` and `</think>` tags.
 - Best for: Qwen3-0.6B, Qwen3-4B, Qwen3-8B and similar models
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 ```
 
 ### DeepSeek-R1 Parser (`deepseek_r1`)
@@ -128,7 +128,7 @@ For DeepSeek-R1 models that may omit the opening `<think>` tag.
 - Content before `</think>` is treated as reasoning even without `<think>`
 
 ```bash
-vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+vllm-mlx serve --model mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
 ```
 
 ## How It Works

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -9,7 +9,7 @@ vllm-mlx provides a FastAPI server with full OpenAI API compatibility.
 Maximum throughput for single user:
 
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 ```
 
 ### Continuous Batching Mode
@@ -17,7 +17,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 For multiple concurrent users:
 
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
 ```
 
 ### With Paged Cache
@@ -25,7 +25,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 Memory-efficient caching for production:
 
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
 ```
 
 ## Server Options
@@ -416,7 +416,7 @@ Point Claude Code directly at your vllm-mlx server:
 
 ```bash
 # Start the server
-vllm-mlx serve mlx-community/Qwen3-Coder-Next-235B-A22B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-Coder-Next-235B-A22B-4bit \
   --continuous-batching \
   --enable-auto-tool-choice \
   --tool-call-parser hermes
@@ -517,7 +517,7 @@ Per-request fields in `requests`:
 Enable OpenAI-compatible tool calling with `--enable-auto-tool-choice`:
 
 ```bash
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice \
   --tool-call-parser mistral
 ```
@@ -570,10 +570,10 @@ For models that show their thinking process (Qwen3, DeepSeek-R1), use `--reasoni
 
 ```bash
 # Qwen3 models
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 
 # DeepSeek-R1 models
-vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+vllm-mlx serve --model mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
 ```
 
 The API response includes a `reasoning` field with the model's thought process:
@@ -698,17 +698,17 @@ Control streaming behavior with `--stream-interval`:
 
 ```bash
 # Smooth streaming
-vllm-mlx serve model --continuous-batching --stream-interval 1
+vllm-mlx serve --model model --continuous-batching --stream-interval 1
 
 # Batched streaming (better for high-latency networks)
-vllm-mlx serve model --continuous-batching --stream-interval 5
+vllm-mlx serve --model model --continuous-batching --stream-interval 5
 ```
 
 ## Open WebUI Integration
 
 ```bash
 # 1. Start vllm-mlx server
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
 # 2. Start Open WebUI
 docker run -d -p 3000:8080 \
@@ -733,7 +733,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+ExecStart=/usr/local/bin/vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching --use-paged-cache --port 8000
 Restart=always
 
@@ -751,7 +751,7 @@ sudo systemctl start vllm-mlx
 For production with 50+ concurrent users:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching \
   --use-paged-cache \
   --api-key your-secret-key \

--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -7,7 +7,7 @@ vllm-mlx supports OpenAI-compatible tool calling (function calling) with automat
 Enable tool calling by adding the `--enable-auto-tool-choice` flag when starting the server:
 
 ```bash
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice \
   --tool-call-parser mistral
 ```
@@ -70,11 +70,11 @@ Use `--tool-call-parser` to select a parser for your model family:
 
 ```bash
 # Devstral Small (optimized for coding and tool use)
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice --tool-call-parser mistral
 
 # Mistral Instruct
-vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
+vllm-mlx serve --model mlx-community/Mistral-7B-Instruct-v0.3-4bit \
   --enable-auto-tool-choice --tool-call-parser mistral
 ```
 
@@ -82,7 +82,7 @@ vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
 
 ```bash
 # Qwen3
-vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit \
   --enable-auto-tool-choice --tool-call-parser qwen
 ```
 
@@ -90,7 +90,7 @@ vllm-mlx serve mlx-community/Qwen3-4B-4bit \
 
 ```bash
 # Llama 3.2
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit \
   --enable-auto-tool-choice --tool-call-parser llama
 ```
 
@@ -98,7 +98,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
 
 ```bash
 # DeepSeek V3
-vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
+vllm-mlx serve --model mlx-community/DeepSeek-V3-0324-4bit \
   --enable-auto-tool-choice --tool-call-parser deepseek
 ```
 
@@ -106,7 +106,7 @@ vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
 
 ```bash
 # Granite 4.0
-vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+vllm-mlx serve --model mlx-community/granite-4.0-tiny-preview-4bit \
   --enable-auto-tool-choice --tool-call-parser granite
 ```
 
@@ -114,7 +114,7 @@ vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
 
 ```bash
 # Nemotron 3 Nano
-vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
+vllm-mlx serve --model mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
   --enable-auto-tool-choice --tool-call-parser nemotron
 ```
 
@@ -122,7 +122,7 @@ vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
 
 ```bash
 # GLM-4.7 Flash
-vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
+vllm-mlx serve --model lmstudio-community/GLM-4.7-Flash-MLX-8bit \
   --enable-auto-tool-choice --tool-call-parser glm47
 ```
 
@@ -130,7 +130,7 @@ vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
 
 ```bash
 # Kimi K2
-vllm-mlx serve mlx-community/Kimi-K2-Instruct-4bit \
+vllm-mlx serve --model mlx-community/Kimi-K2-Instruct-4bit \
   --enable-auto-tool-choice --tool-call-parser kimi
 ```
 
@@ -138,7 +138,7 @@ vllm-mlx serve mlx-community/Kimi-K2-Instruct-4bit \
 
 ```bash
 # xLAM
-vllm-mlx serve mlx-community/xLAM-2-fc-r-4bit \
+vllm-mlx serve --model mlx-community/xLAM-2-fc-r-4bit \
   --enable-auto-tool-choice --tool-call-parser xlam
 ```
 
@@ -147,7 +147,7 @@ vllm-mlx serve mlx-community/xLAM-2-fc-r-4bit \
 If you're not sure which parser to use, the `auto` parser tries to detect the format automatically:
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit \
   --enable-auto-tool-choice --tool-call-parser auto
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,7 +15,7 @@ Start the OpenAI-compatible API server.
 ### Usage
 
 ```bash
-vllm-mlx serve <model> [options]
+vllm-mlx serve --model <model> [options]
 ```
 
 ### Options
@@ -49,47 +49,47 @@ vllm-mlx serve <model> [options]
 
 ```bash
 # Simple mode (single user, max throughput)
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit
 
 # Continuous batching (multiple users)
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
 
 # With memory limit for large models
-vllm-mlx serve mlx-community/GLM-4.7-Flash-4bit \
+vllm-mlx serve --model mlx-community/GLM-4.7-Flash-4bit \
   --continuous-batching \
   --cache-memory-mb 2048
 
 # Production with paged cache
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching \
   --use-paged-cache \
   --port 8000
 
 # With MCP tools
-vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
 
 # Multimodal model
-vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+vllm-mlx serve --model mlx-community/Qwen3-VL-4B-Instruct-3bit
 
 # Reasoning model (separates thinking from answer)
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 
 # DeepSeek reasoning model
-vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+vllm-mlx serve --model mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
 
 # Tool calling with Mistral/Devstral
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice --tool-call-parser mistral
 
 # Tool calling with Granite
-vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+vllm-mlx serve --model mlx-community/granite-4.0-tiny-preview-4bit \
   --enable-auto-tool-choice --tool-call-parser granite
 
 # With API key authentication
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
 
 # Production setup with security options
-vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit \
   --api-key your-secret-key \
   --rate-limit 60 \
   --timeout 120 \

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -126,13 +126,13 @@ Create `mcp.json`:
 ### Development (Single User)
 
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit
 ```
 
 ### Production (Multiple Users)
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching \
   --use-paged-cache \
   --api-key your-secret-key \
@@ -143,7 +143,7 @@ vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
 ### With Tool Calling
 
 ```bash
-vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+vllm-mlx serve --model mlx-community/Devstral-Small-2507-4bit \
   --enable-auto-tool-choice \
   --tool-call-parser mistral \
   --continuous-batching
@@ -152,7 +152,7 @@ vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
 ### With MCP Tools
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit \
   --mcp-config mcp.json \
   --enable-auto-tool-choice \
   --tool-call-parser qwen \
@@ -162,7 +162,7 @@ vllm-mlx serve mlx-community/Qwen3-4B-4bit \
 ### Reasoning Model
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-8B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-8B-4bit \
   --reasoning-parser qwen3 \
   --continuous-batching
 ```
@@ -170,7 +170,7 @@ vllm-mlx serve mlx-community/Qwen3-8B-4bit \
 ### With Embeddings
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+vllm-mlx serve --model mlx-community/Qwen3-4B-4bit \
   --embedding-model mlx-community/multilingual-e5-small-mlx \
   --continuous-batching
 ```
@@ -178,7 +178,7 @@ vllm-mlx serve mlx-community/Qwen3-4B-4bit \
 ### High Throughput
 
 ```bash
-vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+vllm-mlx serve --model mlx-community/Qwen3-0.6B-8bit \
   --continuous-batching \
   --stream-interval 5 \
   --max-num-seqs 256

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -80,13 +80,13 @@ vllm-mlx auto-detects multimodal models by name patterns:
 ### From HuggingFace
 
 ```bash
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit
 ```
 
 ### Local Path
 
 ```bash
-vllm-mlx serve /path/to/local/model
+vllm-mlx serve --model /path/to/local/model
 ```
 
 ## Finding Models

--- a/examples/mcp_tool_use.py
+++ b/examples/mcp_tool_use.py
@@ -9,7 +9,7 @@ with the vllm-mlx server.
 Prerequisites:
 1. Install MCP support: pip install vllm-mlx[mcp]
 2. Create mcp.json config (see example below)
-3. Start server with MCP: vllm-mlx serve <model> --mcp-config mcp.json
+3. Start server with MCP: vllm-mlx serve --model <model> --mcp-config mcp.json
 
 Example mcp.json:
 {
@@ -52,7 +52,7 @@ def main():
 
     if not health.get("mcp"):
         print("\n   Warning: MCP not configured. Start server with --mcp-config")
-        print("   Example: vllm-mlx serve <model> --mcp-config mcp.json")
+        print("   Example: vllm-mlx serve --model <model> --mcp-config mcp.json")
         return
 
     # 2. List available MCP tools

--- a/scripts/add_mtp_weights.py
+++ b/scripts/add_mtp_weights.py
@@ -333,7 +333,7 @@ def main():
     print(f"\nMTP weight file: {mtp_file}")
     print(f"Total MTP keys: {len(mtp_keys)}")
     print(f"\nTo use MTP, start the server with --enable-mtp:")
-    print(f"  vllm-mlx serve mlx-community/Qwen3-Next-80B-A3B-Instruct-6bit \\")
+    print(f"  vllm-mlx serve --model mlx-community/Qwen3-Next-80B-A3B-Instruct-6bit \\")
     print(f"      --enable-mtp --port 1239")
 
 

--- a/scripts/add_mtp_weights_qwen35.py
+++ b/scripts/add_mtp_weights_qwen35.py
@@ -463,7 +463,7 @@ def main():
     print(f"\nMTP weight file: {mtp_file}")
     print(f"Total MTP keys: {len(mtp_weight_keys)}")
     print("\nTo use MTP, start the server with --enable-mtp:")
-    print(f"  vllm-mlx serve {args.mlx_model_path} --enable-mtp")
+    print(f"  vllm-mlx serve --model {args.mlx_model_path} --enable-mtp")
 
 
 if __name__ == "__main__":

--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -8,7 +8,7 @@ Works with both the local vllm-mlx server and any OpenAI-compatible API.
 
 Usage:
     # Start server first:
-    vllm-mlx serve mlx-community/Qwen2.5-3B-Instruct-4bit --port 8000
+    vllm-mlx serve --model mlx-community/Qwen2.5-3B-Instruct-4bit --port 8000
 
     # Run evaluation:
     python tests/evals/gsm8k/gsm8k_eval.py --port 8000 --num-questions 10

--- a/tests/test_paged_cache_benefits.py
+++ b/tests/test_paged_cache_benefits.py
@@ -456,7 +456,7 @@ def main():
     print("  - Hash-based deduplication")
 
     print("\nUsage:")
-    print("  vllm-mlx serve <model> --continuous-batching --use-paged-cache")
+    print("  vllm-mlx serve --model <model> --continuous-batching --use-paged-cache")
     print()
 
 

--- a/tests/test_paged_cache_real_model.py
+++ b/tests/test_paged_cache_real_model.py
@@ -579,7 +579,7 @@ def main():
     print("     TEST COMPLETE")
     print("=" * 70)
     print("\nTo enable paged cache in production:")
-    print("  vllm-mlx serve <model> --continuous-batching --use-paged-cache")
+    print("  vllm-mlx serve --model <model> --continuous-batching --use-paged-cache")
     print()
 
 

--- a/tests/test_streaming_latency.py
+++ b/tests/test_streaming_latency.py
@@ -10,7 +10,7 @@ This script measures:
 
 Usage:
     # Start server first:
-    vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+    vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit
 
     # Run test:
     python tests/test_streaming_latency.py

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4,12 +4,12 @@
 CLI for vllm-mlx.
 
 Commands:
-    vllm-mlx serve <model> --port 8000    Start OpenAI-compatible server
-    vllm-mlx bench <model>                Run benchmark
+    vllm-mlx serve --model <model> --port 8000    Start OpenAI-compatible server
+    vllm-mlx bench --model <model>                Run benchmark
 
 Usage:
-    vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
-    vllm-mlx bench mlx-community/Llama-3.2-1B-Instruct-4bit --num-prompts 10
+    vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+    vllm-mlx bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --num-prompts 10
 """
 
 import argparse
@@ -630,9 +630,11 @@ def bench_kv_cache_command(args):
     )
     print()
     print("Usage:")
-    print("  vllm-mlx serve <model> --continuous-batching --kv-cache-quantization")
     print(
-        "  vllm-mlx serve <model> --continuous-batching --kv-cache-quantization "
+        "  vllm-mlx serve --model <model> --continuous-batching --kv-cache-quantization"
+    )
+    print(
+        "  vllm-mlx serve --model <model> --continuous-batching --kv-cache-quantization "
         "--kv-cache-quantization-bits 4"
     )
 
@@ -644,15 +646,15 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
-  vllm-mlx bench mlx-community/Llama-3.2-1B-Instruct-4bit --num-prompts 10
+  vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+  vllm-mlx bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --num-prompts 10
         """,
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
     # Serve command
     serve_parser = subparsers.add_parser("serve", help="Start OpenAI-compatible server")
-    serve_parser.add_argument("model", type=str, help="Model to serve")
+    serve_parser.add_argument("--model", type=str, required=True, help="Model to serve")
     serve_parser.add_argument(
         "--served-model-name",
         type=str,
@@ -972,7 +974,9 @@ Examples:
     )
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")
-    bench_parser.add_argument("model", type=str, help="Model to benchmark")
+    bench_parser.add_argument(
+        "--model", type=str, required=True, help="Model to benchmark"
+    )
     bench_parser.add_argument(
         "--num-prompts", type=int, default=10, help="Number of prompts"
     )
@@ -1109,7 +1113,9 @@ Examples:
     download_parser = subparsers.add_parser(
         "download", help="Download a model to local cache without starting a server"
     )
-    download_parser.add_argument("model", type=str, help="Model to download")
+    download_parser.add_argument(
+        "--model", type=str, required=True, help="Model to download"
+    )
     download_parser.add_argument(
         "--timeout",
         type=int,


### PR DESCRIPTION
## Summary
- Changes `model` from a positional argument to a `--model` flag in the `serve`, `bench`, and `download` subcommands
- Aligns with vLLM convention (`vllm serve --model`) and the existing `python -m vllm_mlx.server --model` interface
- Updates all docs, examples, and scripts to use `--model` syntax

## Motivation
Users expect `vllm-mlx serve --model foo` but currently must use `vllm-mlx serve foo`. This causes confusion, especially for users coming from vLLM.

## Test plan
- [ ] `vllm-mlx serve --model mlx-community/Llama-3.2-3B-Instruct-4bit` starts correctly
- [ ] `vllm-mlx serve` without `--model` shows a clear "required" error
- [ ] `vllm-mlx bench --model <model>` works
- [ ] `vllm-mlx download --model <model>` works

Closes #290