### PR TITLE
fix(server): enforce MCP sandbox on execute endpoint

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,7 @@
 import json
 import platform
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -168,6 +168,98 @@ class TestCompletionRequest:
         assert request.model == "test-model"
         assert request.prompt == "Once upon a time"
         assert request.max_tokens is None  # uses _default_max_tokens when None
+
+
+class TestMCPExecuteEndpoint:
+    """Test MCP execute endpoint sandbox routing."""
+
+    @pytest.fixture()
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.server import app
+
+        return TestClient(app)
+
+    def test_execute_routes_through_executor(self, client):
+        """REST MCP execute should use ToolExecutor, not raw manager.execute_tool."""
+        import vllm_mlx.server as srv
+
+        mock_manager = MagicMock()
+        mock_manager.execute_tool = AsyncMock(
+            side_effect=AssertionError("manager.execute_tool should not be called")
+        )
+
+        mock_result = MagicMock()
+        mock_result.tool_name = "filesystem__read_file"
+        mock_result.content = "hello"
+        mock_result.is_error = False
+        mock_result.error_message = None
+
+        mock_executor = MagicMock()
+        mock_executor.execute_tool_calls = AsyncMock(
+            return_value=[(mock_result, "mcp-test")]
+        )
+
+        original_manager = srv._mcp_manager
+        original_executor = srv._mcp_executor
+        srv._mcp_manager = mock_manager
+        srv._mcp_executor = mock_executor
+        try:
+            resp = client.post(
+                "/v1/mcp/execute",
+                json={
+                    "tool_name": "filesystem__read_file",
+                    "arguments": {"path": "/tmp/test.txt"},
+                },
+            )
+        finally:
+            srv._mcp_manager = original_manager
+            srv._mcp_executor = original_executor
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tool_name"] == "filesystem__read_file"
+        assert body["content"] == "hello"
+        assert body["is_error"] is False
+        mock_executor.execute_tool_calls.assert_awaited_once()
+        mock_manager.execute_tool.assert_not_awaited()
+
+    def test_execute_returns_sandbox_blocked_result(self, client):
+        """REST MCP execute should surface sandbox blocks via executor result."""
+        import vllm_mlx.server as srv
+
+        mock_result = MagicMock()
+        mock_result.tool_name = "filesystem__read_file"
+        mock_result.content = None
+        mock_result.is_error = True
+        mock_result.error_message = "Tool 'read_file' is blocked by security policy"
+
+        mock_executor = MagicMock()
+        mock_executor.execute_tool_calls = AsyncMock(
+            return_value=[(mock_result, "mcp-test")]
+        )
+
+        original_manager = srv._mcp_manager
+        original_executor = srv._mcp_executor
+        srv._mcp_manager = MagicMock()
+        srv._mcp_executor = mock_executor
+        try:
+            resp = client.post(
+                "/v1/mcp/execute",
+                json={
+                    "tool_name": "filesystem__read_file",
+                    "arguments": {"path": "../secret.txt"},
+                },
+            )
+        finally:
+            srv._mcp_manager = original_manager
+            srv._mcp_executor = original_executor
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_error"] is True
+        assert "blocked by security policy" in body["error_message"]
 
 
 class TestServeCli:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1989,15 +1989,27 @@ async def list_mcp_servers() -> MCPServersResponse:
 @app.post("/v1/mcp/execute", dependencies=[Depends(verify_api_key)])
 async def execute_mcp_tool(request: MCPExecuteRequest) -> MCPExecuteResponse:
     """Execute an MCP tool."""
+    global _mcp_executor
+
     if _mcp_manager is None:
         raise HTTPException(
             status_code=503, detail="MCP not configured. Start server with --mcp-config"
         )
 
-    result = await _mcp_manager.execute_tool(
-        request.tool_name,
-        request.arguments,
-    )
+    if _mcp_executor is None:
+        from vllm_mlx.mcp import ToolExecutor
+
+        _mcp_executor = ToolExecutor(_mcp_manager)
+
+    tool_call = {
+        "id": f"mcp-{uuid.uuid4().hex[:8]}",
+        "type": "function",
+        "function": {
+            "name": request.tool_name,
+            "arguments": request.arguments,
+        },
+    }
+    result, _ = (await _mcp_executor.execute_tool_calls([tool_call], parallel=False))[0]
 
     return MCPExecuteResponse(
         tool_name=result.tool_name,


### PR DESCRIPTION
## Summary
- route `/v1/mcp/execute` through `ToolExecutor` instead of calling the manager directly
- enforce existing sandbox and argument-validation policy on REST-initiated MCP executions
- lazily initialize the executor if MCP is configured but no executor instance exists yet
- add endpoint regressions proving the REST path no longer bypasses sandbox handling

## Testing
- `PYTHONPATH=/private/tmp/vllm-mlx-issue322 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_server.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/server.py tests/test_server.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/server.py tests/test_server.py`

Closes #322.
