### PR TITLE
fix(server): cap request max_tokens

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -45,6 +45,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
 | `--max-tokens` | Default max tokens | 32768 |
+| `--max-request-tokens` | Maximum `max_tokens` accepted from API clients | 32768 |
 | `--default-temperature` | Default temperature when not specified | None |
 | `--default-top-p` | Default top_p when not specified | None |
 | `--stream-interval` | Tokens per stream chunk | 1 |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,6 +35,7 @@ vllm-mlx serve <model> [options]
 | `--no-memory-aware-cache` | Use legacy entry-count cache | False |
 | `--use-paged-cache` | Enable paged KV cache | False |
 | `--max-tokens` | Default max tokens | 32768 |
+| `--max-request-tokens` | Maximum `max_tokens` accepted from API clients | 32768 |
 | `--stream-interval` | Tokens per stream chunk | 1 |
 | `--mcp-config` | Path to MCP config file | None |
 | `--paged-cache-block-size` | Tokens per cache block | 64 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,6 +9,7 @@
 | `--host` | Server host address | `127.0.0.1` |
 | `--port` | Server port | `8000` |
 | `--max-tokens` | Default max tokens | `32768` |
+| `--max-request-tokens` | Maximum `max_tokens` accepted from API clients | `32768` |
 | `--default-temperature` | Default temperature when not specified in request | None |
 | `--default-top-p` | Default top_p when not specified in request | None |
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 # Skip all tests if not on Apple Silicon
 pytestmark = pytest.mark.skipif(
@@ -155,6 +156,17 @@ class TestChatCompletionRequest:
         assert request.video_fps == 2.0
         assert request.video_max_frames == 16
 
+    def test_max_tokens_must_be_positive(self):
+        """Chat completion requests reject zero or negative max_tokens."""
+        from vllm_mlx.server import ChatCompletionRequest, Message
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[Message(role="user", content="Hello")],
+                max_tokens=0,
+            )
+
 
 class TestCompletionRequest:
     """Test CompletionRequest model."""
@@ -168,6 +180,30 @@ class TestCompletionRequest:
         assert request.model == "test-model"
         assert request.prompt == "Once upon a time"
         assert request.max_tokens is None  # uses _default_max_tokens when None
+
+    def test_max_tokens_must_be_positive(self):
+        """Completion requests reject zero or negative max_tokens."""
+        from vllm_mlx.server import CompletionRequest
+
+        with pytest.raises(ValidationError):
+            CompletionRequest(
+                model="test-model", prompt="Once upon a time", max_tokens=0
+            )
+
+
+class TestAnthropicRequest:
+    """Test Anthropic request model."""
+
+    def test_max_tokens_must_be_positive(self):
+        """Anthropic requests reject zero or negative max_tokens."""
+        from vllm_mlx.api.anthropic_models import AnthropicRequest
+
+        with pytest.raises(ValidationError):
+            AnthropicRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=0,
+            )
 
 
 class TestMCPExecuteEndpoint:
@@ -298,6 +334,28 @@ class TestServeCli:
             ["--model", "mlx-community/Llama-3.2-3B-Instruct-4bit"]
         )
         assert server_args.host == "127.0.0.1"
+
+    def test_max_request_tokens_defaults_and_overrides(self):
+        """Serve CLI exposes a separate request max_tokens ceiling."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["serve", "mlx-community/Llama-3.2-3B-Instruct-4bit"])
+        assert args.max_tokens == 32768
+        assert args.max_request_tokens == 32768
+
+        args = parser.parse_args(
+            [
+                "serve",
+                "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "--max-tokens",
+                "2048",
+                "--max-request-tokens",
+                "4096",
+            ]
+        )
+        assert args.max_tokens == 2048
+        assert args.max_request_tokens == 4096
 
     def test_tool_call_parser_accepts_harmony_aliases(self):
         """GPT-OSS/Harmony parsers should be selectable from the serve CLI."""
@@ -778,6 +836,116 @@ class TestRequestTimeoutField:
             model="test-model", prompt="Once upon a time", timeout=120.0
         )
         assert request_with_timeout.timeout == 120.0
+
+
+class TestMaxTokensLimit:
+    """Test server-side max_tokens ceiling enforcement."""
+
+    def test_resolve_request_max_tokens(self):
+        """Explicit requests must stay within the configured server ceiling."""
+        import vllm_mlx.server as server
+
+        original_default = server._default_max_tokens
+        original_limit = server._max_request_tokens
+        try:
+            server._default_max_tokens = 1024
+            server._max_request_tokens = 2048
+
+            assert server._resolve_request_max_tokens(None) == 1024
+            assert server._resolve_request_max_tokens(512) == 512
+
+            with pytest.raises(server.HTTPException) as exc_info:
+                server._resolve_request_max_tokens(4096)
+
+            assert exc_info.value.status_code == 400
+            assert "server limit" in exc_info.value.detail
+        finally:
+            server._default_max_tokens = original_default
+            server._max_request_tokens = original_limit
+
+    @pytest.mark.anyio
+    async def test_create_completion_rejects_over_limit_before_engine_lookup(
+        self, monkeypatch
+    ):
+        """Completions should reject oversized requests at the API boundary."""
+        from vllm_mlx.server import CompletionRequest, create_completion
+        import vllm_mlx.server as server
+
+        monkeypatch.setattr(server, "_max_request_tokens", 1024)
+        monkeypatch.setattr(
+            server,
+            "get_engine",
+            lambda: (_ for _ in ()).throw(AssertionError("engine should not load")),
+        )
+
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Once upon a time",
+            max_tokens=2048,
+        )
+
+        with pytest.raises(server.HTTPException) as exc_info:
+            await create_completion(request, raw_request=None)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_create_chat_completion_rejects_over_limit_before_engine_lookup(
+        self, monkeypatch
+    ):
+        """Chat completions should reject oversized requests at the API boundary."""
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        monkeypatch.setattr(server, "_max_request_tokens", 1024)
+        monkeypatch.setattr(
+            server,
+            "get_engine",
+            lambda: (_ for _ in ()).throw(AssertionError("engine should not load")),
+        )
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+            max_tokens=2048,
+        )
+
+        with pytest.raises(server.HTTPException) as exc_info:
+            await create_chat_completion(request, raw_request=None)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_create_anthropic_message_rejects_over_limit_before_engine_lookup(
+        self, monkeypatch
+    ):
+        """Anthropic requests should reject oversized requests before engine use."""
+        from vllm_mlx.server import create_anthropic_message
+        import vllm_mlx.server as server
+
+        class FakeRequest:
+            async def json(self):
+                return {
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 2048,
+                }
+
+        monkeypatch.setattr(server, "_max_request_tokens", 1024)
+        monkeypatch.setattr(
+            server,
+            "get_engine",
+            lambda: (_ for _ in ()).throw(AssertionError("engine should not load")),
+        )
+
+        with pytest.raises(server.HTTPException) as exc_info:
+            await create_anthropic_message(FakeRequest())
+
+        assert exc_info.value.status_code == 400
 
 
 class TestAPIKeyVerification:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1637,7 +1637,12 @@ class TestSseDoneTermination:
         request = CompletionRequest(model="test-model", prompt="Say hello")
         chunks = [
             chunk
-            async for chunk in stream_completion(FakeEngine(), "Say hello", request)
+            async for chunk in stream_completion(
+                FakeEngine(),
+                "Say hello",
+                request,
+                max_tokens=server._default_max_tokens,
+            )
         ]
 
         done_chunks = [c for c in chunks if c == "data: [DONE]\n\n"]
@@ -1672,7 +1677,12 @@ class TestSseDoneTermination:
         chunks = [
             chunk
             async for chunk in _ensure_sse_terminal(
-                stream_completion(ExplodingEngine(), "Say hello", request),
+                stream_completion(
+                    ExplodingEngine(),
+                    "Say hello",
+                    request,
+                    max_tokens=server._default_max_tokens,
+                ),
                 "data: [DONE]\n\n",
             )
         ]

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -56,7 +56,7 @@ class AnthropicRequest(BaseModel):
     model: str
     messages: list[AnthropicMessage]
     system: str | list[dict] | None = None
-    max_tokens: int  # Required in Anthropic API
+    max_tokens: int = Field(gt=0)  # Required in Anthropic API
     temperature: float | None = None
     top_p: float | None = None
     stream: bool = False

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -163,7 +163,7 @@ class ChatCompletionRequest(BaseModel):
     min_p: float | None = None
     presence_penalty: float | None = None
     repetition_penalty: float | None = None
-    max_tokens: int | None = None
+    max_tokens: int | None = Field(default=None, gt=0)
     stream: bool = False
     stream_options: StreamOptions | None = (
         None  # Streaming options (include_usage, etc.)
@@ -250,7 +250,7 @@ class CompletionRequest(BaseModel):
     min_p: float | None = None
     presence_penalty: float | None = None
     repetition_penalty: float | None = None
-    max_tokens: int | None = None
+    max_tokens: int | None = Field(default=None, gt=0)
     stream: bool = False
     stop: list[str] | None = None
     # Sampling penalties

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -43,12 +43,22 @@ def serve_command(args):
             "Error: --gpu-memory-utilization must be between 0.0 (exclusive) and 1.0 (inclusive)"
         )
         sys.exit(1)
+    if args.max_tokens < 1:
+        print("Error: --max-tokens must be at least 1")
+        sys.exit(1)
+    if args.max_request_tokens < 1:
+        print("Error: --max-request-tokens must be at least 1")
+        sys.exit(1)
+    if args.max_tokens > args.max_request_tokens:
+        print("Error: --max-tokens cannot exceed --max-request-tokens")
+        sys.exit(1)
 
     # Configure server security settings
     server._api_key = args.api_key
     server._default_timeout = args.timeout
     server._metrics_enabled = args.enable_metrics
     server._metrics.configure(enabled=args.enable_metrics)
+    server._max_request_tokens = args.max_request_tokens
     if args.rate_limit > 0:
         server._rate_limiter = RateLimiter(
             requests_per_minute=args.rate_limit, enabled=True
@@ -145,6 +155,7 @@ def serve_command(args):
 
     print(f"Loading model: {args.model}")
     print(f"Default max tokens: {args.max_tokens}")
+    print(f"Max request tokens: {args.max_request_tokens}")
 
     # Store MCP config path for FastAPI startup
     if args.mcp_config:
@@ -237,6 +248,7 @@ def serve_command(args):
         scheduler_config=scheduler_config,
         stream_interval=args.stream_interval if args.continuous_batching else 1,
         max_tokens=args.max_tokens,
+        max_request_tokens=args.max_request_tokens,
         force_mllm=getattr(args, "mllm", False),
         gpu_memory_utilization=args.gpu_memory_utilization,
         served_model_name=args.served_model_name,
@@ -769,6 +781,12 @@ Examples:
         type=int,
         default=32768,
         help="Default max tokens for generation (default: 32768)",
+    )
+    serve_parser.add_argument(
+        "--max-request-tokens",
+        type=int,
+        default=32768,
+        help="Maximum max_tokens accepted from API clients (default: 32768)",
     )
     serve_parser.add_argument(
         "--continuous-batching",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -163,6 +163,7 @@ _model_path: str | None = (
     None  # Actual model path (for cache dir, not affected by --served-model-name)
 )
 _default_max_tokens: int = 32768
+_max_request_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
@@ -190,6 +191,18 @@ def _resolve_top_p(request_value: float | None) -> float:
     if _default_top_p is not None:
         return _default_top_p
     return _FALLBACK_TOP_P
+
+
+def _resolve_request_max_tokens(requested_value: int | None) -> int:
+    """Resolve and validate a request's max_tokens budget."""
+    if requested_value is None:
+        return _default_max_tokens
+    if requested_value > _max_request_tokens:
+        raise HTTPException(
+            status_code=400,
+            detail=f"max_tokens exceeds server limit ({_max_request_tokens})",
+        )
+    return requested_value
 
 
 # Global MCP manager
@@ -1606,6 +1619,7 @@ def load_model(
     scheduler_config=None,
     stream_interval: int = 1,
     max_tokens: int = 32768,
+    max_request_tokens: int = 32768,
     force_mllm: bool = False,
     gpu_memory_utilization: float = 0.90,
     served_model_name: str | None = None,
@@ -1626,6 +1640,7 @@ def load_model(
         scheduler_config: Scheduler config for batched mode
         stream_interval: Tokens to batch before streaming (batched mode only)
         max_tokens: Default max tokens for generation
+        max_request_tokens: Maximum max_tokens accepted from API clients
         force_mllm: Force loading as MLLM even if not auto-detected
         trust_remote_code: Allow HuggingFace remote code execution during model/tokenizer loading
         mtp: Enable native MTP speculative decoding (SimpleEngine only)
@@ -1635,9 +1650,18 @@ def load_model(
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
     """
-    global _engine, _model_name, _model_path, _default_max_tokens, _tool_parser_instance
+    global _engine, _model_name, _model_path, _default_max_tokens
+    global _max_request_tokens, _tool_parser_instance
+
+    if max_tokens < 1:
+        raise ValueError("Default max tokens must be at least 1")
+    if max_request_tokens < 1:
+        raise ValueError("Max request tokens must be at least 1")
+    if max_tokens > max_request_tokens:
+        raise ValueError("Default max tokens cannot exceed max request tokens")
 
     _default_max_tokens = max_tokens
+    _max_request_tokens = max_request_tokens
     _model_path = model_name
     _model_name = served_model_name or model_name
     # Reset tool parser instance when model is reloaded (tokenizer may change)
@@ -1686,6 +1710,7 @@ def load_model(
         logger.info(f"Native tool format enabled for parser: {_tool_call_parser}")
 
     logger.info(f"Default max tokens: {_default_max_tokens}")
+    logger.info(f"Max request tokens: {_max_request_tokens}")
 
 
 def get_usage(output: GenerationOutput) -> Usage:
@@ -2416,6 +2441,7 @@ async def _wait_with_disconnect(
 async def create_completion(request: CompletionRequest, raw_request: Request):
     """Create a text completion."""
     _validate_model_name(request.model)
+    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     engine = get_engine()
     tracker = _metrics.track_inference("completions", stream=request.stream)
 
@@ -2465,7 +2491,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     for i, prompt in enumerate(prompts):
         generate_kwargs = {
             "prompt": prompt,
-            "max_tokens": request.max_tokens or _default_max_tokens,
+            "max_tokens": effective_max_tokens,
             "temperature": _resolve_temperature(request.temperature),
             "top_p": _resolve_top_p(request.top_p),
             "top_k": request.top_k or 0,
@@ -2578,6 +2604,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     ```
     """
     _validate_model_name(request.model)
+    effective_max_tokens = _resolve_request_max_tokens(request.max_tokens)
     engine = get_engine()
     tracker = _metrics.track_inference("chat_completions", stream=request.stream)
 
@@ -2706,7 +2733,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
 
     # Prepare kwargs
     chat_kwargs = {
-        "max_tokens": request.max_tokens or _default_max_tokens,
+        "max_tokens": effective_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
         "top_k": request.top_k or 0,
@@ -3039,6 +3066,8 @@ async def create_anthropic_message(
     anthropic_request = AnthropicRequest(**body)
 
     _validate_model_name(anthropic_request.model)
+    effective_max_tokens = _resolve_request_max_tokens(anthropic_request.max_tokens)
+    engine = get_engine()
 
     # --- Detailed request logging ---
     n_msgs = len(anthropic_request.messages)
@@ -3124,7 +3153,7 @@ async def create_anthropic_message(
                     )
 
     chat_kwargs = {
-        "max_tokens": openai_request.max_tokens or _default_max_tokens,
+        "max_tokens": effective_max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
         "top_k": openai_request.top_k or 0,
@@ -3390,6 +3419,7 @@ async def _stream_anthropic_messages(
     engine: BaseEngine,
     openai_request: ChatCompletionRequest,
     anthropic_request: AnthropicRequest,
+    max_tokens: int,
     metrics_tracker=None,
 ) -> AsyncIterator[str]:
     """
@@ -3416,7 +3446,7 @@ async def _stream_anthropic_messages(
     messages = _normalize_messages(messages)
 
     chat_kwargs = {
-        "max_tokens": openai_request.max_tokens or _default_max_tokens,
+        "max_tokens": max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
         "top_k": openai_request.top_k or 0,
@@ -3692,6 +3722,7 @@ async def stream_completion(
     engine: BaseEngine,
     prompt: str,
     request: CompletionRequest,
+    max_tokens: int,
     repetition_penalty: float | None = None,
     metrics_tracker=None,
 ) -> AsyncIterator[str]:
@@ -3701,7 +3732,7 @@ async def stream_completion(
     completion_tokens = 0
     generate_kwargs = {
         "prompt": prompt,
-        "max_tokens": request.max_tokens or _default_max_tokens,
+        "max_tokens": max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
         "top_k": request.top_k or 0,
@@ -4399,6 +4430,12 @@ Examples:
         type=int,
         default=32768,
         help="Default max tokens for generation",
+    )
+    parser.add_argument(
+        "--max-request-tokens",
+        type=int,
+        default=32768,
+        help="Maximum max_tokens accepted from API clients (default: 32768)",
     )
     parser.add_argument(
         "--api-key",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3047,7 +3047,6 @@ async def create_anthropic_message(
 
     Supports both streaming and non-streaming modes.
     """
-    engine = get_engine()
     tracker = _metrics.track_inference("anthropic_messages", stream=False)
 
     # Parse the raw body to handle Anthropic request format.


### PR DESCRIPTION
## Summary
- add a separate `--max-request-tokens` ceiling for API requests instead of treating the default generation length as the only limit
- enforce positive `max_tokens` in the OpenAI and Anthropic request models and reject oversized requests before any engine work
- apply the same ceiling to completions, chat completions, and Anthropic messages, and document the new server option

## Test plan
- `PYTHONPATH=/private/tmp/vllm-mlx-issue68-max-tokens /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_server.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/api/models.py vllm_mlx/api/anthropic_models.py vllm_mlx/cli.py vllm_mlx/server.py tests/test_server.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/api/models.py vllm_mlx/api/anthropic_models.py vllm_mlx/cli.py vllm_mlx/server.py tests/test_server.py`

Part of #68 (finding #16).