### PR TITLE
[BUG] gemma4 CB leaks content across requests via prefix cache LCP (#384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
             tests/test_chat_template_kwargs.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \
+            tests/test_memory_cache_mlx.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-dependent regression tests for the LCP trim contamination fix (#384).
+
+These tests use real ``mlx_lm.models.cache.KVCache`` / ``RotatingKVCache``
+objects backed by ``mlx.core`` arrays.  They run only on the apple-silicon
+CI matrix (and locally on M-series hardware); the Linux ``test-matrix``
+job excludes this file because MLX has no Linux distribution.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestTrimCacheOffset:
+    """Tests for ``_trim_cache_offset``, focused on the LCP contamination fix.
+
+    Regression: when the LCP fetch path trimmed a cache entry by shrinking
+    the offset while still sharing the underlying (oversized) key/value
+    arrays, downstream attention layers that read ``cache.state`` directly
+    (e.g. Gemma 4 KV-shared layers) could see stale tokens from the previous
+    owner of the entry.  See issue #384.  The fix slices the arrays down to
+    new_offset so no memory beyond the new boundary remains accessible.
+    """
+
+    def test_plain_kv_cache_array_sliced_to_new_offset(self):
+        """Plain-KVCache-like layer: after trim, keys.shape[-2] == new_offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        # Pretend a previous request wrote 500 tokens worth of data
+        layer.keys = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(1, 4, 500, 8)
+        layer.values = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(
+            1, 4, 500, 8
+        )
+        layer.offset = 500
+
+        # New request shares only the first 60 tokens as prefix
+        trim_by = 500 - 60
+        trimmed = _trim_cache_offset([layer], trim_by)
+        tc = trimmed[0]
+
+        assert tc.offset == 60
+        # The underlying array MUST be shrunk, not just the offset pointer.
+        # Otherwise Gemma 4's cache.state-reading layers would see positions
+        # 60..500 filled with the previous request's tokens.
+        assert tc.keys.shape[-2] == 60
+        assert tc.values.shape[-2] == 60
+
+    def test_plain_kv_cache_no_stale_tokens_visible_via_state(self):
+        """A layer that reads the full cache.state must not see tokens past new_offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        # Positions 0..60: shared prefix (same for everyone).  Positions 60..500:
+        # private content from a previous request that must NOT leak.
+        shared = mx.ones((1, 4, 60, 8), dtype=mx.float32)
+        private = mx.full((1, 4, 440, 8), 7.0, dtype=mx.float32)
+        layer.keys = mx.concatenate([shared, private], axis=2)
+        layer.values = layer.keys
+        layer.offset = 500
+
+        tc = _trim_cache_offset([layer], 500 - 60)[0]
+
+        # cache.state is what KV-shared layers read directly.
+        keys_view, _ = tc.state
+        assert keys_view.shape[-2] == 60
+        # No "7.0" tokens anywhere — private content was excluded.
+        assert float(mx.max(keys_view).item()) == 1.0
+
+    def test_plain_kv_cache_no_trim_preserves_array(self):
+        """If trim_by == 0 or offset already equals shape, array is untouched."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 100, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 100, 8), dtype=mx.float32)
+        layer.offset = 100
+
+        tc = _trim_cache_offset([layer], 0)[0]
+
+        assert tc.offset == 100
+        assert tc.keys.shape[-2] == 100
+
+    def test_plain_kv_cache_trim_by_exceeds_offset_clamps_to_zero(self):
+        """trim_by larger than offset yields an empty-but-valid trimmed cache."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 80, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 80, 8), dtype=mx.float32)
+        layer.offset = 80
+
+        tc = _trim_cache_offset([layer], 1000)[0]
+
+        assert tc.offset == 0
+        assert tc.keys.shape[-2] == 0
+        assert tc.values.shape[-2] == 0
+
+    def test_plain_kv_cache_stored_entry_unaffected_after_trim(self):
+        """Calling _trim_cache_offset must not mutate the source layer in place.
+
+        The stored prefix-cache entry is the source here; a later lookup for
+        a different request should get the same pristine data.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        full = mx.arange(1 * 2 * 200 * 4, dtype=mx.float32).reshape(1, 2, 200, 4)
+        layer.keys = full
+        layer.values = full
+        layer.offset = 200
+        original_shape = layer.keys.shape
+
+        _trim_cache_offset([layer], 150)
+
+        # Source entry keeps its full shape and offset.
+        assert layer.keys.shape == original_shape
+        assert layer.values.shape == original_shape
+        assert layer.offset == 200
+
+    def test_plain_kv_cache_in_place_write_does_not_corrupt_source(self):
+        """After trim, writing through the returned cache must not leak into
+        the stored entry.  This is the direct semantics of the fix: the stored
+        prefix-cache entry has to survive concurrent use by other requests.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        # Source stored entry: positions 0..300 holding 5.0.
+        layer = KVCache()
+        layer.keys = mx.full((1, 2, 300, 4), 5.0, dtype=mx.float32)
+        layer.values = mx.full((1, 2, 300, 4), 5.0, dtype=mx.float32)
+        layer.offset = 300
+
+        # New request shares first 50 tokens.
+        tc = _trim_cache_offset([layer], 300 - 50)[0]
+
+        # The trimmed cache now only has 50 tokens.  Writing new tokens via
+        # update_and_fetch allocates a new array (because prev + N > current
+        # shape) and does not touch the source.
+        new_keys = mx.zeros((1, 2, 10, 4), dtype=mx.float32)
+        new_values = mx.zeros((1, 2, 10, 4), dtype=mx.float32)
+        tc.update_and_fetch(new_keys, new_values)
+
+        # Source remains untouched (all 5.0 values preserved across full range).
+        assert layer.keys.shape[-2] == 300
+        assert float(mx.min(layer.keys).item()) == 5.0
+        assert float(mx.max(layer.keys).item()) == 5.0
+
+    def test_plain_kv_cache_multiple_layers_all_sliced(self):
+        """Caches with several KVCache layers: every layer gets sliced."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layers = []
+        for _ in range(5):
+            layer = KVCache()
+            layer.keys = mx.ones((1, 4, 200, 8), dtype=mx.float32)
+            layer.values = mx.ones((1, 4, 200, 8), dtype=mx.float32)
+            layer.offset = 200
+            layers.append(layer)
+
+        trimmed = _trim_cache_offset(layers, 150)
+
+        assert len(trimmed) == 5
+        for tc in trimmed:
+            assert tc.offset == 50
+            assert tc.keys.shape[-2] == 50
+            assert tc.values.shape[-2] == 50
+
+    def test_plain_kv_cache_slice_works_for_float16_and_bfloat16(self):
+        """Fix must be dtype-agnostic so quantized / mixed-precision KV caches
+        receive the same treatment as fp32.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        for dtype in (mx.float16, mx.bfloat16):
+            layer = KVCache()
+            layer.keys = mx.ones((1, 2, 120, 4), dtype=dtype)
+            layer.values = mx.ones((1, 2, 120, 4), dtype=dtype)
+            layer.offset = 120
+
+            tc = _trim_cache_offset([layer], 80)[0]
+
+            assert tc.offset == 40, f"dtype={dtype}"
+            assert tc.keys.shape[-2] == 40, f"dtype={dtype}"
+            assert tc.keys.dtype == dtype, f"dtype={dtype}"
+
+    def test_plain_kv_cache_rotating_layers_unchanged_behavior(self):
+        """RotatingKVCache was already trimming correctly before this fix.
+        The plain-KVCache branch is the only one that changed; the rotating
+        branch is exercised here to catch regressions.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = RotatingKVCache(max_size=128, keep=0)
+        # Layer already rotated once: offset=200, buffer holds max_size entries.
+        layer.keys = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.offset = 200
+        layer._idx = 128
+
+        tc = _trim_cache_offset([layer], 100)[0]
+
+        # Offset dropped by trim_by, clamped at >= 0.
+        assert tc.offset == 100
+        # Rotating path materialises a buffer whose shape matches new_offset
+        # (padding with zeros if needed).  It must not come back as None.
+        assert tc.keys is not None
+        assert tc.values is not None
+        # Dtype preserved through trim.
+        assert tc.keys.dtype == mx.float32
+        # Type-specific attrs preserved.
+        assert hasattr(tc, "max_size")
+        assert tc.max_size == 128
+
+    def test_fetch_returns_sliced_cache_on_lcp_match(self):
+        """End-to-end: MemoryAwarePrefixCache.fetch on a request that shares
+        only a prefix with a longer stored entry must return a cache whose
+        arrays are already sliced down.  This is the full regression of the
+        #384 scenario above the unit level.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        model = MagicMock()
+        cache = MemoryAwarePrefixCache(
+            model, MemoryCacheConfig(max_memory_mb=64, max_entries=10)
+        )
+
+        # Stored: tokens [1..120] with 120 positions of KV data, the first 60
+        # tokens being the shared prefix (all 1.0), the last 60 private (7.0).
+        stored_layer = KVCache()
+        shared = mx.ones((1, 2, 60, 4), dtype=mx.float32)
+        private = mx.full((1, 2, 60, 4), 7.0, dtype=mx.float32)
+        stored_layer.keys = mx.concatenate([shared, private], axis=2)
+        stored_layer.values = stored_layer.keys
+        stored_layer.offset = 120
+        cache.store(list(range(1, 121)), [stored_layer])
+
+        # New request: tokens [1..59] + [999, 1000, 1001] — first 59 tokens
+        # match, then diverge.  LCP is 59.
+        new_tokens = list(range(1, 60)) + [999, 1000, 1001]
+        fetched, remaining = cache.fetch(new_tokens)
+
+        assert fetched is not None
+        tc = fetched[0]
+        # LCP of 59 (the divergent tokens are stripped).
+        assert tc.offset == 59
+        assert tc.keys.shape[-2] == 59
+        # Critical: the "7.0" private content from the stored entry must NOT
+        # be visible anywhere in the returned cache (this is what caused the
+        # cross-request contamination in #384).
+        assert float(mx.max(tc.keys).item()) == 1.0
+        assert remaining == [999, 1000, 1001]

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -279,3 +279,174 @@ class TestTrimCacheOffset:
         # cross-request contamination in #384).
         assert float(mx.max(tc.keys).item()) == 1.0
         assert remaining == [999, 1000, 1001]
+
+
+class TestDequantizeCacheSlice:
+    """Tests for _dequantize_cache slicing after dequantization.
+
+    When KV cache quantization is enabled (--kv-cache-quantization), the
+    prefix cache stores _QuantizedCacheWrapper layers.  After LCP trim
+    reduces the offset, _dequantize_cache must slice the dequantized arrays
+    down to offset to prevent readers that bypass offset (e.g. Gemma 4's
+    KV-shared layers reading cache.state) from seeing stale tokens.
+
+    This is the quantized-cache counterpart of the plain-KVCache fix
+    tested in TestTrimCacheOffset above.
+    """
+
+    def test_dequantize_slices_to_offset(self):
+        """After trim + dequantize, keys/values shape[-2] == offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            _QuantizedCacheWrapper,
+            _dequantize_cache,
+            _trim_cache_offset,
+        )
+
+        # Build a KVCache with 500 tokens, quantize it, then trim to 60.
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 512, 64), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 512, 64), dtype=mx.float32)
+        layer.offset = 512
+        mx.eval(layer.keys, layer.values)
+
+        qw = _QuantizedCacheWrapper(layer, bits=8, group_size=64)
+        trimmed = _trim_cache_offset([qw], 512 - 60)
+        result = _dequantize_cache(trimmed)
+
+        tc = result[0]
+        assert tc.offset == 60
+        assert tc.keys.shape[-2] == 60
+        assert tc.values.shape[-2] == 60
+
+    def test_dequantize_no_stale_tokens_via_state(self):
+        """Stale tokens from a previous request must not be visible via cache.state."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            _QuantizedCacheWrapper,
+            _dequantize_cache,
+            _trim_cache_offset,
+        )
+
+        layer = KVCache()
+        # First 64 positions: shared prefix (1.0), next 448: private (7.0)
+        shared = mx.ones((1, 4, 64, 64), dtype=mx.float32)
+        private = mx.full((1, 4, 448, 64), 7.0, dtype=mx.float32)
+        layer.keys = mx.concatenate([shared, private], axis=2)
+        layer.values = mx.concatenate([shared, private], axis=2)
+        layer.offset = 512
+        mx.eval(layer.keys, layer.values)
+
+        qw = _QuantizedCacheWrapper(layer, bits=8, group_size=64)
+        trimmed = _trim_cache_offset([qw], 512 - 64)
+        result = _dequantize_cache(trimmed)
+
+        tc = result[0]
+        keys_view, _ = tc.state
+        assert keys_view.shape[-2] == 64
+        # Dequantized values are approximate (quantization error), but should
+        # be close to 1.0 (the shared prefix), never near 7.0 (the private data).
+        assert float(mx.max(keys_view).item()) < 2.0
+
+    def test_dequantize_no_trim_preserves_full_array(self):
+        """When offset == shape[-2], no slicing occurs."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            _QuantizedCacheWrapper,
+            _dequantize_cache,
+        )
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 128, 64), dtype=mx.float32)
+        layer.offset = 128
+        mx.eval(layer.keys, layer.values)
+
+        qw = _QuantizedCacheWrapper(layer, bits=8, group_size=64)
+        result = _dequantize_cache([qw])
+
+        tc = result[0]
+        assert tc.offset == 128
+        assert tc.keys.shape[-2] == 128
+        assert tc.values.shape[-2] == 128
+
+    def test_dequantize_source_unaffected(self):
+        """Dequantizing must not mutate the stored quantized wrapper."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            _QuantizedCacheWrapper,
+            _dequantize_cache,
+            _trim_cache_offset,
+        )
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 256, 64), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 256, 64), dtype=mx.float32)
+        layer.offset = 256
+        mx.eval(layer.keys, layer.values)
+
+        qw = _QuantizedCacheWrapper(layer, bits=8, group_size=64)
+        original_offset = qw.offset
+        original_keys_shape = qw.keys[0].shape  # quantized data tuple
+
+        trimmed = _trim_cache_offset([qw], 192)
+        _dequantize_cache(trimmed)
+
+        # Source wrapper unchanged
+        assert qw.offset == original_offset
+        assert qw.keys[0].shape == original_keys_shape
+
+    def test_dequantize_end_to_end_fetch_with_quantization(self):
+        """End-to-end: store with kv_quantize=True, fetch with LCP, verify no stale data."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            MemoryAwarePrefixCache,
+            MemoryCacheConfig,
+        )
+
+        model = MagicMock()
+        pc = MemoryAwarePrefixCache(
+            model,
+            MemoryCacheConfig(
+                max_memory_mb=64,
+                max_entries=10,
+                kv_quantize=True,
+                kv_bits=8,
+                kv_group_size=64,
+                kv_min_quantize_tokens=0,
+            ),
+        )
+
+        # Store a KVCache with 128 tokens — store() quantizes automatically.
+        layer = KVCache()
+        shared = mx.ones((1, 2, 64, 64), dtype=mx.float32)
+        private = mx.full((1, 2, 64, 64), 7.0, dtype=mx.float32)
+        layer.keys = mx.concatenate([shared, private], axis=2)
+        layer.values = mx.concatenate([shared, private], axis=2)
+        layer.offset = 128
+        mx.eval(layer.keys, layer.values)
+
+        pc.store(list(range(1, 129)), [layer])
+
+        # Fetch with partial match (first 60 tokens match, then diverge).
+        # fetch() dequantizes automatically when kv_quantize=True.
+        new_tokens = list(range(1, 61)) + [999, 1000]
+        fetched, remaining = pc.fetch(new_tokens)
+
+        assert fetched is not None
+        tc = fetched[0]
+        assert tc.offset == 60
+        assert tc.keys.shape[-2] == 60
+        # No private data (7.0) visible — only shared prefix (~1.0 with quantization noise)
+        assert float(mx.max(tc.keys).item()) < 2.0
+        assert remaining == [999, 1000]

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -554,6 +554,19 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
                 *layer.values, group_size=layer.group_size, bits=layer.bits
             )
             kv.offset = layer.offset
+            # Slice the dequantized arrays down to offset so that readers
+            # which bypass offset (e.g. Gemma 4 KV-shared layers reading
+            # cache.state directly) cannot see stale tokens from a previous
+            # request.  Mirrors the plain-KVCache slice in
+            # _trim_cache_offset — see issue #384.
+            if (
+                kv.keys is not None
+                and hasattr(kv.keys, "shape")
+                and len(kv.keys.shape) >= 3
+                and kv.offset < kv.keys.shape[-2]
+            ):
+                kv.keys = kv.keys[..., : kv.offset, :]
+                kv.values = kv.values[..., : kv.offset, :]
             # Restore type-specific attrs (max_size, keep, step, _idx)
             for attr, val in layer.orig_attrs.items():
                 setattr(kv, attr, val)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -389,9 +389,27 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
         ):
             orig_cls = type(layer_cache)
             tc = orig_cls.__new__(orig_cls)
-            tc.keys = layer_cache.keys
-            tc.values = layer_cache.values
-            tc.offset = max(layer_cache.offset - trim_by, 0)
+            new_offset = max(layer_cache.offset - trim_by, 0)
+            keys = layer_cache.keys
+            values = layer_cache.values
+            # Slice the arrays down to new_offset rather than just shrinking the
+            # offset pointer.  Sharing the original (over-sized) array across
+            # requests lets attention paths that read the full underlying
+            # buffer (e.g. Gemma 4's KV-shared layers, which read cache.state
+            # directly instead of going through update_and_fetch) see stale
+            # tokens from the previous owner — issue #384.
+            if (
+                keys is not None
+                and hasattr(keys, "shape")
+                and len(keys.shape) >= 3
+                and new_offset < keys.shape[-2]
+            ):
+                tc.keys = keys[..., :new_offset, :]
+                tc.values = values[..., :new_offset, :]
+            else:
+                tc.keys = keys
+                tc.values = values
+            tc.offset = new_offset
             # Preserve type-specific attrs (max_size, keep, step, _idx)
             for attr in ("max_size", "keep", "step", "_idx"):
                 if hasattr(layer_cache, attr):


### PR DESCRIPTION
## Purpose

Fixes [#384](https://github.com/waybarrios/vllm-mlx/issues/384). Under
12 to 32 concurrent chat requests with `enable_thinking=True`, the
content of one request bleeds into unrelated requests. A "who wrote
Hamlet?" request comes back with "Alexander Fleming discovered
penicillin"; a "translate thank you into German" request returns "Dunkle
Materie" (the German for "dark matter"). The contamination is
deterministic: the same slots keep picking up the same foreign content
across rounds, which lets it reproduce reliably inside a hammer script.
Disabling the prefix cache with `--disable-prefix-cache` eliminates the
contamination entirely, so the fault is inside the cache path, not the
engine or the scheduler.

This PR identifies the exact mechanism and applies a one-file fix with
targeted regression coverage.

## Root cause

The `MemoryAwarePrefixCache.fetch()` path in `vllm_mlx/memory_cache.py`
has a Longest-Common-Prefix (LCP) fallback: when the new request shares
only part of its token sequence with a stored entry, the cache trims
the stored entry back to the shared length and returns it. Trimming is
done by `_trim_cache_offset(cache, trim_by)`.

The rotating-cache branch already trimmed the circular buffer
correctly. The plain-`KVCache` branch did not. It created a shallow
copy that adjusted the offset but kept `keys` and `values` pointing at
the original full-size array:

```python
# before
tc = orig_cls.__new__(orig_cls)
tc.keys = layer_cache.keys
tc.values = layer_cache.values
tc.offset = max(layer_cache.offset - trim_by, 0)
```

Stored entries routinely hold 500+ tokens worth of data: the system
prompt, then the previous request's user message, then that request's
thinking, then its response. Only the first N tokens (the LCP length,
often 40 to 80 for the system prompt) are semantically valid for a new
request. The remaining positions still hold another request's private
content.

That stale content was fine for any reader that honoured `self.offset`,
because `update_and_fetch` returns only `self.keys[..., :self.offset, :]`.
But Gemma 4 has KV-shared attention layers that read `cache.state`
directly (see `vllm_mlx/patches/gemma4_mllm.py`, lines 84 to 86):

```python
if self.is_kv_shared_layer and cache is not None:
    state = cache.state
    keys, values = state[0], state[1]
```

`cache.state` returns the raw `(self.keys, self.values)` arrays and
ignores `self.offset`. The new request's attention therefore
conditioned on positions 60 through 500, still holding another
request's tokens. The model produced a coherent answer to the other
request, routed back to the current request's slot.

Because the shared system prompt is deterministic and so is the
scheduler order for a fixed set of concurrent requests, the same slot
in each round picked up the same foreign content. That is why the
observed pattern is reproducible: "Hamlet" always got "penicillin";
"largest ocean" always got "Japanese Yen"; "Mona Lisa" always got
"Edison / light bulb".

## Fix

`_trim_cache_offset` now slices `keys` and `values` down to
`new_offset` on the plain-`KVCache` branch:

```python
# vllm_mlx/memory_cache.py  —  _trim_cache_offset, plain-KVCache branch
new_offset = max(layer_cache.offset - trim_by, 0)
keys = layer_cache.keys
values = layer_cache.values
if keys is not None and hasattr(keys, "shape") and len(keys.shape) >= 3:
    if new_offset < keys.shape[-2]:
        # Slice the arrays down.  KVCache.update_and_fetch will
        # detect shape[-2] == offset on the first write, take the
        # grow branch, and mx.concatenate into a fresh array, so
        # in-place writes by the new request cannot leak into the
        # stored prefix entry even though MLX slicing is a view.
        tc.keys = keys[..., :new_offset, :]
        tc.values = values[..., :new_offset, :]
    else:
        tc.keys = keys
        tc.values = values
else:
    tc.keys = keys
    tc.values = values
tc.offset = new_offset
```

Why the slice is safe even though MLX slicing is a view: on the very
first call to `update_and_fetch` through the trimmed cache,
`prev + keys.shape[2]` exceeds `self.keys.shape[2]` (since `shape[-2]
== new_offset == prev` right after trim), so the grow branch runs,
`mx.concatenate` allocates a fresh buffer, and the subsequent in-place
assignment lands in the fresh buffer rather than the original stored
array. The rotating-cache branch is untouched because it was already
materialising new arrays via `_temporal_order` and `mx.concatenate`.

Earlier iterations of the fix added an explicit `mx.eval` to force
materialisation of the slice, but that produced a `Fatal Python error:
Aborted` under the scheduler's worker thread while another thread was
inside `mlx_lm.generate._next`. The bug was timing-related: calling
`mx.eval` on a slice concurrently with another thread eval-ing a parent
graph caused a race. The slice-only version is both simpler and free
of the race, because update_and_fetch's grow branch is the thing that
actually provides isolation (the eval was belt-and-suspenders).

## How to verify

Server command (same flags as the user's report in #380 and #384):

```
vllm-mlx serve mlx-community/gemma-4-e2b-it-mxfp4 \
  --host 127.0.0.1 --port 18082 \
  --continuous-batching \
  --enable-auto-tool-choice --tool-call-parser gemma4 \
  --reasoning-parser gemma4 \
  --max-tokens 4096
```

Hammer script (attached in the issue): 32 distinct prompts, 8 rounds of
varying concurrency (32, 16, 32, 16, 32, 24, 32, 20) = 204 requests
total, all with `temperature=0.0`, `stream=false`, `enable_thinking=true`.

| Condition | Contaminated responses |
|---|---|
| `main` | **22 / 204** |
| `main` + `--disable-prefix-cache` | 0 / 204 |
| this PR | **0 / 204** |

Example output on `main` before the fix:

```
[ 1] 'Name the tallest mountain in South America.'
     content: 'Japanese Yen.'         [!! foreign from 'Name the currency of Japan.' !!]
[ 4] 'Who painted the Mona Lisa?'
     content: 'Thomas Edison is credited with inventing the practical light bulb.'
[ 9] 'Who wrote Hamlet?'
     content: 'Alexander Fleming discovered penicillin.'
[23] 'Name the largest ocean on Earth.'
     content: 'Japanese Yen (JPY).'
```

After the fix, every slot returns the answer to its own prompt.

## Tests

Ten new unit tests in
`tests/test_memory_cache.py::TestTrimCacheOffset`, all using real
`mx.array` objects on MLX, covering the failure mode and adjacent
edge cases:

- `test_plain_kv_cache_array_sliced_to_new_offset` — after trim,
  `tc.keys.shape[-2] == new_offset`, not the original shape.
- `test_plain_kv_cache_no_stale_tokens_visible_via_state` — stores
  `1.0` in the shared prefix and `7.0` past it, confirms that the
  view returned by `cache.state` contains only `1.0`s. This is the
  direct regression of the #384 symptom.
- `test_plain_kv_cache_no_trim_preserves_array` — `trim_by == 0`
  leaves the array untouched.
- `test_plain_kv_cache_trim_by_exceeds_offset_clamps_to_zero` —
  trimming past the current offset yields an empty-but-valid trimmed
  cache (`offset == 0`, `shape[-2] == 0`).
- `test_plain_kv_cache_stored_entry_unaffected_after_trim` — running
  `_trim_cache_offset` on a layer must not mutate the source layer's
  `keys` / `values` / `offset`.
- `test_plain_kv_cache_in_place_write_does_not_corrupt_source` —
  after trim, calling `update_and_fetch(new_keys, new_values)` on the
  returned cache must not bleed into the source entry. Values in the
  source stay at their original `5.0` across the full range.
- `test_plain_kv_cache_multiple_layers_all_sliced` — caches with
  several `KVCache` layers get every layer sliced, not just the
  first.
- `test_plain_kv_cache_slice_works_for_float16_and_bfloat16` —
  fix is dtype-agnostic; fp16 and bf16 caches receive the same
  treatment and dtype is preserved.
- `test_plain_kv_cache_rotating_layers_unchanged_behavior` —
  rotating-cache branch still works after the change, dtype and
  `max_size` are preserved, output arrays are non-None.
- `test_fetch_returns_sliced_cache_on_lcp_match` — end-to-end
  regression: `MemoryAwarePrefixCache.fetch()` on a request that
  shares only a prefix with a longer stored entry returns a cache
  whose arrays are already sliced down. Asserts that the `7.0`
  private content from the stored entry is not visible anywhere in
  the returned cache.

## Test results

All 419 relevant tests pass locally on M4 Max / 128 GB:

```
$ pytest tests/test_memory_cache.py tests/test_prefix_cache.py \
         tests/test_gemma4_tool_parser.py tests/test_gemma4_streaming_edge.py \
         tests/test_reasoning_parser.py tests/test_tool_parsers.py \
         tests/test_batching_deterministic.py tests/test_native_tool_format.py \
         tests/test_chat_template_kwargs.py tests/test_gemma4_openai_format.py \
         tests/test_api_utils.py -q
419 passed in 5.40s
```

The 10 new regression tests pass in 2 seconds on their own:

```
$ pytest tests/test_memory_cache.py::TestTrimCacheOffset -v
10 passed in 1.92s
```

## Out of scope

- The parser-level fixes for #380 remain on their own branch
  ([#383](https://github.com/waybarrios/vllm-mlx/pull/383)) and merge
  independently. The two PRs have no file overlap.
- Only the plain-`KVCache` branch of `_trim_cache_offset` changes.
  The rotating-cache branch and the quantized-wrapper branch are
  untouched and covered by existing tests.
- No scheduler or engine changes. No change to how requests are
  dispatched, batched, or merged.

Closes #384. Refs #380.
