### PR TITLE
fix(api): make response_format actually work on chatty tool-calling models

### DIFF
--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -126,6 +126,172 @@ class TestExtractJsonFromText:
         result = extract_json_from_text(text)
         assert result == {"outer": {"inner": {"deep": "value"}}}
 
+    def test_chatty_preamble_with_json(self):
+        """
+        Test the classic Minimax / chain-of-thought failure mode:
+        the model explains itself before emitting JSON.
+        """
+        text = (
+            "Let me format this as JSON:\n" '```json\n{"name": "John", "age": 25}\n```'
+        )
+        result = extract_json_from_text(text)
+        assert result == {"name": "John", "age": 25}
+
+    def test_unterminated_markdown_fence(self):
+        """
+        Test truncation: model started ```json fence but ran out of
+        tokens before closing it. Previously returned None.
+        """
+        text = 'Let me format this as JSON:\n```json\n{"name": "John", "age": 25}'
+        result = extract_json_from_text(text)
+        assert result == {"name": "John", "age": 25}
+
+    def test_truncated_json_unclosed_object(self):
+        """Test repair of JSON truncated mid-object (max_tokens hit)."""
+        text = '{"name": "John", "age": 25, "city": "Prague"'
+        result = extract_json_from_text(text)
+        assert result == {"name": "John", "age": 25, "city": "Prague"}
+
+    def test_truncated_json_unclosed_string(self):
+        """Test repair of JSON truncated mid-string."""
+        text = '{"name": "John", "city": "Pra'
+        result = extract_json_from_text(text)
+        assert result == {"name": "John", "city": "Pra"}
+
+    def test_truncated_json_unclosed_nested(self):
+        """Test repair of JSON truncated deep inside nested structures."""
+        text = '{"user": {"name": "John", "items": [1, 2, 3'
+        result = extract_json_from_text(text)
+        assert result == {"user": {"name": "John", "items": [1, 2, 3]}}
+
+    def test_truncated_json_dangling_key(self):
+        """Test repair when truncation leaves a dangling key."""
+        text = '{"name": "John", "age":'
+        result = extract_json_from_text(text)
+        # Dangling "age": should get repaired to null or dropped.
+        assert result is not None
+        assert result.get("name") == "John"
+
+    def test_balanced_scan_prefers_valid_json(self):
+        """
+        Test that balanced-brace scanning picks the first balanced JSON,
+        not a greedy region between first { and last }.
+        """
+        text = 'First: {"a": 1}. Garbage: {broken}'
+        result = extract_json_from_text(text)
+        assert result == {"a": 1}
+
+    def test_json_with_escaped_braces_in_string(self):
+        """Test balanced scanner respects strings containing braces."""
+        text = '{"template": "Hello {user}!", "count": 5}'
+        result = extract_json_from_text(text)
+        assert result == {"template": "Hello {user}!", "count": 5}
+
+    def test_json_with_escaped_quotes(self):
+        """Test balanced scanner respects escaped quotes inside strings."""
+        text = '{"text": "He said \\"hi\\"", "ok": true}'
+        result = extract_json_from_text(text)
+        assert result == {"text": 'He said "hi"', "ok": True}
+
+
+class TestRawJsonToolCallHijackPrevention:
+    """
+    Regression tests for the MiniMax-M2 bug where ``response_format`` with a
+    schema that contained ``"name"`` (e.g. person name) was hijacked into a
+    fake ``function.name`` tool call by the raw-JSON tool-call fallback.
+    """
+
+    def test_response_format_not_hijacked_no_tools(self):
+        """JSON data with 'name' field must not become a tool call."""
+        from vllm_mlx.api.tool_calling import parse_tool_calls
+
+        # Simulate Minimax emitting user-schema JSON after response_format.
+        text = '{"name": "John", "age": 25}'
+        # Request has NO tools — any parse_tool_calls output is a hijack.
+        cleaned, tool_calls = parse_tool_calls(text, request={"tools": None})
+        assert tool_calls is None, f"Hijacked JSON into tool_calls: {tool_calls}"
+
+    def test_response_format_with_response_format_no_tools(self):
+        """
+        Even when the request has ``response_format`` set and no tools,
+        a JSON object with 'name' must not become a tool call.
+        """
+        from vllm_mlx.api.tool_calling import parse_tool_calls
+
+        text = '{"name": "Alice", "age": 30, "city": "Prague"}'
+        cleaned, tool_calls = parse_tool_calls(
+            text,
+            request={
+                "tools": None,
+                "response_format": {"type": "json_object"},
+            },
+        )
+        assert tool_calls is None
+
+    def test_genuine_tool_call_still_detected(self):
+        """
+        Regression guard: a genuine tool call (``name`` + ``arguments``)
+        MUST still be detected when the caller passed ``tools``.
+        """
+        from vllm_mlx.api.tool_calling import parse_tool_calls
+
+        text = '{"name": "get_weather", "arguments": {"city": "Prague"}}'
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        cleaned, tool_calls = parse_tool_calls(text, request={"tools": tools})
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+
+    def test_no_name_no_arguments_not_tool_call(self):
+        """Plain JSON without 'name' stays as content."""
+        from vllm_mlx.api.tool_calling import parse_tool_calls
+
+        text = '{"result": 42, "status": "ok"}'
+        cleaned, tool_calls = parse_tool_calls(
+            text, request={"tools": [{"type": "function"}]}
+        )
+        assert tool_calls is None
+
+    def test_name_only_not_tool_call(self):
+        """
+        ``{"name": "x"}`` without ``"arguments"`` must NOT be a tool call.
+        This is the specific shape that hijacked MiniMax-M2 output.
+        """
+        from vllm_mlx.api.tool_calling import _parse_raw_json_tool_calls
+
+        assert _parse_raw_json_tool_calls('{"name": "John"}') is None
+        assert _parse_raw_json_tool_calls('{"name": "John", "age": 25}') is None
+
+    def test_looks_like_tool_call_helper(self):
+        """Direct coverage for the _looks_like_tool_call heuristic."""
+        from vllm_mlx.api.tool_calling import _looks_like_tool_call
+
+        # Genuine tool calls.
+        assert _looks_like_tool_call({"name": "f", "arguments": {}})
+        assert _looks_like_tool_call({"name": "f", "arguments": '{"a":1}'})
+        assert _looks_like_tool_call(
+            {"name": "get_weather", "arguments": {"city": "Prague"}}
+        )
+        # Not tool calls.
+        assert not _looks_like_tool_call({"name": "John", "age": 25})
+        assert not _looks_like_tool_call({"name": "", "arguments": {}})
+        assert not _looks_like_tool_call({"arguments": {}})
+        assert not _looks_like_tool_call({"name": 123, "arguments": {}})
+        assert not _looks_like_tool_call({"name": "f", "arguments": 42})
+        assert not _looks_like_tool_call("not a dict")
+        assert not _looks_like_tool_call(None)
+
 
 class TestParseJsonOutput:
     """Tests for parse_json_output function."""
@@ -253,6 +419,17 @@ class TestBuildJsonSystemPrompt:
         assert "valid JSON" in result
         assert "only" in result.lower()
 
+    def test_json_object_has_strict_rules(self):
+        """
+        Test that json_object prompt contains explicit no-markdown /
+        no-preamble rules (added to prevent chatty model failures).
+        """
+        result = build_json_system_prompt({"type": "json_object"})
+        assert result is not None
+        assert "STRICT" in result
+        assert "markdown" in result.lower()
+        assert "preamble" in result.lower() or "Preamble" in result
+
     def test_json_schema(self):
         """Test prompt for json_schema mode."""
         response_format = {
@@ -271,6 +448,20 @@ class TestBuildJsonSystemPrompt:
         assert "person" in result
         assert "A person object" in result
         assert "JSON Schema" in result
+
+    def test_json_schema_has_strict_rules(self):
+        """Test json_schema prompt also carries the strict output rules."""
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "person",
+                "schema": {"type": "object"},
+            },
+        }
+        result = build_json_system_prompt(response_format)
+        assert result is not None
+        assert "STRICT" in result
+        assert "markdown" in result.lower()
 
     def test_json_schema_model(self):
         """Test prompt with ResponseFormat model."""

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -21,6 +21,34 @@ from jsonschema import validate, ValidationError
 from .models import FunctionCall, ResponseFormat, ToolCall
 
 
+def _looks_like_tool_call(obj: Any) -> bool:
+    """
+    Heuristic: decide whether a parsed JSON object really represents a tool
+    call as opposed to user data that happens to carry a ``"name"`` field.
+
+    The OpenAI tool-call wire format ALWAYS has both ``"name"`` and
+    ``"arguments"``. Accepting bare ``{"name": ...}`` (previous behaviour)
+    caused ``response_format={"type": "json_schema"}`` payloads with a
+    ``name`` field to be hijacked as fake tool calls (observed on
+    MiniMax-M2: ``{"name": "John", "age": 25}`` -> ``function.name="John"``).
+
+    Args:
+        obj: Parsed JSON object.
+
+    Returns:
+        True if obj looks like a tool call, False otherwise.
+    """
+    if not isinstance(obj, dict):
+        return False
+    if "name" not in obj or "arguments" not in obj:
+        return False
+    if not isinstance(obj["name"], str) or not obj["name"]:
+        return False
+    # ``arguments`` must be a JSON-encoded string or a dict per OpenAI spec.
+    args = obj["arguments"]
+    return isinstance(args, (dict, str))
+
+
 def _parse_raw_json_tool_calls(text: str) -> Optional[List[dict]]:
     """
     Parse raw JSON tool calls from model output.
@@ -29,6 +57,9 @@ def _parse_raw_json_tool_calls(text: str) -> Optional[List[dict]]:
     - Single JSON object: {"name": "func", "arguments": {...}}
     - Multiple objects separated by commas: {...}, {...}
     - JSON array: [{...}, {...}]
+
+    Only accepts objects that carry both ``name`` AND ``arguments`` fields
+    to avoid hijacking user data emitted via ``response_format``.
 
     Args:
         text: Raw model output text
@@ -45,11 +76,13 @@ def _parse_raw_json_tool_calls(text: str) -> Optional[List[dict]]:
     if text.startswith("["):
         try:
             parsed = json.loads(text)
-            if isinstance(parsed, list) and all(
-                isinstance(item, dict) and "name" in item for item in parsed
+            if (
+                isinstance(parsed, list)
+                and parsed
+                and all(_looks_like_tool_call(item) for item in parsed)
             ):
                 return [
-                    {"name": item["name"], "arguments": item.get("arguments", {})}
+                    {"name": item["name"], "arguments": item["arguments"]}
                     for item in parsed
                 ]
         except json.JSONDecodeError:
@@ -71,9 +104,9 @@ def _parse_raw_json_tool_calls(text: str) -> Optional[List[dict]]:
                 json_str = text[start : i + 1]
                 try:
                     obj = json.loads(json_str)
-                    if isinstance(obj, dict) and "name" in obj:
+                    if _looks_like_tool_call(obj):
                         tool_calls.append(
-                            {"name": obj["name"], "arguments": obj.get("arguments", {})}
+                            {"name": obj["name"], "arguments": obj["arguments"]}
                         )
                 except json.JSONDecodeError:
                     pass
@@ -280,8 +313,13 @@ def parse_tool_calls(
     # The user may want to see the model's reasoning process
 
     # Fallback: Raw JSON tool calls (lowest priority)
-    # Only try if no other formats matched
-    if not tool_calls:
+    # Only try if no other formats matched AND the caller actually asked for
+    # tools. When ``tools`` is not set, a bare JSON response is user data
+    # (e.g. from ``response_format``), not a tool invocation — the fallback
+    # would otherwise hijack ``{"name": "John", ...}`` into a fake
+    # ``function.name="John"`` tool call (observed on MiniMax-M2).
+    tools_requested = bool(request and request.get("tools"))
+    if not tool_calls and tools_requested:
         raw_json_calls = _parse_raw_json_tool_calls(cleaned_text)
         if raw_json_calls:
             for call_data in raw_json_calls:
@@ -410,14 +448,145 @@ def validate_json_schema(
         return False, str(e.message)
 
 
+def _scan_balanced_json(text: str, start: int) -> Optional[str]:
+    """
+    Walk forward from ``start`` (which must point at ``{`` or ``[``) and
+    return the substring that represents the first balanced JSON value,
+    respecting strings and escapes. Returns ``None`` if the opening bracket
+    is never closed (truncated output).
+    """
+    if start < 0 or start >= len(text):
+        return None
+    opener = text[start]
+    if opener not in "{[":
+        return None
+    closer = "}" if opener == "{" else "]"
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+            continue
+        if ch == opener:
+            depth += 1
+        elif ch == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+def _repair_truncated_json(fragment: str) -> Optional[Dict[str, Any]]:
+    """
+    Attempt to parse a JSON fragment whose closing brackets were cut off
+    (e.g. because the model hit ``max_tokens`` mid-object).
+
+    Strategy: scan once to determine the open-bracket stack and whether we
+    ended mid-string, then try a handful of repair candidates in order of
+    likelihood:
+
+      1. Close unterminated string, close brackets.
+      2. Also strip a dangling ``,`` / ``:`` before closing.
+      3. Also drop a dangling key (``"k":`` or bare ``"k"``) before closing.
+      4. Drop a dangling partial token (number / true / fals / nul) before
+         closing.
+
+    Returns the first candidate that ``json.loads`` accepts, or ``None``.
+    """
+    if not fragment:
+        return None
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    for ch in fragment:
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if stack and (
+                (ch == "}" and stack[-1] == "{") or (ch == "]" and stack[-1] == "[")
+            ):
+                stack.pop()
+    if not stack and not in_string:
+        return None  # Nothing to repair — caller already tried json.loads.
+
+    def _close(text: str) -> str:
+        for opener in reversed(stack):
+            text += "}" if opener == "{" else "]"
+        return text
+
+    # Base: close unterminated string if any.
+    base = fragment
+    if in_string:
+        if escape:
+            base = base[:-1]  # drop trailing backslash so closing quote sticks
+        base += '"'
+
+    candidates: list[str] = []
+
+    # 1. Close brackets directly.
+    candidates.append(_close(base))
+
+    # 2. Strip a dangling separator (trailing ``,`` / ``:`` / whitespace).
+    stripped_sep = re.sub(r"[,:\s]+$", "", base)
+    if stripped_sep != base:
+        candidates.append(_close(stripped_sep))
+
+    # 3. Drop a dangling key (``"k":`` or bare ``"k"``) inside an object.
+    if stack and stack[-1] == "{":
+        no_key = re.sub(r',?\s*"[^"]*"\s*:?\s*$', "", stripped_sep)
+        if no_key != stripped_sep:
+            candidates.append(_close(no_key))
+
+    # 4. Drop a dangling partial scalar (number / keyword / literal).
+    no_scalar = re.sub(
+        r",?\s*(?:-?\d+(?:\.\d*)?(?:[eE][+-]?\d*)?|t|tr|tru|f|fa|fal|fals|n|nu|nul)$",
+        "",
+        stripped_sep,
+    )
+    if no_scalar != stripped_sep:
+        candidates.append(_close(no_scalar))
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
 def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     """
     Extract JSON from model output text.
 
-    Tries multiple strategies:
+    Tries multiple strategies, in order of specificity:
+
     1. Parse entire text as JSON
-    2. Extract JSON from markdown code blocks
-    3. Find JSON object/array in text
+    2. Extract JSON from complete markdown code blocks (``` ... ```)
+    3. Extract JSON from an unterminated markdown code block (``` json\\n{ ... )
+       — handles the common "chatty + truncation" failure mode where the
+       model starts a ```json fence, never closes it, then hits max_tokens.
+    4. Balanced-brace scan for the first ``{`` or ``[`` in the text
+    5. Repair truncated JSON by closing unclosed brackets/strings
 
     Args:
         text: Raw model output text
@@ -433,7 +602,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     except json.JSONDecodeError:
         pass
 
-    # Strategy 2: Extract from markdown code blocks
+    # Strategy 2: Extract from complete markdown code blocks
     # Match ```json ... ``` or ``` ... ```
     code_block_pattern = r"```(?:json)?\s*([\s\S]*?)\s*```"
     matches = re.findall(code_block_pattern, text)
@@ -443,19 +612,48 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
         except json.JSONDecodeError:
             continue
 
-    # Strategy 3: Find JSON object or array in text
-    # Look for { ... } or [ ... ]
-    json_patterns = [
-        r"(\{[\s\S]*\})",  # Object
-        r"(\[[\s\S]*\])",  # Array
-    ]
-    for pattern in json_patterns:
-        match = re.search(pattern, text)
-        if match:
-            try:
-                return json.loads(match.group(1))
-            except json.JSONDecodeError:
-                continue
+    # Strategy 3: Unterminated markdown fence — take everything after the
+    # last ``` opener. Common truncation case for chatty models.
+    unterminated_fence = re.search(r"```(?:json)?\s*\n?([\s\S]*)$", text)
+    fenced_candidate: Optional[str] = None
+    if unterminated_fence:
+        fenced_candidate = unterminated_fence.group(1).strip()
+        # Drop a trailing ``` if it slipped through the greedy match.
+        if fenced_candidate.endswith("```"):
+            fenced_candidate = fenced_candidate[:-3].strip()
+        try:
+            return json.loads(fenced_candidate)
+        except json.JSONDecodeError:
+            pass
+
+    # Strategy 4: Balanced-brace scan for the first JSON value anywhere.
+    # Preserves correctness better than a greedy regex (which would grab
+    # everything between the first ``{`` and the last ``}``).
+    for opener in ("{", "["):
+        idx = text.find(opener)
+        while idx != -1:
+            candidate = _scan_balanced_json(text, idx)
+            if candidate is not None:
+                try:
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    pass
+            idx = text.find(opener, idx + 1)
+
+    # Strategy 5: Repair a truncated JSON prefix. Try the fenced candidate
+    # first (usually starts right at ``{``), then fall back to the earliest
+    # ``{``/``[`` in the full text.
+    candidates = []
+    if fenced_candidate:
+        candidates.append(fenced_candidate)
+    for opener in ("{", "["):
+        idx = text.find(opener)
+        if idx != -1:
+            candidates.append(text[idx:])
+    for fragment in candidates:
+        repaired = _repair_truncated_json(fragment)
+        if repaired is not None:
+            return repaired
 
     return None
 
@@ -564,10 +762,19 @@ def build_json_system_prompt(
     if format_type == "text":
         return None
 
+    strict_rules = (
+        "Output rules (STRICT):\n"
+        "- Your first character MUST be `{` (or `[`).\n"
+        "- Your last character MUST be `}` (or `]`).\n"
+        "- Do NOT wrap the JSON in a markdown code block (no ``` fences).\n"
+        "- Do NOT prepend any preamble such as "
+        '"Here is the JSON" or "Let me format this".\n'
+        "- Do NOT include comments, trailing explanations, or chain-of-thought.\n"
+    )
+
     if format_type == "json_object":
         return (
-            "You must respond with valid JSON only. "
-            "Do not include any explanation or text outside the JSON object."
+            "You must respond with a single valid JSON value only.\n\n" + strict_rules
         )
 
     if format_type == "json_schema":
@@ -576,13 +783,11 @@ def build_json_system_prompt(
         name = json_schema_spec.get("name", "response")
         description = json_schema_spec.get("description", "")
 
-        prompt = f"You must respond with valid JSON matching the '{name}' schema."
+        prompt = f"You must respond with a single valid JSON value matching the '{name}' schema."
         if description:
             prompt += f" {description}"
-        prompt += (
-            f"\n\nJSON Schema:\n```json\n{json.dumps(schema, indent=2)}\n```\n\n"
-            "Respond with only the JSON object, no additional text or explanation."
-        )
+        prompt += f"\n\nJSON Schema:\n```json\n{json.dumps(schema, indent=2)}\n```\n\n"
+        prompt += strict_rules
         return prompt
 
     return None


### PR DESCRIPTION
## Summary

Two related bugs made `response_format={"type": "json_object" | "json_schema"}` silently return empty content on chatty reasoning models like MiniMax-M2, GLM-4.6, and friends.

## Bug 1 — raw-JSON tool-call fallback hijacks user data

When no specific tool parser matched, `parse_tool_calls` fell through to a raw-JSON fallback that treated ANY object with a `"name"` field as a tool call. Schemas with a `"name"` data field (person name, user name, product name — one of the most common JSON Schema fields) were reclassified as tool calls: `{"name": "John", "age": 25}` became `function.name="John"` with empty arguments, `content=null`, and `finish_reason="tool_calls"`.

Two complementary guards:

1. New `_looks_like_tool_call(obj)` heuristic requires BOTH `"name"` AND `"arguments"` to match the OpenAI tool-call wire format.
2. `parse_tool_calls` only runs the raw-JSON fallback when the caller actually passed `tools`. Without `tools`, any JSON is user data.

Genuine tool calls keep working — XML wrappers (`<invoke>`, `<tool_call>`, `<function=>`) are unaffected, and raw-JSON tool calls still parse when the request declared `tools`.

## Bug 2 — extract_json_from_text loses chatty + truncated output

Even when the tool-call hijack was avoided, two failure modes silently returned `None` from `extract_json_from_text` and fell through to "Failed to extract valid JSON":

1. **Chatty preamble + truncation.** `` Let me format this as JSON:\n```json\n{... `` and hit `max_tokens` before the closing fence. The old matcher only recognised *complete* fences.
2. **Mid-object truncation.** `{"name": "John", "age": 25, "city": "Pra` — the greedy `\{[\s\S]*\}` regex required a closing `}`.

`extract_json_from_text` now tries five ordered strategies:

1. Parse entire text as JSON.
2. Extract from complete markdown code blocks.
3. *(new)* Extract from an *unterminated* markdown fence.
4. Balanced-brace scan respecting strings/escapes (replaces the greedy regex, which could match garbage between the first `{` and the last `}`).
5. *(new)* Repair a truncated prefix by closing unterminated strings and brackets, with fallbacks that strip dangling separators, keys, and partial scalars.

## Stricter system prompt

`build_json_system_prompt` now emits explicit STRICT output rules (first char `{`/`[`, no markdown fences, no preamble, no chain-of-thought) to reduce the incidence of the above failures in the first place.

## Verified against live MiniMax-M2.7

Before (same request, same seed):
```
content: null
tool_calls: [{"function": {"name": "John", "arguments": "{}"}}]
finish_reason: tool_calls
```

After:
```
content: '{"name": "John", "age": 25}'
tool_calls: null
finish_reason: stop
```

## Test plan

- [x] `pytest tests/test_structured_output.py tests/test_minimax_tool_calling.py` — 54 passed, 2 skipped
- [x] Live MiniMax-M2.7 — `response_format=json_schema` returns valid JSON in `content`, `tool_calls=null`, `finish_reason=stop`
- [x] Live MiniMax-M2.7 — genuine tool call (`get_weather`) still emitted with correct `name=get_weather`, `arguments={"city":"Prague"}`
- [x] Live MiniMax-M2.7 — plain chat (no tools, no response_format) unaffected
- [x] New unit tests: `TestRawJsonToolCallHijackPrevention` (6 tests), chatty/truncation coverage in `TestExtractJsonFromText` (9 tests), STRICT-rules coverage in `TestBuildJsonSystemPrompt` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)