### PR TITLE
fix: streaming tool calls drop for Qwen3.6 bracket format

### DIFF
--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -574,6 +574,68 @@ class TestResponsesEndpoint:
         assert created_payload["response"]["id"] == completed_payload["response"]["id"]
         assert completed_payload["response"]["output_text"] == "Hello stream"
 
+    def test_streaming_response_bracket_tool_call_does_not_leak_text(
+        self, client, monkeypatch
+    ):
+        import vllm_mlx.server as srv
+
+        engine = _mock_engine(_output("unused"))
+        engine.chat = AsyncMock(
+            side_effect=AssertionError("stream path should not call chat")
+        )
+        engine._stream_outputs = [
+            _stream_output('[Calling tool: add({"a": 1, "b": 2})'),
+            _stream_output("]", completion_tokens=2, finish_reason="stop"),
+        ]
+        srv._engine = engine
+        monkeypatch.setattr(srv, "_enable_auto_tool_choice", True)
+        monkeypatch.setattr(srv, "_tool_call_parser", "qwen3")
+        monkeypatch.setattr(srv, "_tool_parser_instance", None)
+        monkeypatch.setattr(srv, "_reasoning_parser", None)
+
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "Add two numbers",
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "add",
+                        "description": "Add two numbers",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "integer"},
+                                "b": {"type": "integer"},
+                            },
+                            "required": ["a", "b"],
+                        },
+                    }
+                ],
+            },
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(body)
+        output_text_deltas = [
+            payload["delta"]
+            for event_type, payload in events
+            if event_type == "response.output_text.delta"
+        ]
+        function_call_deltas = [
+            payload
+            for event_type, payload in events
+            if event_type == "response.function_call_arguments.delta"
+        ]
+
+        assert not any("[Calling tool:" in delta for delta in output_text_deltas)
+        assert len(function_call_deltas) == 1
+        assert function_call_deltas[0]["delta"] == '{"a": 1, "b": 2}'
+
     def test_json_object_response_format_is_rejected(self, client):
         import vllm_mlx.server as srv
 

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -1286,6 +1286,29 @@ class TestQwenStreamingBuffering:
                 break
         assert tool_calls_found
 
+    def test_streaming_bracket_call_closing_marker_split(self, parser):
+        """Qwen bracket calls should complete when ')' and ']' split chunks."""
+        chunks = [
+            '[Calling tool: add({"a": 1, "b": 2})',
+            "]",
+        ]
+
+        accumulated = ""
+        emitted = None
+        for chunk in chunks:
+            previous = accumulated
+            accumulated += chunk
+            emitted = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=accumulated,
+                delta_text=chunk,
+            )
+
+        assert emitted is not None
+        assert "tool_calls" in emitted
+        assert emitted["tool_calls"][0]["function"]["name"] == "add"
+        assert emitted["tool_calls"][0]["function"]["arguments"] == ('{"a": 1, "b": 2}')
+
     def test_streaming_partial_marker_buffered(self, parser):
         """Test that partial '<function' is buffered (not leaked as content)."""
         r = parser.extract_tool_calls_streaming(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1365,7 +1365,14 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
 
         content = SPECIAL_TOKENS_PATTERN.sub("", delta_text)
         if tool_parser and delta_text:
-            if not tool_markup_possible and "<" not in delta_text:
+            # Fast path: skip parsing until a tool-markup marker appears.
+            # Use _streaming_tool_markup_possible to catch all supported
+            # shapes (<tool_call>, <function=, [Calling tool:, [TOOL_CALLS],
+            # bare bracket [func({...})], etc.) — the old `"<" not in` check
+            # missed bracket formats and let Qwen3.6-style tool calls leak.
+            if not tool_markup_possible and not _streaming_tool_markup_possible(
+                tool_accumulated_text + delta_text
+            ):
                 tool_accumulated_text += delta_text
             else:
                 if not tool_markup_possible:

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -272,9 +272,11 @@ class QwenToolParser(ToolParser):
 
             return None
 
-        # If we're in a tool call, accumulate and parse at the end
-        # For simplicity, return None during accumulation
-        if "</tool_call>" in delta_text or ")]" in delta_text:
+        # If we're in a tool call, accumulate and parse at the end.
+        # Check current_text (accumulated), not delta_text — closing markers
+        # like ")]" or "</tool_call>" often span token boundaries and may
+        # never appear within a single delta chunk.
+        if "</tool_call>" in current_text or ")]" in current_text:
             # Tool call complete, parse the whole thing
             result = self.extract_tool_calls(current_text)
             if result.tools_called:


### PR DESCRIPTION
## Summary

Fixes two bugs that cause Qwen3.6 `[Calling tool: name({...})]` streaming tool calls to leak into text content instead of emitting structured `tool_calls`.

### Bug 1 — `server.py` `_stream_responses_request` fast-path gate

The Responses API streaming path still uses the old `"<" not in delta_text` gate to decide whether to engage the tool parser. That gate only matches `<tool_call>` / `<function=` shapes — bracket-format deltas start with `[`, so they skip the parser entirely and get emitted as plain text.

The other 4 streaming paths (Anthropic messages and OpenAI chat completions, reasoning and non-reasoning branches) were already refactored to use `_streaming_tool_markup_possible()` in prior PRs (see refs below) but this path was missed.

Fix: use `_streaming_tool_markup_possible(tool_accumulated_text + delta_text)`, matching the other 4 paths.

### Bug 2 — `qwen_tool_parser.extract_tool_calls_streaming` closing-marker check

Detection of a completed bracket-format tool call looks for `)]` or `</tool_call>` in `delta_text` only. In practice those closing markers routinely span token boundaries — e.g. `)` arrives in one delta and `]` in the next — so the check never fires, the parser returns `None` for every chunk, and the entire call gets suppressed without ever being emitted as structured `tool_calls`.

Fix: check `current_text` (accumulated) instead of `delta_text`, so the close is detected reliably regardless of token splits.

## Reproduction

Serve Qwen3.6-35B-A3B-8bit with:

```
vllm-mlx serve mlx-community/Qwen3.6-35B-A3B-8bit \
  --enable-auto-tool-choice \
  --tool-call-parser qwen \
  --reasoning-parser qwen3
```

Run a streaming chat completion with multiple tools (e.g. a create_file tool with `path` and `content` parameters). The model emits a bracket-format tool call. Without these fixes, the client receives `[Calling tool: create_file({"path": "...", "content": "..."})]` as `content` with `finish_reason: null` and zero `tool_calls` deltas. With these fixes, a proper structured `tool_calls` delta is emitted and `finish_reason: tool_calls` is set.

A 40-turn drift test cycling through 5 tools (`get_weather`, `read_file`, `web_search`, `calculator`, `create_file`) held 4 turns before drifting pre-fix, and held all 40 turns post-fix with no drift.

## Related work

- #146 / #305 added bare-bracket recognition to the auto parser
- #304 refactored generic streaming tool calls
- #232 added XML suppression from streaming text

This PR completes the bracket-format coverage by fixing the one remaining Responses API path and the qwen tool parser closing-marker detection.

## Test plan

- [ ] Streaming chat completion with Qwen3.6 and a `create_file`-style tool emits structured `tool_calls`
- [ ] Multi-turn drift test (40 turns, 5 tools) completes without format drift
- [ ] Other streaming paths (Anthropic messages, OpenAI chat, Responses API) still pass existing tool-call tests