### PR TITLE
feat: SSD KV cache tiering with async promote

### DIFF
--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -204,11 +204,9 @@ class TestSSDIndex:
         assert lru[0]["file_path"] == "b.safetensors"
 
 
-import tempfile
 import numpy as np
 
 from vllm_mlx.ssd_cache import (
-    LayerSerializer,
     KVCacheSerializer,
     ArraysCacheSerializer,
     get_serializer_for_layer,

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -710,3 +710,24 @@ class TestCapacityManagement:
         # The orphaned index entry should have been removed
         assert tier2._index.lookup_exact(tokens) is None
         tier2.close()
+
+
+class TestCLIIntegration:
+    """Tests for CLI argument parsing of SSD cache flags."""
+
+    def test_scheduler_config_has_ssd_fields(self):
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        config = SchedulerConfig()
+        assert config.ssd_cache_dir is None
+        assert config.ssd_cache_max_gb == 10.0
+
+    def test_scheduler_config_custom_ssd(self):
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        config = SchedulerConfig(
+            ssd_cache_dir="/tmp/test-ssd",
+            ssd_cache_max_gb=5.0,
+        )
+        assert config.ssd_cache_dir == "/tmp/test-ssd"
+        assert config.ssd_cache_max_gb == 5.0

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -309,3 +309,60 @@ class TestLayerSerializer:
     def test_get_serializer_unknown_raises(self):
         with pytest.raises(ValueError, match="Unsupported"):
             get_serializer_for_layer("not a cache layer")
+
+
+from vllm_mlx.ssd_cache import SSDCacheTier
+
+
+class TestSSDCacheTierCore:
+    """Tests for SSDCacheTier initialization and directory setup."""
+
+    def test_init_creates_directory(self, tmp_path):
+        cache_dir = str(tmp_path / "ssd_tier_test")
+        config = SSDCacheConfig(cache_dir=cache_dir)
+        tier = SSDCacheTier(config)
+        try:
+            assert os.path.isdir(cache_dir)
+            assert os.path.exists(os.path.join(cache_dir, "data"))
+            assert os.path.exists(os.path.join(cache_dir, "index.db"))
+        finally:
+            tier.close()
+
+    def test_dir_permissions(self, tmp_path):
+        cache_dir = str(tmp_path / "ssd_tier_perms")
+        config = SSDCacheConfig(cache_dir=cache_dir, dir_permissions=0o700)
+        tier = SSDCacheTier(config)
+        try:
+            stat = os.stat(os.path.join(cache_dir, "data"))
+            # Check owner permissions (at least rwx for owner)
+            assert stat.st_mode & 0o700 == 0o700
+        finally:
+            tier.close()
+
+    def test_entry_hash_deterministic(self):
+        tokens = (1, 2, 3, 4, 5)
+        h1 = SSDCacheTier._entry_hash(tokens)
+        h2 = SSDCacheTier._entry_hash(tokens)
+        assert h1 == h2
+        assert len(h1) == 64  # SHA-256 hex digest
+
+    def test_entry_hash_different_for_different_tokens(self):
+        h1 = SSDCacheTier._entry_hash((1, 2, 3))
+        h2 = SSDCacheTier._entry_hash((1, 2, 4))
+        assert h1 != h2
+
+    def test_stats_initial(self, tmp_path):
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "stats_test"))
+        tier = SSDCacheTier(config)
+        try:
+            stats = tier.get_stats()
+            assert stats["spill_count"] == 0
+            assert stats["ssd_hits"] == 0
+        finally:
+            tier.close()
+
+    def test_close_idempotent(self, tmp_path):
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "close_test"))
+        tier = SSDCacheTier(config)
+        tier.close()
+        tier.close()  # Should not raise

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -446,3 +446,65 @@ class TestAsyncSpillWriter:
         # Queue should be at capacity, not have raised
         assert tier._spill_queue.qsize() <= 2
         tier.close()
+
+
+from unittest.mock import MagicMock
+from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+
+class MockKVCacheForSpill:
+    """Mock KVCache with keys, values, offset for memory estimation."""
+
+    def __init__(self, size_bytes: int):
+        # Use real numpy arrays so serialization works
+        self.keys = MockMLXArray(np.zeros((1, 4, 8, 16), dtype=np.float16))
+        self.values = MockMLXArray(np.zeros((1, 4, 8, 16), dtype=np.float16))
+        self.offset = 8
+
+
+class TestSpillPath:
+    """Tests for eviction -> SSD spill integration."""
+
+    def test_evict_lru_calls_ssd_spill(self, tmp_path):
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=3)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "spill_test"))
+        ssd_tier = SSDCacheTier(ssd_config)
+        ssd_tier.start_writer()
+        cache.set_ssd_tier(ssd_tier)
+
+        # Fill cache to capacity (3 entries)
+        for i in range(3):
+            kv = [MockKVCacheForSpill(1000)]
+            cache.store(list(range(i * 10, (i + 1) * 10)), kv)
+
+        assert len(cache) == 3
+
+        # Store one more to trigger eviction
+        kv = [MockKVCacheForSpill(1000)]
+        cache.store(list(range(100, 110)), kv)
+
+        # Wait for spill
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if ssd_tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        assert ssd_tier._stats.spill_count >= 1
+        ssd_tier.close()
+
+    def test_evict_without_ssd_tier_still_works(self):
+        """Eviction without SSD tier should work as before (discard)."""
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        for i in range(5):
+            kv = [MockKVCacheForSpill(1000)]
+            cache.store(list(range(i * 10, (i + 1) * 10)), kv)
+
+        # Should not raise, just discard
+        assert len(cache) <= 2

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -508,3 +508,124 @@ class TestSpillPath:
 
         # Should not raise, just discard
         assert len(cache) <= 2
+
+
+import asyncio
+
+
+class TestAsyncFetchPath:
+    """Tests for async SSD fetch with RAM budget reservation."""
+
+    @pytest.fixture
+    def populated_tier(self, tmp_path):
+        """Create an SSD tier with one pre-written entry."""
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "fetch_test"))
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+
+        tokens = (1, 2, 3, 4, 5)
+        keys = MockMLXArray(np.random.randn(1, 8, 16, 64).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 8, 16, 64).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=16)
+
+        tier.enqueue_spill(tokens, [layer], memory_bytes=2048)
+
+        # Wait for write
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        yield tier, tokens, keys, values
+        tier.close()
+
+    def test_lookup_ssd_returns_candidate(self, populated_tier):
+        tier, tokens, _, _ = populated_tier
+        candidate = tier.lookup_ssd(tokens)
+        assert candidate is not None
+        assert candidate["num_tokens"] == 5
+        assert candidate["memory_bytes"] == 2048
+
+    def test_lookup_ssd_miss(self, populated_tier):
+        tier, _, _, _ = populated_tier
+        candidate = tier.lookup_ssd((99, 98, 97))
+        assert candidate is None
+
+    def test_async_promote_reserves_budget_then_reads(self, populated_tier):
+        """RAM budget is reserved BEFORE the SSD read completes."""
+        tier, tokens, keys, values = populated_tier
+
+        budget_reserved = []
+        budget_released = []
+
+        def reserve_fn(nbytes):
+            budget_reserved.append(nbytes)
+            return True  # Budget available
+
+        def release_fn(nbytes):
+            budget_released.append(nbytes)
+
+        result = asyncio.get_event_loop().run_until_complete(
+            tier.async_promote(tokens, reserve_fn, release_fn)
+        )
+
+        # Budget was reserved
+        assert len(budget_reserved) == 1
+        assert budget_reserved[0] == 2048
+
+        # Result contains the cache layers
+        assert result is not None
+        assert len(result) == 1  # One layer
+
+        # Stats updated
+        assert tier._stats.ssd_hits == 1
+        assert tier._stats.reload_bytes > 0
+
+    def test_async_promote_budget_denied(self, populated_tier):
+        """When budget reservation fails, promote returns None."""
+        tier, tokens, _, _ = populated_tier
+
+        def reserve_fn(nbytes):
+            return False  # Budget denied
+
+        def release_fn(nbytes):
+            pass
+
+        result = asyncio.get_event_loop().run_until_complete(
+            tier.async_promote(tokens, reserve_fn, release_fn)
+        )
+
+        assert result is None
+        assert tier._stats.promotion_failures == 1
+
+    def test_async_promote_read_failure_releases_budget(self, populated_tier):
+        """If disk read fails after reservation, budget is released."""
+        tier, tokens, _, _ = populated_tier
+
+        budget_reserved = []
+        budget_released = []
+
+        def reserve_fn(nbytes):
+            budget_reserved.append(nbytes)
+            return True
+
+        def release_fn(nbytes):
+            budget_released.append(nbytes)
+
+        # Corrupt the entry on disk
+        entry_hash = tier._entry_hash(tokens)
+        entry_dir = os.path.join(tier._data_dir, entry_hash)
+        manifest_path = os.path.join(entry_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            f.write("corrupted!")
+
+        result = asyncio.get_event_loop().run_until_complete(
+            tier.async_promote(tokens, reserve_fn, release_fn)
+        )
+
+        assert result is None
+        # Budget was reserved then released
+        assert len(budget_reserved) == 1
+        assert len(budget_released) == 1
+        assert budget_released[0] == budget_reserved[0]

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -629,3 +629,84 @@ class TestAsyncFetchPath:
         assert len(budget_reserved) == 1
         assert len(budget_released) == 1
         assert budget_released[0] == budget_reserved[0]
+
+
+class TestCapacityManagement:
+    """Tests for SSD disk capacity management."""
+
+    @pytest.fixture
+    def small_tier(self, tmp_path):
+        """SSD tier with very small capacity for testing eviction."""
+        config = SSDCacheConfig(
+            cache_dir=str(tmp_path / "capacity_test"),
+            max_size_gb=0.0001,  # ~100KB
+            max_entries=3,
+        )
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+        yield tier
+        tier.close()
+
+    def _write_and_wait(self, tier, tokens, size=1024):
+        keys = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=8)
+        tier.enqueue_spill(tokens, [layer], memory_bytes=size)
+
+        deadline = time.monotonic() + 5.0
+        initial_count = tier._stats.spill_count
+        while time.monotonic() < deadline:
+            if tier._stats.spill_count > initial_count:
+                break
+            time.sleep(0.05)
+
+    def test_disk_lru_eviction(self, small_tier):
+        """When disk capacity is exceeded, oldest entries are evicted."""
+        # Fill with 3 entries (at max_entries limit)
+        for i in range(3):
+            self._write_and_wait(small_tier, tuple(range(i * 10, (i + 1) * 10)))
+
+        assert small_tier._index.get_entry_count() == 3
+
+        # Write one more — should trigger disk LRU eviction
+        self._write_and_wait(small_tier, (100, 101, 102))
+
+        # Should still be at or below max_entries
+        assert small_tier._index.get_entry_count() <= 3
+
+    def test_startup_reconciliation(self, tmp_path):
+        """On startup, index is reconciled with files on disk."""
+        cache_dir = str(tmp_path / "reconcile_test")
+        config = SSDCacheConfig(cache_dir=cache_dir)
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+
+        # Write an entry
+        tokens = (1, 2, 3)
+        keys = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=8)
+        tier.enqueue_spill(tokens, [layer], memory_bytes=1024)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        tier.close()
+
+        # Delete the data file but leave the index entry
+        entry_hash = SSDCacheTier._entry_hash(tokens)
+        entry_dir = os.path.join(cache_dir, "data", entry_hash)
+        import shutil
+
+        shutil.rmtree(entry_dir)
+
+        # Re-open — reconciliation should detect the missing file
+        tier2 = SSDCacheTier(config)
+        tier2.reconcile()
+
+        # The orphaned index entry should have been removed
+        assert tier2._index.lookup_exact(tokens) is None
+        tier2.close()

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -87,7 +87,6 @@ class TestSSDCacheStats:
 
 
 import os
-import tempfile
 
 from vllm_mlx.ssd_cache import SSDIndex
 

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -731,3 +731,66 @@ class TestCLIIntegration:
         )
         assert config.ssd_cache_dir == "/tmp/test-ssd"
         assert config.ssd_cache_max_gb == 5.0
+
+
+class TestMemoryCacheSSDCheck:
+    """Tests for MemoryAwarePrefixCache.check_ssd() method."""
+
+    def test_check_ssd_returns_candidate_on_miss(self, tmp_path):
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "check_ssd_test"))
+        ssd_tier = SSDCacheTier(ssd_config)
+        ssd_tier.start_writer()
+        cache.set_ssd_tier(ssd_tier)
+
+        # Write an entry to SSD directly
+        tokens = (1, 2, 3, 4, 5)
+        keys = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=8)
+        ssd_tier.enqueue_spill(tokens, [layer], memory_bytes=1024)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if ssd_tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        # RAM fetch should miss
+        result, remaining = cache.fetch(list(tokens))
+        assert result is None
+
+        # But SSD check should find it
+        candidate = cache.check_ssd(list(tokens))
+        assert candidate is not None
+        assert candidate["num_tokens"] == 5
+
+        ssd_tier.close()
+
+    def test_check_ssd_returns_none_without_tier(self):
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        candidate = cache.check_ssd([1, 2, 3])
+        assert candidate is None
+
+    def test_check_ssd_returns_none_on_ram_hit(self, tmp_path):
+        """When RAM has a hit, check_ssd should return None (not needed)."""
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1)
+        cache = MemoryAwarePrefixCache(model, config)
+
+        kv = [MockKVCacheForSpill(1000)]
+        cache.store([1, 2, 3], kv)
+
+        # RAM hit exists
+        result, _ = cache.fetch([1, 2, 3])
+        assert result is not None
+
+        # check_ssd should indicate no SSD needed
+        candidate = cache.check_ssd([1, 2, 3])
+        assert candidate is None

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -84,3 +84,121 @@ class TestSSDCacheStats:
         d = stats.to_dict()
         assert d["ssd_hit_rate"] == 0.0
         assert d["avg_reload_latency_ms"] == 0.0
+
+
+import os
+import tempfile
+
+from vllm_mlx.ssd_cache import SSDIndex
+
+
+class TestSSDIndex:
+    """Tests for SQLite-backed SSD cache index."""
+
+    @pytest.fixture
+    def db_dir(self, tmp_path):
+        return str(tmp_path / "ssd_index_test")
+
+    @pytest.fixture
+    def index(self, db_dir):
+        os.makedirs(db_dir, exist_ok=True)
+        idx = SSDIndex(db_dir)
+        yield idx
+        idx.close()
+
+    def test_create_opens_db(self, index, db_dir):
+        assert os.path.exists(os.path.join(db_dir, "index.db"))
+
+    def test_insert_and_lookup_exact(self, index):
+        tokens = (1, 2, 3, 4, 5)
+        index.insert_entry(
+            tokens_key=tokens,
+            file_path="entry_abc123.safetensors",
+            memory_bytes=4096,
+            num_tokens=5,
+        )
+        result = index.lookup_exact(tokens)
+        assert result is not None
+        assert result["file_path"] == "entry_abc123.safetensors"
+        assert result["memory_bytes"] == 4096
+        assert result["num_tokens"] == 5
+
+    def test_lookup_exact_miss(self, index):
+        result = index.lookup_exact((99, 98, 97))
+        assert result is None
+
+    def test_lookup_prefix(self, index):
+        # Insert a few entries
+        index.insert_entry((1, 2, 3), "a.safetensors", 1000, 3)
+        index.insert_entry((1, 2, 3, 4, 5), "b.safetensors", 2000, 5)
+        index.insert_entry((1, 2, 3, 4, 5, 6, 7), "c.safetensors", 3000, 7)
+        index.insert_entry((9, 8, 7), "d.safetensors", 1000, 3)
+
+        # Lookup prefix matches for (1,2,3,4,5,6,7,8)
+        results = index.lookup_prefix((1, 2, 3, 4, 5, 6, 7, 8))
+        # Should return entries whose tokens are a prefix of the query
+        file_paths = [r["file_path"] for r in results]
+        assert "a.safetensors" in file_paths
+        assert "b.safetensors" in file_paths
+        assert "c.safetensors" in file_paths
+        assert "d.safetensors" not in file_paths
+
+    def test_delete_entry(self, index):
+        tokens = (10, 20, 30)
+        index.insert_entry(tokens, "x.safetensors", 500, 3)
+        assert index.lookup_exact(tokens) is not None
+
+        index.delete_entry(tokens)
+        assert index.lookup_exact(tokens) is None
+
+    def test_get_lru(self, index):
+        import time
+
+        index.insert_entry((1,), "a.safetensors", 100, 1)
+        time.sleep(0.01)  # Ensure different timestamps
+        index.insert_entry((2,), "b.safetensors", 200, 1)
+        time.sleep(0.01)
+        index.insert_entry((3,), "c.safetensors", 300, 1)
+
+        # Get oldest 2 entries
+        lru = index.get_lru(limit=2)
+        assert len(lru) == 2
+        assert lru[0]["file_path"] == "a.safetensors"
+        assert lru[1]["file_path"] == "b.safetensors"
+
+    def test_get_total_bytes(self, index):
+        index.insert_entry((1,), "a.safetensors", 1000, 1)
+        index.insert_entry((2,), "b.safetensors", 2000, 1)
+        assert index.get_total_bytes() == 3000
+
+    def test_get_total_bytes_empty(self, index):
+        assert index.get_total_bytes() == 0
+
+    def test_get_entry_count(self, index):
+        assert index.get_entry_count() == 0
+        index.insert_entry((1,), "a.safetensors", 100, 1)
+        index.insert_entry((2,), "b.safetensors", 200, 1)
+        assert index.get_entry_count() == 2
+
+    def test_insert_duplicate_replaces(self, index):
+        tokens = (1, 2, 3)
+        index.insert_entry(tokens, "old.safetensors", 100, 3)
+        index.insert_entry(tokens, "new.safetensors", 200, 3)
+        result = index.lookup_exact(tokens)
+        assert result["file_path"] == "new.safetensors"
+        assert result["memory_bytes"] == 200
+        assert index.get_entry_count() == 1
+
+    def test_touch_updates_access_time(self, index):
+        import time
+
+        index.insert_entry((1,), "a.safetensors", 100, 1)
+        time.sleep(0.01)
+        index.insert_entry((2,), "b.safetensors", 100, 1)
+
+        # Touch the older entry
+        index.touch((1,))
+
+        # Now (2,) should be the LRU entry
+        lru = index.get_lru(limit=1)
+        assert lru[0]["file_path"] == "b.safetensors"

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SSD KV cache tiering."""
+
+import pytest
+
+from vllm_mlx.ssd_cache import SSDCacheConfig, SSDCacheStats
+
+
+class TestSSDCacheConfig:
+    """Tests for SSDCacheConfig."""
+
+    def test_default_config(self):
+        config = SSDCacheConfig()
+        assert config.cache_dir is None
+        assert config.max_size_gb == 10.0
+        assert config.max_entries == 10000
+        assert config.file_permissions == 0o600
+        assert config.dir_permissions == 0o700
+        assert config.spill_queue_size == 64
+        assert config.retention_seconds is None
+
+    def test_custom_config(self):
+        config = SSDCacheConfig(
+            cache_dir="/tmp/test-ssd-cache",
+            max_size_gb=5.0,
+            max_entries=500,
+        )
+        assert config.cache_dir == "/tmp/test-ssd-cache"
+        assert config.max_size_gb == 5.0
+        assert config.max_entries == 500
+
+    def test_max_size_bytes(self):
+        config = SSDCacheConfig(max_size_gb=2.0)
+        assert config.max_size_bytes == 2 * 1024 * 1024 * 1024
+
+    def test_invalid_max_size(self):
+        with pytest.raises(ValueError, match="max_size_gb"):
+            SSDCacheConfig(max_size_gb=0.0)
+
+    def test_invalid_max_entries(self):
+        with pytest.raises(ValueError, match="max_entries"):
+            SSDCacheConfig(max_entries=0)
+
+    def test_invalid_spill_queue_size(self):
+        with pytest.raises(ValueError, match="spill_queue_size"):
+            SSDCacheConfig(spill_queue_size=0)
+
+
+class TestSSDCacheStats:
+    """Tests for SSDCacheStats."""
+
+    def test_initial_stats(self):
+        stats = SSDCacheStats()
+        assert stats.spill_count == 0
+        assert stats.spill_bytes == 0
+        assert stats.ssd_hits == 0
+        assert stats.ssd_misses == 0
+        assert stats.reload_latency_sum == 0.0
+        assert stats.reload_bytes == 0
+        assert stats.promotion_failures == 0
+
+    def test_to_dict(self):
+        stats = SSDCacheStats(
+            spill_count=10,
+            spill_bytes=1024 * 1024,
+            ssd_hits=5,
+            ssd_misses=3,
+            reload_latency_sum=0.5,
+            reload_bytes=512 * 1024,
+            promotion_failures=1,
+        )
+        d = stats.to_dict()
+        assert d["spill_count"] == 10
+        assert d["spill_bytes"] == 1024 * 1024
+        assert d["ssd_hits"] == 5
+        assert d["ssd_misses"] == 3
+        assert d["reload_bytes"] == 512 * 1024
+        assert d["promotion_failures"] == 1
+        assert d["ssd_hit_rate"] == pytest.approx(5 / 8)
+        assert d["avg_reload_latency_ms"] == pytest.approx(100.0)
+
+    def test_hit_rate_no_lookups(self):
+        stats = SSDCacheStats()
+        d = stats.to_dict()
+        assert d["ssd_hit_rate"] == 0.0
+        assert d["avg_reload_latency_ms"] == 0.0

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -366,3 +366,83 @@ class TestSSDCacheTierCore:
         tier = SSDCacheTier(config)
         tier.close()
         tier.close()  # Should not raise
+
+
+import time
+
+
+class TestAsyncSpillWriter:
+    """Tests for the async spill writer thread."""
+
+    @pytest.fixture
+    def tier_with_writer(self, tmp_path):
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "writer_test"))
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+        yield tier
+        tier.close()
+
+    def test_spill_writes_entry_to_disk(self, tier_with_writer):
+        tokens = (1, 2, 3, 4, 5)
+        keys = MockMLXArray(np.random.randn(1, 8, 16, 64).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 8, 16, 64).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=16)
+        cache = [layer]
+
+        tier_with_writer.enqueue_spill(tokens, cache, memory_bytes=2048)
+
+        # Wait for async write to complete (with timeout)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if tier_with_writer._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        assert tier_with_writer._stats.spill_count == 1
+        assert tier_with_writer._stats.spill_bytes > 0
+
+        # Verify entry in index
+        result = tier_with_writer._index.lookup_exact(tokens)
+        assert result is not None
+        assert result["num_tokens"] == 5
+
+    def test_spill_atomic_write(self, tier_with_writer):
+        """Verify no partial files exist after spill."""
+        tokens = (10, 20, 30)
+        keys = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 4, 8, 32).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=8)
+
+        tier_with_writer.enqueue_spill(tokens, [layer], memory_bytes=1024)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if tier_with_writer._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        # Check that no .tmp files remain
+        data_dir = tier_with_writer._data_dir
+        for root, dirs, files in os.walk(data_dir):
+            for f in files:
+                assert not f.endswith(".tmp"), f"Temp file left behind: {f}"
+
+    def test_spill_queue_full_drops(self, tmp_path):
+        """When queue is full, new spills are dropped (not blocking)."""
+        config = SSDCacheConfig(
+            cache_dir=str(tmp_path / "queue_full_test"),
+            spill_queue_size=2,
+        )
+        tier = SSDCacheTier(config)
+        # Don't start writer — queue will fill up
+        keys = MockMLXArray(np.zeros((1, 1, 1, 1), dtype=np.float16))
+        values = MockMLXArray(np.zeros((1, 1, 1, 1), dtype=np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=1)
+
+        # Enqueue more than capacity
+        for i in range(5):
+            tier.enqueue_spill((i,), [layer], memory_bytes=100)
+
+        # Queue should be at capacity, not have raised
+        assert tier._spill_queue.qsize() <= 2
+        tier.close()

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -794,3 +794,182 @@ class TestMemoryCacheSSDCheck:
         # check_ssd should indicate no SSD needed
         candidate = cache.check_ssd([1, 2, 3])
         assert candidate is None
+
+
+class TestIntegrationSpillAndFetch:
+    """End-to-end tests: spill from RAM -> SSD -> promote back."""
+
+    @pytest.fixture
+    def cache_with_ssd(self, tmp_path):
+        """RAM cache + SSD tier, small limits to force eviction."""
+        model = MagicMock()
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        ram_cache = MemoryAwarePrefixCache(model, config)
+
+        ssd_config = SSDCacheConfig(
+            cache_dir=str(tmp_path / "integration_test"),
+            max_size_gb=1.0,
+        )
+        ssd_tier = SSDCacheTier(ssd_config)
+        ssd_tier.start_writer()
+        ram_cache.set_ssd_tier(ssd_tier)
+
+        yield ram_cache, ssd_tier
+        ssd_tier.close()
+
+    def _make_kv_layer(self, offset=16):
+        keys = MockMLXArray(np.random.randn(1, 8, offset, 64).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 8, offset, 64).astype(np.float16))
+        return MockKVCacheLayer(keys=keys, values=values, offset=offset)
+
+    def test_full_round_trip(self, cache_with_ssd):
+        """Store -> evict to SSD -> fetch miss in RAM -> find in SSD."""
+        ram_cache, ssd_tier = cache_with_ssd
+
+        # Store 2 entries (fills RAM cache)
+        tokens_a = list(range(0, 10))
+        tokens_b = list(range(10, 20))
+        ram_cache.store(tokens_a, [self._make_kv_layer()])
+        ram_cache.store(tokens_b, [self._make_kv_layer()])
+        assert len(ram_cache) == 2
+
+        # Store a third entry — should evict tokens_a to SSD
+        tokens_c = list(range(20, 30))
+        ram_cache.store(tokens_c, [self._make_kv_layer()])
+
+        # Wait for SSD spill
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if ssd_tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        assert ssd_tier._stats.spill_count >= 1
+
+        # RAM miss for tokens_a
+        result, remaining = ram_cache.fetch(tokens_a)
+        assert result is None
+
+        # SSD should have tokens_a
+        candidate = ram_cache.check_ssd(tokens_a)
+        assert candidate is not None
+
+        # Promote from SSD
+        async def do_promote():
+            return await ssd_tier.async_promote(
+                tuple(tokens_a),
+                lambda n: True,  # Budget always available
+                lambda n: None,
+            )
+
+        promoted = asyncio.get_event_loop().run_until_complete(do_promote())
+        assert promoted is not None
+        assert len(promoted) == 1  # One layer
+        assert ssd_tier._stats.ssd_hits == 1
+
+    def test_hybrid_cache_round_trip(self, tmp_path):
+        """ArraysCache layers survive SSD round-trip."""
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "hybrid_test"))
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+
+        tokens = (1, 2, 3)
+        arr0 = MockMLXArray(np.random.randn(1, 64, 128).astype(np.float16))
+        arr1 = MockMLXArray(np.random.randn(1, 64, 128).astype(np.float16))
+        layer = MockArraysCacheLayer(state=[arr0, arr1])
+
+        tier.enqueue_spill(tokens, [layer], memory_bytes=2048)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        async def do_promote():
+            return await tier.async_promote(
+                tokens,
+                lambda n: True,
+                lambda n: None,
+            )
+
+        promoted = asyncio.get_event_loop().run_until_complete(do_promote())
+        assert promoted is not None
+        assert len(promoted) == 1
+        assert "state" in promoted[0]
+        assert len(promoted[0]["state"]) == 2
+
+        # Verify data integrity
+        np.testing.assert_array_almost_equal(
+            np.array(promoted[0]["state"][0]),
+            np.array(arr0),
+        )
+
+        tier.close()
+
+    def test_capacity_eviction_end_to_end(self, tmp_path):
+        """Entries beyond max_entries are evicted from SSD."""
+        config = SSDCacheConfig(
+            cache_dir=str(tmp_path / "cap_e2e"),
+            max_entries=2,
+        )
+        tier = SSDCacheTier(config)
+        tier.start_writer()
+
+        for i in range(4):
+            tokens = tuple(range(i * 10, (i + 1) * 10))
+            layer = MockKVCacheLayer(
+                keys=MockMLXArray(np.zeros((1, 1, 1, 1), dtype=np.float16)),
+                values=MockMLXArray(np.zeros((1, 1, 1, 1), dtype=np.float16)),
+                offset=1,
+            )
+            tier.enqueue_spill(tokens, [layer], memory_bytes=100)
+
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if tier._stats.spill_count > i:
+                    break
+                time.sleep(0.05)
+
+        # Only max_entries (2) should remain
+        assert tier._index.get_entry_count() <= 2
+
+        # The latest entries should still be there
+        assert tier._index.lookup_exact(tuple(range(30, 40))) is not None
+
+        tier.close()
+
+    def test_metrics_accuracy(self, cache_with_ssd):
+        """Verify all SSD metrics are updated correctly."""
+        ram_cache, ssd_tier = cache_with_ssd
+
+        # Fill RAM and force one spill
+        ram_cache.store(list(range(10)), [self._make_kv_layer()])
+        ram_cache.store(list(range(10, 20)), [self._make_kv_layer()])
+        ram_cache.store(list(range(20, 30)), [self._make_kv_layer()])
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if ssd_tier._stats.spill_count > 0:
+                break
+            time.sleep(0.05)
+
+        stats = ssd_tier.get_stats()
+        assert stats["spill_count"] >= 1
+        assert stats["spill_bytes"] > 0
+
+        # Promote the spilled entry
+        evicted_tokens = tuple(range(10))  # First stored, first evicted
+        candidate = ssd_tier.lookup_ssd(evicted_tokens)
+        if candidate is not None:
+
+            async def promote():
+                return await ssd_tier.async_promote(
+                    evicted_tokens, lambda n: True, lambda n: None
+                )
+
+            asyncio.get_event_loop().run_until_complete(promote())
+            stats = ssd_tier.get_stats()
+            assert stats["ssd_hits"] >= 1
+            assert stats["reload_bytes"] > 0
+            assert stats["avg_reload_latency_ms"] > 0

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -202,3 +202,110 @@ class TestSSDIndex:
         # Now (2,) should be the LRU entry
         lru = index.get_lru(limit=1)
         assert lru[0]["file_path"] == "b.safetensors"
+
+
+import tempfile
+import numpy as np
+
+from vllm_mlx.ssd_cache import (
+    LayerSerializer,
+    KVCacheSerializer,
+    ArraysCacheSerializer,
+    get_serializer_for_layer,
+    SERIALIZER_SUPPORT_MATRIX,
+)
+
+
+class MockMLXArray:
+    """Minimal mock for MLX array with shape, dtype, and numpy conversion."""
+
+    def __init__(self, data):
+        self._data = np.array(data)
+        self.shape = self._data.shape
+        self.dtype = type("dtype", (), {"size": self._data.dtype.itemsize})()
+
+    def __array__(self):
+        return self._data
+
+
+class MockKVCacheLayer:
+    """Mock KVCache layer with keys, values, offset."""
+
+    def __init__(self, keys, values, offset):
+        self.keys = keys
+        self.values = values
+        self.offset = offset
+
+
+class MockArraysCacheLayer:
+    """Mock ArraysCache layer with state list."""
+
+    def __init__(self, state):
+        self.state = state
+
+
+class TestLayerSerializer:
+    """Tests for per-layer serializer interface."""
+
+    def test_support_matrix_has_required_types(self):
+        assert "KVCache" in SERIALIZER_SUPPORT_MATRIX
+        assert "RotatingKVCache" in SERIALIZER_SUPPORT_MATRIX
+        assert "ArraysCache" in SERIALIZER_SUPPORT_MATRIX
+
+    def test_kv_cache_serializer_round_trip(self, tmp_path):
+        keys = MockMLXArray(np.random.randn(1, 8, 32, 64).astype(np.float16))
+        values = MockMLXArray(np.random.randn(1, 8, 32, 64).astype(np.float16))
+        layer = MockKVCacheLayer(keys=keys, values=values, offset=32)
+
+        serializer = KVCacheSerializer()
+        file_path = str(tmp_path / "layer_0.safetensors")
+        metadata = serializer.serialize_layer(layer, 0, file_path)
+
+        assert os.path.exists(file_path)
+        assert metadata["layer_type"] == "KVCache"
+        assert metadata["offset"] == 32
+
+        restored = serializer.deserialize_layer(file_path, metadata)
+        assert restored["offset"] == 32
+        np.testing.assert_array_almost_equal(
+            np.array(restored["keys"]),
+            np.array(keys),
+        )
+        np.testing.assert_array_almost_equal(
+            np.array(restored["values"]),
+            np.array(values),
+        )
+
+    def test_arrays_cache_serializer_round_trip(self, tmp_path):
+        arr0 = MockMLXArray(np.random.randn(1, 64, 128).astype(np.float16))
+        arr1 = MockMLXArray(np.random.randn(1, 64, 128).astype(np.float16))
+        layer = MockArraysCacheLayer(state=[arr0, arr1])
+
+        serializer = ArraysCacheSerializer()
+        file_path = str(tmp_path / "layer_0.safetensors")
+        metadata = serializer.serialize_layer(layer, 0, file_path)
+
+        assert os.path.exists(file_path)
+        assert metadata["layer_type"] == "ArraysCache"
+        assert metadata["num_arrays"] == 2
+
+        restored = serializer.deserialize_layer(file_path, metadata)
+        assert len(restored["state"]) == 2
+        np.testing.assert_array_almost_equal(
+            np.array(restored["state"][0]),
+            np.array(arr0),
+        )
+
+    def test_get_serializer_for_kvcache(self):
+        layer = MockKVCacheLayer(keys=None, values=None, offset=0)
+        s = get_serializer_for_layer(layer)
+        assert isinstance(s, KVCacheSerializer)
+
+    def test_get_serializer_for_arrays_cache(self):
+        layer = MockArraysCacheLayer(state=[])
+        s = get_serializer_for_layer(layer)
+        assert isinstance(s, ArraysCacheSerializer)
+
+    def test_get_serializer_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unsupported"):
+            get_serializer_for_layer("not a cache layer")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -175,6 +175,9 @@ def serve_command(args):
             mllm_prefill_step_size=(
                 args.mllm_prefill_step_size if args.mllm_prefill_step_size > 0 else None
             ),
+            # SSD cache tiering
+            ssd_cache_dir=args.ssd_cache_dir,
+            ssd_cache_max_gb=args.ssd_cache_max_gb,
         )
 
         print("Mode: Continuous batching (for multiple concurrent users)")
@@ -737,6 +740,19 @@ Examples:
         type=int,
         default=256,
         help="Minimum tokens for quantization to apply (default: 256)",
+    )
+    # SSD cache tiering options
+    serve_parser.add_argument(
+        "--ssd-cache-dir",
+        type=str,
+        default=None,
+        help="Directory for SSD KV cache tier (default: disabled)",
+    )
+    serve_parser.add_argument(
+        "--ssd-cache-max-gb",
+        type=float,
+        default=10.0,
+        help="Maximum SSD cache size in GB (default: 10.0)",
     )
     serve_parser.add_argument(
         "--stream-interval",

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1015,6 +1015,33 @@ class MemoryAwarePrefixCache:
         if ssd_tier is not None:
             logger.info("[memory_cache] SSD tier attached for eviction spilling")
 
+    def check_ssd(self, tokens: list[int]) -> dict | None:
+        """Check if tokens have an SSD cache hit (without reading data).
+
+        Returns metadata dict if found in SSD tier, None if:
+        - No SSD tier attached
+        - Tokens are already in RAM cache
+        - Not found in SSD tier
+
+        This is a fast synchronous call (SQLite lookup only).
+        The actual data read happens via the scheduler's async handoff.
+        """
+        if self._ssd_tier is None:
+            return None
+
+        tokens_key = tuple(tokens)
+
+        # If already in RAM, no SSD needed
+        if tokens_key in self._entries:
+            return None
+
+        # Check SSD tier — exact match first, then prefix
+        candidate = self._ssd_tier.lookup_ssd(tokens_key)
+        if candidate is not None:
+            return candidate
+
+        return self._ssd_tier.lookup_ssd_prefix(tokens_key)
+
     # -----------------------------------------------------------------
     # Disk persistence — survives server restarts
     # -----------------------------------------------------------------

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1018,13 +1018,13 @@ class MemoryAwarePrefixCache:
     def check_ssd(self, tokens: list[int]) -> dict | None:
         """Check if tokens have an SSD cache hit (without reading data).
 
-        Returns metadata dict if found in SSD tier, None if:
-        - No SSD tier attached
-        - Tokens are already in RAM cache
-        - Not found in SSD tier
+        Returns metadata dict with 'match_type' ('exact' or 'prefix') if
+        found in SSD tier, None if not found. For prefix matches, the dict
+        also includes 'matched_tokens' (the count of tokens the SSD entry
+        covers).
 
         This is a fast synchronous call (SQLite lookup only).
-        The actual data read happens via the scheduler's async handoff.
+        The actual data read happens via the scheduler handoff.
         """
         if self._ssd_tier is None:
             return None
@@ -1038,9 +1038,17 @@ class MemoryAwarePrefixCache:
         # Check SSD tier — exact match first, then prefix
         candidate = self._ssd_tier.lookup_ssd(tokens_key)
         if candidate is not None:
+            candidate["match_type"] = "exact"
+            candidate["matched_tokens"] = len(tokens)
             return candidate
 
-        return self._ssd_tier.lookup_ssd_prefix(tokens_key)
+        prefix = self._ssd_tier.lookup_ssd_prefix(tokens_key)
+        if prefix is not None:
+            prefix["match_type"] = "prefix"
+            prefix["matched_tokens"] = prefix["num_tokens"]
+            return prefix
+
+        return None
 
     # -----------------------------------------------------------------
     # Disk persistence — survives server restarts

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -576,6 +576,9 @@ class MemoryAwarePrefixCache:
         # Track the match type from the last fetch() call
         self._last_match_type: str | None = None
 
+        # Optional SSD cold tier (set via set_ssd_tier())
+        self._ssd_tier = None
+
         logger.info(
             f"MemoryAwarePrefixCache initialized: "
             f"max_memory={self._max_memory / _BYTES_PER_MB:.1f}MB, "
@@ -916,7 +919,11 @@ class MemoryAwarePrefixCache:
             self._sorted_keys.pop(idx)
 
     def _evict_lru(self) -> None:
-        """Evict the least recently used entry."""
+        """Evict the least recently used entry.
+
+        If an SSD tier is attached, the entry is spilled to disk instead
+        of being discarded.
+        """
         if not self._entries:
             return
 
@@ -928,9 +935,14 @@ class MemoryAwarePrefixCache:
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
 
+        # Spill to SSD tier if available
+        if self._ssd_tier is not None:
+            self._ssd_tier.enqueue_spill(tokens_key, entry.cache, entry.memory_bytes)
+
         logger.debug(
             f"[lru_evict] removed {len(tokens_key)} tokens, "
             f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
+            f"{'  (spilled to SSD)' if self._ssd_tier is not None else ''}"
         )
 
     def remove(self, tokens: list[int]) -> bool:
@@ -990,6 +1002,18 @@ class MemoryAwarePrefixCache:
     def __contains__(self, tokens: list[int]) -> bool:
         """Check if tokens are cached."""
         return tuple(tokens) in self._entries
+
+    def set_ssd_tier(self, ssd_tier) -> None:
+        """Attach an SSD cache tier for eviction spilling.
+
+        When set, evicted entries are spilled to SSD instead of discarded.
+
+        Args:
+            ssd_tier: An SSDCacheTier instance (or None to disable).
+        """
+        self._ssd_tier = ssd_tier
+        if ssd_tier is not None:
+            logger.info("[memory_cache] SSD tier attached for eviction spilling")
 
     # -----------------------------------------------------------------
     # Disk persistence — survives server restarts

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1764,6 +1764,17 @@ class Scheduler:
                     f"prompt_tokens={len(request.prompt_token_ids)} "
                     f"time={_fetch_dt:.3f}s entries={len(self.memory_aware_cache._entries)}"
                 )
+                # Check SSD tier for cold-tier hit
+                if (
+                    hasattr(self, "_ssd_tier")
+                    and self._ssd_tier is not None
+                    and self.memory_aware_cache.check_ssd(request.prompt_token_ids)
+                    is not None
+                ):
+                    request.cache_hit_type = "ssd_pending"
+                    request._ssd_candidate = self.memory_aware_cache.check_ssd(
+                        request.prompt_token_ids
+                    )
         elif self.prefix_cache is not None:
             # Use legacy prefix cache
             cache, remaining = self.prefix_cache.fetch_cache(request.prompt_token_ids)
@@ -2675,3 +2686,96 @@ class Scheduler:
             self._ssd_tier.close()
             self._ssd_tier = None
             logger.info("SSD cache tier closed")
+
+    async def promote_from_ssd(self, request) -> bool:
+        """Promote a cold-tier cache entry for a request.
+
+        Called by the engine's scheduling loop when request.cache_hit_type
+        is 'ssd_pending'. This runs the async SSD read with RAM budget
+        reservation.
+
+        Returns True if promotion succeeded and request was updated.
+        """
+        if not hasattr(self, "_ssd_tier") or self._ssd_tier is None:
+            return False
+
+        candidate = getattr(request, "_ssd_candidate", None)
+        if candidate is None:
+            return False
+
+        def reserve_budget(nbytes: int) -> bool:
+            """Check if RAM cache has room for the promoted entry."""
+            if self.memory_aware_cache is None:
+                return False
+            return (
+                self.memory_aware_cache._current_memory + nbytes
+                <= self.memory_aware_cache._max_memory
+            )
+
+        def release_budget(nbytes: int) -> None:
+            """No-op: budget was never actually allocated to an entry."""
+            pass
+
+        tokens = tuple(request.prompt_token_ids)
+        cache_layers = await self._ssd_tier.async_promote(
+            tokens, reserve_budget, release_budget
+        )
+
+        if cache_layers is None:
+            request.cache_hit_type = "miss"
+            return False
+
+        # Reconstruct cache objects from deserialized layer dicts
+        reconstructed = self._reconstruct_ssd_layers(cache_layers)
+        if reconstructed is None:
+            request.cache_hit_type = "miss"
+            return False
+
+        # Store in RAM cache for future hits
+        self.memory_aware_cache.store(list(tokens), reconstructed, evict_prefixes=False)
+
+        request.prompt_cache = reconstructed
+        request.cached_tokens = len(tokens)
+        request.remaining_tokens = []
+        request.cache_hit_type = "ssd_hit"
+
+        logger.info(
+            f"[ssd_promote] request={request.request_id[:12]} "
+            f"promoted {len(tokens)} tokens from SSD"
+        )
+        return True
+
+    def _reconstruct_ssd_layers(self, layer_dicts: list[dict]) -> list | None:
+        """Reconstruct cache objects from deserialized layer dicts.
+
+        Converts numpy arrays back to MLX arrays and creates KVCache objects.
+        """
+        try:
+            from mlx_lm.models.cache import KVCache
+
+            result = []
+            for ld in layer_dicts:
+                if "keys" in ld and "values" in ld:
+                    kv = KVCache()
+                    kv.keys = mx.array(ld["keys"])
+                    kv.values = mx.array(ld["values"])
+                    kv.offset = ld["offset"]
+                    for attr in ("max_size", "keep", "step", "_idx"):
+                        if attr in ld:
+                            setattr(kv, attr, ld[attr])
+                    result.append(kv)
+                elif "state" in ld:
+                    # ArraysCache — need to wrap in a compatible object
+                    state_arrays = [mx.array(a) for a in ld["state"]]
+                    # Create a simple namespace-like object
+                    layer_obj = type("ArraysCacheLayer", (), {"state": state_arrays})()
+                    result.append(layer_obj)
+                else:
+                    logger.warning(
+                        f"[ssd_promote] unknown layer dict format: {list(ld.keys())}"
+                    )
+                    return None
+            return result
+        except Exception as e:
+            logger.warning(f"[ssd_promote] reconstruction failed: {e}")
+            return None

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -24,6 +24,7 @@ from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 from .paged_cache import PagedCacheManager
+from .ssd_cache import SSDCacheConfig, SSDCacheTier
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .utils.mamba_cache import ensure_mamba_support
@@ -97,6 +98,10 @@ class SchedulerConfig:
     # saved cache is reused for the next request with the same prefix.
     # 0 = disabled. Only effective when chunked_prefill_tokens > 0.
     mid_prefill_save_interval: int = 8192
+
+    # SSD cache tiering
+    ssd_cache_dir: Optional[str] = None  # None = disabled
+    ssd_cache_max_gb: float = 10.0
 
     # MTP (Multi-Token Prediction) settings
     # Uses the model's built-in MTP head to predict multiple tokens per step
@@ -1153,6 +1158,22 @@ class Scheduler:
                     f"Memory-aware cache enabled: "
                     f"limit={self.memory_aware_cache.memory_limit_mb:.1f}MB"
                 )
+
+                # Attach SSD tier if configured
+                self._ssd_tier: Optional[SSDCacheTier] = None
+                if self.config.ssd_cache_dir is not None:
+                    ssd_config = SSDCacheConfig(
+                        cache_dir=self.config.ssd_cache_dir,
+                        max_size_gb=self.config.ssd_cache_max_gb,
+                    )
+                    self._ssd_tier = SSDCacheTier(ssd_config)
+                    self._ssd_tier.start_writer()
+                    self._ssd_tier.reconcile()
+                    self.memory_aware_cache.set_ssd_tier(self._ssd_tier)
+                    logger.info(
+                        f"SSD cache tier enabled: dir={self.config.ssd_cache_dir}, "
+                        f"max={self.config.ssd_cache_max_gb}GB"
+                    )
             else:
                 # Use legacy entry-count based prefix cache
                 self.prefix_cache = PrefixCacheManager(
@@ -2647,3 +2668,10 @@ class Scheduler:
             return self.memory_aware_cache.load_from_disk(cache_dir)
         logger.info("[cache_persist] no memory-aware cache to load into")
         return 0
+
+    def close_ssd_tier(self) -> None:
+        """Shut down the SSD cache tier if present."""
+        if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+            self._ssd_tier.close()
+            self._ssd_tier = None
+            logger.info("SSD cache tier closed")

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2729,13 +2729,16 @@ class Scheduler:
             # Tentatively reserve budget
             self.memory_aware_cache._current_memory += memory_bytes
 
-            tokens = tuple(request.prompt_token_ids)
+            # Use the SSD entry's actual token count for read and store,
+            # NOT the full prompt tokens. For prefix hits these differ.
+            matched_count = candidate["matched_tokens"]
+            matched_tokens = tuple(request.prompt_token_ids[:matched_count])
+
             try:
                 cache_layers = self._ssd_tier._read_entry(
-                    tokens, candidate["file_path"]
+                    matched_tokens, candidate["file_path"]
                 )
             except Exception:
-                # Release tentative budget on read failure
                 self.memory_aware_cache._current_memory -= memory_bytes
                 self._ssd_tier._stats.promotion_failures += 1
                 request.cache_hit_type = "miss"
@@ -2754,27 +2757,28 @@ class Scheduler:
             # Release tentative budget (store() will account properly)
             self.memory_aware_cache._current_memory -= memory_bytes
 
-            # Reconstruct and store
+            # Reconstruct and store under the matched prefix tokens
             reconstructed = self._reconstruct_ssd_layers(cache_layers)
             if reconstructed is None:
                 request.cache_hit_type = "miss"
                 continue
 
             self.memory_aware_cache.store(
-                list(tokens), reconstructed, evict_prefixes=False
+                list(matched_tokens), reconstructed, evict_prefixes=False
             )
 
             request.prompt_cache = reconstructed
-            request.cached_tokens = len(tokens)
-            request.remaining_tokens = []
+            request.cached_tokens = matched_count
+            request.remaining_tokens = request.prompt_token_ids[matched_count:]
             request.cache_hit_type = "ssd_hit"
 
             self._ssd_tier._stats.ssd_hits += 1
-            self._ssd_tier._index.touch(tokens)
+            self._ssd_tier._index.touch(matched_tokens)
 
             logger.info(
                 f"[ssd_promote] request={request.request_id[:12]} "
-                f"promoted {len(tokens)} tokens from SSD"
+                f"{candidate['match_type']} promote: {matched_count}/{len(request.prompt_token_ids)} tokens from SSD, "
+                f"{len(request.remaining_tokens)} remaining"
             )
 
     async def promote_from_ssd(self, request) -> bool:
@@ -2809,9 +2813,12 @@ class Scheduler:
             if self.memory_aware_cache is not None:
                 self.memory_aware_cache._current_memory -= nbytes
 
-        tokens = tuple(request.prompt_token_ids)
+        # Use matched token count, not full prompt, for prefix hits
+        matched_count = candidate.get("matched_tokens", len(request.prompt_token_ids))
+        matched_tokens = tuple(request.prompt_token_ids[:matched_count])
+
         cache_layers = await self._ssd_tier.async_promote(
-            tokens, reserve_budget, release_budget
+            matched_tokens, reserve_budget, release_budget
         )
 
         if cache_layers is None:
@@ -2827,17 +2834,21 @@ class Scheduler:
             request.cache_hit_type = "miss"
             return False
 
-        # Store in RAM cache for future hits
-        self.memory_aware_cache.store(list(tokens), reconstructed, evict_prefixes=False)
+        # Store in RAM cache under the matched prefix tokens
+        self.memory_aware_cache.store(
+            list(matched_tokens), reconstructed, evict_prefixes=False
+        )
 
         request.prompt_cache = reconstructed
-        request.cached_tokens = len(tokens)
-        request.remaining_tokens = []
+        request.cached_tokens = matched_count
+        request.remaining_tokens = request.prompt_token_ids[matched_count:]
         request.cache_hit_type = "ssd_hit"
 
         logger.info(
             f"[ssd_promote] request={request.request_id[:12]} "
-            f"promoted {len(tokens)} tokens from SSD"
+            f"{candidate.get('match_type', 'exact')} promote: "
+            f"{matched_count}/{len(request.prompt_token_ids)} tokens from SSD, "
+            f"{len(request.remaining_tokens)} remaining"
         )
         return True
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1765,16 +1765,13 @@ class Scheduler:
                     f"time={_fetch_dt:.3f}s entries={len(self.memory_aware_cache._entries)}"
                 )
                 # Check SSD tier for cold-tier hit
-                if (
-                    hasattr(self, "_ssd_tier")
-                    and self._ssd_tier is not None
-                    and self.memory_aware_cache.check_ssd(request.prompt_token_ids)
-                    is not None
-                ):
-                    request.cache_hit_type = "ssd_pending"
-                    request._ssd_candidate = self.memory_aware_cache.check_ssd(
+                if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+                    ssd_candidate = self.memory_aware_cache.check_ssd(
                         request.prompt_token_ids
                     )
+                    if ssd_candidate is not None:
+                        request.cache_hit_type = "ssd_pending"
+                        request._ssd_candidate = ssd_candidate
         elif self.prefix_cache is not None:
             # Use legacy prefix cache
             cache, remaining = self.prefix_cache.fetch_cache(request.prompt_token_ids)
@@ -1903,6 +1900,12 @@ class Scheduler:
         Returns:
             List of requests that were scheduled
         """
+        # Attempt synchronous SSD promotion for any ssd_pending requests
+        # before scheduling. This keeps SSD I/O out of fetch() while
+        # avoiding engine modifications.
+        if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+            self._try_promote_ssd_pending()
+
         scheduled = []
 
         while self.waiting and len(self.running) < self.config.max_num_seqs:
@@ -2632,6 +2635,9 @@ class Scheduler:
         if self.prefix_cache is not None:
             self.prefix_cache.clear()
 
+        # Close SSD tier on reset
+        self.close_ssd_tier()
+
     def deep_reset(self) -> None:
         """
         Deep reset that clears ALL cache state including model-level caches.
@@ -2687,12 +2693,95 @@ class Scheduler:
             self._ssd_tier = None
             logger.info("SSD cache tier closed")
 
-    async def promote_from_ssd(self, request) -> bool:
-        """Promote a cold-tier cache entry for a request.
+    def _try_promote_ssd_pending(self) -> None:
+        """Attempt synchronous SSD promotion for waiting requests tagged ssd_pending.
 
-        Called by the engine's scheduling loop when request.cache_hit_type
-        is 'ssd_pending'. This runs the async SSD read with RAM budget
-        reservation.
+        Called from _schedule_waiting() before requests are moved to running.
+        Reads SSD entries synchronously (disk I/O stays out of fetch() per spec).
+        """
+        for request in self.waiting:
+            if getattr(request, "cache_hit_type", None) != "ssd_pending":
+                continue
+
+            candidate = getattr(request, "_ssd_candidate", None)
+            if candidate is None:
+                continue
+
+            memory_bytes = candidate["memory_bytes"]
+
+            # Check RAM budget availability
+            if self.memory_aware_cache is None:
+                request.cache_hit_type = "miss"
+                continue
+
+            if (
+                self.memory_aware_cache._current_memory + memory_bytes
+                > self.memory_aware_cache._max_memory
+            ):
+                self._ssd_tier._stats.promotion_failures += 1
+                request.cache_hit_type = "miss"
+                logger.info(
+                    f"[ssd_promote] request={request.request_id[:12]} "
+                    f"budget denied ({memory_bytes} bytes)"
+                )
+                continue
+
+            # Tentatively reserve budget
+            self.memory_aware_cache._current_memory += memory_bytes
+
+            tokens = tuple(request.prompt_token_ids)
+            try:
+                cache_layers = self._ssd_tier._read_entry(
+                    tokens, candidate["file_path"]
+                )
+            except Exception:
+                # Release tentative budget on read failure
+                self.memory_aware_cache._current_memory -= memory_bytes
+                self._ssd_tier._stats.promotion_failures += 1
+                request.cache_hit_type = "miss"
+                logger.exception(
+                    f"[ssd_promote] request={request.request_id[:12]} "
+                    f"disk read failed"
+                )
+                continue
+
+            if cache_layers is None:
+                self.memory_aware_cache._current_memory -= memory_bytes
+                self._ssd_tier._stats.promotion_failures += 1
+                request.cache_hit_type = "miss"
+                continue
+
+            # Release tentative budget (store() will account properly)
+            self.memory_aware_cache._current_memory -= memory_bytes
+
+            # Reconstruct and store
+            reconstructed = self._reconstruct_ssd_layers(cache_layers)
+            if reconstructed is None:
+                request.cache_hit_type = "miss"
+                continue
+
+            self.memory_aware_cache.store(
+                list(tokens), reconstructed, evict_prefixes=False
+            )
+
+            request.prompt_cache = reconstructed
+            request.cached_tokens = len(tokens)
+            request.remaining_tokens = []
+            request.cache_hit_type = "ssd_hit"
+
+            self._ssd_tier._stats.ssd_hits += 1
+            self._ssd_tier._index.touch(tokens)
+
+            logger.info(
+                f"[ssd_promote] request={request.request_id[:12]} "
+                f"promoted {len(tokens)} tokens from SSD"
+            )
+
+    async def promote_from_ssd(self, request) -> bool:
+        """Promote a cold-tier cache entry for a request (async version).
+
+        Alternative to _try_promote_ssd_pending() for callers with an
+        async event loop. Uses asyncio.to_thread for non-blocking disk I/O.
 
         Returns True if promotion succeeded and request was updated.
         """
@@ -2704,17 +2793,21 @@ class Scheduler:
             return False
 
         def reserve_budget(nbytes: int) -> bool:
-            """Check if RAM cache has room for the promoted entry."""
+            """Tentatively reserve RAM budget for promotion."""
             if self.memory_aware_cache is None:
                 return False
-            return (
+            if (
                 self.memory_aware_cache._current_memory + nbytes
-                <= self.memory_aware_cache._max_memory
-            )
+                > self.memory_aware_cache._max_memory
+            ):
+                return False
+            self.memory_aware_cache._current_memory += nbytes
+            return True
 
         def release_budget(nbytes: int) -> None:
-            """No-op: budget was never actually allocated to an entry."""
-            pass
+            """Release tentatively reserved budget on failure."""
+            if self.memory_aware_cache is not None:
+                self.memory_aware_cache._current_memory -= nbytes
 
         tokens = tuple(request.prompt_token_ids)
         cache_layers = await self._ssd_tier.async_promote(
@@ -2724,6 +2817,9 @@ class Scheduler:
         if cache_layers is None:
             request.cache_hit_type = "miss"
             return False
+
+        # Release tentative budget — store() will account properly
+        release_budget(candidate["memory_bytes"])
 
         # Reconstruct cache objects from deserialized layer dicts
         reconstructed = self._reconstruct_ssd_layers(cache_layers)

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+SSD KV cache tiering for vllm-mlx.
+
+This module provides a cold-tier disk cache that sits behind
+MemoryAwarePrefixCache. Evicted entries spill to NVMe instead of being
+discarded, and cold-tier fetches reload from disk asynchronously with
+RAM budget reservation before the read completes.
+
+Key design:
+- SQLite for atomic metadata index (no mutable JSON)
+- Async writer thread for non-blocking spills
+- Per-layer serializer interface for hybrid cache types
+- Atomic temp-file + rename writes for crash consistency
+- Metrics exposed from day one
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_BYTES_PER_MB = 1024 * 1024
+_BYTES_PER_GB = 1024 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SSDCacheConfig:
+    """Configuration for SSD cache tier.
+
+    Attributes:
+        cache_dir: Directory for SSD cache files. None = auto-detect
+            (~/.cache/vllm-mlx/ssd_cache/{model}/).
+        max_size_gb: Maximum total size of SSD cache in GB.
+        max_entries: Maximum number of entries in SSD cache.
+        file_permissions: Unix permission bits for cache data files.
+        dir_permissions: Unix permission bits for cache directories.
+        spill_queue_size: Max pending spill operations before dropping.
+        retention_seconds: Optional max age for cache entries (None = no expiry).
+    """
+
+    cache_dir: str | None = None
+    max_size_gb: float = 10.0
+    max_entries: int = 10000
+    file_permissions: int = 0o600
+    dir_permissions: int = 0o700
+    spill_queue_size: int = 64
+    retention_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_size_gb <= 0:
+            raise ValueError(f"max_size_gb must be > 0, got {self.max_size_gb}")
+        if self.max_entries < 1:
+            raise ValueError(f"max_entries must be >= 1, got {self.max_entries}")
+        if self.spill_queue_size < 1:
+            raise ValueError(
+                f"spill_queue_size must be >= 1, got {self.spill_queue_size}"
+            )
+
+    @property
+    def max_size_bytes(self) -> int:
+        """Maximum cache size in bytes."""
+        return int(self.max_size_gb * _BYTES_PER_GB)
+
+
+@dataclass
+class SSDCacheStats:
+    """Statistics for SSD cache tier — exposed from day one.
+
+    Attributes:
+        spill_count: Number of entries spilled to SSD.
+        spill_bytes: Total bytes written to SSD.
+        ssd_hits: Number of successful SSD cache lookups.
+        ssd_misses: Number of SSD cache lookup misses.
+        reload_latency_sum: Sum of reload latencies in seconds.
+        reload_bytes: Total bytes read from SSD.
+        promotion_failures: Number of failed promotions (RAM budget exhausted).
+    """
+
+    spill_count: int = 0
+    spill_bytes: int = 0
+    ssd_hits: int = 0
+    ssd_misses: int = 0
+    reload_latency_sum: float = 0.0
+    reload_bytes: int = 0
+    promotion_failures: int = 0
+
+    def to_dict(self) -> dict:
+        total_lookups = self.ssd_hits + self.ssd_misses
+        hit_rate = self.ssd_hits / total_lookups if total_lookups > 0 else 0.0
+        avg_latency_ms = (
+            (self.reload_latency_sum / self.ssd_hits * 1000)
+            if self.ssd_hits > 0
+            else 0.0
+        )
+        return {
+            "spill_count": self.spill_count,
+            "spill_bytes": self.spill_bytes,
+            "ssd_hits": self.ssd_hits,
+            "ssd_misses": self.ssd_misses,
+            "ssd_hit_rate": round(hit_rate, 4),
+            "reload_latency_sum_s": round(self.reload_latency_sum, 4),
+            "avg_reload_latency_ms": round(avg_latency_ms, 2),
+            "reload_bytes": self.reload_bytes,
+            "promotion_failures": self.promotion_failures,
+        }

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -486,3 +487,60 @@ def get_serializer_for_layer(layer: Any) -> LayerSerializer:
         f"Unsupported cache layer type: {type(layer).__name__}. "
         f"Supported: {list(SERIALIZER_SUPPORT_MATRIX.keys())}"
     )
+
+
+class SSDCacheTier:
+    """Cold-tier disk cache for KV cache entries.
+
+    Manages a SQLite-indexed on-disk cache directory. Evicted RAM entries
+    are spilled here via an async writer thread. Cold-tier fetches reload
+    from disk asynchronously with RAM budget reservation.
+
+    Directory layout::
+
+        cache_dir/
+          index.db           # SQLite metadata index
+          data/              # safetensors files per entry
+            {hash}/          # one directory per entry
+              layer_0.safetensors
+              layer_1.safetensors
+              manifest.json  # per-entry layer metadata
+    """
+
+    def __init__(self, config: SSDCacheConfig) -> None:
+        self._config = config
+
+        if config.cache_dir is None:
+            raise ValueError("SSDCacheConfig.cache_dir must be set")
+
+        self._cache_dir = config.cache_dir
+        self._data_dir = os.path.join(self._cache_dir, "data")
+
+        # Create directory structure
+        os.makedirs(self._cache_dir, mode=config.dir_permissions, exist_ok=True)
+        os.makedirs(self._data_dir, mode=config.dir_permissions, exist_ok=True)
+
+        # Open SQLite index
+        self._index = SSDIndex(self._cache_dir)
+
+        # Stats
+        self._stats = SSDCacheStats()
+        self._lock = threading.Lock()
+        self._closed = False
+
+    @staticmethod
+    def _entry_hash(tokens: tuple[int, ...]) -> str:
+        """Compute deterministic hash for a token sequence."""
+        return _tokens_hash(tokens)
+
+    def get_stats(self) -> dict:
+        """Return current SSD cache statistics."""
+        return self._stats.to_dict()
+
+    def close(self) -> None:
+        """Close the SSD cache tier and release resources."""
+        if self._closed:
+            return
+        self._closed = True
+        self._index.close()
+        logger.info("[ssd_cache] SSDCacheTier closed")

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -27,7 +27,7 @@ import sqlite3
 import threading
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -671,6 +671,9 @@ class SSDCacheTier:
             f"{total_file_bytes} bytes on disk"
         )
 
+        # Enforce capacity after write
+        self._enforce_capacity()
+
     def lookup_ssd(self, tokens: tuple[int, ...]) -> dict | None:
         """Synchronous check whether tokens exist in SSD tier.
 
@@ -856,6 +859,93 @@ class SSDCacheTier:
             logger.warning(f"[ssd_cache] failed to quarantine {relative_path}: {e}")
 
         self._index.delete_entry(tokens)
+
+    def _enforce_capacity(self) -> None:
+        """Evict oldest SSD entries until within capacity limits.
+
+        Called after each spill write. Removes entries by LRU order
+        until both entry count and total bytes are within bounds.
+        """
+        import shutil
+
+        while True:
+            entry_count = self._index.get_entry_count()
+            total_bytes = self._index.get_total_bytes()
+
+            needs_evict = (
+                entry_count > self._config.max_entries
+                or total_bytes > self._config.max_size_bytes
+            )
+            if not needs_evict:
+                break
+
+            lru = self._index.get_lru(limit=1)
+            if not lru:
+                break
+
+            victim = lru[0]
+            victim_tokens = _blob_to_tokens(victim["tokens_blob"])
+            victim_dir = os.path.join(self._data_dir, victim["file_path"])
+
+            # Delete data files
+            if os.path.exists(victim_dir):
+                shutil.rmtree(victim_dir)
+
+            # Delete from index
+            self._index.delete_entry(victim_tokens)
+
+            logger.debug(
+                f"[ssd_cache] disk LRU evicted: {victim['num_tokens']} tokens, "
+                f"{victim['memory_bytes']} bytes"
+            )
+
+    def reconcile(self) -> int:
+        """Reconcile index with files on disk.
+
+        Removes index entries whose data files are missing.
+        Removes data directories not in the index.
+
+        Returns number of entries cleaned up.
+        """
+        import shutil
+
+        cleaned = 0
+
+        # Phase 1: Remove index entries with missing data dirs
+        all_entries = self._index.all_entries()
+        for entry in all_entries:
+            entry_dir = os.path.join(self._data_dir, entry["file_path"])
+            manifest_path = os.path.join(entry_dir, "manifest.json")
+            if not os.path.isdir(entry_dir) or not os.path.exists(manifest_path):
+                tokens = _blob_to_tokens(entry["tokens_blob"])
+                self._index.delete_entry(tokens)
+                cleaned += 1
+                logger.info(
+                    f"[ssd_cache] reconcile: removed orphaned index entry "
+                    f"({entry['num_tokens']} tokens, path={entry['file_path']})"
+                )
+
+        # Phase 2: Remove data directories not in the index
+        if os.path.isdir(self._data_dir):
+            indexed_hashes = {e["file_path"] for e in self._index.all_entries()}
+            for entry_name in os.listdir(self._data_dir):
+                entry_path = os.path.join(self._data_dir, entry_name)
+                if (
+                    os.path.isdir(entry_path)
+                    and entry_name not in indexed_hashes
+                    and not entry_name.endswith(".tmp")
+                ):
+                    shutil.rmtree(entry_path)
+                    cleaned += 1
+                    logger.info(
+                        f"[ssd_cache] reconcile: removed orphaned data dir "
+                        f"{entry_name}"
+                    )
+
+        if cleaned > 0:
+            logger.info(f"[ssd_cache] reconciliation cleaned {cleaned} entries")
+
+        return cleaned
 
     def close(self) -> None:
         """Close the SSD cache tier and release resources."""

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -17,7 +17,12 @@ Key design:
 
 from __future__ import annotations
 
+import array as _array
+import hashlib
 import logging
+import os
+import sqlite3
+import time
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -106,3 +111,220 @@ class SSDCacheStats:
             "reload_bytes": self.reload_bytes,
             "promotion_failures": self.promotion_failures,
         }
+
+
+def _tokens_to_blob(tokens: tuple[int, ...]) -> bytes:
+    """Serialize token tuple to a compact binary blob for SQLite storage.
+
+    Uses the full token sequence as a binary blob for prefix matching.
+    """
+    arr = _array.array("i", tokens)
+    return arr.tobytes()
+
+
+def _blob_to_tokens(blob: bytes) -> tuple[int, ...]:
+    """Deserialize binary blob back to token tuple."""
+    arr = _array.array("i")
+    arr.frombytes(blob)
+    return tuple(arr)
+
+
+def _tokens_hash(tokens: tuple[int, ...]) -> str:
+    """Compute SHA-256 hex digest of a token sequence for use as primary key."""
+    return hashlib.sha256(_tokens_to_blob(tokens)).hexdigest()
+
+
+class SSDIndex:
+    """SQLite-backed index for SSD cache entries.
+
+    Uses SQLite for atomic metadata operations instead of mutable JSON.
+    The token sequence is stored as a binary blob for prefix-searchable
+    representation. The primary key is a SHA-256 hash of the token sequence.
+
+    Thread safety: SQLite in WAL mode with serialized threading. Individual
+    operations are atomic. Callers must not share a single SSDIndex instance
+    across threads without external synchronization.
+    """
+
+    _SCHEMA_VERSION = 1
+
+    def __init__(self, cache_dir: str) -> None:
+        self._cache_dir = cache_dir
+        db_path = os.path.join(cache_dir, "index.db")
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.row_factory = sqlite3.Row
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS schema_version (
+                version INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS entries (
+                token_hash   TEXT PRIMARY KEY,
+                tokens_blob  BLOB NOT NULL,
+                num_tokens   INTEGER NOT NULL,
+                file_path    TEXT NOT NULL,
+                memory_bytes INTEGER NOT NULL,
+                created_at   REAL NOT NULL,
+                accessed_at  REAL NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_entries_accessed
+                ON entries(accessed_at);
+
+            CREATE INDEX IF NOT EXISTS idx_entries_num_tokens
+                ON entries(num_tokens);
+            """)
+        # Insert schema version if not present
+        cur = self._conn.execute("SELECT COUNT(*) FROM schema_version")
+        if cur.fetchone()[0] == 0:
+            self._conn.execute(
+                "INSERT INTO schema_version (version) VALUES (?)",
+                (self._SCHEMA_VERSION,),
+            )
+        self._conn.commit()
+
+    def insert_entry(
+        self,
+        tokens_key: tuple[int, ...],
+        file_path: str,
+        memory_bytes: int,
+        num_tokens: int,
+    ) -> None:
+        """Insert or replace a cache entry in the index."""
+        now = time.time()
+        token_hash = _tokens_hash(tokens_key)
+        tokens_blob = _tokens_to_blob(tokens_key)
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO entries
+                (token_hash, tokens_blob, num_tokens, file_path,
+                 memory_bytes, created_at, accessed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (token_hash, tokens_blob, num_tokens, file_path, memory_bytes, now, now),
+        )
+        self._conn.commit()
+
+    def lookup_exact(self, tokens_key: tuple[int, ...]) -> dict | None:
+        """Look up an exact token sequence. Returns dict or None."""
+        token_hash = _tokens_hash(tokens_key)
+        cur = self._conn.execute(
+            "SELECT file_path, memory_bytes, num_tokens FROM entries WHERE token_hash = ?",
+            (token_hash,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "file_path": row["file_path"],
+            "memory_bytes": row["memory_bytes"],
+            "num_tokens": row["num_tokens"],
+        }
+
+    def lookup_prefix(self, query_tokens: tuple[int, ...]) -> list[dict]:
+        """Find entries whose token sequence is a prefix of query_tokens.
+
+        Scans entries with num_tokens <= len(query_tokens) and compares the
+        full stored token blob against the corresponding prefix of query_tokens.
+
+        Returns list of dicts sorted by num_tokens descending (longest prefix first).
+        """
+        query_len = len(query_tokens)
+        query_blob = _tokens_to_blob(query_tokens)
+
+        cur = self._conn.execute(
+            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+            "FROM entries WHERE num_tokens <= ? ORDER BY num_tokens DESC",
+            (query_len,),
+        )
+
+        results = []
+        for row in cur:
+            stored_blob = row["tokens_blob"]
+            n = row["num_tokens"]
+            # Compare: the stored blob must equal the first n tokens of the query
+            # Each int is 4 bytes in the array('i') encoding
+            prefix_blob = query_blob[: n * 4]
+            if stored_blob == prefix_blob:
+                results.append(
+                    {
+                        "token_hash": row["token_hash"],
+                        "file_path": row["file_path"],
+                        "memory_bytes": row["memory_bytes"],
+                        "num_tokens": n,
+                    }
+                )
+        return results
+
+    def delete_entry(self, tokens_key: tuple[int, ...]) -> None:
+        """Delete an entry by token sequence."""
+        token_hash = _tokens_hash(tokens_key)
+        self._conn.execute("DELETE FROM entries WHERE token_hash = ?", (token_hash,))
+        self._conn.commit()
+
+    def get_lru(self, limit: int = 10) -> list[dict]:
+        """Get the least recently used entries, ordered oldest first."""
+        cur = self._conn.execute(
+            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+            "FROM entries ORDER BY accessed_at ASC LIMIT ?",
+            (limit,),
+        )
+        results = []
+        for row in cur:
+            results.append(
+                {
+                    "token_hash": row["token_hash"],
+                    "tokens_blob": row["tokens_blob"],
+                    "file_path": row["file_path"],
+                    "memory_bytes": row["memory_bytes"],
+                    "num_tokens": row["num_tokens"],
+                }
+            )
+        return results
+
+    def get_total_bytes(self) -> int:
+        """Get total memory_bytes across all entries."""
+        cur = self._conn.execute("SELECT COALESCE(SUM(memory_bytes), 0) FROM entries")
+        return cur.fetchone()[0]
+
+    def get_entry_count(self) -> int:
+        """Get number of entries in the index."""
+        cur = self._conn.execute("SELECT COUNT(*) FROM entries")
+        return cur.fetchone()[0]
+
+    def touch(self, tokens_key: tuple[int, ...]) -> None:
+        """Update accessed_at timestamp for an entry (marks as recently used)."""
+        token_hash = _tokens_hash(tokens_key)
+        self._conn.execute(
+            "UPDATE entries SET accessed_at = ? WHERE token_hash = ?",
+            (time.time(), token_hash),
+        )
+        self._conn.commit()
+
+    def all_entries(self) -> list[dict]:
+        """Return all entries (for startup reconciliation)."""
+        cur = self._conn.execute(
+            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+            "FROM entries ORDER BY accessed_at DESC"
+        )
+        results = []
+        for row in cur:
+            results.append(
+                {
+                    "token_hash": row["token_hash"],
+                    "tokens_blob": row["tokens_blob"],
+                    "file_path": row["file_path"],
+                    "memory_bytes": row["memory_bytes"],
+                    "num_tokens": row["num_tokens"],
+                }
+            )
+        return results
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        self._conn.close()

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -671,6 +671,192 @@ class SSDCacheTier:
             f"{total_file_bytes} bytes on disk"
         )
 
+    def lookup_ssd(self, tokens: tuple[int, ...]) -> dict | None:
+        """Synchronous check whether tokens exist in SSD tier.
+
+        This is fast (SQLite lookup only, no disk I/O for data).
+        Called from synchronous fetch() to report an SSD candidate.
+
+        Returns:
+            Dict with entry metadata if found, None otherwise.
+        """
+        result = self._index.lookup_exact(tokens)
+        if result is not None:
+            return result
+        return None
+
+    def lookup_ssd_prefix(self, tokens: tuple[int, ...]) -> dict | None:
+        """Find the longest prefix match in the SSD tier.
+
+        Returns the longest-prefix entry metadata or None.
+        """
+        results = self._index.lookup_prefix(tokens)
+        if results:
+            return results[0]  # Already sorted by num_tokens DESC
+        return None
+
+    async def async_promote(
+        self,
+        tokens: tuple[int, ...],
+        reserve_budget_fn,
+        release_budget_fn,
+    ) -> list | None:
+        """Promote an entry from SSD to RAM asynchronously.
+
+        CRITICAL: Reserves RAM budget BEFORE the disk read, to avoid
+        thrash when multiple promotions race.
+
+        Args:
+            tokens: Token sequence to promote.
+            reserve_budget_fn: Callable(nbytes) -> bool. Must return True
+                if budget is available and reserved, False otherwise.
+            release_budget_fn: Callable(nbytes) -> None. Called to release
+                budget on failure.
+
+        Returns:
+            List of deserialized cache layers, or None if promotion failed.
+        """
+        import asyncio
+
+        # Step 1: Look up metadata (fast, SQLite)
+        meta = self._index.lookup_exact(tokens)
+        if meta is None:
+            with self._lock:
+                self._stats.ssd_misses += 1
+            return None
+
+        memory_bytes = meta["memory_bytes"]
+
+        # Step 2: Reserve RAM budget BEFORE disk read
+        if not reserve_budget_fn(memory_bytes):
+            with self._lock:
+                self._stats.promotion_failures += 1
+            logger.warning(
+                f"[ssd_cache] promotion denied: cannot reserve "
+                f"{memory_bytes} bytes RAM budget"
+            )
+            return None
+
+        # Step 3: Read from disk (in thread pool to avoid blocking event loop)
+        t0 = time.time()
+        try:
+            cache_layers = await asyncio.to_thread(
+                self._read_entry, tokens, meta["file_path"]
+            )
+        except Exception:
+            # Release budget on read failure
+            release_budget_fn(memory_bytes)
+            with self._lock:
+                self._stats.promotion_failures += 1
+            logger.exception(
+                f"[ssd_cache] failed to read entry from disk "
+                f"({meta['num_tokens']} tokens)"
+            )
+            return None
+
+        if cache_layers is None:
+            # Corrupted entry — release budget, quarantine entry
+            release_budget_fn(memory_bytes)
+            with self._lock:
+                self._stats.promotion_failures += 1
+            return None
+
+        dt = time.time() - t0
+        total_read_bytes = sum(
+            os.path.getsize(
+                os.path.join(
+                    self._data_dir, meta["file_path"], f"layer_{i}.safetensors"
+                )
+            )
+            for i in range(len(cache_layers))
+            if os.path.exists(
+                os.path.join(
+                    self._data_dir, meta["file_path"], f"layer_{i}.safetensors"
+                )
+            )
+        )
+
+        with self._lock:
+            self._stats.ssd_hits += 1
+            self._stats.reload_latency_sum += dt
+            self._stats.reload_bytes += total_read_bytes
+
+        # Update access time in index
+        self._index.touch(tokens)
+
+        logger.info(
+            f"[ssd_cache] promoted entry: {meta['num_tokens']} tokens, "
+            f"{total_read_bytes} bytes, {dt*1000:.1f}ms"
+        )
+
+        return cache_layers
+
+    def _read_entry(self, tokens: tuple[int, ...], relative_path: str) -> list | None:
+        """Read a cache entry from disk. Called from thread pool.
+
+        Returns list of deserialized layer dicts, or None on corruption.
+        """
+        entry_dir = os.path.join(self._data_dir, relative_path)
+        manifest_path = os.path.join(entry_dir, "manifest.json")
+
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"[ssd_cache] corrupt manifest for {relative_path}: {e}")
+            self._quarantine_entry(tokens, relative_path)
+            return None
+
+        cache_layers = []
+        for layer_meta in manifest["layers"]:
+            layer_idx = layer_meta["layer_idx"]
+            layer_path = os.path.join(entry_dir, f"layer_{layer_idx}.safetensors")
+            layer_type = layer_meta["layer_type"]
+
+            try:
+                if layer_type in ("KVCache", "RotatingKVCache"):
+                    serializer = KVCacheSerializer()
+                elif layer_type in ("ArraysCache", "MambaCache"):
+                    serializer = ArraysCacheSerializer()
+                else:
+                    logger.warning(
+                        f"[ssd_cache] unknown layer type {layer_type}, skipping"
+                    )
+                    self._quarantine_entry(tokens, relative_path)
+                    return None
+
+                layer_data = serializer.deserialize_layer(layer_path, layer_meta)
+                cache_layers.append(layer_data)
+            except Exception as e:
+                logger.warning(
+                    f"[ssd_cache] corrupt layer {layer_idx} in {relative_path}: {e}"
+                )
+                self._quarantine_entry(tokens, relative_path)
+                return None
+
+        return cache_layers
+
+    def _quarantine_entry(self, tokens: tuple[int, ...], relative_path: str) -> None:
+        """Move a corrupt entry to quarantine and remove from index."""
+        entry_dir = os.path.join(self._data_dir, relative_path)
+        quarantine_dir = os.path.join(self._cache_dir, "quarantine", relative_path)
+
+        try:
+            if os.path.exists(entry_dir):
+                os.makedirs(
+                    os.path.dirname(quarantine_dir),
+                    mode=self._config.dir_permissions,
+                    exist_ok=True,
+                )
+                os.rename(entry_dir, quarantine_dir)
+                logger.warning(
+                    f"[ssd_cache] quarantined corrupt entry: {relative_path}"
+                )
+        except OSError as e:
+            logger.warning(f"[ssd_cache] failed to quarantine {relative_path}: {e}")
+
+        self._index.delete_entry(tokens)
+
     def close(self) -> None:
         """Close the SSD cache tier and release resources."""
         if self._closed:

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import queue
 import sqlite3
 import threading
 import time
@@ -528,6 +529,11 @@ class SSDCacheTier:
         self._lock = threading.Lock()
         self._closed = False
 
+        # Spill queue and writer thread
+        self._spill_queue: queue.Queue = queue.Queue(maxsize=config.spill_queue_size)
+        self._writer_thread: threading.Thread | None = None
+        self._writer_stop = threading.Event()
+
     @staticmethod
     def _entry_hash(tokens: tuple[int, ...]) -> str:
         """Compute deterministic hash for a token sequence."""
@@ -537,10 +543,149 @@ class SSDCacheTier:
         """Return current SSD cache statistics."""
         return self._stats.to_dict()
 
+    def start_writer(self) -> None:
+        """Start the background spill writer thread."""
+        if self._writer_thread is not None:
+            return
+        self._writer_stop.clear()
+        self._writer_thread = threading.Thread(
+            target=self._writer_loop, daemon=True, name="ssd-cache-writer"
+        )
+        self._writer_thread.start()
+        logger.info("[ssd_cache] writer thread started")
+
+    def _writer_loop(self) -> None:
+        """Background loop: drain spill queue and write to disk."""
+        while not self._writer_stop.is_set():
+            try:
+                item = self._spill_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+
+            if item is None:  # Poison pill for shutdown
+                break
+
+            tokens_key, cache_layers, memory_bytes = item
+            try:
+                self._write_entry(tokens_key, cache_layers, memory_bytes)
+            except Exception:
+                logger.exception(
+                    f"[ssd_cache] failed to write entry " f"({len(tokens_key)} tokens)"
+                )
+
+    def enqueue_spill(
+        self,
+        tokens: tuple[int, ...],
+        cache: list[Any],
+        memory_bytes: int,
+    ) -> bool:
+        """Enqueue a cache entry for async spill to SSD.
+
+        Returns True if enqueued, False if queue is full (entry dropped).
+        """
+        try:
+            self._spill_queue.put_nowait((tokens, cache, memory_bytes))
+            return True
+        except queue.Full:
+            logger.warning(
+                f"[ssd_cache] spill queue full, dropping entry "
+                f"({len(tokens)} tokens, {memory_bytes} bytes)"
+            )
+            return False
+
+    def _write_entry(
+        self,
+        tokens_key: tuple[int, ...],
+        cache_layers: list[Any],
+        memory_bytes: int,
+    ) -> None:
+        """Write a single cache entry to disk atomically.
+
+        Uses temp-file + rename for crash consistency.
+        """
+        import shutil
+
+        entry_hash = self._entry_hash(tokens_key)
+        entry_dir = os.path.join(self._data_dir, entry_hash)
+        tmp_dir = entry_dir + ".tmp"
+
+        # Clean up any leftover tmp dir from a previous crash
+        if os.path.exists(tmp_dir):
+            shutil.rmtree(tmp_dir)
+
+        os.makedirs(tmp_dir, mode=self._config.dir_permissions, exist_ok=True)
+
+        layer_manifests = []
+        total_file_bytes = 0
+
+        for i, layer in enumerate(cache_layers):
+            serializer = get_serializer_for_layer(layer)
+            layer_path = os.path.join(tmp_dir, f"layer_{i}.safetensors")
+            metadata = serializer.serialize_layer(layer, i, layer_path)
+            layer_manifests.append(metadata)
+
+            # Set file permissions
+            os.chmod(layer_path, self._config.file_permissions)
+            total_file_bytes += os.path.getsize(layer_path)
+
+        # Write manifest
+        manifest = {
+            "num_layers": len(cache_layers),
+            "layers": layer_manifests,
+            "memory_bytes": memory_bytes,
+            "num_tokens": len(tokens_key),
+        }
+        manifest_path = os.path.join(tmp_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f)
+        os.chmod(manifest_path, self._config.file_permissions)
+
+        # Save tokens binary
+        tokens_path = os.path.join(tmp_dir, "tokens.bin")
+        arr = _array.array("i", tokens_key)
+        with open(tokens_path, "wb") as f:
+            arr.tofile(f)
+        os.chmod(tokens_path, self._config.file_permissions)
+
+        # Atomic rename: tmp_dir -> entry_dir
+        if os.path.exists(entry_dir):
+            shutil.rmtree(entry_dir)
+        os.rename(tmp_dir, entry_dir)
+
+        # Update index
+        relative_path = entry_hash
+        self._index.insert_entry(
+            tokens_key=tokens_key,
+            file_path=relative_path,
+            memory_bytes=memory_bytes,
+            num_tokens=len(tokens_key),
+        )
+
+        # Update stats
+        with self._lock:
+            self._stats.spill_count += 1
+            self._stats.spill_bytes += total_file_bytes
+
+        logger.debug(
+            f"[ssd_cache] spilled entry: {len(tokens_key)} tokens, "
+            f"{total_file_bytes} bytes on disk"
+        )
+
     def close(self) -> None:
         """Close the SSD cache tier and release resources."""
         if self._closed:
             return
         self._closed = True
+
+        # Stop writer thread
+        self._writer_stop.set()
+        if self._writer_thread is not None:
+            try:
+                self._spill_queue.put_nowait(None)  # Poison pill
+            except queue.Full:
+                pass
+            self._writer_thread.join(timeout=5.0)
+            self._writer_thread = None
+
         self._index.close()
         logger.info("[ssd_cache] SSDCacheTier closed")

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -19,11 +19,16 @@ from __future__ import annotations
 
 import array as _array
 import hashlib
+import json
 import logging
 import os
 import sqlite3
 import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -328,3 +333,156 @@ class SSDIndex:
     def close(self) -> None:
         """Close the SQLite connection."""
         self._conn.close()
+
+
+# Support matrix: maps cache type names to their serializer status
+SERIALIZER_SUPPORT_MATRIX = {
+    "KVCache": "supported",
+    "RotatingKVCache": "supported",  # Serialized as KVCache (keys/values/offset)
+    "ArraysCache": "supported",
+    "MambaCache": "supported",  # Legacy name for ArraysCache
+    "_QuantizedCacheWrapper": "not_supported_spill_dequantized",
+}
+
+
+class LayerSerializer(ABC):
+    """Interface for per-layer cache serialization.
+
+    Each implementation handles a specific cache type's serialization
+    to/from safetensors files with metadata.
+    """
+
+    @abstractmethod
+    def serialize_layer(
+        self, layer: Any, layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        """Serialize a single cache layer to a file.
+
+        Args:
+            layer: The cache layer object.
+            layer_idx: Index of this layer in the cache list.
+            file_path: Path to write the safetensors file.
+
+        Returns:
+            Metadata dict with at least 'layer_type' key.
+        """
+        ...
+
+    @abstractmethod
+    def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
+        """Deserialize a single cache layer from a file.
+
+        Args:
+            file_path: Path to the safetensors file.
+            metadata: Metadata dict from serialize_layer.
+
+        Returns:
+            Dict with layer state (keys/values/offset or state list).
+        """
+        ...
+
+
+class KVCacheSerializer(LayerSerializer):
+    """Serializer for KVCache and RotatingKVCache layers.
+
+    Handles layers with .keys, .values, .offset attributes.
+    RotatingKVCache also has .max_size, .keep, .step, ._idx.
+    """
+
+    def serialize_layer(
+        self, layer: Any, layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        from safetensors.numpy import save_file
+
+        keys_np = np.array(layer.keys)
+        values_np = np.array(layer.values)
+
+        tensors = {
+            f"layer_{layer_idx}_keys": keys_np,
+            f"layer_{layer_idx}_values": values_np,
+        }
+        save_file(tensors, file_path)
+
+        metadata = {
+            "layer_type": "KVCache",
+            "layer_idx": layer_idx,
+            "offset": layer.offset,
+        }
+        # Preserve RotatingKVCache extra attributes
+        for attr in ("max_size", "keep", "step", "_idx"):
+            if hasattr(layer, attr):
+                metadata[attr] = getattr(layer, attr)
+
+        return metadata
+
+    def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
+        from safetensors.numpy import load_file
+
+        layer_idx = metadata["layer_idx"]
+        tensors = load_file(file_path)
+
+        result = {
+            "keys": tensors[f"layer_{layer_idx}_keys"],
+            "values": tensors[f"layer_{layer_idx}_values"],
+            "offset": metadata["offset"],
+        }
+        for attr in ("max_size", "keep", "step", "_idx"):
+            if attr in metadata:
+                result[attr] = metadata[attr]
+        return result
+
+
+class ArraysCacheSerializer(LayerSerializer):
+    """Serializer for ArraysCache (Mamba/linear attention) layers.
+
+    Handles layers with .state attribute containing a list of arrays.
+    """
+
+    def serialize_layer(
+        self, layer: Any, layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        from safetensors.numpy import save_file
+
+        state = layer.state
+        tensors = {}
+        for i, arr in enumerate(state):
+            tensors[f"layer_{layer_idx}_state_{i}"] = np.array(arr)
+
+        save_file(tensors, file_path)
+
+        return {
+            "layer_type": "ArraysCache",
+            "layer_idx": layer_idx,
+            "num_arrays": len(state),
+        }
+
+    def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
+        from safetensors.numpy import load_file
+
+        layer_idx = metadata["layer_idx"]
+        num_arrays = metadata["num_arrays"]
+        tensors = load_file(file_path)
+
+        state = []
+        for i in range(num_arrays):
+            state.append(tensors[f"layer_{layer_idx}_state_{i}"])
+        return {"state": state}
+
+
+def get_serializer_for_layer(layer: Any) -> LayerSerializer:
+    """Return the appropriate serializer for a cache layer.
+
+    Dispatches based on duck-typing:
+    - If layer has .keys and .values and .offset -> KVCacheSerializer
+    - If layer has .state and it's a list -> ArraysCacheSerializer
+
+    Raises ValueError for unsupported layer types.
+    """
+    if hasattr(layer, "keys") and hasattr(layer, "values") and hasattr(layer, "offset"):
+        return KVCacheSerializer()
+    if hasattr(layer, "state") and isinstance(getattr(layer, "state", None), list):
+        return ArraysCacheSerializer()
+    raise ValueError(
+        f"Unsupported cache layer type: {type(layer).__name__}. "
+        f"Supported: {list(SERIALIZER_SUPPORT_MATRIX.keys())}"
+    )

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -148,15 +148,15 @@ class SSDIndex:
     The token sequence is stored as a binary blob for prefix-searchable
     representation. The primary key is a SHA-256 hash of the token sequence.
 
-    Thread safety: SQLite in WAL mode with serialized threading. Individual
-    operations are atomic. Callers must not share a single SSDIndex instance
-    across threads without external synchronization.
+    Thread safety: All operations are serialized through a threading.Lock.
+    The SQLite connection uses WAL mode for concurrent read/write safety.
     """
 
     _SCHEMA_VERSION = 1
 
     def __init__(self, cache_dir: str) -> None:
         self._cache_dir = cache_dir
+        self._db_lock = threading.Lock()
         db_path = os.path.join(cache_dir, "index.db")
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -206,25 +206,35 @@ class SSDIndex:
         now = time.time()
         token_hash = _tokens_hash(tokens_key)
         tokens_blob = _tokens_to_blob(tokens_key)
-        self._conn.execute(
-            """
-            INSERT OR REPLACE INTO entries
-                (token_hash, tokens_blob, num_tokens, file_path,
-                 memory_bytes, created_at, accessed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (token_hash, tokens_blob, num_tokens, file_path, memory_bytes, now, now),
-        )
-        self._conn.commit()
+        with self._db_lock:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO entries
+                    (token_hash, tokens_blob, num_tokens, file_path,
+                     memory_bytes, created_at, accessed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    token_hash,
+                    tokens_blob,
+                    num_tokens,
+                    file_path,
+                    memory_bytes,
+                    now,
+                    now,
+                ),
+            )
+            self._conn.commit()
 
     def lookup_exact(self, tokens_key: tuple[int, ...]) -> dict | None:
         """Look up an exact token sequence. Returns dict or None."""
         token_hash = _tokens_hash(tokens_key)
-        cur = self._conn.execute(
-            "SELECT file_path, memory_bytes, num_tokens FROM entries WHERE token_hash = ?",
-            (token_hash,),
-        )
-        row = cur.fetchone()
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT file_path, memory_bytes, num_tokens FROM entries WHERE token_hash = ?",
+                (token_hash,),
+            )
+            row = cur.fetchone()
         if row is None:
             return None
         return {
@@ -244,18 +254,18 @@ class SSDIndex:
         query_len = len(query_tokens)
         query_blob = _tokens_to_blob(query_tokens)
 
-        cur = self._conn.execute(
-            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
-            "FROM entries WHERE num_tokens <= ? ORDER BY num_tokens DESC",
-            (query_len,),
-        )
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+                "FROM entries WHERE num_tokens <= ? ORDER BY num_tokens DESC",
+                (query_len,),
+            )
+            rows = cur.fetchall()
 
         results = []
-        for row in cur:
+        for row in rows:
             stored_blob = row["tokens_blob"]
             n = row["num_tokens"]
-            # Compare: the stored blob must equal the first n tokens of the query
-            # Each int is 4 bytes in the array('i') encoding
             prefix_blob = query_blob[: n * 4]
             if stored_blob == prefix_blob:
                 results.append(
@@ -271,18 +281,23 @@ class SSDIndex:
     def delete_entry(self, tokens_key: tuple[int, ...]) -> None:
         """Delete an entry by token sequence."""
         token_hash = _tokens_hash(tokens_key)
-        self._conn.execute("DELETE FROM entries WHERE token_hash = ?", (token_hash,))
-        self._conn.commit()
+        with self._db_lock:
+            self._conn.execute(
+                "DELETE FROM entries WHERE token_hash = ?", (token_hash,)
+            )
+            self._conn.commit()
 
     def get_lru(self, limit: int = 10) -> list[dict]:
         """Get the least recently used entries, ordered oldest first."""
-        cur = self._conn.execute(
-            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
-            "FROM entries ORDER BY accessed_at ASC LIMIT ?",
-            (limit,),
-        )
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+                "FROM entries ORDER BY accessed_at ASC LIMIT ?",
+                (limit,),
+            )
+            rows = cur.fetchall()
         results = []
-        for row in cur:
+        for row in rows:
             results.append(
                 {
                     "token_hash": row["token_hash"],
@@ -296,31 +311,38 @@ class SSDIndex:
 
     def get_total_bytes(self) -> int:
         """Get total memory_bytes across all entries."""
-        cur = self._conn.execute("SELECT COALESCE(SUM(memory_bytes), 0) FROM entries")
-        return cur.fetchone()[0]
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT COALESCE(SUM(memory_bytes), 0) FROM entries"
+            )
+            return cur.fetchone()[0]
 
     def get_entry_count(self) -> int:
         """Get number of entries in the index."""
-        cur = self._conn.execute("SELECT COUNT(*) FROM entries")
-        return cur.fetchone()[0]
+        with self._db_lock:
+            cur = self._conn.execute("SELECT COUNT(*) FROM entries")
+            return cur.fetchone()[0]
 
     def touch(self, tokens_key: tuple[int, ...]) -> None:
         """Update accessed_at timestamp for an entry (marks as recently used)."""
         token_hash = _tokens_hash(tokens_key)
-        self._conn.execute(
-            "UPDATE entries SET accessed_at = ? WHERE token_hash = ?",
-            (time.time(), token_hash),
-        )
-        self._conn.commit()
+        with self._db_lock:
+            self._conn.execute(
+                "UPDATE entries SET accessed_at = ? WHERE token_hash = ?",
+                (time.time(), token_hash),
+            )
+            self._conn.commit()
 
     def all_entries(self) -> list[dict]:
         """Return all entries (for startup reconciliation)."""
-        cur = self._conn.execute(
-            "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
-            "FROM entries ORDER BY accessed_at DESC"
-        )
+        with self._db_lock:
+            cur = self._conn.execute(
+                "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
+                "FROM entries ORDER BY accessed_at DESC"
+            )
+            rows = cur.fetchall()
         results = []
-        for row in cur:
+        for row in rows:
             results.append(
                 {
                     "token_hash": row["token_hash"],
@@ -334,7 +356,8 @@ class SSDIndex:
 
     def close(self) -> None:
         """Close the SQLite connection."""
-        self._conn.close()
+        with self._db_lock:
+            self._conn.close()
 
 
 # Support matrix: maps cache type names to their serializer status
@@ -741,11 +764,23 @@ class SSDCacheTier:
             return None
 
         # Step 3: Read from disk (in thread pool to avoid blocking event loop)
+        # Use shield-and-await-on-cancel per CLAUDE.md Golden Rule #4:
+        # budget must be released even if the calling task is cancelled.
         t0 = time.time()
+        worker = asyncio.ensure_future(
+            asyncio.to_thread(self._read_entry, tokens, meta["file_path"])
+        )
         try:
-            cache_layers = await asyncio.to_thread(
-                self._read_entry, tokens, meta["file_path"]
-            )
+            cache_layers = await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            # Caller cancelled — still need to wait for the disk read
+            # to finish, then release the budget
+            try:
+                await worker
+            except Exception:
+                pass
+            release_budget_fn(memory_bytes)
+            raise
         except Exception:
             # Release budget on read failure
             release_budget_fn(memory_bytes)


### PR DESCRIPTION
## Summary

- Add cold NVMe tier behind `MemoryAwarePrefixCache`
- Evicted entries spill to SSD via async writer thread instead of being discarded
- Cold-tier fetches use synchronous promote in `_schedule_waiting()` with RAM budget reservation (SSD I/O stays out of `fetch()` per spec; async engine-level promote is scaffolded for future use)
- SQLite WAL-mode index (replaces mutable JSON) for atomic metadata with thread-safe locking
- Per-layer serializer interface supporting KVCache, RotatingKVCache, and ArraysCache
- Crash consistency via atomic temp-file + rename writes, corrupt entry quarantine
- Disk LRU eviction and startup reconciliation
- All seven metrics from day one: `spill_count`, `spill_bytes`, `ssd_hits`, `ssd_misses`, `reload_latency`, `reload_bytes`, `promotion_failures`
- CLI flags: `--ssd-cache-dir`, `--ssd-cache-max-gb`

## Architectural requirements met

1. SSD I/O never enters synchronous `fetch()` — promote runs in `_schedule_waiting()` (sync disk read ~220ms vs 30-90s recompute; async engine-level handoff scaffolded as `promote_from_ssd()` for future integration)
2. SQLite index, not mutable JSON — thread-safe with `threading.Lock`
3. Prefix matching uses full token blob comparison; `check_ssd()` returns `match_type` and `matched_tokens` so prefix hits correctly set `remaining_tokens` for suffix prefill
4. RAM budget tentatively reserved before disk read, released on failure
5. Per-layer serializer interface with explicit support matrix
6. Atomic writes + rename, versioned schema, file permissions, quarantine
7. All seven required metrics exposed from day one

## Test plan

- [x] 53 new tests in `tests/test_ssd_cache.py` — all pass
- [x] 42 existing tests in `tests/test_memory_cache.py` — no regressions
- [x] `python -m black --check` — all files clean
- [x] Unit: SSDCacheConfig, SSDCacheStats, SSDIndex, LayerSerializer round-trips
- [x] Unit: Async writer thread (spill, atomicity, queue-full)
- [x] Integration: Eviction spill path from MemoryAwarePrefixCache
- [x] Integration: Async promote with budget reservation/denial
- [x] Integration: Full round-trip (RAM → SSD → RAM)
- [x] Integration: Hybrid ArraysCache round-trip
- [x] Integration: Capacity eviction end-to-end