### PR TITLE
fix(mcp): stop loading config from cwd

### DIFF
--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -6,7 +6,9 @@ These tests verify that the MCP command validation properly prevents
 command injection attacks and other security vulnerabilities.
 """
 
+import json
 import re
+
 import pytest
 from vllm_mlx.mcp.security import (
     MCPCommandValidator,
@@ -339,6 +341,88 @@ class TestMCPServerConfigSecurity:
             skip_security_validation=True,
         )
         assert config.command == "bash"
+
+
+class TestMCPConfigDiscovery:
+    """Tests for MCP config discovery paths."""
+
+    def test_load_mcp_config_ignores_current_working_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """Ambient ./mcp.json files should not be auto-loaded."""
+        from vllm_mlx.mcp.config import load_mcp_config
+
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        (cwd / "mcp.json").write_text(json.dumps({"servers": {"cwd": {}}}))
+        monkeypatch.chdir(cwd)
+        monkeypatch.delenv("VLLM_MLX_MCP_CONFIG", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        config = load_mcp_config()
+
+        assert config.servers == {}
+
+    def test_load_mcp_config_allows_explicit_path_in_cwd(self, tmp_path, monkeypatch):
+        """Explicit relative paths should still be honored."""
+        from vllm_mlx.mcp.config import load_mcp_config
+
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        config_path = cwd / "mcp.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "filesystem": {
+                            "transport": "stdio",
+                            "command": "npx",
+                            "args": [
+                                "-y",
+                                "@modelcontextprotocol/server-filesystem",
+                                "/tmp",
+                            ],
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.chdir(cwd)
+
+        config = load_mcp_config("./mcp.json")
+
+        assert "filesystem" in config.servers
+
+    def test_load_mcp_config_uses_user_config_directory(self, tmp_path, monkeypatch):
+        """Per-user config discovery should still work."""
+        from vllm_mlx.mcp.config import load_mcp_config
+
+        home = tmp_path / "home"
+        config_dir = home / ".config" / "vllm-mlx"
+        config_dir.mkdir(parents=True)
+        (config_dir / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "filesystem": {
+                            "transport": "stdio",
+                            "command": "npx",
+                            "args": [
+                                "-y",
+                                "@modelcontextprotocol/server-filesystem",
+                                "/tmp",
+                            ],
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.delenv("VLLM_MLX_MCP_CONFIG", raising=False)
+
+        config = load_mcp_config()
+
+        assert "filesystem" in config.servers
 
 
 class TestDefaultWhitelist:

--- a/vllm_mlx/mcp/config.py
+++ b/vllm_mlx/mcp/config.py
@@ -13,10 +13,8 @@ from .types import MCPConfig, MCPServerConfig
 
 logger = logging.getLogger(__name__)
 
-# Default config search paths
+# Default per-user config search paths
 CONFIG_SEARCH_PATHS = [
-    "./mcp.json",
-    "./mcp.yaml",
     "~/.config/vllm-mlx/mcp.json",
     "~/.config/vllm-mlx/mcp.yaml",
 ]
@@ -32,8 +30,7 @@ def load_mcp_config(path: Optional[Union[str, Path]] = None) -> MCPConfig:
     Search order:
     1. Explicit path argument
     2. VLLM_MLX_MCP_CONFIG environment variable
-    3. ./mcp.json or ./mcp.yaml (current directory)
-    4. ~/.config/vllm-mlx/mcp.json or mcp.yaml
+    3. ~/.config/vllm-mlx/mcp.json or mcp.yaml
 
     Args:
         path: Optional explicit path to config file


### PR DESCRIPTION
## Summary
- remove implicit MCP config discovery from the current working directory
- keep explicit `--mcp-config` / explicit path loading working, along with the per-user `~/.config/vllm-mlx` fallback
- add regression coverage proving ambient `./mcp.json` files are ignored while explicit and user-config paths still load

## Test plan
- `PYTHONPATH=/private/tmp/vllm-mlx-issue68-mcp-config-cwd /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mcp_security.py -q`
- `/opt/ai-runtime/venv-live/bin/python -m black --check --fast vllm_mlx/mcp/config.py tests/test_mcp_security.py`
- `/opt/ai-runtime/venv-live/bin/python -m compileall vllm_mlx/mcp/config.py tests/test_mcp_security.py`

Part of #68 (finding #18).