### PR TITLE
Fix RotatingKVCache merge crash from prefix cache trimming

### DIFF
--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -339,9 +339,38 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
                     tc.values = mx.concatenate([pad_v, kept_v], axis=2)
                     tc._idx = tc.max_size
                 else:
-                    tc.keys = kept_k
-                    tc.values = kept_v
-                    tc._idx = entries_to_keep
+                    if entries_to_keep < new_offset:
+                        # Buffer has fewer entries than offset requires.
+                        # This happens when old_offset > max_size (rotating)
+                        # and the trim brought new_offset below max_size.
+                        # Pad with zeros on the left to maintain the invariant
+                        # size() == keys.shape[2], preventing merge crashes.
+                        pad_n = new_offset - entries_to_keep
+                        pad_k = mx.zeros(
+                            (
+                                kept_k.shape[0],
+                                kept_k.shape[1],
+                                pad_n,
+                                kept_k.shape[3],
+                            ),
+                            dtype=kept_k.dtype,
+                        )
+                        pad_v = mx.zeros(
+                            (
+                                kept_v.shape[0],
+                                kept_v.shape[1],
+                                pad_n,
+                                kept_v.shape[3],
+                            ),
+                            dtype=kept_v.dtype,
+                        )
+                        tc.keys = mx.concatenate([pad_k, kept_k], axis=2)
+                        tc.values = mx.concatenate([pad_v, kept_v], axis=2)
+                        tc._idx = new_offset
+                    else:
+                        tc.keys = kept_k
+                        tc.values = kept_v
+                        tc._idx = entries_to_keep
                 eval_targets.extend([tc.keys, tc.values])
             else:
                 # No entries removed (trim_by == 0 already handled above,

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -849,6 +849,16 @@ class MLLMBatchGenerator:
                 layer_cache.values = layer_cache._trim(trim_size, layer_cache.values)
                 layer_cache._idx = layer_cache.max_size
             layer_cache.offset = min(layer_cache.offset, layer_cache.max_size)
+            # Defensive: ensure size() <= keys.shape[2] to prevent merge crash.
+            # Prefix cache trimming can create offset > keys.shape[2] when
+            # a supersequence/LCP trim crosses the max_size boundary.
+            buf_len = layer_cache.keys.shape[2]
+            if min(layer_cache.offset, layer_cache.max_size) > buf_len:
+                logger.warning(
+                    f"RotatingKVCache offset ({layer_cache.offset}) > "
+                    f"buffer ({buf_len}), capping to buffer size"
+                )
+                layer_cache.offset = buf_len
 
     def _run_chunked_text_prefill(
         self, request: MLLMBatchRequest, cache: List[Any]


### PR DESCRIPTION
## Summary

- Fix `ValueError: [broadcast_shapes]` crash in `BatchRotatingKVCache.merge()` when prefix cache trimming crosses the `max_size` boundary
- When `_trim_cache_offset()` reduces a rotating cache's offset below `max_size`, the buffer can end up smaller than what `size()` reports, causing shape mismatches during merge
- Pad buffer with zeros to maintain the invariant `size() == keys.shape[2]`, plus add a defensive cap in `_trim_rotating_caches()`

## Problem

When `_trim_cache_offset()` trims a `RotatingKVCache` where `old_offset > max_size` and `new_offset < max_size`:
1. `entries_to_keep = max_size - trim_by` (valid entries in the circular buffer)
2. `new_offset = old_offset - trim_by` (absolute position after trim)
3. Gap: `new_offset - entries_to_keep = old_offset - max_size > 0`

This creates a cache where `size()` returns `new_offset` but `keys.shape[2]` is only `entries_to_keep`. When this cache is later merged via `BatchRotatingKVCache.merge()`, the allocation uses `size()` but the copy uses actual buffer dimensions, causing:
```
ValueError: [broadcast_shapes] Shapes (1,8,914,256) and (1,8,1024,256) cannot be broadcast
```

## Fix

**Primary** (`memory_cache.py`): In the `_trim_cache_offset()` else branch, detect when `entries_to_keep < new_offset` and pad the buffer with zeros on the left to match the expected size.

**Defensive** (`mllm_batch_generator.py`): In `_trim_rotating_caches()`, cap `offset` to `keys.shape[2]` before merge with a warning log.

## Test plan

- [x] Verified fix eliminates 461 occurrences of `broadcast_shapes` errors in production logs
- [x] Concurrent requests with shared prefix cache (10 requests across 5 rounds) pass without errors
- [x] No defensive warning logs triggered (primary fix catches all cases)
- [x] Black formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)