### PR TITLE
fix(api): emit a single reasoning_content field

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -631,7 +631,7 @@ class TestModelSerialization:
         msg = AssistantMessage(content="Answer", reasoning="Thought")
         data = msg.model_dump()
         assert data["reasoning_content"] == "Thought"
-        assert data["reasoning"] == "Thought"
+        assert "reasoning" not in data
 
     def test_chat_completion_response_json(self):
         resp = ChatCompletionResponse(
@@ -650,6 +650,35 @@ class TestModelSerialization:
         delta = ChatCompletionChunkDelta(reasoning="thinking")
         data = delta.model_dump()
         assert data["reasoning_content"] == "thinking"
+        assert "reasoning" not in data
+
+    def test_chat_completion_response_serializes_reasoning_content_only(self):
+        resp = ChatCompletionResponse(
+            model="test-model",
+            choices=[
+                ChatCompletionChoice(
+                    message=AssistantMessage(content="Answer", reasoning="Thought")
+                )
+            ],
+        )
+        data = resp.model_dump()
+        message = data["choices"][0]["message"]
+        assert message["reasoning_content"] == "Thought"
+        assert "reasoning" not in message
+
+    def test_chat_completion_chunk_serializes_reasoning_content_only(self):
+        chunk = ChatCompletionChunk(
+            model="test-model",
+            choices=[
+                ChatCompletionChunkChoice(
+                    delta=ChatCompletionChunkDelta(reasoning="thinking"),
+                )
+            ],
+        )
+        data = chunk.model_dump()
+        delta = data["choices"][0]["delta"]
+        assert delta["reasoning_content"] == "thinking"
+        assert "reasoning" not in delta
 
     def test_response_format_json_schema_alias(self):
         schema = ResponseFormatJsonSchema(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -820,7 +820,8 @@ class TestStreamChatCompletion:
         ]
 
         assert payloads[0]["choices"][0]["delta"]["role"] == "assistant"
-        assert payloads[1]["choices"][0]["delta"]["reasoning"] == "reasoning"
+        assert payloads[1]["choices"][0]["delta"]["reasoning_content"] == "reasoning"
+        assert "reasoning" not in payloads[1]["choices"][0]["delta"]
         assert len(tool_payloads) == 1
         assert (
             tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["name"]
@@ -923,7 +924,8 @@ class TestStreamChatCompletion:
         ]
 
         assert tool_parser.calls == []
-        assert payloads[1]["choices"][0]["delta"]["reasoning"] == "reasoning"
+        assert payloads[1]["choices"][0]["delta"]["reasoning_content"] == "reasoning"
+        assert "reasoning" not in payloads[1]["choices"][0]["delta"]
         assert payloads[2]["choices"][0]["delta"]["content"] == "final answer"
         assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -12,7 +12,7 @@ These models define the request and response schemas for:
 import time
 import uuid
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import AliasChoices, BaseModel, Field
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -193,16 +193,15 @@ class AssistantMessage(BaseModel):
 
     role: str = "assistant"
     content: str | None = None
-    reasoning: str | None = (
-        None  # Reasoning/thinking content (when --reasoning-parser is used)
+    reasoning_content: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("reasoning_content", "reasoning"),
     )
     tool_calls: list[ToolCall] | None = None
 
-    @computed_field
     @property
-    def reasoning_content(self) -> str | None:
-        """Alias for reasoning field. Serialized for backwards compatibility with clients expecting reasoning_content."""
-        return self.reasoning
+    def reasoning(self) -> str | None:
+        return self.reasoning_content
 
 
 class ChatCompletionChoice(BaseModel):
@@ -442,16 +441,15 @@ class ChatCompletionChunkDelta(BaseModel):
 
     role: str | None = None
     content: str | None = None
-    reasoning: str | None = (
-        None  # Reasoning/thinking content (when --reasoning-parser is used)
+    reasoning_content: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("reasoning_content", "reasoning"),
     )
     tool_calls: list[dict] | None = None
 
-    @computed_field
     @property
-    def reasoning_content(self) -> str | None:
-        """Alias for reasoning field. Serialized for backwards compatibility with clients expecting reasoning_content."""
-        return self.reasoning
+    def reasoning(self) -> str | None:
+        return self.reasoning_content
 
 
 class ChatCompletionChunkChoice(BaseModel):


### PR DESCRIPTION
## Summary
- stop serializing both `reasoning` and `reasoning_content` in the same response object
- make `reasoning_content` the wire/schema field while preserving `reasoning` as an internal/property alias
- add regression coverage for model serialization and streaming SSE payloads

Closes #310.

## Validation
- `PYTHONPATH=/tmp/vllm-mlx-issue310 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_api_models.py tests/test_server.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/api/models.py tests/test_api_models.py tests/test_server.py`