### PR TITLE
ci: restack Python 3.13 anyio coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -98,19 +98,21 @@ jobs:
 
   test-apple-silicon:
     runs-on: macos-14
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install project and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[vision]"
-          pip install pytest pytest-asyncio
+          pip install -e ".[dev,vision]"
 
       - name: Verify Apple Silicon
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
+    "anyio>=4.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
@@ -135,4 +135,3 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def server_url(request):
     return request.config.getoption("--server-url")
 
 
-@pytest.fixture(params=["asyncio"])
-def anyio_backend(request):
-    """Run anyio-marked tests on asyncio only (trio is not installed)."""
-    return request.param
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Run anyio-marked tests on asyncio only."""
+    return "asyncio"


### PR DESCRIPTION
## Summary
- add Python 3.13 to the Ubuntu unit-test matrix and Apple Silicon MLX job
- switch the dev/test async plugin wiring from pytest-asyncio to anyio
- simplify the shared anyio backend fixture to asyncio-only on current main

## Why
This is the minimal replacement for #226 after #288 landed the test-file conversions. It keeps only the remaining CI/dependency/backend wiring on top of current main.

## Local validation
- python -m pytest tests/test_server.py -q -k "verify_api_key or reasoning_stream"
- python -m pytest tests/test_batching.py -q -k TestEngineAsync
- python -m pytest tests/test_streaming_latency.py -q -k test_output_collector

Supersedes the remaining scope of #226.
