### PR TITLE
feat: add registry-backed multi-model serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --api-key your-secret-key
 ```
 
+### Multi-Model Serving
+
+```bash
+vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --port 8000
+```
+
+This mode uses a YAML registry of named models with lazy loading, memory-budget eviction, and configurable wait/fail/preempt behavior. See [Multi-Model Serving](docs/guides/model-registry.md) for the registry format and ops rollout guidance.
+
 ### Use with OpenAI SDK
 
 ```python
@@ -226,6 +234,7 @@ For full documentation, see the [docs](docs/) directory:
   - [Reasoning Models](docs/guides/reasoning.md)
   - [MCP & Tool Calling](docs/guides/mcp-tools.md)
   - [Continuous Batching](docs/guides/continuous-batching.md)
+  - [Multi-Model Serving](docs/guides/model-registry.md)
 
 - **Reference**
   - [CLI Commands](docs/reference/cli.md)

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -1,0 +1,229 @@
+# Multi-Model Serving
+
+`vllm-mlx` can serve a registry of named models behind one process and one OpenAI-compatible API surface.
+
+This mode is designed for Apple Silicon machines where unified memory is the main constraint:
+
+- models load lazily on first use
+- idle models are evicted with an LRU policy under a memory budget
+- contention can be configured to wait, fail fast, or preempt active models
+- `/v1/models` reflects the configured registry instead of a single default model
+
+## When to Use It
+
+Use registry-backed serving when you want one server to expose multiple models such as:
+
+- a small low-latency chat model
+- a larger reasoning or coding model
+- a multimodal model for image or video requests
+
+Keep single-model serving when you want the smallest operational surface and the highest per-model simplicity.
+
+## Start the Server
+
+```bash
+vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --host 0.0.0.0 --port 8000
+```
+
+You can still use global serve flags such as:
+
+- `--api-key`
+- `--rate-limit`
+- `--timeout`
+- `--default-temperature`
+- `--default-top-p`
+- `--reasoning-parser`
+- `--enable-auto-tool-choice`
+- `--tool-call-parser`
+
+Do not combine `--models-config` with:
+
+- a positional model argument
+- `--served-model-name`
+
+## Registry File
+
+The registry is a YAML file with two top-level sections:
+
+- `manager`: global budget and contention behavior
+- `models`: named model entries that clients select via the OpenAI `model` field
+
+Example:
+
+```yaml
+manager:
+  memory_budget_gb: 100
+  contention_policy:
+    strategy: wait_then_preempt
+    wait_timeout_s: 45
+    preempt_after_s: 15
+
+models:
+  - name: fast
+    path: /Users/david/ai-models/mlx_models/gemma-4-E2B-it-5bit
+    preload: true
+    continuous_batching: false
+    estimated_memory_gb: 4
+
+  - name: smart
+    path: /Users/david/ai-models/mlx_models/Qwen3.5-27B-VLM-MTP-8bit
+    continuous_batching: true
+    enable_mtp: true
+    estimated_memory_gb: 36
+
+  - name: vision
+    path: /Users/david/ai-models/mlx_models/gemma-4-31B-it-6bit
+    mllm: true
+    continuous_batching: true
+    estimated_memory_gb: 44
+```
+
+## Manager Settings
+
+### `memory_budget_gb`
+
+Total resident-model budget for the registry manager.
+
+This is the eviction budget, not the full system RAM size. Leave headroom for:
+
+- KV cache
+- request batching
+- OS / filesystem cache
+- other colocated services
+
+On a 128 GB machine, a practical starting point is often `80-100 GB`.
+
+### `contention_policy`
+
+Controls what happens when a request needs a model that does not currently fit.
+
+Supported strategies:
+
+- `fail`: return capacity failure immediately
+- `wait`: wait for capacity to free up
+- `preempt`: cancel active requests on other models and evict them
+- `wait_then_fail`: wait up to `wait_timeout_s`, then fail
+- `wait_then_preempt`: wait up to `preempt_after_s`, then start preempting, and stop waiting at `wait_timeout_s`
+
+Recommended defaults:
+
+- shared internal service: `wait_then_preempt`
+- user-facing low-latency API: `wait_then_fail`
+- strict isolation / no interruption: `wait`
+
+## Model Entry Fields
+
+Required:
+
+- `name`: request-time model id
+- one of `path`, `source`, or `model`
+
+Optional:
+
+- `preload`: load this model at startup
+- `continuous_batching`: override the global mode for this model
+- `mllm`: force multimodal loading when autodetect is not enough
+- `enable_mtp`: enable native MTP for this model
+- `prefill_step_size`
+- `specprefill`
+- `specprefill_threshold`
+- `specprefill_keep_pct`
+- `specprefill_draft_model`
+- `stream_interval`
+- `gpu_memory_utilization`
+- `estimated_memory_gb`
+
+## Sizing Rules
+
+For deterministic eviction behavior:
+
+- local models should have real weight files on disk
+- non-local model ids should set `estimated_memory_gb`
+
+If a registry entry points at a non-local source and no `estimated_memory_gb` is provided, startup will reject the config. This prevents the manager from making bad eviction decisions from guesswork.
+
+## Request Routing
+
+Clients select a registry entry through the normal OpenAI `model` field:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+resp = client.chat.completions.create(
+    model="smart",
+    messages=[{"role": "user", "content": "Explain speculative decoding."}],
+)
+```
+
+If the requested model is not registered, the server returns `404` and lists the configured model ids.
+
+## Operational Checks
+
+### Inspect registry state
+
+```bash
+curl http://localhost:8000/v1/models
+```
+
+Registry-backed responses include the configured model ids and current state such as:
+
+- `loaded`
+- `loading`
+- `unloaded`
+- `preempting`
+
+### Verify a cold-load path
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "fast",
+    "messages": [{"role": "user", "content": "hello"}],
+    "max_tokens": 32
+  }'
+```
+
+Then repeat with a second model id to verify:
+
+- lazy load works
+- the memory budget is enforced
+- the selected contention policy behaves as expected
+
+## Recommended Rollout
+
+1. Start with local-disk model paths, not remote model ids.
+2. Set `estimated_memory_gb` for every large model, even when local, so your operational budget stays explicit.
+3. Preload only the model that must be instantly available.
+4. Verify `/v1/models` before exposing the endpoint to shared traffic.
+5. Exercise the configured contention strategy under load before production cutover.
+
+## Failure Modes to Expect
+
+- Bad or missing `estimated_memory_gb` on non-local sources: config load failure
+- Too-small `memory_budget_gb`: repeated capacity failures or unnecessary preemption
+- Over-aggressive `preempt` policy: active requests get cancelled during model swaps
+- Too many `preload: true` entries: startup load storm and immediate budget pressure
+
+## Choosing Per-Model Overrides
+
+Use global defaults for the common case, then override only the model-specific performance knobs that materially differ.
+
+Good candidates for per-model overrides:
+
+- `continuous_batching`
+- `enable_mtp`
+- `mllm`
+- `prefill_step_size`
+- `stream_interval`
+
+Keep these global unless you have a strong reason not to:
+
+- auth
+- rate limits
+- request timeout
+- reasoning parser selection
+- tool parser selection
+- manager memory budget / contention policy

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -30,6 +30,16 @@ Memory-efficient caching for production:
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
 ```
 
+### Registry-Backed Multi-Model Serving
+
+Serve a named registry of models behind one endpoint:
+
+```bash
+vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --port 8000
+```
+
+Clients route requests by setting the OpenAI `model` field to one of the configured registry names. See [Multi-Model Serving](model-registry.md) for the registry file format, eviction policy, and rollout guidance.
+
 ## Server Options
 
 | Option | Description | Default |
@@ -54,6 +64,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 | `--embedding-model` | Pre-load an embedding model at startup | None |
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
 | `--tool-call-parser` | Tool call parser (see [Tool Calling](tool-calling.md)) | None |
+| `--models-config` | YAML registry file for multi-model serving | None |
 
 ## API Endpoints
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ vllm-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 - [Tool Calling](guides/tool-calling.md)
 - [MCP & Tool Calling](guides/mcp-tools.md)
 - [Continuous Batching](guides/continuous-batching.md)
+- [Multi-Model Serving](guides/model-registry.md)
 
 ### Reference
 - [CLI Commands](reference/cli.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,6 +16,7 @@ Start the OpenAI-compatible API server.
 
 ```bash
 vllm-mlx serve <model> [options]
+vllm-mlx serve --models-config <yaml> [options]
 ```
 
 ### Options
@@ -49,6 +50,7 @@ vllm-mlx serve <model> [options]
 | `--embedding-model` | Pre-load an embedding model at startup | None |
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
 | `--tool-call-parser` | Tool call parser (`auto`, `mistral`, `qwen`, `llama`, `hermes`, `deepseek`, `kimi`, `granite`, `nemotron`, `xlam`, `functionary`, `glm47`) | None |
+| `--models-config` | YAML registry file for multi-model serving | None |
 
 ### Examples
 
@@ -101,6 +103,9 @@ vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
 # With API key authentication
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
 
+# Registry-backed multi-model serving
+vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --continuous-batching
+
 # Expose Prometheus metrics
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics
 
@@ -111,6 +116,8 @@ vllm-mlx serve mlx-community/Qwen3-4B-4bit \
   --timeout 120 \
   --continuous-batching
 ```
+
+For registry-backed serving, see [Multi-Model Serving](../guides/model-registry.md).
 
 ### Security
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,257 +1,261 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for model registry and multi-engine scenarios."""
+"""Tests for registry-backed multi-model serving."""
 
-import gc
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
 import pytest
-from vllm_mlx import (
-    EngineCore,
-    EngineConfig,
-    SamplingParams,
-    SchedulerConfig,
-    get_registry,
-    ModelOwnershipError,
+
+from vllm_mlx.engine.base import BaseEngine, GenerationOutput
+from vllm_mlx.model_registry import (
+    ContentionPolicy,
+    ModelManager,
+    RegisteredModel,
+    RegistryManagerConfig,
+    RegistryServeDefaults,
+    ResolvedModelConfig,
 )
-
-# Use a small model for fast tests
-TEST_MODEL = "mlx-community/Qwen3-0.6B-8bit"
+from vllm_mlx.utils.download import DownloadConfig
 
 
-@pytest.fixture(scope="module")
-def model_and_tokenizer():
-    """Load model once for all tests in module."""
-    from mlx_lm import load
+class FakeEngine(BaseEngine):
+    """Small test double for model lifecycle behaviour."""
 
-    return load(TEST_MODEL)
+    def __init__(
+        self, config: ResolvedModelConfig, start_gate: asyncio.Event | None = None
+    ):
+        self._config = config
+        self._start_gate = start_gate
+        self.started = 0
+        self.stopped = 0
 
+    @property
+    def model_name(self) -> str:
+        return self._config.resolved_source
 
-class TestModelRegistry:
-    """Tests for model registry functionality."""
+    @property
+    def is_mllm(self) -> bool:
+        return False
 
-    def test_registry_singleton(self):
-        """Test that registry is a singleton."""
-        reg1 = get_registry()
-        reg2 = get_registry()
-        assert reg1 is reg2
+    @property
+    def tokenizer(self) -> Any:
+        return None
 
-    def test_acquire_and_release(self, model_and_tokenizer):
-        """Test basic acquire and release."""
-        model, tokenizer = model_and_tokenizer
-        registry = get_registry()
+    async def start(self) -> None:
+        if self._start_gate is not None:
+            await self._start_gate.wait()
+        self.started += 1
 
-        engine = EngineCore(model, tokenizer, engine_id="test-engine-1")
+    async def stop(self) -> None:
+        self.stopped += 1
 
-        # Verify ownership
-        is_owned, owner_id = registry.is_owned(model)
-        assert is_owned
-        assert owner_id == "test-engine-1"
+    async def generate(self, *args, **kwargs) -> GenerationOutput:
+        return GenerationOutput(text="ok")
 
-        # Release
-        engine.close()
+    async def stream_generate(self, *args, **kwargs):
+        yield GenerationOutput(text="ok", new_text="ok", finished=True)
 
-        # After close(), the engine should no longer own the model
-        assert not engine._owns_model
+    async def chat(self, *args, **kwargs) -> GenerationOutput:
+        return GenerationOutput(text="ok")
 
-        # Note: is_owned() may still return True if weak ref is still alive,
-        # but the engine's _owns_model flag should be False
-        # The registry will clean up stale entries on next cleanup() call
-
-    def test_force_ownership_transfer(self, model_and_tokenizer):
-        """Test that new engine can force ownership from existing one."""
-        model, tokenizer = model_and_tokenizer
-        registry = get_registry()
-
-        # First engine
-        engine1 = EngineCore(model, tokenizer, engine_id="engine-1")
-        assert engine1._owns_model
-
-        # Second engine should take ownership (force=True is default)
-        engine2 = EngineCore(model, tokenizer, engine_id="engine-2")
-        assert engine2._owns_model
-
-        # First engine should have been reset
-        assert engine1.scheduler.batch_generator is None
-
-        # Verify ownership transferred
-        is_owned, owner_id = registry.is_owned(model)
-        assert is_owned
-        assert owner_id == "engine-2"
-
-        # Cleanup
-        engine2.close()
-
-    def test_no_force_raises_error(self, model_and_tokenizer):
-        """Test that force=False raises error when model is owned."""
-        model, tokenizer = model_and_tokenizer
-
-        engine1 = EngineCore(model, tokenizer, engine_id="engine-1")
-
-        try:
-            with pytest.raises(ModelOwnershipError):
-                EngineCore(
-                    model, tokenizer, engine_id="engine-2", force_model_ownership=False
-                )
-        finally:
-            engine1.close()
+    async def stream_chat(self, *args, **kwargs):
+        yield GenerationOutput(text="ok", new_text="ok", finished=True)
 
 
-class TestMultiEngine:
-    """Tests for multi-engine scenarios."""
-
-    def test_sequential_engines_with_close(self, model_and_tokenizer):
-        """Test creating multiple engines sequentially with explicit close."""
-        model, tokenizer = model_and_tokenizer
-        params = SamplingParams(max_tokens=10)
-
-        for i in range(3):
-            engine = EngineCore(model, tokenizer, engine_id=f"seq-engine-{i}")
-            try:
-                result = engine.generate_batch_sync(["Hello"], params)
-                assert len(result) == 1
-                assert result[0].completion_tokens > 0
-            finally:
-                engine.close()
-
-    def test_sequential_engines_without_close(self, model_and_tokenizer):
-        """Test that engines work even without explicit close (force=True)."""
-        model, tokenizer = model_and_tokenizer
-        params = SamplingParams(max_tokens=10)
-
-        # Create engines without closing - should still work due to force=True
-        for i in range(3):
-            engine = EngineCore(model, tokenizer, engine_id=f"noclose-engine-{i}")
-            result = engine.generate_batch_sync(["Hello"], params)
-            assert len(result) == 1
-            assert result[0].completion_tokens > 0
-            # Don't close - next engine should force ownership
-
-        # Clean up last engine
-        engine.close()
-
-    def test_engine_gc_releases_model(self, model_and_tokenizer):
-        """Test that garbage collection releases model ownership."""
-        model, tokenizer = model_and_tokenizer
-        registry = get_registry()
-
-        # Create engine and immediately delete reference
-        engine = EngineCore(model, tokenizer, engine_id="gc-test-engine")
-        assert engine._owns_model
-
-        # Delete and force GC
-        del engine
-        gc.collect()
-
-        # Ownership should be released
-        is_owned, _ = registry.is_owned(model)
-        assert not is_owned
+def _defaults() -> RegistryServeDefaults:
+    return RegistryServeDefaults(
+        continuous_batching=False,
+        force_mllm=False,
+        enable_mtp=False,
+        prefill_step_size=2048,
+        specprefill_enabled=False,
+        specprefill_threshold=8192,
+        specprefill_keep_pct=0.3,
+        specprefill_draft_model=None,
+        stream_interval=1,
+        gpu_memory_utilization=0.9,
+        scheduler_config=None,
+        max_tokens=32768,
+        download_config=DownloadConfig(),
+    )
 
 
-class TestCacheRecovery:
-    """Tests for automatic cache error recovery."""
-
-    def test_recovery_from_simulated_cache_corruption(self, model_and_tokenizer):
-        """Test that scheduler recovers from cache corruption."""
-        model, tokenizer = model_and_tokenizer
-        params = SamplingParams(max_tokens=10)
-
-        engine = EngineCore(model, tokenizer)
-
-        try:
-            # First generation should work
-            result1 = engine.generate_batch_sync(["Hello"], params)
-            assert result1[0].completion_tokens > 0
-
-            # Simulate corruption by clearing batch generator
-            engine.scheduler.batch_generator = None
-            engine.scheduler._current_sampler_params = None
-
-            # Should recover automatically
-            result2 = engine.generate_batch_sync(["World"], params)
-            assert result2[0].completion_tokens > 0
-        finally:
-            engine.close()
-
-    def test_cache_validation_rejects_invalid(self, model_and_tokenizer):
-        """Test that invalid caches are rejected."""
-        model, tokenizer = model_and_tokenizer
-
-        engine = EngineCore(model, tokenizer)
-
-        try:
-            # Test None cache
-            assert not engine.scheduler._validate_cache(None)
-
-            # Test empty list
-            assert not engine.scheduler._validate_cache([])
-
-            # Test list with None
-            assert not engine.scheduler._validate_cache([None, None])
-
-            # Note: valid caches are harder to test without actual generation
-        finally:
-            engine.close()
+def _manager_config(
+    *,
+    budget_gb: float,
+    strategy: str = "wait_then_fail",
+    wait_timeout_s: float | None = 1.0,
+    preempt_after_s: float | None = None,
+) -> RegistryManagerConfig:
+    return RegistryManagerConfig(
+        memory_budget_bytes=int(budget_gb * (1024**3)),
+        policy=ContentionPolicy(
+            strategy=strategy,
+            wait_timeout_s=wait_timeout_s,
+            preempt_after_s=preempt_after_s,
+        ),
+    )
 
 
-class TestBenchmarkScenario:
-    """Tests simulating the benchmark script scenario."""
+def _registry(tmp_path: Path, sizes_gb: dict[str, float]) -> dict[str, RegisteredModel]:
+    registry = {}
+    for name, size_gb in sizes_gb.items():
+        source = tmp_path / name
+        source.mkdir()
+        registry[name] = RegisteredModel(
+            name=name,
+            source=str(source),
+            estimated_memory_bytes=int(size_gb * (1024**3)),
+        )
+    return registry
 
-    def test_benchmark_like_usage(self, model_and_tokenizer):
-        """Test usage pattern similar to benchmark_all_models.py."""
-        model, tokenizer = model_and_tokenizer
 
-        prompts = ["Hello", "World", "Test"]
-        params = SamplingParams(max_tokens=20)
+def test_acquire_shares_single_inflight_load(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        gate = asyncio.Event()
+        created: list[FakeEngine] = []
 
-        config = EngineConfig(
-            scheduler_config=SchedulerConfig(
-                max_num_seqs=256,
-                prefill_batch_size=8,
-                completion_batch_size=32,
-            )
+        def engine_factory(config: ResolvedModelConfig) -> FakeEngine:
+            engine = FakeEngine(config, start_gate=gate)
+            created.append(engine)
+            return engine
+
+        manager = ModelManager(
+            _manager_config(budget_gb=8),
+            registry,
+            _defaults(),
+            engine_factory=engine_factory,
         )
 
-        engine = EngineCore(model, tokenizer, config)
+        first = asyncio.create_task(manager.acquire("alpha"))
+        await asyncio.sleep(0)
+        second = asyncio.create_task(manager.acquire("alpha"))
+        await asyncio.sleep(0)
 
-        try:
-            # Single requests
-            for p in prompts[:2]:
-                result = engine.generate_batch_sync([p], params)[0]
-                assert result.completion_tokens > 0
+        assert len(created) == 1
+        gate.set()
 
-            # Reset and batch
-            engine.scheduler.reset()
-            results = engine.generate_batch_sync(prompts, params)
-            assert len(results) == 3
-            assert all(r.completion_tokens > 0 for r in results)
+        lease_a = await first
+        lease_b = await second
+        assert lease_a.engine is lease_b.engine
+        assert created[0].started == 1
 
-            # Reset and another batch
-            engine.scheduler.reset()
-            results = engine.generate_batch_sync(prompts, params)
-            assert len(results) == 3
-        finally:
-            engine.close()
+        await lease_a.release()
+        await lease_b.release()
 
-    def test_multiple_models_sequentially(self):
-        """Test benchmarking multiple models in sequence."""
-        from mlx_lm import load
+    asyncio.run(_run())
 
-        # Use the same small model twice to simulate different models
-        models = [TEST_MODEL, TEST_MODEL]
-        params = SamplingParams(max_tokens=10)
 
-        for model_name in models:
-            model, tokenizer = load(model_name)
-            engine = EngineCore(model, tokenizer)
+def test_idle_lru_eviction_preserves_budget(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4, "beta": 4, "gamma": 5})
+        created: dict[str, FakeEngine] = {}
 
+        def engine_factory(config: ResolvedModelConfig) -> FakeEngine:
+            engine = FakeEngine(config)
+            created[config.entry.name] = engine
+            return engine
+
+        manager = ModelManager(
+            _manager_config(budget_gb=9),
+            registry,
+            _defaults(),
+            engine_factory=engine_factory,
+        )
+
+        lease = await manager.acquire("alpha")
+        await lease.release()
+        await asyncio.sleep(0.01)
+
+        lease = await manager.acquire("beta")
+        await lease.release()
+        await asyncio.sleep(0.01)
+
+        lease = await manager.acquire("gamma")
+        await lease.release()
+
+        assert "alpha" not in manager._loaded
+        assert "beta" in manager._loaded
+        assert "gamma" in manager._loaded
+        assert created["alpha"].stopped == 1
+        assert created["beta"].stopped == 0
+
+    asyncio.run(_run())
+
+
+def test_preempt_policy_cancels_active_request_and_loads_waiting_model(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 8, "beta": 8})
+        created: dict[str, FakeEngine] = {}
+
+        def engine_factory(config: ResolvedModelConfig) -> FakeEngine:
+            engine = FakeEngine(config)
+            created[config.entry.name] = engine
+            return engine
+
+        manager = ModelManager(
+            _manager_config(
+                budget_gb=10,
+                strategy="preempt",
+                wait_timeout_s=2.0,
+            ),
+            registry,
+            _defaults(),
+            engine_factory=engine_factory,
+        )
+
+        acquired = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def hold_alpha() -> None:
+            lease = await manager.acquire("alpha")
+            acquired.set()
             try:
-                result = engine.generate_batch_sync(["Hello"], params)
-                assert result[0].completion_tokens > 0
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
             finally:
-                engine.close()
+                await lease.release()
 
-            # Force GC between models
-            del model, tokenizer, engine
-            gc.collect()
+        active_task = asyncio.create_task(hold_alpha())
+        await acquired.wait()
+
+        beta_lease = await manager.acquire("beta")
+        await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+        await beta_lease.release()
+
+        with pytest.raises(asyncio.CancelledError):
+            await active_task
+
+        assert "beta" in manager._loaded
+        assert "alpha" not in manager._loaded
+        assert created["alpha"].stopped == 1
+        assert created["beta"].started == 1
+
+    asyncio.run(_run())
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+def test_non_local_registry_entry_requires_explicit_memory_estimate():
+    async def _run():
+        registry = {
+            "remote": RegisteredModel(
+                name="remote",
+                source="mlx-community/some-remote-model",
+            )
+        }
+        manager = ModelManager(
+            _manager_config(budget_gb=8),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        with pytest.raises(ValueError, match="estimated_memory_gb"):
+            await manager.acquire("remote")
+
+    asyncio.run(_run())

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -132,7 +132,7 @@ def test_acquire_shares_single_inflight_load(tmp_path):
         )
 
         first = asyncio.create_task(manager.acquire("alpha"))
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.05)  # give _resolve_source thread time to return
         second = asyncio.create_task(manager.acquire("alpha"))
         await asyncio.sleep(0)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the OpenAI-compatible API server."""
 
+import asyncio
 import json
 import platform
 import sys
@@ -389,6 +390,25 @@ class TestServeCli:
 
         assert args.tool_call_parser == "gpt-oss"
 
+    def test_models_config_allows_registry_backed_serve(self):
+        """Registry-backed serving should not require a positional model."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "--models-config",
+                "/tmp/models.yaml",
+                "--continuous-batching",
+            ]
+        )
+
+        assert args.command == "serve"
+        assert args.model is None
+        assert args.models_config == "/tmp/models.yaml"
+        assert args.continuous_batching is True
+
 
 class TestStandaloneServerCli:
     """Test standalone server CLI argument parsing."""
@@ -463,6 +483,68 @@ class TestLoadModelTrustRemoteCode:
 
 class TestHelperFunctions:
     """Test server helper functions."""
+
+    def test_list_models_prefers_model_manager_registry(self, monkeypatch):
+        """Registry-backed mode should expose configured models through /v1/models."""
+        import vllm_mlx.server as server
+
+        class FakeManager:
+            def list_models(self):
+                return [
+                    {"id": "fast", "status": "loaded"},
+                    {"id": "smart", "status": "unloaded"},
+                ]
+
+        monkeypatch.setattr(server, "_model_manager", FakeManager())
+        monkeypatch.setattr(server, "_model_name", None)
+
+        response = asyncio.run(server.list_models())
+
+        assert [model.id for model in response.data] == ["fast", "smart"]
+
+    def test_validate_model_name_checks_registry_when_present(self, monkeypatch):
+        """Registry-backed validation should accept registered names and reject unknown ones."""
+        from fastapi import HTTPException
+        import vllm_mlx.server as server
+
+        class FakeManager:
+            _registry = {"fast": object(), "smart": object()}
+
+            def has_model(self, name):
+                return name in self._registry
+
+        monkeypatch.setattr(server, "_model_manager", FakeManager())
+        monkeypatch.setattr(server, "_model_name", None)
+
+        server._validate_model_name("fast")
+
+        with pytest.raises(HTTPException) as exc_info:
+            server._validate_model_name("missing")
+
+        assert exc_info.value.status_code == 404
+        assert "fast" in exc_info.value.detail
+
+    def test_build_reasoning_parser_uses_configured_name_and_engine_tokenizer(
+        self, monkeypatch
+    ):
+        """Per-request reasoning parser instances should be built from the configured parser name."""
+        import vllm_mlx.server as server
+
+        class FakeParser:
+            def __init__(self, tokenizer=None):
+                self.tokenizer = tokenizer
+
+        class FakeEngine:
+            tokenizer = object()
+
+        monkeypatch.setattr(server, "_reasoning_parser_name", "fake")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "get_reasoning_parser", lambda name: FakeParser)
+
+        parser = server._build_reasoning_parser(FakeEngine())
+
+        assert isinstance(parser, FakeParser)
+        assert parser.tokenizer is FakeEngine.tokenizer
 
     def test_is_mllm_model_patterns(self):
         """Test MLLM model detection patterns."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -510,6 +510,10 @@ class TestHelperFunctions:
         class FakeManager:
             _registry = {"fast": object(), "smart": object()}
 
+            @property
+            def registered_model_names(self):
+                return sorted(self._registry.keys())
+
             def has_model(self, name):
                 return name in self._registry
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -26,10 +26,21 @@ def serve_command(args):
 
     # Import unified server
     from . import server
+    from .model_registry import RegistryServeDefaults
     from .scheduler import SchedulerConfig
-    from .server import RateLimiter, app, load_model
+    from .server import RateLimiter, app, load_model, load_model_registry
 
     logger = logging.getLogger(__name__)
+
+    if args.models_config and args.model:
+        print("Error: use either positional MODEL or --models-config, not both")
+        sys.exit(1)
+    if not args.models_config and not args.model:
+        print("Error: MODEL is required unless --models-config is provided")
+        sys.exit(1)
+    if args.models_config and args.served_model_name:
+        print("Error: --served-model-name cannot be used with --models-config")
+        sys.exit(1)
 
     # Validate tool calling arguments
     if args.enable_auto_tool_choice and not args.tool_call_parser:
@@ -87,6 +98,7 @@ def serve_command(args):
 
             parser_cls = get_parser(args.reasoning_parser)
             server._reasoning_parser = parser_cls()
+            server._reasoning_parser_name = args.reasoning_parser
             logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")
         except KeyError as e:
             print(f"Error: {e}")
@@ -102,6 +114,7 @@ def serve_command(args):
             sys.exit(1)
     else:
         server._reasoning_parser = None
+        server._reasoning_parser_name = None
 
     # Security summary at startup
     print("=" * 60)
@@ -147,13 +160,15 @@ def serve_command(args):
         max_retries=args.download_retries,
         offline=getattr(args, "offline", False),
     )
-    ensure_model_downloaded(
-        args.model,
-        config=download_config,
-        is_mllm=is_mllm_model(args.model),
-    )
-
-    print(f"Loading model: {args.model}")
+    if args.model:
+        ensure_model_downloaded(
+            args.model,
+            config=download_config,
+            is_mllm=is_mllm_model(args.model),
+        )
+        print(f"Loading model: {args.model}")
+    else:
+        print(f"Loading models config: {args.models_config}")
     print(f"Default max tokens: {args.max_tokens}")
     print(f"Max request tokens: {args.max_request_tokens}")
 
@@ -250,26 +265,44 @@ def serve_command(args):
                 f"keep={args.specprefill_keep_pct*100:.0f}%)"
             )
 
-    # Load model with unified server
-    load_model(
-        args.model,
-        use_batching=args.continuous_batching,
-        scheduler_config=scheduler_config,
-        stream_interval=args.stream_interval if args.continuous_batching else 1,
-        max_tokens=args.max_tokens,
-        max_request_tokens=args.max_request_tokens,
-        force_mllm=getattr(args, "mllm", False),
-        gpu_memory_utilization=args.gpu_memory_utilization,
-        served_model_name=args.served_model_name,
-        trust_remote_code=args.trust_remote_code,
-        mtp=args.enable_mtp,
-        prefill_step_size=args.prefill_step_size,
-        specprefill_enabled=args.specprefill,
-        specprefill_threshold=args.specprefill_threshold,
-        specprefill_keep_pct=args.specprefill_keep_pct,
-        specprefill_draft_model=args.specprefill_draft_model,
-        warm_prompts_path=args.warm_prompts,
-    )
+    if args.models_config:
+        defaults = RegistryServeDefaults(
+            continuous_batching=args.continuous_batching,
+            force_mllm=getattr(args, "mllm", False),
+            enable_mtp=args.enable_mtp,
+            prefill_step_size=args.prefill_step_size,
+            specprefill_enabled=args.specprefill,
+            specprefill_threshold=args.specprefill_threshold,
+            specprefill_keep_pct=args.specprefill_keep_pct,
+            specprefill_draft_model=args.specprefill_draft_model,
+            stream_interval=args.stream_interval if args.continuous_batching else 1,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            scheduler_config=scheduler_config,
+            max_tokens=args.max_tokens,
+            download_config=download_config,
+        )
+        load_model_registry(args.models_config, defaults=defaults)
+    else:
+        # Load model with unified server
+        load_model(
+            args.model,
+            use_batching=args.continuous_batching,
+            scheduler_config=scheduler_config,
+            stream_interval=args.stream_interval if args.continuous_batching else 1,
+            max_tokens=args.max_tokens,
+            max_request_tokens=args.max_request_tokens,
+            force_mllm=getattr(args, "mllm", False),
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            served_model_name=args.served_model_name,
+            trust_remote_code=args.trust_remote_code,
+            mtp=args.enable_mtp,
+            prefill_step_size=args.prefill_step_size,
+            specprefill_enabled=args.specprefill,
+            specprefill_threshold=args.specprefill_threshold,
+            specprefill_keep_pct=args.specprefill_keep_pct,
+            specprefill_draft_model=args.specprefill_draft_model,
+            warm_prompts_path=args.warm_prompts,
+        )
 
     # Start server
     print(f"Starting server at http://{args.host}:{args.port}")
@@ -757,7 +790,13 @@ Examples:
 
     # Serve command
     serve_parser = subparsers.add_parser("serve", help="Start OpenAI-compatible server")
-    serve_parser.add_argument("model", type=str, help="Model to serve")
+    serve_parser.add_argument("model", nargs="?", type=str, help="Model to serve")
+    serve_parser.add_argument(
+        "--models-config",
+        type=str,
+        default=None,
+        help="YAML file describing a registry of models for lazy multi-model serving",
+    )
     serve_parser.add_argument(
         "--served-model-name",
         type=str,

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -19,8 +19,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-import yaml
-
 from .api.utils import is_mllm_model
 from .engine.base import BaseEngine
 from .engine.batched import BatchedEngine
@@ -266,6 +264,8 @@ def load_registry_config(
     defaults: RegistryServeDefaults,
 ) -> tuple[RegistryManagerConfig, dict[str, RegisteredModel]]:
     """Load and validate the models registry YAML file."""
+    import yaml  # lazy: only needed when a registry config is provided
+
     raw = yaml.safe_load(Path(config_path).read_text()) or {}
     models = raw.get("models")
     if not isinstance(models, list) or not models:
@@ -364,6 +364,11 @@ class ModelManager:
     @property
     def memory_budget_bytes(self) -> int:
         return self._config.memory_budget_bytes
+
+    @property
+    def registered_model_names(self) -> list[str]:
+        """Return sorted list of all registered model names."""
+        return sorted(self._registry.keys())
 
     def has_model(self, model_name: str) -> bool:
         return model_name in self._registry
@@ -590,7 +595,7 @@ class ModelManager:
         unload_after_load: LoadedModel | None = None
 
         try:
-            resolved_source = self._resolve_source(entry)
+            resolved_source = await self._resolve_source(entry)
             loaded = await self._instantiate_model(entry, resolved_source)
         except Exception as exc:
             async with self._condition:
@@ -781,7 +786,10 @@ class ModelManager:
         await engine.start()
         return LoadedModel(config=config, engine=engine)
 
-    def _resolve_source(self, entry: RegisteredModel) -> str:
+    async def _resolve_source(self, entry: RegisteredModel) -> str:
+        return await asyncio.to_thread(self._resolve_source_sync, entry)
+
+    def _resolve_source_sync(self, entry: RegisteredModel) -> str:
         source = entry.source
         if Path(source).exists():
             return source

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -1,185 +1,901 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Model Registry for vllm-mlx.
+Registry-backed multi-model serving with memory-budget eviction.
 
-Tracks which models are in use by which engines to prevent
-BatchKVCache conflicts when multiple engines share a model.
-
-The problem: mlx-lm's BatchGenerator maintains internal KV cache state
-tied to the model. When multiple EngineCore instances use the same model,
-the cache objects become incompatible, causing NoneType errors.
-
-Solution: Track model ownership and ensure only one engine's BatchGenerator
-is active for each model at a time.
+The registry maps OpenAI-compatible ``model`` names to concrete local paths or
+declared HuggingFace IDs. Models are loaded lazily, optionally preloaded, and
+evicted according to a memory-budget policy with configurable wait/fail/preempt
+behaviour.
 """
 
+from __future__ import annotations
+
+import asyncio
 import logging
-import threading
-import weakref
-from typing import Any, Dict, Optional, Tuple
+import os
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from .api.utils import is_mllm_model
+from .engine.base import BaseEngine
+from .engine.batched import BatchedEngine
+from .engine.simple import SimpleEngine
+from .scheduler import SchedulerConfig
+from .utils.download import DownloadConfig, ensure_model_downloaded
 
 logger = logging.getLogger(__name__)
 
+try:
+    import psutil
+except ImportError:  # pragma: no cover - optional dependency
+    psutil = None
 
-class ModelOwnershipError(Exception):
-    """Raised when a model is already owned by another engine."""
 
-    pass
+ContentionStrategy = Literal[
+    "fail",
+    "wait",
+    "preempt",
+    "wait_then_fail",
+    "wait_then_preempt",
+]
+
+EngineFactory = Callable[["ResolvedModelConfig"], BaseEngine]
 
 
-class ModelRegistry:
-    """
-    Global registry tracking model ownership.
+class ModelOwnershipError(RuntimeError):
+    """Raised when an EngineCore attempts to use a model already in use."""
 
-    Uses weak references to automatically clean up when engines
-    are garbage collected.
-    """
 
-    _instance: Optional["ModelRegistry"] = None
-    _lock = threading.Lock()
+class _ModelOwnershipRegistry:
+    """Process-local model ownership guard used by EngineCore."""
 
-    def __new__(cls) -> "ModelRegistry":
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._init()
-        return cls._instance
-
-    def _init(self) -> None:
-        """Initialize registry state."""
-        # model_id -> (weak_ref_to_engine, engine_id)
-        self._owners: Dict[int, Tuple[weakref.ref, str]] = {}
-        self._registry_lock = threading.Lock()
+    def __init__(self) -> None:
+        self._owners: dict[int, str] = {}
 
     def acquire(
-        self, model: Any, engine: Any, engine_id: str, force: bool = False
-    ) -> bool:
-        """
-        Attempt to acquire ownership of a model.
+        self,
+        *,
+        model: Any,
+        engine: Any,
+        engine_id: str,
+        force: bool = True,
+    ) -> None:
+        key = id(model)
+        owner = self._owners.get(key)
+        if owner is not None and owner != engine_id and not force:
+            raise ModelOwnershipError(
+                f"Model is already owned by engine {owner}; "
+                f"engine {engine_id} cannot acquire it"
+            )
+        self._owners[key] = engine_id
 
-        Args:
-            model: The MLX model
-            engine: The EngineCore instance
-            engine_id: Unique identifier for the engine
-            force: If True, forcibly take ownership (resets previous owner)
+    def release(self, model: Any, engine_id: str) -> None:
+        key = id(model)
+        owner = self._owners.get(key)
+        if owner == engine_id:
+            self._owners.pop(key, None)
 
-        Returns:
-            True if ownership acquired
 
-        Raises:
-            ModelOwnershipError: If model is owned and force=False
-        """
-        model_id = id(model)
+_ownership_registry = _ModelOwnershipRegistry()
 
-        with self._registry_lock:
-            if model_id in self._owners:
-                weak_ref, owner_id = self._owners[model_id]
-                owner = weak_ref()
 
-                if owner is not None and owner_id != engine_id:
-                    if force:
-                        # Reset the previous owner's scheduler
-                        logger.warning(
-                            f"Model ownership transfer: {owner_id} -> {engine_id}"
-                        )
-                        self._reset_owner(owner)
-                    else:
-                        raise ModelOwnershipError(
-                            f"Model is already owned by engine {owner_id}. "
-                            f"Use force=True or call release() on the "
-                            f"previous engine first."
-                        )
+def get_registry() -> _ModelOwnershipRegistry:
+    """Return the global model ownership registry used by EngineCore."""
+    return _ownership_registry
 
-            # Register new owner
-            self._owners[model_id] = (weakref.ref(engine), engine_id)
-            logger.debug(f"Engine {engine_id} acquired model {model_id}")
-            return True
 
-    def release(self, model: Any, engine_id: str) -> bool:
-        """
-        Release ownership of a model.
+@dataclass(frozen=True)
+class RegistryServeDefaults:
+    """Global serve defaults inherited by registry entries."""
 
-        Args:
-            model: The MLX model
-            engine_id: The engine releasing ownership
+    continuous_batching: bool
+    force_mllm: bool
+    enable_mtp: bool
+    prefill_step_size: int
+    specprefill_enabled: bool
+    specprefill_threshold: int
+    specprefill_keep_pct: float
+    specprefill_draft_model: str | None
+    stream_interval: int
+    gpu_memory_utilization: float
+    scheduler_config: SchedulerConfig | None
+    max_tokens: int
+    download_config: DownloadConfig
 
-        Returns:
-            True if ownership was released
-        """
-        model_id = id(model)
 
-        with self._registry_lock:
-            if model_id in self._owners:
-                _, owner_id = self._owners[model_id]
-                if owner_id == engine_id:
-                    del self._owners[model_id]
-                    logger.debug(f"Engine {engine_id} released model {model_id}")
-                    return True
-        return False
+@dataclass(frozen=True)
+class ContentionPolicy:
+    """Policy used when a new model cannot fit inside the memory budget."""
 
-    def is_owned(self, model: Any) -> Tuple[bool, Optional[str]]:
-        """
-        Check if a model is owned.
+    strategy: ContentionStrategy = "wait_then_fail"
+    wait_timeout_s: float | None = 30.0
+    preempt_after_s: float | None = None
 
-        Returns:
-            Tuple of (is_owned, owner_engine_id)
-        """
-        model_id = id(model)
 
-        with self._registry_lock:
-            if model_id in self._owners:
-                weak_ref, owner_id = self._owners[model_id]
-                if weak_ref() is not None:
-                    return (True, owner_id)
+@dataclass(frozen=True)
+class RegistryManagerConfig:
+    """Global registry manager configuration."""
+
+    memory_budget_bytes: int
+    policy: ContentionPolicy
+
+
+@dataclass(frozen=True)
+class RegisteredModel:
+    """One configured model entry."""
+
+    name: str
+    source: str
+    preload: bool = False
+    continuous_batching: bool | None = None
+    force_mllm: bool | None = None
+    enable_mtp: bool | None = None
+    prefill_step_size: int | None = None
+    specprefill_enabled: bool | None = None
+    specprefill_threshold: int | None = None
+    specprefill_keep_pct: float | None = None
+    specprefill_draft_model: str | None = None
+    stream_interval: int | None = None
+    gpu_memory_utilization: float | None = None
+    estimated_memory_bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedModelConfig:
+    """Effective configuration for a loaded model."""
+
+    entry: RegisteredModel
+    resolved_source: str
+    continuous_batching: bool
+    force_mllm: bool
+    enable_mtp: bool
+    prefill_step_size: int
+    specprefill_enabled: bool
+    specprefill_threshold: int
+    specprefill_keep_pct: float
+    specprefill_draft_model: str | None
+    stream_interval: int
+    gpu_memory_utilization: float
+    scheduler_config: SchedulerConfig | None
+    estimated_memory_bytes: int
+
+
+@dataclass
+class LoadedModel:
+    """Runtime state for a loaded engine."""
+
+    config: ResolvedModelConfig
+    engine: BaseEngine
+    loaded_at: float = field(default_factory=time.time)
+    last_used_at: float = field(default_factory=time.time)
+    active_requests: int = 0
+    active_tasks: set[asyncio.Task[Any]] = field(default_factory=set)
+    preempting: bool = False
+
+
+@dataclass
+class PendingLoad:
+    """A reserved model load in progress."""
+
+    model_name: str
+    required_bytes: int
+    future: asyncio.Future[LoadedModel]
+
+
+@dataclass
+class ModelLease:
+    """Active lease for a loaded model."""
+
+    manager: "ModelManager | None"
+    model_name: str
+    engine: BaseEngine
+    release_cb: Callable[[], Awaitable[None]]
+
+    async def release(self) -> None:
+        if self.manager is None:
+            return
+        manager = self.manager
+        self.manager = None
+        await self.release_cb()
+
+    async def __aenter__(self) -> "ModelLease":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.release()
+
+
+def _clone_scheduler_config(config: SchedulerConfig | None) -> SchedulerConfig | None:
+    """Clone a SchedulerConfig so per-model overrides do not mutate globals."""
+    if config is None:
+        return None
+    return SchedulerConfig(**vars(config))
+
+
+def _parse_memory_budget_bytes(value: Any) -> int:
+    """Parse a memory budget from bytes, MB, or GB."""
+    if value is None:
+        raise ValueError("models-config manager.memory_budget_gb is required")
+    if isinstance(value, (int, float)):
+        return int(float(value) * (1024**3))
+    if isinstance(value, str):
+        raw = value.strip().lower()
+        if raw.endswith("gb"):
+            return int(float(raw[:-2]) * (1024**3))
+        if raw.endswith("mb"):
+            return int(float(raw[:-2]) * (1024**2))
+        if raw.endswith("b"):
+            return int(float(raw[:-1]))
+        return int(float(raw) * (1024**3))
+    raise TypeError(f"Unsupported memory budget value: {value!r}")
+
+
+def _safe_available_memory_bytes() -> int:
+    """Best-effort available system memory."""
+    if psutil is None:  # pragma: no cover - fallback only
+        return 0
+    return int(psutil.virtual_memory().available)
+
+
+def _estimate_model_bytes_from_source(source: str) -> int:
+    """Estimate model footprint from local artifact size when possible."""
+    path = Path(source)
+    if not path.exists():
+        return 0
+
+    if path.is_file():
+        return path.stat().st_size if path.suffix in {".safetensors", ".gguf"} else 0
+
+    total = 0
+    for pattern in ("*.safetensors", "*.gguf"):
+        for fp in path.rglob(pattern):
+            try:
+                total += fp.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def load_registry_config(
+    config_path: str | os.PathLike[str],
+    defaults: RegistryServeDefaults,
+) -> tuple[RegistryManagerConfig, dict[str, RegisteredModel]]:
+    """Load and validate the models registry YAML file."""
+    raw = yaml.safe_load(Path(config_path).read_text()) or {}
+    models = raw.get("models")
+    if not isinstance(models, list) or not models:
+        raise ValueError("models-config must define a non-empty 'models' list")
+
+    manager_raw = raw.get("manager") or {}
+    policy_raw = manager_raw.get("contention_policy") or {}
+    policy = ContentionPolicy(
+        strategy=policy_raw.get("strategy", "wait_then_fail"),
+        wait_timeout_s=(
+            float(policy_raw["wait_timeout_s"])
+            if policy_raw.get("wait_timeout_s") is not None
+            else 30.0
+        ),
+        preempt_after_s=(
+            float(policy_raw["preempt_after_s"])
+            if policy_raw.get("preempt_after_s") is not None
+            else None
+        ),
+    )
+    if policy.strategy not in {
+        "fail",
+        "wait",
+        "preempt",
+        "wait_then_fail",
+        "wait_then_preempt",
+    }:
+        raise ValueError(f"Unsupported contention strategy: {policy.strategy}")
+
+    manager = RegistryManagerConfig(
+        memory_budget_bytes=_parse_memory_budget_bytes(
+            manager_raw.get("memory_budget_gb", manager_raw.get("memory_budget"))
+        ),
+        policy=policy,
+    )
+
+    registry: dict[str, RegisteredModel] = {}
+    for item in models:
+        if not isinstance(item, dict):
+            raise ValueError(f"Invalid model entry: {item!r}")
+        name = item.get("name")
+        source = item.get("path") or item.get("source") or item.get("model")
+        if not name or not source:
+            raise ValueError(
+                f"Each model entry must define 'name' and one of 'path'/'source'/'model': {item!r}"
+            )
+        if name in registry:
+            raise ValueError(f"Duplicate model name in registry: {name}")
+
+        estimated = item.get("estimated_memory_gb")
+        estimated_bytes = (
+            int(float(estimated) * (1024**3)) if estimated is not None else None
+        )
+
+        registry[name] = RegisteredModel(
+            name=name,
+            source=str(source),
+            preload=bool(item.get("preload", False)),
+            continuous_batching=item.get("continuous_batching"),
+            force_mllm=item.get("mllm"),
+            enable_mtp=item.get("enable_mtp"),
+            prefill_step_size=item.get("prefill_step_size"),
+            specprefill_enabled=item.get("specprefill"),
+            specprefill_threshold=item.get("specprefill_threshold"),
+            specprefill_keep_pct=item.get("specprefill_keep_pct"),
+            specprefill_draft_model=item.get("specprefill_draft_model"),
+            stream_interval=item.get("stream_interval"),
+            gpu_memory_utilization=item.get("gpu_memory_utilization"),
+            estimated_memory_bytes=estimated_bytes,
+        )
+
+    return manager, registry
+
+
+class ModelManager:
+    """Registry-backed model manager with lazy load and memory-budget eviction."""
+
+    def __init__(
+        self,
+        manager_config: RegistryManagerConfig,
+        registry: dict[str, RegisteredModel],
+        defaults: RegistryServeDefaults,
+        *,
+        engine_factory: EngineFactory | None = None,
+    ) -> None:
+        self._config = manager_config
+        self._registry = registry
+        self._defaults = defaults
+        self._engine_factory = engine_factory
+        self._loaded: dict[str, LoadedModel] = {}
+        self._loading: dict[str, PendingLoad] = {}
+        self._unloading: dict[str, LoadedModel] = {}
+        self._condition = asyncio.Condition()
+        self._shutting_down = False
+
+    @property
+    def memory_budget_bytes(self) -> int:
+        return self._config.memory_budget_bytes
+
+    def has_model(self, model_name: str) -> bool:
+        return model_name in self._registry
+
+    def list_models(self) -> list[dict[str, Any]]:
+        """Return registry state for /v1/models."""
+        data = []
+        for name, entry in self._registry.items():
+            loaded = self._loaded.get(name)
+            unloading = self._unloading.get(name)
+            loading = self._loading.get(name)
+            state = "unloaded"
+            if loaded is not None:
+                state = "preempting" if loaded.preempting else "loaded"
+            elif loading is not None:
+                state = "loading"
+            elif unloading is not None:
+                state = "unloading"
+
+            estimated = (
+                loaded.config.estimated_memory_bytes
+                if loaded is not None
+                else (
+                    unloading.config.estimated_memory_bytes
+                    if unloading is not None
+                    else (
+                        loading.required_bytes
+                        if loading is not None
+                        else self._resolve_estimated_bytes(entry, entry.source)
+                    )
+                )
+            )
+            data.append(
+                {
+                    "id": name,
+                    "status": state,
+                    "loaded": loaded is not None,
+                    "owned_by": "vllm-mlx",
+                    "source": entry.source,
+                    "memory_gb": round(estimated / (1024**3), 2) if estimated else None,
+                }
+            )
+        return data
+
+    async def preload(self) -> None:
+        """Preload any entries marked preload=true."""
+        for entry in self._registry.values():
+            if entry.preload:
+                lease = await self.acquire(entry.name)
+                await lease.release()
+
+    async def shutdown(self) -> None:
+        """Stop and unload every loaded engine."""
+        pending: list[asyncio.Future[LoadedModel]] = []
+        unloads: list[LoadedModel] = []
+        cancel_tasks: set[asyncio.Task[Any]] = set()
+
+        async with self._condition:
+            self._shutting_down = True
+            pending = [item.future for item in self._loading.values()]
+            for loaded in self._loaded.values():
+                loaded.preempting = True
+                cancel_tasks.update(loaded.active_tasks)
+            for name in list(self._loaded.keys()):
+                if self._loaded[name].active_requests == 0:
+                    unloads.append(self._begin_unload_locked(name))
+            self._condition.notify_all()
+
+        for task in cancel_tasks:
+            task.cancel()
+        await self._run_unloads(unloads)
+
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        remaining: list[LoadedModel] = []
+        async with self._condition:
+            for name in list(self._loaded.keys()):
+                if self._loaded[name].active_requests == 0:
+                    remaining.append(self._begin_unload_locked(name))
+            self._condition.notify_all()
+
+        await self._run_unloads(remaining)
+
+    async def acquire(self, model_name: str) -> ModelLease:
+        """Acquire a lease for a configured model."""
+        if model_name not in self._registry:
+            raise KeyError(model_name)
+
+        start = time.monotonic()
+        while True:
+            load: PendingLoad | None = None
+            unloads: list[LoadedModel] = []
+            cancel_tasks: set[asyncio.Task[Any]] = set()
+            same_model_future: asyncio.Future[LoadedModel] | None = None
+            wait_timeout: float | None = None
+
+            async with self._condition:
+                if self._shutting_down:
+                    raise RuntimeError("Model manager is shutting down")
+
+                claimed = self._claim_loaded_locked(model_name)
+                if claimed is not None:
+                    return claimed
+
+                same_model_future = self._loading.get(model_name, None)
+                if same_model_future is not None:
+                    same_model_future = same_model_future.future
+                elif model_name in self._unloading:
+                    wait_timeout = self._remaining_wait_timeout(start)
                 else:
-                    # Owner was garbage collected, clean up
-                    del self._owners[model_id]
-        return (False, None)
+                    entry = self._registry[model_name]
+                    required_bytes = self._resolve_estimated_bytes(entry, entry.source)
+                    unloads = self._collect_idle_unloads_locked(
+                        model_name, required_bytes
+                    )
+                    if not unloads and self._can_reserve_locked(required_bytes):
+                        load = self._reserve_load_locked(model_name, required_bytes)
+                    elif not unloads:
+                        cancel_tasks = self._maybe_preempt_locked(
+                            model_name=model_name,
+                            required_bytes=required_bytes,
+                            start=start,
+                        )
+                        if not cancel_tasks and not self._should_wait_locked(start):
+                            raise RuntimeError(
+                                f"Cannot load '{model_name}' within memory budget "
+                                f"({self._config.memory_budget_bytes / (1024**3):.1f} GB)"
+                            )
+                        wait_timeout = self._remaining_wait_timeout(start)
 
-    def _reset_owner(self, owner: Any) -> None:
-        """Reset the scheduler of a previous owner."""
+            if unloads:
+                await self._run_unloads(unloads)
+                continue
+
+            if cancel_tasks:
+                for task in cancel_tasks:
+                    task.cancel()
+                timeout = self._remaining_wait_timeout(start)
+                await self._wait_for_change(timeout)
+                continue
+
+            if load is not None:
+                loaded = await self._execute_load(load)
+                async with self._condition:
+                    claimed = self._claim_loaded_locked(
+                        model_name, loaded_override=loaded
+                    )
+                    if claimed is not None:
+                        return claimed
+                continue
+
+            if same_model_future is not None:
+                loaded = await same_model_future
+                async with self._condition:
+                    claimed = self._claim_loaded_locked(
+                        model_name, loaded_override=loaded
+                    )
+                    if claimed is not None:
+                        return claimed
+                continue
+
+            await self._wait_for_change(wait_timeout)
+
+    async def release(self, model_name: str) -> None:
+        """Release a previously acquired model lease."""
+        unload: LoadedModel | None = None
+
+        async with self._condition:
+            loaded = self._loaded.get(model_name)
+            if loaded is None:
+                return
+
+            loaded.active_requests = max(0, loaded.active_requests - 1)
+            loaded.last_used_at = time.time()
+            task = asyncio.current_task()
+            if task is not None:
+                loaded.active_tasks.discard(task)
+
+            if loaded.preempting and loaded.active_requests == 0:
+                unload = self._begin_unload_locked(model_name)
+
+            self._condition.notify_all()
+
+        if unload is not None:
+            await self._run_unloads([unload])
+
+    def _claim_loaded_locked(
+        self,
+        model_name: str,
+        *,
+        loaded_override: LoadedModel | None = None,
+    ) -> ModelLease | None:
+        loaded = loaded_override or self._loaded.get(model_name)
+        if loaded is None:
+            return None
+
+        if loaded_override is not None and model_name not in self._loaded:
+            self._loaded[model_name] = loaded
+
+        if loaded.preempting:
+            return None
+
+        loaded.active_requests += 1
+        loaded.last_used_at = time.time()
+        task = asyncio.current_task()
+        if task is not None:
+            loaded.active_tasks.add(task)
+
+        async def _release() -> None:
+            await self.release(model_name)
+
+        return ModelLease(
+            manager=self,
+            model_name=model_name,
+            engine=loaded.engine,
+            release_cb=_release,
+        )
+
+    async def _execute_load(self, pending: PendingLoad) -> LoadedModel:
+        """Instantiate a reserved model load outside the manager lock."""
+        entry = self._registry[pending.model_name]
+        loaded: LoadedModel | None = None
+        unload_after_load: LoadedModel | None = None
+
         try:
-            if hasattr(owner, "scheduler"):
-                owner.scheduler.deep_reset()
-        except Exception as e:
-            logger.warning(f"Failed to reset previous owner: {e}")
+            resolved_source = self._resolve_source(entry)
+            loaded = await self._instantiate_model(entry, resolved_source)
+        except Exception as exc:
+            async with self._condition:
+                current = self._loading.pop(pending.model_name, None)
+                if current is pending and not current.future.done():
+                    current.future.set_exception(exc)
+                self._condition.notify_all()
+            raise
 
-    def cleanup(self) -> int:
-        """
-        Clean up stale entries (owners that were garbage collected).
+        async with self._condition:
+            current = self._loading.pop(pending.model_name, None)
+            if current is not pending:
+                unload_after_load = loaded
+            elif self._shutting_down:
+                unload_after_load = loaded
+                if not current.future.done():
+                    current.future.set_exception(
+                        RuntimeError("Model manager is shutting down")
+                    )
+            else:
+                self._loaded[pending.model_name] = loaded
+                if not current.future.done():
+                    current.future.set_result(loaded)
+            self._condition.notify_all()
 
-        Returns:
-            Number of entries cleaned up
-        """
-        cleaned = 0
-        with self._registry_lock:
-            stale = [
-                model_id
-                for model_id, (weak_ref, _) in self._owners.items()
-                if weak_ref() is None
-            ]
-            for model_id in stale:
-                del self._owners[model_id]
-                cleaned += 1
-        if cleaned:
-            logger.debug(f"Cleaned up {cleaned} stale registry entries")
-        return cleaned
+        if unload_after_load is not None:
+            await unload_after_load.engine.stop()
+            raise RuntimeError("Model load was aborted before it became available")
 
-    def get_stats(self) -> Dict[str, Any]:
-        """Get registry statistics."""
-        with self._registry_lock:
-            active = sum(1 for _, (ref, _) in self._owners.items() if ref() is not None)
-            return {
-                "total_entries": len(self._owners),
-                "active_owners": active,
-            }
+        return loaded
 
+    async def _wait_for_change(self, timeout: float | None) -> None:
+        async with self._condition:
+            if timeout is None:
+                await self._condition.wait()
+                return
+            if timeout <= 0:
+                raise RuntimeError("Timed out waiting for model capacity")
+            await asyncio.wait_for(self._condition.wait(), timeout=timeout)
 
-# Global singleton
-_registry = ModelRegistry()
+    async def _run_unloads(self, unloads: list[LoadedModel]) -> None:
+        for loaded in unloads:
+            try:
+                await loaded.engine.stop()
+            finally:
+                async with self._condition:
+                    self._unloading.pop(loaded.config.entry.name, None)
+                    self._condition.notify_all()
 
+    def _reserve_load_locked(self, model_name: str, required_bytes: int) -> PendingLoad:
+        future: asyncio.Future[LoadedModel] = asyncio.get_running_loop().create_future()
+        pending = PendingLoad(
+            model_name=model_name,
+            required_bytes=required_bytes,
+            future=future,
+        )
+        self._loading[model_name] = pending
+        return pending
 
-def get_registry() -> ModelRegistry:
-    """Get the global model registry."""
-    return _registry
+    def _begin_unload_locked(self, model_name: str) -> LoadedModel:
+        loaded = self._loaded.pop(model_name)
+        self._unloading[model_name] = loaded
+        return loaded
+
+    def _collect_idle_unloads_locked(
+        self, requested_model: str, required_bytes: int
+    ) -> list[LoadedModel]:
+        selected: list[LoadedModel] = []
+        projected_bytes = self._committed_bytes_locked()
+        candidates = sorted(
+            (
+                loaded
+                for name, loaded in self._loaded.items()
+                if name != requested_model and loaded.active_requests == 0
+            ),
+            key=lambda item: item.last_used_at,
+        )
+
+        for loaded in candidates:
+            if projected_bytes + required_bytes <= self._config.memory_budget_bytes:
+                break
+            selected.append(self._begin_unload_locked(loaded.config.entry.name))
+            projected_bytes -= loaded.config.estimated_memory_bytes
+
+        return selected
+
+    def _maybe_preempt_locked(
+        self,
+        *,
+        model_name: str,
+        required_bytes: int,
+        start: float,
+    ) -> set[asyncio.Task[Any]]:
+        if not self._should_preempt_locked(start):
+            return set()
+
+        cancel_tasks: set[asyncio.Task[Any]] = set()
+        projected_bytes = self._committed_bytes_locked()
+        candidates = sorted(
+            (
+                loaded
+                for name, loaded in self._loaded.items()
+                if name != model_name and loaded.active_requests > 0
+            ),
+            key=lambda item: item.last_used_at,
+        )
+
+        for loaded in candidates:
+            if projected_bytes + required_bytes <= self._config.memory_budget_bytes:
+                break
+            if loaded.preempting:
+                projected_bytes -= loaded.config.estimated_memory_bytes
+                continue
+            loaded.preempting = True
+            cancel_tasks.update(loaded.active_tasks)
+            projected_bytes -= loaded.config.estimated_memory_bytes
+
+        if cancel_tasks:
+            self._condition.notify_all()
+        return cancel_tasks
+
+    def _should_wait_locked(self, start: float) -> bool:
+        strategy = self._config.policy.strategy
+        if strategy == "fail":
+            return False
+        timeout = self._remaining_wait_timeout(start)
+        return timeout is None or timeout > 0
+
+    def _should_preempt_locked(self, start: float) -> bool:
+        policy = self._config.policy
+        elapsed = time.monotonic() - start
+        if policy.strategy == "preempt":
+            return True
+        if policy.strategy != "wait_then_preempt":
+            return False
+        trigger = policy.preempt_after_s if policy.preempt_after_s is not None else 0.0
+        return elapsed >= trigger
+
+    def _remaining_wait_timeout(self, start: float) -> float | None:
+        timeout = self._config.policy.wait_timeout_s
+        if timeout is None or timeout <= 0:
+            return None
+        return max(timeout - (time.monotonic() - start), 0.0)
+
+    def _can_reserve_locked(self, required_bytes: int) -> bool:
+        return (
+            self._committed_bytes_locked() + required_bytes
+            <= self._config.memory_budget_bytes
+        )
+
+    def _committed_bytes_locked(self) -> int:
+        loaded_bytes = sum(
+            loaded.config.estimated_memory_bytes for loaded in self._loaded.values()
+        )
+        loading_bytes = sum(item.required_bytes for item in self._loading.values())
+        unloading_bytes = sum(
+            loaded.config.estimated_memory_bytes for loaded in self._unloading.values()
+        )
+        return loaded_bytes + loading_bytes + unloading_bytes
+
+    async def _instantiate_model(
+        self, entry: RegisteredModel, resolved_source: str
+    ) -> LoadedModel:
+        config = self._resolve_model_config(entry, resolved_source)
+
+        if self._engine_factory is not None:
+            engine = self._engine_factory(config)
+        elif config.continuous_batching:
+            engine = BatchedEngine(
+                model_name=config.resolved_source,
+                scheduler_config=config.scheduler_config,
+                stream_interval=config.stream_interval,
+                force_mllm=config.force_mllm,
+                gpu_memory_utilization=config.gpu_memory_utilization,
+            )
+        else:
+            engine = SimpleEngine(
+                model_name=config.resolved_source,
+                force_mllm=config.force_mllm,
+                mtp=config.enable_mtp,
+                prefill_step_size=config.prefill_step_size,
+                specprefill_enabled=config.specprefill_enabled,
+                specprefill_threshold=config.specprefill_threshold,
+                specprefill_keep_pct=config.specprefill_keep_pct,
+                specprefill_draft_model=config.specprefill_draft_model,
+            )
+
+        await engine.start()
+        return LoadedModel(config=config, engine=engine)
+
+    def _resolve_source(self, entry: RegisteredModel) -> str:
+        source = entry.source
+        if Path(source).exists():
+            return source
+        downloaded = ensure_model_downloaded(
+            source,
+            config=self._defaults.download_config,
+            is_mllm=is_mllm_model(source) or bool(entry.force_mllm),
+        )
+        return str(downloaded)
+
+    def _resolve_estimated_bytes(
+        self, entry: RegisteredModel, resolved_source: str
+    ) -> int:
+        if entry.estimated_memory_bytes is not None:
+            return entry.estimated_memory_bytes
+        estimated = _estimate_model_bytes_from_source(resolved_source)
+        if estimated > 0:
+            return estimated
+        source_path = Path(resolved_source)
+        if not source_path.exists():
+            raise ValueError(
+                "models-config entry "
+                f"'{entry.name}' uses non-local source '{entry.source}' without "
+                "estimated_memory_gb. Registry-backed loading requires an explicit "
+                "memory estimate for non-local models so eviction remains deterministic."
+            )
+
+        available = _safe_available_memory_bytes()
+        if available > 0:
+            logger.warning(
+                "Falling back to a coarse memory estimate for registry entry '%s' "
+                "because no weight files were found under %s; set estimated_memory_gb "
+                "explicitly for deterministic eviction.",
+                entry.name,
+                resolved_source,
+            )
+            return max(available // 8, 1)
+
+        raise ValueError(
+            "Cannot estimate memory for registry entry "
+            f"'{entry.name}' from '{resolved_source}'. Set estimated_memory_gb "
+            "explicitly in the models config."
+        )
+
+    def _resolve_model_config(
+        self, entry: RegisteredModel, resolved_source: str
+    ) -> ResolvedModelConfig:
+        scheduler_config = _clone_scheduler_config(self._defaults.scheduler_config)
+
+        continuous_batching = (
+            entry.continuous_batching
+            if entry.continuous_batching is not None
+            else self._defaults.continuous_batching
+        )
+        force_mllm = (
+            entry.force_mllm
+            if entry.force_mllm is not None
+            else self._defaults.force_mllm
+        )
+        enable_mtp = (
+            entry.enable_mtp
+            if entry.enable_mtp is not None
+            else self._defaults.enable_mtp
+        )
+        prefill_step_size = (
+            entry.prefill_step_size
+            if entry.prefill_step_size is not None
+            else self._defaults.prefill_step_size
+        )
+        specprefill_enabled = (
+            entry.specprefill_enabled
+            if entry.specprefill_enabled is not None
+            else self._defaults.specprefill_enabled
+        )
+        specprefill_threshold = (
+            entry.specprefill_threshold
+            if entry.specprefill_threshold is not None
+            else self._defaults.specprefill_threshold
+        )
+        specprefill_keep_pct = (
+            entry.specprefill_keep_pct
+            if entry.specprefill_keep_pct is not None
+            else self._defaults.specprefill_keep_pct
+        )
+        specprefill_draft_model = (
+            entry.specprefill_draft_model
+            if entry.specprefill_draft_model is not None
+            else self._defaults.specprefill_draft_model
+        )
+        stream_interval = (
+            entry.stream_interval
+            if entry.stream_interval is not None
+            else self._defaults.stream_interval
+        )
+        gpu_memory_utilization = (
+            entry.gpu_memory_utilization
+            if entry.gpu_memory_utilization is not None
+            else self._defaults.gpu_memory_utilization
+        )
+        estimated_memory_bytes = self._resolve_estimated_bytes(entry, resolved_source)
+
+        return ResolvedModelConfig(
+            entry=entry,
+            resolved_source=resolved_source,
+            continuous_batching=continuous_batching,
+            force_mllm=force_mllm,
+            enable_mtp=enable_mtp,
+            prefill_step_size=prefill_step_size,
+            specprefill_enabled=specprefill_enabled,
+            specprefill_threshold=specprefill_threshold,
+            specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_draft_model=specprefill_draft_model,
+            stream_interval=stream_interval,
+            gpu_memory_utilization=gpu_memory_utilization,
+            scheduler_config=scheduler_config,
+            estimated_memory_bytes=estimated_memory_bytes,
+        )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -588,7 +588,7 @@ def get_engine() -> BaseEngine:
 
 def _list_available_model_names() -> list[str]:
     if _model_manager is not None:
-        return sorted(_model_manager._registry.keys())
+        return _model_manager.registered_model_names
     return [_model_name] if _model_name else []
 
 
@@ -4836,9 +4836,10 @@ def main():
 
     # Initialize reasoning parser if specified
     if args.reasoning_parser:
-        global _reasoning_parser
+        global _reasoning_parser, _reasoning_parser_name
         from .reasoning import get_parser
 
+        _reasoning_parser_name = args.reasoning_parser
         parser_cls = get_parser(args.reasoning_parser)
         _reasoning_parser = parser_cls()
         logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2929,9 +2929,9 @@ async def _wait_with_disconnect(
 )
 async def create_completion(request: CompletionRequest, raw_request: Request):
     """Create a text completion."""
+    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     model_ctx = await _acquire_request_model(request.model)
     engine = model_ctx.engine
-    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     tracker = _metrics.track_inference("completions", stream=request.stream)
 
     # Handle single prompt or list of prompts
@@ -3099,9 +3099,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     }
     ```
     """
+    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     model_ctx = await _acquire_request_model(request.model)
     engine = model_ctx.engine
-    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     tracker = _metrics.track_inference("chat_completions", stream=request.stream)
 
     # --- Detailed request logging ---
@@ -3551,9 +3551,9 @@ async def create_anthropic_message(
             raise
     anthropic_request = AnthropicRequest(**body)
 
+    effective_max_tokens = _resolve_request_max_tokens(anthropic_request.max_tokens)
     model_ctx = await _acquire_request_model(anthropic_request.model)
     engine = model_ctx.engine
-    effective_max_tokens = _resolve_request_max_tokens(anthropic_request.max_tokens)
 
     # --- Detailed request logging ---
     n_msgs = len(anthropic_request.messages)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -50,6 +50,7 @@ import time
 import uuid
 from collections import OrderedDict, defaultdict
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
@@ -154,7 +155,14 @@ from .endpoint_model_policies import (
     resolve_stt_model_name,
     resolve_tts_model_name,
 )
+from .model_registry import (
+    ModelLease,
+    ModelManager,
+    RegistryServeDefaults,
+    load_registry_config,
+)
 from .metrics import metrics as _metrics
+from .reasoning import get_parser as get_reasoning_parser
 from .tool_parsers import ToolParserManager
 
 logging.basicConfig(level=logging.INFO)
@@ -162,6 +170,7 @@ logger = logging.getLogger(__name__)
 
 # Global engine instance
 _engine: BaseEngine | None = None
+_model_manager: ModelManager | None = None
 _model_name: str | None = None
 _model_path: str | None = (
     None  # Actual model path (for cache dir, not affected by --served-model-name)
@@ -228,11 +237,12 @@ _auth_warning_logged: bool = False
 
 # Reasoning parser (for models like Qwen3, DeepSeek-R1)
 _reasoning_parser = None  # ReasoningParser instance when enabled
+_reasoning_parser_name: str | None = None
 
 # Tool calling configuration
 _enable_auto_tool_choice: bool = False
 _tool_call_parser: str | None = None  # Parser name: auto, mistral, qwen, llama, hermes
-_tool_parser_instance = None  # Instantiated parser
+_tool_parser_instance = None  # Test override hook; production builds fresh parsers
 _responses_store: OrderedDict[str, dict] = OrderedDict()
 _RESPONSES_STORE_MAX_SIZE: int = 1000
 
@@ -282,6 +292,21 @@ def _log_and_raise_internal_error(log_prefix: str, exc: Exception, detail: str) 
     """Log a sanitized exception string and raise a generic 500 response."""
     logger.error("%s: %s", log_prefix, _sanitize_log_text(exc, limit=500))
     raise HTTPException(status_code=500, detail=detail)
+
+
+@dataclass
+class RequestModelContext:
+    """Request-scoped engine/lease context."""
+
+    model_name: str
+    engine: BaseEngine
+    lease: ModelLease | None = None
+
+    async def release(self) -> None:
+        if self.lease is not None:
+            lease = self.lease
+            self.lease = None
+            await lease.release()
 
 
 def _load_prefix_cache_from_disk() -> None:
@@ -339,11 +364,13 @@ def _get_cache_dir() -> str:
 
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
-    global _engine, _mcp_manager
+    global _engine, _mcp_manager, _model_manager
 
     # Startup: Start engine if loaded (needed for BatchedEngine in uvicorn's event loop)
     if _engine is not None and hasattr(_engine, "_loaded") and not _engine._loaded:
         await _engine.start()
+    if _model_manager is not None:
+        await _model_manager.preload()
 
     # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
     if _engine is not None and hasattr(_engine, "load_cache_from_disk"):
@@ -394,6 +421,9 @@ async def lifespan(app: FastAPI):
     if _engine is not None:
         await _engine.stop()
         logger.info("Engine stopped")
+    if _model_manager is not None:
+        await _model_manager.shutdown()
+        logger.info("Model manager stopped")
 
 
 app = FastAPI(
@@ -556,6 +586,12 @@ def get_engine() -> BaseEngine:
     return _engine
 
 
+def _list_available_model_names() -> list[str]:
+    if _model_manager is not None:
+        return sorted(_model_manager._registry.keys())
+    return [_model_name] if _model_name else []
+
+
 def _coerce_tool_arguments(
     arguments_json: str, tool_name: str, tools: list[dict] | None
 ) -> str:
@@ -605,6 +641,18 @@ def _coerce_tool_arguments(
 
 def _validate_model_name(request_model: str) -> None:
     """Validate that the request model name matches the served model."""
+    if _model_manager is not None:
+        if not _model_manager.has_model(request_model):
+            available = ", ".join(f"`{name}`" for name in _list_available_model_names())
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"The model `{request_model}` does not exist. "
+                    f"Available models: {available}"
+                ),
+            )
+        return
+
     if _model_name and request_model != _model_name:
         raise HTTPException(
             status_code=404,
@@ -613,8 +661,79 @@ def _validate_model_name(request_model: str) -> None:
         )
 
 
+async def _acquire_request_model(request_model: str) -> RequestModelContext:
+    """Acquire the model/engine that should serve this request."""
+    _validate_model_name(request_model)
+
+    if _model_manager is None:
+        engine = get_engine()
+        engine.preserve_native_tool_format = _detect_native_tool_support()
+        return RequestModelContext(
+            model_name=_model_name or request_model, engine=engine
+        )
+
+    try:
+        lease = await _model_manager.acquire(request_model)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    lease.engine.preserve_native_tool_format = _detect_native_tool_support()
+    return RequestModelContext(
+        model_name=request_model,
+        engine=lease.engine,
+        lease=lease,
+    )
+
+
+async def _stream_with_model_context(
+    context: RequestModelContext,
+    stream: AsyncIterator[str],
+) -> AsyncIterator[str]:
+    """Ensure model leases survive for the full streaming response."""
+    try:
+        async for chunk in stream:
+            yield chunk
+    finally:
+        await context.release()
+
+
+def _build_tool_parser(engine: BaseEngine | None):
+    """Create a fresh tool parser instance for a single request/stream."""
+    if not _enable_auto_tool_choice or not _tool_call_parser:
+        return None
+
+    if _tool_parser_instance is not None:
+        if hasattr(_tool_parser_instance, "reset"):
+            _tool_parser_instance.reset()
+        return _tool_parser_instance
+
+    parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
+    tokenizer = getattr(engine, "tokenizer", None) if engine is not None else None
+    return parser_cls(tokenizer)
+
+
+def _build_reasoning_parser(engine: BaseEngine | None = None):
+    """Create a fresh reasoning parser instance for a single request/stream."""
+    tokenizer = getattr(engine, "tokenizer", None) if engine is not None else None
+    if _reasoning_parser_name is not None:
+        parser_cls = get_reasoning_parser(_reasoning_parser_name)
+        try:
+            return parser_cls(tokenizer)
+        except TypeError:
+            return parser_cls()
+    if _reasoning_parser is None:
+        return None
+    try:
+        return type(_reasoning_parser)(tokenizer)
+    except TypeError:
+        return type(_reasoning_parser)()
+
+
 def _parse_tool_calls_with_parser(
-    output_text: str, request: ChatCompletionRequest | None = None
+    output_text: str,
+    request: ChatCompletionRequest | None = None,
+    *,
+    engine: BaseEngine | None = None,
 ) -> tuple[str, list | None]:
     """
     Parse tool calls from model output using the configured parser.
@@ -629,8 +748,6 @@ def _parse_tool_calls_with_parser(
     Returns:
         Tuple of (cleaned_text, tool_calls)
     """
-    global _tool_parser_instance
-
     request_dict = request.model_dump() if request else None
 
     # tool_choice="none" means never return tool calls — skip all parsing
@@ -645,30 +762,11 @@ def _parse_tool_calls_with_parser(
     if not _enable_auto_tool_choice or not _tool_call_parser:
         return parse_tool_calls(output_text, request_dict)
 
-    # Initialize parser if needed
-    if _tool_parser_instance is None:
-        try:
-            parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
-            # Get tokenizer from engine if available
-            tokenizer = None
-            if _engine is not None and hasattr(_engine, "_tokenizer"):
-                tokenizer = _engine._tokenizer
-            _tool_parser_instance = parser_cls(tokenizer)
-            logger.info(f"Initialized tool call parser: {_tool_call_parser}")
-        except Exception as e:
-            logger.warning(
-                "Failed to initialize tool parser '%s': %s",
-                _tool_call_parser,
-                _sanitize_log_text(e, limit=500),
-            )
-            logger.warning("Falling back to generic parser")
-            return parse_tool_calls(output_text, request_dict)
-
-    # Use the configured parser
     try:
-        # Reset parser state between requests
-        _tool_parser_instance.reset()
-        result = _tool_parser_instance.extract_tool_calls(output_text, request_dict)
+        parser = _build_tool_parser(engine)
+        if parser is None:
+            return parse_tool_calls(output_text, request_dict)
+        result = parser.extract_tool_calls(output_text, request_dict)
         if result.tools_called:
             tools = request_dict.get("tools") if request_dict else None
             tool_calls = [
@@ -1803,7 +1901,7 @@ def load_model(
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
     """
-    global _engine, _model_name, _model_path, _default_max_tokens
+    global _engine, _model_manager, _model_name, _model_path, _default_max_tokens
     global _max_request_tokens, _tool_parser_instance, _warm_prompts_path
 
     _warm_prompts_path = warm_prompts_path
@@ -1817,10 +1915,9 @@ def load_model(
 
     _default_max_tokens = max_tokens
     _max_request_tokens = max_request_tokens
+    _model_manager = None
     _model_path = model_name
     _model_name = served_model_name or model_name
-    # Reset tool parser instance when model is reloaded (tokenizer may change)
-    _tool_parser_instance = None
 
     if force_mllm:
         logger.info("Force MLLM mode enabled via --mllm flag")
@@ -1866,6 +1963,29 @@ def load_model(
 
     logger.info(f"Default max tokens: {_default_max_tokens}")
     logger.info(f"Max request tokens: {_max_request_tokens}")
+
+
+def load_model_registry(
+    config_path: str,
+    *,
+    defaults: RegistryServeDefaults,
+) -> None:
+    """Load a registry-backed model manager from YAML configuration."""
+    global _engine, _model_manager, _model_name, _model_path, _default_max_tokens
+
+    manager_config, registry = load_registry_config(config_path, defaults)
+    _engine = None
+    _model_path = None
+    _model_name = None
+    _default_max_tokens = defaults.max_tokens
+    _model_manager = ModelManager(manager_config, registry, defaults)
+
+    logger.info(
+        "Loaded models config: %s (%d models, %.1f GB budget)",
+        config_path,
+        len(registry),
+        manager_config.memory_budget_bytes / (1024**3),
+    )
 
 
 def get_usage(output: GenerationOutput) -> Usage:
@@ -1914,8 +2034,9 @@ async def health():
 
     return {
         "status": "healthy",
-        "model_loaded": _engine is not None,
+        "model_loaded": _engine is not None or _model_manager is not None,
         "model_name": _model_name,
+        "available_models": _list_available_model_names(),
         "model_type": "mllm" if (_engine and _engine.is_mllm) else "llm",
         "mcp": mcp_info,
     }
@@ -1924,6 +2045,16 @@ async def health():
 @app.get("/v1/status", dependencies=[Depends(verify_api_key)])
 async def status():
     """Real-time status with per-request details for debugging and monitoring."""
+    if _model_manager is not None:
+        return {
+            "status": "running",
+            "model_manager": {
+                "memory_budget_gb": round(
+                    _model_manager.memory_budget_bytes / (1024**3), 2
+                ),
+                "models": _model_manager.list_models(),
+            },
+        }
     if _engine is None:
         return {"status": "not_loaded", "model": None, "requests": []}
 
@@ -2047,7 +2178,9 @@ async def clear_prefix_cache():
 async def list_models() -> ModelsResponse:
     """List available models."""
     models = []
-    if _model_name:
+    if _model_manager is not None:
+        models.extend(ModelInfo(id=item["id"]) for item in _model_manager.list_models())
+    elif _model_name:
         models.append(ModelInfo(id=_model_name))
     if _embedding_engine is not None:
         models.append(
@@ -2796,9 +2929,9 @@ async def _wait_with_disconnect(
 )
 async def create_completion(request: CompletionRequest, raw_request: Request):
     """Create a text completion."""
-    _validate_model_name(request.model)
+    model_ctx = await _acquire_request_model(request.model)
+    engine = model_ctx.engine
     effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
-    engine = get_engine()
     tracker = _metrics.track_inference("completions", stream=request.stream)
 
     # Handle single prompt or list of prompts
@@ -2822,18 +2955,21 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
     if request.stream:
         return StreamingResponse(
-            _disconnect_guard(
-                _ensure_sse_terminal(
-                    stream_completion(
-                        engine,
-                        prompts[0],
-                        request,
-                        repetition_penalty=comp_rep_penalty,
-                        metrics_tracker=tracker,
+            _stream_with_model_context(
+                model_ctx,
+                _disconnect_guard(
+                    _ensure_sse_terminal(
+                        stream_completion(
+                            engine,
+                            prompts[0],
+                            request,
+                            repetition_penalty=comp_rep_penalty,
+                            metrics_tracker=tracker,
+                        ),
+                        "data: [DONE]\n\n",
                     ),
-                    "data: [DONE]\n\n",
+                    raw_request,
                 ),
-                raw_request,
             ),
             media_type="text/event-stream",
         )
@@ -2845,52 +2981,55 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     total_completion_tokens = 0
     total_prompt_tokens = 0
 
-    for i, prompt in enumerate(prompts):
-        generate_kwargs = {
-            "prompt": prompt,
-            "max_tokens": effective_max_tokens,
-            "temperature": _resolve_temperature(request.temperature),
-            "top_p": _resolve_top_p(request.top_p),
-            "top_k": request.top_k or 0,
-            "min_p": request.min_p or 0.0,
-            "presence_penalty": request.presence_penalty or 0.0,
-            "stop": request.stop,
-        }
-        if comp_rep_penalty is not None:
-            generate_kwargs["repetition_penalty"] = comp_rep_penalty
-        if request.specprefill is not None:
-            generate_kwargs["specprefill"] = request.specprefill
-        if request.specprefill_keep_pct is not None:
-            generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+    try:
+        for i, prompt in enumerate(prompts):
+            generate_kwargs = {
+                "prompt": prompt,
+                "max_tokens": effective_max_tokens,
+                "temperature": _resolve_temperature(request.temperature),
+                "top_p": _resolve_top_p(request.top_p),
+                "top_k": request.top_k or 0,
+                "min_p": request.min_p or 0.0,
+                "presence_penalty": request.presence_penalty or 0.0,
+                "stop": request.stop,
+            }
+            if comp_rep_penalty is not None:
+                generate_kwargs["repetition_penalty"] = comp_rep_penalty
+            if request.specprefill is not None:
+                generate_kwargs["specprefill"] = request.specprefill
+            if request.specprefill_keep_pct is not None:
+                generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
-        try:
-            output = await _wait_with_disconnect(
-                engine.generate(**generate_kwargs),
-                raw_request,
-                timeout=timeout,
-            )
-        except HTTPException as exc:
-            tracker.finish(result=_metrics_result_from_status(exc.status_code))
-            raise
-        if output is None:
-            tracker.finish(
-                result="client_closed",
-                prompt_tokens=total_prompt_tokens,
-                completion_tokens=total_completion_tokens,
-            )
-            return Response(status_code=499)  # Client closed request
+            try:
+                output = await _wait_with_disconnect(
+                    engine.generate(**generate_kwargs),
+                    raw_request,
+                    timeout=timeout,
+                )
+            except HTTPException as exc:
+                tracker.finish(result=_metrics_result_from_status(exc.status_code))
+                raise
+            if output is None:
+                tracker.finish(
+                    result="client_closed",
+                    prompt_tokens=total_prompt_tokens,
+                    completion_tokens=total_completion_tokens,
+                )
+                return Response(status_code=499)  # Client closed request
 
-        choices.append(
-            CompletionChoice(
-                index=i,
-                text=output.text,
-                finish_reason=output.finish_reason,
+            choices.append(
+                CompletionChoice(
+                    index=i,
+                    text=output.text,
+                    finish_reason=output.finish_reason,
+                )
             )
-        )
-        total_completion_tokens += output.completion_tokens
-        total_prompt_tokens += (
-            output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
-        )
+            total_completion_tokens += output.completion_tokens
+            total_prompt_tokens += (
+                output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
+            )
+    finally:
+        await model_ctx.release()
 
     elapsed = time.perf_counter() - start_time
     tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
@@ -2904,7 +3043,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         completion_tokens=total_completion_tokens,
     )
     return CompletionResponse(
-        model=_model_name,
+        model=model_ctx.model_name,
         choices=choices,
         usage=Usage(
             prompt_tokens=total_prompt_tokens,
@@ -2960,9 +3099,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     }
     ```
     """
-    _validate_model_name(request.model)
+    model_ctx = await _acquire_request_model(request.model)
+    engine = model_ctx.engine
     effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
-    engine = get_engine()
     tracker = _metrics.track_inference("chat_completions", stream=request.stream)
 
     # --- Detailed request logging ---
@@ -3145,18 +3284,21 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
 
     if request.stream:
         return StreamingResponse(
-            _disconnect_guard(
-                _ensure_sse_terminal(
-                    stream_chat_completion(
-                        engine,
-                        messages,
-                        request,
-                        metrics_tracker=tracker,
-                        **chat_kwargs,
+            _stream_with_model_context(
+                model_ctx,
+                _disconnect_guard(
+                    _ensure_sse_terminal(
+                        stream_chat_completion(
+                            engine,
+                            messages,
+                            request,
+                            metrics_tracker=tracker,
+                            **chat_kwargs,
+                        ),
+                        "data: [DONE]\n\n",
                     ),
-                    "data: [DONE]\n\n",
+                    raw_request,
                 ),
-                raw_request,
             ),
             media_type="text/event-stream",
         )
@@ -3174,6 +3316,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     except HTTPException as exc:
         tracker.finish(result=_metrics_result_from_status(exc.status_code))
         raise
+    finally:
+        await model_ctx.release()
     if output is None:
         tracker.finish(result="client_closed")
         return Response(status_code=499)  # Client closed request
@@ -3215,7 +3359,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         completion_tokens=output.completion_tokens,
     )
     return ChatCompletionResponse(
-        model=_model_name,
+        model=model_ctx.model_name,
         choices=[
             ChatCompletionChoice(
                 message=AssistantMessage(
@@ -3407,9 +3551,9 @@ async def create_anthropic_message(
             raise
     anthropic_request = AnthropicRequest(**body)
 
-    _validate_model_name(anthropic_request.model)
+    model_ctx = await _acquire_request_model(anthropic_request.model)
+    engine = model_ctx.engine
     effective_max_tokens = _resolve_request_max_tokens(anthropic_request.max_tokens)
-    engine = get_engine()
 
     # --- Detailed request logging ---
     n_msgs = len(anthropic_request.messages)
@@ -3441,17 +3585,20 @@ async def create_anthropic_message(
             f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"
         )
         return StreamingResponse(
-            _disconnect_guard(
-                _ensure_sse_terminal(
-                    _stream_anthropic_messages(
-                        engine,
-                        openai_request,
-                        anthropic_request,
-                        metrics_tracker=tracker,
+            _stream_with_model_context(
+                model_ctx,
+                _disconnect_guard(
+                    _ensure_sse_terminal(
+                        _stream_anthropic_messages(
+                            engine,
+                            openai_request,
+                            anthropic_request,
+                            metrics_tracker=tracker,
+                        ),
+                        _anthropic_terminal,
                     ),
-                    _anthropic_terminal,
+                    request,
                 ),
-                request,
             ),
             media_type="text/event-stream",
             headers={
@@ -3528,6 +3675,8 @@ async def create_anthropic_message(
     except HTTPException as exc:
         tracker.finish(result=_metrics_result_from_status(exc.status_code))
         raise
+    finally:
+        await model_ctx.release()
     if output is None:
         tracker.finish(result="client_closed")
         return Response(status_code=499)  # Client closed request
@@ -3604,7 +3753,7 @@ async def create_anthropic_message(
     )
 
     anthropic_response = AnthropicResponse(
-        model=_model_name,
+        model=model_ctx.model_name,
         content=content_blocks,
         stop_reason=stop_reason,
         usage=AnthropicUsage(
@@ -3638,60 +3787,67 @@ async def count_anthropic_tokens(request: Request):
     """
     body = await request.json()
 
-    engine = get_engine()
-    tokenizer = engine.tokenizer
+    requested_model = body.get("model")
+    if not requested_model:
+        available = _list_available_model_names()
+        requested_model = available[0] if len(available) == 1 else ""
+    model_ctx = await _acquire_request_model(requested_model)
+    tokenizer = model_ctx.engine.tokenizer
 
     total_tokens = 0
 
-    # System message
-    system = body.get("system", "")
-    if isinstance(system, str) and system:
-        total_tokens += len(tokenizer.encode(system))
-    elif isinstance(system, list):
-        for block in system:
-            if isinstance(block, dict):
-                text = block.get("text", "")
-                if text:
-                    total_tokens += len(tokenizer.encode(text))
-
-    # Messages
-    for msg in body.get("messages", []):
-        content = msg.get("content", "")
-        if isinstance(content, str):
-            if content:
-                total_tokens += len(tokenizer.encode(content))
-        elif isinstance(content, list):
-            for block in content:
+    try:
+        # System message
+        system = body.get("system", "")
+        if isinstance(system, str) and system:
+            total_tokens += len(tokenizer.encode(system))
+        elif isinstance(system, list):
+            for block in system:
                 if isinstance(block, dict):
                     text = block.get("text", "")
                     if text:
                         total_tokens += len(tokenizer.encode(text))
-                    # tool_use input
-                    if block.get("input"):
-                        total_tokens += len(
-                            tokenizer.encode(json.dumps(block["input"]))
-                        )
-                    # tool_result content
-                    sub_content = block.get("content", "")
-                    if isinstance(sub_content, str) and sub_content:
-                        total_tokens += len(tokenizer.encode(sub_content))
-                    elif isinstance(sub_content, list):
-                        for item in sub_content:
-                            if isinstance(item, dict):
-                                item_text = item.get("text", "")
-                                if item_text:
-                                    total_tokens += len(tokenizer.encode(item_text))
 
-    # Tools
-    for tool in body.get("tools", []):
-        name = tool.get("name", "")
-        if name:
-            total_tokens += len(tokenizer.encode(name))
-        desc = tool.get("description", "")
-        if desc:
-            total_tokens += len(tokenizer.encode(desc))
-        if tool.get("input_schema"):
-            total_tokens += len(tokenizer.encode(json.dumps(tool["input_schema"])))
+        # Messages
+        for msg in body.get("messages", []):
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                if content:
+                    total_tokens += len(tokenizer.encode(content))
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        text = block.get("text", "")
+                        if text:
+                            total_tokens += len(tokenizer.encode(text))
+                        # tool_use input
+                        if block.get("input"):
+                            total_tokens += len(
+                                tokenizer.encode(json.dumps(block["input"]))
+                            )
+                        # tool_result content
+                        sub_content = block.get("content", "")
+                        if isinstance(sub_content, str) and sub_content:
+                            total_tokens += len(tokenizer.encode(sub_content))
+                        elif isinstance(sub_content, list):
+                            for item in sub_content:
+                                if isinstance(item, dict):
+                                    item_text = item.get("text", "")
+                                    if item_text:
+                                        total_tokens += len(tokenizer.encode(item_text))
+
+        # Tools
+        for tool in body.get("tools", []):
+            name = tool.get("name", "")
+            if name:
+                total_tokens += len(tokenizer.encode(name))
+            desc = tool.get("description", "")
+            if desc:
+                total_tokens += len(tokenizer.encode(desc))
+            if tool.get("input_schema"):
+                total_tokens += len(tokenizer.encode(json.dumps(tool["input_schema"])))
+    finally:
+        await model_ctx.release()
 
     return {"input_tokens": total_tokens}
 
@@ -3822,7 +3978,7 @@ async def _stream_anthropic_messages(
             "id": msg_id,
             "type": "message",
             "role": "assistant",
-            "model": _model_name,
+            "model": anthropic_request.model,
             "content": [],
             "stop_reason": None,
             "stop_sequence": None,
@@ -3834,12 +3990,13 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
-    use_reasoning = _reasoning_parser is not None and not chat_kwargs.get(
+    reasoning_parser = _build_reasoning_parser(engine)
+    use_reasoning = reasoning_parser is not None and not chat_kwargs.get(
         "logits_processors"
     )
 
-    if use_reasoning:
-        _reasoning_parser.reset_state()
+    if reasoning_parser:
+        reasoning_parser.reset_state()
 
     # Block index tracking: with reasoning parser we use index 0 for
     # thinking and index 1 for text; without parser, index 0 for text.
@@ -3924,7 +4081,7 @@ async def _stream_anthropic_messages(
             # Reasoning parser path
             previous_text = accumulated_text
             accumulated_text += filtered
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+            delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, accumulated_text, filtered
             )
 
@@ -3989,7 +4146,9 @@ async def _stream_anthropic_messages(
             text_block_started = True
 
         # Check for tool calls in accumulated text
-        _, tool_calls = _parse_tool_calls_with_parser(accumulated_text, openai_request)
+        _, tool_calls = _parse_tool_calls_with_parser(
+            accumulated_text, openai_request, engine=engine
+        )
 
         # Close text block
         if text_block_started:
@@ -4099,7 +4258,7 @@ async def stream_completion(
                 "id": f"cmpl-{uuid.uuid4().hex[:8]}",
                 "object": "text_completion",
                 "created": int(time.time()),
-                "model": _model_name,
+                "model": request.model,
                 "choices": [
                     {
                         "index": 0,
@@ -4150,7 +4309,7 @@ async def stream_chat_completion(
     # First chunk with role
     first_chunk = ChatCompletionChunk(
         id=response_id,
-        model=_model_name,
+        model=request.model,
         choices=[
             ChatCompletionChunkChoice(
                 delta=ChatCompletionChunkDelta(role="assistant"),
@@ -4161,14 +4320,15 @@ async def stream_chat_completion(
 
     # Track if we need to add <think> prefix for thinking models (when no reasoning parser)
     # The template adds <think> to the prompt, so the model output starts inside the think block
+    reasoning_parser = _build_reasoning_parser(engine)
     is_thinking_model = (
-        "nemotron" in (engine.model_name or "").lower() and not _reasoning_parser
+        "nemotron" in (engine.model_name or "").lower() and not reasoning_parser
     )
     think_prefix_sent = False
 
     # Reset reasoning parser state for this stream
-    if _reasoning_parser:
-        _reasoning_parser.reset_state()
+    if reasoning_parser:
+        reasoning_parser.reset_state()
 
     # Track accumulated text for reasoning parser
     accumulated_text = ""
@@ -4215,14 +4375,10 @@ async def stream_chat_completion(
                 completion_tokens = output.completion_tokens
 
             # Use reasoning parser if enabled (skip when enable_thinking=False)
-            if (
-                _reasoning_parser
-                and delta_text
-                and request.enable_thinking is not False
-            ):
+            if reasoning_parser and delta_text and request.enable_thinking is not False:
                 previous_text = accumulated_text
                 accumulated_text += delta_text
-                delta_msg = _reasoning_parser.extract_reasoning_streaming(
+                delta_msg = reasoning_parser.extract_reasoning_streaming(
                     previous_text, accumulated_text, delta_text
                 )
 
@@ -4275,7 +4431,7 @@ async def stream_chat_completion(
                                 # Still emit reasoning while buffering tool call
                                 chunk = ChatCompletionChunk(
                                     id=response_id,
-                                    model=_model_name,
+                                    model=request.model,
                                     choices=[
                                         ChatCompletionChunkChoice(
                                             delta=ChatCompletionChunkDelta(
@@ -4307,7 +4463,7 @@ async def stream_chat_completion(
                                         )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
-                                model=_model_name,
+                                model=request.model,
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
@@ -4340,7 +4496,7 @@ async def stream_chat_completion(
 
                 chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=request.model,
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -4415,7 +4571,7 @@ async def stream_chat_completion(
                                         )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
-                                model=_model_name,
+                                model=request.model,
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
@@ -4447,7 +4603,7 @@ async def stream_chat_completion(
 
                 chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=request.model,
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -4481,7 +4637,7 @@ async def stream_chat_completion(
                 )
                 tool_chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=request.model,
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -4552,7 +4708,7 @@ async def stream_chat_completion(
         if include_usage:
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
-                model=_model_name,
+                model=request.model,
                 choices=[],  # Empty choices for usage-only chunk
                 usage=Usage(
                     prompt_tokens=prompt_tokens,


### PR DESCRIPTION
## Summary

Registry-backed multi-model serving with memory-budget eviction for Apple Silicon unified memory.

- **`model_registry.py`**: Complete rewrite — `ModelManager` with acquire/release lease protocol, lazy loading, LRU memory-budget eviction, and configurable wait/fail/preempt contention policies
- **`server.py`**: Per-request engine routing via `RequestModelContext` and `_acquire_request_model`; lease-safe streaming via `_stream_with_model_context`; per-request reasoning/tool parser instantiation; registry-aware `/v1/models`, `/health`, `/v1/status`
- **`cli.py`**: `--models-config` flag with mutual exclusion against positional model arg and `--served-model-name`
- **Docs**: New Multi-Model Serving guide (`docs/guides/model-registry.md`), updated CLI reference and server docs
- **Tests**: 4 async ModelManager lifecycle tests + 4 server integration tests (all passing)

## Usage

```bash
# Single model (unchanged)
vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000

# Multi-model via registry
vllm-mlx serve --models-config models.yaml --port 8000
```

Registry YAML example:
```yaml
manager:
  memory_budget_gb: 100
  contention_policy:
    strategy: wait_then_preempt
    wait_timeout_s: 45
    preempt_after_s: 15

models:
  - name: fast
    path: /path/to/small-model
    preload: true
    estimated_memory_gb: 4
  - name: smart
    path: /path/to/large-model
    continuous_batching: true
    estimated_memory_gb: 36
```

Clients route requests via the standard OpenAI `model` field.

## v2 rebase notes

Rebased cleanly onto current `upstream/main` (b07e2a3). Key integration points with recent upstream changes:
- Metrics tracking (`_metrics.track_inference`, `tracker.finish`) preserved in all endpoint paths
- `_disconnect_guard()` and `_ensure_sse_terminal()` wrappers preserved
- `_normalize_messages()` and response_format handling preserved
- Streaming JSON fence stripper preserved in `stream_chat_completion`

## Test plan

- [x] `pytest tests/test_model_registry.py -x -q` — 4 passed
- [x] `pytest tests/test_server.py -x -q` — 41 passed (including 4 new registry tests)
- [x] `black --check` on all modified files
- [ ] Manual smoke test with real models and registry YAML
- [ ] Verify contention policy behavior under concurrent load