### PR TITLE
fix(mcp): remove config security bypass

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -8,10 +8,13 @@ command injection attacks and other security vulnerabilities.
 
 import re
 import pytest
+from vllm_mlx.mcp import security as mcp_security
+from vllm_mlx.mcp.config import validate_config
 from vllm_mlx.mcp.security import (
     MCPCommandValidator,
     MCPSecurityError,
     ALLOWED_COMMANDS,
+    ALLOW_UNSAFE_ENV_VAR,
     ToolSandbox,
     ToolExecutionAudit,
 )
@@ -250,6 +253,15 @@ class TestUnsafeMode:
         # These should not raise
         validator.validate_args(["; rm -rf /"], "test")
 
+    def test_env_var_enables_global_unsafe_validator(self, monkeypatch):
+        """Test that unsafe mode can only be enabled via environment."""
+        monkeypatch.setenv(ALLOW_UNSAFE_ENV_VAR, "1")
+        monkeypatch.setattr(mcp_security, "_validator", None)
+
+        validator = mcp_security.get_validator()
+
+        validator.validate_command("bash", "test")
+
 
 class TestCustomWhitelist:
     """Tests for custom command whitelist."""
@@ -328,17 +340,24 @@ class TestMCPServerConfigSecurity:
         )
         assert config.url == "https://api.example.com/mcp"
 
-    def test_skip_security_validation(self):
-        """Test that skip_security_validation allows any command (with warning)."""
-        # This should not raise even with dangerous command
-        config = MCPServerConfig(
-            name="unsafe-server",
-            transport=MCPTransport.STDIO,
-            command="bash",
-            args=["-c", "echo hello"],
-            skip_security_validation=True,
-        )
-        assert config.command == "bash"
+    def test_skip_security_validation_field_rejected(self):
+        """Test that config-file security bypass is rejected explicitly."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_config(
+                {
+                    "servers": {
+                        "unsafe-server": {
+                            "transport": "stdio",
+                            "command": "bash",
+                            "args": ["-c", "echo hello"],
+                            "skip_security_validation": True,
+                        }
+                    }
+                }
+            )
+
+        assert "skip_security_validation" in str(exc_info.value)
+        assert ALLOW_UNSAFE_ENV_VAR in str(exc_info.value)
 
 
 class TestDefaultWhitelist:

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -128,6 +128,11 @@ def validate_config(data: Dict[str, Any]) -> MCPConfig:
             # Ensure name is set
             if isinstance(server_data, dict):
                 server_data = server_data.copy()
+                if "skip_security_validation" in server_data:
+                    raise ValueError(
+                        f"Server '{name}' uses removed field 'skip_security_validation'. "
+                        "Use environment variable VLLM_MCP_ALLOW_UNSAFE=1 for explicit local development bypasses."
+                    )
                 server_data["name"] = name
                 servers[name] = MCPServerConfig(**server_data)
             else:

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
+ALLOW_UNSAFE_ENV_VAR = "VLLM_MCP_ALLOW_UNSAFE"
+
 # Whitelist of allowed MCP server commands
 # These are well-known, trusted MCP server executables
 ALLOWED_COMMANDS: Set[str] = {
@@ -299,7 +301,9 @@ def get_validator() -> MCPCommandValidator:
     """Get the global command validator instance."""
     global _validator
     if _validator is None:
-        _validator = MCPCommandValidator()
+        _validator = MCPCommandValidator(
+            allow_unsafe=os.environ.get(ALLOW_UNSAFE_ENV_VAR) == "1"
+        )
     return _validator
 
 

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -43,9 +43,6 @@ class MCPServerConfig:
     enabled: bool = True
     timeout: float = 30.0
 
-    # Security options
-    skip_security_validation: bool = False  # WARNING: Only for development!
-
     def __post_init__(self):
         """Validate configuration."""
         if isinstance(self.transport, str):
@@ -68,15 +65,6 @@ class MCPServerConfig:
     def _validate_security(self) -> None:
         """Validate security of the configuration."""
         from .security import validate_mcp_server_config, MCPSecurityError
-
-        if self.skip_security_validation:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                f"MCP server '{self.name}': Security validation SKIPPED. "
-                f"This is dangerous and should only be used in development!"
-            )
-            return
 
         try:
             validate_mcp_server_config(


### PR DESCRIPTION
## Summary
- remove `skip_security_validation` from MCP server config handling
- reject configs that still try to use the removed field with a clear migration error
- keep unsafe mode available only via `VLLM_MCP_ALLOW_UNSAFE=1` at process start
- add regressions for the removed config bypass and env-gated validator boot

## Testing
- `PYTHONPATH=/tmp/vllm-mlx-issue319 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mcp_security.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/mcp/types.py vllm_mlx/mcp/security.py vllm_mlx/mcp/config.py tests/test_mcp_security.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/mcp/types.py vllm_mlx/mcp/security.py vllm_mlx/mcp/config.py tests/test_mcp_security.py`

Closes #319.
