### PR TITLE
fix(mcp): block high-risk tools by default

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -342,6 +342,34 @@ class TestMCPServerConfigSecurity:
         )
         assert config.url == "https://api.example.com/mcp"
 
+    def test_config_parses_allowed_high_risk_tools(self):
+        """Root MCP config should accept explicit high-risk tool allowlists."""
+        from vllm_mlx.mcp.config import validate_config
+
+        config = validate_config(
+            {
+                "servers": {},
+                "allowed_high_risk_tools": [
+                    "trusted__execute_command",
+                    "run_shell",
+                ],
+            }
+        )
+
+        assert config.allowed_high_risk_tools == {
+            "trusted__execute_command",
+            "run_shell",
+        }
+
+    def test_config_rejects_invalid_allowed_high_risk_tools(self):
+        """High-risk allowlists must be a list of non-empty strings."""
+        from vllm_mlx.mcp.config import validate_config
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_config({"servers": {}, "allowed_high_risk_tools": ["ok", ""]})
+
+        assert "allowed_high_risk_tools" in str(exc_info.value)
+
     def test_skip_security_validation_field_rejected(self):
         """Test that config-file security bypass is rejected explicitly."""
         with pytest.raises(ValueError) as exc_info:
@@ -802,27 +830,25 @@ class TestToolSandboxAuditLogging:
 class TestToolSandboxHighRiskTools:
     """Tests for high-risk tool detection."""
 
-    def test_high_risk_tool_warning(self, caplog):
-        """Test that high-risk tools trigger warning."""
-        import logging
-
+    def test_high_risk_tool_blocked_by_default(self):
+        """High-risk tools should be blocked unless explicitly allowlisted."""
         sandbox = ToolSandbox()
 
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(MCPSecurityError) as exc_info:
             sandbox.validate_tool_execution(
                 tool_name="execute_command",
                 server_name="test",
                 arguments={"cmd": "ls"},
             )
 
-        assert "High-risk tool detected" in caplog.text
-        assert "execute" in caplog.text
+        assert "High-risk tool 'execute_command' is blocked" in str(exc_info.value)
+        assert "allowed_high_risk_tools" in str(exc_info.value)
 
-    def test_high_risk_shell_tool(self, caplog):
-        """Test that shell tools trigger warning."""
+    def test_high_risk_tool_allowed_by_short_name(self, caplog):
+        """Short-name allowlist entries should permit trusted high-risk tools."""
         import logging
 
-        sandbox = ToolSandbox()
+        sandbox = ToolSandbox(allowed_high_risk_tools={"run_shell"})
 
         with caplog.at_level(logging.WARNING):
             sandbox.validate_tool_execution(
@@ -831,7 +857,22 @@ class TestToolSandboxHighRiskTools:
                 arguments={},
             )
 
-        assert "High-risk tool detected" in caplog.text
+        assert "Allowing high-risk tool 'test__run_shell'" in caplog.text
+
+    def test_high_risk_tool_allowed_by_full_name(self, caplog):
+        """Full-name allowlist entries should permit trusted high-risk tools."""
+        import logging
+
+        sandbox = ToolSandbox(allowed_high_risk_tools={"trusted__execute_command"})
+
+        with caplog.at_level(logging.WARNING):
+            sandbox.validate_tool_execution(
+                tool_name="execute_command",
+                server_name="trusted",
+                arguments={"cmd": "ls"},
+            )
+
+        assert "Allowing high-risk tool 'trusted__execute_command'" in caplog.text
 
 
 class TestCustomBlockedPatterns:

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -146,10 +146,20 @@ def validate_config(data: Dict[str, Any]) -> MCPConfig:
     if not isinstance(default_timeout, (int, float)) or default_timeout <= 0:
         raise ValueError("'default_timeout' must be a positive number")
 
+    allowed_high_risk_tools = data.get("allowed_high_risk_tools", [])
+    if not isinstance(allowed_high_risk_tools, list) or any(
+        not isinstance(tool, str) or not tool.strip()
+        for tool in allowed_high_risk_tools
+    ):
+        raise ValueError(
+            "'allowed_high_risk_tools' must be a list of non-empty strings"
+        )
+
     return MCPConfig(
         servers=servers,
         max_tool_calls=max_tool_calls,
         default_timeout=default_timeout,
+        allowed_high_risk_tools=set(allowed_high_risk_tools),
     )
 
 
@@ -184,5 +194,6 @@ def create_example_config() -> str:
         },
         "max_tool_calls": 10,
         "default_timeout": 30.0,
+        "allowed_high_risk_tools": [],
     }
     return json.dumps(example, indent=2)

--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -404,6 +404,7 @@ class ToolSandbox:
         self,
         allowed_tools: Optional[Set[str]] = None,
         blocked_tools: Optional[Set[str]] = None,
+        allowed_high_risk_tools: Optional[Set[str]] = None,
         blocked_arg_patterns: Optional[List[re.Pattern]] = None,
         max_calls_per_minute: int = 60,
         audit_callback: Optional[Callable[[ToolExecutionAudit], None]] = None,
@@ -415,6 +416,7 @@ class ToolSandbox:
         Args:
             allowed_tools: If set, only these tools can be executed (whitelist mode).
             blocked_tools: Tools that are always blocked (blacklist mode).
+            allowed_high_risk_tools: High-risk tools that are explicitly allowed.
             blocked_arg_patterns: Patterns to block in tool arguments.
             max_calls_per_minute: Rate limit for tool calls (0 = unlimited).
             audit_callback: Optional callback for audit events.
@@ -422,6 +424,9 @@ class ToolSandbox:
         """
         self.allowed_tools = allowed_tools
         self.blocked_tools = blocked_tools or set()
+        self.allowed_high_risk_tools = {
+            tool.lower() for tool in (allowed_high_risk_tools or set())
+        }
         self.blocked_arg_patterns = (
             blocked_arg_patterns or DANGEROUS_TOOL_ARG_PATTERNS.copy()
         )
@@ -482,7 +487,7 @@ class ToolSandbox:
                 )
 
         # Check for high-risk tool patterns
-        self._check_high_risk_tool(tool_name)
+        self._check_high_risk_tool(tool_name, full_name)
 
         # Validate arguments
         self._validate_arguments(tool_name, arguments)
@@ -500,16 +505,26 @@ class ToolSandbox:
             or tool_name.lower() in self.blocked_tools
         )
 
-    def _check_high_risk_tool(self, tool_name: str) -> None:
+    def _check_high_risk_tool(self, tool_name: str, full_name: str) -> None:
         """Check if tool matches high-risk patterns."""
         tool_lower = tool_name.lower()
+        full_lower = full_name.lower()
         for pattern in HIGH_RISK_TOOL_PATTERNS:
             if pattern in tool_lower:
-                logger.warning(
-                    f"High-risk tool detected: '{tool_name}' matches pattern '{pattern}'. "
-                    f"Ensure this tool is from a trusted MCP server."
+                if (
+                    tool_lower in self.allowed_high_risk_tools
+                    or full_lower in self.allowed_high_risk_tools
+                ):
+                    logger.warning(
+                        "Allowing high-risk tool '%s' due to explicit allowlist entry",
+                        full_name,
+                    )
+                    return
+                raise MCPSecurityError(
+                    f"High-risk tool '{tool_name}' is blocked by security policy. "
+                    f"Add '{full_name}' or '{tool_name}' to allowed_high_risk_tools "
+                    f"to allow it explicitly."
                 )
-                break
 
     def _validate_arguments(self, tool_name: str, arguments: Dict[str, Any]) -> None:
         """Validate tool arguments for dangerous patterns."""

--- a/vllm_mlx/mcp/types.py
+++ b/vllm_mlx/mcp/types.py
@@ -5,7 +5,7 @@ Type definitions for MCP client support.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 
 class MCPTransport(str, Enum):
@@ -85,6 +85,7 @@ class MCPConfig:
     servers: Dict[str, MCPServerConfig] = field(default_factory=dict)
     max_tool_calls: int = 10
     default_timeout: float = 30.0
+    allowed_high_risk_tools: Set[str] = field(default_factory=set)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "MCPConfig":
@@ -98,6 +99,7 @@ class MCPConfig:
             servers=servers,
             max_tool_calls=data.get("max_tool_calls", 10),
             default_timeout=data.get("default_timeout", 30.0),
+            allowed_high_risk_tools=set(data.get("allowed_high_risk_tools", [])),
         )
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2975,13 +2975,19 @@ async def init_mcp(config_path: str):
     global _mcp_manager, _mcp_executor
 
     try:
-        from vllm_mlx.mcp import MCPClientManager, ToolExecutor, load_mcp_config
+        from vllm_mlx.mcp import (
+            MCPClientManager,
+            ToolExecutor,
+            ToolSandbox,
+            load_mcp_config,
+        )
 
         config = load_mcp_config(config_path)
         _mcp_manager = MCPClientManager(config)
         await _mcp_manager.start()
 
-        _mcp_executor = ToolExecutor(_mcp_manager)
+        sandbox = ToolSandbox(allowed_high_risk_tools=config.allowed_high_risk_tools)
+        _mcp_executor = ToolExecutor(_mcp_manager, sandbox=sandbox)
 
         logger.info(f"MCP initialized with {len(_mcp_manager.get_all_tools())} tools")
 


### PR DESCRIPTION
## Summary
- change MCP high-risk tool detection from warn-only to block-by-default
- add a root-level `allowed_high_risk_tools` MCP config allowlist for trusted exceptions
- thread the allowlist into the MCP executor sandbox and add regression coverage for default blocking and explicit allowlisting

## Test plan
- `PYTHONPATH=/private/tmp/vllm-mlx-issue68-high-risk-tools /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mcp_security.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/mcp/types.py vllm_mlx/mcp/config.py vllm_mlx/mcp/security.py vllm_mlx/server.py tests/test_mcp_security.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/mcp/types.py vllm_mlx/mcp/config.py vllm_mlx/mcp/security.py vllm_mlx/server.py tests/test_mcp_security.py`

Part of #68 (finding #19).