### PR TITLE
Fix constrained decoding enforcer stuck + MLLM gpu-memory-utilization

### DIFF
--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -301,5 +301,133 @@ class TestAnthropicAdapterResponseFormat:
         assert openai_req.response_format is None
 
 
+# ---------------------------------------------------------------------------
+# _simplify_schema — metadata stripping and anyOf flattening.
+# ---------------------------------------------------------------------------
+
+
+class TestSimplifySchema:
+    """Test ``_simplify_schema`` handles metadata and nested anyOf correctly."""
+
+    def test_strips_default_and_metadata(self):
+        from vllm_mlx.constrained.json_schema_processor import _simplify_schema
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "unknown",
+                    "title": "Name",
+                    "description": "The name",
+                    "examples": ["Alice"],
+                },
+            },
+        }
+        result = _simplify_schema(schema)
+        name_prop = result["properties"]["name"]
+        for kw in ("default", "title", "description", "examples"):
+            assert kw not in name_prop, f"{kw!r} should have been stripped"
+        assert name_prop["type"] == "string"
+
+    def test_flattens_nested_anyof(self):
+        from vllm_mlx.constrained.json_schema_processor import _simplify_schema
+
+        schema = {
+            "anyOf": [
+                {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+                {"type": "null"},
+            ]
+        }
+        result = _simplify_schema(schema)
+        # Nested anyOf should be flattened to 3 branches.
+        assert "anyOf" in result
+        assert len(result["anyOf"]) == 3
+
+    def test_fact_batch_schema_simplifies_cleanly(self):
+        """Regression test: the ``fact_batch`` schema that caused enforcer
+        to get stuck in production (nested anyOf + default + $ref + not)."""
+        from vllm_mlx.constrained.json_schema_processor import _simplify_schema
+
+        fact_batch_schema = {
+            "type": "object",
+            "properties": {
+                "facts": {
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {"not": {"$ref": "#/definitions/OpenAiAnyType"}},
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "kind": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "number",
+                                                    "price",
+                                                    "product_name",
+                                                ],
+                                            },
+                                            "value": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 300,
+                                            },
+                                            "confidence": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "high",
+                                                    "medium",
+                                                    "low",
+                                                ],
+                                            },
+                                        },
+                                        "required": ["kind", "value", "confidence"],
+                                        "additionalProperties": False,
+                                    },
+                                    "maxItems": 6,
+                                },
+                            ],
+                            "default": [],
+                        },
+                        {"type": "null"},
+                    ]
+                }
+            },
+            "required": ["facts"],
+            "additionalProperties": False,
+            "definitions": {
+                "OpenAiAnyType": {
+                    "type": ["string", "number", "integer", "boolean", "array", "null"],
+                    "items": {"$ref": "#/definitions/OpenAiAnyType"},
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2019-09/schema#",
+        }
+
+        result = _simplify_schema(fact_batch_schema)
+
+        # $schema must be stripped.
+        assert "$schema" not in result
+        # definitions must be consumed.
+        assert "definitions" not in result
+
+        # The ``facts`` property must exist and contain a flat anyOf.
+        facts = result["properties"]["facts"]
+        assert "anyOf" in facts
+        # ``default`` must be stripped from all levels.
+        assert "default" not in facts
+        for branch in facts["anyOf"]:
+            assert "default" not in branch
+        # No nested anyOf wrappers should remain — each branch is either
+        # the array schema or ``{type: null}``.
+        for branch in facts["anyOf"]:
+            if "anyOf" in branch:
+                # Inner anyOf should have been flattened into the outer one.
+                pytest.fail(f"Nested anyOf still present in branch: {branch!r}")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -62,9 +62,13 @@ def _simplify_schema(schema: dict) -> dict:
     1. Resolves ``$ref`` by inlining referenced definitions (with cycle
        detection so recursive definitions are truncated to ``{}``).
     2. Removes ``not`` sub-schemas (makes the schema more permissive).
-    3. Converts ``type: [t1, t2, ...]`` to ``anyOf: [{type: t1}, ...]``.
-    4. Strips ``$schema`` and ``$id`` metadata keys.
+    3. Strips metadata / serialisation-hint keywords that the enforcer does
+       not understand: ``default``, ``examples``, ``title``, ``description``,
+       ``$schema``, ``$id``.
+    4. Converts ``type: [t1, t2, ...]`` to ``anyOf: [{type: t1}, ...]``.
     5. Cleans up empty ``anyOf`` / ``oneOf`` branches.
+    6. Flattens nested ``anyOf``/``oneOf`` (e.g.
+       ``anyOf: [{anyOf: [A, B]}, C]`` → ``anyOf: [A, B, C]``).
     """
     schema = copy.deepcopy(schema)
     definitions: dict = {}
@@ -104,6 +108,12 @@ def _simplify_schema(schema: dict) -> dict:
         node.pop("not", None)
         node.pop("$schema", None)
         node.pop("$id", None)
+        # Metadata / serialisation hints that lm-format-enforcer doesn't
+        # understand — keeping them causes the parser to mis-navigate.
+        node.pop("default", None)
+        node.pop("examples", None)
+        node.pop("title", None)
+        node.pop("description", None)
 
         # --- type array → anyOf --------------------------------------------
         if isinstance(node.get("type"), list):
@@ -136,6 +146,20 @@ def _simplify_schema(schema: dict) -> dict:
                 node[key] = [it for it in resolved_items if it != {}]
                 if not node[key]:
                     del node[key]
+
+        # --- flatten nested anyOf/oneOf ------------------------------------
+        # ``anyOf: [{anyOf: [A, B]}, C]`` → ``anyOf: [A, B, C]`` when the
+        # wrapper dict has no extra keys.  This removes one level of nesting
+        # that confuses lm-format-enforcer's UnionParser.
+        for key in ("anyOf", "oneOf"):
+            if key in node and isinstance(node[key], list):
+                flattened: list[Any] = []
+                for item in node[key]:
+                    if isinstance(item, dict) and key in item and len(item) == 1:
+                        flattened.extend(item[key])
+                    else:
+                        flattened.append(item)
+                node[key] = flattened
 
         return node
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -213,6 +213,30 @@ class BatchedEngine(BaseEngine):
         self._model = self._mllm_instance.model
         self._processor = self._mllm_instance.processor
 
+        # Set Metal memory limits (same as LLM path)
+        try:
+            import mlx.core as mx
+
+            if mx.metal.is_available():
+                device_info = mx.device_info()
+                max_recommended = device_info.get(
+                    "max_recommended_working_set_size",
+                    device_info.get("memory_size", 0),
+                )
+                if max_recommended > 0:
+                    soft_limit = int(max_recommended * self._gpu_memory_utilization)
+                    mx.set_memory_limit(soft_limit)
+                    mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                    pct = self._gpu_memory_utilization * 100
+                    logger.info(
+                        f"Metal memory limits set: "
+                        f"allocation_limit={soft_limit / 1e9:.1f}GB "
+                        f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
+                        f"cache_limit=32GB"
+                    )
+        except Exception as e:
+            logger.warning(f"Failed to set Metal memory limits: {e}")
+
         # Inject MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
             self._inject_mtp_mllm()


### PR DESCRIPTION
## Summary

- **`_simplify_schema()` now strips metadata keywords** (`default`, `examples`, `title`, `description`) that `lm-format-enforcer` doesn't understand, and **flattens nested `anyOf`/`oneOf`** wrappers (e.g. `anyOf: [{anyOf: [A, B]}, C]` → `anyOf: [A, B, C]`). This prevents the enforcer from getting stuck on schemas like the `fact_batch` pattern (nested anyOf with `$ref`, `not`, and `default` producing empty allowed-sets mid-generation).
- **`_start_mllm()` now sets `mx.set_memory_limit()`**, matching the existing LLM path. Previously `--gpu-memory-utilization` was silently ignored for MLLM models (Gemma 4, GLM-4.6V, Qwen3.5).

## Test plan

- [x] New unit tests: `test_strips_default_and_metadata`, `test_flattens_nested_anyof`, `test_fact_batch_schema_simplifies_cleanly`
- [x] All 19 existing + new tests pass (`pytest tests/test_constrained_decoding.py`)
- [x] `black` + `ruff` clean
- [ ] Production smoke test on MiniMax-M2.7 with `fact_batch` schema
- [ ] Verify no `enforcer stuck` warnings in logs after deploy
- [ ] After MLLM server restart, verify `Metal memory limits set` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)