### PR TITLE
fix(mllm): block local path traversal in multimodal input

### DIFF
--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for MLX Multimodal Language Model (MLLM) wrapper."""
 
+import base64
 import platform
 import sys
 from pathlib import Path
@@ -184,38 +185,38 @@ class TestVideoFrameExtraction:
 class TestImageProcessing:
     """Test image processing functions."""
 
-    def test_process_image_input_local_file(self, test_image_path):
-        """Test processing local image file."""
+    def test_process_image_input_local_file_rejected(self, test_image_path):
+        """Test that local image paths are rejected."""
         from vllm_mlx.models.mllm import process_image_input
 
-        result = process_image_input(test_image_path)
-        assert result == test_image_path
+        with pytest.raises(ValueError, match="Unsupported image input"):
+            process_image_input(test_image_path)
 
-    def test_process_image_input_dict_format(self, test_image_path):
-        """Test processing image in dict format."""
+    def test_process_image_input_dict_format_base64(self):
+        """Test processing image in dict format with base64 payload."""
         from vllm_mlx.models.mllm import process_image_input
 
-        # OpenAI format
-        result = process_image_input({"url": test_image_path})
+        image_b64 = base64.b64encode(b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR").decode()
+        result = process_image_input({"url": f"data:image/png;base64,{image_b64}"})
         assert Path(result).exists()
 
 
 class TestVideoProcessing:
     """Test video processing functions."""
 
-    def test_process_video_input_local_file(self, test_video_path):
-        """Test processing local video file."""
+    def test_process_video_input_local_file_rejected(self, test_video_path):
+        """Test that local video paths are rejected."""
         from vllm_mlx.models.mllm import process_video_input
 
-        result = process_video_input(test_video_path)
-        assert result == test_video_path
+        with pytest.raises(ValueError, match="Unsupported video input"):
+            process_video_input(test_video_path)
 
-    def test_process_video_input_dict_format(self, test_video_path):
-        """Test processing video in dict format."""
+    def test_process_video_input_dict_format_base64(self):
+        """Test processing video in dict format with base64 payload."""
         from vllm_mlx.models.mllm import process_video_input
 
-        # OpenAI format
-        result = process_video_input({"url": test_video_path})
+        video_b64 = base64.b64encode(b"\x00" * 100).decode()
+        result = process_video_input({"url": f"data:video/mp4;base64,{video_b64}"})
         assert Path(result).exists()
 
     def test_process_video_input_empty_raises(self):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -187,74 +187,65 @@ class TestTranslateMessages:
         assert result[0]["content"] == "Hello"
 
     def test_video_url_translated(self):
-        import os
-        import tempfile
+        import base64
 
-        # Create a temp file to act as a "video"
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            f.write(b"\x00" * 100)
-            video_path = f.name
+        video_source = (
+            f"data:video/mp4;base64,{base64.b64encode(b'\\x00' * 100).decode()}"
+        )
 
-        try:
-            model = self._make_model()
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "video", "video": video_path},
-                        {"type": "text", "text": "Describe"},
-                    ],
-                }
-            ]
-            result = model._translate_messages_for_native_video(messages, 2.0, 128)
-            content = result[0]["content"]
+        model = self._make_model()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video", "video": video_source},
+                    {"type": "text", "text": "Describe"},
+                ],
+            }
+        ]
+        result = model._translate_messages_for_native_video(messages, 2.0, 128)
+        content = result[0]["content"]
 
-            # Should have video and text items
-            types = [item["type"] for item in content]
-            assert "video" in types
-            assert "text" in types
+        # Should have video and text items
+        types = [item["type"] for item in content]
+        assert "video" in types
+        assert "text" in types
 
-            # Video item should have fps and max_frames
-            video_item = next(i for i in content if i["type"] == "video")
-            assert video_item["fps"] == 2.0
-            assert video_item["max_frames"] == 128
-        finally:
-            os.unlink(video_path)
+        # Video item should have fps and max_frames
+        video_item = next(i for i in content if i["type"] == "video")
+        assert video_item["fps"] == 2.0
+        assert video_item["max_frames"] == 128
 
     def test_video_url_type_translated(self):
-        import os
-        import tempfile
+        import base64
 
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
-            f.write(b"\x00" * 100)
-            video_path = f.name
+        video_source = (
+            f"data:video/mp4;base64,{base64.b64encode(b'\\x00' * 100).decode()}"
+        )
 
-        try:
-            model = self._make_model()
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "video_url",
-                            "video_url": {"url": video_path},
-                        },
-                        {"type": "text", "text": "Describe"},
-                    ],
-                }
-            ]
-            result = model._translate_messages_for_native_video(messages, 1.0, 64)
-            content = result[0]["content"]
+        model = self._make_model()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": video_source},
+                    },
+                    {"type": "text", "text": "Describe"},
+                ],
+            }
+        ]
+        result = model._translate_messages_for_native_video(messages, 1.0, 64)
+        content = result[0]["content"]
 
-            types = [item["type"] for item in content]
-            assert "video" in types
-            assert "text" in types
+        types = [item["type"] for item in content]
+        assert "video" in types
+        assert "text" in types
 
-            video_item = next(i for i in content if i["type"] == "video")
-            assert video_item["fps"] == 1.0
-            assert video_item["max_frames"] == 64
-        finally:
-            os.unlink(video_path)
+        video_item = next(i for i in content if i["type"] == "video")
+        assert video_item["fps"] == 1.0
+        assert video_item["max_frames"] == 64
 
 
 class TestCollectVideoInputsPydantic:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -189,9 +189,8 @@ class TestTranslateMessages:
     def test_video_url_translated(self):
         import base64
 
-        video_source = (
-            f"data:video/mp4;base64,{base64.b64encode(b'\\x00' * 100).decode()}"
-        )
+        dummy_video_b64 = base64.b64encode(b"\x00" * 100).decode()
+        video_source = f"data:video/mp4;base64,{dummy_video_b64}"
 
         model = self._make_model()
         messages = [
@@ -219,9 +218,8 @@ class TestTranslateMessages:
     def test_video_url_type_translated(self):
         import base64
 
-        video_source = (
-            f"data:video/mp4;base64,{base64.b64encode(b'\\x00' * 100).decode()}"
-        )
+        dummy_video_b64 = base64.b64encode(b"\x00" * 100).decode()
+        video_source = f"data:video/mp4;base64,{dummy_video_b64}"
 
         model = self._make_model()
         messages = [

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -421,7 +421,6 @@ def process_video_input(video: str | dict) -> str:
     Process video input in various formats and return local path.
 
     Supports:
-    - Local file path
     - URL (http/https)
     - Base64 encoded string (data:video/mp4;base64,...)
     - OpenAI format dict: {"url": "..."} or {"url": "data:video/...;base64,..."}
@@ -442,10 +441,6 @@ def process_video_input(video: str | dict) -> str:
     if not video:
         raise ValueError("Empty video input")
 
-    # Check if it's a local file
-    if Path(video).exists():
-        return video
-
     # Check if it's a URL
     if is_url(video):
         return download_video(video)
@@ -454,7 +449,9 @@ def process_video_input(video: str | dict) -> str:
     if is_base64_video(video):
         return decode_base64_video(video)
 
-    raise ValueError(f"Cannot process video: {video[:50]}...")
+    raise ValueError(
+        "Unsupported video input. Only http(s) URLs and data:video base64 payloads are allowed."
+    )
 
 
 # Cache for base64 images to avoid re-saving the same image
@@ -503,7 +500,6 @@ def process_image_input(image: str | dict) -> str:
     Process image input in various formats and return local path.
 
     Supports:
-    - Local file path
     - URL (http/https)
     - Base64 encoded string
     - OpenAI format dict: {"url": "..."} or {"url": "data:image/...;base64,..."}
@@ -526,11 +522,9 @@ def process_image_input(image: str | dict) -> str:
     if is_url(image):
         return download_image(image)
 
-    # Check if it's a local file (only for short strings that could be paths)
-    if len(image) < 4096 and Path(image).exists():
-        return image
-
-    raise ValueError(f"Cannot process image: {image[:50]}...")
+    raise ValueError(
+        "Unsupported image input. Only http(s) URLs and data:image base64 payloads are allowed."
+    )
 
 
 def round_by_factor(x: int, factor: int) -> int:
@@ -756,7 +750,7 @@ class MLXMultimodalLM:
         return self.processor.tokenizer
 
     def _prepare_images(self, images: list) -> list[str]:
-        """Process image inputs and return local file paths."""
+        """Process remote/base64 image inputs into local temp file paths."""
         processed = []
         for img in images:
             try:
@@ -776,7 +770,6 @@ class MLXMultimodalLM:
         Process video input and extract frames.
 
         Supports:
-        - Local file paths
         - URLs (http/https) - will be downloaded
         - Base64 encoded videos (data:video/mp4;base64,...)
         - OpenAI format dicts: {"url": "..."} or {"video_url": {"url": "..."}}
@@ -971,7 +964,7 @@ class MLXMultimodalLM:
     ) -> list[dict]:
         """Translate OpenAI API format messages to process_vision_info format.
 
-        Converts video_url/video types and resolves URLs/base64 to local paths.
+        Converts video_url/video types and resolves remote/base64 inputs to local paths.
         Images are preserved as-is (process_vision_info handles them).
         """
         translated = []
@@ -1072,8 +1065,8 @@ class MLXMultimodalLM:
 
         Args:
             prompt: Text prompt/question
-            images: List of image paths, URLs, or base64 strings
-            videos: List of video inputs (paths, URLs, base64, or OpenAI format dicts)
+            images: List of image URLs or base64 strings
+            videos: List of video inputs (URLs, base64, or OpenAI format dicts)
             audio: List of audio file paths
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
@@ -1994,9 +1987,6 @@ class MLXMultimodalLM:
             Video description text
 
         Example:
-            # Local file
-            model.describe_video("video.mp4")
-
             # URL
             model.describe_video("https://example.com/video.mp4")
 

--- a/vllm_mlx/multimodal_processor.py
+++ b/vllm_mlx/multimodal_processor.py
@@ -108,8 +108,8 @@ class MultimodalProcessor:
 
         Args:
             prompt: Text prompt (already formatted with chat template)
-            images: List of image paths, URLs, or base64 strings
-            videos: List of video inputs
+            images: List of image URLs or base64 strings
+            videos: List of video URLs or base64 inputs
             video_fps: FPS for video frame extraction
             video_max_frames: Max frames per video
             add_special_tokens: Whether to add special tokens


### PR DESCRIPTION
## Summary
- remove local filesystem path handling from multimodal image/video inputs
- accept only http(s) URLs and data: base64 payloads for user-provided media
- update multimodal docs/tests to reflect the tightened contract

## Testing
- `PYTHONPATH=/private/tmp/vllm-mlx-issue320 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mllm.py tests/test_video.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/models/mllm.py vllm_mlx/multimodal_processor.py tests/test_mllm.py tests/test_video.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/models/mllm.py vllm_mlx/multimodal_processor.py tests/test_mllm.py tests/test_video.py`

Closes #320.
