### PR TITLE
feat: add Prometheus server metrics

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -37,6 +37,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--timeout` | Request timeout in seconds | 300 |
+| `--enable-metrics` | Expose Prometheus metrics on `/metrics` | False |
 | `--continuous-batching` | Enable batching for multi-user | False |
 | `--use-paged-cache` | Enable paged KV cache | False |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
@@ -127,6 +128,23 @@ GET /health
 ```
 
 Returns server status.
+
+### Metrics
+
+```bash
+GET /metrics
+```
+
+Prometheus scrape endpoint for server, cache, scheduler, and request metrics.
+The endpoint is disabled by default and is enabled with `--enable-metrics`.
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-metrics
+```
+
+`/metrics` is intentionally unauthenticated. Expose it only on a trusted
+network or behind a reverse proxy / firewall that limits who can scrape it.
 
 ### Anthropic Messages API
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,6 +27,7 @@ vllm-mlx serve <model> [options]
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | 0 |
 | `--timeout` | Request timeout in seconds | 300 |
+| `--enable-metrics` | Expose Prometheus metrics on `/metrics` | False |
 | `--continuous-batching` | Enable batching for multi-user | False |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
@@ -87,6 +88,9 @@ vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
 
 # With API key authentication
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
+
+# Expose Prometheus metrics
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics
 
 # Production setup with security options
 vllm-mlx serve mlx-community/Qwen3-4B-4bit \

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -19,6 +19,7 @@
 | `--api-key` | API key for authentication | None |
 | `--rate-limit` | Requests per minute per client (0 = disabled) | `0` |
 | `--timeout` | Request timeout in seconds | `300` |
+| `--enable-metrics` | Expose Prometheus metrics on `/metrics` | `false` |
 
 ### Batching Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     # Server
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
+    "prometheus-client>=0.20.0",
     # MCP (Model Context Protocol) support
     "mcp>=1.0.0",
     # JSON Schema validation for structured output

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Prometheus server metrics."""
+
+import platform
+import sys
+
+import pytest
+
+# Skip all tests if not on Apple Silicon
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
+
+
+class FakeEngine:
+    """Small fake engine for metrics endpoint tests."""
+
+    model_name = "metrics-model"
+    is_mllm = False
+    preserve_native_tool_format = False
+    tokenizer = None
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def generate(self, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        return GenerationOutput(
+            text="Hello",
+            tokens=[1, 2],
+            prompt_tokens=4,
+            completion_tokens=2,
+            finish_reason="stop",
+        )
+
+    async def stream_generate(self, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        yield GenerationOutput(
+            text="Hel",
+            new_text="Hel",
+            prompt_tokens=4,
+            completion_tokens=1,
+            finished=False,
+        )
+        yield GenerationOutput(
+            text="Hello",
+            new_text="lo",
+            prompt_tokens=4,
+            completion_tokens=2,
+            finish_reason="stop",
+            finished=True,
+        )
+
+    async def chat(self, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        return GenerationOutput(
+            text="Hello from chat",
+            tokens=[1, 2, 3],
+            prompt_tokens=5,
+            completion_tokens=3,
+            finish_reason="stop",
+        )
+
+    async def stream_chat(self, **kwargs):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        yield GenerationOutput(
+            text="Hel",
+            new_text="Hel",
+            prompt_tokens=5,
+            completion_tokens=1,
+            finished=False,
+        )
+        yield GenerationOutput(
+            text="Hello",
+            new_text="lo",
+            prompt_tokens=5,
+            completion_tokens=2,
+            finish_reason="stop",
+            finished=True,
+        )
+
+    def get_stats(self):
+        return {
+            "engine_type": "simple",
+            "is_mllm": False,
+            "num_waiting": 2,
+            "num_running": 1,
+            "steps_executed": 7,
+            "uptime_seconds": 42.5,
+            "metal_active_memory_gb": 1.25,
+            "metal_peak_memory_gb": 2.5,
+            "metal_cache_memory_gb": 0.5,
+            "memory_aware_cache": {
+                "entry_count": 3,
+                "hits": 4,
+                "misses": 1,
+                "evictions": 0,
+                "hit_rate": 0.8,
+                "memory_utilization": 0.25,
+                "tokens_saved": 128,
+                "current_memory_mb": 64,
+                "max_memory_mb": 256,
+            },
+        }
+
+
+@pytest.fixture()
+def metrics_client(monkeypatch):
+    """Create a TestClient with a fresh metrics collector."""
+    from fastapi.testclient import TestClient
+
+    import vllm_mlx.server as server
+    from vllm_mlx.metrics import MetricsCollector
+
+    collector = MetricsCollector()
+    monkeypatch.setattr(server, "_metrics", collector)
+    monkeypatch.setattr(server, "_engine", None)
+    monkeypatch.setattr(server, "_model_name", "metrics-model")
+    monkeypatch.setattr(server, "_api_key", None)
+    monkeypatch.setattr(server, "_mcp_manager", None)
+    monkeypatch.setattr(server, "_reasoning_parser", None)
+    monkeypatch.setattr(server, "_tool_parser_instance", None)
+    monkeypatch.setattr(server, "_tool_call_parser", None)
+    monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+    monkeypatch.setattr(server, "_default_timeout", 30.0)
+    monkeypatch.setattr(server, "_default_max_tokens", 128)
+    monkeypatch.setattr(
+        server,
+        "_rate_limiter",
+        server.RateLimiter(requests_per_minute=60, enabled=False),
+    )
+
+    with TestClient(server.app) as client:
+        yield client, server, collector
+
+
+class TestMetricsEndpoint:
+    """Tests for Prometheus /metrics exposure and accounting."""
+
+    def test_metrics_endpoint_disabled_returns_404(self, metrics_client):
+        client, _server, collector = metrics_client
+
+        collector.configure(enabled=False)
+        response = client.get("/metrics")
+
+        assert response.status_code == 404
+
+    def test_metrics_endpoint_scrapes_runtime_stats(self, metrics_client, monkeypatch):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain; version=")
+        assert "charset=utf-8" in response.headers["content-type"]
+        assert 'vllm_mlx_model_loaded 1.0' in response.text
+        assert 'vllm_mlx_engine_type{engine_type="simple"} 1.0' in response.text
+        assert "vllm_mlx_scheduler_waiting_requests 2.0" in response.text
+        assert 'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
+
+    def test_metrics_collapse_unmatched_paths(self, metrics_client, monkeypatch):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+
+        miss = client.get("/definitely-not-a-real-route")
+        scrape = client.get("/metrics")
+
+        assert miss.status_code == 404
+        assert (
+            'vllm_mlx_http_requests_total{method="GET",path="__unmatched__",status_code="404"} 1.0'
+            in scrape.text
+        )
+
+    def test_completion_request_updates_metrics(self, metrics_client, monkeypatch):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "metrics-model",
+                "prompt": "Hello",
+                "max_tokens": 8,
+            },
+        )
+        scrape = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert (
+            'vllm_mlx_inference_requests_total{endpoint="completions",result="success",stream="false"} 1.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_prompt_tokens_total{endpoint="completions",stream="false"} 4.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_completion_tokens_total{endpoint="completions",stream="false"} 2.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_http_requests_total{method="POST",path="/v1/completions",status_code="200"} 1.0'
+            in scrape.text
+        )
+
+    def test_streaming_chat_records_ttft_and_stream_metrics(
+        self, metrics_client, monkeypatch
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={
+                "model": "metrics-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "max_tokens": 8,
+            },
+        ) as response:
+            body = "".join(response.iter_text())
+
+        scrape = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "data: [DONE]" in body
+        assert (
+            'vllm_mlx_inference_requests_total{endpoint="chat_completions",result="success",stream="true"} 1.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_inference_ttft_seconds_count{endpoint="chat_completions",stream="true"} 1.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_prompt_tokens_total{endpoint="chat_completions",stream="true"} 5.0'
+            in scrape.text
+        )
+        assert (
+            'vllm_mlx_completion_tokens_total{endpoint="chat_completions",stream="true"} 2.0'
+            in scrape.text
+        )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -164,10 +164,12 @@ class TestMetricsEndpoint:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/plain; version=")
         assert "charset=utf-8" in response.headers["content-type"]
-        assert 'vllm_mlx_model_loaded 1.0' in response.text
+        assert "vllm_mlx_model_loaded 1.0" in response.text
         assert 'vllm_mlx_engine_type{engine_type="simple"} 1.0' in response.text
         assert "vllm_mlx_scheduler_waiting_requests 2.0" in response.text
-        assert 'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
+        assert (
+            'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
+        )
 
     def test_metrics_collapse_unmatched_paths(self, metrics_client, monkeypatch):
         client, server, collector = metrics_client

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -47,6 +47,8 @@ def serve_command(args):
     # Configure server security settings
     server._api_key = args.api_key
     server._default_timeout = args.timeout
+    server._metrics_enabled = args.enable_metrics
+    server._metrics.configure(enabled=args.enable_metrics)
     if args.rate_limit > 0:
         server._rate_limiter = RateLimiter(
             requests_per_minute=args.rate_limit, enabled=True
@@ -102,6 +104,10 @@ def serve_command(args):
     else:
         print("  Rate limiting: DISABLED - Use --rate-limit to enable")
     print(f"  Request timeout: {args.timeout}s")
+    if args.enable_metrics:
+        print("  Metrics: ENABLED (/metrics, unauthenticated)")
+    else:
+        print("  Metrics: DISABLED - Use --enable-metrics to expose /metrics")
     if args.enable_auto_tool_choice:
         print(f"  Tool calling: ENABLED (parser: {args.tool_call_parser})")
     else:
@@ -873,6 +879,11 @@ Examples:
         type=float,
         default=300.0,
         help="Default request timeout in seconds (default: 300)",
+    )
+    serve_parser.add_argument(
+        "--enable-metrics",
+        action="store_true",
+        help="Expose Prometheus metrics on /metrics (disabled by default)",
     )
     # Tool calling options
     serve_parser.add_argument(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -12,6 +12,7 @@ LLM engine), so text-only requests must also be routed through it.
 """
 
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -152,6 +153,7 @@ class BatchedEngine(BaseEngine):
                 limit and emergency threshold (0.0-1.0, default 0.90)
         """
         self._model_name = model_name
+        self._created_at = time.time()
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
@@ -878,6 +880,7 @@ class BatchedEngine(BaseEngine):
         stats = {
             "engine_type": "batched",
             "model_name": self._model_name,
+            "uptime_seconds": time.time() - self._created_at,
             "is_mllm": self._is_mllm,
             "loaded": self._loaded,
             "stream_interval": self._stream_interval,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -8,6 +8,7 @@ performance when serving a single user at a time.
 
 import asyncio
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -78,6 +79,7 @@ class SimpleEngine(BaseEngine):
             specprefill_draft_model: Path to small draft model for importance scoring
         """
         self._model_name = model_name
+        self._created_at = time.time()
         self._trust_remote_code = trust_remote_code
         self._enable_cache = enable_cache
         self._is_mllm = force_mllm or is_mllm_model(model_name)
@@ -1288,6 +1290,7 @@ class SimpleEngine(BaseEngine):
         stats = {
             "engine_type": "simple",
             "model_name": self._model_name,
+            "uptime_seconds": time.time() - self._created_at,
             "is_mllm": self._is_mllm,
             "loaded": self._loaded,
         }

--- a/vllm_mlx/metrics.py
+++ b/vllm_mlx/metrics.py
@@ -365,7 +365,9 @@ class MetricsCollector:
         stats = engine.get_stats() if engine is not None else {}
 
         self._prom["model_loaded"].set(1 if engine is not None else 0)
-        current_engine_type = stats.get("engine_type", "unknown") if engine else "unknown"
+        current_engine_type = (
+            stats.get("engine_type", "unknown") if engine else "unknown"
+        )
         for engine_type in ("simple", "batched", "unknown"):
             self._prom["engine_type"].labels(engine_type=engine_type).set(
                 1 if current_engine_type == engine_type else 0
@@ -411,7 +413,9 @@ class MetricsCollector:
         if isinstance(cache_stats, dict):
             self._prom["cache_entry_count"].set(
                 _coerce_float(
-                    cache_stats.get("entry_count", cache_stats.get("allocated_blocks", 0))
+                    cache_stats.get(
+                        "entry_count", cache_stats.get("allocated_blocks", 0)
+                    )
                 )
             )
             self._prom["cache_hits"].set(
@@ -431,7 +435,11 @@ class MetricsCollector:
                 )
             )
             self._prom["cache_utilization_ratio"].set(
-                _coerce_float(cache_stats.get("memory_utilization", cache_stats.get("utilization", 0.0)))
+                _coerce_float(
+                    cache_stats.get(
+                        "memory_utilization", cache_stats.get("utilization", 0.0)
+                    )
+                )
             )
             self._prom["cache_tokens_saved"].set(
                 _coerce_float(cache_stats.get("tokens_saved", 0))

--- a/vllm_mlx/metrics.py
+++ b/vllm_mlx/metrics.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Prometheus-first server metrics for vllm-mlx.
+
+The public surface is a small internal abstraction that keeps instrumentation
+call sites stable even if we add OpenTelemetry export later.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _bool_str(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class InferenceTracker:
+    """Request-scoped inference timing and token accounting."""
+
+    collector: "MetricsCollector | None"
+    endpoint: str
+    stream: bool
+    start_time: float = field(default_factory=time.perf_counter)
+    _finished: bool = False
+    _ttft_observed: bool = False
+
+    def observe_ttft(self) -> None:
+        if self.collector is None or self._ttft_observed:
+            return
+        self.collector.observe_ttft(
+            endpoint=self.endpoint,
+            stream=self.stream,
+            value=time.perf_counter() - self.start_time,
+        )
+        self._ttft_observed = True
+
+    def finish(
+        self,
+        *,
+        result: str,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+    ) -> None:
+        if self.collector is None or self._finished:
+            return
+        self.collector.observe_inference(
+            endpoint=self.endpoint,
+            stream=self.stream,
+            result=result,
+            duration=time.perf_counter() - self.start_time,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
+        self._finished = True
+
+
+class MetricsCollector:
+    """Lazy Prometheus-backed metrics collector."""
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._lock = threading.Lock()
+        self._prom = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def configure(self, *, enabled: bool) -> None:
+        with self._lock:
+            self._enabled = enabled
+            if not enabled or self._prom is not None:
+                return
+            self._init_prometheus()
+
+    def _init_prometheus(self) -> None:
+        from prometheus_client import (
+            CONTENT_TYPE_LATEST,
+            CollectorRegistry,
+            Counter,
+            Gauge,
+            Histogram,
+            generate_latest,
+        )
+
+        registry = CollectorRegistry(auto_describe=True)
+        self._prom = {
+            "registry": registry,
+            "generate_latest": generate_latest,
+            "content_type": CONTENT_TYPE_LATEST,
+            "http_requests_total": Counter(
+                "vllm_mlx_http_requests_total",
+                "HTTP requests handled by the server.",
+                ["method", "path", "status_code"],
+                registry=registry,
+            ),
+            "http_request_duration_seconds": Histogram(
+                "vllm_mlx_http_request_duration_seconds",
+                "HTTP request latency in seconds.",
+                ["method", "path"],
+                registry=registry,
+                buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+            ),
+            "http_requests_in_flight": Gauge(
+                "vllm_mlx_http_requests_in_flight",
+                "HTTP requests currently in flight.",
+                ["method", "path"],
+                registry=registry,
+            ),
+            "inference_requests_total": Counter(
+                "vllm_mlx_inference_requests_total",
+                "Inference requests completed by endpoint.",
+                ["endpoint", "stream", "result"],
+                registry=registry,
+            ),
+            "inference_request_duration_seconds": Histogram(
+                "vllm_mlx_inference_request_duration_seconds",
+                "End-to-end inference latency in seconds.",
+                ["endpoint", "stream"],
+                registry=registry,
+                buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+            ),
+            "inference_ttft_seconds": Histogram(
+                "vllm_mlx_inference_ttft_seconds",
+                "Time to first token for streaming endpoints.",
+                ["endpoint", "stream"],
+                registry=registry,
+                buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+            ),
+            "prompt_tokens_total": Counter(
+                "vllm_mlx_prompt_tokens_total",
+                "Prompt/input tokens processed by endpoint.",
+                ["endpoint", "stream"],
+                registry=registry,
+            ),
+            "completion_tokens_total": Counter(
+                "vllm_mlx_completion_tokens_total",
+                "Generated output tokens produced by endpoint.",
+                ["endpoint", "stream"],
+                registry=registry,
+            ),
+            "model_loaded": Gauge(
+                "vllm_mlx_model_loaded",
+                "Whether a generation model is currently loaded.",
+                registry=registry,
+            ),
+            "engine_type": Gauge(
+                "vllm_mlx_engine_type",
+                "Current engine mode.",
+                ["engine_type"],
+                registry=registry,
+            ),
+            "engine_is_mllm": Gauge(
+                "vllm_mlx_engine_is_mllm",
+                "Whether the loaded engine is multimodal.",
+                registry=registry,
+            ),
+            "scheduler_waiting_requests": Gauge(
+                "vllm_mlx_scheduler_waiting_requests",
+                "Requests currently waiting in the scheduler.",
+                registry=registry,
+            ),
+            "scheduler_running_requests": Gauge(
+                "vllm_mlx_scheduler_running_requests",
+                "Requests currently running in the scheduler.",
+                registry=registry,
+            ),
+            "engine_steps_executed": Gauge(
+                "vllm_mlx_engine_steps_executed",
+                "Scheduler/engine steps executed since startup.",
+                registry=registry,
+            ),
+            "engine_uptime_seconds": Gauge(
+                "vllm_mlx_engine_uptime_seconds",
+                "Engine uptime in seconds.",
+                registry=registry,
+            ),
+            "metal_memory_bytes": Gauge(
+                "vllm_mlx_metal_memory_bytes",
+                "Metal memory usage in bytes.",
+                ["kind"],
+                registry=registry,
+            ),
+            "cache_type": Gauge(
+                "vllm_mlx_cache_type",
+                "Current active cache backend.",
+                ["cache_type"],
+                registry=registry,
+            ),
+            "cache_entry_count": Gauge(
+                "vllm_mlx_cache_entry_count",
+                "Cache entries or allocated blocks, depending on cache type.",
+                registry=registry,
+            ),
+            "cache_hits": Gauge(
+                "vllm_mlx_cache_hits",
+                "Cache hits since startup/reset.",
+                registry=registry,
+            ),
+            "cache_misses": Gauge(
+                "vllm_mlx_cache_misses",
+                "Cache misses since startup/reset.",
+                registry=registry,
+            ),
+            "cache_evictions": Gauge(
+                "vllm_mlx_cache_evictions",
+                "Cache evictions since startup/reset.",
+                registry=registry,
+            ),
+            "cache_hit_rate": Gauge(
+                "vllm_mlx_cache_hit_rate",
+                "Cache hit rate.",
+                registry=registry,
+            ),
+            "cache_utilization_ratio": Gauge(
+                "vllm_mlx_cache_utilization_ratio",
+                "Cache utilization ratio.",
+                registry=registry,
+            ),
+            "cache_memory_bytes": Gauge(
+                "vllm_mlx_cache_memory_bytes",
+                "Cache memory usage in bytes.",
+                registry=registry,
+            ),
+            "cache_memory_limit_bytes": Gauge(
+                "vllm_mlx_cache_memory_limit_bytes",
+                "Cache memory limit in bytes when available.",
+                registry=registry,
+            ),
+            "cache_tokens_saved": Gauge(
+                "vllm_mlx_cache_tokens_saved",
+                "Prompt tokens saved by cache reuse since startup/reset.",
+                registry=registry,
+            ),
+            "model_registry_entries": Gauge(
+                "vllm_mlx_model_registry_entries",
+                "Tracked model ownership entries.",
+                registry=registry,
+            ),
+            "model_registry_active_owners": Gauge(
+                "vllm_mlx_model_registry_active_owners",
+                "Active model owners in the registry.",
+                registry=registry,
+            ),
+            "mcp_connected_servers": Gauge(
+                "vllm_mlx_mcp_connected_servers",
+                "Connected MCP servers.",
+                registry=registry,
+            ),
+            "mcp_total_servers": Gauge(
+                "vllm_mlx_mcp_total_servers",
+                "Configured MCP servers.",
+                registry=registry,
+            ),
+            "mcp_tools_available": Gauge(
+                "vllm_mlx_mcp_tools_available",
+                "Available MCP tools.",
+                registry=registry,
+            ),
+        }
+
+    def track_inference(self, endpoint: str, *, stream: bool) -> InferenceTracker:
+        if not self._enabled:
+            return InferenceTracker(None, endpoint, stream)
+        return InferenceTracker(self, endpoint, stream)
+
+    def observe_http_start(self, *, method: str, path: str) -> None:
+        if not self._enabled or self._prom is None:
+            return
+        self._prom["http_requests_in_flight"].labels(method=method, path=path).inc()
+
+    def observe_http_finish(
+        self,
+        *,
+        method: str,
+        path: str,
+        status_code: int,
+        duration: float,
+    ) -> None:
+        if not self._enabled or self._prom is None:
+            return
+        self._prom["http_requests_in_flight"].labels(method=method, path=path).dec()
+        self._prom["http_requests_total"].labels(
+            method=method,
+            path=path,
+            status_code=str(status_code),
+        ).inc()
+        self._prom["http_request_duration_seconds"].labels(
+            method=method,
+            path=path,
+        ).observe(duration)
+
+    def observe_inference(
+        self,
+        *,
+        endpoint: str,
+        stream: bool,
+        result: str,
+        duration: float,
+        prompt_tokens: int,
+        completion_tokens: int,
+    ) -> None:
+        if not self._enabled or self._prom is None:
+            return
+        stream_label = _bool_str(stream)
+        self._prom["inference_requests_total"].labels(
+            endpoint=endpoint,
+            stream=stream_label,
+            result=result,
+        ).inc()
+        self._prom["inference_request_duration_seconds"].labels(
+            endpoint=endpoint,
+            stream=stream_label,
+        ).observe(duration)
+        if prompt_tokens > 0:
+            self._prom["prompt_tokens_total"].labels(
+                endpoint=endpoint,
+                stream=stream_label,
+            ).inc(prompt_tokens)
+        if completion_tokens > 0:
+            self._prom["completion_tokens_total"].labels(
+                endpoint=endpoint,
+                stream=stream_label,
+            ).inc(completion_tokens)
+
+    def observe_ttft(self, *, endpoint: str, stream: bool, value: float) -> None:
+        if not self._enabled or self._prom is None:
+            return
+        self._prom["inference_ttft_seconds"].labels(
+            endpoint=endpoint,
+            stream=_bool_str(stream),
+        ).observe(value)
+
+    def _update_engine_gauges(
+        self,
+        *,
+        engine: Any | None,
+        mcp_manager: Any | None,
+    ) -> None:
+        assert self._prom is not None
+
+        stats = engine.get_stats() if engine is not None else {}
+
+        self._prom["model_loaded"].set(1 if engine is not None else 0)
+        current_engine_type = stats.get("engine_type", "unknown") if engine else "unknown"
+        for engine_type in ("simple", "batched", "unknown"):
+            self._prom["engine_type"].labels(engine_type=engine_type).set(
+                1 if current_engine_type == engine_type else 0
+            )
+        self._prom["engine_is_mllm"].set(1 if stats.get("is_mllm") else 0)
+
+        self._prom["scheduler_waiting_requests"].set(
+            _coerce_int(stats.get("num_waiting"))
+        )
+        self._prom["scheduler_running_requests"].set(
+            _coerce_int(stats.get("num_running"))
+        )
+        self._prom["engine_steps_executed"].set(
+            _coerce_int(stats.get("steps_executed"))
+        )
+        self._prom["engine_uptime_seconds"].set(
+            _coerce_float(stats.get("uptime_seconds"))
+        )
+
+        self._prom["metal_memory_bytes"].labels(kind="active").set(
+            _coerce_float(stats.get("metal_active_memory_gb")) * 1e9
+        )
+        self._prom["metal_memory_bytes"].labels(kind="peak").set(
+            _coerce_float(stats.get("metal_peak_memory_gb")) * 1e9
+        )
+        self._prom["metal_memory_bytes"].labels(kind="cache").set(
+            _coerce_float(stats.get("metal_cache_memory_gb")) * 1e9
+        )
+
+        cache_type = "none"
+        cache_stats = None
+        for candidate in ("memory_aware_cache", "paged_cache", "prefix_cache"):
+            if candidate in stats:
+                cache_type = candidate
+                cache_stats = stats[candidate]
+                break
+
+        for candidate in ("none", "prefix_cache", "memory_aware_cache", "paged_cache"):
+            self._prom["cache_type"].labels(cache_type=candidate).set(
+                1 if cache_type == candidate else 0
+            )
+
+        if isinstance(cache_stats, dict):
+            self._prom["cache_entry_count"].set(
+                _coerce_float(
+                    cache_stats.get("entry_count", cache_stats.get("allocated_blocks", 0))
+                )
+            )
+            self._prom["cache_hits"].set(
+                _coerce_float(cache_stats.get("hits", cache_stats.get("cache_hits", 0)))
+            )
+            self._prom["cache_misses"].set(
+                _coerce_float(
+                    cache_stats.get("misses", cache_stats.get("cache_misses", 0))
+                )
+            )
+            self._prom["cache_evictions"].set(
+                _coerce_float(cache_stats.get("evictions", 0))
+            )
+            self._prom["cache_hit_rate"].set(
+                _coerce_float(
+                    cache_stats.get("hit_rate", cache_stats.get("cache_hit_rate", 0.0))
+                )
+            )
+            self._prom["cache_utilization_ratio"].set(
+                _coerce_float(cache_stats.get("memory_utilization", cache_stats.get("utilization", 0.0)))
+            )
+            self._prom["cache_tokens_saved"].set(
+                _coerce_float(cache_stats.get("tokens_saved", 0))
+            )
+            self._prom["cache_memory_bytes"].set(
+                _coerce_float(cache_stats.get("current_memory_mb", 0.0)) * 1024 * 1024
+            )
+            self._prom["cache_memory_limit_bytes"].set(
+                _coerce_float(cache_stats.get("max_memory_mb", 0.0)) * 1024 * 1024
+            )
+        else:
+            self._prom["cache_entry_count"].set(0)
+            self._prom["cache_hits"].set(0)
+            self._prom["cache_misses"].set(0)
+            self._prom["cache_evictions"].set(0)
+            self._prom["cache_hit_rate"].set(0)
+            self._prom["cache_utilization_ratio"].set(0)
+            self._prom["cache_tokens_saved"].set(0)
+            self._prom["cache_memory_bytes"].set(0)
+            self._prom["cache_memory_limit_bytes"].set(0)
+
+        try:
+            from .model_registry import get_registry
+
+            registry_stats = get_registry().get_stats()
+        except Exception:
+            registry_stats = {}
+        self._prom["model_registry_entries"].set(
+            _coerce_int(registry_stats.get("total_entries"))
+        )
+        self._prom["model_registry_active_owners"].set(
+            _coerce_int(registry_stats.get("active_owners"))
+        )
+
+        if mcp_manager is not None:
+            try:
+                statuses = list(mcp_manager.get_server_status())
+                connected = sum(1 for s in statuses if s.state.value == "connected")
+                total = len(statuses)
+                tools = len(mcp_manager.get_all_tools())
+            except Exception:
+                connected = total = tools = 0
+        else:
+            connected = total = tools = 0
+        self._prom["mcp_connected_servers"].set(connected)
+        self._prom["mcp_total_servers"].set(total)
+        self._prom["mcp_tools_available"].set(tools)
+
+    def render_metrics(
+        self,
+        *,
+        engine: Any | None,
+        mcp_manager: Any | None,
+    ) -> tuple[bytes, str]:
+        if not self._enabled:
+            raise RuntimeError("metrics_disabled")
+        if self._prom is None:
+            self._init_prometheus()
+        self._update_engine_gauges(engine=engine, mcp_manager=mcp_manager)
+        return (
+            self._prom["generate_latest"](self._prom["registry"]),
+            self._prom["content_type"],
+        )
+
+
+metrics = MetricsCollector()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2496,7 +2496,9 @@ async def stream_completion(
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
             prompt_tokens = (
-                output.prompt_tokens if hasattr(output, "prompt_tokens") else prompt_tokens
+                output.prompt_tokens
+                if hasattr(output, "prompt_tokens")
+                else prompt_tokens
             )
             completion_tokens = (
                 output.completion_tokens
@@ -2512,7 +2514,9 @@ async def stream_completion(
                     {
                         "index": 0,
                         "text": output.new_text,
-                        "finish_reason": output.finish_reason if output.finished else None,
+                        "finish_reason": (
+                            output.finish_reason if output.finished else None
+                        ),
                     }
                 ],
             }
@@ -2623,7 +2627,11 @@ async def stream_chat_completion(
                 completion_tokens = output.completion_tokens
 
             # Use reasoning parser if enabled (skip when enable_thinking=False)
-            if _reasoning_parser and delta_text and request.enable_thinking is not False:
+            if (
+                _reasoning_parser
+                and delta_text
+                and request.enable_thinking is not False
+            ):
                 previous_text = accumulated_text
                 accumulated_text += delta_text
                 delta_msg = _reasoning_parser.extract_reasoning_streaming(
@@ -2878,7 +2886,9 @@ async def stream_chat_completion(
                                             ),
                                         },
                                     }
-                                    for i, tc in enumerate(final_parse_result.tool_calls)
+                                    for i, tc in enumerate(
+                                        final_parse_result.tool_calls
+                                    )
                                 ]
                             ),
                             finish_reason="tool_calls",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -55,6 +55,7 @@ import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
 from fastapi.responses import Response, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.routing import Match
 
 # Import from new modular API
 # Re-export for backwards compatibility with tests
@@ -109,6 +110,7 @@ from .api.utils import (
     is_mllm_model,  # noqa: F401
 )
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
+from .metrics import metrics as _metrics
 from .tool_parsers import ToolParserManager
 
 logging.basicConfig(level=logging.INFO)
@@ -124,6 +126,7 @@ _default_max_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
+_metrics_enabled = False
 
 _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
@@ -260,6 +263,66 @@ app = FastAPI(
 )
 
 security = HTTPBearer(auto_error=False)
+
+
+def _metrics_result_from_status(status_code: int) -> str:
+    """Map HTTP-ish status codes to low-cardinality inference results."""
+    if status_code == 499:
+        return "client_closed"
+    if status_code == 504:
+        return "timeout"
+    if status_code >= 500:
+        return "error"
+    return "success"
+
+
+def _metrics_path_for_request(request: Request) -> str:
+    """Prefer route templates over raw URLs to keep metrics cardinality bounded."""
+    route = request.scope.get("route")
+    if route is not None:
+        path = getattr(route, "path", None)
+        if path:
+            return str(path)
+    for candidate in app.router.routes:
+        match, _ = candidate.matches(request.scope)
+        if match in (Match.FULL, Match.PARTIAL):
+            path = getattr(candidate, "path", None)
+            if path:
+                return str(path)
+    return "__unmatched__"
+
+
+@app.middleware("http")
+async def _metrics_middleware(request: Request, call_next):
+    """Capture generic HTTP request metrics when enabled."""
+    if not _metrics.enabled:
+        return await call_next(request)
+
+    method = request.method
+    path = _metrics_path_for_request(request)
+    if path == "/metrics":
+        return await call_next(request)
+
+    start_time = time.perf_counter()
+    _metrics.observe_http_start(method=method, path=path)
+    try:
+        response = await call_next(request)
+    except Exception:
+        _metrics.observe_http_finish(
+            method=method,
+            path=path,
+            status_code=500,
+            duration=time.perf_counter() - start_time,
+        )
+        raise
+
+    _metrics.observe_http_finish(
+        method=method,
+        path=path,
+        status_code=response.status_code,
+        duration=time.perf_counter() - start_time,
+    )
+    return response
 
 
 class RateLimiter:
@@ -644,6 +707,19 @@ def get_usage(output: GenerationOutput) -> Usage:
     )
 
 
+@app.get("/metrics")
+async def metrics():
+    """Prometheus scrape endpoint (disabled by default)."""
+    if not _metrics.enabled:
+        raise HTTPException(status_code=404, detail="Metrics endpoint is disabled")
+
+    payload, content_type = _metrics.render_metrics(
+        engine=_engine,
+        mcp_manager=_mcp_manager,
+    )
+    return Response(content=payload, headers={"Content-Type": content_type})
+
+
 @app.get("/health")
 async def health():
     """Health check endpoint."""
@@ -802,6 +878,7 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
     - Any BERT/XLM-RoBERTa/ModernBERT model from HuggingFace
     """
     global _embedding_engine
+    tracker = _metrics.track_inference("embeddings", stream=False)
 
     try:
         # Resolve model name
@@ -849,7 +926,7 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
             EmbeddingData(index=i, embedding=vec) for i, vec in enumerate(embeddings)
         ]
 
-        return EmbeddingResponse(
+        response = EmbeddingResponse(
             data=data,
             model=model_name,
             usage=EmbeddingUsage(
@@ -857,17 +934,26 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
                 total_tokens=prompt_tokens,
             ),
         )
+        tracker.finish(
+            result="success",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=0,
+        )
+        return response
 
     except ImportError:
+        tracker.finish(result="error")
         raise HTTPException(
             status_code=503,
             detail=(
                 "mlx-embeddings not installed. Install with: pip install mlx-embeddings"
             ),
         )
-    except HTTPException:
+    except HTTPException as exc:
+        tracker.finish(result=_metrics_result_from_status(exc.status_code))
         raise
     except Exception as e:
+        tracker.finish(result="error")
         logger.error(f"Embedding generation failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -965,6 +1051,7 @@ async def create_transcription(
     - parakeet-tdt-0.6b-v2 (English, fastest)
     """
     global _stt_engine
+    tracker = _metrics.track_inference("audio_transcriptions", stream=False)
 
     try:
         from .audio.stt import STTEngine  # Lazy import - optional feature
@@ -997,8 +1084,10 @@ async def create_transcription(
             os.unlink(tmp_path)
 
         if response_format == "text":
+            tracker.finish(result="success")
             return result.text
 
+        tracker.finish(result="success")
         return {
             "text": result.text,
             "language": result.language,
@@ -1006,11 +1095,16 @@ async def create_transcription(
         }
 
     except ImportError:
+        tracker.finish(result="error")
         raise HTTPException(
             status_code=503,
             detail="mlx-audio not installed. Install with: pip install mlx-audio",
         )
+    except HTTPException as exc:
+        tracker.finish(result=_metrics_result_from_status(exc.status_code))
+        raise
     except Exception as e:
+        tracker.finish(result="error")
         logger.error(f"Transcription failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -1033,6 +1127,7 @@ async def create_speech(
     - voxcpm (Chinese/English)
     """
     global _tts_engine
+    tracker = _metrics.track_inference("audio_speech", stream=False)
 
     try:
         from .audio.tts import TTSEngine  # Lazy import - optional feature
@@ -1059,14 +1154,20 @@ async def create_speech(
         content_type = (
             "audio/wav" if response_format == "wav" else f"audio/{response_format}"
         )
+        tracker.finish(result="success")
         return Response(content=audio_bytes, media_type=content_type)
 
     except ImportError:
+        tracker.finish(result="error")
         raise HTTPException(
             status_code=503,
             detail="mlx-audio not installed. Install with: pip install mlx-audio",
         )
+    except HTTPException as exc:
+        tracker.finish(result=_metrics_result_from_status(exc.status_code))
+        raise
     except Exception as e:
+        tracker.finish(result="error")
         logger.error(f"TTS generation failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -1300,6 +1401,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     """Create a text completion."""
     _validate_model_name(request.model)
     engine = get_engine()
+    tracker = _metrics.track_inference("completions", stream=request.stream)
 
     # Handle single prompt or list of prompts
     prompts = request.prompt if isinstance(request.prompt, list) else [request.prompt]
@@ -1327,6 +1429,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     prompts[0],
                     request,
                     repetition_penalty=comp_rep_penalty,
+                    metrics_tracker=tracker,
                 ),
                 raw_request,
             ),
@@ -1358,12 +1461,21 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         if request.specprefill_keep_pct is not None:
             generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
-        output = await _wait_with_disconnect(
-            engine.generate(**generate_kwargs),
-            raw_request,
-            timeout=timeout,
-        )
+        try:
+            output = await _wait_with_disconnect(
+                engine.generate(**generate_kwargs),
+                raw_request,
+                timeout=timeout,
+            )
+        except HTTPException as exc:
+            tracker.finish(result=_metrics_result_from_status(exc.status_code))
+            raise
         if output is None:
+            tracker.finish(
+                result="client_closed",
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
+            )
             return Response(status_code=499)  # Client closed request
 
         choices.append(
@@ -1384,6 +1496,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         f"Completion: {total_prompt_tokens} prompt + {total_completion_tokens} completion tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
+    tracker.finish(
+        result="success",
+        prompt_tokens=total_prompt_tokens,
+        completion_tokens=total_completion_tokens,
+    )
     return CompletionResponse(
         model=_model_name,
         choices=choices,
@@ -1443,6 +1560,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     """
     _validate_model_name(request.model)
     engine = get_engine()
+    tracker = _metrics.track_inference("chat_completions", stream=request.stream)
 
     # --- Detailed request logging ---
     n_msgs = len(request.messages)
@@ -1563,7 +1681,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     if request.stream:
         return StreamingResponse(
             _disconnect_guard(
-                stream_chat_completion(engine, messages, request, **chat_kwargs),
+                stream_chat_completion(
+                    engine,
+                    messages,
+                    request,
+                    metrics_tracker=tracker,
+                    **chat_kwargs,
+                ),
                 raw_request,
             ),
             media_type="text/event-stream",
@@ -1573,12 +1697,17 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     start_time = time.perf_counter()
     timeout = request.timeout or _default_timeout
 
-    output = await _wait_with_disconnect(
-        engine.chat(messages=messages, **chat_kwargs),
-        raw_request,
-        timeout=timeout,
-    )
+    try:
+        output = await _wait_with_disconnect(
+            engine.chat(messages=messages, **chat_kwargs),
+            raw_request,
+            timeout=timeout,
+        )
+    except HTTPException as exc:
+        tracker.finish(result=_metrics_result_from_status(exc.status_code))
+        raise
     if output is None:
+        tracker.finish(result="client_closed")
         return Response(status_code=499)  # Client closed request
 
     elapsed = time.perf_counter() - start_time
@@ -1612,6 +1741,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Determine finish reason
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
 
+    tracker.finish(
+        result="success",
+        prompt_tokens=output.prompt_tokens,
+        completion_tokens=output.completion_tokens,
+    )
     return ChatCompletionResponse(
         model=_model_name,
         choices=[
@@ -1751,6 +1885,7 @@ async def create_anthropic_message(
     Supports both streaming and non-streaming modes.
     """
     engine = get_engine()
+    tracker = _metrics.track_inference("anthropic_messages", stream=False)
 
     # Parse the raw body to handle Anthropic request format.
     # Some clients (e.g. Claude Code) may send JSON with invalid escape
@@ -1794,7 +1929,12 @@ async def create_anthropic_message(
     if anthropic_request.stream:
         return StreamingResponse(
             _disconnect_guard(
-                _stream_anthropic_messages(engine, openai_request, anthropic_request),
+                _stream_anthropic_messages(
+                    engine,
+                    openai_request,
+                    anthropic_request,
+                    metrics_tracker=tracker,
+                ),
                 request,
             ),
             media_type="text/event-stream",
@@ -1827,12 +1967,17 @@ async def create_anthropic_message(
     start_time = time.perf_counter()
     timeout = _default_timeout
 
-    output = await _wait_with_disconnect(
-        engine.chat(messages=messages, **chat_kwargs),
-        request,
-        timeout=timeout,
-    )
+    try:
+        output = await _wait_with_disconnect(
+            engine.chat(messages=messages, **chat_kwargs),
+            request,
+            timeout=timeout,
+        )
+    except HTTPException as exc:
+        tracker.finish(result=_metrics_result_from_status(exc.status_code))
+        raise
     if output is None:
+        tracker.finish(result="client_closed")
         return Response(status_code=499)  # Client closed request
 
     elapsed = time.perf_counter() - start_time
@@ -1902,6 +2047,11 @@ async def create_anthropic_message(
             input_tokens=output.prompt_tokens,
             output_tokens=output.completion_tokens,
         ),
+    )
+    tracker.finish(
+        result="success",
+        prompt_tokens=output.prompt_tokens,
+        completion_tokens=output.completion_tokens,
     )
     return Response(
         content=anthropic_response.model_dump_json(exclude_none=True),
@@ -2036,6 +2186,7 @@ async def _stream_anthropic_messages(
     engine: BaseEngine,
     openai_request: ChatCompletionRequest,
     anthropic_request: AnthropicRequest,
+    metrics_tracker=None,
 ) -> AsyncIterator[str]:
     """
     Stream Anthropic Messages API SSE events.
@@ -2050,6 +2201,8 @@ async def _stream_anthropic_messages(
     """
     msg_id = f"msg_{uuid.uuid4().hex[:24]}"
     start_time = time.perf_counter()
+    result_label = "success"
+    prompt_tokens = 0
 
     # Extract messages for engine
     messages, images, videos = extract_multimodal_content(
@@ -2132,151 +2285,177 @@ async def _stream_anthropic_messages(
             tool_parser = _tool_parser_instance
             tool_parser.reset()
 
-    async for output in engine.stream_chat(messages=messages, **chat_kwargs):
-        delta_text = output.new_text
+    try:
+        async for output in engine.stream_chat(messages=messages, **chat_kwargs):
+            if metrics_tracker is not None:
+                metrics_tracker.observe_ttft()
+            delta_text = output.new_text
 
-        # Track token counts
-        if hasattr(output, "completion_tokens") and output.completion_tokens:
-            completion_tokens = output.completion_tokens
+            if hasattr(output, "prompt_tokens") and output.prompt_tokens:
+                prompt_tokens = output.prompt_tokens
 
-        if not delta_text:
-            continue
+            # Track token counts
+            if hasattr(output, "completion_tokens") and output.completion_tokens:
+                completion_tokens = output.completion_tokens
 
-        # Filter special tokens
-        filtered = SPECIAL_TOKENS_PATTERN.sub("", delta_text)
-        if not filtered:
-            continue
+            if not delta_text:
+                continue
 
-        if not use_reasoning:
-            # Simple path — no reasoning parsing
+            # Filter special tokens
+            filtered = SPECIAL_TOKENS_PATTERN.sub("", delta_text)
+            if not filtered:
+                continue
+
+            if not use_reasoning:
+                # Simple path — no reasoning parsing
+                accumulated_text += filtered
+                content_to_emit = filtered
+
+                # Filter tool call markup during streaming
+                if tool_parser and content_to_emit:
+                    if not tool_markup_possible and "<" not in content_to_emit:
+                        tool_accumulated_text += content_to_emit
+                    else:
+                        if not tool_markup_possible:
+                            tool_markup_possible = True
+                        tool_previous = tool_accumulated_text
+                        tool_accumulated_text += content_to_emit
+                        tool_result = tool_parser.extract_tool_calls_streaming(
+                            tool_previous, tool_accumulated_text, content_to_emit
+                        )
+                        if tool_result is None or "tool_calls" in tool_result:
+                            # Inside tool markup or tool calls detected — suppress
+                            continue
+                        content_to_emit = tool_result.get("content", "")
+                        if content_to_emit:
+                            content_to_emit = _TOOL_MARKUP_PATTERN.sub(
+                                "", content_to_emit
+                            )
+                        if not content_to_emit:
+                            continue
+
+                yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': 0, 'delta': {'type': 'text_delta', 'text': content_to_emit}})}\n\n"
+                continue
+
+            # Reasoning parser path
+            previous_text = accumulated_text
             accumulated_text += filtered
-            content_to_emit = filtered
+            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+                previous_text, accumulated_text, filtered
+            )
 
-            # Filter tool call markup during streaming
-            if tool_parser and content_to_emit:
-                if not tool_markup_possible and "<" not in content_to_emit:
-                    tool_accumulated_text += content_to_emit
-                else:
-                    if not tool_markup_possible:
-                        tool_markup_possible = True
-                    tool_previous = tool_accumulated_text
-                    tool_accumulated_text += content_to_emit
-                    tool_result = tool_parser.extract_tool_calls_streaming(
-                        tool_previous, tool_accumulated_text, content_to_emit
-                    )
-                    if tool_result is None or "tool_calls" in tool_result:
-                        # Inside tool markup or tool calls detected — suppress
-                        continue
-                    content_to_emit = tool_result.get("content", "")
-                    if content_to_emit:
-                        content_to_emit = _TOOL_MARKUP_PATTERN.sub("", content_to_emit)
-                    if not content_to_emit:
-                        continue
+            if delta_msg is None:
+                continue
 
-            yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': 0, 'delta': {'type': 'text_delta', 'text': content_to_emit}})}\n\n"
-            continue
+            if delta_msg.reasoning:
+                if not thinking_block_started:
+                    yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': thinking_index, 'content_block': {'type': 'thinking', 'thinking': ''}})}\n\n"
+                    thinking_block_started = True
+                yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': thinking_index, 'delta': {'type': 'thinking_delta', 'thinking': delta_msg.reasoning}})}\n\n"
 
-        # Reasoning parser path
-        previous_text = accumulated_text
-        accumulated_text += filtered
-        delta_msg = _reasoning_parser.extract_reasoning_streaming(
-            previous_text, accumulated_text, filtered
+            if delta_msg.content:
+                content_to_emit = delta_msg.content
+
+                # Filter tool call markup during streaming
+                if tool_parser and content_to_emit:
+                    if not tool_markup_possible and "<" not in content_to_emit:
+                        tool_accumulated_text += content_to_emit
+                    else:
+                        if not tool_markup_possible:
+                            tool_markup_possible = True
+                        tool_previous = tool_accumulated_text
+                        tool_accumulated_text += content_to_emit
+                        tool_result = tool_parser.extract_tool_calls_streaming(
+                            tool_previous, tool_accumulated_text, content_to_emit
+                        )
+                        if tool_result is None or "tool_calls" in tool_result:
+                            # Inside tool markup or tool calls detected — suppress
+                            continue
+                        content_to_emit = tool_result.get("content", "")
+                        if content_to_emit:
+                            content_to_emit = _TOOL_MARKUP_PATTERN.sub(
+                                "", content_to_emit
+                            )
+                        if not content_to_emit:
+                            continue
+
+                if thinking_block_started and not text_block_started:
+                    # Close thinking block, open text block
+                    yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': thinking_index})}\n\n"
+                    yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
+                    text_block_started = True
+                elif not text_block_started:
+                    # No thinking was emitted, start text block at index 0
+                    text_index = 0
+                    yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
+                    text_block_started = True
+                yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': text_index, 'delta': {'type': 'text_delta', 'text': content_to_emit}})}\n\n"
+
+        # Close any open thinking block that was never followed by text
+        if thinking_block_started and not text_block_started:
+            yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': thinking_index})}\n\n"
+            # Emit empty text block so response always has text content
+            text_index = thinking_index + 1
+            yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
+            text_block_started = True
+
+        # Check for tool calls in accumulated text
+        _, tool_calls = _parse_tool_calls_with_parser(accumulated_text, openai_request)
+
+        # Close text block
+        if text_block_started:
+            yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': text_index})}\n\n"
+
+        # If there are tool calls, emit tool_use blocks
+        next_index = (text_index + 1) if text_block_started else 0
+        if tool_calls:
+            for i, tc in enumerate(tool_calls):
+                tool_index = next_index + i
+                try:
+                    tool_input = json.loads(tc.function.arguments)
+                except (json.JSONDecodeError, AttributeError):
+                    tool_input = {}
+
+                yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': tool_index, 'content_block': {'type': 'tool_use', 'id': tc.id, 'name': tc.function.name, 'input': {}}})}\n\n"
+                yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': tool_index, 'delta': {'type': 'input_json_delta', 'partial_json': json.dumps(tool_input)}})}\n\n"
+                yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': tool_index})}\n\n"
+
+        # Determine stop reason
+        stop_reason = "tool_use" if tool_calls else "end_turn"
+
+        # Emit message_delta with stop_reason and usage
+        message_delta = {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"output_tokens": completion_tokens},
+        }
+        yield f"event: message_delta\ndata: {json.dumps(message_delta)}\n\n"
+
+        # Log throughput
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Anthropic messages (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
-        if delta_msg is None:
-            continue
-
-        if delta_msg.reasoning:
-            if not thinking_block_started:
-                yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': thinking_index, 'content_block': {'type': 'thinking', 'thinking': ''}})}\n\n"
-                thinking_block_started = True
-            yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': thinking_index, 'delta': {'type': 'thinking_delta', 'thinking': delta_msg.reasoning}})}\n\n"
-
-        if delta_msg.content:
-            content_to_emit = delta_msg.content
-
-            # Filter tool call markup during streaming
-            if tool_parser and content_to_emit:
-                if not tool_markup_possible and "<" not in content_to_emit:
-                    tool_accumulated_text += content_to_emit
-                else:
-                    if not tool_markup_possible:
-                        tool_markup_possible = True
-                    tool_previous = tool_accumulated_text
-                    tool_accumulated_text += content_to_emit
-                    tool_result = tool_parser.extract_tool_calls_streaming(
-                        tool_previous, tool_accumulated_text, content_to_emit
-                    )
-                    if tool_result is None or "tool_calls" in tool_result:
-                        # Inside tool markup or tool calls detected — suppress
-                        continue
-                    content_to_emit = tool_result.get("content", "")
-                    if content_to_emit:
-                        content_to_emit = _TOOL_MARKUP_PATTERN.sub("", content_to_emit)
-                    if not content_to_emit:
-                        continue
-
-            if thinking_block_started and not text_block_started:
-                # Close thinking block, open text block
-                yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': thinking_index})}\n\n"
-                yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
-                text_block_started = True
-            elif not text_block_started:
-                # No thinking was emitted, start text block at index 0
-                text_index = 0
-                yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
-                text_block_started = True
-            yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': text_index, 'delta': {'type': 'text_delta', 'text': content_to_emit}})}\n\n"
-
-    # Close any open thinking block that was never followed by text
-    if thinking_block_started and not text_block_started:
-        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': thinking_index})}\n\n"
-        # Emit empty text block so response always has text content
-        text_index = thinking_index + 1
-        yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': text_index, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
-        text_block_started = True
-
-    # Check for tool calls in accumulated text
-    _, tool_calls = _parse_tool_calls_with_parser(accumulated_text, openai_request)
-
-    # Close text block
-    if text_block_started:
-        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': text_index})}\n\n"
-
-    # If there are tool calls, emit tool_use blocks
-    next_index = (text_index + 1) if text_block_started else 0
-    if tool_calls:
-        for i, tc in enumerate(tool_calls):
-            tool_index = next_index + i
-            try:
-                tool_input = json.loads(tc.function.arguments)
-            except (json.JSONDecodeError, AttributeError):
-                tool_input = {}
-
-            yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': tool_index, 'content_block': {'type': 'tool_use', 'id': tc.id, 'name': tc.function.name, 'input': {}}})}\n\n"
-            yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': tool_index, 'delta': {'type': 'input_json_delta', 'partial_json': json.dumps(tool_input)}})}\n\n"
-            yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': tool_index})}\n\n"
-
-    # Determine stop reason
-    stop_reason = "tool_use" if tool_calls else "end_turn"
-
-    # Emit message_delta with stop_reason and usage
-    message_delta = {
-        "type": "message_delta",
-        "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-        "usage": {"output_tokens": completion_tokens},
-    }
-    yield f"event: message_delta\ndata: {json.dumps(message_delta)}\n\n"
-
-    # Log throughput
-    elapsed = time.perf_counter() - start_time
-    tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
-    logger.info(
-        f"Anthropic messages (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
-    )
-
-    # Emit message_stop
-    yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"
+        # Emit message_stop
+        yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"
+    except HTTPException as exc:
+        result_label = _metrics_result_from_status(exc.status_code)
+        raise
+    except (asyncio.CancelledError, GeneratorExit):
+        result_label = "cancelled"
+        raise
+    except Exception:
+        result_label = "error"
+        raise
+    finally:
+        if metrics_tracker is not None:
+            metrics_tracker.finish(
+                result=result_label,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
 
 
 # =============================================================================
@@ -2289,8 +2468,12 @@ async def stream_completion(
     prompt: str,
     request: CompletionRequest,
     repetition_penalty: float | None = None,
+    metrics_tracker=None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
+    result = "success"
+    prompt_tokens = 0
+    completion_tokens = 0
     generate_kwargs = {
         "prompt": prompt,
         "max_tokens": request.max_tokens or _default_max_tokens,
@@ -2308,36 +2491,65 @@ async def stream_completion(
     if request.specprefill_keep_pct is not None:
         generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
 
-    async for output in engine.stream_generate(**generate_kwargs):
-        data = {
-            "id": f"cmpl-{uuid.uuid4().hex[:8]}",
-            "object": "text_completion",
-            "created": int(time.time()),
-            "model": _model_name,
-            "choices": [
-                {
-                    "index": 0,
-                    "text": output.new_text,
-                    "finish_reason": output.finish_reason if output.finished else None,
-                }
-            ],
-        }
-        if output.finished:
-            data["usage"] = get_usage(output).model_dump()
-        yield f"data: {json.dumps(data)}\n\n"
+    try:
+        async for output in engine.stream_generate(**generate_kwargs):
+            if metrics_tracker is not None:
+                metrics_tracker.observe_ttft()
+            prompt_tokens = (
+                output.prompt_tokens if hasattr(output, "prompt_tokens") else prompt_tokens
+            )
+            completion_tokens = (
+                output.completion_tokens
+                if hasattr(output, "completion_tokens")
+                else completion_tokens
+            )
+            data = {
+                "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+                "object": "text_completion",
+                "created": int(time.time()),
+                "model": _model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "text": output.new_text,
+                        "finish_reason": output.finish_reason if output.finished else None,
+                    }
+                ],
+            }
+            if output.finished:
+                data["usage"] = get_usage(output).model_dump()
+            yield f"data: {json.dumps(data)}\n\n"
 
-    yield "data: [DONE]\n\n"
+        yield "data: [DONE]\n\n"
+    except HTTPException as exc:
+        result = _metrics_result_from_status(exc.status_code)
+        raise
+    except (asyncio.CancelledError, GeneratorExit):
+        result = "cancelled"
+        raise
+    except Exception:
+        result = "error"
+        raise
+    finally:
+        if metrics_tracker is not None:
+            metrics_tracker.finish(
+                result=result,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
 
 
 async def stream_chat_completion(
     engine: BaseEngine,
     messages: list,
     request: ChatCompletionRequest,
+    metrics_tracker=None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response."""
     response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
     start_time = time.perf_counter()
+    result_label = "success"
 
     # Check if we should include usage in the final chunk
     include_usage = request.stream_options and request.stream_options.include_usage
@@ -2396,302 +2608,323 @@ async def stream_chat_completion(
             tool_parser = _tool_parser_instance
             tool_parser.reset()
 
-    # Stream content
-    async for output in engine.stream_chat(messages=messages, **kwargs):
-        delta_text = output.new_text
-        last_output = output
+    try:
+        # Stream content
+        async for output in engine.stream_chat(messages=messages, **kwargs):
+            if metrics_tracker is not None:
+                metrics_tracker.observe_ttft()
+            delta_text = output.new_text
+            last_output = output
 
-        # Track token counts from output (updated each chunk)
-        if hasattr(output, "prompt_tokens") and output.prompt_tokens:
-            prompt_tokens = output.prompt_tokens
-        if hasattr(output, "completion_tokens") and output.completion_tokens:
-            completion_tokens = output.completion_tokens
+            # Track token counts from output (updated each chunk)
+            if hasattr(output, "prompt_tokens") and output.prompt_tokens:
+                prompt_tokens = output.prompt_tokens
+            if hasattr(output, "completion_tokens") and output.completion_tokens:
+                completion_tokens = output.completion_tokens
 
-        # Use reasoning parser if enabled (skip when enable_thinking=False)
-        if _reasoning_parser and delta_text and request.enable_thinking is not False:
-            previous_text = accumulated_text
-            accumulated_text += delta_text
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
-                previous_text, accumulated_text, delta_text
-            )
+            # Use reasoning parser if enabled (skip when enable_thinking=False)
+            if _reasoning_parser and delta_text and request.enable_thinking is not False:
+                previous_text = accumulated_text
+                accumulated_text += delta_text
+                delta_msg = _reasoning_parser.extract_reasoning_streaming(
+                    previous_text, accumulated_text, delta_text
+                )
 
-            if delta_msg is None:
-                # Skip this chunk (e.g., <think> token itself)
-                continue
+                if delta_msg is None:
+                    # Skip this chunk (e.g., <think> token itself)
+                    continue
 
-            content = delta_msg.content
-            reasoning = delta_msg.reasoning
+                content = delta_msg.content
+                reasoning = delta_msg.reasoning
 
-            # Some models (e.g. MiniMax) wrap tool calls in <think>
-            # blocks, so reasoning parser captures tool call XML as
-            # reasoning while content stays None.  Redirect reasoning
-            # to the content stream so the tool parser can handle it.
-            if tool_parser and reasoning and not content:
-                _check = tool_accumulated_text + reasoning
-                if (
-                    "<minimax:tool_call>" in _check
-                    or "<tool_call>" in _check
-                    or '<invoke name="' in _check
-                ):
-                    content = reasoning
-                    reasoning = None
+                # Some models (e.g. MiniMax) wrap tool calls in <think>
+                # blocks, so reasoning parser captures tool call XML as
+                # reasoning while content stays None.  Redirect reasoning
+                # to the content stream so the tool parser can handle it.
+                if tool_parser and reasoning and not content:
+                    _check = tool_accumulated_text + reasoning
+                    if (
+                        "<minimax:tool_call>" in _check
+                        or "<tool_call>" in _check
+                        or '<invoke name="' in _check
+                    ):
+                        content = reasoning
+                        reasoning = None
 
-            # Tool call parsing on content portion
-            if tool_parser and content:
-                if not tool_markup_possible and "<" not in content:
-                    tool_accumulated_text += content
-                    # Suppress whitespace-only content when tools are active;
-                    # avoids emitting stray newlines before tool call XML.
-                    if not content.strip():
-                        continue
-                else:
-                    if not tool_markup_possible:
-                        tool_markup_possible = True
-                    tool_previous = tool_accumulated_text
-                    tool_accumulated_text += content
-                    tool_result = tool_parser.extract_tool_calls_streaming(
-                        tool_previous, tool_accumulated_text, content
-                    )
+                # Tool call parsing on content portion
+                if tool_parser and content:
+                    if not tool_markup_possible and "<" not in content:
+                        tool_accumulated_text += content
+                        # Suppress whitespace-only content when tools are active;
+                        # avoids emitting stray newlines before tool call XML.
+                        if not content.strip():
+                            continue
+                    else:
+                        if not tool_markup_possible:
+                            tool_markup_possible = True
+                        tool_previous = tool_accumulated_text
+                        tool_accumulated_text += content
+                        tool_result = tool_parser.extract_tool_calls_streaming(
+                            tool_previous, tool_accumulated_text, content
+                        )
 
-                    if tool_result is None:
-                        # Inside tool markup - suppress content output
-                        if reasoning:
-                            # Still emit reasoning while buffering tool call
+                        if tool_result is None:
+                            # Inside tool markup - suppress content output
+                            if reasoning:
+                                # Still emit reasoning while buffering tool call
+                                chunk = ChatCompletionChunk(
+                                    id=response_id,
+                                    model=_model_name,
+                                    choices=[
+                                        ChatCompletionChunkChoice(
+                                            delta=ChatCompletionChunkDelta(
+                                                reasoning=reasoning,
+                                            ),
+                                            finish_reason=None,
+                                        )
+                                    ],
+                                    usage=None,
+                                )
+                                yield f"data: {chunk.model_dump_json()}\n\n"
+                            continue
+
+                        if "tool_calls" in tool_result:
+                            # Emit structured tool calls
+                            tool_calls_detected = True
+                            # Coerce arguments against tool schemas
+                            tools = (
+                                request.model_dump().get("tools")
+                                if request and request.tools
+                                else None
+                            )
+                            if tools:
+                                for tc in tool_result["tool_calls"]:
+                                    fn = tc.get("function", {})
+                                    if "arguments" in fn and "name" in fn:
+                                        fn["arguments"] = _coerce_tool_arguments(
+                                            fn["arguments"], fn["name"], tools
+                                        )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
                                 model=_model_name,
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
+                                            tool_calls=tool_result["tool_calls"],
                                             reasoning=reasoning,
                                         ),
-                                        finish_reason=None,
+                                        finish_reason=(
+                                            "tool_calls" if output.finished else None
+                                        ),
                                     )
                                 ],
-                                usage=None,
+                                usage=get_usage(output) if output.finished else None,
                             )
                             yield f"data: {chunk.model_dump_json()}\n\n"
-                        continue
+                            continue
 
-                    if "tool_calls" in tool_result:
-                        # Emit structured tool calls
-                        tool_calls_detected = True
-                        # Coerce arguments against tool schemas
-                        tools = (
-                            request.model_dump().get("tools")
-                            if request and request.tools
-                            else None
+                        # Normal content from tool parser
+                        content = tool_result.get("content", "")
+                        # Strip any leaked tool markup tags
+                        if content:
+                            content = _TOOL_MARKUP_PATTERN.sub("", content)
+
+                chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_model_name,
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                content=content if content else None,
+                                reasoning=reasoning,
+                            ),
+                            finish_reason=(
+                                "tool_calls"
+                                if (output.finished and tool_calls_detected)
+                                else (output.finish_reason if output.finished else None)
+                            ),
                         )
-                        if tools:
-                            for tc in tool_result["tool_calls"]:
-                                fn = tc.get("function", {})
-                                if "arguments" in fn and "name" in fn:
-                                    fn["arguments"] = _coerce_tool_arguments(
-                                        fn["arguments"], fn["name"], tools
-                                    )
-                        chunk = ChatCompletionChunk(
-                            id=response_id,
-                            model=_model_name,
-                            choices=[
-                                ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        tool_calls=tool_result["tool_calls"],
-                                        reasoning=reasoning,
-                                    ),
-                                    finish_reason=(
-                                        "tool_calls" if output.finished else None
-                                    ),
-                                )
-                            ],
-                            usage=get_usage(output) if output.finished else None,
+                    ],
+                    usage=get_usage(output) if output.finished else None,
+                )
+                yield f"data: {chunk.model_dump_json()}\n\n"
+            else:
+                # Standard path without reasoning parsing
+                content = delta_text
+
+                # Filter special tokens that may leak into streaming output
+                if content:
+                    content = SPECIAL_TOKENS_PATTERN.sub("", content)
+
+                # Add <think> prefix on first content chunk for thinking models
+                if is_thinking_model and not think_prefix_sent and content:
+                    content = "<think>" + content
+                    think_prefix_sent = True
+
+                # Tool call streaming parsing
+                if tool_parser and delta_text:
+                    # Fast path: skip full parsing until '<' is seen in the stream,
+                    # which could start tool markup (e.g. <tool_call>). This avoids
+                    # per-token string scanning on the growing accumulated text.
+                    if not tool_markup_possible and "<" not in delta_text:
+                        tool_accumulated_text += delta_text
+                        # No tool markup yet, fall through to normal chunk emission
+                    else:
+                        if not tool_markup_possible:
+                            tool_markup_possible = True
+                        tool_previous = tool_accumulated_text
+                        tool_accumulated_text += delta_text
+                        tool_result = tool_parser.extract_tool_calls_streaming(
+                            tool_previous, tool_accumulated_text, delta_text
                         )
-                        yield f"data: {chunk.model_dump_json()}\n\n"
-                        continue
 
-                    # Normal content from tool parser
-                    content = tool_result.get("content", "")
-                    # Strip any leaked tool markup tags
-                    if content:
-                        content = _TOOL_MARKUP_PATTERN.sub("", content)
+                        if tool_result is None:
+                            # Inside tool markup - suppress output
+                            continue
 
-            chunk = ChatCompletionChunk(
-                id=response_id,
-                model=_model_name,
-                choices=[
-                    ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(
-                            content=content if content else None,
-                            reasoning=reasoning,
-                        ),
-                        finish_reason=(
-                            "tool_calls"
-                            if (output.finished and tool_calls_detected)
-                            else (output.finish_reason if output.finished else None)
-                        ),
-                    )
-                ],
-                usage=get_usage(output) if output.finished else None,
-            )
-            yield f"data: {chunk.model_dump_json()}\n\n"
-        else:
-            # Standard path without reasoning parsing
-            content = delta_text
-
-            # Filter special tokens that may leak into streaming output
-            if content:
-                content = SPECIAL_TOKENS_PATTERN.sub("", content)
-
-            # Add <think> prefix on first content chunk for thinking models
-            if is_thinking_model and not think_prefix_sent and content:
-                content = "<think>" + content
-                think_prefix_sent = True
-
-            # Tool call streaming parsing
-            if tool_parser and delta_text:
-                # Fast path: skip full parsing until '<' is seen in the stream,
-                # which could start tool markup (e.g. <tool_call>). This avoids
-                # per-token string scanning on the growing accumulated text.
-                if not tool_markup_possible and "<" not in delta_text:
-                    tool_accumulated_text += delta_text
-                    # No tool markup yet, fall through to normal chunk emission
-                else:
-                    if not tool_markup_possible:
-                        tool_markup_possible = True
-                    tool_previous = tool_accumulated_text
-                    tool_accumulated_text += delta_text
-                    tool_result = tool_parser.extract_tool_calls_streaming(
-                        tool_previous, tool_accumulated_text, delta_text
-                    )
-
-                    if tool_result is None:
-                        # Inside tool markup - suppress output
-                        continue
-
-                    if "tool_calls" in tool_result:
-                        # Emit structured tool calls
-                        tool_calls_detected = True
-                        # Coerce arguments against tool schemas
-                        tools = (
-                            request.model_dump().get("tools")
-                            if request and request.tools
-                            else None
-                        )
-                        if tools:
-                            for tc in tool_result["tool_calls"]:
-                                fn = tc.get("function", {})
-                                if "arguments" in fn and "name" in fn:
-                                    fn["arguments"] = _coerce_tool_arguments(
-                                        fn["arguments"], fn["name"], tools
-                                    )
-                        chunk = ChatCompletionChunk(
-                            id=response_id,
-                            model=_model_name,
-                            choices=[
-                                ChatCompletionChunkChoice(
-                                    delta=ChatCompletionChunkDelta(
-                                        tool_calls=tool_result["tool_calls"]
-                                    ),
-                                    finish_reason=(
-                                        "tool_calls" if output.finished else None
-                                    ),
-                                )
-                            ],
-                            usage=get_usage(output) if output.finished else None,
-                        )
-                        yield f"data: {chunk.model_dump_json()}\n\n"
-                        continue
-
-                    # Normal content from tool parser
-                    content = tool_result.get("content", "")
-                    # Strip any leaked tool markup tags
-                    if content:
-                        content = _TOOL_MARKUP_PATTERN.sub("", content)
-
-            chunk = ChatCompletionChunk(
-                id=response_id,
-                model=_model_name,
-                choices=[
-                    ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(
-                            content=content if content else None
-                        ),
-                        finish_reason=(
-                            "tool_calls"
-                            if (output.finished and tool_calls_detected)
-                            else (output.finish_reason if output.finished else None)
-                        ),
-                    )
-                ],
-                usage=get_usage(output) if output.finished else None,
-            )
-            yield f"data: {chunk.model_dump_json()}\n\n"
-
-    # Fallback: if tool parser accumulated text but never emitted tool_calls
-    # (e.g., </tool_call> never arrived, or <function= block still incomplete)
-    if (
-        tool_parser
-        and tool_accumulated_text
-        and not tool_calls_detected
-        and (
-            "<tool_call>" in tool_accumulated_text
-            or "<|tool_call>" in tool_accumulated_text
-            or "<function" in tool_accumulated_text
-        )
-    ):
-        result = tool_parser.extract_tool_calls(tool_accumulated_text)
-        if result.tools_called:
-            tools = (
-                request.model_dump().get("tools") if request and request.tools else None
-            )
-            tool_chunk = ChatCompletionChunk(
-                id=response_id,
-                model=_model_name,
-                choices=[
-                    ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(
-                            tool_calls=[
-                                {
-                                    "index": i,
-                                    "id": tc["id"],
-                                    "type": "function",
-                                    "function": {
-                                        "name": tc["name"],
-                                        "arguments": _coerce_tool_arguments(
-                                            tc["arguments"], tc["name"], tools
+                        if "tool_calls" in tool_result:
+                            # Emit structured tool calls
+                            tool_calls_detected = True
+                            # Coerce arguments against tool schemas
+                            tools = (
+                                request.model_dump().get("tools")
+                                if request and request.tools
+                                else None
+                            )
+                            if tools:
+                                for tc in tool_result["tool_calls"]:
+                                    fn = tc.get("function", {})
+                                    if "arguments" in fn and "name" in fn:
+                                        fn["arguments"] = _coerce_tool_arguments(
+                                            fn["arguments"], fn["name"], tools
+                                        )
+                            chunk = ChatCompletionChunk(
+                                id=response_id,
+                                model=_model_name,
+                                choices=[
+                                    ChatCompletionChunkChoice(
+                                        delta=ChatCompletionChunkDelta(
+                                            tool_calls=tool_result["tool_calls"]
                                         ),
-                                    },
-                                }
-                                for i, tc in enumerate(result.tool_calls)
-                            ]
-                        ),
-                        finish_reason="tool_calls",
-                    )
-                ],
+                                        finish_reason=(
+                                            "tool_calls" if output.finished else None
+                                        ),
+                                    )
+                                ],
+                                usage=get_usage(output) if output.finished else None,
+                            )
+                            yield f"data: {chunk.model_dump_json()}\n\n"
+                            continue
+
+                        # Normal content from tool parser
+                        content = tool_result.get("content", "")
+                        # Strip any leaked tool markup tags
+                        if content:
+                            content = _TOOL_MARKUP_PATTERN.sub("", content)
+
+                chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_model_name,
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                content=content if content else None
+                            ),
+                            finish_reason=(
+                                "tool_calls"
+                                if (output.finished and tool_calls_detected)
+                                else (output.finish_reason if output.finished else None)
+                            ),
+                        )
+                    ],
+                    usage=get_usage(output) if output.finished else None,
+                )
+                yield f"data: {chunk.model_dump_json()}\n\n"
+
+        # Fallback: if tool parser accumulated text but never emitted tool_calls
+        # (e.g., </tool_call> never arrived, or <function= block still incomplete)
+        if (
+            tool_parser
+            and tool_accumulated_text
+            and not tool_calls_detected
+            and (
+                "<tool_call>" in tool_accumulated_text
+                or "<|tool_call>" in tool_accumulated_text
+                or "<function" in tool_accumulated_text
             )
-            yield f"data: {tool_chunk.model_dump_json()}\n\n"
+        ):
+            final_parse_result = tool_parser.extract_tool_calls(tool_accumulated_text)
+            if final_parse_result.tools_called:
+                tools = (
+                    request.model_dump().get("tools")
+                    if request and request.tools
+                    else None
+                )
+                tool_chunk = ChatCompletionChunk(
+                    id=response_id,
+                    model=_model_name,
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(
+                                tool_calls=[
+                                    {
+                                        "index": i,
+                                        "id": tc["id"],
+                                        "type": "function",
+                                        "function": {
+                                            "name": tc["name"],
+                                            "arguments": _coerce_tool_arguments(
+                                                tc["arguments"], tc["name"], tools
+                                            ),
+                                        },
+                                    }
+                                    for i, tc in enumerate(final_parse_result.tool_calls)
+                                ]
+                            ),
+                            finish_reason="tool_calls",
+                        )
+                    ],
+                )
+                yield f"data: {tool_chunk.model_dump_json()}\n\n"
 
-    # Log throughput
-    elapsed = time.perf_counter() - start_time
-    tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
-    logger.info(
-        f"Chat completion (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
-    )
+        # Log throughput
+        elapsed = time.perf_counter() - start_time
+        tokens_per_sec = completion_tokens / elapsed if elapsed > 0 else 0
+        logger.info(
+            f"Chat completion (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
+        )
 
-    # Send final chunk with usage if requested
-    if include_usage:
-        usage_chunk = ChatCompletionChunk(
-            id=response_id,
-            model=_model_name,
-            choices=[],  # Empty choices for usage-only chunk
-            usage=Usage(
+        # Send final chunk with usage if requested
+        if include_usage:
+            usage_chunk = ChatCompletionChunk(
+                id=response_id,
+                model=_model_name,
+                choices=[],  # Empty choices for usage-only chunk
+                usage=Usage(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=prompt_tokens + completion_tokens,
+                ),
+            )
+            yield f"data: {usage_chunk.model_dump_json()}\n\n"
+
+        yield "data: [DONE]\n\n"
+    except HTTPException as exc:
+        result_label = _metrics_result_from_status(exc.status_code)
+        raise
+    except (asyncio.CancelledError, GeneratorExit):
+        result_label = "cancelled"
+        raise
+    except Exception:
+        result_label = "error"
+        raise
+    finally:
+        if metrics_tracker is not None:
+            metrics_tracker.finish(
+                result=result_label,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
-                total_tokens=prompt_tokens + completion_tokens,
-            ),
-        )
-        yield f"data: {usage_chunk.model_dump_json()}\n\n"
-
-    yield "data: [DONE]\n\n"
+            )
 
 
 # =============================================================================
@@ -2797,6 +3030,11 @@ Examples:
         help="Default request timeout in seconds (default: 300)",
     )
     parser.add_argument(
+        "--enable-metrics",
+        action="store_true",
+        help="Expose Prometheus metrics on /metrics (disabled by default)",
+    )
+    parser.add_argument(
         "--rate-limit",
         type=int,
         default=0,
@@ -2838,10 +3076,12 @@ Examples:
     args = parser.parse_args()
 
     # Set global configuration
-    global _api_key, _default_timeout, _rate_limiter
+    global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
     global _default_temperature, _default_top_p
     _api_key = args.api_key
     _default_timeout = args.timeout
+    _metrics_enabled = args.enable_metrics
+    _metrics.configure(enabled=args.enable_metrics)
     if args.default_temperature is not None:
         _default_temperature = args.default_temperature
     if args.default_top_p is not None:
@@ -2867,6 +3107,10 @@ Examples:
     else:
         logger.warning("  Rate limiting: DISABLED - Use --rate-limit to enable")
     logger.info(f"  Request timeout: {args.timeout}s")
+    if args.enable_metrics:
+        logger.info("  Metrics: ENABLED (/metrics, unauthenticated)")
+    else:
+        logger.info("  Metrics: DISABLED - Use --enable-metrics to expose /metrics")
     logger.info("=" * 60)
 
     # Set MCP config for lifespan


### PR DESCRIPTION
## Summary
- add opt-in Prometheus metrics with a new `/metrics` endpoint
- instrument HTTP and inference request paths, including TTFT and token counters
- expose scrape-time engine, scheduler, cache, model-registry, and MCP gauges
- wire `--enable-metrics` through both `vllm-mlx serve` and `python -m vllm_mlx.server`
- document the new metrics surface and add dedicated regression coverage

## Validation
- `python -m compileall vllm_mlx/server.py vllm_mlx/metrics.py vllm_mlx/cli.py tests/test_metrics.py`
- `PYTHONPATH=/tmp/vllm-mlx-prometheus:/tmp/vllm-mlx-metrics /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_metrics.py tests/test_server.py -q`
