### PR TITLE
Fix Gemma 4 streaming reasoning parser: buffer partial markers

### DIFF
--- a/tests/test_gemma4_streaming_edge.py
+++ b/tests/test_gemma4_streaming_edge.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Unit tests for Gemma4 streaming parser edge cases."""
+
+import sys
+
+sys.path.insert(0, "/Users/janhilgard/vllm-mlx-upstream")
+
+from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+
+
+def stream_parse(parser, text, token_list):
+    """Feed token_list to parser one-by-one, accumulating reasoning/content."""
+    parser.reset_state()
+    accumulated = ""
+    reasoning_parts = []
+    content_parts = []
+    for tok in token_list:
+        prev = accumulated
+        accumulated += tok
+        msg = parser.extract_reasoning_streaming(prev, accumulated, tok)
+        if msg is None:
+            continue
+        if msg.reasoning:
+            reasoning_parts.append(msg.reasoning)
+        if msg.content:
+            content_parts.append(msg.content)
+    return "".join(reasoning_parts), "".join(content_parts)
+
+
+def test_channel_marker_split_across_tokens():
+    """<|channel> alone should not leak into reasoning if response follows."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "reasoning text",
+        "<|channel>",
+        "response",
+        "\n",
+        "content text",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert "<|channel>" not in reasoning, f"Marker leaked into reasoning: {reasoning!r}"
+    assert "<|channel>" not in content, f"Marker leaked into content: {content!r}"
+    assert reasoning == "reasoning text", f"Got: {reasoning!r}"
+    assert content == "content text", f"Got: {content!r}"
+    print("[PASS] test_channel_marker_split_across_tokens")
+
+
+def test_leading_newline_after_transition():
+    """Leading \\n after <|channel>response should be stripped from content."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "reasoning",
+        "<|channel>response",
+        "\n",  # marker in one token, \n in next
+        "actual content",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert content == "actual content", f"Got: {content!r}"
+    print("[PASS] test_leading_newline_after_transition")
+
+
+def test_realistic_deterministic_production_stream():
+    """Reproduce realistic production output with many small deltas."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "The",
+        " user",
+        " said",
+        ' "',
+        "hi",
+        '".',
+        " Plan",
+        ":",
+        " greet",
+        " politely",
+        ".",
+        "\n",
+        "<|channel>",
+        "response",
+        "\n",
+        "Hello",
+        "!",
+        " How",
+        " can",
+        " I",
+        " help",
+        " you",
+        " today",
+        "?",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert "<|channel>" not in reasoning, f"Marker leaked: {reasoning!r}"
+    assert "<|channel>" not in content, f"Marker leaked: {content!r}"
+    assert (
+        reasoning == 'The user said "hi". Plan: greet politely.\n'
+    ), f"Got: {reasoning!r}"
+    assert content == "Hello! How can I help you today?", f"Got: {content!r}"
+    print("[PASS] test_realistic_deterministic_production_stream")
+
+
+def test_standard_format_with_split():
+    """Standard <|channel>thought...<channel|>content format, split token."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "reasoning",
+        "<channel|>",
+        "content",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert reasoning == "reasoning", f"Got: {reasoning!r}"
+    assert content == "content", f"Got: {content!r}"
+    print("[PASS] test_standard_format_with_split")
+
+
+def test_no_transition_stays_in_thinking():
+    """When model never emits transition marker, all goes to reasoning."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "reasoning with",
+        " no",
+        " transition",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert reasoning == "reasoning with no transition", f"Got: {reasoning!r}"
+    assert content == "", f"Got: {content!r}"
+    print("[PASS] test_no_transition_stays_in_thinking")
+
+
+def test_finalize_stream_fallback():
+    """B: If stream ends in thinking phase, finalize should allow fallback."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "draft answer here",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    # Should still classify as reasoning (current correct behavior)
+    assert reasoning == "draft answer here", f"Got: {reasoning!r}"
+    # Finalize hook should return any pending partial marker buffer
+    msg = parser.finalize_stream()
+    # If parser buffered a partial <|channel> at end of stream, it should flush here
+    assert msg is None or msg.reasoning is not None or msg.content is not None
+    print("[PASS] test_finalize_stream_fallback")
+
+
+def test_partial_marker_at_end_flushed():
+    """If stream ends with buffered partial marker, finalize emits it."""
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "thought",
+        "\n",
+        "text",
+        "<|channel>",  # partial — could be transition or just end
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    # At this point, "<|channel>" should be buffered, not emitted
+    assert "<|channel>" not in reasoning, f"Leaked: {reasoning!r}"
+    # Finalize flushes the buffered marker as reasoning (it wasn't transition)
+    msg = parser.finalize_stream()
+    if msg and msg.reasoning:
+        reasoning += msg.reasoning
+    assert reasoning == "text<|channel>", f"Got: {reasoning!r}"
+    print("[PASS] test_partial_marker_at_end_flushed")
+
+
+if __name__ == "__main__":
+    test_channel_marker_split_across_tokens()
+    test_leading_newline_after_transition()
+    test_realistic_deterministic_production_stream()
+    test_standard_format_with_split()
+    test_no_transition_stays_in_thinking()
+    test_finalize_stream_fallback()
+    test_partial_marker_at_end_flushed()
+    print("\nAll tests passed!")

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -108,3 +108,19 @@ class ReasoningParser(ABC):
         This is intentionally a default no-op implementation.
         """
         pass
+
+    def finalize_stream(self) -> DeltaMessage | None:  # noqa: B027
+        """
+        Finalize streaming state at end of stream.
+
+        Called after the last delta is processed but before the stream
+        closes. Parsers that buffer partial markers internally should
+        flush any remaining text here.
+
+        Default implementation is a no-op (returns None).
+
+        Returns:
+            DeltaMessage with any pending reasoning/content to emit,
+            or None if nothing to flush.
+        """
+        return None

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -52,6 +52,13 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         Output: reasoning="Let me think...", content="The answer is 42."
 
     When no tags are present, the entire output is treated as content.
+
+    Streaming buffering:
+        Partial markers at a delta boundary (e.g. "<|channel>" without a
+        following "response" yet) are buffered internally so they don't
+        leak into reasoning/content. The buffer is either consumed when
+        the marker completes in a later delta, or flushed as reasoning
+        via finalize_stream() when the stream ends.
     """
 
     @property
@@ -61,6 +68,63 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
     @property
     def end_token(self) -> str:
         return "<channel|>"
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        # Trailing text withheld because it could complete into a marker
+        # (e.g. "<|channel>" that might become "<|channel>response" next delta).
+        self._pending: str = ""
+        # Tracks whether we have emitted the first content delta past the
+        # <|channel>response transition — used to strip the leading newline.
+        self._content_seen: bool = False
+
+    def reset_state(self):
+        super().reset_state()
+        self._pending = ""
+        self._content_seen = False
+
+    def _trailing_partial_marker_len(self, text: str) -> int:
+        """
+        Return length of trailing substring of `text` that is a proper prefix
+        of any transition marker (<channel|>, <|channel>response, <|channel>).
+
+        Only counts PROPER prefixes — if the marker is already complete in
+        `text`, no buffering is needed. Returns 0 if no partial match.
+
+        We must never buffer legitimate content. For <|channel>, only buffer
+        when it appears AT THE END and is not followed by more text (i.e.,
+        `response` or `thought` hasn't arrived yet).
+        """
+        markers = (_RESPONSE_MARKER, self.end_token, self.start_token)
+        max_len = 0
+        for marker in markers:
+            # Scan from longest proper prefix downwards
+            for i in range(min(len(marker) - 1, len(text)), 0, -1):
+                if text.endswith(marker[:i]):
+                    # Proper prefix match; ensure we're not inside a completed
+                    # marker (which would already be handled by other logic).
+                    if not text.endswith(marker):
+                        if i > max_len:
+                            max_len = i
+                        break
+        return max_len
+
+    def finalize_stream(self) -> DeltaMessage | None:
+        """
+        Flush any buffered partial marker at the end of stream.
+
+        If the stream ends while we have a partial marker buffered (e.g.
+        model emitted "<|channel>" as its last token and got truncated by
+        max_tokens), emit it as reasoning so the client doesn't lose the
+        text. Content phase flushes as content.
+        """
+        if not self._pending:
+            return None
+        pending = self._pending
+        self._pending = ""
+        if self._phase == "content":
+            return DeltaMessage(content=pending)
+        return DeltaMessage(reasoning=pending)
 
     def extract_reasoning(
         self,
@@ -119,7 +183,38 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         - No tags: treat as content (Gemma 4 doesn't inject tags in prompt)
         - <|channel>thought: enter reasoning mode, strip channel name
         - <channel|> or <|channel>response: transition to content mode
+
+        Partial markers at delta boundaries are buffered internally to
+        prevent leaking them as reasoning/content.
         """
+        # Buffer trailing partial marker so it doesn't leak into output.
+        # Process only the "safe" portion (without the partial trailing bytes).
+        trailing = self._trailing_partial_marker_len(current_text)
+        safe_current = current_text[:-trailing] if trailing else current_text
+        prev_trailing = self._trailing_partial_marker_len(previous_text)
+        safe_previous = (
+            previous_text[:-prev_trailing] if prev_trailing else previous_text
+        )
+
+        # Update buffered pending text for external flush (finalize_stream).
+        self._pending = current_text[len(safe_current) :]
+
+        # If no new safe text this delta, suppress emission — everything
+        # new is buffered as a potential marker prefix.
+        if len(safe_current) <= len(safe_previous):
+            return None
+
+        safe_delta = safe_current[len(safe_previous) :]
+
+        return self._extract_from_safe_text(safe_previous, safe_current, safe_delta)
+
+    def _extract_from_safe_text(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        """Parse safe (non-buffered) text using the original logic."""
         # No channel tokens at all — plain content
         if self.start_token not in current_text and self.end_token not in current_text:
             return DeltaMessage(content=delta_text)
@@ -128,16 +223,24 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         if _RESPONSE_MARKER in current_text:
             if _RESPONSE_MARKER not in previous_text:
                 # Transition happening in this delta
-                # Find what (if any) content comes after the marker
+                self._phase = "content"
                 marker_pos = current_text.find(_RESPONSE_MARKER)
                 after_marker = current_text[marker_pos + len(_RESPONSE_MARKER) :]
                 after_marker = after_marker.lstrip("\n")
                 if after_marker:
+                    self._content_seen = True
                     return DeltaMessage(content=after_marker)
                 return None  # Suppress the marker itself
             else:
-                # Already past transition — pure content
-                # But we need to only emit the NEW text (delta)
+                # Already past transition — pure content.
+                # Strip leading newline(s) from the FIRST content delta after
+                # the marker (tokenizer often emits "\n" as its own token).
+                if not self._content_seen:
+                    stripped = delta_text.lstrip("\n")
+                    self._content_seen = bool(stripped)
+                    if not stripped:
+                        return None
+                    return DeltaMessage(content=stripped)
                 return DeltaMessage(content=delta_text)
 
         # Delegate to base class for standard <|channel>/<channel|> handling
@@ -147,7 +250,6 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
 
         # Strip "thought" channel name from initial reasoning
         if result is not None and result.reasoning is not None:
-            r = result.reasoning
             # First reasoning delta after <|channel> will be "thought" or "thought\n"
             if self.start_token in current_text:
                 # Check if this is the very first reasoning content


### PR DESCRIPTION
## Summary

The streaming reasoning parser for Gemma 4 had two edge-case bugs that caused marker leakage when channel transition markers spanned token boundaries.

### Problems

1. **Partial `<|channel>` marker leak**: when a delta ended with a prefix of `<|channel>` (e.g. `<|` or `<|chan`), the prefix was emitted as reasoning text instead of being buffered for the next delta.

2. **Leading newline after transition**: the tokenizer often emits `\n` as its own token right after `<|channel>response`. This leading newline was being included in the first content delta.

### Fix

- **`_trailing_partial_marker_len()`** detects any trailing proper prefix of the three transition markers (`<|channel>response`, `<channel|>`, `<|channel>`) and buffers it internally in `self._pending`. On subsequent deltas, buffered text is re-combined with new text; only the "safe" prefix (without the new trailing partial) is parsed.
- **Leading newline stripping** for the first content delta after the `<|channel>response` marker (`self._content_seen` flag).
- **New `finalize_stream()` hook** on `ReasoningParser` base class lets the server flush any still-buffered text when the stream ends mid-marker (e.g. model hits `max_tokens` during `<|channel>` and the closing never arrives). Default implementation is a no-op. Gemma 4 override flushes pending text as reasoning (or content if already past the transition). Integrating this into `server.py` streaming endpoints is a small follow-up that can be done in a separate PR.

## Test plan

- [x] Added `tests/test_gemma4_streaming_edge.py` with 7 passing unit tests:
  - Marker split across multiple tokens
  - Leading newline stripping
  - Realistic token-by-token stream (matches production output)
  - Standard `<channel|>` format with marker splits
  - Absence of transition (all reasoning)
  - `finalize_stream()` hook behavior
  - Buffered partial marker flushed on stream end
- [x] Verified in production: identical reasoning/content split between streaming and non-streaming paths for deterministic prompts (`temperature=0, seed=N`) with Gemma 4 26B-A4B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)