### PR TITLE
[BUG] gemma4: tool-call stop token, nullable arg parsing, streaming reasoning leak (#380)

### DIFF
--- a/tests/test_gemma4_streaming_edge.py
+++ b/tests/test_gemma4_streaming_edge.py
@@ -27,6 +27,27 @@ def stream_parse(parser, text, token_list):
     return "".join(reasoning_parts), "".join(content_parts)
 
 
+def test_thought_label_split_across_deltas():
+    """The channel-name word 'thought' can arrive split across deltas in
+    production streams. The parser must buffer the partial prefix rather than
+    leak 'th' / 'tho' / 'thou' / 'thoug' into the reasoning output.
+    """
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "tho",        # partial "thought" label
+        "ught",       # completes the label
+        "\n",
+        "real reasoning",
+        "<channel|>",
+        "content",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert reasoning == "real reasoning", f"Label leaked: {reasoning!r}"
+    assert content == "content", f"Got content: {content!r}"
+    print("[PASS] test_thought_label_split_across_deltas")
+
+
 def test_channel_marker_split_across_tokens():
     """<|channel> alone should not leak into reasoning if response follows."""
     parser = Gemma4ReasoningParser()

--- a/tests/test_gemma4_streaming_edge.py
+++ b/tests/test_gemma4_streaming_edge.py
@@ -35,8 +35,8 @@ def test_thought_label_split_across_deltas():
     parser = Gemma4ReasoningParser()
     tokens = [
         "<|channel>",
-        "tho",        # partial "thought" label
-        "ught",       # completes the label
+        "tho",  # partial "thought" label
+        "ught",  # completes the label
         "\n",
         "real reasoning",
         "<channel|>",

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -167,7 +167,6 @@ class TestGemma4ToolParserExtract:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"text": 'line1\nline2 said "hello"'}
 
-
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""
 
@@ -237,4 +236,47 @@ class TestGemma4Registration:
 
     def test_native_format_false(self):
         assert Gemma4ToolParser.SUPPORTS_NATIVE_TOOL_FORMAT is False
+
+    def test_extra_stop_tokens_declares_tool_response(self):
+        """Gemma 4 treats <|tool_response> (id 50) as end-of-generation
+        after a tool call. The parser exposes it so the server can merge it
+        into the request's stop sequences.
+        Reference: llama.cpp PR #21418.
+        """
+        parser = Gemma4ToolParser()
+        assert "<|tool_response>" in parser.extra_stop_tokens
+
+    def test_abstract_parser_default_empty_stop_tokens(self):
+        """Other parsers that don't override keep an empty default."""
+        from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+        assert ToolParser.extra_stop_tokens == []
+
+    def test_merge_helper_adds_parser_extras(self):
+        """get_parser_stop_tokens adds the parser's EOG tokens on top of user stops."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        merged = get_parser_stop_tokens("gemma4", ["END"])
+        assert "END" in merged
+        assert "<|tool_response>" in merged
+
+    def test_merge_helper_dedupes(self):
+        """Parser extra tokens already present in user stops aren't duplicated."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        merged = get_parser_stop_tokens("gemma4", ["<|tool_response>"])
+        assert merged.count("<|tool_response>") == 1
+
+    def test_merge_helper_unknown_parser_is_passthrough(self):
+        """Unknown parser name leaves user stops untouched."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        assert get_parser_stop_tokens("nonexistent_parser_xyz", ["A"]) == ["A"]
+
+    def test_merge_helper_none_parser_is_passthrough(self):
+        """No parser name returns user stops as-is."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        assert get_parser_stop_tokens(None, ["A"]) == ["A"]
+        assert get_parser_stop_tokens(None, None) == []
         assert Gemma4ToolParser.supports_native_format() is False

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -189,7 +189,9 @@ class TestGemma4ToolParserExtract:
 
     def test_bare_string_preserves_null_and_bool_literals(self):
         """null/true/false must NOT be treated as bare strings."""
-        output = "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        output = (
+            "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        )
         result = self.parser.extract_tool_calls(output)
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"flag": None, "ready": True, "done": False, "name": "bob"}

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -167,6 +167,42 @@ class TestGemma4ToolParserExtract:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"text": 'line1\nline2 said "hello"'}
 
+    def test_bare_string_value_without_delimiters(self):
+        """Nullable type (e.g. ["string", "null"]) makes the template skip the
+        <|"|> wrap around string values. The parser must still produce valid
+        JSON with the value as a string.
+        Reference: llama.cpp PR #21327.
+        """
+        output = "<|tool_call>call:set_state{domain:light}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"domain": "light"}
+
+    def test_bare_string_mixed_with_number_and_bool(self):
+        """Bare string value must not interfere with numeric/bool parsing."""
+        output = "<|tool_call>call:update{name:alice,count:5,active:true}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"name": "alice", "count": 5, "active": True}
+
+    def test_bare_string_preserves_null_and_bool_literals(self):
+        """null/true/false must NOT be treated as bare strings."""
+        output = "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"flag": None, "ready": True, "done": False, "name": "bob"}
+
+    def test_bare_string_in_array(self):
+        """Enum-without-type: array of bare strings should be quoted per element."""
+        output = "<|tool_call>call:filter{tags:[alpha,beta,gamma]}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"tags": ["alpha", "beta", "gamma"]}
+
+
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""
 

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -28,6 +28,11 @@ from .think_parser import BaseThinkingReasoningParser
 # Channel names that follow <|channel> — stripped from output
 _THOUGHT_PREFIX = "thought"
 _RESPONSE_MARKER = "<|channel>response"
+# Full "open-thinking" marker. Kept as a buffering target so that partial
+# prefixes arriving mid-stream (e.g. "<|channel>th", "<|channel>thoug") are
+# held back until the label completes, instead of leaking 'th', 'tho', etc.
+# into the reasoning output.
+_THOUGHT_MARKER = "<|channel>thought"
 
 
 def _strip_channel_name(text: str, prefix: str) -> str:
@@ -95,7 +100,7 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         when it appears AT THE END and is not followed by more text (i.e.,
         `response` or `thought` hasn't arrived yet).
         """
-        markers = (_RESPONSE_MARKER, self.end_token, self.start_token)
+        markers = (_RESPONSE_MARKER, _THOUGHT_MARKER, self.end_token, self.start_token)
         max_len = 0
         for marker in markers:
             # Scan from longest proper prefix downwards

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -155,7 +155,7 @@ from .endpoint_model_policies import (
     resolve_tts_model_name,
 )
 from .metrics import metrics as _metrics
-from .tool_parsers import ToolParserManager
+from .tool_parsers import ToolParserManager, get_parser_stop_tokens
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -3128,6 +3128,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Add tools if provided
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
+
+    # Merge stop sequences: user-supplied + parser-declared EOG tokens.
+    # Gemma 4's <|tool_response> is the canonical example — without it the
+    # model keeps generating text after a tool call (llama.cpp PR #21418).
+    parser_name = _tool_call_parser if _enable_auto_tool_choice else None
+    merged_stop = get_parser_stop_tokens(parser_name, request.stop)
+    if merged_stop:
+        chat_kwargs["stop"] = merged_stop
 
     # Wire constrained decoding logits processor if available.  Must be
     # appended after all other kwargs because the engine may merge it with

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -62,6 +62,7 @@ from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 
+
 def get_parser_stop_tokens(
     parser_name: str | None,
     user_stops: list[str] | None,

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -62,11 +62,36 @@ from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 
+def get_parser_stop_tokens(
+    parser_name: str | None,
+    user_stops: list[str] | None,
+) -> list[str]:
+    """Merge user-supplied stops with parser-declared extras (deduped).
+
+    Some models declare end-of-generation tokens beyond the tokenizer's default
+    eos set — e.g. Gemma 4's ``<|tool_response>`` which signals the runtime's
+    turn after a tool call. Parsers expose those via ``extra_stop_tokens``.
+    """
+    stops = list(user_stops or [])
+    if not parser_name:
+        return stops
+    try:
+        parser_cls = ToolParserManager.get_tool_parser(parser_name)
+    except (KeyError, ImportError):
+        return stops
+    for s in getattr(parser_cls, "extra_stop_tokens", []):
+        if s not in stops:
+            stops.append(s)
+    return stops
+
+
 __all__ = [
     # Base classes
     "ToolParser",
     "ToolParserManager",
     "ExtractedToolCallInformation",
+    # Helpers
+    "get_parser_stop_tokens",
     # Specific parsers
     "AutoToolParser",
     "Gemma4ToolParser",

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -50,6 +50,12 @@ class ToolParser(ABC):
     # without needing conversion to text format.
     SUPPORTS_NATIVE_TOOL_FORMAT: bool = False
 
+    # Extra stop tokens specific to this parser's model format. The server
+    # merges these into the request's `stop` list when the parser is active,
+    # so the model halts on format-specific EOG markers (e.g. Gemma 4's
+    # <|tool_response>) that are not part of the tokenizer's default eos set.
+    extra_stop_tokens: list[str] = []
+
     @classmethod
     def supports_native_format(cls) -> bool:
         """

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -45,6 +45,15 @@ _CALL_PREFIX = re.compile(r"call:(\w+)\s*\{")
 # Pattern to quote bare keys: word followed by : at start or after , or {
 _BARE_KEY = re.compile(r"(?<=[{,])\s*(\w+)\s*:")
 
+# Pattern to quote bare string VALUES that the template omitted <|"|> around.
+# This fires when a schema uses a nullable type like ["string","null"] or an
+# enum field without explicit "type": the template takes the non-STRING branch
+# and emits the value raw. Preceded by a value-position separator (: [ ,), a
+# word starting with a letter, followed by ,/}/]. JSON literals true/false/null
+# are filtered out inside the substitution. Ref: llama.cpp PR #21327.
+_BARE_VALUE = re.compile(r"(?<=[:\[,])(\s*)([A-Za-z_][\w\-]*)(?=\s*[,}\]])")
+_JSON_LITERALS = frozenset({"true", "false", "null"})
+
 # Max arg block length to prevent runaway parsing on malformed input (1 MB)
 _MAX_ARG_BLOCK_LEN = 1_048_576
 
@@ -85,15 +94,27 @@ def _find_balanced_brace(text: str, start: int) -> int:
     return -1
 
 
+def _quote_bare_value(m: re.Match) -> str:
+    """Substitution callback for _BARE_VALUE — quotes bare identifiers that
+    are not JSON literals (true/false/null)."""
+    ws, word = m.group(1), m.group(2)
+    if word in _JSON_LITERALS:
+        return m.group(0)
+    return f'{ws}"{word}"'
+
+
 def _gemma4_args_to_json(text: str) -> str:
     """Convert Gemma 4 tool call args to valid JSON.
 
-    Three-step conversion (ORDER MATTERS):
+    Four-step conversion (ORDER MATTERS):
     1. Extract <|"|>-delimited strings into numbered \\x00N\\x00 placeholders.
        This protects string contents from step 2's bare-key quoting -- without
        this, a string value like "key: value" would be corrupted.
     2. Quote bare keys (word: -> "word":) now that strings are safe.
-    3. Restore placeholders as properly JSON-escaped strings via json.dumps().
+    3. Quote bare string VALUES that the template emitted without <|"|>
+       wrappers. Happens with nullable/enum schemas where the STRING branch
+       of the template isn't taken.
+    4. Restore placeholders as properly JSON-escaped strings via json.dumps().
        Uses a single re.sub pass (O(len(text))) instead of per-placeholder replace.
     """
     strings: list[str] = []
@@ -108,7 +129,10 @@ def _gemma4_args_to_json(text: str) -> str:
     # Step 2: Quote bare keys
     text = _BARE_KEY.sub(r'"\1":', text)
 
-    # Step 3: Restore captured strings as properly escaped JSON strings
+    # Step 3: Quote bare string values (nullable / enum-without-type schemas)
+    text = _BARE_VALUE.sub(_quote_bare_value, text)
+
+    # Step 4: Restore captured strings as properly escaped JSON strings
     def _restore(m: re.Match) -> str:
         idx = int(m.group(1))
         return json.dumps(strings[idx]) if idx < len(strings) else m.group(0)

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -133,6 +133,13 @@ class Gemma4ToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser gemma4 are set.
     """
 
+    # The chat template renders <|tool_response> (token 50) when the assistant
+    # emits a tool call without its own tool_responses block — it's the signal
+    # that it's the runtime's turn, not the model's. Treat it as EOG so the
+    # model doesn't keep generating past the tool call.
+    # Ref: llama.cpp PR #21418.
+    extra_stop_tokens = ["<|tool_response>"]
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:


### PR DESCRIPTION
## Purpose

Fixes three correctness bugs in the Gemma 4 stack reported in
[#380](https://github.com/waybarrios/vllm-mlx/issues/380):

1. The model keeps generating (or loops) after emitting a tool call —
   `<|tool_response>` is not treated as end-of-generation.
2. Tool calls with nullable (`"type": ["string", "null"]`) or
   enum-without-explicit-type schemas are dropped because the parser cannot
   understand bare, unwrapped values.
3. The streaming reasoning parser leaks the partial label `"th"` / `"tho"`
   into `reasoning_content` when the token `<|channel>thought` is split
   across delta boundaries.

None of these required touching the engine or KV-cache path. The PR is
strictly a parser/server correctness patch and has no impact on the
active v1 engine work.

---

## Bug A — `<|tool_response>` is not a stop token

### Symptom

When a Gemma 4 model issues a tool call, it often continues generating
after `<tool_call|>`, producing extra content or looping (confirmed by
downstream reports like QwenPaw #2947 and vLLM #40080).

### Root cause

Gemma 4's chat template renders `<|tool_response>` (token `50`, special)
right after the assistant emits a tool call — it is the signal that the
runtime should now execute the tool and return a response. In other
words, `<|tool_response>` is the turn boundary from the model's side and
must stop generation. Our tokenizer does not include it in the default
`eos_token_id` set, so the model never halts on it. This is the same fix
landed in
[ggml-org/llama.cpp#21418](https://github.com/ggml-org/llama.cpp/pull/21418).

### Fix

Add an `extra_stop_tokens` class attribute to the abstract `ToolParser`,
declare it on `Gemma4ToolParser`, and merge it into the chat request's
`stop` list at the server layer.

```python
# vllm_mlx/tool_parsers/abstract_tool_parser.py
class ToolParser(ABC):
    ...
    # Extra stop tokens specific to this parser's model format. The server
    # merges these into the request's `stop` list when the parser is active.
    extra_stop_tokens: list[str] = []
```

```python
# vllm_mlx/tool_parsers/gemma4_tool_parser.py
class Gemma4ToolParser(ToolParser):
    # <|tool_response> is the model-side turn boundary after a tool call.
    extra_stop_tokens = ["<|tool_response>"]
```

```python
# vllm_mlx/tool_parsers/__init__.py — new helper
def get_parser_stop_tokens(
    parser_name: str | None,
    user_stops: list[str] | None,
) -> list[str]:
    """Merge user-supplied stops with parser-declared extras (deduped)."""
    ...
```

```python
# vllm_mlx/server.py — inside create_chat_completion, just after tools are set
parser_name = _tool_call_parser if _enable_auto_tool_choice else None
merged_stop = get_parser_stop_tokens(parser_name, request.stop)
if merged_stop:
    chat_kwargs["stop"] = merged_stop
```

### Verification

End-to-end test hitting a live server with `--continuous-batching
--enable-auto-tool-choice --tool-call-parser gemma4` and the following
schema:

```python
{"type": "function", "function": {"name": "get_weather",
  "parameters": {"type": "object",
    "properties": {"city": {"type": "string"}},
    "required": ["city"]}}}
```

Request: `"What's the weather in Tokyo?"` — response:

```
finish_reason:     tool_calls
tool_calls count:  1
content:           None
completion tokens: 15
```

15 tokens, clean stop, no trailing rambling.

---

## Bug B — nullable / enum-without-type arguments are dropped

### Symptom

Tool calls using OpenAPI-style schemas with nullable types or enum fields
without an explicit `"type"` silently fail. The parser logs:

```
WARNING Gemma 4 tool parser: failed to parse args for call:set_state:
        Expecting value: line 1 column 11 (char 10)
```

### Root cause

The Jinja chat template decides whether to wrap a value in `<|"|> ... <|"|>`
by checking `value['type'] | upper == 'STRING'`. For a schema like
`{"type": ["string", "null"]}` or `{"enum": [...]}` with no `"type"`, that
branch is not taken, so the model's expected output is a **bare** value:

```
<|tool_call>call:set_state{domain:light}<tool_call|>
```

Our parser ran three passes — capture `<|"|>` strings, quote bare keys,
restore strings — but never quoted bare **values**. `json.loads` rejected
the result as invalid JSON, and the tool call was reported as not called.

This matches the failure class fixed in
[ggml-org/llama.cpp#21327](https://github.com/ggml-org/llama.cpp/pull/21327).

### Fix

Add a fourth pass that quotes identifiers appearing in value position
(after `:`, `[`, or `,`), while leaving JSON literals (`true`, `false`,
`null`) and numeric values untouched.

```python
# vllm_mlx/tool_parsers/gemma4_tool_parser.py
_BARE_VALUE = re.compile(r"(?<=[:\[,])(\s*)([A-Za-z_][\w\-]*)(?=\s*[,}\]])")
_JSON_LITERALS = frozenset({"true", "false", "null"})

def _quote_bare_value(m: re.Match) -> str:
    ws, word = m.group(1), m.group(2)
    if word in _JSON_LITERALS:
        return m.group(0)
    return f'{ws}"{word}"'

def _gemma4_args_to_json(text: str) -> str:
    text = _STRING_DELIM_RE.sub(_capture, text)        # 1. extract delimited strings
    text = _BARE_KEY.sub(r'"\1":', text)                # 2. quote bare keys
    text = _BARE_VALUE.sub(_quote_bare_value, text)     # 3. NEW: quote bare values
    text = _PLACEHOLDER_RE.sub(_restore, text)          # 4. restore strings
    return text
```

Placeholders (`\x00N\x00`) and negative numbers (starting with `-`) are
not captured because the pattern requires a leading letter/underscore,
so the existing paths are untouched.

### Verification

Live request with a realistic schema (nullable enum + enum-without-type):

```python
"parameters": {"type": "object", "properties": {
    "area":   {"type": "string"},
    "state":  {"type": ["string", "null"], "enum": ["on", "off"]},
    "brightness": {"enum": ["low", "medium", "high"]},
}}
```

Request: `"Set the kitchen light to on with medium brightness."` — response:

```
args_raw:  {"area":"kitchen","brightness":"medium","state":"on"}
args:      {'area': 'kitchen', 'brightness': 'medium', 'state': 'on'}
no <|"|> artifact in args_raw: True
```

All three fields are correctly typed strings and `json.loads` succeeds.

---

## Bug C — streaming reasoning parser leaks `"th"` / `"tho"`

### Symptom

When the parser streams reasoning and the token sequence lands
`<|channel>` + `"tho"` + `"ught"` across delta boundaries, the first
delta emits `"tho"` into `reasoning_content` before the strip logic
recognises the `"thought"` label. Observed directly via a targeted
probe:

```
streamed reasoning = 'thoreal reasoning'
                     ^^^
```

### Root cause

The buffering function `_trailing_partial_marker_len` only considered the
bare markers `<|channel>response`, `<channel|>`, and `<|channel>`. Proper
prefixes of the longer label `<|channel>thought` were not buffered, so
partial characters of `"thought"` slipped through to the parent
streaming parser before the label-strip logic saw the full word.

### Fix

Register `<|channel>thought` as a buffering target too. The parser then
withholds any trailing proper prefix (e.g. `"<|channel>tho"`) until the
full label lands, at which point the existing strip path consumes it.

```python
# vllm_mlx/reasoning/gemma4_parser.py
_THOUGHT_MARKER = "<|channel>thought"
...
markers = (_RESPONSE_MARKER, _THOUGHT_MARKER, self.end_token, self.start_token)
```

### Verification

Streaming request with `enable_thinking=True` against the live server:

```
reasoning head:  'Thinking Process:\n1.  **Analyze the request:** ...'
content head:    '4'
no 'th'-ish leak at start:  True
no markers leaked:          True
```

---

## Test results

### Unit tests added

- `tests/test_gemma4_tool_parser.py`:
  - `test_extra_stop_tokens_declares_tool_response`
  - `test_abstract_parser_default_empty_stop_tokens`
  - `test_merge_helper_adds_parser_extras`
  - `test_merge_helper_dedupes`
  - `test_merge_helper_unknown_parser_is_passthrough`
  - `test_merge_helper_none_parser_is_passthrough`
  - `test_bare_string_value_without_delimiters`
  - `test_bare_string_mixed_with_number_and_bool`
  - `test_bare_string_preserves_null_and_bool_literals`
  - `test_bare_string_in_array`
- `tests/test_gemma4_streaming_edge.py`:
  - `test_thought_label_split_across_deltas`

### Full test suite

```
$ pytest tests/ --ignore=tests/test_moe_top_k.py
========= 1561 passed, 11 skipped, 22 deselected in 25.35s =========
```

(One pre-existing flaky perf test, `test_batched_faster_than_sequential`,
fails under parallel load and passes in isolation — unrelated to this PR.)

### End-to-end

All three fixes validated against a running server with the flags from
the issue on M4 Max / 128 GB:

```
== Fix A — tool_response stop token ==                 PASS
== Fix B — nullable/enum bare string args ==           PASS
== Fix C — streaming reasoning, no label leak ==       PASS
```

---

## Out of scope — follow-up

The fourth symptom from #380 (**continuous-batching produces nonsense
output**) was **reproduced** while investigating this PR: under 12
concurrent requests with `enable_thinking=True` on
`mlx-community/gemma-4-e2b-it-mxfp4`, the content from one request
bleeds into the response of unrelated concurrent requests. Example:

```
[11] user: 'Briefly, what is dark matter?'
     content: ''   (response redirected)
[ 3] user: 'Explain what a hash table is in 30 words or less.'
     content: 'Dark matter is a hypothetical form of matter ...'
[ 4] user: 'Who painted the Mona Lisa?'
     content: 'Dark matter is a hypothetical form of matter ...'
[ 6] user: "Translate 'thank you' into German."
     content: 'Dunkle Materie.'   (literally "dark matter" in German)
```

This is a pre-existing engine-level bug (KV-cache / scheduler state
leak in the MLLM continuous-batching path). It is orthogonal to the
parser and server changes in this PR and will be filed separately with
the repro script.

---

Closes (partially) #380. Refs:
- [ggml-org/llama.cpp#21418](https://github.com/ggml-org/llama.cpp/pull/21418)
- [ggml-org/llama.cpp#21327](https://github.com/ggml-org/llama.cpp/pull/21327)
