### PR TITLE
fix(guided): Outlines tokenizer compat for structured output decoding

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -605,6 +605,11 @@ See [Reasoning Models Guide](reasoning.md) for full details.
 
 Force the model to return valid JSON using `response_format`:
 
+For `json_object` and `json_schema`, vLLM-MLX uses token-level guided
+decoding when tools are not active. Tool-calling requests keep the legacy
+prompt-instruction fallback so structured output and tool parsing do not
+compete for the same generation surface.
+
 ### JSON Object Mode
 
 Returns any valid JSON:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
     "mcp>=1.0.0",
     # JSON Schema validation for structured output
     "jsonschema>=4.0.0",
+    # Token-level guided decoding for structured output
+    "outlines>=1.2.12",
     # pytz is required by gradio but not declared as a dependency
     # See: https://github.com/waybarrios/vllm-mlx/issues/23
     "pytz>=2024.1",

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -145,6 +145,11 @@ class TestSamplingParams:
         assert params.stop == ["END"]
         assert params.stop_token_ids == [1, 2]
 
+    def test_response_format_field(self):
+        """Structured-output requests must carry response_format through batching."""
+        params = SamplingParams(response_format={"type": "json_object"})
+        assert params.response_format == {"type": "json_object"}
+
 
 class TestRequestOutput:
     """Tests for RequestOutput."""
@@ -215,6 +220,42 @@ class TestSchedulerBasic:
     def mock_model(self):
         """Create a mock model."""
         return MagicMock()
+
+    def test_scheduler_passes_guided_processors_to_batch_generator(
+        self, mock_model, mock_tokenizer
+    ):
+        """Guided decoding must reach BatchGenerator.insert on text batching."""
+        from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+        captured = {}
+
+        class FakeBatchGenerator:
+            def insert(self, prompts, **kwargs):
+                captured["prompts"] = prompts
+                captured["kwargs"] = kwargs
+                return [123]
+
+        scheduler = Scheduler(
+            mock_model,
+            mock_tokenizer,
+            SchedulerConfig(enable_prefix_cache=False),
+        )
+        scheduler.batch_generator = FakeBatchGenerator()
+        scheduler._current_sampler_params = (0.7, 0.9, 0.0)
+        scheduler._guided_decoding_factory = MagicMock()
+        scheduler._guided_decoding_factory.build_processors.return_value = [
+            "guided_proc"
+        ]
+
+        request = Request(
+            request_id="guided-1",
+            prompt="return json",
+            sampling_params=SamplingParams(response_format={"type": "json_object"}),
+        )
+        scheduler.add_request(request)
+        scheduler._schedule_waiting()
+
+        assert captured["kwargs"]["logits_processors"] == [["guided_proc"]]
 
     def test_chunked_prefill_accepts_prompt_checkpoints(self, monkeypatch):
         """Chunked prefill must match mlx-lm's 7-field prompt tuples."""

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -16,6 +16,7 @@ Test Cases:
 import base64
 import os
 import tempfile
+from collections import deque
 from unittest.mock import MagicMock
 
 import pytest
@@ -91,6 +92,19 @@ class TestMLLMBatchRequest:
         assert req.temperature == 0.7
         assert req.top_p == 0.9
         assert req.output_tokens == []
+
+    def test_request_guided_processors(self):
+        """Guided-decoding processors should be stored per request."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        req = MLLMBatchRequest(
+            uid=2,
+            request_id="guided-req",
+            prompt="json please",
+            logits_processors=["guided_proc"],
+        )
+
+        assert req.logits_processors == ["guided_proc"]
 
 
 class TestMLLMBatchResponse:
@@ -233,6 +247,45 @@ class TestMLLMBatch:
         assert len(batch) == 2
         assert batch.uids == [1, 3]
         assert batch.request_ids == ["req-1", "req-3"]
+
+
+class TestMLLMSchedulerGuidedDecoding:
+    """Tests for MLLM guided-decoding wiring."""
+
+    def test_schedule_waiting_attaches_guided_processors(self):
+        """Scheduler must carry guided processors into MLLM batch requests."""
+        from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
+        from vllm_mlx.request import SamplingParams
+
+        captured = {}
+
+        class FakeBatchGenerator:
+            def insert(self, requests):
+                captured["requests"] = requests
+                return [77]
+
+        scheduler = MLLMScheduler.__new__(MLLMScheduler)
+        scheduler.waiting = deque()
+        scheduler.running = {}
+        scheduler.requests = {}
+        scheduler.request_id_to_uid = {}
+        scheduler.uid_to_request_id = {}
+        scheduler.config = type("Cfg", (), {"max_num_seqs": 16})()
+        scheduler.batch_generator = FakeBatchGenerator()
+        scheduler._ensure_batch_generator = lambda: None
+        scheduler._build_request_logits_processors = lambda params: ["guided_proc"]
+
+        request = MLLMRequest(
+            request_id="mllm-guided",
+            prompt="return json",
+            sampling_params=SamplingParams(response_format={"type": "json_object"}),
+        )
+        scheduler.waiting.append(request)
+
+        scheduled = scheduler._schedule_waiting()
+
+        assert len(scheduled) == 1
+        assert captured["requests"][0].logits_processors == ["guided_proc"]
 
 
 class TestMLLMBatchStats:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -709,6 +709,188 @@ class TestRateLimiterHTTPResponse:
         assert allowed is True
 
 
+class TestStructuredOutputServerPath:
+    """Tests for structured-output server integration."""
+
+    @pytest.mark.anyio
+    async def test_guided_decoding_skips_prompt_injection_and_passes_response_format(
+        self, monkeypatch
+    ):
+        """Structured output should use guided decoding instead of prompt injection."""
+        import vllm_mlx.server as server
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        captured = {}
+
+        class FakeEngine:
+            is_mllm = False
+            model_name = "fake-engine"
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                captured["messages"] = messages
+                captured["kwargs"] = kwargs
+                return GenerationOutput(
+                    text='{"status":"ok"}',
+                    prompt_tokens=4,
+                    completion_tokens=3,
+                    finish_reason="stop",
+                )
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        async def passthrough(coro, raw_request, timeout=None):
+            return await coro
+
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+        monkeypatch.setattr(server, "_wait_with_disconnect", passthrough)
+
+        def fail_prompt_injection(_response_format):
+            raise AssertionError("guided decoding should skip prompt injection")
+
+        monkeypatch.setattr(server, "build_json_system_prompt", fail_prompt_injection)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Return JSON.")],
+            response_format={"type": "json_object"},
+        )
+
+        response = await create_chat_completion(request, FakeRequest())
+
+        assert captured["messages"] == [{"role": "user", "content": "Return JSON."}]
+        assert captured["kwargs"]["response_format"].type == "json_object"
+        assert response.choices[0].message.content == '{"status": "ok"}'
+
+    @pytest.mark.anyio
+    async def test_tools_keep_prompt_injection_path(self, monkeypatch):
+        """Tools should keep the legacy JSON instruction path, not guided decoding."""
+        import vllm_mlx.server as server
+        from vllm_mlx.api.models import ToolDefinition
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        captured = {}
+
+        class FakeEngine:
+            is_mllm = False
+            model_name = "fake-engine"
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                captured["messages"] = messages
+                captured["kwargs"] = kwargs
+                return GenerationOutput(
+                    text='{"status":"ok"}',
+                    prompt_tokens=4,
+                    completion_tokens=3,
+                    finish_reason="stop",
+                )
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        async def passthrough(coro, raw_request, timeout=None):
+            return await coro
+
+        monkeypatch.setattr(server, "_engine", FakeEngine())
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+        monkeypatch.setattr(server, "_wait_with_disconnect", passthrough)
+
+        injected_messages = [{"role": "system", "content": "Return JSON only."}]
+
+        def fake_prompt_injection(response_format):
+            captured["response_format_for_prompt"] = response_format
+            return "Return JSON only."
+
+        def fake_inject(messages, instruction):
+            captured["pre_injection_messages"] = messages
+            captured["instruction"] = instruction
+            return injected_messages
+
+        monkeypatch.setattr(server, "build_json_system_prompt", fake_prompt_injection)
+        monkeypatch.setattr(server, "_inject_json_instruction", fake_inject)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Return JSON.")],
+            response_format={"type": "json_object"},
+            tools=[
+                ToolDefinition(
+                    function={
+                        "name": "lookup",
+                        "description": "Lookup a value",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                )
+            ],
+        )
+
+        await create_chat_completion(request, FakeRequest())
+
+        assert captured["response_format_for_prompt"].type == "json_object"
+        assert captured["instruction"] == "Return JSON only."
+        assert captured["messages"] == injected_messages
+        assert "response_format" not in captured["kwargs"]
+
+    @pytest.mark.anyio
+    async def test_invalid_guided_decoding_schema_returns_400(self):
+        """Malformed json_schema requests should fail as bad requests."""
+        from fastapi import HTTPException
+
+        import vllm_mlx.server as server
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        class FakeEngine:
+            is_mllm = False
+            model_name = "fake-engine"
+            preserve_native_tool_format = False
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Return JSON.")],
+            response_format={"type": "json_schema", "json_schema": {"name": "broken"}},
+        )
+
+        monkeypatch = pytest.MonkeyPatch()
+        try:
+            monkeypatch.setattr(server, "_engine", FakeEngine())
+            with pytest.raises(HTTPException) as exc_info:
+                await create_chat_completion(request, FakeRequest())
+            assert exc_info.value.status_code == 400
+        finally:
+            monkeypatch.undo()
+
+
 class TestStreamChatCompletion:
     """Tests for streaming chat completion behavior."""
 

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -14,6 +14,11 @@ from vllm_mlx.api.tool_calling import (
     build_json_system_prompt,
 )
 from vllm_mlx.api.models import ResponseFormat, ResponseFormatJsonSchema
+from vllm_mlx.guided_decoding import (
+    normalize_response_format,
+    response_format_to_schema,
+    uses_guided_decoding,
+)
 
 
 class TestValidateJsonSchema:
@@ -231,6 +236,33 @@ class TestParseJsonOutput:
         cleaned, parsed, is_valid, error = parse_json_output(text, response_format)
         assert parsed == {"colors": ["red", "blue"]}
         assert is_valid is True
+
+
+class TestGuidedDecodingHelpers:
+    """Tests for response-format normalization and schema selection."""
+
+    def test_normalize_response_format_model(self):
+        response_format = ResponseFormat(type="json_object")
+        assert normalize_response_format(response_format) == {
+            "type": "json_object",
+            "json_schema": None,
+        }
+
+    def test_response_format_to_schema_json_object(self):
+        assert response_format_to_schema({"type": "json_object"}) == {
+            "type": "object",
+            "additionalProperties": True,
+        }
+
+    def test_response_format_to_schema_json_schema_requires_schema(self):
+        with pytest.raises(ValueError, match="requires a non-empty schema"):
+            response_format_to_schema(
+                {"type": "json_schema", "json_schema": {"name": "broken"}}
+            )
+
+    def test_uses_guided_decoding(self):
+        assert uses_guided_decoding({"type": "json_object"}) is True
+        assert uses_guided_decoding({"type": "text"}) is False
 
 
 class TestBuildJsonSystemPrompt:

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from jsonschema import validate, ValidationError
 
+from ..guided_decoding import normalize_response_format
 from .models import FunctionCall, ResponseFormat, ToolCall
 
 
@@ -483,18 +484,7 @@ def parse_json_output(
     if response_format is None:
         return text, None, True, None
 
-    # Normalize response_format to dict
-    if isinstance(response_format, ResponseFormat):
-        rf_dict = {"type": response_format.type, "json_schema": None}
-        if response_format.json_schema:
-            rf_dict["json_schema"] = {
-                "name": response_format.json_schema.name,
-                "description": response_format.json_schema.description,
-                "schema": response_format.json_schema.schema_,
-                "strict": response_format.json_schema.strict,
-            }
-    else:
-        rf_dict = response_format
+    rf_dict = normalize_response_format(response_format)
 
     format_type = rf_dict.get("type", "text")
 
@@ -546,18 +536,7 @@ def build_json_system_prompt(
     if response_format is None:
         return None
 
-    # Normalize to dict
-    if isinstance(response_format, ResponseFormat):
-        rf_dict = {"type": response_format.type, "json_schema": None}
-        if response_format.json_schema:
-            rf_dict["json_schema"] = {
-                "name": response_format.json_schema.name,
-                "description": response_format.json_schema.description,
-                "schema": response_format.json_schema.schema_,
-                "strict": response_format.json_schema.strict,
-            }
-    else:
-        rf_dict = response_format
+    rf_dict = normalize_response_format(response_format)
 
     format_type = rf_dict.get("type", "text")
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -560,6 +560,7 @@ class BatchedEngine(BaseEngine):
                 min_p=kwargs.pop("min_p", 0.0),
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+                response_format=kwargs.pop("response_format", None),
             )
 
             return GenerationOutput(
@@ -582,6 +583,7 @@ class BatchedEngine(BaseEngine):
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
+            response_format=kwargs.pop("response_format", None),
         )
 
         output = await self._engine.generate(
@@ -642,6 +644,7 @@ class BatchedEngine(BaseEngine):
                 min_p=kwargs.pop("min_p", 0.0),
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+                response_format=kwargs.pop("response_format", None),
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
@@ -667,6 +670,7 @@ class BatchedEngine(BaseEngine):
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
+            response_format=kwargs.pop("response_format", None),
         )
 
         prefix_boundary = kwargs.pop("prefix_boundary", 0)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -581,6 +581,7 @@ class SimpleEngine(BaseEngine):
             self._is_mllm
             and self._text_model is not None
             and not _has_media_content(messages)
+            and kwargs.get("response_format") is None
         ):
             logger.info("Text-only request → LLM path (MTP=True)")
             async for chunk in self._stream_generate_text(

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Guided decoding helpers for structured output.
+
+This module keeps the public ``response_format`` contract stable while using
+Outlines-backed MLX logits processors underneath.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def normalize_response_format(
+    response_format: Any | dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Normalize ``ResponseFormat`` models into a plain dict."""
+    if response_format is None:
+        return None
+
+    if hasattr(response_format, "type") and hasattr(response_format, "json_schema"):
+        rf_dict = {"type": response_format.type, "json_schema": None}
+        if response_format.json_schema:
+            rf_dict["json_schema"] = {
+                "name": response_format.json_schema.name,
+                "description": response_format.json_schema.description,
+                "schema": response_format.json_schema.schema_,
+                "strict": response_format.json_schema.strict,
+            }
+        return rf_dict
+
+    return dict(response_format)
+
+
+def response_format_to_schema(
+    response_format: Any | dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """
+    Convert a response-format request into the JSON schema used for guidance.
+
+    ``json_object`` is treated as an unconstrained object schema, while
+    ``json_schema`` uses the user-provided schema verbatim.
+    """
+    rf_dict = normalize_response_format(response_format)
+    if rf_dict is None:
+        return None
+
+    format_type = rf_dict.get("type", "text")
+    if format_type == "text":
+        return None
+    if format_type == "json_object":
+        return {
+            "type": "object",
+            "additionalProperties": True,
+        }
+    if format_type == "json_schema":
+        json_schema_spec = rf_dict.get("json_schema") or {}
+        schema = json_schema_spec.get("schema")
+        if not isinstance(schema, dict) or not schema:
+            raise ValueError(
+                "response_format.type='json_schema' requires a non-empty schema"
+            )
+        return schema
+
+    raise ValueError(f"Unsupported response_format type: {format_type}")
+
+
+def uses_guided_decoding(
+    response_format: Any | dict[str, Any] | None,
+) -> bool:
+    """Return True when a response format should engage guided decoding."""
+    return response_format_to_schema(response_format) is not None
+
+
+class GuidedDecodingFactory:
+    """Create fresh per-request logits processors for structured output."""
+
+    def __init__(self, model: Any, tokenizer: Any):
+        try:
+            from outlines.models import from_mlxlm
+        except ImportError as exc:  # pragma: no cover - dependency failure
+            raise ImportError(
+                "Structured output guided decoding requires the 'outlines' package"
+            ) from exc
+
+        self._outlines_model = from_mlxlm(model, tokenizer)
+
+    def build_processors(
+        self,
+        response_format: Any | dict[str, Any] | None,
+    ) -> list[Any] | None:
+        """Build fresh Outlines logits processors for a request."""
+        schema = response_format_to_schema(response_format)
+        if schema is None:
+            return None
+
+        from outlines.backends import get_json_schema_logits_processor
+
+        processor = get_json_schema_logits_processor(
+            None,
+            self._outlines_model,
+            json.dumps(schema, separators=(",", ":"), ensure_ascii=False),
+        )
+        return [processor]

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -84,6 +84,24 @@ class GuidedDecodingFactory:
                 "Structured output guided decoding requires the 'outlines' package"
             ) from exc
 
+        # Outlines TransformerTokenizer reads eos_token_id, eos_token, and
+        # all_special_tokens from tokenizer._tokenizer (the raw backend).
+        # Modern transformers keeps these on the wrapper only. Patch them
+        # onto the raw backend so Outlines can find them.
+        inner = getattr(tokenizer, "_tokenizer", None)
+        if inner is not None:
+            for attr in (
+                "eos_token_id",
+                "eos_token",
+                "pad_token_id",
+                "pad_token",
+                "all_special_tokens",
+            ):
+                if not hasattr(inner, attr):
+                    val = getattr(tokenizer, attr, None)
+                    if val is not None:
+                        setattr(inner, attr, val)
+
         self._outlines_model = from_mlxlm(model, tokenizer)
 
     def build_processors(
@@ -102,4 +120,74 @@ class GuidedDecodingFactory:
             self._outlines_model,
             json.dumps(schema, separators=(",", ":"), ensure_ascii=False),
         )
+        # Wrap: BatchGenerator passes (tokens: list, logits: mx.array) but
+        # Outlines expects (input_ids: mx.array, logits: mx.array).
+        return [_wrap_outlines_processor(processor)]
+
+    def build_raw_processors(
+        self,
+        response_format: Any | dict[str, Any] | None,
+    ) -> list[Any] | None:
+        """Build raw Outlines processors for serial stream_generate path.
+
+        The serial path in mlx-lm already handles token tracking and passes
+        (tokens: mx.array, logits: mx.array) — no wrapping needed.
+        """
+        schema = response_format_to_schema(response_format)
+        if schema is None:
+            return None
+
+        from outlines.backends import get_json_schema_logits_processor
+
+        processor = get_json_schema_logits_processor(
+            None,
+            self._outlines_model,
+            json.dumps(schema, separators=(",", ":"), ensure_ascii=False),
+        )
         return [processor]
+
+
+def _wrap_outlines_processor(processor):
+    """Adapt Outlines processor to BatchGenerator's (list, mx.array) interface.
+
+    BatchGenerator passes the full token history (prompt + generated) but
+    Outlines' FSM expects only generated tokens. Track the prompt length
+    on the first call and slice subsequent calls to generated-only.
+    """
+    import mlx.core as mx
+
+    prompt_len = None
+
+    def wrapped(token_ids, logits):
+        nonlocal prompt_len
+        import logging
+
+        _log = logging.getLogger("vllm_mlx.guided_decoding")
+        if isinstance(token_ids, list):
+            if prompt_len is None:
+                prompt_len = len(token_ids)
+                _log.info("Guided wrapper: prompt_len=%d", prompt_len)
+            generated = token_ids[prompt_len:]
+            _log.info(
+                "Guided wrapper: generated=%d tokens, first_few=%s",
+                len(generated),
+                generated[:5],
+            )
+            token_ids = (
+                mx.array(generated, dtype=mx.int32)
+                if generated
+                else mx.zeros((0,), dtype=mx.int32)
+            )
+        result = processor(token_ids, logits)
+        # Debug: check if masking is effective
+        if _log.isEnabledFor(logging.DEBUG):
+            import numpy as np
+
+            r = np.array(
+                result.tolist()[0] if len(result.shape) == 2 else result.tolist()
+            )
+            finite = np.isfinite(r)
+            _log.debug("Guided: %d/%d tokens allowed (non-inf)", finite.sum(), len(r))
+        return result
+
+    return wrapped

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -60,6 +60,7 @@ class MLLMBatchRequest:
     min_p: float = 0.0
     presence_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    logits_processors: Optional[List[Callable]] = None
 
     # Processed inputs (set after vision preprocessing)
     input_ids: Optional[mx.array] = None
@@ -1221,12 +1222,13 @@ class MLLMBatchGenerator:
         # Create initial y (first generated tokens)
         y = mx.array(first_tokens)
 
-        # Build per-request logits processors (repetition_penalty, presence_penalty)
+        # Build per-request logits processors (guided decoding + penalties)
         from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
         batch_logits_processors = []
         has_any_lp = False
         for req in requests:
+            combined_lp = list(req.logits_processors or [])
             need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
             need_pres = req.presence_penalty and req.presence_penalty != 0.0
             if need_rep or need_pres:
@@ -1236,13 +1238,16 @@ class MLLMBatchGenerator:
                 if need_pres:
                     lp_kwargs["presence_penalty"] = req.presence_penalty
                 lp = make_logits_processors(**lp_kwargs)
-                batch_logits_processors.append(lp)
-                has_any_lp = True
+                if lp:
+                    combined_lp.extend(lp)
                 logger.info(
                     f"[sampling] request={req.request_id[:12]} "
                     f"rep_penalty={req.repetition_penalty} "
                     f"pres_penalty={req.presence_penalty}"
                 )
+            if combined_lp:
+                batch_logits_processors.append(combined_lp)
+                has_any_lp = True
             else:
                 batch_logits_processors.append(None)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -31,6 +31,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
+from .guided_decoding import GuidedDecodingFactory
 from .mllm_batch_generator import (
     MLLMBatchGenerator,
     MLLMBatchRequest,
@@ -198,6 +199,7 @@ class MLLMScheduler:
 
         # Batch generator (created lazily)
         self.batch_generator: Optional[MLLMBatchGenerator] = None
+        self._guided_decoding_factory: Optional[GuidedDecodingFactory] = None
 
         # Request management - following vLLM's design
         self.waiting: deque[MLLMRequest] = deque()  # Waiting queue (FCFS)
@@ -322,6 +324,33 @@ class MLLMScheduler:
                         num_draft_tokens=self.config.mtp_num_draft_tokens,
                     )
 
+    def _get_guided_decoding_factory(self) -> GuidedDecodingFactory:
+        """Lazily initialize the guided-decoding factory for batched MLLM."""
+        self._ensure_batch_generator()
+        if self.batch_generator is None:
+            raise RuntimeError("MLLM batch generator not initialized")
+        if self._guided_decoding_factory is None:
+            tokenizer = (
+                self.processor.tokenizer
+                if hasattr(self.processor, "tokenizer")
+                else self.processor
+            )
+            self._guided_decoding_factory = GuidedDecodingFactory(
+                self.batch_generator.language_model,
+                tokenizer,
+            )
+        return self._guided_decoding_factory
+
+    def _build_request_logits_processors(
+        self, sampling_params: SamplingParams
+    ) -> Optional[List[Any]]:
+        """Build per-request guided-decoding processors for MLLM batching."""
+        if sampling_params.response_format is None:
+            return None
+        return self._get_guided_decoding_factory().build_processors(
+            sampling_params.response_format
+        )
+
     # ========== Sync API (step-based) ==========
 
     def add_request(
@@ -362,6 +391,7 @@ class MLLMScheduler:
             min_p=kwargs.pop("min_p", 0.0),
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+            response_format=kwargs.pop("response_format", None),
         )
 
         request = MLLMRequest(
@@ -491,6 +521,9 @@ class MLLMScheduler:
                 min_p=request.sampling_params.min_p,
                 presence_penalty=request.sampling_params.presence_penalty,
                 repetition_penalty=request.sampling_params.repetition_penalty,
+                logits_processors=self._build_request_logits_processors(
+                    request.sampling_params
+                ),
             )
             batch_requests.append(batch_req)
 

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -8,7 +8,7 @@ integrating with vLLM's model execution system.
 
 import logging
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Any, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,7 @@ class MLXLanguageModel:
         self.model = None
         self.tokenizer = None
         self._loaded = False
+        self._guided_decoding_factory = None
 
     def load(self) -> None:
         """Load the model and tokenizer."""
@@ -140,6 +141,20 @@ class MLXLanguageModel:
         )
         return processors if processors else None
 
+    def _build_guided_logits_processors(self, response_format: Any = None):
+        """Build fresh guided-decoding processors for a request."""
+        if response_format is None:
+            return None
+
+        if self._guided_decoding_factory is None:
+            from ..guided_decoding import GuidedDecodingFactory
+
+            self._guided_decoding_factory = GuidedDecodingFactory(
+                self.model, self.tokenizer
+            )
+
+        return self._guided_decoding_factory.build_processors(response_format)
+
     def generate(
         self,
         prompt: str,
@@ -151,6 +166,8 @@ class MLXLanguageModel:
         presence_penalty: float = 0.0,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list | None = None,
+        response_format: Any = None,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -177,9 +194,17 @@ class MLXLanguageModel:
 
         # Create sampler and logits processors with full Unsloth params
         sampler = self._create_sampler(temperature, top_p, top_k, min_p)
-        logits_processors = self._create_logits_processors(
+        penalty_processors = self._create_logits_processors(
             presence_penalty, repetition_penalty
         )
+        guided_processors = self._build_guided_logits_processors(response_format)
+        all_processors = None
+        if penalty_processors or logits_processors or guided_processors:
+            all_processors = (
+                (logits_processors or [])
+                + (penalty_processors or [])
+                + (guided_processors or [])
+            )
 
         # Generate text
         output_text = generate(
@@ -188,7 +213,7 @@ class MLXLanguageModel:
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
-            logits_processors=logits_processors,
+            logits_processors=all_processors,
             verbose=False,
         )
 
@@ -216,6 +241,7 @@ class MLXLanguageModel:
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
         logits_processors: list | None = None,
+        response_format: Any = None,
         **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
@@ -245,10 +271,15 @@ class MLXLanguageModel:
         penalty_processors = self._create_logits_processors(
             presence_penalty, repetition_penalty
         )
+        guided_processors = self._build_guided_logits_processors(response_format)
         # Merge any externally-provided logits_processors with penalty processors
         all_processors = None
-        if penalty_processors or logits_processors:
-            all_processors = (logits_processors or []) + (penalty_processors or [])
+        if penalty_processors or logits_processors or guided_processors:
+            all_processors = (
+                (logits_processors or [])
+                + (penalty_processors or [])
+                + (guided_processors or [])
+            )
 
         # Count prompt tokens once upfront
         num_prompt_tokens = len(self.tokenizer.encode(prompt))

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -23,6 +23,7 @@ import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 import numpy as np
@@ -710,6 +711,7 @@ class MLXMultimodalLM:
         self.config = None
         self._loaded = False
         self._video_native = False
+        self._guided_decoding_factory = None
 
         # Initialize MLLM prefix cache manager (with vision embedding caching)
         self._cache_manager: MLLMPrefixCacheManager | None = None
@@ -754,6 +756,32 @@ class MLXMultimodalLM:
     def get_tokenizer(self):
         """Get the text tokenizer (not the multimodal processor)."""
         return self.processor.tokenizer
+
+    def _merge_guided_logits_processors(
+        self,
+        response_format: Any = None,
+        logits_processors: list | None = None,
+    ) -> list | None:
+        """Merge guided-decoding processors into the current processor list."""
+        if response_format is None:
+            return logits_processors
+
+        if self._guided_decoding_factory is None:
+            from ..guided_decoding import GuidedDecodingFactory
+
+            language_model = getattr(self.model, "language_model", self.model)
+            tokenizer = getattr(self.processor, "tokenizer", self.processor)
+            self._guided_decoding_factory = GuidedDecodingFactory(
+                language_model, tokenizer
+            )
+
+        guided_processors = self._guided_decoding_factory.build_processors(
+            response_format
+        )
+        if not guided_processors:
+            return logits_processors
+
+        return list(logits_processors or []) + list(guided_processors)
 
     def _prepare_images(self, images: list) -> list[str]:
         """Process image inputs and return local file paths."""
@@ -1251,6 +1279,16 @@ class MLXMultimodalLM:
             yield output.text
             return
 
+        response_format = kwargs.pop("response_format", None)
+        existing_logits_processors = kwargs.pop("logits_processors", None)
+        if response_format is not None:
+            kwargs["logits_processors"] = self._merge_guided_logits_processors(
+                response_format,
+                existing_logits_processors,
+            )
+        elif existing_logits_processors is not None:
+            kwargs["logits_processors"] = existing_logits_processors
+
         images = images or []
         videos = videos or []
 
@@ -1330,6 +1368,15 @@ class MLXMultimodalLM:
         tools = kwargs.pop("tools", None)
         use_cache = kwargs.pop("use_cache", True)
         enable_thinking = kwargs.pop("enable_thinking", True)
+        response_format = kwargs.pop("response_format", None)
+        existing_logits_processors = kwargs.pop("logits_processors", None)
+        if response_format is not None:
+            kwargs["logits_processors"] = self._merge_guided_logits_processors(
+                response_format,
+                existing_logits_processors,
+            )
+        elif existing_logits_processors is not None:
+            kwargs["logits_processors"] = existing_logits_processors
 
         # Collect video inputs from messages
         _msg_video_inputs = self._collect_video_inputs(messages)
@@ -1703,6 +1750,16 @@ class MLXMultimodalLM:
             self.load()
 
         try:
+            response_format = kwargs.pop("response_format", None)
+            existing_logits_processors = kwargs.pop("logits_processors", None)
+            if response_format is not None:
+                kwargs["logits_processors"] = self._merge_guided_logits_processors(
+                    response_format,
+                    existing_logits_processors,
+                )
+            elif existing_logits_processors is not None:
+                kwargs["logits_processors"] = existing_logits_processors
+
             from mlx_vlm import stream_generate
             from mlx_vlm.prompt_utils import get_chat_template
         except ImportError:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -61,6 +61,7 @@ class SamplingParams:
     repetition_penalty: float = 1.0
     stop: Optional[List[str]] = None
     stop_token_ids: Optional[List[int]] = None
+    response_format: Any | None = None
 
     def __post_init__(self):
         if self.stop is None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -22,6 +22,7 @@ from mlx_lm.generate import BatchGenerator
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
+from .guided_decoding import GuidedDecodingFactory
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 from .paged_cache import PagedCacheManager
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
@@ -1113,6 +1114,7 @@ class Scheduler:
         # BatchGenerator - the actual batching engine
         self.batch_generator: Optional[BatchGenerator] = None
         self._current_sampler_params: Optional[Tuple] = None
+        self._guided_decoding_factory: Optional[GuidedDecodingFactory] = None
 
         # Prefix cache for KV state reuse
         self.prefix_cache: Optional[PrefixCacheManager] = None
@@ -1490,6 +1492,35 @@ class Scheduler:
             self._close_batch_generator()
             self.batch_generator = self._create_batch_generator(sampling_params)
             self._current_sampler_params = sampler_params
+
+    def _get_guided_decoding_factory(self) -> GuidedDecodingFactory:
+        """Lazily initialize the guided-decoding factory for this scheduler."""
+        if self._guided_decoding_factory is None:
+            self._guided_decoding_factory = GuidedDecodingFactory(
+                self.model, self._actual_tokenizer
+            )
+        return self._guided_decoding_factory
+
+    def _build_request_logits_processors(
+        self, sampling_params: SamplingParams
+    ) -> Optional[List[Any]]:
+        """Build per-request logits processors for penalties and JSON guidance."""
+        processors: List[Any] = []
+
+        rep_penalty = sampling_params.repetition_penalty
+        if rep_penalty and rep_penalty != 1.0:
+            rep_processors = make_logits_processors(repetition_penalty=rep_penalty)
+            if rep_processors:
+                processors.extend(rep_processors)
+
+        if sampling_params.response_format is not None:
+            guided_processors = self._get_guided_decoding_factory().build_processors(
+                sampling_params.response_format
+            )
+            if guided_processors:
+                processors.extend(guided_processors)
+
+        return processors or None
 
     def _validate_cache(self, cache: Any) -> bool:
         """
@@ -1912,15 +1943,7 @@ class Scheduler:
                 request.remaining_tokens = request.prompt_token_ids
                 tokens_to_process = request.prompt_token_ids
 
-            # Build per-request logits_processors from repetition_penalty
-            rep_penalty = request.sampling_params.repetition_penalty
-            lp = None
-            if rep_penalty and rep_penalty != 1.0:
-                lp = make_logits_processors(repetition_penalty=rep_penalty)
-                logger.info(
-                    f"[rep_penalty] request={request.request_id[:12]} "
-                    f"penalty={rep_penalty} processors={len(lp)}"
-                )
+            lp = self._build_request_logits_processors(request.sampling_params)
 
             # Insert into BatchGenerator with optional cache.
             # Wrap in try/except: if cache shapes are incompatible
@@ -1972,6 +1995,7 @@ class Scheduler:
                     else ""
                 )
                 tokens_to_prefill = len(tokens_to_process)
+                rep_penalty = request.sampling_params.repetition_penalty
                 rep_info = (
                     f" rep_penalty={rep_penalty}"
                     if rep_penalty and rep_penalty != 1.0

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -109,6 +109,7 @@ from .api.utils import (
     is_mllm_model,  # noqa: F401
 )
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
+from .guided_decoding import uses_guided_decoding
 from .tool_parsers import ToolParserManager
 
 logging.basicConfig(level=logging.INFO)
@@ -218,6 +219,15 @@ def _get_cache_dir() -> str:
     )
     logger.info(f"[_get_cache_dir] cache_dir={cache_dir!r}")
     return cache_dir
+
+
+def _should_use_guided_decoding(request: ChatCompletionRequest) -> bool:
+    """Return True when structured output should use token-level guidance."""
+    if request.response_format is None:
+        return False
+    if request.tools and request.tool_choice != "none":
+        return False
+    return uses_guided_decoding(request.response_format)
 
 
 async def lifespan(app: FastAPI):
@@ -1513,9 +1523,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             if has_media:
                 break
 
-    # Handle response_format - inject system prompt if needed
+    # Handle response_format. Use true token-level guided decoding when
+    # tools are not active; otherwise keep the prompt-instruction fallback.
     response_format = request.response_format
-    if response_format:
+    try:
+        guided_decoding = _should_use_guided_decoding(request)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if response_format and not guided_decoding:
         json_instruction = build_json_system_prompt(response_format)
         if json_instruction:
             # Inject JSON instruction into messages
@@ -1555,6 +1570,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Enable/disable thinking mode per request
     if request.enable_thinking is not None:
         chat_kwargs["enable_thinking"] = request.enable_thinking
+    if guided_decoding:
+        chat_kwargs["response_format"] = response_format
 
     # Add tools if provided
     if request.tools and request.tool_choice != "none":


### PR DESCRIPTION
## Summary

Fixes Outlines integration issues for guided structured output decoding (#313) on Apple Silicon:

- **Tokenizer backend patching:** Outlines `TransformerTokenizer` reads `eos_token_id`, `eos_token`, `all_special_tokens` from the raw `tokenizers.Tokenizer` backend, but modern transformers only sets these on the `PreTrainedTokenizer` wrapper. `GuidedDecodingFactory` now patches them onto the raw backend.
- **Prompt token stripping:** `BatchGenerator` passes full token history to logits processors, but Outlines FSM expects only generated tokens. Wrapper tracks prompt length and slices.
- **Token type adaptation:** `BatchGenerator` passes `list[int]`, Outlines expects `mx.array`. Wrapper converts.
- **`build_raw_processors()`:** for serial `stream_generate` path which handles token tracking natively.

## Known limitation

The Outlines FSM compiles and runs, but hits state transition errors on the first generated token (`No next state found for state 256 with token ID 198`). This appears to be a tokenizer-to-vocabulary mapping issue between how Outlines builds the FSM and the model's actual token space. Investigation ongoing.

## Test plan

- [x] Tokenizer patching verified: `eos_token_id`, `eos_token`, `all_special_tokens` set on raw backend
- [x] Factory initialization succeeds on Qwen 3.5 122B
- [x] Processor builds and runs (no import/attribute errors)
- [ ] FSM state transitions need vocabulary alignment fix