### PR TITLE
fix(mllm): block SSRF in remote media fetches

### DIFF
--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -123,6 +123,67 @@ class TestMLLMHelperFunctions:
         assert not is_url("/path/to/file.jpg")
         assert not is_url("data:image/png;base64,AAAA")
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "http://127.0.0.1/private.jpg",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://localhost/private.jpg",
+            "http://[::1]/private.jpg",
+        ],
+    )
+    def test_validate_url_safety_rejects_unsafe_targets(self, url):
+        """Test that local and private targets are rejected."""
+        from vllm_mlx.models.mllm import UnsafeRemoteURLError, _validate_url_safety
+
+        with pytest.raises(UnsafeRemoteURLError):
+            _validate_url_safety(url)
+
+    def test_validate_url_safety_allows_public_ip(self):
+        """Test that public literal IPs remain allowed."""
+        from vllm_mlx.models.mllm import _validate_url_safety
+
+        _validate_url_safety("https://8.8.8.8/image.jpg")
+
+    def test_request_with_safe_redirects_blocks_unsafe_redirect(self, monkeypatch):
+        """Test that redirect hops are validated before a second request."""
+        from vllm_mlx.models import mllm
+
+        calls = []
+
+        class FakeResponse:
+            def __init__(self, url, status_code, headers):
+                self.url = url
+                self.status_code = status_code
+                self.headers = headers
+                self.is_redirect = status_code in {301, 302, 303, 307, 308}
+                self.is_permanent_redirect = status_code in {301, 308}
+
+            def close(self):
+                return None
+
+        def fake_request(method, url, **kwargs):
+            calls.append((method, url, kwargs["allow_redirects"]))
+            return FakeResponse(
+                url,
+                302,
+                {"location": "http://127.0.0.1/internal.jpg"},
+            )
+
+        monkeypatch.setattr(mllm.requests, "request", fake_request)
+
+        with pytest.raises(mllm.UnsafeRemoteURLError):
+            mllm._request_with_safe_redirects(
+                "GET",
+                "https://8.8.8.8/image.jpg",
+                timeout=30,
+                headers={"User-Agent": "test"},
+                stream=True,
+            )
+
+        assert calls == [("GET", "https://8.8.8.8/image.jpg", False)]
+
 
 class TestVideoFrameExtraction:
     """Test video frame extraction functions."""
@@ -199,6 +260,18 @@ class TestImageProcessing:
         result = process_image_input({"url": test_image_path})
         assert Path(result).exists()
 
+    def test_download_image_blocks_unsafe_url_before_request(self, monkeypatch):
+        """Test that blocked image URLs fail before any request is made."""
+        from vllm_mlx.models import mllm
+
+        def fail_request(*args, **kwargs):
+            raise AssertionError("requests.request should not be called")
+
+        monkeypatch.setattr(mllm.requests, "request", fail_request)
+
+        with pytest.raises(mllm.UnsafeRemoteURLError):
+            mllm.download_image("http://169.254.169.254/latest/meta-data/")
+
 
 class TestVideoProcessing:
     """Test video processing functions."""
@@ -227,6 +300,18 @@ class TestVideoProcessing:
 
         with pytest.raises(ValueError):
             process_video_input({})
+
+    def test_download_video_blocks_unsafe_url_before_request(self, monkeypatch):
+        """Test that blocked video URLs fail before any request is made."""
+        from vllm_mlx.models import mllm
+
+        def fail_request(*args, **kwargs):
+            raise AssertionError("requests.request should not be called")
+
+        monkeypatch.setattr(mllm.requests, "request", fail_request)
+
+        with pytest.raises(mllm.UnsafeRemoteURLError):
+            mllm.download_video("http://127.0.0.1/internal.mp4")
 
 
 # =============================================================================

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -15,15 +15,17 @@ Features:
 
 import atexit
 import base64
+import ipaddress
 import logging
 import math
 import os
+import socket
 import tempfile
 import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import numpy as np
 import requests
@@ -115,6 +117,12 @@ class FileSizeExceededError(Exception):
     pass
 
 
+class UnsafeRemoteURLError(ValueError):
+    """Raised when a remote media URL targets an unsafe destination."""
+
+    pass
+
+
 @dataclass
 class MultimodalInput:
     """Input for multimodal generation."""
@@ -182,6 +190,83 @@ def decode_base64_image(
     return base64.b64decode(base64_string)
 
 
+def _validate_url_safety(url: str) -> None:
+    """Reject remote URLs that target local or private network resources."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise UnsafeRemoteURLError(
+            f"Unsupported remote media URL scheme: {parsed.scheme or '<missing>'}"
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeRemoteURLError("Remote media URL must include a hostname")
+
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise UnsafeRemoteURLError(
+            f"Remote media URL targets a blocked host: {hostname}"
+        )
+
+    try:
+        resolved_ips = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            addrinfo = socket.getaddrinfo(
+                hostname,
+                parsed.port or (443 if parsed.scheme == "https" else 80),
+                type=socket.SOCK_STREAM,
+            )
+        except socket.gaierror as exc:
+            raise UnsafeRemoteURLError(
+                f"Failed to resolve remote media host {hostname}: {exc}"
+            ) from exc
+        resolved_ips = [ipaddress.ip_address(info[4][0]) for info in addrinfo]
+
+    blocked_ips = [str(ip) for ip in resolved_ips if not ip.is_global]
+    if blocked_ips:
+        raise UnsafeRemoteURLError(
+            f"Remote media URL resolves to blocked address(es): {', '.join(sorted(set(blocked_ips)))}"
+        )
+
+
+def _request_with_safe_redirects(
+    method: str,
+    url: str,
+    *,
+    timeout: int,
+    headers: dict[str, str],
+    stream: bool = False,
+    max_redirects: int = 5,
+):
+    """Issue a requests call while validating every redirect target."""
+    current_url = url
+    for _ in range(max_redirects + 1):
+        _validate_url_safety(current_url)
+        response = requests.request(
+            method,
+            current_url,
+            timeout=timeout,
+            headers=headers,
+            allow_redirects=False,
+            verify=True,
+            stream=stream,
+        )
+        if not response.is_redirect and not response.is_permanent_redirect:
+            return response
+
+        location = response.headers.get("location")
+        response.close()
+        if not location:
+            raise UnsafeRemoteURLError(
+                f"Remote media URL redirect missing Location header: {current_url}"
+            )
+        current_url = urljoin(current_url, location)
+
+    raise UnsafeRemoteURLError(
+        f"Remote media URL exceeded redirect limit ({max_redirects}): {url}"
+    )
+
+
 def download_image(url: str, timeout: int = 30, max_size: int = MAX_IMAGE_SIZE) -> str:
     """
     Download image from URL and return local path.
@@ -203,8 +288,8 @@ def download_image(url: str, timeout: int = 30, max_size: int = MAX_IMAGE_SIZE) 
 
     # First, make a HEAD request to check Content-Length
     try:
-        head_response = requests.head(
-            url, timeout=timeout, headers=headers, allow_redirects=True, verify=True
+        head_response = _request_with_safe_redirects(
+            "HEAD", url, timeout=timeout, headers=headers
         )
         content_length = head_response.headers.get("content-length")
         if content_length and int(content_length) > max_size:
@@ -216,8 +301,8 @@ def download_image(url: str, timeout: int = 30, max_size: int = MAX_IMAGE_SIZE) 
         # HEAD request failed, proceed with GET and check during download
         pass
 
-    response = requests.get(
-        url, timeout=timeout, headers=headers, stream=True, verify=True
+    response = _request_with_safe_redirects(
+        "GET", url, timeout=timeout, headers=headers, stream=True
     )
     response.raise_for_status()
 
@@ -241,7 +326,7 @@ def download_image(url: str, timeout: int = 30, max_size: int = MAX_IMAGE_SIZE) 
         ext = ".webp"
     else:
         # Try to get from URL
-        path = urlparse(url).path
+        path = urlparse(response.url).path
         ext = Path(path).suffix or ".jpg"
 
     # Save to temp file with size checking during download
@@ -293,8 +378,8 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
 
     # First, make a HEAD request to check Content-Length
     try:
-        head_response = requests.head(
-            url, timeout=timeout, headers=headers, allow_redirects=True, verify=True
+        head_response = _request_with_safe_redirects(
+            "HEAD", url, timeout=timeout, headers=headers
         )
         content_length = head_response.headers.get("content-length")
         if content_length and int(content_length) > max_size:
@@ -306,8 +391,8 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
         # HEAD request failed, proceed with GET and check during download
         pass
 
-    response = requests.get(
-        url, timeout=timeout, headers=headers, stream=True, verify=True
+    response = _request_with_safe_redirects(
+        "GET", url, timeout=timeout, headers=headers, stream=True
     )
     response.raise_for_status()
 
@@ -333,7 +418,7 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
         ext = ".mkv"
     else:
         # Try to get from URL
-        path = urlparse(url).path
+        path = urlparse(response.url).path
         ext = Path(path).suffix or ".mp4"
 
     # Save to temp file (stream for larger files) with size checking


### PR DESCRIPTION
## Summary
- validate remote image/video URLs before any network fetch
- reject non-http(s), localhost, and any host that resolves to non-global addresses
- validate every redirect hop so redirected private targets are blocked too
- add regressions proving blocked URLs never reach requests and redirects cannot bypass the guard

## Testing
- PYTHONPATH=/tmp/vllm-mlx-issue318 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mllm.py -q -k 'validate_url_safety or safe_redirects or blocks_unsafe_url_before_request'
- /opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/models/mllm.py tests/test_mllm.py
- /opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/models/mllm.py tests/test_mllm.py

Closes #318.