### PR TITLE
fix(server): require explicit trust_remote_code opt-in

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@
 import json
 import platform
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -171,6 +172,23 @@ class TestCompletionRequest:
 class TestServeCli:
     """Test serve CLI argument parsing."""
 
+    def test_trust_remote_code_flag_defaults_false(self):
+        """Serve CLI should require explicit opt-in for remote code loading."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["serve", "mlx-community/Llama-3.2-3B-Instruct-4bit"])
+        assert args.trust_remote_code is False
+
+        args = parser.parse_args(
+            [
+                "serve",
+                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "--trust-remote-code",
+            ]
+        )
+        assert args.trust_remote_code is True
+
     def test_tool_call_parser_accepts_harmony_aliases(self):
         """GPT-OSS/Harmony parsers should be selectable from the serve CLI."""
         from vllm_mlx.cli import create_parser
@@ -201,6 +219,72 @@ class TestServeCli:
         )
 
         assert args.tool_call_parser == "gpt-oss"
+
+
+class TestStandaloneServerCli:
+    """Test standalone server CLI argument parsing."""
+
+    def test_trust_remote_code_flag_defaults_false(self):
+        """Standalone server should require explicit opt-in for remote code loading."""
+        from vllm_mlx.server import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            ["--model", "mlx-community/Llama-3.2-3B-Instruct-4bit"]
+        )
+        assert args.trust_remote_code is False
+
+        args = parser.parse_args(
+            [
+                "--model",
+                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "--trust-remote-code",
+            ]
+        )
+        assert args.trust_remote_code is True
+
+
+class TestLoadModelTrustRemoteCode:
+    """Test load_model trust_remote_code wiring into engine constructors."""
+
+    def test_load_model_simple_defaults_trust_remote_code_false(self):
+        """SimpleEngine should receive trust_remote_code=False by default."""
+        from vllm_mlx import server
+
+        fake_engine = MagicMock()
+        fake_loop = MagicMock()
+
+        with (
+            patch.object(
+                server, "SimpleEngine", return_value=fake_engine
+            ) as mock_engine,
+            patch.object(server, "_detect_native_tool_support", return_value=False),
+            patch("vllm_mlx.server.asyncio.new_event_loop", return_value=fake_loop),
+            patch("vllm_mlx.server.asyncio.set_event_loop"),
+        ):
+            server.load_model("test-model", use_batching=False)
+
+        assert mock_engine.call_args.kwargs["trust_remote_code"] is False
+
+    def test_load_model_batched_forwards_explicit_trust_remote_code(self):
+        """BatchedEngine should receive explicit trust_remote_code opt-in."""
+        from vllm_mlx import server
+
+        fake_engine = MagicMock()
+
+        with (
+            patch.object(
+                server, "BatchedEngine", return_value=fake_engine
+            ) as mock_engine,
+            patch.object(server, "_detect_native_tool_support", return_value=False),
+        ):
+            server.load_model(
+                "test-model",
+                use_batching=True,
+                trust_remote_code=True,
+            )
+
+        assert mock_engine.call_args.kwargs["trust_remote_code"] is True
 
 
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -108,6 +108,10 @@ def serve_command(args):
         print("  Metrics: ENABLED (/metrics, unauthenticated)")
     else:
         print("  Metrics: DISABLED - Use --enable-metrics to expose /metrics")
+    if args.trust_remote_code:
+        print("  Remote code loading: ENABLED (--trust-remote-code)")
+    else:
+        print("  Remote code loading: DISABLED (default)")
     if args.enable_auto_tool_choice:
         print(f"  Tool calling: ENABLED (parser: {args.tool_call_parser})")
     else:
@@ -230,6 +234,7 @@ def serve_command(args):
         force_mllm=getattr(args, "mllm", False),
         gpu_memory_utilization=args.gpu_memory_utilization,
         served_model_name=args.served_model_name,
+        trust_remote_code=args.trust_remote_code,
         mtp=args.enable_mtp,
         prefill_step_size=args.prefill_step_size,
         specprefill_enabled=args.specprefill,
@@ -942,6 +947,11 @@ Examples:
         "--mllm",
         action="store_true",
         help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns",
+    )
+    serve_parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow HuggingFace remote code execution during model/tokenizer loading",
     )
     # Generation defaults
     serve_parser.add_argument(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -134,7 +134,7 @@ class BatchedEngine(BaseEngine):
     def __init__(
         self,
         model_name: str,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -53,7 +53,7 @@ class SimpleEngine(BaseEngine):
     def __init__(
         self,
         model_name: str,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         enable_cache: bool = True,
         force_mllm: bool = False,
         mtp: bool = False,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -690,7 +690,7 @@ class MLXMultimodalLM:
     def __init__(
         self,
         model_name: str,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         enable_cache: bool = True,
         cache_size: int = 50,
     ):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -617,6 +617,7 @@ def load_model(
     force_mllm: bool = False,
     gpu_memory_utilization: float = 0.90,
     served_model_name: str | None = None,
+    trust_remote_code: bool = False,
     mtp: bool = False,
     prefill_step_size: int = 2048,
     specprefill_enabled: bool = False,
@@ -634,6 +635,7 @@ def load_model(
         stream_interval: Tokens to batch before streaming (batched mode only)
         max_tokens: Default max tokens for generation
         force_mllm: Force loading as MLLM even if not auto-detected
+        trust_remote_code: Allow HuggingFace remote code execution during model/tokenizer loading
         mtp: Enable native MTP speculative decoding (SimpleEngine only)
         prefill_step_size: Chunk size for prompt prefill processing (default: 2048)
         specprefill_enabled: Enable SpecPrefill (SimpleEngine only)
@@ -656,6 +658,7 @@ def load_model(
         logger.info(f"Loading model with BatchedEngine: {model_name}")
         _engine = BatchedEngine(
             model_name=model_name,
+            trust_remote_code=trust_remote_code,
             scheduler_config=scheduler_config,
             stream_interval=stream_interval,
             force_mllm=force_mllm,
@@ -668,6 +671,7 @@ def load_model(
         logger.info(f"Loading model with SimpleEngine: {model_name}")
         _engine = SimpleEngine(
             model_name=model_name,
+            trust_remote_code=trust_remote_code,
             force_mllm=force_mllm,
             mtp=mtp,
             prefill_step_size=prefill_step_size,
@@ -3000,6 +3004,82 @@ async def init_mcp(config_path: str):
 
 def main():
     """Run the server."""
+    parser = create_parser()
+    args = parser.parse_args()
+
+    # Set global configuration
+    global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
+    global _default_temperature, _default_top_p
+    _api_key = args.api_key
+    _default_timeout = args.timeout
+    _metrics_enabled = args.enable_metrics
+    _metrics.configure(enabled=args.enable_metrics)
+    if args.default_temperature is not None:
+        _default_temperature = args.default_temperature
+    if args.default_top_p is not None:
+        _default_top_p = args.default_top_p
+
+    # Configure rate limiter
+    if args.rate_limit > 0:
+        _rate_limiter = RateLimiter(requests_per_minute=args.rate_limit, enabled=True)
+        logger.info(
+            f"Rate limiting enabled: {args.rate_limit} requests/minute per client"
+        )
+
+    # Security summary at startup
+    logger.info("=" * 60)
+    logger.info("SECURITY CONFIGURATION")
+    logger.info("=" * 60)
+    if _api_key:
+        logger.info("  Authentication: ENABLED (API key required)")
+    else:
+        logger.warning("  Authentication: DISABLED - Use --api-key to enable")
+    if args.rate_limit > 0:
+        logger.info(f"  Rate limiting: ENABLED ({args.rate_limit} req/min)")
+    else:
+        logger.warning("  Rate limiting: DISABLED - Use --rate-limit to enable")
+    logger.info(f"  Request timeout: {args.timeout}s")
+    if args.enable_metrics:
+        logger.info("  Metrics: ENABLED (/metrics, unauthenticated)")
+    else:
+        logger.info("  Metrics: DISABLED - Use --enable-metrics to expose /metrics")
+    if args.trust_remote_code:
+        logger.warning("  Remote code loading: ENABLED (--trust-remote-code)")
+    else:
+        logger.info("  Remote code loading: DISABLED (default)")
+    logger.info("=" * 60)
+
+    # Set MCP config for lifespan
+    if args.mcp_config:
+        os.environ["VLLM_MLX_MCP_CONFIG"] = args.mcp_config
+
+    # Initialize reasoning parser if specified
+    if args.reasoning_parser:
+        global _reasoning_parser
+        from .reasoning import get_parser
+
+        parser_cls = get_parser(args.reasoning_parser)
+        _reasoning_parser = parser_cls()
+        logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")
+
+    # Pre-load embedding model if specified
+    load_embedding_model(args.embedding_model, lock=True)
+
+    # Load model before starting server
+    load_model(
+        args.model,
+        use_batching=args.continuous_batching,
+        max_tokens=args.max_tokens,
+        force_mllm=args.mllm,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    # Start server
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the standalone server CLI parser."""
     parser = argparse.ArgumentParser(
         description="vllm-mlx OpenAI-compatible server for LLM and MLLM inference",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -3037,6 +3117,11 @@ Examples:
         "--mllm",
         action="store_true",
         help="Force loading as MLLM (multimodal language model)",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow HuggingFace remote code execution during model/tokenizer loading",
     )
     parser.add_argument(
         "--continuous-batching",
@@ -3110,73 +3195,7 @@ Examples:
         default=None,
         help="Default top_p for generation when not specified in request",
     )
-
-    args = parser.parse_args()
-
-    # Set global configuration
-    global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
-    global _default_temperature, _default_top_p
-    _api_key = args.api_key
-    _default_timeout = args.timeout
-    _metrics_enabled = args.enable_metrics
-    _metrics.configure(enabled=args.enable_metrics)
-    if args.default_temperature is not None:
-        _default_temperature = args.default_temperature
-    if args.default_top_p is not None:
-        _default_top_p = args.default_top_p
-
-    # Configure rate limiter
-    if args.rate_limit > 0:
-        _rate_limiter = RateLimiter(requests_per_minute=args.rate_limit, enabled=True)
-        logger.info(
-            f"Rate limiting enabled: {args.rate_limit} requests/minute per client"
-        )
-
-    # Security summary at startup
-    logger.info("=" * 60)
-    logger.info("SECURITY CONFIGURATION")
-    logger.info("=" * 60)
-    if _api_key:
-        logger.info("  Authentication: ENABLED (API key required)")
-    else:
-        logger.warning("  Authentication: DISABLED - Use --api-key to enable")
-    if args.rate_limit > 0:
-        logger.info(f"  Rate limiting: ENABLED ({args.rate_limit} req/min)")
-    else:
-        logger.warning("  Rate limiting: DISABLED - Use --rate-limit to enable")
-    logger.info(f"  Request timeout: {args.timeout}s")
-    if args.enable_metrics:
-        logger.info("  Metrics: ENABLED (/metrics, unauthenticated)")
-    else:
-        logger.info("  Metrics: DISABLED - Use --enable-metrics to expose /metrics")
-    logger.info("=" * 60)
-
-    # Set MCP config for lifespan
-    if args.mcp_config:
-        os.environ["VLLM_MLX_MCP_CONFIG"] = args.mcp_config
-
-    # Initialize reasoning parser if specified
-    if args.reasoning_parser:
-        global _reasoning_parser
-        from .reasoning import get_parser
-
-        parser_cls = get_parser(args.reasoning_parser)
-        _reasoning_parser = parser_cls()
-        logger.info(f"Reasoning parser enabled: {args.reasoning_parser}")
-
-    # Pre-load embedding model if specified
-    load_embedding_model(args.embedding_model, lock=True)
-
-    # Load model before starting server
-    load_model(
-        args.model,
-        use_batching=args.continuous_batching,
-        max_tokens=args.max_tokens,
-        force_mllm=args.mllm,
-    )
-
-    # Start server
-    uvicorn.run(app, host=args.host, port=args.port)
+    return parser
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- default `trust_remote_code` to false across engine and MLLM constructors
- add explicit `--trust-remote-code` opt-in to both `vllm-mlx serve` and `python -m vllm_mlx.server`
- thread the flag through `load_model()` into both simple and batched engine creation
- add regressions covering parser defaults and engine wiring

## Testing
- `PYTHONPATH=/tmp/vllm-mlx-issue321 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_server.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/engine/simple.py vllm_mlx/engine/batched.py vllm_mlx/models/mllm.py vllm_mlx/server.py vllm_mlx/cli.py tests/test_server.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/engine/simple.py vllm_mlx/engine/batched.py vllm_mlx/models/mllm.py vllm_mlx/server.py vllm_mlx/cli.py tests/test_server.py`

Closes #321.
