### PR TITLE
feat: thinking-aware logits processor with token budget

### DIFF
--- a/tests/test_thinking_processor.py
+++ b/tests/test_thinking_processor.py
@@ -1,0 +1,501 @@
+"""Tests for ThinkingAwareLogitsProcessor and supporting utilities."""
+
+import os
+from typing import Callable
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.constrained.thinking_processor import (
+    BoundedSuffixMatcher,
+    Phase,
+    ThinkingAwareLogitsProcessor,
+)
+
+
+class TestBoundedSuffixMatcher:
+    def test_single_token_match(self):
+        m = BoundedSuffixMatcher([42])
+        assert m.feed(42) is True
+
+    def test_single_token_no_match(self):
+        m = BoundedSuffixMatcher([42])
+        assert m.feed(99) is False
+
+    def test_multi_token_sequence(self):
+        m = BoundedSuffixMatcher([10, 20, 30])
+        assert m.feed(10) is False
+        assert m.feed(20) is False
+        assert m.feed(30) is True
+
+    def test_partial_match_then_mismatch_resets(self):
+        m = BoundedSuffixMatcher([10, 20, 30])
+        assert m.feed(10) is False
+        assert m.feed(20) is False
+        assert m.feed(99) is False  # mismatch
+        # Must restart; next 10,20,30 should still match
+        assert m.feed(10) is False
+        assert m.feed(20) is False
+        assert m.feed(30) is True
+
+    def test_overlapping_prefix_not_missed(self):
+        # Target: [1, 1, 2]. Stream: 1, 1, 1, 2.
+        # A naive reset-to-0 matcher would miss this.
+        m = BoundedSuffixMatcher([1, 1, 2])
+        assert m.feed(1) is False
+        assert m.feed(1) is False  # partial: [1, 1]
+        assert m.feed(1) is False  # buf=[1, 1, 1] != [1, 1, 2]
+        assert m.feed(2) is True  # buf=[1, 1, 2] == target
+
+    def test_back_to_back_matches(self):
+        m = BoundedSuffixMatcher([5, 6])
+        assert m.feed(5) is False
+        assert m.feed(6) is True
+        # Second match immediately
+        assert m.feed(5) is False
+        assert m.feed(6) is True
+
+    def test_empty_target_raises(self):
+        with pytest.raises(ValueError):
+            BoundedSuffixMatcher([])
+
+
+# --- ThinkingAwareLogitsProcessor tests ---
+
+# Use small token IDs for test markers.
+# <think> = [10, 11], </think> = [20, 21]
+_START_IDS = [10, 11]
+_END_IDS = [20, 21]
+_VOCAB_SIZE = 100
+
+
+def _make_processor(
+    budget: int = 1000,
+    inner: Callable | None = None,
+    start_ids: list[int] = _START_IDS,
+    end_ids: list[int] = _END_IDS,
+) -> ThinkingAwareLogitsProcessor:
+    return ThinkingAwareLogitsProcessor(
+        start_token_ids=start_ids,
+        end_token_ids=end_ids,
+        thinking_token_budget=budget,
+        inner=inner,
+        vocab_size=_VOCAB_SIZE,
+    )
+
+
+def _uniform_logits() -> mx.array:
+    return mx.zeros((_VOCAB_SIZE,))
+
+
+def _feed_sequence(
+    proc: ThinkingAwareLogitsProcessor,
+    token_ids: list[int],
+) -> list[mx.array]:
+    """Feed a sequence of token IDs one at a time, returning logits after each."""
+    results = []
+    tokens_so_far = []
+    for tid in token_ids:
+        tokens_so_far.append(tid)
+        logits = proc(mx.array(tokens_so_far), _uniform_logits())
+        results.append(logits)
+    return results
+
+
+class TestPhaseTransitions:
+    def test_starts_in_idle(self):
+        proc = _make_processor()
+        assert proc.state == Phase.IDLE
+
+    def test_idle_to_thinking_on_start_sequence(self):
+        proc = _make_processor()
+        _feed_sequence(proc, [10, 11])  # <think>
+        assert proc.state == Phase.THINKING
+
+    def test_thinking_to_content_on_natural_end(self):
+        proc = _make_processor()
+        _feed_sequence(proc, [10, 11, 50, 51, 20, 21])  # <think> tokens </think>
+        assert proc.state == Phase.CONTENT
+
+    def test_content_is_terminal_no_reentry(self):
+        proc = _make_processor()
+        _feed_sequence(proc, [10, 11, 50, 20, 21])  # reach CONTENT
+        assert proc.state == Phase.CONTENT
+        _feed_sequence(proc, [10, 11])  # emit start markers again
+        assert proc.state == Phase.CONTENT  # no re-entry
+
+    def test_idle_passes_logits_through(self):
+        proc = _make_processor()
+        logits = _uniform_logits()
+        tokens = mx.array([99])
+        result = proc(tokens, logits)
+        # In IDLE, logits are unchanged
+        assert mx.array_equal(result, logits)
+
+    def test_thinking_passes_logits_through(self):
+        proc = _make_processor()
+        _feed_sequence(proc, [10, 11])  # enter THINKING
+        logits = _uniform_logits()
+        result = proc(mx.array([10, 11, 50]), logits)
+        assert mx.array_equal(result, logits)
+
+    def test_thinking_tokens_counted(self):
+        proc = _make_processor(budget=100)
+        _feed_sequence(proc, [10, 11, 50, 51, 52])
+        # 3 thinking tokens (50, 51, 52), start sequence not counted
+        assert proc.thinking_tokens == 3
+
+    def test_prompt_has_think_tag_starts_in_thinking(self):
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=_START_IDS,
+            end_token_ids=_END_IDS,
+            thinking_token_budget=100,
+            vocab_size=_VOCAB_SIZE,
+            prompt_has_think_tag=True,
+        )
+        assert proc.state == Phase.THINKING
+        _feed_sequence(proc, [50])
+        assert proc.thinking_tokens == 1
+
+    def test_prompt_has_think_tag_budget_zero(self):
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=_START_IDS,
+            end_token_ids=_END_IDS,
+            thinking_token_budget=0,
+            vocab_size=_VOCAB_SIZE,
+            prompt_has_think_tag=True,
+        )
+        assert proc.state == Phase.TRANSITIONING
+
+    def test_prompt_has_think_tag_counts_and_transitions(self):
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=_START_IDS,
+            end_token_ids=_END_IDS,
+            thinking_token_budget=3,
+            vocab_size=_VOCAB_SIZE,
+            prompt_has_think_tag=True,
+        )
+        _feed_sequence(proc, [50, 51, 52])
+        assert proc.thinking_tokens == 3
+        assert proc.state == Phase.TRANSITIONING
+
+
+class TestBudgetEnforcement:
+    def test_budget_forces_transition(self):
+        proc = _make_processor(budget=3)
+        # <think>(10,11) + 3 thinking tokens + should transition
+        _feed_sequence(proc, [10, 11, 50, 51, 52])
+        assert proc.state == Phase.TRANSITIONING
+        assert proc.thinking_tokens == 3
+
+    def test_transition_forces_end_sequence(self):
+        proc = _make_processor(budget=2)
+        # <think>(10,11) + 2 tokens -> transition
+        results = _feed_sequence(proc, [10, 11, 50, 51])
+        assert proc.state == Phase.TRANSITIONING
+        # Now feed through transition: should force end tokens [20, 21]
+        tokens_so_far = [10, 11, 50, 51]
+
+        # First transition token
+        tokens_so_far.append(0)  # placeholder, processor overrides logits
+        logits = proc(mx.array(tokens_so_far), _uniform_logits())
+        # Only token 20 should have logit 0, rest -inf
+        assert logits[20].item() == 0.0
+        assert logits[0].item() == float("-inf")
+
+        # Second transition token
+        tokens_so_far.append(0)
+        logits = proc(mx.array(tokens_so_far), _uniform_logits())
+        assert logits[21].item() == 0.0
+        assert proc.state == Phase.CONTENT
+
+    def test_transition_forces_end_sequence_2d_logits(self):
+        """Verify forced transition works with (1, vocab) shaped logits."""
+        proc = _make_processor(budget=2)
+        _feed_sequence(proc, [10, 11, 50, 51])
+        assert proc.state == Phase.TRANSITIONING
+        tokens_so_far = [10, 11, 50, 51, 0]
+        logits_2d = mx.zeros((1, _VOCAB_SIZE))
+        result = proc(mx.array(tokens_so_far), logits_2d)
+        assert result.shape == (1, _VOCAB_SIZE)
+        assert result[0, 20].item() == 0.0
+        assert result[0, 0].item() == float("-inf")
+
+    def test_forced_transition_tokens_not_counted(self):
+        proc = _make_processor(budget=2)
+        _feed_sequence(proc, [10, 11, 50, 51])  # 2 thinking tokens
+        assert proc.thinking_tokens == 2
+        # Feed through forced transition
+        _feed_sequence(proc, [20, 21])  # these are transition control tokens
+        assert proc.thinking_tokens == 2  # unchanged
+
+    def test_budget_zero_immediate_transition(self):
+        proc = _make_processor(budget=0)
+        _feed_sequence(proc, [10, 11])  # <think> detected
+        assert proc.state == Phase.TRANSITIONING
+        assert proc.thinking_tokens == 0
+
+    def test_natural_end_before_budget(self):
+        proc = _make_processor(budget=100)
+        _feed_sequence(proc, [10, 11, 50, 20, 21])  # natural </think>
+        assert proc.state == Phase.CONTENT
+        # tokens 50 and 20 are counted; end detection only fires when the
+        # full end sequence (20, 21) is matched, so 20 is counted before
+        # the match completes on 21.
+        assert proc.thinking_tokens == 2
+
+    def test_budget_boundary_allows_exactly_n(self):
+        proc = _make_processor(budget=5)
+        _feed_sequence(proc, [10, 11, 50, 51, 52, 53, 54])
+        # 5 thinking tokens (50-54), budget=5, next would exceed -> TRANSITIONING
+        assert proc.thinking_tokens == 5
+        assert proc.state == Phase.TRANSITIONING
+
+
+class TestInnerDelegation:
+    def test_inner_not_called_during_thinking(self):
+        calls = []
+
+        def mock_inner(tokens, logits):
+            calls.append(len(tokens))
+            return logits
+
+        proc = _make_processor(budget=100, inner=mock_inner)
+        _feed_sequence(proc, [10, 11, 50, 51])  # IDLE then THINKING
+        assert len(calls) == 0
+
+    def test_inner_called_during_content(self):
+        calls = []
+
+        def mock_inner(tokens, logits):
+            calls.append(len(tokens))
+            return logits * 2  # distinguishable modification
+
+        proc = _make_processor(budget=100, inner=mock_inner)
+        _feed_sequence(proc, [10, 11, 50, 20, 21])  # reach CONTENT
+        assert proc.state == Phase.CONTENT
+        # inner is called once during _feed_sequence when the end matcher
+        # fires on token 21 and state transitions to CONTENT.
+        assert len(calls) == 1
+
+        tokens = mx.array([10, 11, 50, 20, 21, 60])
+        logits = _uniform_logits()
+        result = proc(tokens, logits)
+        assert len(calls) == 2  # second call from explicit invocation
+        assert mx.array_equal(result, logits * 2)
+
+    def test_no_inner_passes_through_in_content(self):
+        proc = _make_processor(budget=100, inner=None)
+        _feed_sequence(proc, [10, 11, 50, 20, 21])  # reach CONTENT
+        logits = _uniform_logits()
+        tokens = mx.array([10, 11, 50, 20, 21, 60])
+        result = proc(tokens, logits)
+        assert mx.array_equal(result, logits)
+
+
+# =============================================================================
+# API model and adapter tests
+# =============================================================================
+
+from vllm_mlx.api.models import ChatCompletionRequest, Usage
+from vllm_mlx.api.anthropic_models import AnthropicRequest, AnthropicUsage
+from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
+
+
+class TestApiModels:
+    def test_chat_request_accepts_thinking_token_budget(self):
+        req = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking_token_budget=8192,
+        )
+        assert req.thinking_token_budget == 8192
+
+    def test_chat_request_budget_none_by_default(self):
+        req = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert req.thinking_token_budget is None
+
+    def test_chat_request_budget_zero(self):
+        req = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking_token_budget=0,
+        )
+        assert req.thinking_token_budget == 0
+
+    def test_usage_has_reasoning_tokens(self):
+        u = Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        assert u.reasoning_tokens is None
+        u2 = Usage(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            reasoning_tokens=5,
+        )
+        assert u2.reasoning_tokens == 5
+
+    def test_anthropic_request_accepts_thinking_token_budget(self):
+        req = AnthropicRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1024,
+            thinking_token_budget=4096,
+        )
+        assert req.thinking_token_budget == 4096
+
+    def test_anthropic_usage_has_reasoning_tokens(self):
+        u = AnthropicUsage(input_tokens=10, output_tokens=20)
+        assert u.reasoning_tokens is None
+        u2 = AnthropicUsage(input_tokens=10, output_tokens=20, reasoning_tokens=8)
+        assert u2.reasoning_tokens == 8
+
+
+class TestAnthropicAdapter:
+    def test_budget_forwarded_through_adapter(self):
+        req = AnthropicRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=1024,
+            thinking_token_budget=4096,
+        )
+        openai_req = anthropic_to_openai(req)
+        assert openai_req.thinking_token_budget == 4096
+
+    def test_budget_none_when_not_set(self):
+        req = AnthropicRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=1024,
+        )
+        openai_req = anthropic_to_openai(req)
+        assert openai_req.thinking_token_budget is None
+
+
+class TestResolver:
+    def test_request_value_takes_precedence(self):
+        import vllm_mlx.server as srv
+
+        original = srv._default_thinking_token_budget
+        try:
+            srv._default_thinking_token_budget = 4096
+            assert srv._resolve_thinking_token_budget(8192) == 8192
+        finally:
+            srv._default_thinking_token_budget = original
+
+    def test_server_default_used_when_no_request_value(self):
+        import vllm_mlx.server as srv
+
+        original = srv._default_thinking_token_budget
+        try:
+            srv._default_thinking_token_budget = 4096
+            assert srv._resolve_thinking_token_budget(None) == 4096
+        finally:
+            srv._default_thinking_token_budget = original
+
+    def test_none_when_no_default_and_no_request(self):
+        import vllm_mlx.server as srv
+
+        original = srv._default_thinking_token_budget
+        try:
+            srv._default_thinking_token_budget = None
+            assert srv._resolve_thinking_token_budget(None) is None
+        finally:
+            srv._default_thinking_token_budget = original
+
+    def test_zero_is_valid_budget(self):
+        import vllm_mlx.server as srv
+
+        assert srv._resolve_thinking_token_budget(0) == 0
+
+
+class TestDecisionTree:
+    """Test the processor construction decision tree logic."""
+
+    def test_thinking_budget_json_builds_unified(self):
+        mock_json = lambda tokens, logits: logits  # noqa: E731
+        proc = _make_processor(budget=8192, inner=mock_json)
+        assert isinstance(proc, ThinkingAwareLogitsProcessor)
+        assert proc._inner is mock_json
+
+    def test_thinking_budget_no_json_builds_unified(self):
+        proc = _make_processor(budget=8192, inner=None)
+        assert isinstance(proc, ThinkingAwareLogitsProcessor)
+        assert proc._inner is None
+
+    def test_thinking_no_budget_json_is_fallback(self):
+        """No budget + JSON = server must fall back to forcing thinking off.
+        Processor alone cannot enforce this; server-level decision."""
+        # Documented for integration test coverage.
+        pass
+
+    def test_no_parser_budget_is_noop(self):
+        """Budget without a parser is meaningless.
+        Server gates on parser availability."""
+        # Documented for integration test coverage.
+        pass
+
+
+INTEGRATION = os.environ.get("VLLM_MLX_TEST_THINKING_INTEGRATION", "")
+
+
+@pytest.mark.skipif(
+    not INTEGRATION,
+    reason="Set VLLM_MLX_TEST_THINKING_INTEGRATION=1 to run",
+)
+class TestThinkingIntegration:
+    """Integration tests requiring a running Qwen model.
+
+    Run with: VLLM_MLX_TEST_THINKING_INTEGRATION=1 pytest ...
+    Requires a Qwen 3.x model server on localhost:8080 with
+    --reasoning-parser qwen3.
+    """
+
+    def test_budget_caps_reasoning_tokens(self):
+        """With budget=100, reasoning_tokens should be <= 100."""
+        import httpx
+
+        resp = httpx.post(
+            "http://localhost:8080/v1/chat/completions",
+            json={
+                "model": "qwen3.5-27b",
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+                "max_tokens": 4096,
+                "thinking_token_budget": 100,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        usage = data.get("usage", {})
+        assert usage.get("reasoning_tokens") is not None
+        assert usage["reasoning_tokens"] <= 100
+        # Content should be non-empty
+        content = data["choices"][0]["message"]["content"]
+        assert content and len(content.strip()) > 0
+
+    def test_budget_with_json_produces_valid_json(self):
+        """Thinking + JSON + budget should produce valid JSON content."""
+        import httpx
+        import json
+
+        resp = httpx.post(
+            "http://localhost:8080/v1/chat/completions",
+            json={
+                "model": "qwen3.5-27b",
+                "messages": [{"role": "user", "content": 'Return {"answer": 42}'}],
+                "max_tokens": 4096,
+                "thinking_token_budget": 200,
+                "response_format": {"type": "json_object"},
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"]
+        parsed = json.loads(content)  # must be valid JSON
+        assert isinstance(parsed, dict)

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -95,6 +95,7 @@ def anthropic_to_openai(request: AnthropicRequest) -> ChatCompletionRequest:
         # Forward response_format as-is; ChatCompletionRequest coerces raw
         # dicts into the strict ResponseFormat model via pydantic.
         response_format=request.response_format,
+        thinking_token_budget=request.thinking_token_budget,
     )
 
 

--- a/vllm_mlx/api/anthropic_models.py
+++ b/vllm_mlx/api/anthropic_models.py
@@ -69,6 +69,8 @@ class AnthropicRequest(BaseModel):
     # clients commonly forward it via extra_body or top-level for structured
     # output / constrained decoding on this endpoint).
     response_format: dict | None = None
+    # Thinking token budget: caps reasoning tokens via logits-level enforcement
+    thinking_token_budget: int | None = Field(default=None, ge=0)
 
 
 # =============================================================================
@@ -83,6 +85,7 @@ class AnthropicUsage(BaseModel):
     output_tokens: int = 0
     cache_creation_input_tokens: int | None = None
     cache_read_input_tokens: int | None = None
+    reasoning_tokens: int | None = None
 
 
 class AnthropicResponseContentBlock(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Any
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, model_serializer
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -189,6 +189,8 @@ class ChatCompletionRequest(BaseModel):
     specprefill_keep_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
+    # Thinking token budget: caps reasoning tokens as a sub-limit of max_tokens
+    thinking_token_budget: int | None = Field(default=None, ge=0)
 
 
 class AssistantMessage(BaseModel):
@@ -221,6 +223,18 @@ class Usage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    # Only present when reasoning parsing is active; omitted from serialization
+    # when None so existing tests and clients are not affected.
+    reasoning_tokens: int | None = Field(
+        default=None, json_schema_extra={"nullable": True}
+    )
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        d = handler(self)
+        if d.get("reasoning_tokens") is None:
+            d.pop("reasoning_tokens", None)
+        return d
 
 
 class ChatCompletionResponse(BaseModel):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -79,6 +79,8 @@ def serve_command(args):
         server._default_top_p = args.default_top_p
     server._max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     server._max_tts_input_chars = args.max_tts_input_chars
+    if args.default_thinking_token_budget is not None:
+        server._default_thinking_token_budget = args.default_thinking_token_budget
 
     # Configure reasoning parser
     if args.reasoning_parser:
@@ -1107,6 +1109,14 @@ Examples:
         type=float,
         default=None,
         help="Override default top_p for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-thinking-token-budget",
+        type=int,
+        default=None,
+        help="Default thinking token budget for reasoning models. Caps reasoning "
+        "tokens as a sub-limit of max_tokens via logits-level enforcement. "
+        "Per-request thinking_token_budget overrides this.",
     )
     # Embedding model option
     serve_parser.add_argument(

--- a/vllm_mlx/constrained/__init__.py
+++ b/vllm_mlx/constrained/__init__.py
@@ -13,9 +13,11 @@ from .json_schema_processor import (
     LMFormatEnforcerNotAvailableError,
     is_available,
 )
+from .thinking_processor import ThinkingAwareLogitsProcessor
 
 __all__ = [
     "JSONSchemaLogitsProcessor",
     "LMFormatEnforcerNotAvailableError",
+    "ThinkingAwareLogitsProcessor",
     "is_available",
 ]

--- a/vllm_mlx/constrained/thinking_processor.py
+++ b/vllm_mlx/constrained/thinking_processor.py
@@ -1,0 +1,169 @@
+"""Thinking-aware logits processor for reasoning models.
+
+Manages the full thinking lifecycle: budget enforcement, phase transitions,
+and content-phase constrained decoding delegation.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections import deque
+from typing import Callable
+
+import mlx.core as mx
+
+
+class BoundedSuffixMatcher:
+    """Detect a target token sequence in a stream using a rolling suffix buffer.
+
+    Unlike a naive sequential matcher that resets to position 0 on mismatch,
+    this uses a bounded buffer that catches overlapping prefixes.
+    """
+
+    __slots__ = ("target", "_buf", "_max_len")
+
+    def __init__(self, target_ids: list[int]) -> None:
+        if not target_ids:
+            raise ValueError("target_ids must be non-empty")
+        self.target = tuple(target_ids)
+        self._max_len = len(target_ids)
+        self._buf: deque[int] = deque(maxlen=self._max_len)
+
+    def feed(self, token_id: int) -> bool:
+        """Feed one token. Returns True when the buffer suffix equals the target."""
+        self._buf.append(token_id)
+        return len(self._buf) == self._max_len and tuple(self._buf) == self.target
+
+    def reset(self) -> None:
+        """Clear the buffer."""
+        self._buf.clear()
+
+
+class Phase(enum.Enum):
+    """Thinking lifecycle phases."""
+
+    IDLE = "idle"
+    THINKING = "thinking"
+    TRANSITIONING = "transitioning"
+    CONTENT = "content"
+
+
+class ThinkingAwareLogitsProcessor:
+    """Unified logits processor for thinking-model lifecycle management.
+
+    Manages a four-phase state machine:
+      IDLE -> THINKING -> TRANSITIONING -> CONTENT
+
+    - IDLE: before reasoning start tokens. Pass through.
+    - THINKING: inside reasoning span. Count tokens, pass through.
+    - TRANSITIONING: forcing reasoning end sequence via logits masking.
+    - CONTENT: after reasoning closed. Delegate to inner processor.
+
+    No re-entry into THINKING after CONTENT is reached.
+    """
+
+    __slots__ = (
+        "_start_matcher",
+        "_end_matcher",
+        "_end_token_ids",
+        "_thinking_token_budget",
+        "_inner",
+        "_vocab_size",
+        "_state",
+        "_thinking_tokens",
+        "_transition_index",
+    )
+
+    def __init__(
+        self,
+        start_token_ids: list[int],
+        end_token_ids: list[int],
+        thinking_token_budget: int,
+        inner: Callable[[mx.array, mx.array], mx.array] | None = None,
+        vocab_size: int = 152064,
+        prompt_has_think_tag: bool = False,
+    ) -> None:
+        self._start_matcher = BoundedSuffixMatcher(start_token_ids)
+        self._end_matcher = BoundedSuffixMatcher(end_token_ids)
+        self._end_token_ids = list(end_token_ids)
+        self._thinking_token_budget = thinking_token_budget
+        self._inner = inner
+        self._vocab_size = vocab_size
+        self._thinking_tokens = 0
+        self._transition_index = 0
+        # When the chat template already injected <think> into the prompt,
+        # the first generated token is already inside the thinking span.
+        # Start in THINKING (or TRANSITIONING if budget=0) instead of IDLE.
+        if prompt_has_think_tag:
+            if thinking_token_budget == 0:
+                self._state = Phase.TRANSITIONING
+            else:
+                self._state = Phase.THINKING
+        else:
+            self._state = Phase.IDLE
+
+    @property
+    def state(self) -> Phase:
+        return self._state
+
+    @property
+    def thinking_tokens(self) -> int:
+        return self._thinking_tokens
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        # Extract the last token ID from the sequence.
+        last_token = tokens[-1].item()
+
+        if self._state == Phase.IDLE:
+            if self._start_matcher.feed(last_token):
+                self._state = Phase.THINKING
+                # Check budget=0: transition immediately
+                if self._thinking_token_budget == 0:
+                    self._state = Phase.TRANSITIONING
+                    self._transition_index = 0
+            return logits
+
+        if self._state == Phase.THINKING:
+            # Check for natural end of thinking
+            if self._end_matcher.feed(last_token):
+                self._state = Phase.CONTENT
+                return self._call_inner(tokens, logits)
+
+            # Count this as a thinking token (start sequence tokens are not
+            # counted because state was IDLE when they were emitted).
+            self._thinking_tokens += 1
+
+            # Check if budget is now exhausted: the *next* token would exceed.
+            if self._thinking_tokens >= self._thinking_token_budget:
+                self._state = Phase.TRANSITIONING
+                self._transition_index = 0
+
+            return logits
+
+        if self._state == Phase.TRANSITIONING:
+            return self._force_transition(logits)
+
+        # Phase.CONTENT
+        return self._call_inner(tokens, logits)
+
+    def _force_transition(self, logits: mx.array) -> mx.array:
+        """Force the next token in the reasoning end sequence."""
+        target_id = self._end_token_ids[self._transition_index]
+        # Mask all logits to -inf, then set the target token to 0.
+        # Handle both 1-D (vocab,) and 2-D (1, vocab) logits shapes.
+        masked = mx.full(logits.shape, float("-inf"))
+        if masked.ndim == 1:
+            masked[target_id] = 0.0
+        else:
+            masked[..., target_id] = 0.0
+        self._transition_index += 1
+        if self._transition_index >= len(self._end_token_ids):
+            self._state = Phase.CONTENT
+            self._end_matcher.reset()
+        return masked
+
+    def _call_inner(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        """Delegate to inner processor if present."""
+        if self._inner is not None:
+            return self._inner(tokens, logits)
+        return logits

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -172,6 +172,9 @@ _max_request_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
+_default_thinking_token_budget: int | None = (
+    None  # Set via --default-thinking-token-budget
+)
 _metrics_enabled = False
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
@@ -196,6 +199,13 @@ def _resolve_top_p(request_value: float | None) -> float:
     if _default_top_p is not None:
         return _default_top_p
     return _FALLBACK_TOP_P
+
+
+def _resolve_thinking_token_budget(request_value: int | None) -> int | None:
+    """Resolve thinking token budget: request > CLI default > None."""
+    if request_value is not None:
+        return request_value
+    return _default_thinking_token_budget
 
 
 def _resolve_request_max_tokens(requested_value: int | None) -> int:
@@ -1883,6 +1893,24 @@ def get_usage(output: GenerationOutput) -> Usage:
     )
 
 
+def _get_reasoning_token_count(
+    thinking_proc,
+    reasoning_text: str | None,
+    engine,
+) -> int | None:
+    """Extract reasoning token count: authoritative from processor, best-effort from text."""
+    if thinking_proc is not None:
+        return thinking_proc.thinking_tokens
+    if reasoning_text:
+        tokenizer = _get_engine_tokenizer(engine)
+        if tokenizer is not None:
+            try:
+                return len(tokenizer.encode(reasoning_text, add_special_tokens=False))
+            except Exception:
+                pass
+    return None
+
+
 @app.get("/metrics")
 async def metrics():
     """Prometheus scrape endpoint (disabled by default)."""
@@ -3129,19 +3157,67 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
 
-    # Wire constrained decoding logits processor if available.  Must be
-    # appended after all other kwargs because the engine may merge it with
-    # penalty processors internally.
-    if json_logits_processor is not None:
+    # --- Thinking-aware processor decision tree ---
+    _budget = _resolve_thinking_token_budget(
+        getattr(request, "thinking_token_budget", None)
+    )
+    _budget_effective = _budget is not None
+
+    # Use the global _reasoning_parser for tag info.
+    # NOTE: ideally this would be a request-local parser instance, but
+    # upstream does not yet have _build_reasoning_parser.
+    _req_parser = _reasoning_parser
+    _parser_has_tags = (
+        _req_parser is not None
+        and hasattr(_req_parser, "start_token")
+        and hasattr(_req_parser, "end_token")
+    )
+
+    _thinking_on = chat_kwargs.get("enable_thinking") is not False
+    _ctk = chat_kwargs.get("chat_template_kwargs")
+    if _ctk and _ctk.get("enable_thinking") is False:
+        _thinking_on = False
+
+    _thinking_proc = None
+
+    if _thinking_on and _budget_effective and _parser_has_tags:
+        # Build unified thinking-aware processor.
+        from vllm_mlx.constrained import ThinkingAwareLogitsProcessor
+
+        _tokenizer = _get_engine_tokenizer(engine)
+        _tap = ThinkingAwareLogitsProcessor(
+            start_token_ids=_tokenizer.encode(
+                _req_parser.start_token, add_special_tokens=False
+            ),
+            end_token_ids=_tokenizer.encode(
+                _req_parser.end_token, add_special_tokens=False
+            ),
+            thinking_token_budget=_budget,
+            inner=json_logits_processor,
+            vocab_size=_tokenizer.vocab_size,
+            prompt_has_think_tag=_thinking_on,
+        )
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [_tap]
+        _thinking_proc = _tap
+    elif _thinking_on and not _budget_effective and json_logits_processor is not None:
+        # Fallback: thinking + JSON but no budget -> force thinking off.
         existing = chat_kwargs.get("logits_processors") or []
         chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
-        # Constrained decoding is incompatible with reasoning parsers:
-        # the model cannot emit <think> tags when forced to produce JSON.
-        # Suppress thinking so the reasoning parser doesn't capture the
-        # JSON output as reasoning_content.
-        if request.enable_thinking is None:
-            request.enable_thinking = False
-            chat_kwargs["enable_thinking"] = False
+        request.enable_thinking = False
+        chat_kwargs["enable_thinking"] = False
+        ctk = chat_kwargs.get("chat_template_kwargs")
+        if ctk is not None:
+            ctk["enable_thinking"] = False
+    elif json_logits_processor is not None:
+        # No thinking or thinking without budget -> JSON processor directly.
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
+    # else: no processor needed.
+
+    # Pass _thinking_proc through kwargs so stream_chat_completion can report
+    # reasoning_tokens in the usage chunk.
+    chat_kwargs["_thinking_proc"] = _thinking_proc
 
     if request.stream:
         return StreamingResponse(
@@ -3230,6 +3306,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             total_tokens=output.prompt_tokens + output.completion_tokens,
+            reasoning_tokens=_get_reasoning_token_count(
+                _thinking_proc, reasoning_text, engine
+            ),
         ),
     )
 
@@ -3510,11 +3589,57 @@ async def create_anthropic_message(
     if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
 
-    if json_logits_processor is not None:
+    # --- Thinking-aware processor decision tree (Anthropic path) ---
+    _budget = _resolve_thinking_token_budget(
+        getattr(openai_request, "thinking_token_budget", None)
+    )
+    _budget_effective = _budget is not None
+
+    # Use the global _reasoning_parser for tag info.
+    # NOTE: ideally this would be a request-local parser instance.
+    _req_parser = _reasoning_parser
+    _parser_has_tags = (
+        _req_parser is not None
+        and hasattr(_req_parser, "start_token")
+        and hasattr(_req_parser, "end_token")
+    )
+
+    _thinking_on = chat_kwargs.get("enable_thinking") is not False
+    _ctk = chat_kwargs.get("chat_template_kwargs")
+    if _ctk and _ctk.get("enable_thinking") is False:
+        _thinking_on = False
+
+    _thinking_proc = None
+
+    if _thinking_on and _budget_effective and _parser_has_tags:
+        from vllm_mlx.constrained import ThinkingAwareLogitsProcessor
+
+        _tokenizer = _get_engine_tokenizer(engine)
+        _tap = ThinkingAwareLogitsProcessor(
+            start_token_ids=_tokenizer.encode(
+                _req_parser.start_token, add_special_tokens=False
+            ),
+            end_token_ids=_tokenizer.encode(
+                _req_parser.end_token, add_special_tokens=False
+            ),
+            thinking_token_budget=_budget,
+            inner=json_logits_processor,
+            vocab_size=_tokenizer.vocab_size,
+            prompt_has_think_tag=_thinking_on,
+        )
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [_tap]
+        _thinking_proc = _tap
+    elif _thinking_on and not _budget_effective and json_logits_processor is not None:
         existing = chat_kwargs.get("logits_processors") or []
         chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
-        # Suppress thinking: constrained decoding prevents <think> tags.
         chat_kwargs["enable_thinking"] = False
+        ctk = chat_kwargs.get("chat_template_kwargs")
+        if ctk is not None:
+            ctk["enable_thinking"] = False
+    elif json_logits_processor is not None:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
 
     start_time = time.perf_counter()
     timeout = _default_timeout
@@ -3541,7 +3666,9 @@ async def create_anthropic_message(
     reasoning_text, cleaned_text, tool_calls = _extract_reasoning_and_tool_calls(
         output.text,
         openai_request,
-        allow_reasoning=json_logits_processor is None,
+        # Allow reasoning when thinking processor is managing the lifecycle,
+        # even if a JSON logits processor is also active (as inner delegate).
+        allow_reasoning=json_logits_processor is None or _thinking_proc is not None,
     )
 
     # Post-hoc response_format validation / normalization (safety net even
@@ -3610,6 +3737,9 @@ async def create_anthropic_message(
         usage=AnthropicUsage(
             input_tokens=output.prompt_tokens,
             output_tokens=output.completion_tokens,
+            reasoning_tokens=_get_reasoning_token_count(
+                _thinking_proc, reasoning_text, engine
+            ),
         ),
     )
     tracker.finish(
@@ -3794,6 +3924,7 @@ async def _stream_anthropic_messages(
 
     # Wire constrained decoding if response_format was requested via the
     # Anthropic extension field and tools are not also requested.
+    json_logits_processor = None
     response_format = getattr(openai_request, "response_format", None)
     if response_format is not None and not (
         openai_request.tools and openai_request.tool_choice != "none"
@@ -3804,16 +3935,56 @@ async def _stream_anthropic_messages(
         tokenizer_obj = _get_engine_tokenizer(engine)
         if tokenizer_obj is not None:
             try:
-                processor = build_json_logits_processor(response_format, tokenizer_obj)
+                json_logits_processor = build_json_logits_processor(
+                    response_format, tokenizer_obj
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to build JSON logits processor (Anthropic stream): %s",
                     exc,
                 )
-                processor = None
-            if processor is not None:
-                chat_kwargs["logits_processors"] = [processor]
-                chat_kwargs["enable_thinking"] = False
+                json_logits_processor = None
+
+    # --- Thinking-aware processor decision tree (Anthropic streaming) ---
+    _budget = _resolve_thinking_token_budget(
+        getattr(openai_request, "thinking_token_budget", None)
+    )
+    _budget_effective = _budget is not None
+
+    _req_parser = _reasoning_parser
+    _parser_has_tags = (
+        _req_parser is not None
+        and hasattr(_req_parser, "start_token")
+        and hasattr(_req_parser, "end_token")
+    )
+
+    _thinking_on = chat_kwargs.get("enable_thinking") is not False
+
+    if _thinking_on and _budget_effective and _parser_has_tags:
+        from vllm_mlx.constrained import ThinkingAwareLogitsProcessor
+
+        _tokenizer = _get_engine_tokenizer(engine)
+        _tap = ThinkingAwareLogitsProcessor(
+            start_token_ids=_tokenizer.encode(
+                _req_parser.start_token, add_special_tokens=False
+            ),
+            end_token_ids=_tokenizer.encode(
+                _req_parser.end_token, add_special_tokens=False
+            ),
+            thinking_token_budget=_budget,
+            inner=json_logits_processor,
+            vocab_size=_tokenizer.vocab_size,
+            prompt_has_think_tag=_thinking_on,
+        )
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [_tap]
+    elif _thinking_on and not _budget_effective and json_logits_processor is not None:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
+        chat_kwargs["enable_thinking"] = False
+    elif json_logits_processor is not None:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
 
     # Emit message_start
     message_start = {
@@ -4140,6 +4311,7 @@ async def stream_chat_completion(
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response."""
+    _thinking_proc = kwargs.pop("_thinking_proc", None)
     response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
     start_time = time.perf_counter()
     result_label = "success"
@@ -4558,6 +4730,9 @@ async def stream_chat_completion(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    reasoning_tokens=_get_reasoning_token_count(
+                        _thinking_proc, None, engine
+                    ),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"


### PR DESCRIPTION
## Summary

- Add `ThinkingAwareLogitsProcessor` with a four-phase state machine
  (IDLE/THINKING/TRANSITIONING/CONTENT) that manages the thinking lifecycle
  for reasoning models (Qwen 3.x, DeepSeek-R1, etc.)
- `thinking_token_budget` request parameter caps reasoning tokens as a
  sub-limit of `max_tokens` via logits-level enforcement
- Thinking-aware constrained decoding: JSON/schema enforcer only activates
  during CONTENT phase, replacing the force-thinking-off workaround
- `usage.reasoning_tokens` in responses for token accounting
- `--default-thinking-token-budget` server CLI argument
- `/v1/messages` (Anthropic) parity via adapter forwarding

## Motivation

Thinking models can spend their entire `max_tokens` budget on reasoning
without ever producing content (vllm-project/vllm#38894). The current
workaround forces thinking off when constrained decoding is active, which
loses reasoning quality. This feature makes thinking and constrained
decoding coexist correctly.

## Design

When `thinking_token_budget` is set, a logits processor tracks tokens
inside `<think>...</think>`. When the budget is exhausted, it forces the
reasoning end sequence by masking logits, then transitions to content
phase. During content phase, it delegates to an inner JSON/schema
enforcer if present.

Budget within `max_tokens`: if `max_tokens=32768` and
`thinking_token_budget=8192`, the model gets up to 8K for thinking and the
remaining 24K+ for content.

## Phase 2 roadmap

Budget-only requests (no inner JSON constraint) can re-enable MTP after
the reasoning phase ends, recovering speculative decoding speedup for
content generation.

## Test plan

- [ ] 40 offline unit tests covering state machine transitions, budget
  enforcement, inner processor delegation, bounded suffix matcher, API
  models, Anthropic adapter forwarding, and decision tree coverage
- [ ] 2 env-gated integration tests (thinking budget cap, thinking+JSON)
- [ ] Verify no regressions in existing test suites