### PR TITLE
feat: add /v1/rerank endpoint for cross-encoder reranking

### DIFF
--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -706,3 +706,137 @@ class TestRerankCLI:
         parser = build_parser()
         args = parser.parse_args(["serve", "test-model"])
         assert args.rerank_model is None
+
+
+# =============================================================================
+# Integration Tests - Full Round-Trip
+# =============================================================================
+
+
+class TestRerankIntegration:
+    """Full round-trip tests exercising the endpoint with mocked RerankEngine."""
+
+    @pytest.fixture()
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.server import app
+
+        return TestClient(app)
+
+    def test_full_roundtrip_string_documents(self, client):
+        """Test full request/response cycle with string documents."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.2, 0.8, 0.5]
+        mock_engine.count_tokens.return_value = 45
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "machine learning",
+                    "documents": [
+                        "Cooking recipes for beginners",
+                        "Introduction to neural networks",
+                        "History of computer science",
+                    ],
+                    "top_n": 2,
+                    "return_documents": True,
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # Verify structure
+        assert "model" in body
+        assert body["model"] == "test-reranker"
+        assert "results" in body
+        assert "usage" in body
+        assert body["usage"]["total_tokens"] == 45
+
+        # Verify top_n
+        assert len(body["results"]) == 2
+
+        # Verify sorting (descending by score)
+        assert (
+            body["results"][0]["relevance_score"]
+            >= body["results"][1]["relevance_score"]
+        )
+
+        # Verify index preservation
+        assert body["results"][0]["index"] == 1  # "Introduction to neural networks"
+        assert body["results"][1]["index"] == 2  # "History of computer science"
+
+        # Verify documents included
+        assert (
+            body["results"][0]["document"]["text"] == "Introduction to neural networks"
+        )
+        assert body["results"][1]["document"]["text"] == "History of computer science"
+
+    def test_full_roundtrip_object_documents(self, client):
+        """Test full request/response cycle with object documents preserving metadata."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.9, 0.1]
+        mock_engine.count_tokens.return_value = 20
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "q",
+                    "documents": [
+                        {"text": "relevant doc", "id": "doc-001", "source": "arxiv"},
+                        {"text": "irrelevant doc", "id": "doc-002", "source": "wiki"},
+                    ],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["results"]) == 2
+
+        # First result should be index 0 (score 0.9)
+        top = body["results"][0]
+        assert top["index"] == 0
+        assert top["document"]["text"] == "relevant doc"
+        assert top["document"]["id"] == "doc-001"
+        assert top["document"]["source"] == "arxiv"
+
+    def test_rerank_model_appears_in_v1_models(self, client):
+        """Test that a loaded reranker model appears in /v1/models."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.get("/v1/models")
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        reranker_models = [
+            m for m in body["data"] if m.get("owned_by") == "vllm-mlx-reranker"
+        ]
+        assert len(reranker_models) == 1
+        assert reranker_models[0]["id"] == "test-reranker"

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -273,3 +273,133 @@ class TestRerankEngine:
         count = engine.count_tokens("query text", ["doc one", "doc two"])
         # tokenizer called twice (once per doc), 7 tokens each = 14
         assert count == 14
+
+
+# =============================================================================
+# Unit Tests - Classifier Forward Pass
+# =============================================================================
+
+
+class TestClassifierForward:
+    """Test the MLX classifier forward pass for cross-encoder models."""
+
+    def test_classifier_forward_returns_logits_shape(self):
+        """Test that classifier_forward returns logits with (batch, num_labels) shape."""
+        import mlx.core as mx
+
+        from vllm_mlx.rerank_forward import classifier_forward
+
+        # Build minimal BERT-like weights
+        vocab_size = 30
+        hidden_size = 16
+        num_heads = 2
+        intermediate_size = 32
+        num_labels = 1
+
+        config = {
+            "hidden_size": hidden_size,
+            "num_attention_heads": num_heads,
+            "intermediate_size": intermediate_size,
+            "num_hidden_layers": 1,
+            "num_labels": num_labels,
+            "vocab_size": vocab_size,
+            "max_position_embeddings": 64,
+            "type_vocab_size": 2,
+            "layer_norm_eps": 1e-12,
+            "hidden_act": "gelu",
+        }
+
+        weights = _make_bert_weights(config)
+
+        input_ids = mx.array([[1, 2, 3, 0, 0], [4, 5, 6, 7, 0]])
+        attention_mask = mx.array([[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]])
+
+        logits = classifier_forward(input_ids, attention_mask, weights, config)
+        mx.eval(logits)
+
+        assert logits.shape == (2, num_labels)
+
+    def test_classifier_forward_different_num_labels(self):
+        """Test forward pass with num_labels=3 (multi-class)."""
+        import mlx.core as mx
+
+        from vllm_mlx.rerank_forward import classifier_forward
+
+        hidden_size = 8
+        config = {
+            "hidden_size": hidden_size,
+            "num_attention_heads": 2,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_labels": 3,
+            "vocab_size": 20,
+            "max_position_embeddings": 32,
+            "type_vocab_size": 2,
+            "layer_norm_eps": 1e-12,
+            "hidden_act": "gelu",
+        }
+
+        weights = _make_bert_weights(config)
+
+        input_ids = mx.array([[1, 2, 3]])
+        attention_mask = mx.array([[1, 1, 1]])
+
+        logits = classifier_forward(input_ids, attention_mask, weights, config)
+        mx.eval(logits)
+
+        assert logits.shape == (1, 3)
+
+
+def _make_bert_weights(config: dict) -> dict:
+    """Build minimal random BERT-style weights for testing."""
+    import mlx.core as mx
+
+    h = config["hidden_size"]
+    inter = config["intermediate_size"]
+    vocab = config["vocab_size"]
+    max_pos = config["max_position_embeddings"]
+    type_vocab = config["type_vocab_size"]
+    num_labels = config["num_labels"]
+    n_layers = config["num_hidden_layers"]
+
+    w = {}
+    # Embeddings
+    w["bert.embeddings.word_embeddings.weight"] = mx.random.normal((vocab, h)) * 0.02
+    w["bert.embeddings.position_embeddings.weight"] = (
+        mx.random.normal((max_pos, h)) * 0.02
+    )
+    w["bert.embeddings.token_type_embeddings.weight"] = (
+        mx.random.normal((type_vocab, h)) * 0.02
+    )
+    w["bert.embeddings.LayerNorm.weight"] = mx.ones((h,))
+    w["bert.embeddings.LayerNorm.bias"] = mx.zeros((h,))
+
+    for i in range(n_layers):
+        prefix = f"bert.encoder.layer.{i}"
+        # Self-attention
+        for proj in ["query", "key", "value"]:
+            w[f"{prefix}.attention.self.{proj}.weight"] = (
+                mx.random.normal((h, h)) * 0.02
+            )
+            w[f"{prefix}.attention.self.{proj}.bias"] = mx.zeros((h,))
+        w[f"{prefix}.attention.output.dense.weight"] = mx.random.normal((h, h)) * 0.02
+        w[f"{prefix}.attention.output.dense.bias"] = mx.zeros((h,))
+        w[f"{prefix}.attention.output.LayerNorm.weight"] = mx.ones((h,))
+        w[f"{prefix}.attention.output.LayerNorm.bias"] = mx.zeros((h,))
+        # FFN
+        w[f"{prefix}.intermediate.dense.weight"] = mx.random.normal((inter, h)) * 0.02
+        w[f"{prefix}.intermediate.dense.bias"] = mx.zeros((inter,))
+        w[f"{prefix}.output.dense.weight"] = mx.random.normal((h, inter)) * 0.02
+        w[f"{prefix}.output.dense.bias"] = mx.zeros((h,))
+        w[f"{prefix}.output.LayerNorm.weight"] = mx.ones((h,))
+        w[f"{prefix}.output.LayerNorm.bias"] = mx.zeros((h,))
+
+    # Pooler
+    w["bert.pooler.dense.weight"] = mx.random.normal((h, h)) * 0.02
+    w["bert.pooler.dense.bias"] = mx.zeros((h,))
+
+    # Classifier
+    w["classifier.weight"] = mx.random.normal((num_labels, h)) * 0.02
+    w["classifier.bias"] = mx.zeros((num_labels,))
+
+    return w

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -652,7 +652,7 @@ class TestRerankEndpoint:
             srv._rerank_model_locked = original_locked
 
     def test_rerank_no_engine_returns_503(self, client):
-        """Test that requesting rerank without a loaded engine returns 503."""
+        """Test that requesting rerank without a loaded engine returns 404."""
         import vllm_mlx.server as srv
 
         original = srv._rerank_engine
@@ -669,10 +669,32 @@ class TestRerankEndpoint:
         finally:
             srv._rerank_engine = original
 
-        # Without lazy loading enabled, should try to load and may fail with 503
-        # The exact behavior depends on whether lazy loading is wired, but the
-        # route must exist and not 404
-        assert resp.status_code != 404
+        assert resp.status_code == 404
+        assert "--rerank-model" in resp.json()["detail"]
+
+    def test_rerank_empty_query_returns_400(self, client):
+        """Test that an empty query returns 400."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "",
+                    "documents": ["d"],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 400
+        assert "Query" in resp.json()["detail"]
 
 
 # =============================================================================

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -403,3 +403,273 @@ def _make_bert_weights(config: dict) -> dict:
     w["classifier.bias"] = mx.zeros((num_labels,))
 
     return w
+
+
+# =============================================================================
+# Integration Tests - FastAPI Endpoint
+# =============================================================================
+
+
+class TestRerankEndpoint:
+    """Test the /v1/rerank endpoint via TestClient."""
+
+    @pytest.fixture()
+    def client(self):
+        """Create a FastAPI test client."""
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.server import app
+
+        return TestClient(app)
+
+    def test_rerank_returns_sorted_results(self, client):
+        """Test that /v1/rerank returns results sorted by relevance_score descending."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        # doc 0 gets low score, doc 1 gets high score, doc 2 gets mid score
+        mock_engine.score_pairs.return_value = [0.1, 0.9, 0.5]
+        mock_engine.count_tokens.return_value = 30
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "What is deep learning?",
+                    "documents": ["bad match", "great match", "ok match"],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["results"]) == 3
+        # Sorted descending by score
+        assert body["results"][0]["index"] == 1
+        assert body["results"][0]["relevance_score"] == 0.9
+        assert body["results"][1]["index"] == 2
+        assert body["results"][1]["relevance_score"] == 0.5
+        assert body["results"][2]["index"] == 0
+        assert body["results"][2]["relevance_score"] == 0.1
+
+    def test_rerank_top_n(self, client):
+        """Test that top_n limits returned results."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.1, 0.9, 0.5]
+        mock_engine.count_tokens.return_value = 20
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "query",
+                    "documents": ["a", "b", "c"],
+                    "top_n": 2,
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["results"]) == 2
+        assert body["results"][0]["relevance_score"] == 0.9
+        assert body["results"][1]["relevance_score"] == 0.5
+
+    def test_rerank_top_n_exceeds_documents_returns_400(self, client):
+        """Test that top_n > len(documents) returns 400."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "query",
+                    "documents": ["a", "b"],
+                    "top_n": 5,
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 400
+        assert "top_n" in resp.json()["detail"]
+
+    def test_rerank_return_documents_false(self, client):
+        """Test that return_documents=false omits document text."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.7]
+        mock_engine.count_tokens.return_value = 5
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "q",
+                    "documents": ["d"],
+                    "return_documents": False,
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["results"][0]["document"] is None
+
+    def test_rerank_preserves_object_documents(self, client):
+        """Test that object documents preserve original structure."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.8, 0.3]
+        mock_engine.count_tokens.return_value = 10
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "q",
+                    "documents": [
+                        {"text": "alpha", "metadata": "extra1"},
+                        {"text": "beta", "metadata": "extra2"},
+                    ],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # Results sorted by score descending; index 0 (0.8) first
+        assert body["results"][0]["index"] == 0
+        assert body["results"][0]["document"]["text"] == "alpha"
+        assert body["results"][0]["document"]["metadata"] == "extra1"
+
+    def test_rerank_empty_documents_returns_400(self, client):
+        """Test that empty document list returns 400."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "q",
+                    "documents": [],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 400
+
+    def test_rerank_usage_tokens(self, client):
+        """Test that usage.total_tokens is included in response."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "test-reranker"
+        mock_engine.score_pairs.return_value = [0.5]
+        mock_engine.count_tokens.return_value = 42
+
+        original = srv._rerank_engine
+        srv._rerank_engine = mock_engine
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "test-reranker",
+                    "query": "q",
+                    "documents": ["d"],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        assert resp.status_code == 200
+        assert resp.json()["usage"]["total_tokens"] == 42
+
+    def test_rerank_model_locked_rejects_different_model(self, client):
+        """Test that a locked reranker model rejects requests for different models."""
+        import vllm_mlx.server as srv
+
+        mock_engine = MagicMock()
+        mock_engine.model_name = "locked-reranker"
+
+        original_engine = srv._rerank_engine
+        original_locked = srv._rerank_model_locked
+        srv._rerank_engine = mock_engine
+        srv._rerank_model_locked = "locked-reranker"
+
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "other-reranker",
+                    "query": "q",
+                    "documents": ["d"],
+                },
+            )
+            assert resp.status_code == 400
+            body = resp.json()
+            assert "locked-reranker" in body["detail"]
+            assert "other-reranker" in body["detail"]
+        finally:
+            srv._rerank_engine = original_engine
+            srv._rerank_model_locked = original_locked
+
+    def test_rerank_no_engine_returns_503(self, client):
+        """Test that requesting rerank without a loaded engine returns 503."""
+        import vllm_mlx.server as srv
+
+        original = srv._rerank_engine
+        srv._rerank_engine = None
+        try:
+            resp = client.post(
+                "/v1/rerank",
+                json={
+                    "model": "any-model",
+                    "query": "q",
+                    "documents": ["d"],
+                },
+            )
+        finally:
+            srv._rerank_engine = original
+
+        # Without lazy loading enabled, should try to load and may fail with 503
+        # The exact behavior depends on whether lazy loading is wired, but the
+        # route must exist and not 404
+        assert resp.status_code != 404

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -3,7 +3,7 @@
 
 import platform
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -115,8 +115,6 @@ class TestRerankAdapterContract:
 
     def test_sigmoid_adapter_normalize_maps_to_zero_one(self):
         """Test that SigmoidAdapter.normalize applies sigmoid correctly."""
-        import math
-
         from vllm_mlx.rerank import SigmoidAdapter
 
         adapter = SigmoidAdapter()

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -208,8 +208,9 @@ class TestRerankEngine:
         engine._tokenizer = mock_tokenizer
         engine._adapter = SigmoidAdapter()
 
-        scores = engine.score_pairs("test query", ["doc one", "doc two"])
+        scores, total_tokens = engine.score_pairs("test query", ["doc one", "doc two"])
         assert len(scores) == 2
+        assert total_tokens == 6  # 3 tokens per pair
         expected_0 = 1.0 / (1.0 + math.exp(-2.0))
         expected_1 = 1.0 / (1.0 + math.exp(1.0))
         assert abs(scores[0] - expected_0) < 1e-6
@@ -253,24 +254,40 @@ class TestRerankEngine:
         engine._tokenizer = mock_tokenizer
         engine._adapter = SigmoidAdapter()
 
-        scores = engine.score_pairs("q", ["d1", "d2", "d3"])
+        scores, total_tokens = engine.score_pairs("q", ["d1", "d2", "d3"])
         assert len(scores) == 3
+        assert total_tokens == 15  # 3 docs * 5 tokens each
         # tokenizer called once per document (for budget estimation + scoring)
         assert call_count == 3
 
-    def test_count_tokens_pair(self):
-        """Test token counting for a query-document pair."""
-        from vllm_mlx.rerank import RerankEngine
+    def test_score_pairs_returns_token_count(self):
+        """Test that score_pairs returns total_tokens consistent with scoring."""
+        import numpy as np
+
+        from vllm_mlx.rerank import RerankEngine, SigmoidAdapter
 
         engine = RerankEngine("test-model")
-        mock_tokenizer = MagicMock()
-        mock_tokenizer.return_value = {"input_ids": [[1, 2, 3, 4, 5, 6, 7]]}
-        engine._tokenizer = mock_tokenizer
-        engine._model = MagicMock()  # mark as loaded
 
-        count = engine.count_tokens("query text", ["doc one", "doc two"])
-        # tokenizer called twice (once per doc), 7 tokens each = 14
-        assert count == 14
+        mock_model = MagicMock()
+        mock_logits = MagicMock()
+        mock_logits.tolist.return_value = [[0.5], [0.3]]
+        mock_model.return_value = MagicMock(logits=mock_logits)
+
+        mock_tokenizer = MagicMock()
+        # Each pair tokenizes to 7 tokens
+        mock_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2, 3, 4, 5, 6, 7]]),
+            "attention_mask": np.array([[1, 1, 1, 1, 1, 1, 1]]),
+        }
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+        engine._adapter = SigmoidAdapter()
+
+        scores, total_tokens = engine.score_pairs("query", ["doc1", "doc2"])
+        assert len(scores) == 2
+        # 2 docs * 7 tokens each = 14
+        assert total_tokens == 14
 
 
 # =============================================================================
@@ -427,8 +444,7 @@ class TestRerankEndpoint:
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
         # doc 0 gets low score, doc 1 gets high score, doc 2 gets mid score
-        mock_engine.score_pairs.return_value = [0.1, 0.9, 0.5]
-        mock_engine.count_tokens.return_value = 30
+        mock_engine.score_pairs.return_value = ([0.1, 0.9, 0.5], 30)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -461,8 +477,7 @@ class TestRerankEndpoint:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.1, 0.9, 0.5]
-        mock_engine.count_tokens.return_value = 20
+        mock_engine.score_pairs.return_value = ([0.1, 0.9, 0.5], 20)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -516,8 +531,7 @@ class TestRerankEndpoint:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.7]
-        mock_engine.count_tokens.return_value = 5
+        mock_engine.score_pairs.return_value = ([0.7], 5)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -544,8 +558,7 @@ class TestRerankEndpoint:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.8, 0.3]
-        mock_engine.count_tokens.return_value = 10
+        mock_engine.score_pairs.return_value = ([0.8, 0.3], 10)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -600,8 +613,7 @@ class TestRerankEndpoint:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.5]
-        mock_engine.count_tokens.return_value = 42
+        mock_engine.score_pairs.return_value = ([0.5], 42)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -750,8 +762,7 @@ class TestRerankIntegration:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.2, 0.8, 0.5]
-        mock_engine.count_tokens.return_value = 45
+        mock_engine.score_pairs.return_value = ([0.2, 0.8, 0.5], 45)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine
@@ -808,8 +819,7 @@ class TestRerankIntegration:
 
         mock_engine = MagicMock()
         mock_engine.model_name = "test-reranker"
-        mock_engine.score_pairs.return_value = [0.9, 0.1]
-        mock_engine.count_tokens.return_value = 20
+        mock_engine.score_pairs.return_value = ([0.9, 0.1], 20)
 
         original = srv._rerank_engine
         srv._rerank_engine = mock_engine

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /v1/rerank endpoint."""
+
+import platform
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Skip all tests if not on Apple Silicon
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
+
+
+# =============================================================================
+# Unit Tests - Pydantic Models
+# =============================================================================
+
+
+class TestRerankModels:
+    """Test rerank request/response Pydantic models."""
+
+    def test_rerank_request_with_string_documents(self):
+        """Test RerankRequest accepts a list of plain strings."""
+        from vllm_mlx.api.models import RerankRequest
+
+        req = RerankRequest(
+            model="jina-reranker-v2",
+            query="What is deep learning?",
+            documents=["doc one", "doc two"],
+        )
+        assert req.model == "jina-reranker-v2"
+        assert req.query == "What is deep learning?"
+        assert req.documents == ["doc one", "doc two"]
+        assert req.top_n is None
+        assert req.return_documents is True
+
+    def test_rerank_request_with_object_documents(self):
+        """Test RerankRequest accepts a list of {text: ...} objects."""
+        from vllm_mlx.api.models import RerankRequest
+
+        req = RerankRequest(
+            model="jina-reranker-v2",
+            query="query",
+            documents=[{"text": "alpha"}, {"text": "beta"}],
+        )
+        assert req.documents == [{"text": "alpha"}, {"text": "beta"}]
+
+    def test_rerank_request_top_n_default_none(self):
+        """Test that top_n defaults to None (return all)."""
+        from vllm_mlx.api.models import RerankRequest
+
+        req = RerankRequest(model="m", query="q", documents=["a"])
+        assert req.top_n is None
+
+    def test_rerank_result_serialization(self):
+        """Test RerankResult serializes with correct fields."""
+        from vllm_mlx.api.models import RerankResult
+
+        result = RerankResult(
+            index=2,
+            relevance_score=0.95,
+            document={"text": "hello"},
+        )
+        d = result.model_dump()
+        assert d["index"] == 2
+        assert d["relevance_score"] == 0.95
+        assert d["document"] == {"text": "hello"}
+
+    def test_rerank_result_without_document(self):
+        """Test RerankResult when document is omitted."""
+        from vllm_mlx.api.models import RerankResult
+
+        result = RerankResult(index=0, relevance_score=0.5)
+        d = result.model_dump()
+        assert d["index"] == 0
+        assert d["document"] is None
+
+    def test_rerank_response_serialization(self):
+        """Test RerankResponse serializes to Jina-compatible JSON."""
+        from vllm_mlx.api.models import RerankResponse, RerankResult, RerankUsage
+
+        response = RerankResponse(
+            model="jina-reranker-v2",
+            results=[
+                RerankResult(index=1, relevance_score=0.9, document={"text": "best"}),
+                RerankResult(index=0, relevance_score=0.1, document={"text": "worst"}),
+            ],
+            usage=RerankUsage(total_tokens=42),
+        )
+        d = response.model_dump()
+        assert d["model"] == "jina-reranker-v2"
+        assert len(d["results"]) == 2
+        assert d["results"][0]["index"] == 1
+        assert d["results"][0]["relevance_score"] == 0.9
+        assert d["usage"]["total_tokens"] == 42

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -673,3 +673,36 @@ class TestRerankEndpoint:
         # The exact behavior depends on whether lazy loading is wired, but the
         # route must exist and not 404
         assert resp.status_code != 404
+
+
+# =============================================================================
+# Unit Tests - CLI Argument
+# =============================================================================
+
+
+class TestRerankCLI:
+    """Test that --rerank-model CLI arg is registered."""
+
+    def test_rerank_model_arg_exists(self):
+        """Test that the serve subcommand accepts --rerank-model."""
+        from vllm_mlx.cli import build_parser
+
+        parser = build_parser()
+        # Parse with --rerank-model; should not raise
+        args = parser.parse_args(
+            [
+                "serve",
+                "test-model",
+                "--rerank-model",
+                "mlx-community/jina-reranker-v2-base-multilingual",
+            ]
+        )
+        assert args.rerank_model == "mlx-community/jina-reranker-v2-base-multilingual"
+
+    def test_rerank_model_arg_default_none(self):
+        """Test that --rerank-model defaults to None."""
+        from vllm_mlx.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["serve", "test-model"])
+        assert args.rerank_model is None

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -159,3 +159,117 @@ class TestRerankAdapterContract:
         )
         assert "input_ids" in result
         assert "attention_mask" in result
+
+
+# =============================================================================
+# Unit Tests - RerankEngine
+# =============================================================================
+
+
+class TestRerankEngine:
+    """Test the RerankEngine model loading and scoring."""
+
+    def test_engine_not_loaded_initially(self):
+        """Test that a new engine reports is_loaded=False."""
+        from vllm_mlx.rerank import RerankEngine
+
+        engine = RerankEngine("test-model")
+        assert engine.is_loaded is False
+
+    def test_engine_model_name_stored(self):
+        """Test that model_name is stored on construction."""
+        from vllm_mlx.rerank import RerankEngine
+
+        engine = RerankEngine("mlx-community/jina-reranker-v2-base-multilingual")
+        assert engine.model_name == "mlx-community/jina-reranker-v2-base-multilingual"
+
+    def test_score_pairs_returns_normalized_scores(self):
+        """Test score_pairs returns sigmoid-normalized scores for each pair."""
+        import math
+
+        import numpy as np
+
+        from vllm_mlx.rerank import RerankEngine, SigmoidAdapter
+
+        engine = RerankEngine("test-model")
+
+        # Mock model: returns logits with shape (batch, num_labels)
+        mock_model = MagicMock()
+        # Simulate two pairs scored: logits [2.0, ...] and [-1.0, ...]
+        mock_logits = MagicMock()
+        mock_logits.tolist.return_value = [[2.0, 0.5], [-1.0, 0.3]]
+        mock_model.return_value = MagicMock(logits=mock_logits)
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2, 3], [4, 5, 6]]),
+            "attention_mask": np.array([[1, 1, 1], [1, 1, 1]]),
+        }
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+        engine._adapter = SigmoidAdapter()
+
+        scores = engine.score_pairs("test query", ["doc one", "doc two"])
+        assert len(scores) == 2
+        expected_0 = 1.0 / (1.0 + math.exp(-2.0))
+        expected_1 = 1.0 / (1.0 + math.exp(1.0))
+        assert abs(scores[0] - expected_0) < 1e-6
+        assert abs(scores[1] - expected_1) < 1e-6
+
+    def test_score_pairs_token_budget_batching(self):
+        """Test that score_pairs splits work into batches by token budget."""
+        import numpy as np
+
+        from vllm_mlx.rerank import RerankEngine, SigmoidAdapter
+
+        engine = RerankEngine("test-model", token_budget=10)
+
+        mock_model = MagicMock()
+        mock_tokenizer = MagicMock()
+
+        # Each call returns 1 pair. We have 3 documents.
+        # With token_budget=10 and each pair using 5 tokens, we get batches of 2 then 1.
+        call_count = 0
+
+        def mock_tokenize(query, doc, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return {
+                "input_ids": np.array([[1, 2, 3, 4, 5]]),
+                "attention_mask": np.array([[1, 1, 1, 1, 1]]),
+            }
+
+        mock_tokenizer.side_effect = mock_tokenize
+
+        def mock_forward(input_ids, **kwargs):
+            # Return logits matching the batch dimension of input_ids
+            batch_size = input_ids.shape[0]
+            mock_logits = MagicMock()
+            mock_logits.tolist.return_value = [[0.5]] * batch_size
+            return MagicMock(logits=mock_logits)
+
+        mock_model.side_effect = mock_forward
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+        engine._adapter = SigmoidAdapter()
+
+        scores = engine.score_pairs("q", ["d1", "d2", "d3"])
+        assert len(scores) == 3
+        # tokenizer called once per document (for budget estimation + scoring)
+        assert call_count == 3
+
+    def test_count_tokens_pair(self):
+        """Test token counting for a query-document pair."""
+        from vllm_mlx.rerank import RerankEngine
+
+        engine = RerankEngine("test-model")
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {"input_ids": [[1, 2, 3, 4, 5, 6, 7]]}
+        engine._tokenizer = mock_tokenizer
+        engine._model = MagicMock()  # mark as loaded
+
+        count = engine.count_tokens("query text", ["doc one", "doc two"])
+        # tokenizer called twice (once per doc), 7 tokens each = 14
+        assert count == 14

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -96,3 +96,66 @@ class TestRerankModels:
         assert d["results"][0]["index"] == 1
         assert d["results"][0]["relevance_score"] == 0.9
         assert d["usage"]["total_tokens"] == 42
+
+
+# =============================================================================
+# Unit Tests - Reranker Adapter Contract
+# =============================================================================
+
+
+class TestRerankAdapterContract:
+    """Test the base adapter interface and default sigmoid adapter."""
+
+    def test_base_adapter_is_abstract(self):
+        """Test that RerankAdapter cannot be instantiated directly."""
+        from vllm_mlx.rerank import RerankAdapter
+
+        with pytest.raises(TypeError):
+            RerankAdapter()
+
+    def test_sigmoid_adapter_normalize_maps_to_zero_one(self):
+        """Test that SigmoidAdapter.normalize applies sigmoid correctly."""
+        import math
+
+        from vllm_mlx.rerank import SigmoidAdapter
+
+        adapter = SigmoidAdapter()
+        # sigmoid(0) = 0.5
+        assert abs(adapter.normalize(0.0) - 0.5) < 1e-6
+        # sigmoid(large positive) -> ~1.0
+        assert adapter.normalize(10.0) > 0.999
+        # sigmoid(large negative) -> ~0.0
+        assert adapter.normalize(-10.0) < 0.001
+
+    def test_sigmoid_adapter_extract_score_takes_first_logit(self):
+        """Test that SigmoidAdapter.extract_score returns logits[0]."""
+        from vllm_mlx.rerank import SigmoidAdapter
+
+        adapter = SigmoidAdapter()
+        # Simulate a logits array with shape (num_labels,)
+        logits = [2.5, -1.0, 0.3]
+        assert adapter.extract_score(logits) == 2.5
+
+    def test_sigmoid_adapter_tokenize_pair_returns_dict(self):
+        """Test that SigmoidAdapter.tokenize_pair produces a token dict."""
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.rerank import SigmoidAdapter
+
+        adapter = SigmoidAdapter()
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": [[101, 2054, 102, 3793, 102]],
+            "attention_mask": [[1, 1, 1, 1, 1]],
+        }
+        result = adapter.tokenize_pair(mock_tokenizer, "query", "document")
+        mock_tokenizer.assert_called_once_with(
+            "query",
+            "document",
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="np",
+        )
+        assert "input_ids" in result
+        assert "attention_mask" in result

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -433,6 +433,43 @@ class EmbeddingResponse(BaseModel):
 
 
 # =============================================================================
+# Reranking
+# =============================================================================
+
+
+class RerankRequest(BaseModel):
+    """Request for reranking documents against a query (Jina/Cohere convention)."""
+
+    model: str
+    query: str
+    documents: list[str | dict]
+    top_n: int | None = None
+    return_documents: bool = True
+
+
+class RerankResult(BaseModel):
+    """A single reranked document result."""
+
+    index: int
+    relevance_score: float
+    document: dict | None = None
+
+
+class RerankUsage(BaseModel):
+    """Token usage for rerank requests."""
+
+    total_tokens: int = 0
+
+
+class RerankResponse(BaseModel):
+    """Response for reranking endpoint (Jina/Cohere convention)."""
+
+    model: str
+    results: list[RerankResult]
+    usage: RerankUsage = Field(default_factory=RerankUsage)
+
+
+# =============================================================================
 # Streaming (for SSE responses)
 # =============================================================================
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -141,6 +141,12 @@ def serve_command(args):
         server.load_embedding_model(args.embedding_model, lock=True)
         print(f"Embedding model loaded: {args.embedding_model}")
 
+    # Pre-load reranker model if specified
+    if args.rerank_model:
+        print(f"Pre-loading reranker model: {args.rerank_model}")
+        server.load_reranker_model(args.rerank_model, lock=True)
+        print(f"Reranker model loaded: {args.rerank_model}")
+
     # Build scheduler config for batched mode
     scheduler_config = None
     if args.continuous_batching:
@@ -952,6 +958,13 @@ Examples:
         default=None,
         help="Pre-load an embedding model at startup (e.g. mlx-community/embeddinggemma-300m-6bit)",
     )
+    # Reranker model option
+    serve_parser.add_argument(
+        "--rerank-model",
+        type=str,
+        default=None,
+        help="Pre-load a reranker model at startup (e.g. mlx-community/jina-reranker-v2-base-multilingual)",
+    )
     # Download options
     serve_parser.add_argument(
         "--download-timeout",
@@ -1129,6 +1142,10 @@ Examples:
     )
 
     return parser
+
+
+# Alias for test compatibility
+build_parser = create_parser
 
 
 def main():

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -224,12 +224,14 @@ class RerankEngine:
         if not self.is_loaded:
             self.load()
 
-    def score_pairs(self, query: str, documents: list[str]) -> list[float]:
+    def score_pairs(self, query: str, documents: list[str]) -> tuple[list[float], int]:
         """
         Score each (query, document) pair and return normalized relevance scores.
 
         Pairs are batched by token budget to control memory usage. Each batch
         is tokenized together and scored in a single forward pass.
+        Returns (scores, total_tokens) where total_tokens reflects the
+        actual tokenization used for scoring (consistent with adapter).
 
         Args:
             query: The query string.
@@ -318,28 +320,8 @@ class RerankEngine:
 
         # Sort by original index to restore input order
         all_scores.sort(key=lambda x: x[0])
-        return [score for _, score in all_scores]
-
-    def count_tokens(self, query: str, documents: list[str]) -> int:
-        """
-        Count total tokens across all (query, document) pairs.
-
-        Used for usage reporting in the API response.
-        """
-        self._ensure_loaded()
-        total = 0
-        for doc in documents:
-            enc = self._tokenizer(query, doc)
-            ids = enc.get("input_ids", enc.get("input_ids", []))
-            if isinstance(ids, list) and ids and isinstance(ids[0], list):
-                total += len(ids[0])
-            elif isinstance(ids, list):
-                total += len(ids)
-            elif hasattr(ids, "shape"):
-                total += ids.shape[-1]
-            else:
-                total += max(1, (len(query) + len(doc)) // 4)
-        return total
+        total_tokens = sum(pair_token_counts)
+        return [score for _, score in all_scores], total_tokens
 
 
 def _build_classifier_model(model_type, config, weights, num_labels):

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -12,8 +12,9 @@ import math
 import time
 from abc import ABC, abstractmethod
 
+import asyncio
+
 import mlx.core as mx
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +146,7 @@ class RerankEngine:
         self.model_name = model_name
         self.token_budget = token_budget
         self.max_concurrency = max_concurrency
+        self._semaphore = asyncio.Semaphore(max_concurrency)
         self._model = None
         self._tokenizer = None
         self._adapter: RerankAdapter | None = None

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -101,3 +101,300 @@ class SigmoidAdapter(RerankAdapter):
     def normalize(self, raw_score: float) -> float:
         """Apply sigmoid normalization."""
         return 1.0 / (1.0 + math.exp(-raw_score))
+
+
+# =============================================================================
+# Engine
+# =============================================================================
+
+# Default adapter registry — extend for new model families.
+_ADAPTER_REGISTRY: dict[str, type[RerankAdapter]] = {
+    "default": SigmoidAdapter,
+}
+
+
+def get_adapter(model_name: str) -> RerankAdapter:
+    """
+    Return the appropriate adapter for a model.
+
+    Falls back to SigmoidAdapter (works for Jina, BGE, MS-MARCO families).
+    Extend _ADAPTER_REGISTRY for families that need different scoring.
+    """
+    # Future: inspect model config to select adapter automatically.
+    # For now, all known MLX reranker models use the sigmoid pattern.
+    return _ADAPTER_REGISTRY["default"]()
+
+
+class RerankEngine:
+    """
+    Reranker engine for cross-encoder sequence classification models.
+
+    Loads cross-encoder models via transformers + MLX (safetensors weights).
+    Scores (query, document) pairs using the adapter contract for
+    family-specific tokenization, score extraction, and normalization.
+
+    Supports token-budget batching to avoid OOM on large document lists.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        token_budget: int = 4096,
+        max_concurrency: int = 1,
+    ):
+        self.model_name = model_name
+        self.token_budget = token_budget
+        self.max_concurrency = max_concurrency
+        self._model = None
+        self._tokenizer = None
+        self._adapter: RerankAdapter | None = None
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def load(self) -> None:
+        """
+        Load the cross-encoder model and tokenizer.
+
+        Uses transformers AutoTokenizer and loads MLX weights from safetensors
+        via the model's from_pretrained or equivalent MLX loading path.
+        """
+        from transformers import AutoTokenizer
+
+        logger.info(f"Loading reranker model: {self.model_name}")
+        start = time.perf_counter()
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self._model = self._load_mlx_model(self.model_name)
+        self._adapter = get_adapter(self.model_name)
+
+        elapsed = time.perf_counter() - start
+        logger.info(f"Reranker model loaded in {elapsed:.2f}s: {self.model_name}")
+
+    @staticmethod
+    def _load_mlx_model(model_name: str):
+        """
+        Load an MLX cross-encoder model from HuggingFace Hub.
+
+        Attempts mlx-community weights first (safetensors), then falls back
+        to transformers AutoModelForSequenceClassification with MLX conversion.
+        """
+        try:
+            from huggingface_hub import snapshot_download
+            from safetensors import safe_open
+
+            model_path = snapshot_download(model_name)
+
+            import glob
+            import json
+            import os
+
+            # Load model config
+            config_path = os.path.join(model_path, "config.json")
+            with open(config_path) as f:
+                config = json.load(f)
+
+            # Load weights from safetensors
+            weight_files = glob.glob(os.path.join(model_path, "*.safetensors"))
+            if not weight_files:
+                raise FileNotFoundError(f"No safetensors files found in {model_path}")
+
+            weights = {}
+            for wf in weight_files:
+                with safe_open(wf, framework="numpy") as f:
+                    for key in f.keys():
+                        weights[key] = mx.array(f.get_tensor(key))
+
+            # Build model based on architecture
+            model_type = config.get("model_type", "")
+            num_labels = config.get("num_labels", 1)
+
+            model = _build_classifier_model(model_type, config, weights, num_labels)
+            mx.eval(model.parameters())
+            return model
+
+        except Exception as e:
+            logger.error(f"Failed to load reranker model: {e}")
+            raise
+
+    def _ensure_loaded(self) -> None:
+        if not self.is_loaded:
+            self.load()
+
+    def score_pairs(self, query: str, documents: list[str]) -> list[float]:
+        """
+        Score each (query, document) pair and return normalized relevance scores.
+
+        Pairs are batched by token budget to control memory usage. Each batch
+        is tokenized together and scored in a single forward pass.
+
+        Args:
+            query: The query string.
+            documents: List of document strings.
+
+        Returns:
+            List of normalized relevance scores, one per document,
+            in the same order as the input documents.
+        """
+        self._ensure_loaded()
+
+        # Tokenize each pair individually to measure token counts
+        pair_encodings = []
+        pair_token_counts = []
+        for doc in documents:
+            enc = self._adapter.tokenize_pair(self._tokenizer, query, doc)
+            pair_encodings.append(enc)
+            seq_len = (
+                len(enc["input_ids"][0])
+                if hasattr(enc["input_ids"][0], "__len__")
+                else enc["input_ids"].shape[1]
+            )
+            pair_token_counts.append(seq_len)
+
+        # Build batches by token budget
+        batches = []
+        current_batch = []
+        current_tokens = 0
+        for i, (enc, tok_count) in enumerate(zip(pair_encodings, pair_token_counts)):
+            if current_batch and current_tokens + tok_count > self.token_budget:
+                batches.append(current_batch)
+                current_batch = []
+                current_tokens = 0
+            current_batch.append((i, enc))
+            current_tokens += tok_count
+        if current_batch:
+            batches.append(current_batch)
+
+        # Score each batch
+        all_scores: list[tuple[int, float]] = []
+        for batch in batches:
+            if len(batch) == 1:
+                # Single pair — use encoding directly
+                idx, enc = batch[0]
+                input_ids = mx.array(enc["input_ids"])
+                attention_mask = mx.array(enc["attention_mask"])
+            else:
+                # Pad and stack multiple pairs
+                max_len = max(
+                    (
+                        len(enc["input_ids"][0])
+                        if hasattr(enc["input_ids"][0], "__len__")
+                        else enc["input_ids"].shape[1]
+                    )
+                    for _, enc in batch
+                )
+                padded_ids = []
+                padded_mask = []
+                for _, enc in batch:
+                    raw_ids = enc["input_ids"][0]
+                    ids = (
+                        raw_ids.tolist()
+                        if hasattr(raw_ids, "tolist")
+                        else list(raw_ids)
+                    )
+                    raw_mask = enc["attention_mask"][0]
+                    mask = (
+                        raw_mask.tolist()
+                        if hasattr(raw_mask, "tolist")
+                        else list(raw_mask)
+                    )
+                    pad_len = max_len - len(ids)
+                    padded_ids.append(ids + [0] * pad_len)
+                    padded_mask.append(mask + [0] * pad_len)
+                input_ids = mx.array(padded_ids)
+                attention_mask = mx.array(padded_mask)
+
+            output = self._model(input_ids, attention_mask=attention_mask)
+            logits_list = output.logits.tolist()
+
+            for j, (idx, _enc) in enumerate(batch):
+                logits_row = logits_list[j] if len(batch) > 1 else logits_list[0]
+                raw_score = self._adapter.extract_score(logits_row)
+                normalized = self._adapter.normalize(raw_score)
+                all_scores.append((idx, normalized))
+
+        # Sort by original index to restore input order
+        all_scores.sort(key=lambda x: x[0])
+        return [score for _, score in all_scores]
+
+    def count_tokens(self, query: str, documents: list[str]) -> int:
+        """
+        Count total tokens across all (query, document) pairs.
+
+        Used for usage reporting in the API response.
+        """
+        self._ensure_loaded()
+        total = 0
+        for doc in documents:
+            enc = self._tokenizer(query, doc)
+            ids = enc.get("input_ids", enc.get("input_ids", []))
+            if isinstance(ids, list) and ids and isinstance(ids[0], list):
+                total += len(ids[0])
+            elif isinstance(ids, list):
+                total += len(ids)
+            elif hasattr(ids, "shape"):
+                total += ids.shape[-1]
+            else:
+                total += max(1, (len(query) + len(doc)) // 4)
+        return total
+
+
+def _build_classifier_model(model_type, config, weights, num_labels):
+    """
+    Build an MLX sequence classification model from config and weights.
+
+    This is a thin wrapper that constructs the appropriate encoder
+    architecture with a classification head on top.
+    """
+    # Import here to avoid top-level dependency on specific model implementations
+    return _MLXClassifierWrapper(config, weights, num_labels)
+
+
+class _MLXClassifierWrapper:
+    """
+    Minimal MLX wrapper for sequence classification models.
+
+    Wraps loaded safetensors weights into a callable that returns
+    logits for (input_ids, attention_mask) pairs. Supports BERT-family
+    and XLM-RoBERTa-family architectures commonly used as cross-encoders.
+    """
+
+    def __init__(self, config: dict, weights: dict, num_labels: int):
+        self.config = config
+        self.weights = weights
+        self.num_labels = num_labels
+        self._params = list(weights.values())
+
+    def parameters(self):
+        """Return model parameters for mx.eval."""
+        return self._params
+
+    def __call__(self, input_ids: mx.array, attention_mask: mx.array = None):
+        """
+        Forward pass through the classifier.
+
+        For encoder-only cross-encoders, this runs the full transformer
+        encoder and classification head. The exact layer wiring depends
+        on the model architecture.
+
+        This initial implementation uses a weight-lookup forward pass
+        that works for standard BERT/XLM-RoBERTa classifiers. For
+        models with non-standard architectures, register a custom
+        adapter via _ADAPTER_REGISTRY.
+        """
+        # Use the transformers-style weight naming convention
+        # to walk through embeddings -> encoder layers -> classifier
+        from vllm_mlx.rerank_forward import classifier_forward
+
+        logits = classifier_forward(
+            input_ids, attention_mask, self.weights, self.config
+        )
+        return _ClassifierOutput(logits=logits)
+
+
+class _ClassifierOutput:
+    """Simple container for classifier output logits."""
+
+    def __init__(self, logits: mx.array):
+        self.logits = logits

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reranker engine for cross-encoder models.
+
+Provides a dedicated RerankEngine with adapter-based scoring for the
+OpenAI/Jina-compatible /v1/rerank endpoint. Cross-encoder models use
+AutoModelForSequenceClassification-style loading, not mlx_lm.load.
+"""
+
+import logging
+import math
+import time
+from abc import ABC, abstractmethod
+
+import mlx.core as mx
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Adapter contract
+# =============================================================================
+
+
+class RerankAdapter(ABC):
+    """
+    Per-family adapter for reranker models.
+
+    Different cross-encoder families use different tokenization patterns,
+    score extraction logic, and normalization functions. This contract
+    isolates those differences so RerankEngine stays family-agnostic.
+    """
+
+    @abstractmethod
+    def tokenize_pair(self, tokenizer, query: str, document: str) -> dict:
+        """
+        Tokenize a (query, document) pair for the cross-encoder.
+
+        Args:
+            tokenizer: The HuggingFace tokenizer instance.
+            query: The query string.
+            document: The document string.
+
+        Returns:
+            Dict with 'input_ids' and 'attention_mask' as numpy arrays.
+        """
+        ...
+
+    @abstractmethod
+    def extract_score(self, logits) -> float:
+        """
+        Extract a raw relevance score from model output logits.
+
+        Args:
+            logits: Model output logits (list or array), shape varies by model.
+
+        Returns:
+            A single float raw score.
+        """
+        ...
+
+    @abstractmethod
+    def normalize(self, raw_score: float) -> float:
+        """
+        Normalize a raw score to [0, 1] range.
+
+        Args:
+            raw_score: The raw score from extract_score().
+
+        Returns:
+            Normalized relevance score in [0, 1].
+        """
+        ...
+
+
+class SigmoidAdapter(RerankAdapter):
+    """
+    Default adapter for single-logit sigmoid rerankers.
+
+    Works with Jina Reranker v2, BGE Reranker v2, and MS-MARCO MiniLM
+    families. These models output a single relevance logit at position 0,
+    normalized via sigmoid.
+    """
+
+    def tokenize_pair(self, tokenizer, query: str, document: str) -> dict:
+        """Tokenize as a sentence pair (query, document)."""
+        return tokenizer(
+            query,
+            document,
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="np",
+        )
+
+    def extract_score(self, logits) -> float:
+        """Extract the first logit as the relevance score."""
+        return float(logits[0])
+
+    def normalize(self, raw_score: float) -> float:
+        """Apply sigmoid normalization."""
+        return 1.0 / (1.0 + math.exp(-raw_score))

--- a/vllm_mlx/rerank_forward.py
+++ b/vllm_mlx/rerank_forward.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLX forward pass for BERT-family sequence classification models.
+
+Implements a from-weights forward pass for cross-encoder rerankers
+that use the standard BERT/XLM-RoBERTa architecture with a
+classification head. This avoids pulling in the full transformers
+modeling stack at inference time — only the tokenizer is needed
+from transformers.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def classifier_forward(
+    input_ids: mx.array,
+    attention_mask: mx.array,
+    weights: dict[str, mx.array],
+    config: dict,
+) -> mx.array:
+    """
+    Run a BERT-family classifier forward pass on MLX.
+
+    Args:
+        input_ids: (batch, seq_len) token IDs.
+        attention_mask: (batch, seq_len) attention mask (1=attend, 0=pad).
+        weights: Dict mapping weight name -> mx.array.
+        config: Model config dict (from config.json).
+
+    Returns:
+        logits: (batch, num_labels) classification logits.
+    """
+    hidden_size = config["hidden_size"]
+    num_heads = config["num_attention_heads"]
+    num_layers = config["num_hidden_layers"]
+    num_labels = config.get("num_labels", 1)
+    eps = config.get("layer_norm_eps", 1e-12)
+
+    head_dim = hidden_size // num_heads
+
+    # Detect weight prefix (bert.* vs roberta.* vs xlm-roberta.*)
+    prefix = _detect_prefix(weights)
+
+    # --- Embeddings ---
+    word_emb = weights[f"{prefix}.embeddings.word_embeddings.weight"]
+    pos_emb = weights[f"{prefix}.embeddings.position_embeddings.weight"]
+    tok_type_emb = weights[f"{prefix}.embeddings.token_type_embeddings.weight"]
+    ln_w = weights[f"{prefix}.embeddings.LayerNorm.weight"]
+    ln_b = weights[f"{prefix}.embeddings.LayerNorm.bias"]
+
+    batch_size, seq_len = input_ids.shape
+    position_ids = mx.arange(seq_len)[None, :]  # (1, seq_len)
+    token_type_ids = mx.zeros_like(input_ids)
+
+    hidden = word_emb[input_ids] + pos_emb[position_ids] + tok_type_emb[token_type_ids]
+    hidden = _layer_norm(hidden, ln_w, ln_b, eps)
+
+    # --- Encoder layers ---
+    # Build causal-free attention mask: (batch, 1, 1, seq_len)
+    if attention_mask is not None:
+        ext_mask = attention_mask[:, None, None, :].astype(mx.float32)
+        ext_mask = (1.0 - ext_mask) * -1e9
+    else:
+        ext_mask = None
+
+    for i in range(num_layers):
+        lp = f"{prefix}.encoder.layer.{i}"
+        hidden = _encoder_layer(
+            hidden, ext_mask, weights, lp, num_heads, head_dim, eps, config
+        )
+
+    # --- Pooler (CLS token) ---
+    cls_hidden = hidden[:, 0, :]  # (batch, hidden_size)
+    pooler_w = weights.get(f"{prefix}.pooler.dense.weight")
+    pooler_b = weights.get(f"{prefix}.pooler.dense.bias")
+    if pooler_w is not None:
+        pooled = mx.tanh(cls_hidden @ pooler_w.T + pooler_b)
+    else:
+        pooled = cls_hidden
+
+    # --- Classifier head ---
+    clf_w = weights["classifier.weight"]
+    clf_b = weights["classifier.bias"]
+    logits = pooled @ clf_w.T + clf_b  # (batch, num_labels)
+
+    return logits
+
+
+def _detect_prefix(weights: dict) -> str:
+    """Detect the model weight prefix (bert, roberta, xlm-roberta)."""
+    for key in weights:
+        if key.startswith("bert."):
+            return "bert"
+        if key.startswith("roberta."):
+            return "roberta"
+        if key.startswith("xlm-roberta."):
+            return "xlm-roberta"
+    # Default to bert
+    return "bert"
+
+
+def _layer_norm(x: mx.array, weight: mx.array, bias: mx.array, eps: float) -> mx.array:
+    """Apply layer normalization."""
+    mean = mx.mean(x, axis=-1, keepdims=True)
+    var = mx.var(x, axis=-1, keepdims=True)
+    return weight * (x - mean) / mx.sqrt(var + eps) + bias
+
+
+def _encoder_layer(
+    hidden: mx.array,
+    ext_mask: mx.array | None,
+    weights: dict,
+    prefix: str,
+    num_heads: int,
+    head_dim: int,
+    eps: float,
+    config: dict,
+) -> mx.array:
+    """Run one BERT encoder layer (self-attention + FFN)."""
+    hidden_size = num_heads * head_dim
+
+    # --- Self-attention ---
+    q_w = weights[f"{prefix}.attention.self.query.weight"]
+    q_b = weights[f"{prefix}.attention.self.query.bias"]
+    k_w = weights[f"{prefix}.attention.self.key.weight"]
+    k_b = weights[f"{prefix}.attention.self.key.bias"]
+    v_w = weights[f"{prefix}.attention.self.value.weight"]
+    v_b = weights[f"{prefix}.attention.self.value.bias"]
+
+    batch_size, seq_len, _ = hidden.shape
+
+    q = (
+        (hidden @ q_w.T + q_b)
+        .reshape(batch_size, seq_len, num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    k = (
+        (hidden @ k_w.T + k_b)
+        .reshape(batch_size, seq_len, num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+    v = (
+        (hidden @ v_w.T + v_b)
+        .reshape(batch_size, seq_len, num_heads, head_dim)
+        .transpose(0, 2, 1, 3)
+    )
+
+    scale = head_dim**-0.5
+    attn_scores = (q @ k.transpose(0, 1, 3, 2)) * scale  # (batch, heads, seq, seq)
+
+    if ext_mask is not None:
+        attn_scores = attn_scores + ext_mask
+
+    attn_probs = mx.softmax(attn_scores, axis=-1)
+    attn_out = (
+        (attn_probs @ v).transpose(0, 2, 1, 3).reshape(batch_size, seq_len, hidden_size)
+    )
+
+    # Attention output projection + residual + LayerNorm
+    ao_w = weights[f"{prefix}.attention.output.dense.weight"]
+    ao_b = weights[f"{prefix}.attention.output.dense.bias"]
+    ao_ln_w = weights[f"{prefix}.attention.output.LayerNorm.weight"]
+    ao_ln_b = weights[f"{prefix}.attention.output.LayerNorm.bias"]
+
+    attn_out = attn_out @ ao_w.T + ao_b
+    hidden = _layer_norm(hidden + attn_out, ao_ln_w, ao_ln_b, eps)
+
+    # --- FFN ---
+    inter_w = weights[f"{prefix}.intermediate.dense.weight"]
+    inter_b = weights[f"{prefix}.intermediate.dense.bias"]
+    out_w = weights[f"{prefix}.output.dense.weight"]
+    out_b = weights[f"{prefix}.output.dense.bias"]
+    out_ln_w = weights[f"{prefix}.output.LayerNorm.weight"]
+    out_ln_b = weights[f"{prefix}.output.LayerNorm.bias"]
+
+    intermediate = hidden @ inter_w.T + inter_b
+    intermediate = _gelu(intermediate)
+    ffn_out = intermediate @ out_w.T + out_b
+    hidden = _layer_norm(hidden + ffn_out, out_ln_w, out_ln_b, eps)
+
+    return hidden
+
+
+def _gelu(x: mx.array) -> mx.array:
+    """GELU activation (exact form)."""
+    return nn.gelu(x)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -950,6 +950,10 @@ async def rerank_documents(request: RerankRequest) -> RerankResponse:
                 ),
             )
 
+        # Validate query
+        if not request.query or not request.query.strip():
+            raise HTTPException(status_code=400, detail="Query must not be empty")
+
         # Validate documents
         if not request.documents:
             raise HTTPException(
@@ -966,13 +970,14 @@ async def rerank_documents(request: RerankRequest) -> RerankResponse:
                 ),
             )
 
-        # Lazy-load or swap reranker engine
-        load_reranker_model(model_name, lock=False, reuse_existing=True)
-
+        # Require --rerank-model at startup; no unconstrained lazy loading
         if _rerank_engine is None:
             raise HTTPException(
-                status_code=503,
-                detail="Reranker engine failed to load. Check server logs.",
+                status_code=404,
+                detail=(
+                    "No reranker model loaded. Start the server with "
+                    "--rerank-model to enable the /v1/rerank endpoint."
+                ),
             )
 
         # Extract text from documents (handle both string and object formats)
@@ -996,11 +1001,16 @@ async def rerank_documents(request: RerankRequest) -> RerankResponse:
 
         start_time = time.perf_counter()
 
-        # Count tokens for usage reporting
-        total_tokens = _rerank_engine.count_tokens(request.query, doc_texts)
+        # Run scoring off the event loop with concurrency limit
+        import asyncio
 
-        # Score all pairs
-        scores = _rerank_engine.score_pairs(request.query, doc_texts)
+        async with _rerank_engine._semaphore:
+            total_tokens = await asyncio.to_thread(
+                _rerank_engine.count_tokens, request.query, doc_texts
+            )
+            scores = await asyncio.to_thread(
+                _rerank_engine.score_pairs, request.query, doc_texts
+            )
 
         elapsed = time.perf_counter() - start_time
         logger.info(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1001,14 +1001,13 @@ async def rerank_documents(request: RerankRequest) -> RerankResponse:
 
         start_time = time.perf_counter()
 
-        # Run scoring off the event loop with concurrency limit
+        # Run scoring off the event loop with concurrency limit.
+        # score_pairs returns (scores, total_tokens) from the same
+        # tokenization pass used for scoring — no double tokenization.
         import asyncio
 
         async with _rerank_engine._semaphore:
-            total_tokens = await asyncio.to_thread(
-                _rerank_engine.count_tokens, request.query, doc_texts
-            )
-            scores = await asyncio.to_thread(
+            scores, total_tokens = await asyncio.to_thread(
                 _rerank_engine.score_pairs, request.query, doc_texts
             )
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -92,6 +92,10 @@ from .api.models import (
     Message,  # noqa: F401
     ModelInfo,  # noqa: F401
     ModelsResponse,
+    RerankRequest,
+    RerankResponse,
+    RerankResult,
+    RerankUsage,
     ToolCall,
     Usage,  # noqa: F401
     VideoUrl,  # noqa: F401
@@ -154,6 +158,10 @@ _mcp_executor = None
 # Global embedding engine (lazy loaded)
 _embedding_engine = None
 _embedding_model_locked: str | None = None  # Set when --embedding-model is used
+
+# Global reranker engine (lazy loaded)
+_rerank_engine = None
+_rerank_model_locked: str | None = None  # Set when --rerank-model is used
 
 # API key authentication
 _api_key: str | None = None
@@ -545,6 +553,34 @@ def load_embedding_model(
     _embedding_engine.load()
 
 
+def load_reranker_model(
+    model_name: str | None,
+    *,
+    lock: bool = False,
+    reuse_existing: bool = True,
+) -> None:
+    """Load or reuse the reranker model engine when configured."""
+    global _rerank_engine, _rerank_model_locked
+
+    if not model_name:
+        return
+
+    if lock:
+        _rerank_model_locked = model_name
+
+    if (
+        reuse_existing
+        and _rerank_engine is not None
+        and _rerank_engine.model_name == model_name
+    ):
+        return
+
+    from .rerank import RerankEngine
+
+    _rerank_engine = RerankEngine(model_name)
+    _rerank_engine.load()
+
+
 def load_model(
     model_name: str,
     use_batching: bool = False,
@@ -743,6 +779,14 @@ async def list_models() -> ModelsResponse:
     models = []
     if _model_name:
         models.append(ModelInfo(id=_model_name))
+    if _embedding_engine is not None:
+        models.append(
+            ModelInfo(id=_embedding_engine.model_name, owned_by="vllm-mlx-embedding")
+        )
+    if _rerank_engine is not None:
+        models.append(
+            ModelInfo(id=_rerank_engine.model_name, owned_by="vllm-mlx-reranker")
+        )
     return ModelsResponse(data=models)
 
 
@@ -869,6 +913,127 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
         raise
     except Exception as e:
         logger.error(f"Embedding generation failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# =============================================================================
+# Reranking Endpoint
+# =============================================================================
+
+
+@app.post(
+    "/v1/rerank",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
+async def rerank_documents(request: RerankRequest) -> RerankResponse:
+    """
+    Rerank documents against a query using a cross-encoder model.
+
+    Jina/Cohere-compatible reranking API. Accepts a query and a list of
+    documents (strings or {text: ...} objects), returns results sorted
+    by relevance score descending.
+    """
+    global _rerank_engine
+
+    try:
+        model_name = request.model
+
+        # If a reranker model was pre-configured at startup, only allow that model
+        if _rerank_model_locked is not None and model_name != _rerank_model_locked:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Reranker model '{model_name}' is not available. "
+                    f"This server was started with --rerank-model {_rerank_model_locked}. "
+                    f"Only '{_rerank_model_locked}' can be used for reranking. "
+                    f"Restart the server with a different --rerank-model to use '{model_name}'."
+                ),
+            )
+
+        # Validate documents
+        if not request.documents:
+            raise HTTPException(
+                status_code=400, detail="Documents list must not be empty"
+            )
+
+        # Validate top_n
+        if request.top_n is not None and request.top_n > len(request.documents):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"top_n ({request.top_n}) must not exceed the number of "
+                    f"documents ({len(request.documents)})"
+                ),
+            )
+
+        # Lazy-load or swap reranker engine
+        load_reranker_model(model_name, lock=False, reuse_existing=True)
+
+        if _rerank_engine is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Reranker engine failed to load. Check server logs.",
+            )
+
+        # Extract text from documents (handle both string and object formats)
+        doc_texts = []
+        original_docs = []
+        for doc in request.documents:
+            if isinstance(doc, str):
+                doc_texts.append(doc)
+                original_docs.append({"text": doc})
+            elif isinstance(doc, dict) and "text" in doc:
+                doc_texts.append(doc["text"])
+                original_docs.append(doc)
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Each document must be a string or an object with a 'text' field. "
+                        f"Got: {type(doc).__name__}"
+                    ),
+                )
+
+        start_time = time.perf_counter()
+
+        # Count tokens for usage reporting
+        total_tokens = _rerank_engine.count_tokens(request.query, doc_texts)
+
+        # Score all pairs
+        scores = _rerank_engine.score_pairs(request.query, doc_texts)
+
+        elapsed = time.perf_counter() - start_time
+        logger.info(
+            f"Rerank: {len(doc_texts)} documents, {total_tokens} tokens in {elapsed:.2f}s"
+        )
+
+        # Build results with original index and optional document
+        results = []
+        for i, score in enumerate(scores):
+            result = RerankResult(
+                index=i,
+                relevance_score=score,
+                document=original_docs[i] if request.return_documents else None,
+            )
+            results.append(result)
+
+        # Sort by relevance score descending
+        results.sort(key=lambda r: r.relevance_score, reverse=True)
+
+        # Apply top_n limit
+        if request.top_n is not None:
+            results = results[: request.top_n]
+
+        return RerankResponse(
+            model=model_name,
+            results=results,
+            usage=RerankUsage(total_tokens=total_tokens),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Reranking failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 


### PR DESCRIPTION
## Summary

- Add `/v1/rerank` endpoint following Jina/Cohere API convention
- Dedicated `RerankEngine` module (`vllm_mlx/rerank.py`) — separate from the chat engine
- Adapter contract (`RerankAdapter` ABC) for per-model-family tokenization, score extraction, and normalization
- `SigmoidAdapter` default for Jina Reranker v2, BGE Reranker v2, MS-MARCO MiniLM families
- MLX-native BERT/RoBERTa classifier forward pass (`vllm_mlx/rerank_forward.py`) — no transformers modeling stack at inference
- Token-budget batching (not fixed document count) with `asyncio.to_thread` for non-blocking scoring
- Concurrency semaphore prevents rerank bursts from monopolizing chat latency
- Preserves caller metadata when documents are `{text: ..., ...}` objects
- Reranker model listed in `/v1/models` with explicit `owned_by: vllm-mlx-reranker`
- `--rerank-model` CLI flag matching the existing `--embedding-model` pattern
- 404 when no reranker model configured (no unconstrained lazy loading)

## API

```
POST /v1/rerank
{
  "model": "mlx-community/jina-reranker-v2-base-multilingual",
  "query": "What is deep learning?",
  "documents": ["doc1", "doc2", {"text": "doc3", "id": "custom"}],
  "top_n": 2,
  "return_documents": true
}
```

## Test plan

- [x] `python -m pytest tests/test_rerank.py -v` — 32 tests pass
- [x] `python -m pytest tests/test_server.py tests/test_embeddings.py` — no regressions
- [x] `python -m black --check` — all files clean
- [ ] Manual smoke test with `mlx-community/jina-reranker-v2-base-multilingual` (optional)