### PR TITLE
Add JSON Schema constrained decoding via lm-format-enforcer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
     "mcp>=1.0.0",
     # JSON Schema validation for structured output
     "jsonschema>=4.0.0",
+    # Constrained decoding (grammar-guided generation for response_format)
+    "lm-format-enforcer>=0.10.9",
     # pytz is required by gradio but not declared as a dependency
     # See: https://github.com/waybarrios/vllm-mlx/issues/23
     "pytz>=2024.1",

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for JSON-schema constrained decoding.
+
+Covers:
+
+* ``vllm_mlx.constrained.cache`` — tokenizer-data construction and caching.
+* ``vllm_mlx.constrained.json_schema_processor.JSONSchemaLogitsProcessor``
+  — mask shape, token filtering, schema enforcement.
+* ``vllm_mlx.api.tool_calling.build_json_logits_processor`` — builder glue.
+* ``vllm_mlx.api.anthropic_adapter.anthropic_to_openai`` — propagation of
+  the OpenAI-compatible ``response_format`` extension field from
+  ``/v1/messages`` requests.
+
+These tests are pure-logic: they use a minimal fake tokenizer (ASCII
+vocabulary) to avoid pulling in a 200k-entry HF tokenizer at test time.
+They skip gracefully when ``lm-format-enforcer`` is not installed, so CI
+running with a minimal dependency set still passes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
+from vllm_mlx.api.models import ResponseFormat, ResponseFormatJsonSchema
+from vllm_mlx.api.tool_calling import build_json_logits_processor
+from vllm_mlx.constrained import is_available
+from vllm_mlx.constrained.cache import clear_cache, get_tokenizer_data
+
+# Skip all processor-level tests if the optional dependency is missing.
+pytestmark_lmfe = pytest.mark.skipif(
+    not is_available(),
+    reason="lm-format-enforcer not installed",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake tokenizer — just enough API surface for the cache + processor.
+# ---------------------------------------------------------------------------
+
+
+class _FakeTokenizer:
+    """
+    Deterministic, tiny tokenizer for unit tests.
+
+    Vocabulary is a small ASCII set (digits, brackets, whitespace, quotes,
+    a handful of letters).  IDs start at 0 and are stable across instances.
+    Special tokens (EOS/BOS) occupy the end of the range.
+    """
+
+    def __init__(self) -> None:
+        chars = list('0123456789{}[]:," \n\ttrueflasnul')
+        # Deduplicate while preserving order.
+        seen: set[str] = set()
+        unique: list[str] = []
+        for c in chars:
+            if c not in seen:
+                seen.add(c)
+                unique.append(c)
+        self._id_to_tok = unique + ["<eos>", "<bos>"]
+        self._tok_to_id = {t: i for i, t in enumerate(self._id_to_tok)}
+        self.vocab_size = len(self._id_to_tok)
+        self.eos_token_id = self._tok_to_id["<eos>"]
+        self.all_special_ids = [
+            self._tok_to_id["<eos>"],
+            self._tok_to_id["<bos>"],
+        ]
+
+    def __len__(self) -> int:
+        return self.vocab_size
+
+    def encode(self, text: str) -> list[int]:
+        out: list[int] = []
+        for ch in text:
+            if ch in self._tok_to_id:
+                out.append(self._tok_to_id[ch])
+        return out
+
+    def decode(self, ids: list[int]) -> str:
+        parts: list[str] = []
+        for i in ids:
+            if 0 <= i < len(self._id_to_tok):
+                tok = self._id_to_tok[i]
+                if not tok.startswith("<"):
+                    parts.append(tok)
+        return "".join(parts)
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self._tok_to_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer-data cache.
+# ---------------------------------------------------------------------------
+
+
+@pytestmark_lmfe
+class TestTokenizerDataCache:
+    def test_builds_data_for_fake_tokenizer(self):
+        tok = _FakeTokenizer()
+        data = get_tokenizer_data(tok)
+        assert data is not None
+        assert data.vocab_size == tok.vocab_size
+
+    def test_cache_reuse_same_tokenizer(self):
+        tok = _FakeTokenizer()
+        first = get_tokenizer_data(tok)
+        second = get_tokenizer_data(tok)
+        assert first is second  # cached object returned verbatim
+
+    def test_separate_tokenizers_get_separate_entries(self):
+        a = _FakeTokenizer()
+        b = _FakeTokenizer()
+        assert get_tokenizer_data(a) is not get_tokenizer_data(b)
+
+
+# ---------------------------------------------------------------------------
+# build_json_logits_processor() — builder glue.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJsonLogitsProcessor:
+    """These tests don't require lm-format-enforcer — they just check glue."""
+
+    def test_text_returns_none(self):
+        tok = _FakeTokenizer()
+        result = build_json_logits_processor({"type": "text"}, tok)
+        assert result is None
+
+    def test_none_returns_none(self):
+        tok = _FakeTokenizer()
+        result = build_json_logits_processor(None, tok)
+        assert result is None
+
+    def test_unsupported_type_returns_none(self):
+        tok = _FakeTokenizer()
+        result = build_json_logits_processor({"type": "xml"}, tok)
+        assert result is None
+
+    @pytestmark_lmfe
+    def test_json_object_builds_processor(self):
+        tok = _FakeTokenizer()
+        result = build_json_logits_processor({"type": "json_object"}, tok)
+        assert result is not None
+
+    @pytestmark_lmfe
+    def test_json_schema_builds_processor(self):
+        tok = _FakeTokenizer()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "person",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "age": {"type": "integer"},
+                    },
+                    "required": ["name", "age"],
+                },
+            },
+        }
+        result = build_json_logits_processor(response_format, tok)
+        assert result is not None
+
+    @pytestmark_lmfe
+    def test_json_schema_pydantic_model(self):
+        tok = _FakeTokenizer()
+        response_format = ResponseFormat(
+            type="json_schema",
+            json_schema=ResponseFormatJsonSchema(
+                name="result",
+                schema={"type": "object", "properties": {"ok": {"type": "boolean"}}},
+            ),
+        )
+        result = build_json_logits_processor(response_format, tok)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# JSONSchemaLogitsProcessor — mask semantics.
+# ---------------------------------------------------------------------------
+
+
+@pytestmark_lmfe
+class TestProcessorMask:
+    def _make_processor(self, schema: dict | None = None):
+        from vllm_mlx.constrained import JSONSchemaLogitsProcessor
+
+        tok = _FakeTokenizer()
+        return JSONSchemaLogitsProcessor(schema, tok), tok
+
+    def test_mask_shape_matches_logits(self):
+        import mlx.core as mx
+
+        processor, tok = self._make_processor()
+        # Emulate: one prompt token already consumed, cursor at first
+        # generation step (tokens contains prompt+1 generated).
+        prompt = tok.encode(" ")  # a single harmless token as "prompt"
+        tokens = mx.array(prompt)
+        logits = mx.zeros((tok.vocab_size,))
+        masked = processor(tokens, logits)
+        assert masked.shape == logits.shape
+
+    def test_mask_shape_matches_2d_logits(self):
+        import mlx.core as mx
+
+        processor, tok = self._make_processor()
+        prompt = tok.encode(" ")
+        tokens = mx.array(prompt)
+        logits = mx.zeros((1, tok.vocab_size))
+        masked = processor(tokens, logits)
+        assert masked.shape == logits.shape
+
+    def test_allows_at_least_one_token_at_start(self):
+        """At the start of a JSON value, at least ``{`` or ``[`` must pass."""
+        import mlx.core as mx
+
+        processor, tok = self._make_processor()
+        prompt = tok.encode(" ")
+        tokens = mx.array(prompt)
+        logits = mx.zeros((tok.vocab_size,))
+        masked = processor(tokens, logits)
+        # At least one finite entry must remain.
+        finite = (masked != -float("inf")).sum().item()
+        assert finite >= 1
+
+    def test_processor_never_crashes_on_arbitrary_state(self):
+        """Defensive: even with unexpected token history, returns logits."""
+        import mlx.core as mx
+
+        processor, _ = self._make_processor()
+        # Pass nonsensical tokens — the processor's except handler should
+        # catch any parser error and return the original logits unchanged.
+        tokens = mx.array([999999])  # out-of-vocab id
+        logits = mx.zeros((8,))
+        result = processor(tokens, logits)
+        assert result.shape == logits.shape
+
+
+# ---------------------------------------------------------------------------
+# Anthropic adapter — response_format propagation.
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicAdapterResponseFormat:
+    def test_response_format_propagates_dict(self):
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=50,
+            response_format={"type": "json_object"},
+        )
+        openai_req = anthropic_to_openai(req)
+        assert openai_req.response_format is not None
+        # ChatCompletionRequest coerces the dict into ResponseFormat.
+        rf_type = (
+            openai_req.response_format.type
+            if hasattr(openai_req.response_format, "type")
+            else openai_req.response_format.get("type")
+        )
+        assert rf_type == "json_object"
+
+    def test_response_format_json_schema_propagates(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Give a name")],
+            max_tokens=50,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "person", "schema": schema},
+            },
+        )
+        openai_req = anthropic_to_openai(req)
+        assert openai_req.response_format is not None
+        rf = openai_req.response_format
+        rf_type = rf.type if hasattr(rf, "type") else rf.get("type")
+        assert rf_type == "json_schema"
+
+    def test_missing_response_format_is_none(self):
+        req = AnthropicRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=50,
+        )
+        openai_req = anthropic_to_openai(req)
+        assert openai_req.response_format is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -92,6 +92,9 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
         stop=request.stop_sequences,
         tools=tools,
         tool_choice=tool_choice,
+        # Forward response_format as-is; ChatCompletionRequest coerces raw
+        # dicts into the strict ResponseFormat model via pydantic.
+        response_format=request.response_format,
     )
 
 

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -65,6 +65,10 @@ class AnthropicRequest(BaseModel):
     tool_choice: dict | None = None
     metadata: dict | None = None
     top_k: int | None = None
+    # OpenAI-compatible extension (not in the official Anthropic spec, but
+    # clients commonly forward it via extra_body or top-level for structured
+    # output / constrained decoding on this endpoint).
+    response_format: dict | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -912,3 +912,85 @@ def build_json_system_prompt(
         return prompt
 
     return None
+
+
+def build_json_logits_processor(
+    response_format: ResponseFormat | dict[str, Any] | None,
+    tokenizer: Any,
+):
+    """
+    Build a logits processor that constrains generation to valid JSON matching
+    ``response_format``.
+
+    Unlike :func:`build_json_system_prompt` which nudges the model via the
+    system prompt, this processor masks logits at every generation step so
+    the model *cannot* emit invalid JSON (grammar-guided decoding).
+
+    Args:
+        response_format: ``ResponseFormat`` specification (or dict).
+        tokenizer: The tokenizer used by the engine.  May be a HF tokenizer,
+            a ``mlx_lm.TokenizerWrapper``, or a VLM ``processor``; the
+            underlying tokenizer is resolved automatically.
+
+    Returns:
+        A callable ``(tokens, logits) -> logits`` suitable for passing to
+        ``mlx_lm.stream_generate`` via ``logits_processors``.  ``None`` when
+        no constraint is needed (e.g. ``type=text``) or when constrained
+        decoding cannot be enabled (missing optional dependency, tokenizer
+        incompatibility) — in that case the caller should fall back to the
+        system-prompt path.
+    """
+    if response_format is None:
+        return None
+
+    # Normalize to dict
+    if isinstance(response_format, ResponseFormat):
+        format_type = response_format.type
+        schema: dict | None = None
+        if response_format.json_schema is not None:
+            schema = response_format.json_schema.schema_
+    elif isinstance(response_format, dict):
+        format_type = response_format.get("type", "text")
+        json_schema_spec = response_format.get("json_schema") or {}
+        if isinstance(json_schema_spec, dict):
+            schema = json_schema_spec.get("schema")
+        else:
+            schema = getattr(json_schema_spec, "schema_", None) or getattr(
+                json_schema_spec, "schema", None
+            )
+    else:
+        return None
+
+    if format_type == "text":
+        return None
+
+    if format_type not in ("json_object", "json_schema"):
+        return None
+
+    try:
+        from ..constrained import (
+            JSONSchemaLogitsProcessor,
+            LMFormatEnforcerNotAvailableError,
+            is_available,
+        )
+    except ImportError:
+        # Constrained decoding module could not be imported; fall back.
+        return None
+
+    if not is_available():
+        # ``lm-format-enforcer`` optional dependency missing; fall back.
+        return None
+
+    # ``json_schema`` without an actual schema degrades to ``json_object``
+    # (both paths pass ``schema=None`` to the processor).
+    if format_type == "json_object" or (format_type == "json_schema" and not schema):
+        schema = None
+
+    try:
+        return JSONSchemaLogitsProcessor(schema=schema, tokenizer=tokenizer)
+    except LMFormatEnforcerNotAvailableError:
+        return None
+    except Exception:
+        # Malformed schema or tokenizer issue — fall back to prompt-only
+        # mode.  Callers still run post-hoc validation as a safety net.
+        return None

--- a/vllm_mlx/constrained/__init__.py
+++ b/vllm_mlx/constrained/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Constrained decoding for grammar-guided generation.
+
+Provides logits processors that mask token probabilities during generation
+so the model can only emit sequences matching a target grammar (e.g. a JSON
+schema).  Used by the ``response_format`` parameter on the chat completion
+and Anthropic Messages endpoints.
+"""
+
+from .json_schema_processor import (
+    JSONSchemaLogitsProcessor,
+    LMFormatEnforcerNotAvailableError,
+    is_available,
+)
+
+__all__ = [
+    "JSONSchemaLogitsProcessor",
+    "LMFormatEnforcerNotAvailableError",
+    "is_available",
+]

--- a/vllm_mlx/constrained/cache.py
+++ b/vllm_mlx/constrained/cache.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Cache of ``TokenEnforcerTokenizerData`` objects keyed by tokenizer identity.
+
+Building ``TokenEnforcerTokenizerData`` requires iterating over the entire
+vocabulary (up to 200k tokens on MiniMax/GLM) and decoding each token.  The
+cost is ~1-2 seconds per model and the result is independent of the JSON
+schema, so we cache it for the lifetime of the process.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Keyed by ``id(tokenizer)`` because tokenizer instances are not hashable
+# across HF/MLX wrappers, but each server loads a single tokenizer per model.
+_CACHE: dict[int, Any] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _resolve_inner_tokenizer(tokenizer: Any) -> Any:
+    """
+    VLM processors wrap the actual tokenizer under ``processor.tokenizer``.
+    ``mlx_lm.tokenizer_utils.TokenizerWrapper`` exposes it via ``_tokenizer``.
+    Return the most-unwrapped tokenizer that still has the HF
+    ``all_special_ids`` / ``eos_token_id`` surface.
+
+    Note: on HF ``PreTrainedTokenizerFast``, ``_tokenizer`` points at the
+    rust-level object which lacks ``all_special_ids``; unwrapping to that
+    level would cause every special token (``<eos>``, ``<pad>``, ``\\n``,
+    ``<|think|>`` …) to leak into ``regular_tokens`` and end up in
+    ``TokenizerPrefixTree.root`` as an always-allowed token.  We only
+    unwrap when the inner layer still exposes ``all_special_ids``.
+    """
+    # VLM processor wrapper exposes the HF tokenizer under ``tokenizer``.
+    inner = getattr(tokenizer, "tokenizer", None)
+    if (
+        inner is not None
+        and inner is not tokenizer
+        and hasattr(inner, "all_special_ids")
+    ):
+        tokenizer = inner
+    # mlx_lm TokenizerWrapper keeps the raw HF tokenizer under ``_tokenizer``.
+    # Only unwrap if the inner object still exposes the HF tokenizer surface.
+    inner = getattr(tokenizer, "_tokenizer", None)
+    if inner is not None and hasattr(inner, "all_special_ids"):
+        tokenizer = inner
+    return tokenizer
+
+
+def _build_regular_tokens_list(
+    tokenizer: Any, vocab_size: int
+) -> list[tuple[int, str, bool]]:
+    """
+    Enumerate the regular (non-special) tokens in the vocabulary and produce
+    the ``(token_id, decoded_with_leading_space_marker, is_word_start)`` tuples
+    required by ``TokenEnforcerTokenizerData``.
+
+    Mirrors the reference implementation in ``lmformatenforcer.integrations.
+    transformers`` but works with the HF tokenizer surface only (so we do not
+    need a hard transformers dependency at the right version).
+    """
+    try:
+        special_ids = set(tokenizer.all_special_ids)
+    except AttributeError:
+        special_ids = set()
+
+    try:
+        token_0 = tokenizer.encode("0")[-1]
+    except Exception:
+        token_0 = None
+
+    regular_tokens: list[tuple[int, str, bool]] = []
+    for token_idx in range(vocab_size):
+        if token_idx in special_ids:
+            continue
+        try:
+            decoded_regular = tokenizer.decode([token_idx])
+        except Exception:
+            continue
+        if token_0 is not None:
+            try:
+                decoded_after_0 = tokenizer.decode([token_0, token_idx])[1:]
+            except Exception:
+                decoded_after_0 = decoded_regular
+        else:
+            decoded_after_0 = decoded_regular
+        is_word_start_token = len(decoded_after_0) > len(decoded_regular)
+        regular_tokens.append((token_idx, decoded_after_0, is_word_start_token))
+    return regular_tokens
+
+
+def _get_eos_token_id(tokenizer: Any) -> int | list[int]:
+    # Some tokenizers expose multiple EOS candidates (e.g. Gemma 4 has
+    # [1 <eos>, 106 <end_of_turn>, 50 <|think|>] in generation_config.json).
+    # Prefer the list form so all stop tokens are treated as EOS by the
+    # enforcer; otherwise the model may emit an out-of-schema stop token
+    # that the enforcer did not mask (because it's a special token not in
+    # ``regular_tokens``), yet the inference runtime still treats as stop.
+    eos_list = getattr(tokenizer, "eos_token_ids", None)
+    if isinstance(eos_list, (list, tuple)) and eos_list:
+        return list(eos_list)
+    eos = getattr(tokenizer, "eos_token_id", None)
+    if eos is not None:
+        return eos
+    return 0
+
+
+def _get_vocab_size(tokenizer: Any) -> int:
+    vs = getattr(tokenizer, "vocab_size", None)
+    if isinstance(vs, int) and vs > 0:
+        return vs
+    try:
+        return len(tokenizer)
+    except TypeError:
+        pass
+    get_vocab = getattr(tokenizer, "get_vocab", None)
+    if callable(get_vocab):
+        return len(get_vocab())
+    raise ValueError("Cannot determine tokenizer vocab size")
+
+
+def _decode_function(tokenizer: Any, tokens: list[int]) -> str:
+    try:
+        decoded = tokenizer.decode(tokens)
+    except Exception:
+        return ""
+    return decoded.rstrip("\ufffd") if isinstance(decoded, str) else ""
+
+
+def get_tokenizer_data(tokenizer: Any) -> Any | None:
+    """
+    Return a cached ``TokenEnforcerTokenizerData`` for ``tokenizer``.
+
+    Returns ``None`` if ``lm-format-enforcer`` is not installed or the
+    tokenizer cannot be adapted.
+    """
+    try:
+        from lmformatenforcer.tokenenforcer import TokenEnforcerTokenizerData
+    except ImportError:
+        return None
+
+    inner = _resolve_inner_tokenizer(tokenizer)
+    key = id(inner)
+    with _CACHE_LOCK:
+        cached = _CACHE.get(key)
+        if cached is not None:
+            return cached
+
+    try:
+        vocab_size = _get_vocab_size(inner)
+    except Exception as exc:
+        logger.warning(
+            "Could not determine vocab size for constrained decoding: %s", exc
+        )
+        return None
+
+    try:
+        regular_tokens = _build_regular_tokens_list(inner, vocab_size)
+        decode_fn = functools.partial(_decode_function, inner)
+        eos_token_id = _get_eos_token_id(inner)
+        data = TokenEnforcerTokenizerData(
+            regular_tokens,
+            decode_fn,
+            eos_token_id,
+            False,  # use_bitmask
+            vocab_size,
+        )
+    except Exception as exc:
+        logger.warning("Failed to build TokenEnforcerTokenizerData: %s", exc)
+        return None
+
+    with _CACHE_LOCK:
+        _CACHE[key] = data
+    return data
+
+
+def clear_cache() -> None:
+    """Drop the cache (mainly for tests)."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -1,0 +1,613 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+``JSONSchemaLogitsProcessor`` — a ``mlx_lm``-compatible logits processor that
+masks the vocabulary so the model can only emit tokens forming a valid JSON
+value (optionally matching a JSON schema).
+
+The processor implements the signature expected by ``mlx_lm.generate.generate_step``
+and ``vllm_mlx``'s batched engine alike:
+
+    processor(tokens: mx.array, logits: mx.array) -> mx.array
+
+``tokens`` contains the full sequence generated for this request so far
+(prompt + previously emitted tokens), and ``logits`` is the last-step logits
+row.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+from .cache import get_tokenizer_data
+
+logger = logging.getLogger(__name__)
+
+
+class LMFormatEnforcerNotAvailableError(RuntimeError):
+    """Raised when ``lm-format-enforcer`` is required but not installed."""
+
+
+def is_available() -> bool:
+    """Return ``True`` iff ``lm-format-enforcer`` is importable."""
+    try:
+        import lmformatenforcer  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# A permissive "any JSON value" schema for ``response_format.type = json_object``.
+# JSON spec allows any of {object, array, string, number, boolean, null} at the
+# top level, but realistic OpenAI ``json_object`` mode expects an object or
+# array at the root.
+_GENERIC_JSON_SCHEMA: dict = {
+    "anyOf": [
+        {"type": "object"},
+        {"type": "array"},
+    ]
+}
+
+
+def _simplify_schema(schema: dict) -> dict:
+    """Pre-process a JSON Schema for ``lm-format-enforcer`` compatibility.
+
+    ``lm-format-enforcer`` does not support ``$ref``, ``not``, ``type`` as an
+    array, or recursive definitions.  This function:
+
+    1. Resolves ``$ref`` by inlining referenced definitions (with cycle
+       detection so recursive definitions are truncated to ``{}``).
+    2. Removes ``not`` sub-schemas (makes the schema more permissive).
+    3. Converts ``type: [t1, t2, ...]`` to ``anyOf: [{type: t1}, ...]``.
+    4. Strips ``$schema`` and ``$id`` metadata keys.
+    5. Cleans up empty ``anyOf`` / ``oneOf`` branches.
+    """
+    schema = copy.deepcopy(schema)
+    definitions: dict = {}
+    definitions.update(schema.pop("definitions", {}))
+    definitions.update(schema.pop("$defs", {}))
+
+    resolving: set[str] = set()  # cycle guard
+
+    def _resolve(node: Any, depth: int = 0) -> Any:
+        if depth > 12 or not isinstance(node, dict):
+            return node
+
+        # --- resolve $ref --------------------------------------------------
+        if "$ref" in node:
+            ref: str = node["$ref"]
+            parts = ref.split("/")
+            if (
+                len(parts) == 3
+                and parts[0] == "#"
+                and parts[1] in ("definitions", "$defs")
+            ):
+                name = parts[2]
+                if name in definitions and ref not in resolving:
+                    resolving.add(ref)
+                    resolved = copy.deepcopy(definitions[name])
+                    # Merge extra keys (e.g. ``default``) from the $ref node.
+                    for k, v in node.items():
+                        if k != "$ref" and k not in resolved:
+                            resolved[k] = v
+                    result = _resolve(resolved, depth + 1)
+                    resolving.discard(ref)
+                    return result
+            # Circular or unresolvable — return empty (= any).
+            return {}
+
+        # --- remove unsupported keywords -----------------------------------
+        node.pop("not", None)
+        node.pop("$schema", None)
+        node.pop("$id", None)
+
+        # --- type array → anyOf --------------------------------------------
+        if isinstance(node.get("type"), list):
+            types = node.pop("type")
+            items_schema = node.pop("items", None)
+            branches: list[dict] = []
+            for t in types:
+                branch: dict[str, Any] = {"type": t}
+                if t == "array" and items_schema is not None:
+                    branch["items"] = _resolve(copy.deepcopy(items_schema), depth + 1)
+                branches.append(branch)
+            existing = node.pop("anyOf", [])
+            node["anyOf"] = existing + branches
+
+        # --- recurse into sub-schemas --------------------------------------
+        if "properties" in node and isinstance(node["properties"], dict):
+            for k in list(node["properties"]):
+                node["properties"][k] = _resolve(node["properties"][k], depth + 1)
+
+        for key in ("items", "additionalProperties"):
+            if key in node and isinstance(node[key], dict):
+                node[key] = _resolve(node[key], depth + 1)
+
+        for key in ("allOf", "anyOf", "oneOf"):
+            if key in node and isinstance(node[key], list):
+                # Resolve each branch; drop empty dicts (= "any", redundant
+                # inside anyOf since they make the whole constraint trivially
+                # true — but keeping one "any" branch confuses the enforcer).
+                resolved_items = [_resolve(item, depth + 1) for item in node[key]]
+                node[key] = [it for it in resolved_items if it != {}]
+                if not node[key]:
+                    del node[key]
+
+        return node
+
+    return _resolve(schema)
+
+
+def _force_no_additional_properties(schema: dict) -> dict:
+    """Return a deep copy of *schema* with ``additionalProperties: false``
+    injected into every object-type sub-schema that declares ``properties``.
+
+    ``lm-format-enforcer`` has a bug where multi-character tokens spanning
+    JSON structural boundaries (e.g., a single token that decodes to ``""``)
+    can produce empty or whitespace-only keys, causing ``KeyError`` crashes in
+    ``jsonschemaparser.py``.  Setting ``additionalProperties: false`` tells the
+    enforcer's trie traversal that only the declared property names are valid
+    keys, which significantly narrows the allowed tokens and prevents most of
+    these boundary-spanning issues.
+    """
+    schema = copy.deepcopy(schema)
+    _inject_no_additional_props(schema)
+    return schema
+
+
+def _inject_no_additional_props(node: Any) -> None:
+    """Recursively inject ``additionalProperties: false`` into *node*."""
+    if not isinstance(node, dict):
+        return
+    if "properties" in node and "additionalProperties" not in node:
+        node["additionalProperties"] = False
+    for value in node.values():
+        if isinstance(value, dict):
+            _inject_no_additional_props(value)
+        elif isinstance(value, list):
+            for item in value:
+                _inject_no_additional_props(item)
+
+
+def _collect_property_names(schema: dict | None) -> set[str]:
+    """Collect all property names declared anywhere in *schema*."""
+    names: set[str] = set()
+    if schema is None:
+        return names
+    _walk_properties(schema, names)
+    return names
+
+
+def _walk_properties(node: Any, names: set[str]) -> None:
+    if not isinstance(node, dict):
+        return
+    props = node.get("properties")
+    if isinstance(props, dict):
+        names.update(props.keys())
+        for v in props.values():
+            _walk_properties(v, names)
+    for key in ("items", "additionalProperties", "not"):
+        if key in node and isinstance(node[key], dict):
+            _walk_properties(node[key], names)
+    for key in ("allOf", "anyOf", "oneOf"):
+        if key in node and isinstance(node[key], list):
+            for item in node[key]:
+                _walk_properties(item, names)
+
+
+class JSONSchemaLogitsProcessor:
+    """
+    Logits processor that constrains generation to valid JSON.
+
+    Parameters
+    ----------
+    schema:
+        The JSON Schema the output must match.  When ``None``, any valid JSON
+        object/array is accepted (``json_object`` mode).
+    tokenizer:
+        The tokenizer used for generation.  Its vocabulary is iterated once
+        (via :mod:`vllm_mlx.constrained.cache`) and cached for subsequent
+        requests.
+    """
+
+    def __init__(
+        self,
+        schema: dict | None,
+        tokenizer: Any,
+    ) -> None:
+        if not is_available():
+            raise LMFormatEnforcerNotAvailableError(
+                "lm-format-enforcer is not installed. "
+                'Install it with `pip install "lm-format-enforcer>=0.10.9"`.'
+            )
+
+        from lmformatenforcer import JsonSchemaParser, TokenEnforcer
+
+        self._tokenizer = tokenizer
+        self._schema = schema
+        self._tok_data = get_tokenizer_data(tokenizer)
+        if self._tok_data is None:
+            raise LMFormatEnforcerNotAvailableError(
+                "Could not build TokenEnforcerTokenizerData for this tokenizer."
+            )
+
+        # Pre-process schema: resolve $ref, remove 'not', convert type arrays.
+        # Then harden: force ``additionalProperties: false`` on all object
+        # sub-schemas to prevent the enforcer from allowing arbitrary keys.
+        self._disabled = False
+        if schema is not None:
+            parser_schema = _simplify_schema(schema)
+            parser_schema = _force_no_additional_properties(parser_schema)
+        else:
+            parser_schema = _GENERIC_JSON_SCHEMA
+
+        try:
+            self._parser = JsonSchemaParser(parser_schema)
+            self._enforcer = TokenEnforcer(self._tok_data, self._parser)
+        except Exception as exc:
+            logger.warning(
+                "JSONSchemaLogitsProcessor: enforcer init failed (%s); "
+                "falling back to unconstrained generation",
+                exc,
+            )
+            self._disabled = True
+            self._parser = None  # type: ignore[assignment]
+            self._enforcer = None  # type: ignore[assignment]
+
+        # Bootstrap the enforcer's ``prefix_states`` with the empty tuple so
+        # that subsequent ``get_allowed_tokens([t1, t2, ...])`` calls can find
+        # their ``prev_step_tuple`` and apply characters incrementally rather
+        # than treating the whole sequence as a prompt and resetting to the
+        # root parser.
+        if not self._disabled:
+            try:
+                self._enforcer.get_allowed_tokens([])
+            except Exception as exc:
+                logger.warning(
+                    "TokenEnforcer bootstrap failed (%s); "
+                    "falling back to unconstrained generation",
+                    exc,
+                )
+                self._disabled = True
+
+        self._prompt_len: int | None = None
+        self._vocab_size: int = self._tok_data.vocab_size
+
+        # EOS/stop tokens cache.
+        eos_id = getattr(self._tok_data, "eos_token_id", None)
+        if isinstance(eos_id, (list, tuple, set)):
+            self._eos_set: set[int] = {int(e) for e in eos_id}
+        elif eos_id is not None:
+            self._eos_set = {int(eos_id)}
+        else:
+            self._eos_set = set()
+
+        # Pre-compute valid property name prefixes for key-start filtering.
+        all_names = _collect_property_names(schema)
+        self._valid_key_first_chars: set[str] = {n[0] for n in all_names if n}
+        self._valid_key_names: set[str] = all_names
+
+        # Lazy decode cache — populated on demand.
+        self._token_decode_cache: dict[int, str | None] = {}
+
+    # ------------------------------------------------------------------
+
+    def _suffix(self, tokens_list: list[int]) -> list[int]:
+        """Return the slice of ``tokens`` that corresponds to generated output."""
+        if self._prompt_len is None:
+            self._prompt_len = max(0, len(tokens_list) - 1)
+        return tokens_list[self._prompt_len :]
+
+    def _decode_token_cached(self, tok_id: int) -> str | None:
+        """Return the decoded text for a single token (cached)."""
+        cached = self._token_decode_cache.get(tok_id)
+        if cached is not None:
+            return cached
+        if tok_id in self._token_decode_cache:
+            return None  # previously cached as None
+        try:
+            decoded = self._tokenizer.decode([tok_id])
+        except Exception:
+            self._token_decode_cache[tok_id] = None
+            return None
+        result = decoded if isinstance(decoded, str) else None
+        self._token_decode_cache[tok_id] = result
+        return result
+
+    def _decode_suffix(self, suffix: list[int]) -> str | None:
+        """Decode suffix tokens to text."""
+        if not suffix:
+            return ""
+        try:
+            decoded = self._tokenizer.decode(list(suffix))
+        except Exception:
+            return None
+        return decoded if isinstance(decoded, str) else None
+
+    def _suffix_is_complete_json(self, suffix: list[int]) -> bool:
+        """Return True if the decoded ``suffix`` parses as a complete JSON value."""
+        if not suffix:
+            return False
+        text = self._decode_suffix(suffix)
+        if not text:
+            return False
+        text = text.strip()
+        if not text:
+            return False
+        try:
+            json.loads(text)
+        except (ValueError, json.JSONDecodeError):
+            return False
+        return True
+
+    def _get_json_context(self, suffix: list[int]) -> str:
+        """Determine the JSON structural context of the current suffix.
+
+        Returns one of:
+        - ``"key_start"``: expecting a new key (after ``{`` or ``,``)
+        - ``"in_key"``: inside an open key string
+        - ``"other"``: any other position
+        """
+        text = self._decode_suffix(suffix)
+        if text is None:
+            return "other"
+        if not text:
+            return "other"  # no output yet — need ``{`` first, not a key
+
+        # Walk through the text tracking open/close of JSON strings so
+        # we can tell whether the suffix ends inside a string.
+        in_string = False
+        i = 0
+        last_quote_pos = -1
+        while i < len(text):
+            ch = text[i]
+            if in_string:
+                if ch == "\\" and i + 1 < len(text):
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+            else:
+                if ch == '"':
+                    in_string = True
+                    last_quote_pos = i
+            i += 1
+
+        if in_string:
+            # We're inside an open string.  Determine if it's a key or value.
+            # A key is opened right after ``{``/``,`` + optional whitespace.
+            # Check what was before the opening quote.
+            before = text[:last_quote_pos].rstrip()
+            if not before or before[-1] in ("{", ","):
+                return "in_key"
+            return "other"  # it's a value string
+
+        stripped = text.rstrip()
+        if not stripped:
+            return "other"  # only whitespace → haven't started JSON yet
+        if stripped[-1] in ("{", ","):
+            return "key_start"
+        return "other"
+
+    def _filter_at_key_context(
+        self, context: str, suffix: list[int], allowed: list[int]
+    ) -> list[int]:
+        """Apply schema-aware filtering when in key-related context.
+
+        At ``key_start``: only allow tokens that begin a valid key, whitespace,
+        ``}``, or just ``"``.
+        At ``in_key``: only allow tokens compatible with continuing a valid
+        property name (no leading whitespace; content must be a valid prefix).
+        """
+        if not self._valid_key_names:
+            return allowed  # no schema info → skip filtering
+
+        if context == "key_start":
+            return self._filter_key_start_tokens(suffix, allowed)
+        elif context == "in_key":
+            return self._filter_in_key_tokens(suffix, allowed)
+        return allowed
+
+    def _filter_key_start_tokens(
+        self, suffix: list[int], allowed: list[int]
+    ) -> list[int]:
+        """Filter tokens at key-start position.
+
+        Only permit tokens that:
+        - Are whitespace-only (before the key ``"``)
+        - Decode to ``}`` (close object)
+        - Start a valid key: ``"`` followed by a valid first char
+        """
+        result = []
+        for tok_id in allowed:
+            if tok_id in self._eos_set:
+                continue  # EOS at key-start is handled separately
+            tok_text = self._decode_token_cached(tok_id)
+            if tok_text is None:
+                result.append(tok_id)
+                continue
+            stripped = tok_text.lstrip()
+            if not stripped:
+                # Pure whitespace — allowed before key
+                result.append(tok_id)
+                continue
+            if stripped[0] == "}":
+                # Closing brace — end of object
+                result.append(tok_id)
+                continue
+            if stripped[0] == '"':
+                # Opening a key — validate content
+                rest = stripped[1:]
+                if not rest:
+                    # Just ``"`` — will be validated on next step
+                    result.append(tok_id)
+                    continue
+                # Check if rest starts with a valid key character
+                if rest[0] in self._valid_key_first_chars:
+                    # Further check: does the key content (up to closing ``"``)
+                    # match a prefix of a known property name?
+                    close_idx = rest.find('"')
+                    if close_idx < 0:
+                        # Key not yet closed — check prefix
+                        if self._is_valid_key_prefix(rest):
+                            result.append(tok_id)
+                    else:
+                        # Key fully contained in this token
+                        key_name = rest[:close_idx]
+                        if key_name in self._valid_key_names:
+                            result.append(tok_id)
+                    continue
+                # First char not in valid set → skip
+                continue
+            # Other chars (digits, letters without quote) → skip at key-start
+            continue
+        return result if result else allowed  # safety: never return empty
+
+    def _filter_in_key_tokens(self, suffix: list[int], allowed: list[int]) -> list[int]:
+        """Filter tokens when we're inside an open key string.
+
+        Only allow tokens whose content continues a valid property name.
+        Reject whitespace-only/leading-whitespace tokens.
+        """
+        # Figure out what key content we've accumulated so far.
+        text = self._decode_suffix(suffix)
+        if text is None:
+            return allowed
+
+        # Find the last unmatched ``"`` — everything after it is key content
+        # accumulated so far.
+        last_open = text.rfind('"')
+        if last_open < 0:
+            return allowed
+        key_so_far = text[last_open + 1 :]
+
+        result = []
+        for tok_id in allowed:
+            tok_text = self._decode_token_cached(tok_id)
+            if tok_text is None:
+                result.append(tok_id)
+                continue
+            # Token must not start with whitespace (no ws inside keys)
+            if tok_text and tok_text[0] in (" ", "\t", "\n", "\r"):
+                continue
+            # Check if key_so_far + tok_text is a valid key prefix
+            candidate = key_so_far + tok_text
+            # If the closing ``"`` is in tok_text, extract the full key
+            close_idx = tok_text.find('"')
+            if close_idx >= 0:
+                full_key = key_so_far + tok_text[:close_idx]
+                if full_key in self._valid_key_names:
+                    result.append(tok_id)
+            else:
+                # Key still open — check if it's a valid prefix
+                if self._is_valid_key_prefix(candidate):
+                    result.append(tok_id)
+        return result if result else allowed
+
+    def _is_valid_key_prefix(self, prefix: str) -> bool:
+        """Return True if *prefix* is a prefix of at least one valid key name."""
+        return any(name.startswith(prefix) for name in self._valid_key_names)
+
+    def _build_allow_mask(self, allowed: list[int], vocab_size: int) -> mx.array:
+        """
+        Build a 1-D mask of length ``vocab_size`` where allowed positions are
+        ``0`` and disallowed positions are ``-inf``.
+
+        ``vocab_size`` is taken from the actual logits tensor so that models
+        whose embedding dimension exceeds the tokenizer vocabulary (e.g.
+        MiniMax-M2.7 with 200,064 vs tokenizer 200,000) are handled
+        correctly.
+        """
+        if not allowed:
+            return mx.full((vocab_size,), -float("inf"))
+        allowed_clamped = [i for i in allowed if 0 <= i < vocab_size]
+        if not allowed_clamped:
+            return mx.full((vocab_size,), -float("inf"))
+        buf = [-float("inf")] * vocab_size
+        for i in allowed_clamped:
+            buf[i] = 0.0
+        return mx.array(buf, dtype=mx.float32)
+
+    # ------------------------------------------------------------------
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        """Apply the allowed-tokens mask to ``logits``."""
+        if self._disabled:
+            return logits
+
+        try:
+            tokens_list = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
+            if isinstance(tokens_list, int):
+                tokens_list = [tokens_list]
+            elif tokens_list and isinstance(tokens_list[0], list):
+                tokens_list = tokens_list[0]
+
+            suffix = self._suffix(tokens_list)
+            allowed_result = self._enforcer.get_allowed_tokens(
+                tokens_list if suffix == tokens_list else suffix
+            )
+            allowed = getattr(allowed_result, "allowed_tokens", allowed_result)
+            if allowed is None:
+                return logits
+
+            allowed_list = list(allowed)
+
+            # --- EOS guard: only permit EOS when output is valid JSON ---
+            if (
+                self._eos_set
+                and any(t in self._eos_set for t in allowed_list)
+                and not self._suffix_is_complete_json(suffix)
+            ):
+                allowed_list = [t for t in allowed_list if t not in self._eos_set]
+
+            # --- Schema-aware key filter ---
+            context = self._get_json_context(suffix)
+            if context in ("key_start", "in_key"):
+                allowed_list = self._filter_at_key_context(
+                    context, suffix, allowed_list
+                )
+
+            # --- Recovery: if enforcer returns empty set AND output is not
+            # complete JSON, the schema is likely unsupported — disable the
+            # processor and let the model generate freely (system prompt +
+            # post-validation still apply).  Only force EOS if the output
+            # already parses as valid JSON (generation is done).
+            if not allowed_list:
+                if self._suffix_is_complete_json(suffix) and self._eos_set:
+                    allowed_list = sorted(self._eos_set)
+                else:
+                    logger.warning(
+                        "JSONLP: enforcer stuck (empty allowed-set at "
+                        "suffix_len=%d); disabling constrained decoding "
+                        "for this request",
+                        len(suffix),
+                    )
+                    self._disabled = True
+                    return logits
+
+            actual_vocab = logits.shape[-1]
+            mask = self._build_allow_mask(allowed_list, actual_vocab)
+            if logits.ndim == 2 and logits.shape[0] == 1:
+                mask = mask[None, :]
+            return logits + mask
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(
+                "JSONSchemaLogitsProcessor crashed; disabling for this request: %s",
+                exc,
+            )
+            self._disabled = True
+            return logits
+
+    # Diagnostic helpers -------------------------------------------------
+
+    @property
+    def schema(self) -> dict | None:
+        return self._schema
+
+    @property
+    def vocab_size(self) -> int:
+        return self._vocab_size

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -562,6 +562,7 @@ class BatchedEngine(BaseEngine):
                 min_p=kwargs.pop("min_p", 0.0),
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+                logits_processors=kwargs.pop("logits_processors", None),
             )
 
             return GenerationOutput(
@@ -584,6 +585,7 @@ class BatchedEngine(BaseEngine):
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
+            logits_processors=kwargs.pop("logits_processors", None),
         )
 
         output = await self._engine.generate(
@@ -644,6 +646,7 @@ class BatchedEngine(BaseEngine):
                 min_p=kwargs.pop("min_p", 0.0),
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+                logits_processors=kwargs.pop("logits_processors", None),
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
@@ -669,6 +672,7 @@ class BatchedEngine(BaseEngine):
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
+            logits_processors=kwargs.pop("logits_processors", None),
         )
 
         prefix_boundary = kwargs.pop("prefix_boundary", 0)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -60,6 +60,10 @@ class MLLMBatchRequest:
     min_p: float = 0.0
     presence_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    # Extra logits processors (e.g. JSON schema constrained decoding).
+    # Merged with built-in repetition/presence penalty processors in
+    # ``_prefill_batch``.
+    logits_processors: Optional[List[Callable]] = None
 
     # Processed inputs (set after vision preprocessing)
     input_ids: Optional[mx.array] = None
@@ -1198,6 +1202,14 @@ class MLLMBatchGenerator:
                             logits = logits.logits
 
                         last_logits = logits[:, -1, :]
+
+                        # Apply per-request logits processors BEFORE sampler
+                        # for first-token sampling (prefix cache hit path).
+                        if getattr(req, "logits_processors", None):
+                            empty_tokens = mx.array([], dtype=mx.int32)
+                            for processor in req.logits_processors:
+                                last_logits = processor(empty_tokens, last_logits)
+
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
@@ -1236,6 +1248,14 @@ class MLLMBatchGenerator:
                             logits = logits.logits
 
                         last_logits = logits[:, -1, :]
+
+                        # Apply per-request logits processors BEFORE sampler
+                        # for first-token sampling (prefix cache exact hit).
+                        if getattr(req, "logits_processors", None):
+                            empty_tokens = mx.array([], dtype=mx.int32)
+                            for processor in req.logits_processors:
+                                last_logits = processor(empty_tokens, last_logits)
+
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
@@ -1266,8 +1286,22 @@ class MLLMBatchGenerator:
                         else:
                             logits = self._run_vision_encoding(req, cache=request_cache)
 
-                        # Extract last token logits and sample
+                        # Extract last token logits
                         last_logits = logits[:, -1, :]
+
+                        # Apply per-request logits processors BEFORE sampler
+                        # (e.g. JSON schema constrained decoding).  Without
+                        # this, the first generated token is unconstrained —
+                        # the model can emit special tokens like <|channel>
+                        # that the schema disallows.  Subsequent tokens are
+                        # masked in ``_step``; this mirrors that behavior for
+                        # the first token sampled from prefill output.
+                        # ``output_tokens`` is empty at prefill time.
+                        if getattr(req, "logits_processors", None):
+                            empty_tokens = mx.array([], dtype=mx.int32)
+                            for processor in req.logits_processors:
+                                last_logits = processor(empty_tokens, last_logits)
+
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
@@ -1353,7 +1387,10 @@ class MLLMBatchGenerator:
         # Create initial y (first generated tokens)
         y = mx.array(first_tokens)
 
-        # Build per-request logits processors (repetition_penalty, presence_penalty)
+        # Build per-request logits processors.  Combines built-in
+        # (repetition_penalty, presence_penalty) with any caller-supplied
+        # processors (e.g. JSON schema constrained decoding via
+        # ``lm-format-enforcer``).
         from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
         batch_logits_processors = []
@@ -1361,20 +1398,28 @@ class MLLMBatchGenerator:
         for req in requests:
             need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
             need_pres = req.presence_penalty and req.presence_penalty != 0.0
+            combined: List[Callable] = []
             if need_rep or need_pres:
                 lp_kwargs = {}
                 if need_rep:
                     lp_kwargs["repetition_penalty"] = req.repetition_penalty
                 if need_pres:
                     lp_kwargs["presence_penalty"] = req.presence_penalty
-                lp = make_logits_processors(**lp_kwargs)
-                batch_logits_processors.append(lp)
-                has_any_lp = True
+                combined.extend(make_logits_processors(**lp_kwargs))
                 logger.info(
                     f"[sampling] request={req.request_id[:12]} "
                     f"rep_penalty={req.repetition_penalty} "
                     f"pres_penalty={req.presence_penalty}"
                 )
+            if req.logits_processors:
+                combined.extend(req.logits_processors)
+                logger.info(
+                    f"[sampling] request={req.request_id[:12]} "
+                    f"extra_logits_processors={len(req.logits_processors)}"
+                )
+            if combined:
+                batch_logits_processors.append(combined)
+                has_any_lp = True
             else:
                 batch_logits_processors.append(None)
 
@@ -1455,10 +1500,15 @@ class MLLMBatchGenerator:
             for e in range(logits.shape[0]):
                 sample_logits = logits[e : e + 1]
                 if logits_processors[e]:
+                    # Build full context: output_tokens + current input token.
+                    # ``output_tokens[e]`` lacks the current step's input token
+                    # because it hasn't been appended yet; adding it here gives
+                    # logits processors (e.g. JSON schema enforcer) accurate
+                    # context about what has been generated so far.
+                    cur_tok = int(input_tokens[e, 0])
+                    full_context = output_tokens[e] + [cur_tok]
                     for processor in logits_processors[e]:
-                        sample_logits = processor(
-                            mx.array(output_tokens[e]), sample_logits
-                        )
+                        sample_logits = processor(mx.array(full_context), sample_logits)
                 processed_logits.append(sample_logits)
             logits = mx.concatenate(processed_logits, axis=0)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -346,7 +346,9 @@ class MLLMScheduler:
             temperature: Sampling temperature
             top_p: Top-p sampling
             request_id: Optional custom request ID
-            **kwargs: Additional generation parameters
+            **kwargs: Additional generation parameters.  ``logits_processors``
+                — list of callables ``(tokens, logits) -> logits`` applied
+                during sampling (e.g. constrained JSON decoding).
 
         Returns:
             Request ID for tracking
@@ -362,6 +364,7 @@ class MLLMScheduler:
             min_p=kwargs.pop("min_p", 0.0),
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+            logits_processors=kwargs.pop("logits_processors", None),
         )
 
         request = MLLMRequest(
@@ -509,6 +512,7 @@ class MLLMScheduler:
                 min_p=request.sampling_params.min_p,
                 presence_penalty=request.sampling_params.presence_penalty,
                 repetition_penalty=request.sampling_params.repetition_penalty,
+                logits_processors=request.sampling_params.logits_processors,
             )
             batch_requests.append(batch_req)
 

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -151,6 +151,7 @@ class MLXLanguageModel:
         presence_penalty: float = 0.0,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list | None = None,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -166,6 +167,9 @@ class MLXLanguageModel:
             presence_penalty: Additive penalty for token presence
             repetition_penalty: Multiplicative penalty for repeating tokens
             stop: List of stop sequences
+            logits_processors: Optional externally-supplied logits processors
+                (e.g. JSON schema constrained decoding).  Merged with built-in
+                penalty processors.
 
         Returns:
             GenerationOutput with generated text and tokens
@@ -177,9 +181,13 @@ class MLXLanguageModel:
 
         # Create sampler and logits processors with full Unsloth params
         sampler = self._create_sampler(temperature, top_p, top_k, min_p)
-        logits_processors = self._create_logits_processors(
+        penalty_processors = self._create_logits_processors(
             presence_penalty, repetition_penalty
         )
+        # Merge any externally-provided logits_processors with penalty processors
+        all_processors = penalty_processors or []
+        if logits_processors:
+            all_processors = list(logits_processors) + all_processors
 
         # Generate text
         output_text = generate(
@@ -188,7 +196,7 @@ class MLXLanguageModel:
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
-            logits_processors=logits_processors,
+            logits_processors=all_processors if all_processors else None,
             verbose=False,
         )
 

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -9,7 +9,7 @@ request management system, simplified for MLX backend.
 import enum
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from .paged_cache import BlockTable
@@ -61,6 +61,10 @@ class SamplingParams:
     repetition_penalty: float = 1.0
     stop: Optional[List[str]] = None
     stop_token_ids: Optional[List[int]] = None
+    # Extra per-request logits processors (e.g. JSON schema constrained
+    # decoding via ``lm-format-enforcer``).  These are merged with any
+    # built-in processors (repetition/presence penalty) at batch time.
+    logits_processors: Optional[List[Callable]] = None
 
     def __post_init__(self):
         if self.stop is None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1922,15 +1922,27 @@ class Scheduler:
                 request.remaining_tokens = request.prompt_token_ids
                 tokens_to_process = request.prompt_token_ids
 
-            # Build per-request logits_processors from repetition_penalty
+            # Build per-request logits_processors from repetition_penalty and
+            # any caller-supplied extras (e.g. JSON schema constrained
+            # decoding).
             rep_penalty = request.sampling_params.repetition_penalty
-            lp = None
+            extra_lp = request.sampling_params.logits_processors or []
+            combined_lp: list = []
             if rep_penalty and rep_penalty != 1.0:
-                lp = make_logits_processors(repetition_penalty=rep_penalty)
+                combined_lp.extend(
+                    make_logits_processors(repetition_penalty=rep_penalty)
+                )
                 logger.info(
                     f"[rep_penalty] request={request.request_id[:12]} "
-                    f"penalty={rep_penalty} processors={len(lp)}"
+                    f"penalty={rep_penalty}"
                 )
+            if extra_lp:
+                combined_lp.extend(extra_lp)
+                logger.info(
+                    f"[logits_proc] request={request.request_id[:12]} "
+                    f"extra_processors={len(extra_lp)}"
+                )
+            lp = combined_lp
 
             # Insert into BatchGenerator with optional cache.
             # Wrap in try/except: if cache shapes are incompatible
@@ -1939,9 +1951,10 @@ class Scheduler:
             insert_kwargs = {
                 "max_tokens": [request.sampling_params.max_tokens],
                 "caches": [cache_to_use] if cache_to_use else None,
+                # Always pass logits_processors (even empty list) so that
+                # mlx_lm BatchGenerator never stores None per-sequence.
+                "logits_processors": [lp] if lp else [[]],
             }
-            if lp:
-                insert_kwargs["logits_processors"] = [lp]
             try:
                 uids = self.batch_generator.insert(
                     [tokens_to_process],

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -99,6 +99,7 @@ from .api.models import (
 )
 from .api.tool_calling import (
     StreamingJsonFenceStripper,
+    build_json_logits_processor,
     build_json_system_prompt,
     convert_tools_for_template,
     parse_json_output,
@@ -1648,11 +1649,40 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
 
     # Handle response_format - inject system prompt if needed
     response_format = request.response_format
+    json_logits_processor = None
     if response_format:
         json_instruction = build_json_system_prompt(response_format)
         if json_instruction:
             # Inject JSON instruction into messages
             messages = _inject_json_instruction(messages, json_instruction)
+
+        # Build a grammar-guided logits processor so the model *cannot*
+        # emit invalid JSON.  If the optional ``lm-format-enforcer``
+        # dependency is missing, or the tokenizer cannot be adapted, this
+        # returns ``None`` and we fall back to prompt-only guidance plus
+        # post-hoc validation.  ``tools`` + ``response_format`` is an
+        # undefined combination in the OpenAI spec — we skip the
+        # constraint in that case so tool-call markup can still be
+        # emitted.
+        if not (request.tools and request.tool_choice != "none"):
+            tokenizer_obj = _get_engine_tokenizer(engine)
+            if tokenizer_obj is not None:
+                try:
+                    json_logits_processor = build_json_logits_processor(
+                        response_format, tokenizer_obj
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to build JSON logits processor: %s", exc)
+                    json_logits_processor = None
+                if json_logits_processor is not None:
+                    logger.info(
+                        "Constrained decoding enabled for response_format.type=%s",
+                        (
+                            getattr(response_format, "type", None)
+                            if not isinstance(response_format, dict)
+                            else response_format.get("type")
+                        ),
+                    )
 
     # Resolve repetition penalty
     rep_penalty = request.repetition_penalty
@@ -1692,6 +1722,20 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Add tools if provided
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
+
+    # Wire constrained decoding logits processor if available.  Must be
+    # appended after all other kwargs because the engine may merge it with
+    # penalty processors internally.
+    if json_logits_processor is not None:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
+        # Constrained decoding is incompatible with reasoning parsers:
+        # the model cannot emit <think> tags when forced to produce JSON.
+        # Suppress thinking so the reasoning parser doesn't capture the
+        # JSON output as reasoning_content.
+        if request.enable_thinking is None:
+            request.enable_thinking = False
+            chat_kwargs["enable_thinking"] = False
 
     if request.stream:
         return StreamingResponse(
@@ -1762,7 +1806,13 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             # Return JSON as string
             cleaned_text = json.dumps(parsed_json)
         if not is_valid:
-            logger.warning(f"JSON validation failed: {error}")
+            if json_logits_processor is not None:
+                # Constrained decoding was active yet validation still failed.
+                # This is unexpected and indicates a bug in the grammar
+                # integration — log at error level so it surfaces in CI/logs.
+                logger.error("Constrained decoding produced invalid JSON: %s", error)
+            else:
+                logger.warning(f"JSON validation failed: {error}")
 
     # Determine finish reason
     finish_reason = "tool_calls" if tool_calls else output.finish_reason
@@ -1848,6 +1898,21 @@ def _normalize_messages(messages: list[dict]) -> list[dict]:
         logger.info(f"Normalized messages: {', '.join(parts)}")
 
     return merged
+
+
+def _get_engine_tokenizer(engine) -> object | None:
+    """
+    Return the tokenizer backing ``engine``, if exposed.
+
+    Different engine classes store the tokenizer under different attributes.
+    We try the common ones and return ``None`` if nothing matches, so that
+    optional features like constrained decoding can degrade gracefully.
+    """
+    for attr in ("_tokenizer", "tokenizer", "_processor", "processor"):
+        tok = getattr(engine, attr, None)
+        if tok is not None:
+            return tok
+    return None
 
 
 def _inject_json_instruction(messages: list, instruction: str) -> list:
@@ -1977,6 +2042,36 @@ async def create_anthropic_message(
     )
     messages = _normalize_messages(messages)
 
+    # Handle response_format (propagated from Anthropic request via adapter):
+    # inject prompt-level instruction AND wire a grammar-guided logits
+    # processor so the model cannot emit invalid JSON.
+    response_format = openai_request.response_format
+    json_logits_processor = None
+    if response_format:
+        json_instruction = build_json_system_prompt(response_format)
+        if json_instruction:
+            messages = _inject_json_instruction(messages, json_instruction)
+        if not (openai_request.tools and openai_request.tool_choice != "none"):
+            tokenizer_obj = _get_engine_tokenizer(engine)
+            if tokenizer_obj is not None:
+                try:
+                    json_logits_processor = build_json_logits_processor(
+                        response_format, tokenizer_obj
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to build JSON logits processor: %s", exc)
+                    json_logits_processor = None
+                if json_logits_processor is not None:
+                    logger.info(
+                        "Constrained decoding enabled for Anthropic "
+                        "response_format.type=%s",
+                        (
+                            getattr(response_format, "type", None)
+                            if not isinstance(response_format, dict)
+                            else response_format.get("type")
+                        ),
+                    )
+
     chat_kwargs = {
         "max_tokens": openai_request.max_tokens or _default_max_tokens,
         "temperature": openai_request.temperature,
@@ -1989,6 +2084,12 @@ async def create_anthropic_message(
 
     if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
+
+    if json_logits_processor is not None:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
+        # Suppress thinking: constrained decoding prevents <think> tags.
+        chat_kwargs["enable_thinking"] = False
 
     start_time = time.perf_counter()
     timeout = _default_timeout
@@ -2020,13 +2121,33 @@ async def create_anthropic_message(
     else:
         cleaned_text, tool_calls = output.text, None
 
-    # Extract reasoning if parser is configured
+    # Extract reasoning if parser is configured — skip when constrained
+    # decoding was active (no <think> tags possible).
     reasoning_text = None
-    if _reasoning_parser and not tool_calls:
+    if _reasoning_parser and not tool_calls and json_logits_processor is None:
         text_to_parse = cleaned_text or output.text
         reasoning_text, cleaned_text = _reasoning_parser.extract_reasoning(
             text_to_parse
         )
+
+    # Post-hoc response_format validation / normalization (safety net even
+    # when constrained decoding was active).
+    if response_format and not tool_calls:
+        json_input = cleaned_text or output.text
+        _, parsed_json, is_valid, error = parse_json_output(json_input, response_format)
+        if parsed_json is not None:
+            cleaned_text = json.dumps(parsed_json)
+        if not is_valid:
+            if json_logits_processor is not None:
+                logger.error(
+                    "Constrained decoding produced invalid JSON on "
+                    "Anthropic endpoint: %s",
+                    error,
+                )
+            else:
+                logger.warning(
+                    "JSON validation failed on Anthropic endpoint: %s", error
+                )
 
     # Clean output text
     final_content = None
@@ -2253,6 +2374,29 @@ async def _stream_anthropic_messages(
     if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
+    # Wire constrained decoding if response_format was requested via the
+    # Anthropic extension field and tools are not also requested.
+    response_format = getattr(openai_request, "response_format", None)
+    if response_format is not None and not (
+        openai_request.tools and openai_request.tool_choice != "none"
+    ):
+        json_instruction = build_json_system_prompt(response_format)
+        if json_instruction:
+            messages = _inject_json_instruction(messages, json_instruction)
+        tokenizer_obj = _get_engine_tokenizer(engine)
+        if tokenizer_obj is not None:
+            try:
+                processor = build_json_logits_processor(response_format, tokenizer_obj)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to build JSON logits processor (Anthropic stream): %s",
+                    exc,
+                )
+                processor = None
+            if processor is not None:
+                chat_kwargs["logits_processors"] = [processor]
+                chat_kwargs["enable_thinking"] = False
+
     # Emit message_start
     message_start = {
         "type": "message_start",
@@ -2272,7 +2416,9 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
-    use_reasoning = _reasoning_parser is not None
+    use_reasoning = _reasoning_parser is not None and not chat_kwargs.get(
+        "logits_processors"
+    )
 
     if use_reasoning:
         _reasoning_parser.reset_state()
@@ -2956,6 +3102,39 @@ async def stream_chat_completion(
                     ],
                 )
                 yield f"data: {tool_chunk.model_dump_json()}\n\n"
+
+        # Safety-net validation: if response_format was requested, verify the
+        # accumulated output still parses.  When constrained decoding is active
+        # this should always succeed; if it fails we log loudly (error) so we
+        # notice grammar-integration regressions.  When constrained decoding was
+        # *not* active (optional dep missing, incompatible tokenizer, combined
+        # with tools), we log at warning level only — the prompt-only path is
+        # best-effort.
+        if (
+            getattr(request, "response_format", None) is not None
+            and not tool_calls_detected
+        ):
+            try:
+                _, _parsed, _is_valid, _err = parse_json_output(
+                    accumulated_text, request.response_format
+                )
+                if not _is_valid:
+                    # Determine whether constrained decoding was wired up.  We
+                    # passed the processor through ``kwargs`` so its presence is
+                    # the signal.
+                    has_constrained = any(
+                        p.__class__.__name__ == "JSONSchemaLogitsProcessor"
+                        for p in (kwargs.get("logits_processors") or [])
+                    )
+                    if has_constrained:
+                        logger.error(
+                            "Streaming constrained decoding produced invalid JSON: %s",
+                            _err,
+                        )
+                    else:
+                        logger.warning("Streaming JSON validation failed: %s", _err)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Streaming JSON validation raised: %s", exc)
 
         # Log throughput
         elapsed = time.perf_counter() - start_time


### PR DESCRIPTION
## Summary

- Add **grammar-guided constrained decoding** for `response_format` (both `json_schema` and `json_object`) using [`lm-format-enforcer`](https://github.com/noamgat/lm-format-enforcer)
- Token-level logits masking ensures the model can **only emit tokens that form valid JSON** matching the requested schema
- Works with all engine paths: SimpleEngine, BatchedEngine (non-MLLM scheduler), and MLLM BatchGenerator (continuous batching)
- Falls back gracefully to prompt-only guidance when `lm-format-enforcer` is not installed

## Key implementation details

### New module: `vllm_mlx/constrained/`
- `json_schema_processor.py` — `JSONSchemaLogitsProcessor` that wraps `lm-format-enforcer`'s `TokenEnforcer`
  - **`_simplify_schema()`** — resolves `$ref` references (with cycle detection for recursive definitions), removes unsupported `not` keywords, and converts `type` arrays to `anyOf` — fixes crash on complex schemas like OpenAI's `OpenAiAnyType` pattern
  - Schema-aware key filtering to work around known enforcer bugs with multi-char boundary tokens
  - EOS guard prevents premature stop before JSON is complete
  - **Graceful fallback** — when the enforcer gets stuck on an unsupported schema (empty allowed-set), disables constrained decoding for that request instead of force-terminating with EOS after 3 tokens
  - Dynamic vocab sizing from logits tensor (handles models where embedding dim > tokenizer vocab, e.g. MiniMax-M2.7 200,064 vs 200,000)
- `cache.py` — LRU cache for `TokenEnforcerTokenizerData` (built once per model, reused across requests)

### Wiring
- `server.py` — builds processor when `response_format` is present, injects into all engine paths
- `mllm_batch_generator.py` — applies logits processors in all 3 prefill paths (cache miss, prefix hit, exact hit) and in `_step()` with correct token context
- `scheduler.py` — merges JSON processor with repetition penalty processors per request; **always passes `logits_processors` (empty list) to mlx_lm BatchGenerator** to prevent `TypeError: 'NoneType' object is not iterable` when a non-constrained request follows a constrained one
- Reasoning parsers are automatically suppressed when constrained decoding is active (incompatible — model cannot emit `<think>` tags when constrained to JSON)

### Anthropic endpoint
- `response_format` field added to `AnthropicRequest` (extension) and propagated through `anthropic_to_openai()` adapter

## Test plan

- [x] 16 unit tests pass (`tests/test_constrained_decoding.py`)
- [x] Gemma 4 26B-A4B: single request, 3 concurrent batch, streaming — all valid JSON
- [x] MiniMax-M2.7 (230B): single request, 3 concurrent batch, streaming — all valid JSON
- [x] Complex `$ref`/`not` schemas (e.g. `fact_batch` with recursive `OpenAiAnyType`) — valid JSON with constrained decoding
- [x] Non-constrained request after constrained request — no crash (logits_processors fix)
- [x] `json_object` mode (no schema) works on both models
- [x] Regression: normal requests without `response_format` unaffected
- [x] Black/ruff clean
- [x] All CI checks pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>