### PR TITLE
Strip markdown code fences from streaming response_format content

### DIFF
--- a/tests/test_streaming_fence_stripper.py
+++ b/tests/test_streaming_fence_stripper.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``StreamingJsonFenceStripper`` — strips markdown code fences
+from streamed ``response_format`` content.
+"""
+
+from vllm_mlx.api.tool_calling import StreamingJsonFenceStripper
+
+
+def _stream(chunks):
+    """Feed ``chunks`` through a fresh stripper and collect emitted text."""
+    s = StreamingJsonFenceStripper()
+    out = []
+    for c in chunks:
+        out.append(s.feed(c))
+    out.append(s.finalize())
+    return "".join(out)
+
+
+class TestStreamingFenceStripperNoFence:
+    def test_single_delta_no_fence(self):
+        assert _stream(['{"answer": true}']) == '{"answer": true}'
+
+    def test_multiple_deltas_no_fence(self):
+        assert _stream(["{", '"a"', ":", "1", "}"]) == '{"a":1}'
+
+    def test_empty_input(self):
+        assert _stream([]) == ""
+
+    def test_only_empty_deltas(self):
+        assert _stream(["", "", ""]) == ""
+
+    def test_content_with_inner_backticks_preserved(self):
+        # Backticks inside a string value must not be interpreted as a fence.
+        text = '{"code": "x `y` z"}'
+        assert _stream([text]) == text
+
+
+class TestStreamingFenceStripperLeadingFence:
+    def test_leading_backticks_json_newline(self):
+        assert _stream(['```json\n{"a": 1}']) == '{"a": 1}'
+
+    def test_leading_backticks_json(self):
+        assert _stream(['```json{"a": 1}']) == '{"a": 1}'
+
+    def test_leading_backticks_newline(self):
+        assert _stream(['```\n{"a": 1}']) == '{"a": 1}'
+
+    def test_leading_bare_backticks(self):
+        assert _stream(['```{"a": 1}']) == '{"a": 1}'
+
+    def test_leading_whitespace_then_fence(self):
+        assert _stream(['  \n ```json\n{"a": 1}']) == '{"a": 1}'
+
+    def test_fence_split_across_deltas_at_backticks(self):
+        # Classic case: tokenizer splits ``` from ``json``.
+        assert _stream(["```", 'json\n{"a":1}']) == '{"a":1}'
+
+    def test_fence_split_inside_json_word(self):
+        assert _stream(["```jso", 'n\n{"a":1}']) == '{"a":1}'
+
+    def test_fence_split_after_each_char(self):
+        assert (
+            _stream(["`", "`", "`", "j", "s", "o", "n", "\n", '{"a":1}']) == '{"a":1}'
+        )
+
+    def test_no_fence_but_starts_with_backtick_char(self):
+        # A single backtick should NOT be treated as a fence prefix forever —
+        # as soon as a non-fence-prefix char arrives, we emit.
+        assert _stream(["`hello`"]) == "`hello`"
+
+
+class TestStreamingFenceStripperTrailingFence:
+    def test_trailing_backticks(self):
+        assert _stream(['{"a": 1}```']) == '{"a": 1}'
+
+    def test_trailing_newline_backticks(self):
+        assert _stream(['{"a": 1}\n```']) == '{"a": 1}'
+
+    def test_trailing_newline_backticks_newline(self):
+        assert _stream(['{"a": 1}\n```\n']) == '{"a": 1}'
+
+    def test_trailing_fence_split_across_deltas(self):
+        assert _stream(['{"a": 1}', "\n`", "``\n"]) == '{"a": 1}'
+
+    def test_full_wrap_single_delta(self):
+        assert _stream(['```json\n{"a": 1}\n```']) == '{"a": 1}'
+
+    def test_full_wrap_split_deltas(self):
+        assert _stream(["```json\n", '{"a": ', "1}", "\n", "```"]) == '{"a": 1}'
+
+
+class TestStreamingFenceStripperOrdering:
+    def test_no_fence_emits_incrementally(self):
+        s = StreamingJsonFenceStripper()
+        # Long-enough chunk: should emit everything except last 5 chars now.
+        first = s.feed('{"result": "ok", "count": 42}')
+        # 29 chars in; held back = 5, so 24 emitted.
+        assert first == '{"result": "ok", "count"'
+        last = s.finalize()
+        assert last == ": 42}"
+        assert first + last == '{"result": "ok", "count": 42}'
+
+    def test_leading_fence_emits_past_holdback(self):
+        s = StreamingJsonFenceStripper()
+        out1 = s.feed('```json\n{"a": 1, "b": 2, "c": 3}')
+        # After stripping fence: '{"a": 1, "b": 2, "c": 3}' (24 chars).
+        # Emit 24 - 5 = 19 chars now.
+        assert out1 == '{"a": 1, "b": 2, "c'
+        out2 = s.finalize()
+        assert out2 == '": 3}'
+        assert out1 + out2 == '{"a": 1, "b": 2, "c": 3}'
+
+    def test_leading_fence_only_no_content(self):
+        # Stream ends with just the fence and no JSON — should emit nothing.
+        assert _stream(["```json\n"]) == ""
+
+    def test_leading_partial_fence_only(self):
+        # Stream ends with just a partial fence — finalize should strip it.
+        assert _stream(["```js"]) == ""
+
+
+class TestStreamingFenceStripperEdgeCases:
+    def test_content_ending_with_backtick_in_string(self):
+        # Single trailing backtick at end of content — held back then emitted.
+        text = '{"note": "end `"}'
+        assert _stream([text]) == text
+
+    def test_fence_with_extra_whitespace_around_closing(self):
+        # Extra whitespace after closing fence still strips.
+        assert _stream(['{"a": 1}\n```   ']) == '{"a": 1}'
+
+    def test_array_output(self):
+        assert _stream(["```json\n[1, 2, 3]\n```"]) == "[1, 2, 3]"
+
+    def test_empty_object(self):
+        assert _stream(["```json\n{}\n```"]) == "{}"

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -460,6 +460,127 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+class StreamingJsonFenceStripper:
+    """Strip markdown code fences from streamed content when response_format is set.
+
+    Without guided decoding, chat models often wrap their JSON output in markdown
+    fences (```json ... ```) even when the system prompt says not to. The non-
+    streaming path strips those via ``extract_json_from_text`` / ``parse_json_output``,
+    but the streaming path used to emit the raw deltas, so clients got
+    ``"```json{...}```"`` instead of ``"{...}"``.
+
+    This filter buffers just enough text to detect:
+      * a leading fence like ``"```"``, ``"```json"``, ``"```\\n"`` or
+        ``"```json\\n"`` (with optional leading whitespace), possibly split
+        across SSE deltas, and
+      * a trailing fence like ``"```"`` or ``"\\n```\\n"`` on stream end.
+
+    Leading-whitespace and leading fences are consumed; trailing fences are
+    dropped in :meth:`finalize`. Non-fenced content passes through with at most
+    a ``_TAIL_HOLDBACK``-char delay.
+    """
+
+    # Opening fence forms to strip, longest first (longest match wins).
+    _OPENINGS = ("```json\n", "```json", "```\n", "```")
+    # Characters held back at the tail to detect a trailing fence across deltas.
+    # 5 covers ``"\n```\n"``.
+    _TAIL_HOLDBACK = 5
+
+    def __init__(self) -> None:
+        self._buf: str = ""
+        self._past_opening: bool = False
+
+    def feed(self, delta: str) -> str:
+        """Append a content delta and return the portion safe to emit now."""
+        if not delta:
+            return ""
+
+        self._buf += delta
+
+        if not self._past_opening:
+            ls = self._buf.lstrip()
+            if not ls:
+                # Still only whitespace — wait for content.
+                return ""
+
+            # If ``ls`` is a strict prefix of any opening (shorter than the
+            # opening), the rest of the fence might still arrive in the next
+            # delta — keep buffering.
+            for opening in self._OPENINGS:
+                if len(ls) < len(opening) and opening.startswith(ls):
+                    return ""
+
+            # Try to match a complete opening fence (longest first).
+            matched: Optional[str] = None
+            for opening in self._OPENINGS:
+                if ls.startswith(opening):
+                    matched = opening
+                    break
+
+            if matched is not None:
+                # Drop the fence and any immediate whitespace that followed.
+                self._buf = ls[len(matched) :].lstrip()
+            else:
+                # Not a fence — keep the stripped text.
+                self._buf = ls
+            self._past_opening = True
+
+        # Dynamic holdback: walk backwards across any trailing whitespace and
+        # backticks so a closing fence cannot straddle the emit boundary, and
+        # additionally keep at least ``_TAIL_HOLDBACK`` chars to absorb fences
+        # that span delta boundaries.
+        buf = self._buf
+        i = len(buf)
+        while i > 0 and (buf[i - 1] == "`" or buf[i - 1].isspace()):
+            i -= 1
+        safe_end = min(i, len(buf) - self._TAIL_HOLDBACK)
+        if safe_end <= 0:
+            return ""
+
+        to_emit = buf[:safe_end]
+        self._buf = buf[safe_end:]
+        return to_emit
+
+    def finalize(self) -> str:
+        """Flush the remaining buffer, dropping any trailing fence."""
+        tail = self._buf
+        self._buf = ""
+        if not tail:
+            return ""
+
+        if not self._past_opening:
+            # Stream ended before we ever transitioned past the (potential)
+            # opening — either drop a strict-prefix fence that never finished
+            # arriving, or strip a complete leading fence.
+            ls = tail.lstrip()
+            # Check strict-prefix FIRST: ``"```js"`` is a prefix of
+            # ``"```json\n"`` and should be dropped entirely rather than
+            # partially matched by the bare ``"```"`` opening.
+            is_partial_prefix = False
+            for opening in self._OPENINGS:
+                if len(ls) < len(opening) and opening.startswith(ls):
+                    is_partial_prefix = True
+                    break
+            if is_partial_prefix:
+                ls = ""
+            else:
+                matched: Optional[str] = None
+                for opening in self._OPENINGS:
+                    if ls.startswith(opening):
+                        matched = opening
+                        break
+                if matched is not None:
+                    ls = ls[len(matched) :].lstrip()
+            tail = ls
+            self._past_opening = True
+
+        stripped = tail.rstrip()
+        for closing in ("\n```", "```"):
+            if stripped.endswith(closing):
+                return stripped[: -len(closing)].rstrip()
+        return tail
+
+
 def parse_json_output(
     text: str, response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None
 ) -> Tuple[str, Optional[Dict[str, Any]], bool, Optional[str]]:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -98,6 +98,7 @@ from .api.models import (
     VideoUrl,  # noqa: F401
 )
 from .api.tool_calling import (
+    StreamingJsonFenceStripper,
     build_json_system_prompt,
     convert_tools_for_template,
     parse_json_output,
@@ -2617,6 +2618,21 @@ async def stream_chat_completion(
     completion_tokens = 0
     last_output = None
 
+    # Response-format streaming filter — strip markdown code fences from
+    # content when client asked for JSON. Non-streaming path strips fences
+    # via ``parse_json_output``; without this, streaming clients see
+    # ``"```json{...}```"`` instead of ``"{...}"`` for models that wrap
+    # their structured output in markdown (e.g. Gemma 4).
+    fence_stripper: StreamingJsonFenceStripper | None = None
+    _rf = getattr(request, "response_format", None)
+    _rf_type = None
+    if _rf is not None:
+        _rf_type = getattr(_rf, "type", None)
+        if _rf_type is None and isinstance(_rf, dict):
+            _rf_type = _rf.get("type")
+    if _rf_type in ("json_object", "json_schema"):
+        fence_stripper = StreamingJsonFenceStripper()
+
     # Tool call streaming state
     global _tool_parser_instance
     tool_parser = None
@@ -2765,6 +2781,14 @@ async def stream_chat_completion(
                         if content:
                             content = _TOOL_MARKUP_PATTERN.sub("", content)
 
+                # Strip markdown code fences when response_format is set.
+                if fence_stripper is not None and not tool_calls_detected:
+                    content = fence_stripper.feed(content) if content else ""
+                    if output.finished:
+                        flush = fence_stripper.finalize()
+                        if flush:
+                            content = content + flush
+
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=_model_name,
@@ -2857,6 +2881,14 @@ async def stream_chat_completion(
                         # Strip any leaked tool markup tags
                         if content:
                             content = _TOOL_MARKUP_PATTERN.sub("", content)
+
+                # Strip markdown code fences when response_format is set.
+                if fence_stripper is not None and not tool_calls_detected:
+                    content = fence_stripper.feed(content) if content else ""
+                    if output.finished:
+                        flush = fence_stripper.finalize()
+                        if flush:
+                            content = content + flush
 
                 chunk = ChatCompletionChunk(
                     id=response_id,


### PR DESCRIPTION
## Summary

When a client requests structured output via `response_format={"type": "json_object" | "json_schema", ...}` **and** uses streaming, models that don't have guided-decoding enforcement (e.g. Gemma 4) often wrap the JSON in a markdown fence, so the client sees:

```
```json
{"pain_points": [...]}
```
```

instead of `{"pain_points": [...]}`. The non-streaming path already strips these via `parse_json_output` / `extract_json_from_text`, but the streaming path emitted the raw deltas — breaking `json.loads` on the client.

## Repro

Before this PR, on a Gemma 4 server with `response_format={"type": "json_schema", ...}`:

| Mode          | Output                                                 |
|---------------|--------------------------------------------------------|
| Non-streaming | `{"pain_points": [...]}` ✓ valid JSON                 |
| Streaming     | ``` ```json\n{"pain_points":[...]}\n``` ``` ❌ fenced |

After this PR:

| Mode          | Output                                                 |
|---------------|--------------------------------------------------------|
| Non-streaming | `{"pain_points": [...]}` ✓ valid JSON                 |
| Streaming     | `{"pain_points":[...]}` ✓ valid JSON                  |

## Design — `StreamingJsonFenceStripper`

A small stateful filter (`vllm_mlx/api/tool_calling.py`) that:

- Strips a leading fence (`` ``` ``, `` ```json ``, `` ```\n ``, `` ```json\n ``, with optional leading whitespace), detecting and consuming fences **split across delta boundaries** (e.g. one delta sends `` ``` `` and the next sends `json\n{...}`).
- Holds back a small tail (~5 chars + any trailing whitespace/backticks) so a closing fence cannot straddle the emit boundary.
- On `finalize()`, drops any trailing `` ``` `` / `` \n``` ``, and also drops a strict-prefix fence that never completed (e.g. stream ended on `` ```js ``).

## Wiring

`stream_chat_completion` in `vllm_mlx/server.py`:

1. Instantiates `fence_stripper` when `request.response_format.type in {"json_object", "json_schema"}`, handling both the pydantic `ResponseFormat` model and a plain `dict`.
2. Routes `content` through `fence_stripper.feed(...)` in both content emit sites (reasoning-parser path and standard path) — but **only** when no tool calls have been detected (tool outputs are never wrapped in JSON fences).
3. On the final delta (`output.finished == True`), appends `fence_stripper.finalize()` to the content of that chunk so buffered tail text is flushed in-place.

## Tests

28 unit tests in `tests/test_streaming_fence_stripper.py` cover:

- No-fence passthrough, incremental emits, inner backticks preserved
- Leading fences in every form, including split across every single character
- Trailing fences (including split across deltas, extra whitespace)
- Full wraps and empty objects/arrays
- Edge cases: single trailing backtick in string, partial fence prefix at EOS, bare-backtick content

## Verified

Tested against a live Gemma 4 service (`mlx-community/gemma-4-26b-a4b-it` mixed 6/8-bit) with streaming + `json_schema`:

- Before: `'```json\n{"pain_points": [...]}\n```'` — not parseable
- After:  `'{"pain_points": [...]}'` — valid JSON ✓

Non-JSON streaming and Minimax streaming (which already worked via a stricter system prompt) both unchanged — regression-verified.

## Test plan

- [x] `pytest tests/test_streaming_fence_stripper.py -v` — 28 passed
- [x] `uvx black vllm_mlx/ tests/test_streaming_fence_stripper.py` — clean
- [x] Live test: Gemma 4 streaming + `json_schema` → valid JSON
- [x] Regression: plain streaming (no `response_format`) unaffected