### PR TITLE
Fix MLLM tool call arguments not converted from JSON string to dict

### DIFF
--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -13,6 +13,7 @@ from vllm_mlx.tool_parsers import (
     DeepSeekToolParser,
     FunctionaryToolParser,
     Gemma4ToolParser,
+    Glm47ToolParser,
     GraniteToolParser,
     HermesToolParser,
     KimiToolParser,
@@ -38,6 +39,7 @@ class TestNativeToolFormatCapability:
             FunctionaryToolParser,
             KimiToolParser,
             HermesToolParser,
+            Glm47ToolParser,
         ]
         for parser_cls in native_parsers:
             assert (
@@ -75,6 +77,7 @@ class TestNativeToolFormatCapability:
             "functionary",
             "kimi",
             "hermes",
+            "glm47",
         ]:
             parser_cls = ToolParserManager.get_tool_parser(name)
             assert (

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1485,6 +1485,20 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             messages.append(msg_dict)
         images, videos = [], []  # MLLM extracts these from messages
         logger.debug(f"MLLM: Processing {len(messages)} messages")
+        # Convert tool_call arguments from JSON string to dict so that
+        # chat templates can iterate them (e.g. GLM-4.6V calls .items()).
+        # The LLM path does this inside extract_multimodal_content(), but
+        # the MLLM path bypasses that function.
+        if engine.preserve_native_tool_format:
+            for msg_dict in messages:
+                for tc in msg_dict.get("tool_calls") or []:
+                    func = tc.get("function") or {}
+                    args = func.get("arguments")
+                    if isinstance(args, str):
+                        try:
+                            func["arguments"] = json.loads(args)
+                        except (json.JSONDecodeError, ValueError):
+                            pass
         messages = _normalize_messages(messages)
     else:
         # For LLM, extract text, images, and videos separately

--- a/vllm_mlx/tool_parsers/glm47_tool_parser.py
+++ b/vllm_mlx/tool_parsers/glm47_tool_parser.py
@@ -38,6 +38,8 @@ class Glm47ToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser glm47 are set.
     """
 
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
+
     # Match entire tool call block
     TOOL_CALL_PATTERN = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
 


### PR DESCRIPTION
## Summary

- The MLLM code path in `server.py` bypasses `extract_multimodal_content()`, which is responsible for converting `tool_call.arguments` from JSON strings to dicts. Chat templates that iterate over arguments (e.g. GLM-4.6V: `{% for k, v in _args.items() %}`) crash with `jinja2.exceptions.UndefinedError: 'str object' has no attribute 'items'`.
- Add the same JSON string-to-dict conversion in the MLLM code path.
- Enable `SUPPORTS_NATIVE_TOOL_FORMAT` for the GLM-4.7 tool parser, since its chat template requires dict-form arguments.

## Test plan

- [x] Existing `test_native_tool_format.py` updated — GLM-4.7 parser added to native support assertions
- [x] All 100 tests pass (`pytest tests/test_native_tool_format.py tests/test_tool_parsers.py`)
- [x] Verified end-to-end on GLM-4.6V (107B MoE) with `--mllm` flag: tool call response cycle returns 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)