### PR TITLE
fix: stop stripping <tool_call> tags and add GLM-4 reasoning parser

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -184,7 +184,10 @@ class TestSimpleEngineConcurrency:
                 ],
             )
 
-            assert output.text == '{"name":"bash","arguments":{"command":"pwd"}}'
+            assert (
+                output.text
+                == '<tool_call>{"name":"bash","arguments":{"command":"pwd"}}</tool_call>'
+            )
             assert output.tokens == [7, 8, 9]
             assert output.prompt_tokens == 11
             assert output.completion_tokens == 4

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -21,8 +21,7 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
     r"<\|channel\|>|<\|message\|>|<\|start\|>|<\|return\|>|<\|call\|>|<\|constrain\|>|"
     r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]|"
-    r"\[e~\[|\]~b\][a-z]*|\]~!b\[|"
-    r"</?tool_call>|</?tool_call_reasoning>"
+    r"\[e~\[|\]~b\][a-z]*|\]~!b\["
 )
 
 

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -77,6 +77,7 @@ def _register_builtin_parsers():
     """Register built-in parsers."""
     from .deepseek_r1_parser import DeepSeekR1ReasoningParser
     from .gemma4_parser import Gemma4ReasoningParser
+    from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
@@ -86,6 +87,8 @@ def _register_builtin_parsers():
     register_parser("gpt_oss", GptOssReasoningParser)
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("gemma4", Gemma4ReasoningParser)
+    # GLM-4 uses <think> tags WITHOUT injection — no tags = content, not reasoning
+    register_parser("glm4", Glm4ReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for GLM-4 models (GLM-4.5-Air, GLM-4.6V, GLM-4.7, etc.).
+
+GLM-4 uses <think>...</think> tags for reasoning content, same as Qwen3.
+However, unlike Qwen3, GLM-4 does NOT inject <think> in the prompt —
+the model decides autonomously whether to reason.
+
+This means:
+- Output without tags = normal response (no reasoning)
+- Output with tags = reasoning + content
+
+This is the opposite of Qwen3 where no tags = pure reasoning (because
+<think> was injected in the prompt and the model hit max_tokens).
+"""
+
+from .base import DeltaMessage
+from .think_parser import BaseThinkingReasoningParser
+
+_BOX_START = "<|begin_of_box|>"
+_BOX_END = "<|end_of_box|>"
+
+
+class Glm4ReasoningParser(BaseThinkingReasoningParser):
+    """
+    Reasoning parser for GLM-4 models.
+
+    GLM-4 uses <think>...</think> tokens to denote reasoning text.
+    Unlike Qwen3, the template does NOT inject <think> in the prompt,
+    so output without tags is a normal response (not truncated reasoning).
+
+    Supports three scenarios:
+    1. Both tags in output: <think>reasoning</think>content
+    2. Only closing tag (think in prompt): reasoning</think>content
+    3. No tags: pure content (NOT reasoning)
+
+    Example (with thinking):
+        Input: "<think>Let me analyze...</think>The answer is 42."
+        Output: reasoning="Let me analyze...", content="The answer is 42."
+
+    Example (no thinking):
+        Input: "The answer is 42."
+        Output: reasoning=None, content="The answer is 42."
+    """
+
+    @property
+    def start_token(self) -> str:
+        return "<think>"
+
+    @property
+    def end_token(self) -> str:
+        return "</think>"
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+    ) -> tuple[str | None, str | None]:
+        cleaned = model_output.replace(_BOX_START, "").replace(_BOX_END, "")
+        return super().extract_reasoning(cleaned)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        """
+        Extract reasoning from streaming delta.
+
+        Overrides base class pre_think behavior: when no tags have been seen,
+        emit delta as content (not reasoning). GLM-4 doesn't inject <think>
+        in the prompt, so early tokens without tags are normal content.
+
+        Once <think> is seen, delegates to base class state machine.
+        """
+        # Strip GLM-4.6V box container tags (special tokens, always whole)
+        delta_text = delta_text.replace(_BOX_START, "").replace(_BOX_END, "")
+        if not delta_text:
+            return None
+
+        start_tok = self.start_token
+        end_tok = self.end_token
+
+        # In pre_think phase: check if we should treat as content
+        if self._phase == "pre_think":
+            # If start tag appeared, transition to thinking via base class
+            if start_tok in current_text:
+                return super().extract_reasoning_streaming(
+                    previous_text, current_text, delta_text
+                )
+
+            # If end tag appeared without start (implicit mode from agent)
+            if end_tok in current_text:
+                return super().extract_reasoning_streaming(
+                    previous_text, current_text, delta_text
+                )
+
+            # No tags yet — GLM-4 doesn't inject <think>, so this is content
+            return DeltaMessage(content=delta_text)
+
+        # In thinking or content phase, delegate to base class
+        return super().extract_reasoning_streaming(
+            previous_text, current_text, delta_text
+        )


### PR DESCRIPTION
## Summary

- **Remove `<tool_call>` from `SPECIAL_TOKENS_PATTERN`** — `clean_output_text()` was stripping `<tool_call>` / `</tool_call>` tags from model output *before* the tool call parser had a chance to detect them. This broke tool call detection for all models using XML-style tool call markup (GLM-4.7, GLM-4.6V, etc.).
- **Add `Glm4ReasoningParser`** — GLM-4 models do *not* inject `<think>` into the prompt, so output without think tags is normal content (not truncated reasoning). The new parser inherits from `BaseThinkingReasoningParser` (which already handles this correctly) and adds GLM-4.6V `<|begin_of_box|>`/`<|end_of_box|>` token stripping plus a streaming override that emits content (not reasoning) in the pre-think phase.

## Root cause

`SPECIAL_TOKENS_PATTERN` included `</?tool_call>|</?tool_call_reasoning>`. The `clean_output_text()` function applied this regex to model output in `batched.py` before returning the text to the server, which then passed the *already-stripped* text to the tool call parser. Since the `<tool_call>` tags were gone, the parser could never match them → `tool_calls: null` on every request.

## Test plan

- [x] Tool call detection: `get_weather({"city": "Prague"})` correctly parsed
- [x] Text generation: `content` field populated (not null)
- [x] Reasoning extraction: `<think>` blocks correctly separated
- [x] Gemma 4 unaffected (different parser, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)