### PR TITLE
Adding missing required max_tokens for terminal

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3447,6 +3447,7 @@ async def create_anthropic_message(
                         engine,
                         openai_request,
                         anthropic_request,
+                        max_tokens=effective_max_tokens,
                         metrics_tracker=tracker,
                     ),
                     _anthropic_terminal,


### PR DESCRIPTION
**Description**
_stream_anthropic_messages method requires passing max_tokens otherwise 500 errors happen
**Solution**
Adding required parameter max_tokens=effective_max_tokens,