### PR TITLE
feat: server-side sampling defaults for top_k, min_p, presence/repetition_penalty

### DIFF
--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -77,6 +77,14 @@ def serve_command(args):
         server._default_temperature = args.default_temperature
     if args.default_top_p is not None:
         server._default_top_p = args.default_top_p
+    if args.default_top_k is not None:
+        server._default_top_k = args.default_top_k
+    if args.default_min_p is not None:
+        server._default_min_p = args.default_min_p
+    if args.default_presence_penalty is not None:
+        server._default_presence_penalty = args.default_presence_penalty
+    if args.default_repetition_penalty is not None:
+        server._default_repetition_penalty = args.default_repetition_penalty
     server._max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     server._max_tts_input_chars = args.max_tts_input_chars
 
@@ -1107,6 +1115,30 @@ Examples:
         type=float,
         default=None,
         help="Override default top_p for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Override default top_k for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Override default min_p for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Override default presence_penalty for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help="Override default repetition_penalty for all requests (default: use model default)",
     )
     # Embedding model option
     serve_parser.add_argument(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -172,12 +172,20 @@ _max_request_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
+_default_top_k: int | None = None  # Set via --default-top-k
+_default_min_p: float | None = None  # Set via --default-min-p
+_default_presence_penalty: float | None = None  # Set via --default-presence-penalty
+_default_repetition_penalty: float | None = None  # Set via --default-repetition-penalty
 _metrics_enabled = False
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
 
 _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
+_FALLBACK_TOP_K = 0
+_FALLBACK_MIN_P = 0.0
+_FALLBACK_PRESENCE_PENALTY = 0.0
+_FALLBACK_REPETITION_PENALTY = 1.0
 
 
 def _resolve_temperature(request_value: float | None) -> float:
@@ -196,6 +204,42 @@ def _resolve_top_p(request_value: float | None) -> float:
     if _default_top_p is not None:
         return _default_top_p
     return _FALLBACK_TOP_P
+
+
+def _resolve_top_k(request_value: int | None) -> int:
+    """Resolve top_k: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_top_k is not None:
+        return _default_top_k
+    return _FALLBACK_TOP_K
+
+
+def _resolve_min_p(request_value: float | None) -> float:
+    """Resolve min_p: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_min_p is not None:
+        return _default_min_p
+    return _FALLBACK_MIN_P
+
+
+def _resolve_presence_penalty(request_value: float | None) -> float:
+    """Resolve presence_penalty: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_presence_penalty is not None:
+        return _default_presence_penalty
+    return _FALLBACK_PRESENCE_PENALTY
+
+
+def _resolve_repetition_penalty(request_value: float | None) -> float:
+    """Resolve repetition_penalty: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_repetition_penalty is not None:
+        return _default_repetition_penalty
+    return _FALLBACK_REPETITION_PENALTY
 
 
 def _resolve_request_max_tokens(requested_value: int | None) -> int:
@@ -2817,9 +2861,6 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         f"prompt_preview={_sanitize_log_text(prompt_preview, limit=200)}"
     )
 
-    # Resolve repetition penalty for completions
-    comp_rep_penalty = request.repetition_penalty
-
     if request.stream:
         return StreamingResponse(
             _disconnect_guard(
@@ -2828,7 +2869,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         engine,
                         prompts[0],
                         request,
-                        repetition_penalty=comp_rep_penalty,
+                        repetition_penalty=_resolve_repetition_penalty(
+                            request.repetition_penalty
+                        ),
                         metrics_tracker=tracker,
                     ),
                     "data: [DONE]\n\n",
@@ -2851,13 +2894,14 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             "max_tokens": effective_max_tokens,
             "temperature": _resolve_temperature(request.temperature),
             "top_p": _resolve_top_p(request.top_p),
-            "top_k": request.top_k or 0,
-            "min_p": request.min_p or 0.0,
-            "presence_penalty": request.presence_penalty or 0.0,
+            "top_k": _resolve_top_k(request.top_k),
+            "min_p": _resolve_min_p(request.min_p),
+            "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
+            "repetition_penalty": _resolve_repetition_penalty(
+                request.repetition_penalty
+            ),
             "stop": request.stop,
         }
-        if comp_rep_penalty is not None:
-            generate_kwargs["repetition_penalty"] = comp_rep_penalty
         if request.specprefill is not None:
             generate_kwargs["specprefill"] = request.specprefill
         if request.specprefill_keep_pct is not None:
@@ -3088,21 +3132,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         ),
                     )
 
-    # Resolve repetition penalty
-    rep_penalty = request.repetition_penalty
-
     # Prepare kwargs
     chat_kwargs = {
         "max_tokens": effective_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
-        "repetition_penalty": request.repetition_penalty or 1.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(request.repetition_penalty),
     }
-    if rep_penalty is not None:
-        chat_kwargs["repetition_penalty"] = rep_penalty
 
     # Add multimodal content
     if has_media:
@@ -3501,10 +3540,12 @@ async def create_anthropic_message(
         "max_tokens": effective_max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
-        "top_k": openai_request.top_k or 0,
-        "min_p": openai_request.min_p or 0.0,
-        "presence_penalty": openai_request.presence_penalty or 0.0,
-        "repetition_penalty": openai_request.repetition_penalty or 1.0,
+        "top_k": _resolve_top_k(openai_request.top_k),
+        "min_p": _resolve_min_p(openai_request.min_p),
+        "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(
+            openai_request.repetition_penalty
+        ),
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -3783,10 +3824,12 @@ async def _stream_anthropic_messages(
         "max_tokens": max_tokens,
         "temperature": openai_request.temperature,
         "top_p": openai_request.top_p,
-        "top_k": openai_request.top_k or 0,
-        "min_p": openai_request.min_p or 0.0,
-        "presence_penalty": openai_request.presence_penalty or 0.0,
-        "repetition_penalty": openai_request.repetition_penalty or 1.0,
+        "top_k": _resolve_top_k(openai_request.top_k),
+        "min_p": _resolve_min_p(openai_request.min_p),
+        "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(
+            openai_request.repetition_penalty
+        ),
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -4069,9 +4112,9 @@ async def stream_completion(
         "max_tokens": max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
         "stop": request.stop,
     }
     if repetition_penalty is not None:
@@ -4628,6 +4671,8 @@ def main():
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
     global _default_temperature, _default_top_p
+    global _default_top_k, _default_min_p
+    global _default_presence_penalty, _default_repetition_penalty
     global _max_audio_upload_bytes, _max_tts_input_chars
     _api_key = args.api_key
     _default_timeout = args.timeout
@@ -4637,6 +4682,14 @@ def main():
         _default_temperature = args.default_temperature
     if args.default_top_p is not None:
         _default_top_p = args.default_top_p
+    if args.default_top_k is not None:
+        _default_top_k = args.default_top_k
+    if args.default_min_p is not None:
+        _default_min_p = args.default_min_p
+    if args.default_presence_penalty is not None:
+        _default_presence_penalty = args.default_presence_penalty
+    if args.default_repetition_penalty is not None:
+        _default_repetition_penalty = args.default_repetition_penalty
     _max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     _max_tts_input_chars = args.max_tts_input_chars
 
@@ -4673,6 +4726,23 @@ def main():
         f"TTS input limit: {args.max_tts_input_chars} chars"
     )
     logger.info("=" * 60)
+
+    # Log sampling defaults when any are configured
+    sampling_overrides = {
+        "temperature": _default_temperature,
+        "top_p": _default_top_p,
+        "top_k": _default_top_k,
+        "min_p": _default_min_p,
+        "presence_penalty": _default_presence_penalty,
+        "repetition_penalty": _default_repetition_penalty,
+    }
+    active = {k: v for k, v in sampling_overrides.items() if v is not None}
+    if active:
+        logger.info("SAMPLING DEFAULTS (server-side overrides)")
+        for param, value in active.items():
+            logger.info(f"  {param}: {value}")
+    else:
+        logger.info("SAMPLING DEFAULTS: none (using per-request or fallback values)")
 
     # Set MCP config for lifespan
     if args.mcp_config:
@@ -4825,6 +4895,30 @@ Examples:
         type=float,
         default=None,
         help="Default top_p for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Default top_k for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Default min_p for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Default presence_penalty for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help="Default repetition_penalty for generation when not specified in request",
     )
     parser.add_argument(
         "--max-audio-upload-mb",


### PR DESCRIPTION
## Summary

This extends the server-side sampling defaults pattern from PR #41 (which added `--default-temperature` and `--default-top-p`) to cover the remaining sampling parameters:

- `--default-top-k` (int) -- server-wide top_k default
- `--default-min-p` (float) -- server-wide min_p default
- `--default-presence-penalty` (float) -- server-wide presence_penalty default
- `--default-repetition-penalty` (float) -- server-wide repetition_penalty default

### Why this matters

When deploying models that need specific sampling configurations (e.g., Unsloth-recommended presets for Qwen, Gemma, Nemotron families), operators currently have no way to set server-wide defaults for these parameters. Clients that omit them get hardcoded neutral fallbacks (`top_k=0`, `min_p=0.0`, `presence_penalty=0.0`, `repetition_penalty=1.0`), which may not be optimal for the loaded model.

### Design

Each new parameter follows the same three-tier resolution as temperature/top_p:

```
request value (if not None) > CLI default > fallback constant
```

The resolve functions use **`is not None` checks, not truthiness**. This is critical because `top_k=0` and `presence_penalty=0.0` are valid explicit values that a client may send to override a non-neutral server default. Using truthiness (`or`) would silently discard these.

### Changes

- **server.py**: 4 new globals, 4 new `_resolve_*` functions, 4 new CLI args, wired in `main()`, all `X or fallback` patterns replaced with resolve calls, sampling defaults logged at startup
- **cli.py**: 4 new `serve_parser` arguments, wired in `serve_command()`

### Cleanup

This also removes a small redundancy in the completions and chat handlers where `repetition_penalty` was set via `or 1.0` and then immediately overwritten by a conditional `if rep_penalty is not None` block. The resolve function handles both cases cleanly.

## Test plan

- [x] `pytest tests/test_server.py -q` -- 72 passed, 3 deselected
- [x] `black --check` -- no formatting changes needed
- [ ] Manual: start server with `--default-repetition-penalty 1.1 --default-min-p 0.1`, confirm startup log shows overrides, confirm requests without explicit params use server defaults, confirm requests with explicit `repetition_penalty=1.0` override the server default