### PR TITLE
Fix Metal encoder race when aborting requests mid-forward-pass

### DIFF
--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -400,6 +400,16 @@ class MLLMBatchGenerator:
         # executor threads.
         self._aborted_request_ids: set = set()
 
+        # Deferred removal queue — UIDs scheduled for removal from another
+        # thread (typically the event loop on client disconnect).  The
+        # actual removal, which mutates `active_batch` and touches MLX
+        # arrays, must happen on the scheduler thread to avoid a race with
+        # an in-flight forward pass.  Metal asserts ("encodeSignalEvent
+        # with uncommitted encoder") if two threads submit GPU work on the
+        # same stream concurrently.  See `schedule_removal` /
+        # `process_pending_removals`.
+        self._pending_removal_uids: set = set()
+
         # Vision embedding cache for repeated images
         self.vision_cache = VisionEmbeddingCache(
             max_pixel_entries=vision_cache_size,
@@ -591,6 +601,37 @@ class MLLMBatchGenerator:
         """
         self._aborted_request_ids.add(request_id)
         logger.info(f"[abort_prefill] Marked {request_id} for prefill abort")
+
+    def schedule_removal(self, uids: List[int]) -> None:
+        """Thread-safe deferred removal of UIDs from the batch.
+
+        Safe to call from any thread (typically the event loop during
+        client-disconnect cleanup).  The actual `remove()`, which creates
+        ``mx.array`` instances and filters the KV cache, runs on the
+        scheduler thread via :meth:`process_pending_removals` at the next
+        batch boundary.  This avoids the Metal ``encodeSignalEvent:
+        uncommitted encoder`` crash that occurs when two threads submit
+        GPU work on the same stream concurrently.
+        """
+        for uid in uids:
+            self._pending_removal_uids.add(uid)
+
+    def process_pending_removals(self) -> None:
+        """Remove any UIDs enqueued via :meth:`schedule_removal`.
+
+        MUST be called from the scheduler thread only, at a safe point
+        (e.g. the start of :meth:`MLLMScheduler.step` before any forward
+        pass has been issued).  Safe to call even when the queue is
+        empty (no-op).
+        """
+        if not self._pending_removal_uids:
+            return
+        # Atomically snapshot and clear the queue.  `set` ops are
+        # GIL-protected, and concurrent `schedule_removal` calls that
+        # arrive after the snapshot will simply be processed next step.
+        uids = list(self._pending_removal_uids)
+        self._pending_removal_uids.clear()
+        self.remove(uids)
 
     def __del__(self):
         try:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -422,11 +422,29 @@ class MLLMScheduler:
             except ValueError:
                 pass
 
-        # Remove from batch generator
+        # Remove from batch generator.
+        #
+        # IMPORTANT: `abort_request` may be called from the asyncio event
+        # loop (e.g. in `stream_outputs`' `finally` block on client
+        # disconnect) while `scheduler.step()` — and therefore the
+        # batch generator's forward pass — is running on a separate
+        # executor thread (see engine_core.py: loop.run_in_executor).
+        #
+        # Calling `batch_generator.remove([uid])` eagerly here would
+        # trigger `active_batch.filter(...)`, which creates an
+        # `mx.array` and submits Metal work.  If the scheduler thread
+        # has an open Metal encoder mid-forward-pass, two threads
+        # submit to the same stream concurrently and Metal asserts
+        # with ``encodeSignalEvent:value: with uncommitted encoder``,
+        # aborting the process.
+        #
+        # Instead we defer the removal to the scheduler thread: it
+        # will drain the queue at the next safe boundary (start of
+        # step(), before any forward pass).
         if request_id in self.request_id_to_uid:
             uid = self.request_id_to_uid[request_id]
             if self.batch_generator is not None:
-                self.batch_generator.remove([uid])
+                self.batch_generator.schedule_removal([uid])
             del self.uid_to_request_id[uid]
             del self.request_id_to_uid[request_id]
 
@@ -667,6 +685,14 @@ class MLLMScheduler:
             MLLMSchedulerOutput with results of this step
         """
         output = MLLMSchedulerOutput()
+
+        # Drain any deferred removals queued from other threads (e.g.
+        # the asyncio event loop during client-disconnect aborts).
+        # This MUST run before any forward pass to avoid the Metal
+        # ``encodeSignalEvent: uncommitted encoder`` race.  See
+        # `abort_request` and `MLLMBatchGenerator.schedule_removal`.
+        if self.batch_generator is not None:
+            self.batch_generator.process_pending_removals()
 
         # Schedule waiting requests
         scheduled = self._schedule_waiting()


### PR DESCRIPTION
## Summary

Fixes a hard crash (`encodeSignalEvent:value: with uncommitted encoder` / `Abort trap: 6`) that occurs on Apple Silicon when a client disconnects during a long prefill.

`MLLMScheduler.abort_request` runs on the asyncio event loop (e.g. `stream_outputs`' `finally` block), while `scheduler.step()` — and therefore the batch generator's forward pass — runs on the executor thread (see `engine_core.py: loop.run_in_executor(_executor, self.scheduler.step)`).

The old code eagerly called `batch_generator.remove([uid])` from the event-loop thread, which in turn called `active_batch.filter(...)` and created fresh `mx.array` instances. When the scheduler thread happened to have an open Metal encoder mid-forward-pass, two threads submitted GPU work to the same stream concurrently and Metal aborted the process.

## Repro

* Gemma 4 26B-A4B on Apple Silicon, continuous batching, `--max-num-seqs 16`
* Send a ~10k-token prefill
* Client disconnects after several minutes (e.g. HTTP client timeout)
* Server crashes with:
  ```
  -[IOGPUMetalCommandBuffer encodeSignalEvent:value:]:427:
  failed assertion `encodeSignalEvent:value: with uncommitted encoder'
  Abort trap: 6
  ```

## Fix

Defer the removal to the scheduler thread:

* `MLLMBatchGenerator.schedule_removal(uids)` — thread-safe enqueue (GIL-protected `set.add`).
* `MLLMBatchGenerator.process_pending_removals()` — drains the queue on the scheduler thread at a safe point.
* `MLLMScheduler.step()` calls `process_pending_removals()` at the start, before any forward pass is issued.
* `MLLMScheduler.abort_request()` now calls `schedule_removal` instead of `remove` directly.

The existing `abort_prefill` path (which only mutates a GIL-protected set of request IDs checked between prefill chunks) is unchanged.

## Test plan

- [x] `uvx black vllm_mlx/` — formatting clean
- [x] Gemma 4 26B-A4B starts normally after patch
- [x] `schedule_removal` / `process_pending_removals` visible on `MLLMBatchGenerator` at runtime
- [x] 6 parallel 10k-token prefill requests force-disconnected by client → server stays healthy
- [x] Recovery test: normal chat completion works after the abort stress
- [x] No `encodeSignalEvent` / `uncommitted encoder` lines in error log after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)