### PR TITLE
fix: preserve reasoning when tool calls are present

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1369,6 +1369,192 @@ class TestStreamChatCompletion:
         assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 
 
+class TestReasoningAndToolCallsNonStreaming:
+    """Non-streaming coexistence of reasoning extraction and tool parsing."""
+
+    @pytest.fixture()
+    def client(self):
+        """Create a FastAPI test client."""
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.server import app
+
+        return TestClient(app)
+
+    def test_chat_completion_preserves_reasoning_with_tool_calls(
+        self, client, monkeypatch
+    ):
+        """Reasoning should survive when tool calls are present in final output."""
+        import vllm_mlx.server as server
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import ToolCall, FunctionCall
+
+        parsed_inputs = []
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                return GenerationOutput(
+                    text="<think>Need tool</think><tool_call>",
+                    prompt_tokens=7,
+                    completion_tokens=3,
+                    finish_reason="stop",
+                )
+
+        class FakeReasoningParser:
+            def extract_reasoning(self, model_output):
+                assert model_output == "<think>Need tool</think><tool_call>"
+                return "Need tool", "<tool_call>"
+
+        def fake_parse_tool_calls(text, request):
+            parsed_inputs.append(text)
+            if text == "<tool_call>":
+                return None, [
+                    ToolCall(
+                        id="call_1",
+                        type="function",
+                        function=FunctionCall(
+                            name="get_weather",
+                            arguments='{"city":"Paris"}',
+                        ),
+                    )
+                ]
+            return text, None
+
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+        monkeypatch.setattr(server, "_model_name", "test-model")
+        monkeypatch.setattr(server, "_default_timeout", 30.0)
+        monkeypatch.setattr(server, "_default_max_tokens", 128)
+        monkeypatch.setattr(server, "_api_key", None)
+        monkeypatch.setattr(
+            server,
+            "_rate_limiter",
+            server.RateLimiter(requests_per_minute=60, enabled=False),
+        )
+        monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
+        monkeypatch.setattr(server, "_parse_tool_calls_with_parser", fake_parse_tool_calls)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+                "max_tokens": 32,
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        choice = body["choices"][0]
+        assert parsed_inputs == ["<tool_call>"]
+        assert choice["message"]["content"] is None
+        assert choice["message"]["reasoning_content"] == "Need tool"
+        assert choice["message"]["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert choice["finish_reason"] == "tool_calls"
+
+    def test_anthropic_message_preserves_thinking_with_tool_use(
+        self, client, monkeypatch
+    ):
+        """Anthropic non-streaming should emit thinking and tool_use blocks."""
+        import vllm_mlx.server as server
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import ToolCall, FunctionCall
+
+        parsed_inputs = []
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                return GenerationOutput(
+                    text="<think>Need tool</think><tool_call>",
+                    prompt_tokens=11,
+                    completion_tokens=4,
+                    finish_reason="stop",
+                )
+
+        class FakeReasoningParser:
+            def extract_reasoning(self, model_output):
+                assert model_output == "<think>Need tool</think><tool_call>"
+                return "Need tool", "<tool_call>"
+
+        def fake_parse_tool_calls(text, request):
+            parsed_inputs.append(text)
+            if text == "<tool_call>":
+                return None, [
+                    ToolCall(
+                        id="call_1",
+                        type="function",
+                        function=FunctionCall(
+                            name="get_weather",
+                            arguments='{"city":"Paris"}',
+                        ),
+                    )
+                ]
+            return text, None
+
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+        monkeypatch.setattr(server, "_model_name", "test-model")
+        monkeypatch.setattr(server, "_default_timeout", 30.0)
+        monkeypatch.setattr(server, "_default_max_tokens", 128)
+        monkeypatch.setattr(server, "_api_key", None)
+        monkeypatch.setattr(
+            server,
+            "_rate_limiter",
+            server.RateLimiter(requests_per_minute=60, enabled=False),
+        )
+        monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
+        monkeypatch.setattr(server, "_parse_tool_calls_with_parser", fake_parse_tool_calls)
+
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test-model",
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "Weather?"}],
+                "tools": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert parsed_inputs == ["<tool_call>"]
+        assert body["stop_reason"] == "tool_use"
+        assert [block["type"] for block in body["content"]] == ["thinking", "tool_use"]
+        assert body["content"][0]["thinking"] == "Need tool"
+        assert body["content"][1]["name"] == "get_weather"
+        assert body["content"][1]["input"] == {"city": "Paris"}
+
+
 # =============================================================================
 # Integration Tests (require running server)
 # =============================================================================

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1435,7 +1435,9 @@ class TestReasoningAndToolCallsNonStreaming:
             server.RateLimiter(requests_per_minute=60, enabled=False),
         )
         monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
-        monkeypatch.setattr(server, "_parse_tool_calls_with_parser", fake_parse_tool_calls)
+        monkeypatch.setattr(
+            server, "_parse_tool_calls_with_parser", fake_parse_tool_calls
+        )
 
         response = client.post(
             "/v1/chat/completions",
@@ -1523,7 +1525,9 @@ class TestReasoningAndToolCallsNonStreaming:
             server.RateLimiter(requests_per_minute=60, enabled=False),
         )
         monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
-        monkeypatch.setattr(server, "_parse_tool_calls_with_parser", fake_parse_tool_calls)
+        monkeypatch.setattr(
+            server, "_parse_tool_calls_with_parser", fake_parse_tool_calls
+        )
 
         response = client.post(
             "/v1/messages",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -603,7 +603,6 @@ def _parse_tool_calls_with_parser(
         logger.warning(f"Tool parser error: {e}")
         return parse_tool_calls(output_text, request_dict)
 
-
 def _new_response_item_id(prefix: str) -> str:
     """Generate stable OpenAI-style item ids."""
     return f"{prefix}_{uuid.uuid4().hex}"
@@ -1481,6 +1480,46 @@ def _responses_sse_event(event_type: str, payload: BaseModel | dict) -> str:
         else json.dumps(payload)
     )
     return f"event: {event_type}\ndata: {data}\n\n"
+
+
+def _extract_reasoning_and_tool_calls(
+    output_text: str,
+    request: ChatCompletionRequest | None = None,
+    *,
+    allow_reasoning: bool = True,
+) -> tuple[str | None, str | None, list | None]:
+    """
+    Extract reasoning first, then parse tool calls from the cleaned content.
+
+    Non-streaming responses can contain both a reasoning block and structured
+    tool calls in the same final output. If tool parsing runs first and the
+    response contains tools, the caller can no longer reliably recover the
+    reasoning segment because the usual response path skips reasoning parsing
+    once tool_calls is truthy.
+    """
+    reasoning_text = None
+    text_for_tool_parse = output_text
+
+    if _reasoning_parser and allow_reasoning:
+        reasoning_text, cleaned_reasoning_text = _reasoning_parser.extract_reasoning(
+            output_text
+        )
+        if cleaned_reasoning_text is not None:
+            text_for_tool_parse = cleaned_reasoning_text
+        elif reasoning_text is not None:
+            text_for_tool_parse = ""
+
+    # Skip tool parsing when the request defines no tools — otherwise the
+    # parser can misinterpret JSON output (e.g. response_format) as tool calls.
+    if request is not None and getattr(request, "tools", None):
+        cleaned_text, tool_calls = _parse_tool_calls_with_parser(
+            text_for_tool_parse or "",
+            request,
+        )
+    else:
+        cleaned_text, tool_calls = text_for_tool_parse, None
+
+    return reasoning_text, cleaned_text, tool_calls
 
 
 def _detect_native_tool_support() -> bool:
@@ -2797,28 +2836,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         f"Chat completion: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
-    # Parse tool calls from output using configured parser
-    # Skip tool parsing when request has no tools — otherwise the parser
-    # can misinterpret JSON output (e.g. response_format) as tool calls.
-    if request.tools:
-        cleaned_text, tool_calls = _parse_tool_calls_with_parser(output.text, request)
-    else:
-        cleaned_text, tool_calls = output.text, None
-
-    # Extract reasoning content (strips channel tokens before JSON extraction)
-    # Skip reasoning parser when enable_thinking=False (no think tags expected)
-    reasoning_text = None
-    if _reasoning_parser and request.enable_thinking is not False:
-        # Always use original output.text for reasoning extraction so
-        # <think> content is preserved even when tool calls are present.
-        text_to_parse = output.text
-        reasoning_text, remaining_text = _reasoning_parser.extract_reasoning(
-            text_to_parse
-        )
-        # Only update cleaned_text from reasoning parser when no tool calls
-        # (tool parser already set cleaned_text appropriately)
-        if not tool_calls:
-            cleaned_text = remaining_text
+    reasoning_text, cleaned_text, tool_calls = _extract_reasoning_and_tool_calls(
+        output.text,
+        request,
+        allow_reasoning=request.enable_thinking is not False,
+    )
 
     # Process response_format if specified (after reasoning parser cleaned the text)
     if response_format and not tool_calls:
@@ -3164,22 +3186,11 @@ async def create_anthropic_message(
         f"Anthropic messages: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
     )
 
-    # Parse tool calls (skip when no tools to avoid misinterpreting output)
-    if openai_request.tools:
-        cleaned_text, tool_calls = _parse_tool_calls_with_parser(
-            output.text, openai_request
-        )
-    else:
-        cleaned_text, tool_calls = output.text, None
-
-    # Extract reasoning if parser is configured — skip when constrained
-    # decoding was active (no <think> tags possible).
-    reasoning_text = None
-    if _reasoning_parser and not tool_calls and json_logits_processor is None:
-        text_to_parse = cleaned_text or output.text
-        reasoning_text, cleaned_text = _reasoning_parser.extract_reasoning(
-            text_to_parse
-        )
+    reasoning_text, cleaned_text, tool_calls = _extract_reasoning_and_tool_calls(
+        output.text,
+        openai_request,
+        allow_reasoning=json_logits_processor is None,
+    )
 
     # Post-hoc response_format validation / normalization (safety net even
     # when constrained decoding was active).

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1487,7 +1487,7 @@ def _extract_reasoning_and_tool_calls(
     request: ChatCompletionRequest | None = None,
     *,
     allow_reasoning: bool = True,
-) -> tuple[str | None, str | None, list | None]:
+) -> tuple[str | None, str | None, list[ToolCall] | None]:
     """
     Extract reasoning first, then parse tool calls from the cleaned content.
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -603,6 +603,7 @@ def _parse_tool_calls_with_parser(
         logger.warning(f"Tool parser error: {e}")
         return parse_tool_calls(output_text, request_dict)
 
+
 def _new_response_item_id(prefix: str) -> str:
     """Generate stable OpenAI-style item ids."""
     return f"{prefix}_{uuid.uuid4().hex}"


### PR DESCRIPTION
## Summary
- extract non-streaming reasoning before running tool-call parsing
- reuse the same coexistence logic for both OpenAI and Anthropic response paths
- add endpoint-level regressions proving reasoning survives alongside structured tool calls / tool_use blocks

Closes #161.

## Validation
- `python -m compileall vllm_mlx/server.py tests/test_server.py`
- `PYTHONPATH=/tmp/vllm-mlx-issue161 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_server.py -q`
