### PR TITLE
fix(mcp): block interpreter inline execution flags

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -137,6 +137,52 @@ class TestArgumentValidation:
 
         assert "dangerous pattern" in str(exc_info.value)
 
+    def test_python_inline_code_flag_blocked(self):
+        """Test that python -c is rejected even though python is whitelisted."""
+        validator = MCPCommandValidator(check_path_exists=False)
+
+        with pytest.raises(MCPSecurityError) as exc_info:
+            validator.validate_command_args("python3", ["-c", "print('owned')"], "test")
+
+        assert "inline Python execution" in str(exc_info.value)
+
+    def test_node_eval_flag_blocked(self):
+        """Test that node --eval is rejected."""
+        validator = MCPCommandValidator(check_path_exists=False)
+
+        with pytest.raises(MCPSecurityError) as exc_info:
+            validator.validate_command_args(
+                "node",
+                ["--eval=console.log('owned')"],
+                "test",
+            )
+
+        assert "inline JavaScript evaluation" in str(exc_info.value)
+
+    def test_npx_call_flag_blocked(self):
+        """Test that npx -c shell execution is rejected."""
+        validator = MCPCommandValidator(check_path_exists=False)
+
+        with pytest.raises(MCPSecurityError) as exc_info:
+            validator.validate_command_args("npx", ["-c", "echo owned"], "test")
+
+        assert "shell command execution" in str(exc_info.value)
+
+    def test_interpreter_normal_launch_args_still_pass(self):
+        """Test that standard MCP launches are unaffected."""
+        validator = MCPCommandValidator(check_path_exists=False)
+
+        validator.validate_command_args(
+            "npx",
+            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            "filesystem",
+        )
+        validator.validate_command_args(
+            "uvx",
+            ["mcp-server-sqlite", "--db-path", "data.db"],
+            "sqlite",
+        )
+
 
 class TestEnvironmentValidation:
     """Tests for environment variable validation."""
@@ -307,6 +353,30 @@ class TestMCPServerConfigSecurity:
             )
 
         assert "not in the allowed commands whitelist" in str(exc_info.value)
+
+    def test_inline_python_execution_in_config_rejected(self):
+        """Test that interpreter eval forms are rejected in config."""
+        with pytest.raises(ValueError) as exc_info:
+            MCPServerConfig(
+                name="inline-python",
+                transport=MCPTransport.STDIO,
+                command="python3",
+                args=["-c", "print('owned')"],
+            )
+
+        assert "inline Python execution" in str(exc_info.value)
+
+    def test_node_eval_in_config_rejected(self):
+        """Test that node eval forms are rejected in config."""
+        with pytest.raises(ValueError) as exc_info:
+            MCPServerConfig(
+                name="inline-node",
+                transport=MCPTransport.STDIO,
+                command="node",
+                args=["--eval=console.log('owned')"],
+            )
+
+        assert "inline JavaScript evaluation" in str(exc_info.value)
 
     def test_command_injection_in_config_rejected(self):
         """Test that command injection in config is rejected."""

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -75,6 +75,28 @@ DANGEROUS_ARG_PATTERNS: List[re.Pattern] = [
     re.compile(r"<\s*/"),  # Read from absolute path
 ]
 
+# Explicit inline-code execution forms for interpreter-like commands. These
+# combinations turn an otherwise whitelisted runtime into a raw code-execution
+# primitive and are not needed for normal MCP server launches.
+BLOCKED_COMMAND_ARG_RULES: Dict[str, Dict[str, str]] = {
+    "python": {
+        "-c": "inline Python execution",
+    },
+    "python3": {
+        "-c": "inline Python execution",
+    },
+    "node": {
+        "-e": "inline JavaScript evaluation",
+        "--eval": "inline JavaScript evaluation",
+        "-p": "JavaScript evaluation/print",
+        "--print": "JavaScript evaluation/print",
+    },
+    "npx": {
+        "-c": "shell command execution",
+        "--call": "shell command execution",
+    },
+}
+
 
 class MCPSecurityError(Exception):
     """Raised when MCP security validation fails."""
@@ -208,6 +230,50 @@ class MCPCommandValidator:
             f"MCP server '{server_name}': {len(args)} arguments validated successfully"
         )
 
+    def validate_command_args(
+        self,
+        command: str,
+        args: List[str],
+        server_name: str,
+    ) -> None:
+        """
+        Validate command-specific argument combinations.
+
+        Some whitelisted runtimes (python, node, npx) remain acceptable for
+        launching packaged MCP servers, but inline evaluator flags such as
+        ``python -c`` and ``node -e`` must be rejected.
+        """
+        if self.allow_unsafe or not args:
+            return
+
+        base_command = Path(command).name
+        blocked_rules = BLOCKED_COMMAND_ARG_RULES.get(base_command)
+        if not blocked_rules:
+            return
+
+        for i, arg in enumerate(args):
+            if arg in blocked_rules:
+                raise MCPSecurityError(
+                    f"MCP server '{server_name}': Argument {i} '{arg}' enables "
+                    f"{blocked_rules[arg]} for '{base_command}', which is not allowed."
+                )
+
+            if base_command == "node" and arg.startswith("--eval="):
+                raise MCPSecurityError(
+                    f"MCP server '{server_name}': Argument {i} '{arg}' enables "
+                    "inline JavaScript evaluation for 'node', which is not allowed."
+                )
+
+            if base_command == "npx" and arg.startswith("--call="):
+                raise MCPSecurityError(
+                    f"MCP server '{server_name}': Argument {i} '{arg}' enables "
+                    "shell command execution for 'npx', which is not allowed."
+                )
+
+        logger.debug(
+            f"MCP server '{server_name}': command-specific arguments validated"
+        )
+
     def validate_env(self, env: Optional[Dict[str, str]], server_name: str) -> None:
         """
         Validate environment variables for dangerous values.
@@ -338,6 +404,8 @@ def validate_mcp_server_config(
 
     if args:
         validator.validate_args(args, server_name)
+        if command:
+            validator.validate_command_args(command, args, server_name)
 
     if env:
         validator.validate_env(env, server_name)


### PR DESCRIPTION
## Summary
- harden MCP command validation against inline code-execution forms on whitelisted runtimes
- block `python -c`, `node -e` / `--eval`, and `npx -c` style launches while keeping normal MCP server invocations intact
- add focused validator and config-model regressions for the blocked combinations

## Test plan
- `PYTHONPATH=/private/tmp/vllm-mlx-issue68-f6 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mcp_security.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/mcp/security.py tests/test_mcp_security.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/mcp/security.py tests/test_mcp_security.py`

Addresses finding #6 in #68.
