### PR TITLE
fix(server): protect Anthropic and utility endpoints

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import platform
 import sys
 
 import pytest
+from fastapi.testclient import TestClient
 
 # Skip all tests if not on Apple Silicon
 pytestmark = pytest.mark.skipif(
@@ -681,7 +682,81 @@ class TestRateLimiterHTTPResponse:
         assert allowed is False
         assert retry_after is not None
         assert retry_after > 0
-        assert retry_after <= 60  # Should be within a minute
+
+
+class TestEndpointSecurityDependencies:
+    """Test auth/rate-limit coverage on protected endpoints."""
+
+    @pytest.fixture
+    def client(self):
+        import vllm_mlx.server as server
+
+        return TestClient(server.app)
+
+    @pytest.fixture(autouse=True)
+    def restore_security_state(self):
+        import vllm_mlx.server as server
+
+        original_key = server._api_key
+        original_limiter = server._rate_limiter
+        try:
+            yield
+        finally:
+            server._api_key = original_key
+            server._rate_limiter = original_limiter
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/v1/status"),
+            ("get", "/v1/cache/stats"),
+            ("delete", "/v1/cache"),
+            ("post", "/v1/messages"),
+            ("post", "/v1/messages/count_tokens"),
+        ],
+    )
+    def test_endpoints_require_api_key(self, client, method, path):
+        import vllm_mlx.server as server
+
+        server._api_key = "test-secret"
+
+        kwargs = {}
+        if method == "post":
+            kwargs["json"] = {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 16,
+            }
+
+        response = getattr(client, method)(path, **kwargs)
+        assert response.status_code == 401
+        assert response.json()["detail"] == "API key required"
+
+    @pytest.mark.parametrize("path", ["/v1/messages", "/v1/messages/count_tokens"])
+    def test_anthropic_endpoints_apply_rate_limit(self, client, path, monkeypatch):
+        import vllm_mlx.server as server
+
+        server._api_key = "test-secret"
+
+        def deny_all(_client_id):
+            return False, 7
+
+        monkeypatch.setattr(server._rate_limiter, "enabled", True)
+        monkeypatch.setattr(server._rate_limiter, "is_allowed", deny_all)
+
+        response = client.post(
+            path,
+            headers={"Authorization": "Bearer test-secret"},
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 16,
+            },
+        )
+
+        assert response.status_code == 429
+        assert "Rate limit exceeded" in response.json()["detail"]
+        assert response.headers["Retry-After"] == "7"
 
     def test_rate_limiter_window_cleanup(self):
         """Test that rate limiter cleans up old requests from sliding window."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -669,7 +669,7 @@ async def health():
     }
 
 
-@app.get("/v1/status")
+@app.get("/v1/status", dependencies=[Depends(verify_api_key)])
 async def status():
     """Real-time status with per-request details for debugging and monitoring."""
     if _engine is None:
@@ -699,7 +699,7 @@ async def status():
     }
 
 
-@app.get("/v1/cache/stats")
+@app.get("/v1/cache/stats", dependencies=[Depends(verify_api_key)])
 async def cache_stats():
     """Get cache statistics for debugging and monitoring."""
     try:
@@ -718,7 +718,7 @@ async def cache_stats():
         return {"error": "Cache stats not available (mlx_vlm not loaded)"}
 
 
-@app.delete("/v1/cache")
+@app.delete("/v1/cache", dependencies=[Depends(verify_api_key)])
 async def clear_cache():
     """Clear all caches."""
     try:
@@ -1738,7 +1738,9 @@ def _convert_anthropic_stop_reason(openai_reason: str | None) -> str:
     return mapping.get(openai_reason or "", "end_turn")
 
 
-@app.post("/v1/messages")
+@app.post(
+    "/v1/messages", dependencies=[Depends(verify_api_key), Depends(check_rate_limit)]
+)
 async def create_anthropic_message(
     request: Request,
 ):
@@ -1909,7 +1911,10 @@ async def create_anthropic_message(
     )
 
 
-@app.post("/v1/messages/count_tokens")
+@app.post(
+    "/v1/messages/count_tokens",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
 async def count_anthropic_tokens(request: Request):
     """
     Count tokens for an Anthropic Messages API request.


### PR DESCRIPTION
## Summary
- require API key auth on `/v1/status`, `/v1/cache/stats`, and `/v1/cache` when the server is started with `--api-key`
- require both auth and rate limiting on `/v1/messages` and `/v1/messages/count_tokens`
- add HTTP-level regression tests covering the protected endpoint matrix and Anthropic rate limiting

Closes #317.

## Validation
- `PYTHONPATH=/tmp/vllm-mlx-issue317 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_server.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/server.py tests/test_server.py`