### PR TITLE
fix(mllm): increment total_prompt_tokens when scheduling requests

### DIFF
--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -498,6 +498,8 @@ class MLLMScheduler:
             self.running[request.request_id] = request
             scheduled.append(request)
 
+            self.total_prompt_tokens += request.num_prompt_tokens
+
         # Insert into batch generator
         if batch_requests and self.batch_generator is not None:
             uids = self.batch_generator.insert(batch_requests)


### PR DESCRIPTION
## Summary
- `MLLMScheduler._schedule_waiting()` was missing `self.total_prompt_tokens += request.num_prompt_tokens`
- After image/VLM requests, `total_prompt_tokens` stayed at 0 while `total_completion_tokens` was correctly tracked
- Matches the existing pattern in the LLM `TextBatchScheduler` at `scheduler.py:1968`

## One-line fix
```python
self.total_prompt_tokens += request.num_prompt_tokens
```
Added after `scheduled.append(request)` in `_schedule_waiting()`.

## Test plan
- [ ] Start server with a VLM model, send an image request
- [ ] Check `/v1/status` — `total_prompt_tokens` should be > 0
- [ ] Verify `total_completion_tokens` still works correctly

Closes #260