### PR TITLE
fix(gemma4): Comprehensive UAT and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
             tests/test_chat_template_kwargs.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \
+            tests/test_memory_cache_mlx.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_gemma4_streaming_edge.py
+++ b/tests/test_gemma4_streaming_edge.py
@@ -27,6 +27,27 @@ def stream_parse(parser, text, token_list):
     return "".join(reasoning_parts), "".join(content_parts)
 
 
+def test_thought_label_split_across_deltas():
+    """The channel-name word 'thought' can arrive split across deltas in
+    production streams. The parser must buffer the partial prefix rather than
+    leak 'th' / 'tho' / 'thou' / 'thoug' into the reasoning output.
+    """
+    parser = Gemma4ReasoningParser()
+    tokens = [
+        "<|channel>",
+        "tho",        # partial "thought" label
+        "ught",       # completes the label
+        "\n",
+        "real reasoning",
+        "<channel|>",
+        "content",
+    ]
+    reasoning, content = stream_parse(parser, None, tokens)
+    assert reasoning == "real reasoning", f"Label leaked: {reasoning!r}"
+    assert content == "content", f"Got content: {content!r}"
+    print("[PASS] test_thought_label_split_across_deltas")
+
+
 def test_channel_marker_split_across_tokens():
     """<|channel> alone should not leak into reasoning if response follows."""
     parser = Gemma4ReasoningParser()

--- a/tests/test_gemma4_streaming_edge.py
+++ b/tests/test_gemma4_streaming_edge.py
@@ -35,8 +35,8 @@ def test_thought_label_split_across_deltas():
     parser = Gemma4ReasoningParser()
     tokens = [
         "<|channel>",
-        "tho",        # partial "thought" label
-        "ught",       # completes the label
+        "tho",  # partial "thought" label
+        "ught",  # completes the label
         "\n",
         "real reasoning",
         "<channel|>",

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -167,7 +167,6 @@ class TestGemma4ToolParserExtract:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"text": 'line1\nline2 said "hello"'}
 
-
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""
 
@@ -237,4 +236,47 @@ class TestGemma4Registration:
 
     def test_native_format_false(self):
         assert Gemma4ToolParser.SUPPORTS_NATIVE_TOOL_FORMAT is False
+
+    def test_extra_stop_tokens_declares_tool_response(self):
+        """Gemma 4 treats <|tool_response> (id 50) as end-of-generation
+        after a tool call. The parser exposes it so the server can merge it
+        into the request's stop sequences.
+        Reference: llama.cpp PR #21418.
+        """
+        parser = Gemma4ToolParser()
+        assert "<|tool_response>" in parser.extra_stop_tokens
+
+    def test_abstract_parser_default_empty_stop_tokens(self):
+        """Other parsers that don't override keep an empty default."""
+        from vllm_mlx.tool_parsers.abstract_tool_parser import ToolParser
+
+        assert ToolParser.extra_stop_tokens == []
+
+    def test_merge_helper_adds_parser_extras(self):
+        """get_parser_stop_tokens adds the parser's EOG tokens on top of user stops."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        merged = get_parser_stop_tokens("gemma4", ["END"])
+        assert "END" in merged
+        assert "<|tool_response>" in merged
+
+    def test_merge_helper_dedupes(self):
+        """Parser extra tokens already present in user stops aren't duplicated."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        merged = get_parser_stop_tokens("gemma4", ["<|tool_response>"])
+        assert merged.count("<|tool_response>") == 1
+
+    def test_merge_helper_unknown_parser_is_passthrough(self):
+        """Unknown parser name leaves user stops untouched."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        assert get_parser_stop_tokens("nonexistent_parser_xyz", ["A"]) == ["A"]
+
+    def test_merge_helper_none_parser_is_passthrough(self):
+        """No parser name returns user stops as-is."""
+        from vllm_mlx.tool_parsers import get_parser_stop_tokens
+
+        assert get_parser_stop_tokens(None, ["A"]) == ["A"]
+        assert get_parser_stop_tokens(None, None) == []
         assert Gemma4ToolParser.supports_native_format() is False

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -189,7 +189,9 @@ class TestGemma4ToolParserExtract:
 
     def test_bare_string_preserves_null_and_bool_literals(self):
         """null/true/false must NOT be treated as bare strings."""
-        output = "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        output = (
+            "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        )
         result = self.parser.extract_tool_calls(output)
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"flag": None, "ready": True, "done": False, "name": "bob"}

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -167,6 +167,42 @@ class TestGemma4ToolParserExtract:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args == {"text": 'line1\nline2 said "hello"'}
 
+    def test_bare_string_value_without_delimiters(self):
+        """Nullable type (e.g. ["string", "null"]) makes the template skip the
+        <|"|> wrap around string values. The parser must still produce valid
+        JSON with the value as a string.
+        Reference: llama.cpp PR #21327.
+        """
+        output = "<|tool_call>call:set_state{domain:light}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"domain": "light"}
+
+    def test_bare_string_mixed_with_number_and_bool(self):
+        """Bare string value must not interfere with numeric/bool parsing."""
+        output = "<|tool_call>call:update{name:alice,count:5,active:true}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"name": "alice", "count": 5, "active": True}
+
+    def test_bare_string_preserves_null_and_bool_literals(self):
+        """null/true/false must NOT be treated as bare strings."""
+        output = "<|tool_call>call:cfg{flag:null,ready:true,done:false,name:bob}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"flag": None, "ready": True, "done": False, "name": "bob"}
+
+    def test_bare_string_in_array(self):
+        """Enum-without-type: array of bare strings should be quoted per element."""
+        output = "<|tool_call>call:filter{tags:[alpha,beta,gamma]}<tool_call|>"
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"tags": ["alpha", "beta", "gamma"]}
+
+
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""
 

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-dependent regression tests for the LCP trim contamination fix (#384).
+
+These tests use real ``mlx_lm.models.cache.KVCache`` / ``RotatingKVCache``
+objects backed by ``mlx.core`` arrays.  They run only on the apple-silicon
+CI matrix (and locally on M-series hardware); the Linux ``test-matrix``
+job excludes this file because MLX has no Linux distribution.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestTrimCacheOffset:
+    """Tests for ``_trim_cache_offset``, focused on the LCP contamination fix.
+
+    Regression: when the LCP fetch path trimmed a cache entry by shrinking
+    the offset while still sharing the underlying (oversized) key/value
+    arrays, downstream attention layers that read ``cache.state`` directly
+    (e.g. Gemma 4 KV-shared layers) could see stale tokens from the previous
+    owner of the entry.  See issue #384.  The fix slices the arrays down to
+    new_offset so no memory beyond the new boundary remains accessible.
+    """
+
+    def test_plain_kv_cache_array_sliced_to_new_offset(self):
+        """Plain-KVCache-like layer: after trim, keys.shape[-2] == new_offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        # Pretend a previous request wrote 500 tokens worth of data
+        layer.keys = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(1, 4, 500, 8)
+        layer.values = mx.arange(1 * 4 * 500 * 8, dtype=mx.float32).reshape(
+            1, 4, 500, 8
+        )
+        layer.offset = 500
+
+        # New request shares only the first 60 tokens as prefix
+        trim_by = 500 - 60
+        trimmed = _trim_cache_offset([layer], trim_by)
+        tc = trimmed[0]
+
+        assert tc.offset == 60
+        # The underlying array MUST be shrunk, not just the offset pointer.
+        # Otherwise Gemma 4's cache.state-reading layers would see positions
+        # 60..500 filled with the previous request's tokens.
+        assert tc.keys.shape[-2] == 60
+        assert tc.values.shape[-2] == 60
+
+    def test_plain_kv_cache_no_stale_tokens_visible_via_state(self):
+        """A layer that reads the full cache.state must not see tokens past new_offset."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        # Positions 0..60: shared prefix (same for everyone).  Positions 60..500:
+        # private content from a previous request that must NOT leak.
+        shared = mx.ones((1, 4, 60, 8), dtype=mx.float32)
+        private = mx.full((1, 4, 440, 8), 7.0, dtype=mx.float32)
+        layer.keys = mx.concatenate([shared, private], axis=2)
+        layer.values = layer.keys
+        layer.offset = 500
+
+        tc = _trim_cache_offset([layer], 500 - 60)[0]
+
+        # cache.state is what KV-shared layers read directly.
+        keys_view, _ = tc.state
+        assert keys_view.shape[-2] == 60
+        # No "7.0" tokens anywhere — private content was excluded.
+        assert float(mx.max(keys_view).item()) == 1.0
+
+    def test_plain_kv_cache_no_trim_preserves_array(self):
+        """If trim_by == 0 or offset already equals shape, array is untouched."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 100, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 100, 8), dtype=mx.float32)
+        layer.offset = 100
+
+        tc = _trim_cache_offset([layer], 0)[0]
+
+        assert tc.offset == 100
+        assert tc.keys.shape[-2] == 100
+
+    def test_plain_kv_cache_trim_by_exceeds_offset_clamps_to_zero(self):
+        """trim_by larger than offset yields an empty-but-valid trimmed cache."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 4, 80, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 80, 8), dtype=mx.float32)
+        layer.offset = 80
+
+        tc = _trim_cache_offset([layer], 1000)[0]
+
+        assert tc.offset == 0
+        assert tc.keys.shape[-2] == 0
+        assert tc.values.shape[-2] == 0
+
+    def test_plain_kv_cache_stored_entry_unaffected_after_trim(self):
+        """Calling _trim_cache_offset must not mutate the source layer in place.
+
+        The stored prefix-cache entry is the source here; a later lookup for
+        a different request should get the same pristine data.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = KVCache()
+        full = mx.arange(1 * 2 * 200 * 4, dtype=mx.float32).reshape(1, 2, 200, 4)
+        layer.keys = full
+        layer.values = full
+        layer.offset = 200
+        original_shape = layer.keys.shape
+
+        _trim_cache_offset([layer], 150)
+
+        # Source entry keeps its full shape and offset.
+        assert layer.keys.shape == original_shape
+        assert layer.values.shape == original_shape
+        assert layer.offset == 200
+
+    def test_plain_kv_cache_in_place_write_does_not_corrupt_source(self):
+        """After trim, writing through the returned cache must not leak into
+        the stored entry.  This is the direct semantics of the fix: the stored
+        prefix-cache entry has to survive concurrent use by other requests.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        # Source stored entry: positions 0..300 holding 5.0.
+        layer = KVCache()
+        layer.keys = mx.full((1, 2, 300, 4), 5.0, dtype=mx.float32)
+        layer.values = mx.full((1, 2, 300, 4), 5.0, dtype=mx.float32)
+        layer.offset = 300
+
+        # New request shares first 50 tokens.
+        tc = _trim_cache_offset([layer], 300 - 50)[0]
+
+        # The trimmed cache now only has 50 tokens.  Writing new tokens via
+        # update_and_fetch allocates a new array (because prev + N > current
+        # shape) and does not touch the source.
+        new_keys = mx.zeros((1, 2, 10, 4), dtype=mx.float32)
+        new_values = mx.zeros((1, 2, 10, 4), dtype=mx.float32)
+        tc.update_and_fetch(new_keys, new_values)
+
+        # Source remains untouched (all 5.0 values preserved across full range).
+        assert layer.keys.shape[-2] == 300
+        assert float(mx.min(layer.keys).item()) == 5.0
+        assert float(mx.max(layer.keys).item()) == 5.0
+
+    def test_plain_kv_cache_multiple_layers_all_sliced(self):
+        """Caches with several KVCache layers: every layer gets sliced."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layers = []
+        for _ in range(5):
+            layer = KVCache()
+            layer.keys = mx.ones((1, 4, 200, 8), dtype=mx.float32)
+            layer.values = mx.ones((1, 4, 200, 8), dtype=mx.float32)
+            layer.offset = 200
+            layers.append(layer)
+
+        trimmed = _trim_cache_offset(layers, 150)
+
+        assert len(trimmed) == 5
+        for tc in trimmed:
+            assert tc.offset == 50
+            assert tc.keys.shape[-2] == 50
+            assert tc.values.shape[-2] == 50
+
+    def test_plain_kv_cache_slice_works_for_float16_and_bfloat16(self):
+        """Fix must be dtype-agnostic so quantized / mixed-precision KV caches
+        receive the same treatment as fp32.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        for dtype in (mx.float16, mx.bfloat16):
+            layer = KVCache()
+            layer.keys = mx.ones((1, 2, 120, 4), dtype=dtype)
+            layer.values = mx.ones((1, 2, 120, 4), dtype=dtype)
+            layer.offset = 120
+
+            tc = _trim_cache_offset([layer], 80)[0]
+
+            assert tc.offset == 40, f"dtype={dtype}"
+            assert tc.keys.shape[-2] == 40, f"dtype={dtype}"
+            assert tc.keys.dtype == dtype, f"dtype={dtype}"
+
+    def test_plain_kv_cache_rotating_layers_unchanged_behavior(self):
+        """RotatingKVCache was already trimming correctly before this fix.
+        The plain-KVCache branch is the only one that changed; the rotating
+        branch is exercised here to catch regressions.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        from vllm_mlx.memory_cache import _trim_cache_offset
+
+        layer = RotatingKVCache(max_size=128, keep=0)
+        # Layer already rotated once: offset=200, buffer holds max_size entries.
+        layer.keys = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.values = mx.ones((1, 4, 128, 8), dtype=mx.float32)
+        layer.offset = 200
+        layer._idx = 128
+
+        tc = _trim_cache_offset([layer], 100)[0]
+
+        # Offset dropped by trim_by, clamped at >= 0.
+        assert tc.offset == 100
+        # Rotating path materialises a buffer whose shape matches new_offset
+        # (padding with zeros if needed).  It must not come back as None.
+        assert tc.keys is not None
+        assert tc.values is not None
+        # Dtype preserved through trim.
+        assert tc.keys.dtype == mx.float32
+        # Type-specific attrs preserved.
+        assert hasattr(tc, "max_size")
+        assert tc.max_size == 128
+
+    def test_fetch_returns_sliced_cache_on_lcp_match(self):
+        """End-to-end: MemoryAwarePrefixCache.fetch on a request that shares
+        only a prefix with a longer stored entry must return a cache whose
+        arrays are already sliced down.  This is the full regression of the
+        #384 scenario above the unit level.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        model = MagicMock()
+        cache = MemoryAwarePrefixCache(
+            model, MemoryCacheConfig(max_memory_mb=64, max_entries=10)
+        )
+
+        # Stored: tokens [1..120] with 120 positions of KV data, the first 60
+        # tokens being the shared prefix (all 1.0), the last 60 private (7.0).
+        stored_layer = KVCache()
+        shared = mx.ones((1, 2, 60, 4), dtype=mx.float32)
+        private = mx.full((1, 2, 60, 4), 7.0, dtype=mx.float32)
+        stored_layer.keys = mx.concatenate([shared, private], axis=2)
+        stored_layer.values = stored_layer.keys
+        stored_layer.offset = 120
+        cache.store(list(range(1, 121)), [stored_layer])
+
+        # New request: tokens [1..59] + [999, 1000, 1001] — first 59 tokens
+        # match, then diverge.  LCP is 59.
+        new_tokens = list(range(1, 60)) + [999, 1000, 1001]
+        fetched, remaining = cache.fetch(new_tokens)
+
+        assert fetched is not None
+        tc = fetched[0]
+        # LCP of 59 (the divergent tokens are stripped).
+        assert tc.offset == 59
+        assert tc.keys.shape[-2] == 59
+        # Critical: the "7.0" private content from the stored entry must NOT
+        # be visible anywhere in the returned cache (this is what caused the
+        # cross-request contamination in #384).
+        assert float(mx.max(tc.keys).item()) == 1.0
+        assert remaining == [999, 1000, 1001]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1120,6 +1120,33 @@ Examples:
         default=None,
         help="Override default top_p for all requests (default: use model default)",
     )
+    serve_parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Override default top_k for all requests "
+        "(falls back to generation_config.json, then 0 / disabled)",
+    )
+    serve_parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Override default min_p for all requests "
+        "(falls back to generation_config.json, then 0.0 / disabled)",
+    )
+    serve_parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Override default presence_penalty for all requests (falls back to 0.0)",
+    )
+    serve_parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help="Override default repetition_penalty for all requests "
+        "(falls back to generation_config.json, then 1.0)",
+    )
     # Embedding model option
     serve_parser.add_argument(
         "--embedding-model",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -72,9 +72,8 @@ def serve_command(args):
         server._enable_auto_tool_choice = False
         server._tool_call_parser = None
 
-    # Configure generation defaults. CLI values are applied here pre-load
-    # so _apply_generation_config_defaults() (called after load_model)
-    # only fills in values the operator did NOT pin via CLI.
+    # Apply CLI sampling defaults pre-load so _apply_generation_config_defaults
+    # (post-load) only fills in what the operator didn't pin.
     if args.default_temperature is not None:
         server._default_temperature = args.default_temperature
     if args.default_top_p is not None:
@@ -281,8 +280,7 @@ def serve_command(args):
         warm_prompts_path=args.warm_prompts,
     )
 
-    # Fill in any sampling default the operator didn't pin via CLI from
-    # the loaded model's generation_config.json.
+    # Fill remaining sampling defaults from generation_config.json.
     server._apply_generation_config_defaults()
 
     # Start server

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -72,11 +72,21 @@ def serve_command(args):
         server._enable_auto_tool_choice = False
         server._tool_call_parser = None
 
-    # Configure generation defaults
+    # Configure generation defaults. CLI values are applied here pre-load
+    # so _apply_generation_config_defaults() (called after load_model)
+    # only fills in values the operator did NOT pin via CLI.
     if args.default_temperature is not None:
         server._default_temperature = args.default_temperature
     if args.default_top_p is not None:
         server._default_top_p = args.default_top_p
+    if getattr(args, "default_top_k", None) is not None:
+        server._default_top_k = args.default_top_k
+    if getattr(args, "default_min_p", None) is not None:
+        server._default_min_p = args.default_min_p
+    if getattr(args, "default_presence_penalty", None) is not None:
+        server._default_presence_penalty = args.default_presence_penalty
+    if getattr(args, "default_repetition_penalty", None) is not None:
+        server._default_repetition_penalty = args.default_repetition_penalty
     server._max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     server._max_tts_input_chars = args.max_tts_input_chars
 
@@ -270,6 +280,10 @@ def serve_command(args):
         specprefill_draft_model=args.specprefill_draft_model,
         warm_prompts_path=args.warm_prompts,
     )
+
+    # Fill in any sampling default the operator didn't pin via CLI from
+    # the loaded model's generation_config.json.
+    server._apply_generation_config_defaults()
 
     # Start server
     print(f"Starting server at http://{args.host}:{args.port}")

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -450,18 +450,10 @@ class BatchedEngine(BaseEngine):
         logger.info("BatchedEngine stopped")
 
     def _tokenizer_lock(self):
-        """Return the batch generator's tokenizer lock, or a null context.
-        Shared with ``MLLMBatchGenerator._preprocess_request`` so chat-template
-        rendering and preprocess tokenization can't race on the same Rust-backed
-        tokenizer.
-        """
-        import contextlib
+        """Module-level HF-fast-tokenizer mutex shared with preprocess."""
+        from ..mllm_batch_generator import TOKENIZER_LOCK
 
-        if self._mllm_scheduler is not None:
-            bg = self._mllm_scheduler.batch_generator
-            if bg is not None and getattr(bg, "tokenizer_lock", None) is not None:
-                return bg.tokenizer_lock
-        return contextlib.nullcontext()
+        return TOKENIZER_LOCK
 
     def _apply_chat_template(
         self,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -532,72 +532,20 @@ class BatchedEngine(BaseEngine):
             return prompt + "\nassistant:"
 
     @staticmethod
-    def _expand_video_frames(
-        messages: list[dict[str, Any]],
-    ) -> tuple[list[dict[str, Any]], list[str]]:
-        """Replace video content parts with N image placeholders and return
-        the flat list of frame paths.
-
-        Batched path needs the template to emit one image token per extracted
-        frame; without this, frames arrive at prepare_inputs with no matching
-        placeholder in input_ids and the model silently sees no media.
-        Mirrors what MLXMultimodalLM._prepare_chat_messages does inline.
-        """
-        from ..models.mllm import (
-            DEFAULT_FPS,
-            MAX_FRAMES,
-            extract_video_frames_smart,
-            process_video_input,
-            save_frames_to_temp,
-        )
-
-        all_frames: list[str] = []
-        rewritten: list[dict[str, Any]] = []
-
+    def _messages_have_video(messages: list[dict[str, Any]]) -> bool:
+        """True if any message content part is a video or video_url."""
         for msg in messages:
             if not isinstance(msg, dict):
-                rewritten.append(msg)
                 continue
             content = msg.get("content")
             if not isinstance(content, list):
-                rewritten.append(msg)
                 continue
-
-            new_content: list = []
             for part in content:
                 if hasattr(part, "model_dump"):
                     part = part.model_dump(exclude_none=True)
-                if not isinstance(part, dict):
-                    new_content.append(part)
-                    continue
-                part_type = part.get("type", "")
-                if part_type in ("video", "video_url"):
-                    url_obj = part.get(part_type)
-                    if isinstance(url_obj, dict):
-                        url = url_obj.get("url", "")
-                    else:
-                        url = url_obj or part.get("url", "")
-                    if not url:
-                        continue
-                    try:
-                        vpath = process_video_input(url)
-                        frames = extract_video_frames_smart(
-                            vpath, fps=DEFAULT_FPS, max_frames=MAX_FRAMES
-                        )
-                        frame_paths = save_frames_to_temp(frames)
-                    except Exception as exc:
-                        logger.warning(
-                            f"Failed to extract video frames: {type(exc).__name__}: {exc}"
-                        )
-                        frame_paths = []
-                    all_frames.extend(frame_paths)
-                    for _ in frame_paths:
-                        new_content.append({"type": "image"})
-                else:
-                    new_content.append(part)
-            rewritten.append({**msg, "content": new_content})
-
-        return rewritten, all_frames
+                if isinstance(part, dict) and part.get("type") in ("video", "video_url"):
+                    return True
+        return False
 
     @staticmethod
     def _prepare_mllm_messages(
@@ -851,20 +799,27 @@ class BatchedEngine(BaseEngine):
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
 
-        # Expand inline video content into frame images so the chat template
-        # emits a matching image placeholder per frame.
-        if any(
-            isinstance(m, dict)
-            and isinstance(m.get("content"), list)
-            and any(
-                isinstance(p, dict) and p.get("type") in ("video", "video_url")
-                for p in m["content"]
-            )
-            for m in messages
+        # Native video path: Gemma 4 (and Qwen-VL) emit their own
+        # <|image>...<|video|>...<image|> interleave with timestamps when
+        # the processor sees {type: video}. Batched can't consume that
+        # shape through its text-prompt scheduler, so delegate a video
+        # request to the MLXMultimodalLM's native pipeline for this call.
+        if (
+            self._is_mllm
+            and self._mllm_instance is not None
+            and getattr(self._mllm_instance, "_video_native", False)
+            and (all_videos or self._messages_have_video(messages))
         ):
-            messages, video_frames = self._expand_video_frames(messages)
-            all_images.extend(video_frames)
-            all_videos = []  # frames are now in all_images
+            import asyncio
+
+            return await asyncio.to_thread(
+                self._mllm_instance.chat,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                tools=tools,
+                **kwargs,
+            )
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -995,20 +950,31 @@ class BatchedEngine(BaseEngine):
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
 
-        # Expand inline video content into frame images so the chat template
-        # emits a matching image placeholder per frame.
-        if any(
-            isinstance(m, dict)
-            and isinstance(m.get("content"), list)
-            and any(
-                isinstance(p, dict) and p.get("type") in ("video", "video_url")
-                for p in m["content"]
-            )
-            for m in messages
+        # Native video path: Gemma 4 (and Qwen-VL) handle video via their own
+        # processor interleave. Delegate to MLXMultimodalLM.stream_chat for
+        # video requests so the native markers survive.
+        if (
+            self._is_mllm
+            and self._mllm_instance is not None
+            and getattr(self._mllm_instance, "_video_native", False)
+            and (all_videos or self._messages_have_video(messages))
         ):
-            messages, video_frames = self._expand_video_frames(messages)
-            all_images.extend(video_frames)
-            all_videos = []
+            import asyncio
+
+            def _run():
+                return list(
+                    self._mllm_instance.stream_chat(
+                        messages=messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        tools=tools,
+                        **kwargs,
+                    )
+                )
+
+            for chunk in await asyncio.to_thread(_run):
+                yield chunk
+            return
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -180,9 +180,13 @@ class BatchedEngine(BaseEngine):
 
     @property
     def tokenizer(self) -> Any:
-        """Get the tokenizer."""
+        """Return the processor for MLLM (matches SimpleEngine) so callers that
+        rely on ``name_or_path`` or processor-level methods get a live handle.
+        The processor exposes ``.encode`` via its inner tokenizer, which is the
+        only method the token-counting caller uses.
+        """
         if self._is_mllm and self._processor:
-            return getattr(self._processor, "tokenizer", self._processor)
+            return self._processor
         return self._tokenizer
 
     async def start(self) -> None:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1153,6 +1153,23 @@ class BatchedEngine(BaseEngine):
             return self._engine.get_cache_stats()
         return None
 
+    @property
+    def has_ssd_cache_tier(self) -> bool:
+        """True when an SSD cold tier is already managing durable persistence.
+
+        When present, the lifespan one-shot ``save_cache_to_disk`` /
+        ``load_cache_from_disk`` hooks should be skipped — the SSD tier
+        writes through on eviction and survives crashes on its own.
+        """
+        if self._mllm_scheduler is not None:
+            if getattr(self._mllm_scheduler, "_ssd_tier", None) is not None:
+                return True
+        if self._engine is not None:
+            inner = getattr(self._engine, "scheduler", None)
+            if inner is not None and getattr(inner, "_ssd_tier", None) is not None:
+                return True
+        return False
+
     def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk for persistence across restarts."""
         if self._mllm_scheduler and self._mllm_scheduler.batch_generator:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -532,6 +532,74 @@ class BatchedEngine(BaseEngine):
             return prompt + "\nassistant:"
 
     @staticmethod
+    def _expand_video_frames(
+        messages: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Replace video content parts with N image placeholders and return
+        the flat list of frame paths.
+
+        Batched path needs the template to emit one image token per extracted
+        frame; without this, frames arrive at prepare_inputs with no matching
+        placeholder in input_ids and the model silently sees no media.
+        Mirrors what MLXMultimodalLM._prepare_chat_messages does inline.
+        """
+        from ..models.mllm import (
+            DEFAULT_FPS,
+            MAX_FRAMES,
+            extract_video_frames_smart,
+            process_video_input,
+            save_frames_to_temp,
+        )
+
+        all_frames: list[str] = []
+        rewritten: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if not isinstance(msg, dict):
+                rewritten.append(msg)
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                rewritten.append(msg)
+                continue
+
+            new_content: list = []
+            for part in content:
+                if hasattr(part, "model_dump"):
+                    part = part.model_dump(exclude_none=True)
+                if not isinstance(part, dict):
+                    new_content.append(part)
+                    continue
+                part_type = part.get("type", "")
+                if part_type in ("video", "video_url"):
+                    url_obj = part.get(part_type)
+                    if isinstance(url_obj, dict):
+                        url = url_obj.get("url", "")
+                    else:
+                        url = url_obj or part.get("url", "")
+                    if not url:
+                        continue
+                    try:
+                        vpath = process_video_input(url)
+                        frames = extract_video_frames_smart(
+                            vpath, fps=DEFAULT_FPS, max_frames=MAX_FRAMES
+                        )
+                        frame_paths = save_frames_to_temp(frames)
+                    except Exception as exc:
+                        logger.warning(
+                            f"Failed to extract video frames: {type(exc).__name__}: {exc}"
+                        )
+                        frame_paths = []
+                    all_frames.extend(frame_paths)
+                    for _ in frame_paths:
+                        new_content.append({"type": "image"})
+                else:
+                    new_content.append(part)
+            rewritten.append({**msg, "content": new_content})
+
+        return rewritten, all_frames
+
+    @staticmethod
     def _prepare_mllm_messages(
         messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
@@ -783,6 +851,21 @@ class BatchedEngine(BaseEngine):
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
 
+        # Expand inline video content into frame images so the chat template
+        # emits a matching image placeholder per frame.
+        if any(
+            isinstance(m, dict)
+            and isinstance(m.get("content"), list)
+            and any(
+                isinstance(p, dict) and p.get("type") in ("video", "video_url")
+                for p in m["content"]
+            )
+            for m in messages
+        ):
+            messages, video_frames = self._expand_video_frames(messages)
+            all_images.extend(video_frames)
+            all_videos = []  # frames are now in all_images
+
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
@@ -911,6 +994,21 @@ class BatchedEngine(BaseEngine):
         _, extracted_images, extracted_videos = extract_multimodal_content(messages)
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
+
+        # Expand inline video content into frame images so the chat template
+        # emits a matching image placeholder per frame.
+        if any(
+            isinstance(m, dict)
+            and isinstance(m.get("content"), list)
+            and any(
+                isinstance(p, dict) and p.get("type") in ("video", "video_url")
+                for p in m["content"]
+            )
+            for m in messages
+        ):
+            messages, video_frames = self._expand_video_frames(messages)
+            all_images.extend(video_frames)
+            all_videos = []
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -273,9 +273,12 @@ class BatchedEngine(BaseEngine):
         prefill_step_size = getattr(
             self._scheduler_config, "mllm_prefill_step_size", None
         )
+        chunked_prefill = getattr(self._scheduler_config, "chunked_prefill_tokens", 0)
         mllm_extra = {}
         if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
+        if chunked_prefill:
+            mllm_extra["chunked_prefill_tokens"] = chunked_prefill
         mllm_config = MLLMSchedulerConfig(
             max_num_seqs=max_num_seqs,
             prefill_batch_size=prefill_batch_size,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -455,6 +455,94 @@ class BatchedEngine(BaseEngine):
 
         return TOKENIZER_LOCK
 
+    def _native_video_preprocess(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+    ) -> tuple[str, dict[str, Any]]:
+        """Run MLXMultimodalLM's native multimodal preprocessing under the
+        tokenizer lock and return (prompt, preprocessed_kwargs) ready to
+        hand to the scheduler.
+        """
+        from ..mllm_batch_generator import TOKENIZER_LOCK
+
+        with TOKENIZER_LOCK:
+            prompt, gen_kwargs = self._mllm_instance._prepare_native_video_inputs(
+                messages,
+                tools=tools,
+            )
+        extra_kwargs: dict[str, Any] = {}
+        for key in ("video_grid_thw", "image_grid_thw"):
+            val = gen_kwargs.get(key)
+            if val is not None:
+                extra_kwargs[key] = val
+        return prompt, {
+            "preprocessed_input_ids": gen_kwargs.get("input_ids"),
+            "preprocessed_pixel_values": gen_kwargs.get("pixel_values"),
+            "preprocessed_attention_mask": gen_kwargs.get("mask"),
+            "preprocessed_extra_kwargs": extra_kwargs or None,
+        }
+
+    async def _generate_native_video(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+        enable_thinking: bool | None,
+        **kwargs,
+    ) -> GenerationOutput:
+        """Non-streaming video-native path through the batched scheduler."""
+        import asyncio
+
+        prompt, pre = await asyncio.to_thread(
+            self._native_video_preprocess,
+            messages,
+            tools,
+            chat_template_kwargs,
+        )
+        return await self.generate(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            **pre,
+            **kwargs,
+        )
+
+    async def _stream_generate_native_video(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+        enable_thinking: bool | None,
+        **kwargs,
+    ) -> AsyncIterator[GenerationOutput]:
+        """Streaming video-native path through the batched scheduler."""
+        import asyncio
+
+        prompt, pre = await asyncio.to_thread(
+            self._native_video_preprocess,
+            messages,
+            tools,
+            chat_template_kwargs,
+        )
+        async for output in self.stream_generate(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            **pre,
+            **kwargs,
+        ):
+            yield output
+
     def _apply_chat_template(
         self,
         messages: list[dict[str, Any]],
@@ -628,6 +716,10 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                preprocessed_input_ids=kwargs.pop("preprocessed_input_ids", None),
+                preprocessed_pixel_values=kwargs.pop("preprocessed_pixel_values", None),
+                preprocessed_attention_mask=kwargs.pop("preprocessed_attention_mask", None),
+                preprocessed_extra_kwargs=kwargs.pop("preprocessed_extra_kwargs", None),
             )
 
             return GenerationOutput(
@@ -712,6 +804,10 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                preprocessed_input_ids=kwargs.pop("preprocessed_input_ids", None),
+                preprocessed_pixel_values=kwargs.pop("preprocessed_pixel_values", None),
+                preprocessed_attention_mask=kwargs.pop("preprocessed_attention_mask", None),
+                preprocessed_extra_kwargs=kwargs.pop("preprocessed_extra_kwargs", None),
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
@@ -799,34 +895,34 @@ class BatchedEngine(BaseEngine):
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
 
-        # Native video path: Gemma 4 (and Qwen-VL) emit their own
-        # <|image>...<|video|>...<image|> interleave with timestamps when
-        # the processor sees {type: video}. Batched can't consume that
-        # shape through its text-prompt scheduler, so delegate a video
-        # request to the MLXMultimodalLM's native pipeline for this call.
+        # Convert tools for template
+        template_tools = convert_tools_for_template(tools) if tools else None
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        enable_thinking = kwargs.pop("enable_thinking", None)
+
+        # Native multimodal pipeline (video_native models: Gemma 4, Qwen-VL,
+        # etc.). When a request has video, Gemma 4's processor emits its own
+        # <|image>...<|video|>...<image|> interleave with timestamps; the
+        # batched path can't reconstruct that from a rendered string, so we
+        # pre-tokenize via MLXMultimodalLM._prepare_native_video_inputs and
+        # hand the scheduler a request with input_ids / pixel_values /
+        # video_grid_thw already populated.
         if (
             self._is_mllm
             and self._mllm_instance is not None
             and getattr(self._mllm_instance, "_video_native", False)
-            and (all_videos or self._messages_have_video(messages))
+            and self._messages_have_video(messages)
         ):
-            import asyncio
-
-            return await asyncio.to_thread(
-                self._mllm_instance.chat,
-                messages=messages,
+            return await self._generate_native_video(
+                messages,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                top_p=top_p,
                 tools=tools,
+                chat_template_kwargs=chat_template_kwargs,
+                enable_thinking=enable_thinking,
                 **kwargs,
             )
-
-        # Convert tools for template
-        template_tools = convert_tools_for_template(tools) if tools else None
-        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
-
-        # Per-request enable_thinking override
-        enable_thinking = kwargs.pop("enable_thinking", None)
 
         # Apply chat template
         prompt = self._apply_chat_template(
@@ -950,38 +1046,31 @@ class BatchedEngine(BaseEngine):
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
 
-        # Native video path: Gemma 4 (and Qwen-VL) handle video via their own
-        # processor interleave. Delegate to MLXMultimodalLM.stream_chat for
-        # video requests so the native markers survive.
+        # Convert tools for template
+        template_tools = convert_tools_for_template(tools) if tools else None
+        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        enable_thinking = kwargs.pop("enable_thinking", None)
+
+        # Native multimodal pipeline: pre-tokenize via MLXMultimodalLM and
+        # hand the scheduler an already-preprocessed request. See chat().
         if (
             self._is_mllm
             and self._mllm_instance is not None
             and getattr(self._mllm_instance, "_video_native", False)
-            and (all_videos or self._messages_have_video(messages))
+            and self._messages_have_video(messages)
         ):
-            import asyncio
-
-            def _run():
-                return list(
-                    self._mllm_instance.stream_chat(
-                        messages=messages,
-                        max_tokens=max_tokens,
-                        temperature=temperature,
-                        tools=tools,
-                        **kwargs,
-                    )
-                )
-
-            for chunk in await asyncio.to_thread(_run):
-                yield chunk
+            async for output in self._stream_generate_native_video(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                chat_template_kwargs=chat_template_kwargs,
+                enable_thinking=enable_thinking,
+                **kwargs,
+            ):
+                yield output
             return
-
-        # Convert tools for template
-        template_tools = convert_tools_for_template(tools) if tools else None
-        chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
-
-        # Per-request enable_thinking override
-        enable_thinking = kwargs.pop("enable_thinking", None)
 
         # Apply chat template
         prompt = self._apply_chat_template(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -274,6 +274,8 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "mllm_prefill_step_size", None
         )
         chunked_prefill = getattr(self._scheduler_config, "chunked_prefill_tokens", 0)
+        ssd_cache_dir = getattr(self._scheduler_config, "ssd_cache_dir", None)
+        ssd_cache_max_gb = getattr(self._scheduler_config, "ssd_cache_max_gb", 10.0)
         mllm_extra = {}
         if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
@@ -291,6 +293,8 @@ class BatchedEngine(BaseEngine):
             kv_cache_quantization=kv_quant,
             kv_cache_quantization_bits=kv_bits,
             kv_cache_quantization_group_size=kv_group_size,
+            ssd_cache_dir=ssd_cache_dir,
+            ssd_cache_max_gb=ssd_cache_max_gb,
             **mllm_extra,
         )
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -442,6 +442,20 @@ class BatchedEngine(BaseEngine):
         self._loaded = False
         logger.info("BatchedEngine stopped")
 
+    def _tokenizer_lock(self):
+        """Return the batch generator's tokenizer lock, or a null context.
+        Shared with ``MLLMBatchGenerator._preprocess_request`` so chat-template
+        rendering and preprocess tokenization can't race on the same Rust-backed
+        tokenizer.
+        """
+        import contextlib
+
+        if self._mllm_scheduler is not None:
+            bg = self._mllm_scheduler.batch_generator
+            if bg is not None and getattr(bg, "tokenizer_lock", None) is not None:
+                return bg.tokenizer_lock
+        return contextlib.nullcontext()
+
     def _apply_chat_template(
         self,
         messages: list[dict[str, Any]],
@@ -490,10 +504,16 @@ class BatchedEngine(BaseEngine):
             if tools and "tools" not in template_kwargs:
                 template_kwargs["tools"] = tools
 
+            # Serialize HF-fast-tokenizer access with the batch generator's
+            # lock. Without it, concurrent async handlers racing on
+            # apply_chat_template trip ``RuntimeError: Already borrowed``
+            # against the same Rust-backed tokenizer state.
+            lock = self._tokenizer_lock()
             try:
-                return template_applicator.apply_chat_template(
-                    messages, **template_kwargs
-                )
+                with lock:
+                    return template_applicator.apply_chat_template(
+                        messages, **template_kwargs
+                    )
             except TypeError as e:
                 # Some templates don't accept extra kwargs; retry without them.
                 logger.debug(f"Chat template TypeError, retrying without extras: {e}")
@@ -503,9 +523,10 @@ class BatchedEngine(BaseEngine):
                     *(chat_template_kwargs or {}).keys(),
                 ]:
                     template_kwargs.pop(key, None)
-                return template_applicator.apply_chat_template(
-                    messages, **template_kwargs
-                )
+                with lock:
+                    return template_applicator.apply_chat_template(
+                        messages, **template_kwargs
+                    )
         else:
             # Fallback for models without apply_chat_template
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
@@ -837,8 +858,9 @@ class BatchedEngine(BaseEngine):
             if hasattr(tokenizer, "tokenizer"):
                 tokenizer = tokenizer.tokenizer
 
-            real_tokens = tokenizer.encode(real_prompt)
-            dummy_tokens = tokenizer.encode(dummy_prompt)
+            with self._tokenizer_lock():
+                real_tokens = tokenizer.encode(real_prompt)
+                dummy_tokens = tokenizer.encode(dummy_prompt)
 
             # Find LCP — the point where the two diverge is the boundary
             lcp = 0

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -533,6 +533,27 @@ class SimpleEngine(BaseEngine):
                 finish_reason=output.finish_reason,
             )
         else:
+            # Diagnostic: render the prompt the model is about to see so we
+            # can verify the chat template handled tool_calls / tool_responses
+            # the way we expect. Logged at DEBUG so it only fires when opted
+            # in via --log-level debug.
+            if logger.isEnabledFor(logging.DEBUG):
+                try:
+                    _tok = self._model.tokenizer
+                    _dbg_tok = (
+                        _tok.tokenizer if hasattr(_tok, "tokenizer") else _tok
+                    )
+                    _rendered = _dbg_tok.apply_chat_template(
+                        messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        tools=template_tools,
+                        **chat_template_kwargs,
+                    )
+                    logger.debug("[RENDERED PROMPT] %r", _rendered)
+                except Exception as exc:
+                    logger.debug(f"[RENDERED PROMPT] render failed: {exc}")
+
             output = await self._run_blocking_serialized(
                 self._model.chat,
                 messages=messages,
@@ -622,6 +643,27 @@ class SimpleEngine(BaseEngine):
         if self._is_mllm:
             if self._text_model is not None:
                 logger.info("Media request → MLLM path")
+
+            # Diagnostic: render the prompt the model is about to see so we
+            # can verify the chat template handled tool_calls / tool_responses
+            # as expected. Logged at DEBUG level only.
+            if logger.isEnabledFor(logging.DEBUG):
+                try:
+                    _tok = self._model.tokenizer
+                    _dbg_tok = (
+                        _tok.tokenizer if hasattr(_tok, "tokenizer") else _tok
+                    )
+                    _rendered = _dbg_tok.apply_chat_template(
+                        messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        tools=template_tools,
+                        **chat_template_kwargs,
+                    )
+                    logger.debug("[RENDERED PROMPT] %r", _rendered)
+                except Exception as exc:
+                    logger.debug(f"[RENDERED PROMPT] render failed: {exc}")
+
             # For MLLM, use stream_chat which yields tokens incrementally.
             # Must hold _generation_lock to prevent concurrent Metal access
             # (e.g. OpenCode sends title + main request simultaneously).

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -533,27 +533,6 @@ class SimpleEngine(BaseEngine):
                 finish_reason=output.finish_reason,
             )
         else:
-            # Diagnostic: render the prompt the model is about to see so we
-            # can verify the chat template handled tool_calls / tool_responses
-            # the way we expect. Logged at DEBUG so it only fires when opted
-            # in via --log-level debug.
-            if logger.isEnabledFor(logging.DEBUG):
-                try:
-                    _tok = self._model.tokenizer
-                    _dbg_tok = (
-                        _tok.tokenizer if hasattr(_tok, "tokenizer") else _tok
-                    )
-                    _rendered = _dbg_tok.apply_chat_template(
-                        messages,
-                        tokenize=False,
-                        add_generation_prompt=True,
-                        tools=template_tools,
-                        **chat_template_kwargs,
-                    )
-                    logger.debug("[RENDERED PROMPT] %r", _rendered)
-                except Exception as exc:
-                    logger.debug(f"[RENDERED PROMPT] render failed: {exc}")
-
             output = await self._run_blocking_serialized(
                 self._model.chat,
                 messages=messages,
@@ -643,26 +622,6 @@ class SimpleEngine(BaseEngine):
         if self._is_mllm:
             if self._text_model is not None:
                 logger.info("Media request → MLLM path")
-
-            # Diagnostic: render the prompt the model is about to see so we
-            # can verify the chat template handled tool_calls / tool_responses
-            # as expected. Logged at DEBUG level only.
-            if logger.isEnabledFor(logging.DEBUG):
-                try:
-                    _tok = self._model.tokenizer
-                    _dbg_tok = (
-                        _tok.tokenizer if hasattr(_tok, "tokenizer") else _tok
-                    )
-                    _rendered = _dbg_tok.apply_chat_template(
-                        messages,
-                        tokenize=False,
-                        add_generation_prompt=True,
-                        tools=template_tools,
-                        **chat_template_kwargs,
-                    )
-                    logger.debug("[RENDERED PROMPT] %r", _rendered)
-                except Exception as exc:
-                    logger.debug(f"[RENDERED PROMPT] render failed: {exc}")
 
             # For MLLM, use stream_chat which yields tokens incrementally.
             # Must hold _generation_lock to prevent concurrent Metal access

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -260,15 +260,18 @@ class _CacheEntry:
 def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
     """Create copies of cache layers with the last ``trim_by`` positions removed.
 
-    This is used when returning a cached KV state to the scheduler so that
-    the last N positions are "freed" and the model will recompute them on the
-    next forward pass (preventing duplicate KV entries).
+    Used when returning a cached KV state to the scheduler so the last N
+    positions are "freed" and the model recomputes them on the next
+    forward pass (preventing duplicate KV entries).
 
-    For plain KVCache: reduces offset (surplus data beyond offset is harmless
-    since merge slices to ``keys[:, :, :offset, :]``).
+    For plain KVCache: MUST slice keys/values to the new offset. Shrinking
+    the offset alone leaves stale content in the underlying array, and
+    Gemma 4's KV-shared attention layers read ``cache.state`` directly
+    (bypassing update_and_fetch), so they attend to that stale content and
+    condition on another sequence's private tokens.
 
-    For RotatingKVCache: actually trims the circular buffer — reducing offset
-    alone breaks ``size()`` / ``_temporal_order`` invariants.
+    For RotatingKVCache: actually trims the circular buffer — reducing
+    offset alone breaks ``size()`` / ``_temporal_order`` invariants.
 
     Supports KVCache, RotatingKVCache, and _QuantizedCacheWrapper.
     """
@@ -389,13 +392,36 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
         ):
             orig_cls = type(layer_cache)
             tc = orig_cls.__new__(orig_cls)
-            tc.keys = layer_cache.keys
-            tc.values = layer_cache.values
-            tc.offset = max(layer_cache.offset - trim_by, 0)
-            # Preserve type-specific attrs (max_size, keep, step, _idx)
-            for attr in ("max_size", "keep", "step", "_idx"):
+            new_offset = max(layer_cache.offset - trim_by, 0)
+            # MUST slice the arrays down to new_offset, not just shrink the
+            # offset pointer. Gemma 4's KV-shared attention layers read
+            # ``cache.state`` (raw keys/values) directly rather than going
+            # through ``update_and_fetch``, so any stale slots past
+            # new_offset get attended to and condition the next request on
+            # another sequence's private content. The LCP-fallback path in
+            # MemoryAwarePrefixCache.fetch() exercises exactly this: a new
+            # request gets handed a trimmed entry whose underlying array
+            # still holds the stored sequence's tail, producing coherent-
+            # but-wrong outputs across unrelated concurrent requests under
+            # continuous batching.
+            k_src = layer_cache.keys
+            v_src = layer_cache.values
+            if k_src is not None and k_src.shape[2] > new_offset:
+                tc.keys = k_src[:, :, :new_offset, :]
+                tc.values = v_src[:, :, :new_offset, :]
+                eval_targets.extend([tc.keys, tc.values])
+            else:
+                tc.keys = k_src
+                tc.values = v_src
+            tc.offset = new_offset
+            # Preserve type-specific attrs (max_size, keep, step, _idx).
+            # _idx, when present, must track the new buffer size so that
+            # size() / _temporal_order stay consistent after trimming.
+            for attr in ("max_size", "keep", "step"):
                 if hasattr(layer_cache, attr):
                     setattr(tc, attr, getattr(layer_cache, attr))
+            if hasattr(layer_cache, "_idx"):
+                tc._idx = new_offset
             trimmed.append(tc)
         else:
             trimmed.append(layer_cache)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -386,9 +386,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
             orig_cls = type(layer_cache)
             tc = orig_cls.__new__(orig_cls)
             new_offset = max(layer_cache.offset - trim_by, 0)
-            # Slice to new_offset, not only shrink the pointer: Gemma 4's
-            # KV-shared layers read cache.state directly and would otherwise
-            # attend to stale trailing slots from a prior sequence.
+            # Slice to new_offset, not only shrink the pointer: KV-shared
+            # attention layers read ``cache.state`` directly and would
+            # otherwise attend to stale trailing slots from a prior sequence.
             k_src = layer_cache.keys
             v_src = layer_cache.values
             if k_src is not None and k_src.shape[2] > new_offset:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -262,16 +262,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
 
     Used when returning a cached KV state to the scheduler so the last N
     positions are "freed" and the model recomputes them on the next
-    forward pass (preventing duplicate KV entries).
-
-    For plain KVCache: MUST slice keys/values to the new offset. Shrinking
-    the offset alone leaves stale content in the underlying array, and
-    Gemma 4's KV-shared attention layers read ``cache.state`` directly
-    (bypassing update_and_fetch), so they attend to that stale content and
-    condition on another sequence's private tokens.
-
-    For RotatingKVCache: actually trims the circular buffer — reducing
-    offset alone breaks ``size()`` / ``_temporal_order`` invariants.
+    forward pass. For RotatingKVCache the circular buffer is actually
+    trimmed — reducing offset alone breaks ``size()`` / ``_temporal_order``
+    invariants.
 
     Supports KVCache, RotatingKVCache, and _QuantizedCacheWrapper.
     """
@@ -393,17 +386,9 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
             orig_cls = type(layer_cache)
             tc = orig_cls.__new__(orig_cls)
             new_offset = max(layer_cache.offset - trim_by, 0)
-            # MUST slice the arrays down to new_offset, not just shrink the
-            # offset pointer. Gemma 4's KV-shared attention layers read
-            # ``cache.state`` (raw keys/values) directly rather than going
-            # through ``update_and_fetch``, so any stale slots past
-            # new_offset get attended to and condition the next request on
-            # another sequence's private content. The LCP-fallback path in
-            # MemoryAwarePrefixCache.fetch() exercises exactly this: a new
-            # request gets handed a trimmed entry whose underlying array
-            # still holds the stored sequence's tail, producing coherent-
-            # but-wrong outputs across unrelated concurrent requests under
-            # continuous batching.
+            # Slice to new_offset, not only shrink the pointer: Gemma 4's
+            # KV-shared layers read cache.state directly and would otherwise
+            # attend to stale trailing slots from a prior sequence.
             k_src = layer_cache.keys
             v_src = layer_cache.values
             if k_src is not None and k_src.shape[2] > new_offset:
@@ -414,9 +399,6 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
                 tc.keys = k_src
                 tc.values = v_src
             tc.offset = new_offset
-            # Preserve type-specific attrs (max_size, keep, step, _idx).
-            # _idx, when present, must track the new buffer size so that
-            # size() / _temporal_order stay consistent after trimming.
             for attr in ("max_size", "keep", "step"):
                 if hasattr(layer_cache, attr):
                     setattr(tc, attr, getattr(layer_cache, attr))

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -386,18 +386,24 @@ def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
             orig_cls = type(layer_cache)
             tc = orig_cls.__new__(orig_cls)
             new_offset = max(layer_cache.offset - trim_by, 0)
-            # Slice to new_offset, not only shrink the pointer: KV-shared
-            # attention layers read ``cache.state`` directly and would
-            # otherwise attend to stale trailing slots from a prior sequence.
-            k_src = layer_cache.keys
-            v_src = layer_cache.values
-            if k_src is not None and k_src.shape[2] > new_offset:
-                tc.keys = k_src[:, :, :new_offset, :]
-                tc.values = v_src[:, :, :new_offset, :]
+            # Slice to new_offset rather than only shrinking the offset
+            # pointer: KV-shared attention layers read cache.state directly
+            # (bypassing update_and_fetch) and would otherwise attend to
+            # stale trailing slots from the previous owner — upstream #384.
+            keys = layer_cache.keys
+            values = layer_cache.values
+            if (
+                keys is not None
+                and hasattr(keys, "shape")
+                and len(keys.shape) >= 3
+                and new_offset < keys.shape[-2]
+            ):
+                tc.keys = keys[..., :new_offset, :]
+                tc.values = values[..., :new_offset, :]
                 eval_targets.extend([tc.keys, tc.values])
             else:
-                tc.keys = k_src
-                tc.values = v_src
+                tc.keys = keys
+                tc.values = values
             tc.offset = new_offset
             for attr in ("max_size", "keep", "step"):
                 if hasattr(layer_cache, attr):

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -905,10 +905,89 @@ class MemoryAwarePrefixCache:
                 self._last_match_type = "lcp"
                 return _clone_cache_for_fetch(trimmed_cache), remaining
 
+        # RAM miss — try the SSD cold tier before giving up. Sync-read and
+        # promote into RAM so the next hit stays hot. The SSD tier is the
+        # durable half of the cache (SQLite index + safetensors data,
+        # survives process crashes), so this is also how caches persist
+        # across restarts.
+        if self._ssd_tier is not None:
+            promoted_entry = self._try_promote_from_ssd(tokens_key)
+            if promoted_entry is not None:
+                self._stats.hits += 1
+                self._stats.tokens_saved += len(tokens)
+                self._last_match_type = "ssd_exact"
+                return _clone_cache_for_fetch(promoted_entry.cache), []
+
         self._stats.misses += 1
         self._last_match_type = "miss"
 
         return None, tokens
+
+    def _try_promote_from_ssd(
+        self, tokens_key: tuple[int, ...]
+    ) -> _CacheEntry | None:
+        """Sync SSD lookup + read + RAM store. Returns the promoted entry
+        (now also resident in RAM) or None if SSD missed or the disk read
+        failed.
+
+        Runs on the calling thread — keep calls to this outside the hot
+        MLX decode path. For prefill-time fetches the cost of a single
+        SSD read (tens of MB → tens of ms on NVMe) is dwarfed by the
+        alternative of a full re-prefill.
+        """
+        meta = self._ssd_tier.lookup_ssd(tokens_key)
+        if meta is None:
+            prefix_meta = self._ssd_tier.lookup_ssd_prefix(tokens_key)
+            if prefix_meta is None:
+                return None
+            meta = prefix_meta
+            matched_count = meta.get("matched_tokens") or meta.get("num_tokens")
+            if matched_count is None or matched_count <= 0:
+                return None
+            lookup_key = tuple(tokens_key[:matched_count])
+        else:
+            lookup_key = tokens_key
+
+        memory_bytes = meta.get("memory_bytes", 0)
+        # Reserve the RAM budget before the disk read so concurrent
+        # promotions don't race past max_memory.
+        if self._current_memory + memory_bytes > self._max_memory:
+            try:
+                self._ssd_tier._stats.promotion_failures += 1
+            except Exception:
+                pass
+            return None
+
+        try:
+            cache_layers = self._ssd_tier._read_entry(lookup_key, meta["file_path"])
+        except Exception:
+            logger.exception("[ssd_promote] read failed for %d tokens", len(lookup_key))
+            return None
+        if cache_layers is None:
+            return None
+
+        entry = _CacheEntry(
+            tokens=lookup_key,
+            cache=cache_layers,
+            memory_bytes=memory_bytes or estimate_kv_cache_memory(cache_layers),
+        )
+        self._entries[lookup_key] = entry
+        self._current_memory += entry.memory_bytes
+        bisect.insort(self._sorted_keys, lookup_key)
+        self._stats.entry_count = len(self._entries)
+        self._stats.current_memory_bytes = self._current_memory
+        # Bump touch time in SSD index so recently-promoted entries outlive
+        # colder neighbours during retention-driven eviction.
+        try:
+            self._ssd_tier._index.touch(lookup_key)
+        except Exception:
+            pass
+        logger.info(
+            "[ssd_promote] hit: promoted %d tokens (%.1fMB) into RAM",
+            len(lookup_key),
+            entry.memory_bytes / _BYTES_PER_MB,
+        )
+        return entry
 
     def store(
         self, tokens: list[int], cache: list[Any], evict_prefixes: bool = True

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -545,12 +545,25 @@ def _clone_cache_for_fetch(cache: list[Any]) -> list[Any]:
         if isinstance(layer, _QuantizedCacheWrapper):
             orig_cls = layer.orig_type
             kv = orig_cls.__new__(orig_cls)
-            kv.keys = mx.dequantize(
+            keys = mx.dequantize(
                 *layer.keys, group_size=layer.group_size, bits=layer.bits
             )
-            kv.values = mx.dequantize(
+            values = mx.dequantize(
                 *layer.values, group_size=layer.group_size, bits=layer.bits
             )
+            # Slice to offset so stale trailing slots (e.g. from a post-trim
+            # wrapper whose quantized arrays still cover the pre-trim length)
+            # don't leak into attention on the next forward pass.
+            if (
+                keys is not None
+                and hasattr(keys, "shape")
+                and len(keys.shape) >= 3
+                and layer.offset < keys.shape[-2]
+            ):
+                keys = keys[..., : layer.offset, :]
+                values = values[..., : layer.offset, :]
+            kv.keys = keys
+            kv.values = values
             kv.offset = layer.offset
             for attr, val in layer.orig_attrs.items():
                 setattr(kv, attr, val)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -530,6 +530,143 @@ def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> li
     return quantized
 
 
+def _pack_cache_for_spill(cache: list[Any]) -> list[dict[str, Any]]:
+    """Convert cache layers to numpy-backed dicts for the SSD writer.
+
+    Must be called on the MLX executor thread — the conversions touch
+    ``mx.array.view`` and trigger buffer-protocol materialisation, both
+    of which must run on the thread that owns Metal work. The writer
+    thread receives plain dicts with numpy arrays and JSON-serialisable
+    metadata, never MLX objects.
+    """
+    from .ssd_cache import _mlx_array_to_numpy
+
+    packed: list[dict[str, Any]] = []
+    for layer in cache:
+        if isinstance(layer, _QuantizedCacheWrapper):
+            k_wq, k_wq_dt = _mlx_array_to_numpy(layer.keys[0])
+            k_sc, k_sc_dt = _mlx_array_to_numpy(layer.keys[1])
+            k_bs, k_bs_dt = _mlx_array_to_numpy(layer.keys[2])
+            v_wq, v_wq_dt = _mlx_array_to_numpy(layer.values[0])
+            v_sc, v_sc_dt = _mlx_array_to_numpy(layer.values[1])
+            v_bs, v_bs_dt = _mlx_array_to_numpy(layer.values[2])
+            packed.append(
+                {
+                    "layer_type": "_QuantizedCacheWrapper",
+                    "arrays": {
+                        "keys_wq": k_wq,
+                        "keys_scales": k_sc,
+                        "keys_biases": k_bs,
+                        "values_wq": v_wq,
+                        "values_scales": v_sc,
+                        "values_biases": v_bs,
+                    },
+                    "dtypes": {
+                        "keys_wq": k_wq_dt,
+                        "keys_scales": k_sc_dt,
+                        "keys_biases": k_bs_dt,
+                        "values_wq": v_wq_dt,
+                        "values_scales": v_sc_dt,
+                        "values_biases": v_bs_dt,
+                    },
+                    "offset": layer.offset,
+                    "bits": layer.bits,
+                    "group_size": layer.group_size,
+                    "orig_type": layer.orig_type.__name__,
+                    "orig_attrs": layer.orig_attrs,
+                }
+            )
+            continue
+        if hasattr(layer, "state") and isinstance(getattr(layer, "state", None), list):
+            # ArraysCache — not expected for the MLLM path but kept for
+            # completeness with the LLM scheduler's cache.
+            state_arrays = []
+            state_dtypes = []
+            for s in layer.state:
+                np_arr, dt = _mlx_array_to_numpy(s)
+                state_arrays.append(np_arr)
+                state_dtypes.append(dt)
+            packed.append(
+                {
+                    "layer_type": type(layer).__name__,
+                    "arrays": {f"state_{i}": a for i, a in enumerate(state_arrays)},
+                    "dtypes": {f"state_{i}": d for i, d in enumerate(state_dtypes)},
+                    "num_arrays": len(state_arrays),
+                }
+            )
+            continue
+        # Plain KVCache / RotatingKVCache
+        k_np, k_dt = _mlx_array_to_numpy(layer.keys)
+        v_np, v_dt = _mlx_array_to_numpy(layer.values)
+        entry: dict[str, Any] = {
+            "layer_type": type(layer).__name__,
+            "arrays": {"keys": k_np, "values": v_np},
+            "dtypes": {"keys": k_dt, "values": v_dt},
+            "offset": layer.offset,
+        }
+        for attr in ("max_size", "keep", "step", "_idx"):
+            if hasattr(layer, attr):
+                entry[attr] = getattr(layer, attr)
+        packed.append(entry)
+    return packed
+
+
+def _unpack_cache_from_ssd(layer_dicts: list[dict[str, Any]]) -> list[Any]:
+    """Inverse of ``_pack_cache_for_spill``: reconstruct MLX cache objects.
+
+    Must be called on the MLX executor thread since it constructs MLX
+    arrays. Handles KVCache, RotatingKVCache, and ``_QuantizedCacheWrapper``
+    — the last is rebuilt with its original cache class preserved so
+    subsequent dequantize calls restore the correct shape.
+    """
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from .ssd_cache import _numpy_to_mlx_array
+
+    rebuilt: list[Any] = []
+    for ld in layer_dicts:
+        layer_type = ld.get("layer_type")
+        if layer_type == "_QuantizedCacheWrapper":
+            dtypes = ld.get("dtypes", {})
+            keys_tuple = tuple(
+                _numpy_to_mlx_array(ld["keys"][i], dtypes.get(name))
+                for i, name in enumerate(("keys_wq", "keys_scales", "keys_biases"))
+            )
+            values_tuple = tuple(
+                _numpy_to_mlx_array(ld["values"][i], dtypes.get(name))
+                for i, name in enumerate(("values_wq", "values_scales", "values_biases"))
+            )
+            wrapper = _QuantizedCacheWrapper.__new__(_QuantizedCacheWrapper)
+            wrapper.keys = keys_tuple
+            wrapper.values = values_tuple
+            wrapper.offset = ld["offset"]
+            wrapper.bits = ld["bits"]
+            wrapper.group_size = ld["group_size"]
+            type_name = ld["orig_type"]
+            wrapper.orig_type = (
+                RotatingKVCache if type_name == "RotatingKVCache" else KVCache
+            )
+            wrapper.orig_attrs = ld["orig_attrs"]
+            rebuilt.append(wrapper)
+            continue
+        if layer_type == "RotatingKVCache":
+            layer = RotatingKVCache(
+                max_size=ld.get("max_size", 1024),
+                keep=ld.get("keep", 0),
+            )
+        else:
+            layer = KVCache()
+        dtypes = ld.get("dtypes", {})
+        layer.keys = _numpy_to_mlx_array(ld.get("keys"), dtypes.get("keys"))
+        layer.values = _numpy_to_mlx_array(ld.get("values"), dtypes.get("values"))
+        layer.offset = ld.get("offset", 0)
+        for attr in ("max_size", "keep", "step", "_idx"):
+            if attr in ld and hasattr(layer, attr):
+                setattr(layer, attr, ld[attr])
+        rebuilt.append(layer)
+    return rebuilt
+
+
 def _clone_cache_for_fetch(cache: list[Any]) -> list[Any]:
     """Return a per-request copy of a stored cache entry.
 
@@ -959,11 +1096,22 @@ class MemoryAwarePrefixCache:
             return None
 
         try:
-            cache_layers = self._ssd_tier._read_entry(lookup_key, meta["file_path"])
+            layer_dicts = self._ssd_tier._read_entry(lookup_key, meta["file_path"])
         except Exception:
             logger.exception("[ssd_promote] read failed for %d tokens", len(lookup_key))
             return None
-        if cache_layers is None:
+        if layer_dicts is None:
+            return None
+
+        try:
+            cache_layers = _unpack_cache_from_ssd(layer_dicts)
+        except Exception as exc:
+            logger.warning(
+                "[ssd_promote] unpack failed for %d tokens: %s: %s",
+                len(lookup_key),
+                type(exc).__name__,
+                exc,
+            )
             return None
 
         entry = _CacheEntry(
@@ -1125,9 +1273,20 @@ class MemoryAwarePrefixCache:
         self._stats.entry_count = len(self._entries)
         self._stats.current_memory_bytes = self._current_memory
 
-        # Spill to SSD tier if available
+        # Spill to SSD tier if available. Layers are packed to numpy-backed
+        # dicts here (on the MLX executor thread) so the writer thread
+        # never touches MLX arrays directly — quantized wrappers keep
+        # their (wq, scales, biases) compact form, and bfloat16 is
+        # preserved bit-for-bit via uint16 reinterpret.
         if self._ssd_tier is not None:
-            self._ssd_tier.enqueue_spill(tokens_key, entry.cache, entry.memory_bytes)
+            try:
+                packed = _pack_cache_for_spill(entry.cache)
+                self._ssd_tier.enqueue_spill(tokens_key, packed, entry.memory_bytes)
+            except Exception as exc:
+                logger.warning(
+                    f"[lru_evict] pack-for-spill failed for "
+                    f"{len(tokens_key)} tokens: {type(exc).__name__}: {exc}"
+                )
 
         logger.debug(
             f"[lru_evict] removed {len(tokens_key)} tokens, "

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import bisect
 import logging
 import math
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -529,18 +530,19 @@ def _quantize_cache(cache: list[Any], bits: int = 8, group_size: int = 64) -> li
     return quantized
 
 
-def _dequantize_cache(cache: list[Any]) -> list[Any]:
-    """Dequantize _QuantizedCacheWrapper layers and copy non-quantized layers.
+def _clone_cache_for_fetch(cache: list[Any]) -> list[Any]:
+    """Return a per-request copy of a stored cache entry.
 
-    All layers are copied (never returned by reference) so that the model's
-    ``update_and_fetch`` mutations don't corrupt the stored cache entry.
+    Dequantizes ``_QuantizedCacheWrapper`` layers and deep-copies all other
+    layers (new ``mx.array`` for keys/values, fresh cache object) so the
+    model's ``update_and_fetch`` — which mutates RotatingKVCache buffers in
+    place — can't corrupt the stored entry the next request will re-fetch.
     """
     import mlx.core as mx
 
     result = []
     for layer in cache:
         if isinstance(layer, _QuantizedCacheWrapper):
-            # Reconstruct original cache type from quantized data
             orig_cls = layer.orig_type
             kv = orig_cls.__new__(orig_cls)
             kv.keys = mx.dequantize(
@@ -550,13 +552,10 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
                 *layer.values, group_size=layer.group_size, bits=layer.bits
             )
             kv.offset = layer.offset
-            # Restore type-specific attrs (max_size, keep, step, _idx)
             for attr, val in layer.orig_attrs.items():
                 setattr(kv, attr, val)
             result.append(kv)
         elif hasattr(layer, "keys") and hasattr(layer, "offset"):
-            # Deep-copy non-quantized cache layers (e.g. RotatingKVCache)
-            # so model's in-place mutations don't corrupt stored entries
             orig_cls = type(layer)
             kv = orig_cls.__new__(orig_cls)
             kv.keys = mx.array(layer.keys) if layer.keys is not None else None
@@ -569,6 +568,11 @@ def _dequantize_cache(cache: list[Any]) -> list[Any]:
         else:
             result.append(layer)
     return result
+
+
+# Alias kept for call sites that conceptually "dequantize"; they now always
+# get a deep copy even when no quantization was used.
+_dequantize_cache = _clone_cache_for_fetch
 
 
 def _compute_model_fingerprint(model: Any) -> str:
@@ -623,7 +627,10 @@ class MemoryAwarePrefixCache:
     - OrderedDict for O(1) LRU operations
 
     Thread Safety:
-        This class is NOT thread-safe. Use external locking if needed.
+        All public methods hold ``self._lock`` while touching ``_entries``,
+        ``_sorted_keys``, ``_current_memory``, and ``_stats``. Safe to call
+        ``fetch`` / ``store`` / ``remove`` / ``clear`` / ``save_to_disk`` /
+        ``load_from_disk`` from multiple threads.
     """
 
     def __init__(
@@ -664,6 +671,11 @@ class MemoryAwarePrefixCache:
         # Optional SSD cold tier (set via set_ssd_tier())
         self._ssd_tier = None
 
+        # Protects _entries / _sorted_keys / _current_memory / _stats across
+        # threads. Re-entrant because a few helpers call back into locked
+        # methods (e.g. clear → _evict_lru chain during test teardown).
+        self._lock = threading.RLock()
+
         logger.info(
             f"MemoryAwarePrefixCache initialized: "
             f"max_memory={self._max_memory / _BYTES_PER_MB:.1f}MB, "
@@ -689,6 +701,12 @@ class MemoryAwarePrefixCache:
             - cache: Cached KV state if found, None otherwise
             - remaining_tokens: Tokens that still need processing
         """
+        with self._lock:
+            return self._fetch_locked(tokens)
+
+    def _fetch_locked(
+        self, tokens: list[int]
+    ) -> tuple[list[Any] | None, list[int]]:
         if not tokens:
             self._stats.misses += 1
             self._last_match_type = "miss"
@@ -703,12 +721,7 @@ class MemoryAwarePrefixCache:
             self._stats.hits += 1
             self._stats.tokens_saved += len(tokens)
             self._last_match_type = "exact"
-            cache_out = (
-                _dequantize_cache(entry.cache)
-                if self._config.kv_quantize
-                else entry.cache
-            )
-            return cache_out, []
+            return _clone_cache_for_fetch(entry.cache), []
 
         # --- O(log N) prefix & supersequence match via sorted index ---
         best_match: _CacheEntry | None = None
@@ -778,23 +791,13 @@ class MemoryAwarePrefixCache:
                 self._stats.hits += 1
                 self._stats.tokens_saved += n_requested
                 self._last_match_type = "supersequence"
-                trimmed_cache = (
-                    _dequantize_cache(trimmed_cache)
-                    if self._config.kv_quantize
-                    else trimmed_cache
-                )
-                return trimmed_cache, []
+                return _clone_cache_for_fetch(trimmed_cache), []
             else:
                 self._entries.move_to_end(best_super.tokens)
                 self._stats.hits += 1
                 self._stats.tokens_saved += n_requested
                 self._last_match_type = "supersequence"
-                cache_out = (
-                    _dequantize_cache(best_super.cache)
-                    if self._config.kv_quantize
-                    else best_super.cache
-                )
-                return cache_out, []
+                return _clone_cache_for_fetch(best_super.cache), []
 
         # --- Prefix match ---
         if best_match is not None:
@@ -803,12 +806,7 @@ class MemoryAwarePrefixCache:
             self._stats.tokens_saved += best_length
             remaining = tokens[best_length:]
             self._last_match_type = "prefix"
-            cache_out = (
-                _dequantize_cache(best_match.cache)
-                if self._config.kv_quantize
-                else best_match.cache
-            )
-            return cache_out, remaining
+            return _clone_cache_for_fetch(best_match.cache), remaining
 
         # --- LCP (Longest Common Prefix) for divergent sequences ---
         # This handles the agentic pattern: same system+context prefix
@@ -819,18 +817,19 @@ class MemoryAwarePrefixCache:
 
         if sorted_keys:
             idx = bisect.bisect_left(sorted_keys, tokens_key)
-            # Check neighbors around insertion point (they share the most
-            # common prefix due to lexicographic ordering).
-            for i in (idx - 1, idx):
-                if i < 0 or i >= len(sorted_keys):
-                    continue
+            # Scan outward from the insertion point and stop on first-token
+            # divergence (lexicographic order clusters same-first-token
+            # entries contiguously).
+            first = tokens_key[0]
+            for i in range(idx - 1, -1, -1):
                 cached_key = sorted_keys[i]
+                if cached_key[0] != first:
+                    break
                 if cached_key == tokens_key:
-                    continue  # Skip exact (already handled)
+                    continue
                 min_len = min(len(cached_key), len(tokens_key))
                 if min_len <= best_lcp_length:
                     continue
-                # Compute LCP length
                 lcp = 0
                 for j in range(min_len):
                     if cached_key[j] != tokens_key[j]:
@@ -839,10 +838,23 @@ class MemoryAwarePrefixCache:
                 if lcp > best_lcp_length:
                     best_lcp_entry = self._entries[cached_key]
                     best_lcp_length = lcp
-                    logger.debug(
-                        f"[cache_fetch] LCP scan: cached_len={len(cached_key)} "
-                        f"req_len={len(tokens_key)} lcp={lcp}"
-                    )
+            for i in range(idx, len(sorted_keys)):
+                cached_key = sorted_keys[i]
+                if cached_key[0] != first:
+                    break
+                if cached_key == tokens_key:
+                    continue
+                min_len = min(len(cached_key), len(tokens_key))
+                if min_len <= best_lcp_length:
+                    continue
+                lcp = 0
+                for j in range(min_len):
+                    if cached_key[j] != tokens_key[j]:
+                        break
+                    lcp = j + 1
+                if lcp > best_lcp_length:
+                    best_lcp_entry = self._entries[cached_key]
+                    best_lcp_length = lcp
 
         if best_lcp_entry is not None and best_lcp_length > 0:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
@@ -878,12 +890,7 @@ class MemoryAwarePrefixCache:
                     f"trimmed={excess} remaining={len(remaining)}"
                 )
                 self._last_match_type = "lcp"
-                trimmed_cache = (
-                    _dequantize_cache(trimmed_cache)
-                    if self._config.kv_quantize
-                    else trimmed_cache
-                )
-                return trimmed_cache, remaining
+                return _clone_cache_for_fetch(trimmed_cache), remaining
 
         self._stats.misses += 1
         self._last_match_type = "miss"
@@ -912,6 +919,12 @@ class MemoryAwarePrefixCache:
         Returns:
             True if stored successfully, False if rejected.
         """
+        with self._lock:
+            return self._store_locked(tokens, cache, evict_prefixes)
+
+    def _store_locked(
+        self, tokens: list[int], cache: list[Any], evict_prefixes: bool
+    ) -> bool:
         if not tokens or not cache:
             return False
 
@@ -1041,21 +1054,23 @@ class MemoryAwarePrefixCache:
             True if entry was found and removed.
         """
         tokens_key = tuple(tokens)
-        entry = self._entries.pop(tokens_key, None)
-        if entry is not None:
-            self._current_memory -= entry.memory_bytes
-            self._remove_from_sorted(tokens_key)
-            self._stats.entry_count = len(self._entries)
-            self._stats.current_memory_bytes = self._current_memory
-            return True
-        return False
+        with self._lock:
+            entry = self._entries.pop(tokens_key, None)
+            if entry is not None:
+                self._current_memory -= entry.memory_bytes
+                self._remove_from_sorted(tokens_key)
+                self._stats.entry_count = len(self._entries)
+                self._stats.current_memory_bytes = self._current_memory
+                return True
+            return False
 
     def clear(self) -> None:
         """Clear all cached entries."""
-        self._entries.clear()
-        self._sorted_keys.clear()
-        self._current_memory = 0
-        self._stats = CacheStats(max_memory_bytes=self._max_memory)
+        with self._lock:
+            self._entries.clear()
+            self._sorted_keys.clear()
+            self._current_memory = 0
+            self._stats = CacheStats(max_memory_bytes=self._max_memory)
         logger.debug("Cache cleared")
 
     def get_stats(self) -> dict[str, Any]:
@@ -1156,9 +1171,17 @@ class MemoryAwarePrefixCache:
         import os
         import time as _time
 
-        if not self._entries:
-            logger.info("[cache_persist] nothing to save (0 entries)")
-            return False
+        with self._lock:
+            if not self._entries:
+                logger.info("[cache_persist] nothing to save (0 entries)")
+                return False
+
+            # Snapshot entries under the lock; writes themselves happen outside
+            # so a long save doesn't block fetch/store. Entries are safe to
+            # iterate post-snapshot because cache entries are effectively
+            # immutable once stored.
+            entries_snapshot = list(self._entries.items())
+            total_memory_snapshot = self._current_memory
 
         t0 = _time.monotonic()
         os.makedirs(cache_dir, exist_ok=True)
@@ -1172,13 +1195,13 @@ class MemoryAwarePrefixCache:
         index = {
             "version": _CACHE_PERSIST_VERSION,
             "model_fingerprint": self._model_fingerprint,
-            "num_entries": len(self._entries),
-            "total_memory_bytes": self._current_memory,
+            "num_entries": len(entries_snapshot),
+            "total_memory_bytes": total_memory_snapshot,
             "entries": [],
         }
 
         saved = 0
-        for i, (tokens_key, entry) in enumerate(self._entries.items()):
+        for i, (tokens_key, entry) in enumerate(entries_snapshot):
             entry_path = os.path.join(cache_dir, f"entry_{i}.safetensors")
             try:
                 save_prompt_cache(
@@ -1217,9 +1240,9 @@ class MemoryAwarePrefixCache:
 
         dt = _time.monotonic() - t0
         logger.info(
-            f"[cache_persist] SAVED {saved}/{len(self._entries)} entries "
+            f"[cache_persist] SAVED {saved}/{len(entries_snapshot)} entries "
             f"to {cache_dir} in {dt:.1f}s "
-            f"({self._current_memory / _BYTES_PER_MB:.0f}MB total)"
+            f"({total_memory_snapshot / _BYTES_PER_MB:.0f}MB total)"
         )
         return saved > 0
 
@@ -1305,9 +1328,10 @@ class MemoryAwarePrefixCache:
                     cache=cache,
                     memory_bytes=memory,
                 )
-                self._entries[tokens_key] = entry
-                self._current_memory += memory
-                bisect.insort(self._sorted_keys, tokens_key)
+                with self._lock:
+                    self._entries[tokens_key] = entry
+                    self._current_memory += memory
+                    bisect.insort(self._sorted_keys, tokens_key)
                 loaded += 1
 
                 logger.info(
@@ -1319,8 +1343,9 @@ class MemoryAwarePrefixCache:
             except Exception as e:
                 logger.warning(f"[cache_persist] failed to load entry {i}: {e}")
 
-        self._stats.entry_count = len(self._entries)
-        self._stats.current_memory_bytes = self._current_memory
+        with self._lock:
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
 
         dt = _time.monotonic() - t0
         logger.info(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -32,6 +32,16 @@ from .vision_embedding_cache import VisionEmbeddingCache
 logger = logging.getLogger(__name__)
 
 
+# Module-level lock serializing all HF-fast-tokenizer access across threads.
+# The Rust-backed tokenizer raises ``RuntimeError: Already borrowed`` when
+# two Python threads hold its inner state at once. The lock has to live
+# above the MLLMBatchGenerator instance because the generator itself is
+# constructed lazily on first request — during that construction the
+# tokenizer is already being used (``_compute_think_suffix_len``), while
+# concurrent request handlers may also try to tokenize.
+TOKENIZER_LOCK = threading.Lock()
+
+
 class PrefillAbortedError(Exception):
     """Raised when a prefill is aborted due to client disconnect."""
 
@@ -430,13 +440,10 @@ class MLLMBatchGenerator:
             prefill_step_size = capped
         self.prefill_step_size = prefill_step_size
 
-        # Serializes all HF-fast-tokenizer access (processor.apply_chat_template,
-        # processor(prompt), tokenizer.encode, etc). The Rust-backed tokenizer
-        # raises ``RuntimeError: Already borrowed`` when two Python threads
-        # hold its inner state at once — which happens with async request
-        # handlers templating a prompt while the scheduler thread tokenizes
-        # a prior request. Acquire via ``tokenizer_lock`` at every call site.
-        self.tokenizer_lock = threading.Lock()
+        # Alias the module-level TOKENIZER_LOCK on the instance for
+        # backward-compatible callers (engine/scheduler reach it via the
+        # batch generator when one exists).
+        self.tokenizer_lock = TOKENIZER_LOCK
 
         # Request management
         self.unprocessed_requests: List[MLLMBatchRequest] = []
@@ -608,18 +615,19 @@ class MLLMBatchGenerator:
             dummy = [{"role": "user", "content": "x"}]
 
             try:
-                text_with = applicator.apply_chat_template(
-                    dummy,
-                    tokenize=False,
-                    add_generation_prompt=True,
-                    enable_thinking=True,
-                )
-                text_without = applicator.apply_chat_template(
-                    dummy,
-                    tokenize=False,
-                    add_generation_prompt=True,
-                    enable_thinking=False,
-                )
+                with TOKENIZER_LOCK:
+                    text_with = applicator.apply_chat_template(
+                        dummy,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        enable_thinking=True,
+                    )
+                    text_without = applicator.apply_chat_template(
+                        dummy,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        enable_thinking=False,
+                    )
             except TypeError:
                 return 0
 
@@ -629,8 +637,9 @@ class MLLMBatchGenerator:
             for tag in ["<think>\n", "<think>"]:
                 if text_with.endswith(tag) and not text_without.endswith(tag):
                     tokenizer = getattr(self.processor, "tokenizer", self.processor)
-                    suffix_tokens = tokenizer.encode(tag)
-                    base_tokens = tokenizer.encode("")
+                    with TOKENIZER_LOCK:
+                        suffix_tokens = tokenizer.encode(tag)
+                        base_tokens = tokenizer.encode("")
                     suffix_len = len(suffix_tokens) - len(base_tokens)
                     if suffix_len > 0:
                         logger.info(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1062,6 +1062,14 @@ class MLLMBatchGenerator:
         if request.image_grid_thw is not None:
             kwargs["image_grid_thw"] = request.image_grid_thw
 
+        pv = request.pixel_values
+        pv_shape = getattr(pv, "shape", None) if pv is not None else None
+        logger.info(
+            f"[vision] request={request.request_id[:12]} "
+            f"pixel_values={'set' if pv is not None else 'NONE'} "
+            f"shape={pv_shape} input_ids_len={request.input_ids.size if request.input_ids is not None else 0}"
+        )
+
         # Run full VLM forward pass with cache.
         # The VLM passes cache= through to self.language_model(),
         # so the language model writes KV state directly into our cache.

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1086,12 +1086,28 @@ class MLLMBatchGenerator:
         # For text-only requests, we check the prefix cache first. If there's
         # a hit, we skip the full VLM forward and run only the language model
         # on the remaining (uncached) tokens.
+        from mlx_lm.sample_utils import make_sampler as _make_sampler
+
         first_tokens = []
         all_logprobs = []
         per_request_caches = []
 
         aborted_requests = []
         for req in requests:
+            # Per-request sampler honoring the request's own temperature /
+            # top_p / top_k / min_p — used for first-token sampling below
+            # and stored in ``batch_samplers`` for subsequent ``_step`` calls.
+            # Without this, every first token was drawn from the scheduler's
+            # hardcoded ``make_sampler(temp=0.7, top_p=0.9)`` regardless of
+            # what the caller requested, which clamps caller-specified
+            # temperatures and collapses generation for models tuned at
+            # other settings (e.g. Gemma 4 at temp=0.95).
+            req_sampler = _make_sampler(
+                temp=req.temperature,
+                top_p=req.top_p,
+                top_k=req.top_k,
+                min_p=req.min_p,
+            )
             try:
                 # Check abort before starting prefill
                 if req.request_id in self._aborted_request_ids:
@@ -1213,7 +1229,7 @@ class MLLMBatchGenerator:
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
-                        sampled = self.sampler(logprobs)
+                        sampled = req_sampler(logprobs)
                         mx.eval(sampled, logprobs)
 
                         first_tokens.append(sampled.item())
@@ -1259,7 +1275,7 @@ class MLLMBatchGenerator:
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
-                        sampled = self.sampler(logprobs)
+                        sampled = req_sampler(logprobs)
                         mx.eval(sampled, logprobs)
 
                         first_tokens.append(sampled.item())
@@ -1305,7 +1321,7 @@ class MLLMBatchGenerator:
                         logprobs = last_logits - mx.logsumexp(
                             last_logits, axis=-1, keepdims=True
                         )
-                        sampled = self.sampler(logprobs)
+                        sampled = req_sampler(logprobs)
 
                         mx.eval(sampled, logprobs)
 
@@ -1423,25 +1439,30 @@ class MLLMBatchGenerator:
             else:
                 batch_logits_processors.append(None)
 
-        # Build per-request samplers for top_k/min_p
+        # Per-request samplers. Built unconditionally so that every request
+        # samples at its own ``temperature`` / ``top_p`` / ``top_k`` /
+        # ``min_p`` during ``_step`` — matching the first-token sampler
+        # already built above. A previous version gated sampler creation on
+        # ``top_k != 0 or min_p != 0.0`` which caused every "default"
+        # request to silently fall through to ``self.sampler``, a scheduler
+        # global hardcoded at ``temp=0.7, top_p=0.9`` regardless of what
+        # the caller asked for.
         batch_samplers = []
-        has_any_sampler = False
         for req in requests:
-            if req.top_k != 0 or req.min_p != 0.0:
-                s = make_sampler(
+            batch_samplers.append(
+                make_sampler(
                     temp=req.temperature,
                     top_p=req.top_p,
                     top_k=req.top_k,
                     min_p=req.min_p,
                 )
-                batch_samplers.append(s)
-                has_any_sampler = True
-                logger.info(
-                    f"[sampling] request={req.request_id[:12]} "
-                    f"top_k={req.top_k} min_p={req.min_p}"
-                )
-            else:
-                batch_samplers.append(None)
+            )
+            logger.info(
+                f"[sampling] request={req.request_id[:12]} "
+                f"temp={req.temperature} top_p={req.top_p} "
+                f"top_k={req.top_k} min_p={req.min_p}"
+            )
+        has_any_sampler = bool(batch_samplers)
 
         self._stats.prompt_time += time.perf_counter() - tic
 

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1433,6 +1433,34 @@ class MLLMBatchGenerator:
             if not requests:
                 return None
 
+        # Store prompt-only KV for text-only requests right after prefill
+        # completes. The generation-end store (``_maybe_store_prefix_cache``)
+        # trims by the full output count, which wipes sliding-window layers
+        # entirely on long generations — stored entries come back empty on
+        # fetch and force a full re-prefill next turn. Storing here trims
+        # by only (last prompt token + think suffix), so the SWA layers
+        # keep up to ``sliding_window - (1 + S)`` prompt tokens. Next-turn
+        # LCP match can actually reuse the KV state.
+        for req, rc in zip(requests, per_request_caches):
+            if (
+                self.prefix_cache is None
+                or not req.is_text_only
+                or req.input_ids is None
+            ):
+                continue
+            try:
+                input_ids_list = req.input_ids.reshape(-1).tolist()
+                S = self._think_suffix_len
+                cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
+                trim_amount = 1 + S
+                store_cache = _trim_cache_offset(rc, trim_amount)
+                self.prefix_cache.store(cache_key, store_cache)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to store prefix cache after prefill for "
+                    f"{req.request_id}: {type(e).__name__}: {e}"
+                )
+
         # Merge per-request caches into batched caches.
         # Both KVCache.merge() and ArraysCache.merge() produce batch-aware
         # caches that support filter/extend/extract for continuous batching.
@@ -1851,12 +1879,16 @@ class MLLMBatchGenerator:
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Store prompt-only KV: trim generated tokens (+ think
                     # suffix) so the stored offset equals key length exactly.
-                    # The exact-match path trims by 1 at fetch time to
-                    # re-derive logits for the last prompt token.
                     output_count = batch.num_tokens[i]
                     S = self._think_suffix_len
                     total_trim = output_count + S
                     prompt_cache = _trim_cache_offset(extracted, total_trim)
+                    # Skip writes that wiped every sliding-window layer —
+                    # this happens when output_count exceeds the SWA buffer
+                    # size. The prefill-completion store in _process_prompts
+                    # already captured a usable copy of this entry.
+                    if self._has_empty_rotating_cache(prompt_cache):
+                        continue
                     cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
                     self.prefix_cache.store(cache_key, prompt_cache)
                 except Exception as e:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2443,42 +2443,38 @@ def install_chunked_prefill_mllm(
                     samplers=[req_sampler] if req_sampler else None,
                 )
 
-                # Extend active batch or set as new
+                # Convert per-request cache to batch-compatible format via
+                # merge. Both branches need _trim_rotating_caches FIRST so
+                # rotating buffers larger than max_size don't reach .merge()
+                # and trip the shape check inside mlx-lm.
+                from mlx_lm.models.cache import RotatingKVCache
+
+                request_cache = partial["cache"]
+                batch_gen._trim_rotating_caches(request_cache)
+                for layer_cache in request_cache:
+                    if isinstance(layer_cache, RotatingKVCache):
+                        if layer_cache.keys is not None:
+                            actual_buf = layer_cache.keys.shape[2]
+                            if layer_cache._idx != actual_buf and actual_buf > 0:
+                                layer_cache.keys = layer_cache._temporal_order(
+                                    layer_cache.keys
+                                )
+                                layer_cache.values = layer_cache._temporal_order(
+                                    layer_cache.values
+                                )
+                                # Use the post-_temporal_order size — the
+                                # call can shrink keys back to max_size on
+                                # a wrapped ring buffer.
+                                layer_cache._idx = layer_cache.keys.shape[2]
+
+                merged_cache = [
+                    request_cache[layer_idx].merge([request_cache[layer_idx]])
+                    for layer_idx in range(len(request_cache))
+                ]
+                new_batch.cache = merged_cache
                 if batch_gen.active_batch is not None:
-                    # Convert per-request cache to batch-compatible format
-                    # via merge (same as _process_prompts does)
-                    from mlx_lm.models.cache import RotatingKVCache
-
-                    request_cache = partial["cache"]
-                    batch_gen._trim_rotating_caches(request_cache)
-                    for layer_cache in request_cache:
-                        if isinstance(layer_cache, RotatingKVCache):
-                            if layer_cache.keys is not None:
-                                actual_buf = layer_cache.keys.shape[2]
-                                if layer_cache._idx != actual_buf and actual_buf > 0:
-                                    layer_cache.keys = layer_cache._temporal_order(
-                                        layer_cache.keys
-                                    )
-                                    layer_cache.values = layer_cache._temporal_order(
-                                        layer_cache.values
-                                    )
-                                    layer_cache._idx = actual_buf
-
-                    # Merge single-request cache into batch cache format
-                    merged_cache = [
-                        request_cache[layer_idx].merge([request_cache[layer_idx]])
-                        for layer_idx in range(len(request_cache))
-                    ]
-                    new_batch.cache = merged_cache
                     batch_gen.active_batch.extend(new_batch)
                 else:
-                    # No active batch — merge cache for batch format
-                    request_cache = partial["cache"]
-                    merged_cache = [
-                        request_cache[layer_idx].merge([request_cache[layer_idx]])
-                        for layer_idx in range(len(request_cache))
-                    ]
-                    new_batch.cache = merged_cache
                     batch_gen.active_batch = new_batch
 
                 # Store in prefix cache (prompt-only)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -929,14 +929,19 @@ class MLLMBatchGenerator:
 
     @staticmethod
     def _trim_rotating_caches(cache_list):
-        """Trim RotatingKVCache buffers restored from prefix cache.
+        """Normalize RotatingKVCache buffers restored from prefix cache.
 
-        Prefix cache stores the full KV state (offset may exceed max_size for
-        sliding-window layers).  RotatingKVCache._update_in_place computes
-        ``new_size = min(step, max_size - prev)`` which goes negative when
-        ``prev > max_size``, crashing with "Negative dimensions not allowed".
+        Prefix-cache entries can contain over-sized buffers (buf_len >
+        max_size) from a supersequence/LCP trim that crossed the max_size
+        boundary. RotatingKVCache._update_in_place then computes
+        ``new_size = min(step, max_size - prev)`` with ``prev > max_size``,
+        going negative ("Negative dimensions not allowed").
 
-        Trimming the buffer to max_size and clamping offset/idx prevents this.
+        Trim over-sized buffers back to max_size. DO NOT clamp
+        ``layer_cache.offset`` — it tracks the global token position and
+        is consumed by RoPE. Clamping it to max_size would tell RoPE a
+        12K-token prefill landed at position 1024, making every
+        subsequently generated token hallucinate.
         """
         from mlx_lm.models.cache import RotatingKVCache
 
@@ -952,7 +957,6 @@ class MLLMBatchGenerator:
                 layer_cache.keys = layer_cache._trim(trim_size, layer_cache.keys)
                 layer_cache.values = layer_cache._trim(trim_size, layer_cache.values)
                 layer_cache._idx = layer_cache.max_size
-            layer_cache.offset = min(layer_cache.offset, layer_cache.max_size)
             # Defensive: ensure size() <= keys.shape[2] to prevent merge crash.
             # Prefix cache trimming can create offset > keys.shape[2] when
             # a supersequence/LCP trim crosses the max_size boundary.

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1054,39 +1054,49 @@ class MLLMBatchGenerator:
         """
         Run the initial VLM forward pass to encode vision and get first logits.
 
-        This runs the full VLM model (vision + language) on the prompt,
-        which encodes the images and fills the provided KV cache.
+        Mirrors the multimodal prefill in ``mlx_vlm.generate.generate_step``:
+        1. ``model.get_input_embeddings(input_ids, pixel_values, mask=mask, **extras)``
+           merges vision features into the text embeddings and returns any
+           derived state (position_ids, mrope deltas, …).
+        2. ``language_model(inputs=..., inputs_embeds=..., cache=cache, **state)``
+           runs prefill into the caller-provided cache.
 
-        Args:
-            request: Preprocessed request with input_ids and pixel_values
-            cache: KV cache list for the language model. If provided, the
-                   language model writes its KV state directly into this cache
-                   during the forward pass.
-
-        Returns:
-            Logits from the forward pass
+        Keeping the split identical to upstream means ``mask`` is named
+        correctly, ``video_grid_thw`` / ``image_grid_thw`` flow through
+        ``**kwargs``, and any embedding-time state the model needs for
+        decode (e.g. M-RoPE deltas) is forwarded without guessing.
         """
-        # Build model call kwargs
-        kwargs = dict(request.extra_kwargs)
-
-        if request.pixel_values is not None:
-            kwargs["pixel_values"] = request.pixel_values
-        if request.attention_mask is not None:
-            kwargs["attention_mask"] = request.attention_mask
+        extras = dict(request.extra_kwargs)
         if request.image_grid_thw is not None:
-            kwargs["image_grid_thw"] = request.image_grid_thw
+            extras["image_grid_thw"] = request.image_grid_thw
 
-        # Run full VLM forward pass with cache.
-        # The VLM passes cache= through to self.language_model(),
-        # so the language model writes KV state directly into our cache.
         input_ids = request.input_ids
         if input_ids.ndim == 1:
             input_ids = input_ids[None, :]
 
-        output = self.model(input_ids, cache=cache, **kwargs)
+        embedding_output = self.model.get_input_embeddings(
+            input_ids,
+            request.pixel_values,
+            mask=request.attention_mask,
+            **extras,
+        )
+        inputs_embeds = embedding_output.inputs_embeds
+        extras.update(
+            {
+                k: v
+                for k, v in embedding_output.to_dict().items()
+                if k != "inputs_embeds" and v is not None
+            }
+        )
+
+        output = self.language_model(
+            inputs=input_ids,
+            inputs_embeds=inputs_embeds,
+            cache=cache,
+            **extras,
+        )
         request.vision_encoded = True
 
-        # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
             return output.logits
         return output

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -759,10 +759,19 @@ class MLLMBatchGenerator:
         3. Running vision encoder to get features
 
         Uses vision cache to skip processing for repeated images.
+        Idempotent: if input_ids is already set for text-only requests,
+        returns immediately (avoids redundant tokenization when called
+        from both chunked prefill interleaving and _process_prompts).
 
         Args:
             request: Request to preprocess
         """
+        # Already preprocessed (e.g. by chunked prefill interleaving).
+        # Only skip for text-only requests; vision requests need pixel cache
+        # lookup even if input_ids was set by a previous preprocess call.
+        if request.input_ids is not None and not request.images and not request.videos:
+            return
+
         from mlx_vlm.utils import prepare_inputs
 
         tic = time.perf_counter()
@@ -2185,3 +2194,444 @@ def install_mtp_mllm(
         f"[MTP-MLLM] installed with num_draft_tokens={num_draft_tokens}, "
         f"always-advance verified mode"
     )
+
+
+def install_chunked_prefill_mllm(
+    batch_gen: "MLLMBatchGenerator",
+    budget: int = 1024,
+) -> None:
+    """Install interleaved prefill/decode on an MLLMBatchGenerator.
+
+    When a long text-only request arrives while an active batch is generating,
+    instead of blocking the entire batch for 20-30s during prefill, this
+    processes ONE chunk of the new request's prefill per step, interleaved
+    with generation steps for the active batch.
+
+    This keeps throughput for existing requests at 30-50 tok/s instead of
+    dropping to 1-5 tok/s during long prefills.
+
+    Args:
+        batch_gen: The MLLMBatchGenerator to patch.
+        budget: Max tokens to prefill per step (chunk size).
+    """
+    from mlx_lm.models.cache import make_prompt_cache
+
+    _orig_next = batch_gen._next
+    batch_gen._partial = None
+    batch_gen._chunked_prefill_budget = budget
+
+    logger.info(
+        f"[chunked-prefill-mllm] Installing interleaved prefill/decode "
+        f"(budget={budget} tokens/step)"
+    )
+
+    def _generation_step() -> List[MLLMBatchResponse]:
+        """Run one generation step for the active batch. Returns responses."""
+        # Collect pending error responses
+        error_responses = list(batch_gen._pending_error_responses)
+        batch_gen._pending_error_responses.clear()
+
+        batch = batch_gen.active_batch
+        if batch is None:
+            return error_responses
+
+        tic = time.perf_counter()
+        y, logprobs = batch.y, batch.logprobs
+        output_tokens = (
+            [req.output_tokens for req in batch.requests]
+            if batch.logits_processors
+            else None
+        )
+        batch.y, batch.logprobs = batch_gen._step(
+            y[:, None],
+            batch.cache,
+            batch.logits_processors,
+            output_tokens,
+            batch.samplers,
+        )
+        # Synchronous eval — must have results before context switch
+        # between prefill cache and batch cache
+        mx.eval(batch.y, batch.logprobs)
+
+        y = y.tolist()
+        batch_gen._stats.generation_time += time.perf_counter() - tic
+
+        # Build responses and track finished
+        keep_idx = []
+        end_idx = []
+        responses = []
+
+        for i, (token, uid, request_id, num_tok, max_tok, req) in enumerate(
+            zip(
+                y,
+                batch.uids,
+                batch.request_ids,
+                batch.num_tokens,
+                batch.max_tokens,
+                batch.requests,
+            )
+        ):
+            num_tok += 1
+            batch.num_tokens[i] = num_tok
+            req.num_tokens = num_tok
+            req.output_tokens.append(token)
+
+            finish_reason = None
+
+            if token in batch_gen.stop_tokens:
+                finish_reason = "stop"
+                end_idx.append(i)
+            elif num_tok >= max_tok:
+                finish_reason = "length"
+                end_idx.append(i)
+            else:
+                keep_idx.append(i)
+
+            if finish_reason is not None:
+                batch_gen._prefill_progress.pop(request_id, None)
+
+            responses.append(
+                MLLMBatchResponse(
+                    uid=uid,
+                    request_id=request_id,
+                    token=token,
+                    logprobs=logprobs[i],
+                    finish_reason=finish_reason,
+                    prompt_cache=(
+                        (lambda idx=i: batch.extract_cache(idx))
+                        if finish_reason is not None
+                        else None
+                    ),
+                )
+            )
+
+        # Store caches for finished text-only requests BEFORE filtering
+        batch_gen._maybe_store_prefix_cache(batch, end_idx)
+
+        # Remove finished requests from batch
+        if end_idx:
+            if keep_idx:
+                batch.filter(keep_idx)
+            else:
+                batch_gen.active_batch = None
+
+        batch_gen._stats.generation_tokens += len(responses)
+        return error_responses + responses
+
+    def _chunked_next() -> List[MLLMBatchResponse]:
+        """Interleaved prefill/decode: one prefill chunk + one gen step."""
+
+        # === Phase 1: Continue partial prefill ===
+        if batch_gen._partial is not None:
+            partial = batch_gen._partial
+            req = partial["request"]
+
+            # Abort check
+            if req.request_id in batch_gen._aborted_request_ids:
+                batch_gen._aborted_request_ids.discard(req.request_id)
+                batch_gen._partial = None
+                mx.clear_cache()
+                batch_gen._prefill_progress.pop(req.request_id, None)
+                batch_gen._pending_error_responses.append(
+                    MLLMBatchResponse(
+                        uid=req.uid,
+                        request_id=req.request_id,
+                        token=0,
+                        logprobs=mx.zeros(1),
+                        finish_reason="abort",
+                    )
+                )
+                return _generation_step()
+
+            step = batch_gen._chunked_prefill_budget
+            remaining = partial["remaining_ids"]
+            remaining_count = remaining.shape[1]
+
+            if remaining_count > step:
+                # Process ONE chunk
+                tic = time.perf_counter()
+                batch_gen.language_model(remaining[:, :step], cache=partial["cache"])
+                mx.eval([c.state for c in partial["cache"]])
+                partial["remaining_ids"] = remaining[:, step:]
+                partial["processed"] += step
+                partial["chunk_count"] += 1
+                batch_gen._prefill_progress[req.request_id] = (
+                    partial["cached_count"] + partial["processed"],
+                    partial["total"],
+                )
+                batch_gen._stats.prompt_time += time.perf_counter() - tic
+
+                # Periodic memory cleanup
+                if partial["chunk_count"] % 4 == 0:
+                    mx.clear_cache()
+
+                return _generation_step()
+            else:
+                # Last chunk — finalize prefill
+                tic = time.perf_counter()
+                logits = batch_gen.language_model(remaining, cache=partial["cache"])
+                if hasattr(logits, "logits"):
+                    logits = logits.logits
+                last_logits = logits[:, -1, :]
+
+                # Apply logits processors for first token
+                if getattr(req, "logits_processors", None):
+                    empty_tokens = mx.array([], dtype=mx.int32)
+                    for processor in req.logits_processors:
+                        last_logits = processor(empty_tokens, last_logits)
+
+                logprobs = last_logits - mx.logsumexp(
+                    last_logits, axis=-1, keepdims=True
+                )
+                sampled = batch_gen.sampler(logprobs)
+                mx.eval(sampled, logprobs)
+
+                batch_gen._prefill_progress[req.request_id] = (
+                    partial["total"],
+                    partial["total"],
+                )
+                batch_gen._stats.prompt_time += time.perf_counter() - tic
+
+                # Build single-request batch
+                from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
+                req_lp = []
+                need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
+                need_pres = req.presence_penalty and req.presence_penalty != 0.0
+                if need_rep or need_pres:
+                    lp_kwargs = {}
+                    if need_rep:
+                        lp_kwargs["repetition_penalty"] = req.repetition_penalty
+                    if need_pres:
+                        lp_kwargs["presence_penalty"] = req.presence_penalty
+                    req_lp.extend(make_logits_processors(**lp_kwargs))
+                if req.logits_processors:
+                    req_lp.extend(req.logits_processors)
+
+                req_sampler = None
+                if req.top_k != 0 or req.min_p != 0.0:
+                    req_sampler = make_sampler(
+                        temp=req.temperature,
+                        top_p=req.top_p,
+                        top_k=req.top_k,
+                        min_p=req.min_p,
+                    )
+
+                new_batch = MLLMBatch(
+                    uids=[req.uid],
+                    request_ids=[req.request_id],
+                    y=sampled,
+                    logprobs=[logprobs.squeeze(0)],
+                    max_tokens=[req.max_tokens],
+                    num_tokens=[0],
+                    cache=partial["cache"],
+                    requests=[req],
+                    logits_processors=[req_lp] if req_lp else None,
+                    samplers=[req_sampler] if req_sampler else None,
+                )
+
+                # Extend active batch or set as new
+                if batch_gen.active_batch is not None:
+                    # Convert per-request cache to batch-compatible format
+                    # via merge (same as _process_prompts does)
+                    from mlx_lm.models.cache import RotatingKVCache
+
+                    request_cache = partial["cache"]
+                    batch_gen._trim_rotating_caches(request_cache)
+                    for layer_cache in request_cache:
+                        if isinstance(layer_cache, RotatingKVCache):
+                            if layer_cache.keys is not None:
+                                actual_buf = layer_cache.keys.shape[2]
+                                if layer_cache._idx != actual_buf and actual_buf > 0:
+                                    layer_cache.keys = layer_cache._temporal_order(
+                                        layer_cache.keys
+                                    )
+                                    layer_cache.values = layer_cache._temporal_order(
+                                        layer_cache.values
+                                    )
+                                    layer_cache._idx = actual_buf
+
+                    # Merge single-request cache into batch cache format
+                    merged_cache = [
+                        request_cache[layer_idx].merge([request_cache[layer_idx]])
+                        for layer_idx in range(len(request_cache))
+                    ]
+                    new_batch.cache = merged_cache
+                    batch_gen.active_batch.extend(new_batch)
+                else:
+                    # No active batch — merge cache for batch format
+                    request_cache = partial["cache"]
+                    merged_cache = [
+                        request_cache[layer_idx].merge([request_cache[layer_idx]])
+                        for layer_idx in range(len(request_cache))
+                    ]
+                    new_batch.cache = merged_cache
+                    batch_gen.active_batch = new_batch
+
+                # Store in prefix cache (prompt-only)
+                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                    try:
+                        input_ids_list = req.input_ids.reshape(-1).tolist()
+                        S = batch_gen._think_suffix_len
+                        cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
+                        # Trim output: we stored 0 output tokens
+                        trim_amount = 1 + S  # last prompt token + think suffix
+                        store_cache = _trim_cache_offset(partial["cache"], trim_amount)
+                        batch_gen.prefix_cache.store(cache_key, store_cache)
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to store prefix cache after chunked "
+                            f"prefill for {req.request_id}: {e}"
+                        )
+
+                logger.info(
+                    f"[chunked-prefill-mllm] Completed interleaved prefill "
+                    f"for {req.request_id[:12]}: "
+                    f"{partial['total']} tokens in {partial['chunk_count']} chunks"
+                )
+                batch_gen._partial = None
+                mx.clear_cache()
+                return _generation_step()
+
+        # === Phase 2: No partial — check for new requests ===
+        batch = batch_gen.active_batch
+        num_active = len(batch) if batch else 0
+
+        if num_active == 0:
+            # No active batch — use original logic (no interleaving benefit)
+            return _orig_next()
+
+        if batch_gen.unprocessed_requests:
+            # Find first text-only request eligible for interleaving
+            text_only_req = None
+            for r in batch_gen.unprocessed_requests:
+                if not r.images and not r.videos:
+                    text_only_req = r
+                    break
+
+            if text_only_req is not None:
+                try:
+                    # Preprocess to get input_ids
+                    batch_gen._preprocess_request(text_only_req)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to preprocess request "
+                        f"{text_only_req.request_id}: {e}"
+                    )
+                    batch_gen.unprocessed_requests.remove(text_only_req)
+                    batch_gen._pending_error_responses.append(
+                        MLLMBatchResponse(
+                            uid=text_only_req.uid,
+                            request_id=text_only_req.request_id,
+                            token=0,
+                            logprobs=mx.zeros(1),
+                            finish_reason="error",
+                        )
+                    )
+                    return _generation_step()
+
+                # Check prefix cache
+                input_ids = text_only_req.input_ids
+                if input_ids.ndim == 1:
+                    input_ids = input_ids[None, :]
+
+                cached_kv = None
+                remaining_ids = None
+                cached_count = 0
+                total_tokens = input_ids.shape[1]
+
+                if batch_gen.prefix_cache is not None:
+                    input_ids_list = input_ids.reshape(-1).tolist()
+                    S = batch_gen._think_suffix_len
+                    lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
+                    cached_kv, remaining_ids = batch_gen.prefix_cache.fetch(lookup_ids)
+                    if cached_kv is not None and S > 0:
+                        remaining_ids = list(remaining_ids) + input_ids_list[-S:]
+
+                    # Check for empty rotating cache
+                    if cached_kv is not None and batch_gen._has_empty_rotating_cache(
+                        cached_kv
+                    ):
+                        cached_kv = None
+                        remaining_ids = None
+
+                if cached_kv is not None and remaining_ids:
+                    # Prefix cache hit
+                    request_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    batch_gen._trim_rotating_caches(request_cache)
+                    remaining = mx.array(remaining_ids)[None, :]
+                    cached_count = total_tokens - len(remaining_ids)
+                    remaining_count = len(remaining_ids)
+                elif cached_kv is not None and not remaining_ids:
+                    # Exact hit — treat as very short remaining (1 token)
+                    request_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    batch_gen._trim_rotating_caches(request_cache)
+                    remaining = input_ids[:, -1:]
+                    cached_count = total_tokens - 1
+                    remaining_count = 1
+                else:
+                    # Cache miss — full prefill
+                    request_cache = make_prompt_cache(batch_gen.language_model)
+                    remaining = input_ids
+                    cached_count = 0
+                    remaining_count = total_tokens
+
+                # Decide: interleave or immediate
+                if remaining_count > batch_gen._chunked_prefill_budget:
+                    # LONG prompt — start partial (interleaved) prefill
+                    logger.info(
+                        f"[chunked-prefill-mllm] Starting interleaved prefill "
+                        f"for {text_only_req.request_id[:12]}: "
+                        f"{remaining_count} remaining tokens "
+                        f"(cached={cached_count}, "
+                        f"budget={batch_gen._chunked_prefill_budget})"
+                    )
+                    batch_gen._partial = {
+                        "request": text_only_req,
+                        "cache": request_cache,
+                        "remaining_ids": remaining,
+                        "processed": 0,
+                        "total": total_tokens,
+                        "cached_count": cached_count,
+                        "chunk_count": 0,
+                    }
+                    batch_gen.unprocessed_requests.remove(text_only_req)
+                    text_only_req.vision_encoded = True
+
+                    # Process first chunk immediately
+                    step = batch_gen._chunked_prefill_budget
+                    tic = time.perf_counter()
+                    batch_gen.language_model(remaining[:, :step], cache=request_cache)
+                    mx.eval([c.state for c in request_cache])
+                    batch_gen._partial["remaining_ids"] = remaining[:, step:]
+                    batch_gen._partial["processed"] = step
+                    batch_gen._partial["chunk_count"] = 1
+                    batch_gen._prefill_progress[text_only_req.request_id] = (
+                        cached_count + step,
+                        total_tokens,
+                    )
+                    batch_gen._stats.prompt_time += time.perf_counter() - tic
+
+                    return _generation_step()
+                # else: SHORT prompt — fall through to _orig_next.
+                # _preprocess_request is idempotent for text-only (sets
+                # input_ids if not already set); _process_prompts checks
+                # input_ids and skips redundant preprocessing.
+
+        # === Phase 3: No partial, no long prompt — original behavior ===
+        return _orig_next()
+
+    # Patch remove() to handle partial abort
+    _orig_remove = batch_gen.remove
+
+    def _patched_remove(uids: List[int]) -> None:
+        if batch_gen._partial is not None:
+            if batch_gen._partial["request"].uid in set(uids):
+                batch_gen._partial = None
+                mx.clear_cache()
+        _orig_remove(uids)
+
+    batch_gen.remove = _patched_remove
+    batch_gen._next = _chunked_next
+
+    logger.info(f"[chunked-prefill-mllm] Installed (budget={budget} tokens/step)")

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -101,6 +101,12 @@ class MLLMBatchRequest:
     # Text-only flag (no images/videos — eligible for prefix cache)
     is_text_only: bool = False
 
+    # Upstream-tokenized flag: when the engine has already run the
+    # native multimodal pipeline (processor + vision encoder setup) and
+    # pre-populated input_ids/pixel_values/extra_kwargs, _preprocess_request
+    # trusts those and skips its own tokenization path.
+    is_preprocessed: bool = False
+
     # Generation state
     num_tokens: int = 0  # Tokens generated so far
     output_tokens: List[int] = field(default_factory=list)
@@ -779,6 +785,14 @@ class MLLMBatchGenerator:
         Args:
             request: Request to preprocess
         """
+        # Upstream-preprocessed (engine ran the native multimodal pipeline
+        # end-to-end): trust the pre-populated input_ids / pixel_values /
+        # extra_kwargs and set is_text_only based on whether pixel data came
+        # along so _process_prompts routes to the correct prefill path.
+        if request.is_preprocessed:
+            request.is_text_only = request.pixel_values is None
+            return
+
         # Already preprocessed (e.g. by chunked prefill interleaving).
         # Only skip for text-only requests; vision requests need pixel cache
         # lookup even if input_ids was set by a previous preprocess call.

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -17,6 +17,7 @@ Architecture:
 """
 
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -383,6 +384,14 @@ class MLLMBatchGenerator:
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
         self.prefill_step_size = prefill_step_size
+
+        # Serializes all HF-fast-tokenizer access (processor.apply_chat_template,
+        # processor(prompt), tokenizer.encode, etc). The Rust-backed tokenizer
+        # raises ``RuntimeError: Already borrowed`` when two Python threads
+        # hold its inner state at once — which happens with async request
+        # handlers templating a prompt while the scheduler thread tokenizes
+        # a prior request. Acquire via ``tokenizer_lock`` at every call site.
+        self.tokenizer_lock = threading.Lock()
 
         # Request management
         self.unprocessed_requests: List[MLLMBatchRequest] = []
@@ -775,13 +784,16 @@ class MLLMBatchGenerator:
             getattr(model_config, "image_token_index", None) if model_config else None
         )
 
-        # Prepare inputs using mlx_vlm
-        inputs = prepare_inputs(
-            self.processor,
-            images=all_images if all_images else None,
-            prompts=request.prompt,
-            image_token_index=image_token_index,
-        )
+        # Prepare inputs using mlx_vlm. Serialize with tokenizer_lock since
+        # prepare_inputs ends up calling the HF fast tokenizer, which raises
+        # ``RuntimeError: Already borrowed`` under concurrent access.
+        with self.tokenizer_lock:
+            inputs = prepare_inputs(
+                self.processor,
+                images=all_images if all_images else None,
+                prompts=request.prompt,
+                image_token_index=image_token_index,
+            )
 
         request.input_ids = inputs.get("input_ids")
         request.pixel_values = inputs.get("pixel_values")

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1094,14 +1094,8 @@ class MLLMBatchGenerator:
 
         aborted_requests = []
         for req in requests:
-            # Per-request sampler honoring the request's own temperature /
-            # top_p / top_k / min_p — used for first-token sampling below
-            # and stored in ``batch_samplers`` for subsequent ``_step`` calls.
-            # Without this, every first token was drawn from the scheduler's
-            # hardcoded ``make_sampler(temp=0.7, top_p=0.9)`` regardless of
-            # what the caller requested, which clamps caller-specified
-            # temperatures and collapses generation for models tuned at
-            # other settings (e.g. Gemma 4 at temp=0.95).
+            # Per-request first-token sampler from the request's own
+            # temperature / top_p / top_k / min_p.
             req_sampler = _make_sampler(
                 temp=req.temperature,
                 top_p=req.top_p,
@@ -1439,14 +1433,8 @@ class MLLMBatchGenerator:
             else:
                 batch_logits_processors.append(None)
 
-        # Per-request samplers. Built unconditionally so that every request
-        # samples at its own ``temperature`` / ``top_p`` / ``top_k`` /
-        # ``min_p`` during ``_step`` — matching the first-token sampler
-        # already built above. A previous version gated sampler creation on
-        # ``top_k != 0 or min_p != 0.0`` which caused every "default"
-        # request to silently fall through to ``self.sampler``, a scheduler
-        # global hardcoded at ``temp=0.7, top_p=0.9`` regardless of what
-        # the caller asked for.
+        # Per-request samplers for ``_step`` — built unconditionally so
+        # every request honors its own sampling params during decode.
         batch_samplers = []
         for req in requests:
             batch_samplers.append(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1062,14 +1062,6 @@ class MLLMBatchGenerator:
         if request.image_grid_thw is not None:
             kwargs["image_grid_thw"] = request.image_grid_thw
 
-        pv = request.pixel_values
-        pv_shape = getattr(pv, "shape", None) if pv is not None else None
-        logger.info(
-            f"[vision] request={request.request_id[:12]} "
-            f"pixel_values={'set' if pv is not None else 'NONE'} "
-            f"shape={pv_shape} input_ids_len={request.input_ids.size if request.input_ids is not None else 0}"
-        )
-
         # Run full VLM forward pass with cache.
         # The VLM passes cache= through to self.language_model(),
         # so the language model writes KV state directly into our cache.

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -40,6 +40,21 @@ class PrefillAbortedError(Exception):
         super().__init__(f"Prefill aborted for request {request_id}")
 
 
+def _smallest_sliding_window(model: Any) -> Optional[int]:
+    """Smallest sliding_window among the model's SWA layers, or None."""
+    cfg = getattr(model, "config", None) or getattr(model, "args", None)
+    if cfg is None:
+        return None
+    sw = getattr(cfg, "sliding_window", None)
+    if sw is None:
+        text_cfg = getattr(cfg, "text_config", None)
+        if text_cfg is not None:
+            sw = getattr(text_cfg, "sliding_window", None)
+    if isinstance(sw, int) and sw > 0:
+        return sw
+    return None
+
+
 @dataclass
 class MLLMBatchRequest:
     """
@@ -231,7 +246,19 @@ class MLLMBatch:
                 cache.keep = getattr(c, "keep", 0)
                 result.append(cache)
             else:
-                result.append(c.extract(idx))
+                extracted = c.extract(idx)
+                # Detach from the batch's shared buffers: c.extract may hand
+                # back slice views of the batch KV tensor, which would mutate
+                # under the extracted cache if the batch keeps generating for
+                # other slots. Materialise owned arrays.
+                if (
+                    extracted is not None
+                    and hasattr(extracted, "keys")
+                    and extracted.keys is not None
+                ):
+                    extracted.keys = mx.array(extracted.keys)
+                    extracted.values = mx.array(extracted.values)
+                result.append(extracted)
         return result
 
 
@@ -383,6 +410,20 @@ class MLLMBatchGenerator:
 
         self.prefill_batch_size = prefill_batch_size
         self.completion_batch_size = max(completion_batch_size, prefill_batch_size)
+        # Cap step size at half the smallest sliding window the language model
+        # uses. Chunked prefill into a rotating KV cache evicts the previous
+        # chunk wholesale at each boundary; queries early in the next chunk
+        # then see no in-window context, breaking SWA layers. Keeping step
+        # ≤ window/2 guarantees every query sees at least window/2 prior
+        # tokens in its cache.
+        sliding_window = _smallest_sliding_window(self.language_model)
+        if sliding_window and prefill_step_size > sliding_window // 2:
+            capped = max(sliding_window // 2, 64)
+            logger.info(
+                f"MLLMBatchGenerator: capping prefill_step_size "
+                f"{prefill_step_size} → {capped} (sliding_window={sliding_window})"
+            )
+            prefill_step_size = capped
         self.prefill_step_size = prefill_step_size
 
         # Serializes all HF-fast-tokenizer access (processor.apply_chat_template,
@@ -787,13 +828,28 @@ class MLLMBatchGenerator:
         # Prepare inputs using mlx_vlm. Serialize with tokenizer_lock since
         # prepare_inputs ends up calling the HF fast tokenizer, which raises
         # ``RuntimeError: Already borrowed`` under concurrent access.
-        with self.tokenizer_lock:
-            inputs = prepare_inputs(
-                self.processor,
-                images=all_images if all_images else None,
-                prompts=request.prompt,
-                image_token_index=image_token_index,
-            )
+        # prepare_inputs sets ``tokenizer.pad_token = tokenizer.eos_token``
+        # when pad_token is None, a persistent mutation on the shared
+        # tokenizer. Snapshot and restore so the rest of the system sees
+        # the original values.
+        tok = getattr(self.processor, "tokenizer", self.processor)
+        prev_pad = getattr(tok, "pad_token", None)
+        prev_pad_id = getattr(tok, "pad_token_id", None)
+        try:
+            with self.tokenizer_lock:
+                inputs = prepare_inputs(
+                    self.processor,
+                    images=all_images if all_images else None,
+                    prompts=request.prompt,
+                    image_token_index=image_token_index,
+                )
+        finally:
+            if prev_pad is None and getattr(tok, "pad_token", None) is not None:
+                try:
+                    tok.pad_token = prev_pad
+                    tok.pad_token_id = prev_pad_id
+                except Exception:
+                    pass
 
         request.input_ids = inputs.get("input_ids")
         request.pixel_values = inputs.get("pixel_values")

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2556,15 +2556,16 @@ def install_chunked_prefill_mllm(
                         remaining_ids = None
 
                 if cached_kv is not None and remaining_ids:
-                    # Prefix cache hit
-                    request_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    # Prefix cache hit. fetch() already returns an owned
+                    # deep copy, so no further copy is needed here.
+                    request_cache = cached_kv
                     batch_gen._trim_rotating_caches(request_cache)
                     remaining = mx.array(remaining_ids)[None, :]
                     cached_count = total_tokens - len(remaining_ids)
                     remaining_count = len(remaining_ids)
                 elif cached_kv is not None and not remaining_ids:
                     # Exact hit — treat as very short remaining (1 token)
-                    request_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    request_cache = cached_kv
                     batch_gen._trim_rotating_caches(request_cache)
                     remaining = input_ids[:, -1:]
                     cached_count = total_tokens - 1

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -417,6 +417,10 @@ class MLLMBatchGenerator:
         # ≤ window/2 guarantees every query sees at least window/2 prior
         # tokens in its cache.
         sliding_window = _smallest_sliding_window(self.language_model)
+        logger.info(
+            f"MLLMBatchGenerator: detected sliding_window={sliding_window} "
+            f"(prefill_step_size={prefill_step_size})"
+        )
         if sliding_window and prefill_step_size > sliding_window // 2:
             capped = max(sliding_window // 2, 64)
             logger.info(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -835,37 +835,6 @@ class MLLMBatchGenerator:
         )
 
     @staticmethod
-    def _copy_prefix_cache(cache_list):
-        """Create shallow copies of cache objects to prevent mutation of stored prefix cache.
-
-        MLX arrays are immutable and safe to share, but cache objects have mutable
-        Python attributes (offset, _idx) that get modified by update_and_fetch().
-        Without copying, the stored prefix cache entry is corrupted after each use.
-        """
-        from mlx_lm.models.cache import KVCache, RotatingKVCache
-
-        copies = []
-        for c in cache_list:
-            if isinstance(c, RotatingKVCache):
-                new_c = RotatingKVCache(c.max_size, c.keep)
-                new_c.step = c.step
-                new_c.keys = c.keys
-                new_c.values = c.values
-                new_c.offset = c.offset
-                new_c._idx = c._idx
-                copies.append(new_c)
-            elif isinstance(c, KVCache):
-                new_c = KVCache()
-                new_c.step = c.step
-                new_c.keys = c.keys
-                new_c.values = c.values
-                new_c.offset = c.offset
-                copies.append(new_c)
-            else:
-                copies.append(c)
-        return copies
-
-    @staticmethod
     def _has_empty_rotating_cache(cache_list):
         """Check if any RotatingKVCache layer has no data (keys=None).
 
@@ -1166,8 +1135,8 @@ class MLLMBatchGenerator:
 
                 if cached_kv is not None and remaining_ids:
                     # Prefix/LCP match — run language model on remaining tokens.
-                    # Copy cache to prevent mutation of stored prefix cache entry.
-                    request_cache = self._copy_prefix_cache(cached_kv)
+                    # fetch() already deep-copies, so cached_kv is owned by us.
+                    request_cache = cached_kv
                     self._trim_rotating_caches(request_cache)
                     remaining = mx.array(remaining_ids)[None, :]
                     cached_count = len(input_ids_list) - len(remaining_ids)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -311,13 +311,19 @@ class MLLMScheduler:
             )
 
             # Install chunked prefill BEFORE MTP (MTP wraps _next,
-            # chunked replaces it — MTP then wraps the chunked version)
+            # chunked replaces it — MTP then wraps the chunked version).
+            # Cap at prefill_step_size so the sliding-window safety cap the
+            # generator applied also governs the interleaved budget.
             if self.config.chunked_prefill_tokens > 0:
                 from .mllm_batch_generator import install_chunked_prefill_mllm
 
+                budget = min(
+                    self.config.chunked_prefill_tokens,
+                    self.batch_generator.prefill_step_size,
+                )
                 install_chunked_prefill_mllm(
                     self.batch_generator,
-                    budget=self.config.chunked_prefill_tokens,
+                    budget=budget,
                 )
 
             # Install MTP if enabled and language model supports it

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -97,6 +97,14 @@ class MLLMRequest:
     sampling_params: SamplingParams = field(default_factory=SamplingParams)
     arrival_time: float = field(default_factory=time.time)
 
+    # Pre-computed inputs — set when the engine has already tokenized +
+    # ran the vision/audio/video processor upstream (e.g. video-native
+    # models). _preprocess_request trusts these and skips its own path.
+    preprocessed_input_ids: Optional[Any] = None
+    preprocessed_pixel_values: Optional[Any] = None
+    preprocessed_attention_mask: Optional[Any] = None
+    preprocessed_extra_kwargs: Optional[Dict[str, Any]] = None
+
     # Batch generator UID (assigned when scheduled)
     batch_uid: Optional[int] = None
 
@@ -383,12 +391,23 @@ class MLLMScheduler:
             logits_processors=kwargs.pop("logits_processors", None),
         )
 
+        # Extract upstream-preprocessed inputs if the engine handed us pre-
+        # tokenized native-multimodal inputs (e.g. Gemma 4 video pipeline).
+        preprocessed_input_ids = kwargs.pop("preprocessed_input_ids", None)
+        preprocessed_pixel_values = kwargs.pop("preprocessed_pixel_values", None)
+        preprocessed_attention_mask = kwargs.pop("preprocessed_attention_mask", None)
+        preprocessed_extra_kwargs = kwargs.pop("preprocessed_extra_kwargs", None)
+
         request = MLLMRequest(
             request_id=request_id,
             prompt=prompt,
             images=images,
             videos=videos,
             sampling_params=sampling_params,
+            preprocessed_input_ids=preprocessed_input_ids,
+            preprocessed_pixel_values=preprocessed_pixel_values,
+            preprocessed_attention_mask=preprocessed_attention_mask,
+            preprocessed_extra_kwargs=preprocessed_extra_kwargs,
         )
 
         # Estimate prompt token count for monitoring (text tokens only;
@@ -537,6 +556,18 @@ class MLLMScheduler:
                 repetition_penalty=request.sampling_params.repetition_penalty,
                 logits_processors=request.sampling_params.logits_processors,
             )
+            # Propagate pre-computed tokenization + vision inputs from the
+            # engine's native-multimodal pipeline so the batch generator
+            # doesn't re-tokenize (which would lose the native interleave).
+            if request.preprocessed_input_ids is not None:
+                batch_req.input_ids = request.preprocessed_input_ids
+                batch_req.pixel_values = request.preprocessed_pixel_values
+                batch_req.attention_mask = request.preprocessed_attention_mask
+                extras = dict(request.preprocessed_extra_kwargs or {})
+                if "image_grid_thw" in extras:
+                    batch_req.image_grid_thw = extras.pop("image_grid_thw")
+                batch_req.extra_kwargs = extras
+                batch_req.is_preprocessed = True
             batch_requests.append(batch_req)
 
             request.status = RequestStatus.RUNNING

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -845,36 +845,33 @@ class MLLMScheduler:
     async def _process_loop(self) -> None:
         """Main async processing loop.
 
-        Every scheduler step runs on the single-worker ``mllm-step``
-        executor thread. Two invariants follow:
+        Every scheduler step runs on the process-wide MLX executor
+        thread (see ``vllm_mlx.mlx_thread``). Two invariants follow:
 
-        1. **Correctness.** MLX's per-stream state (command buffer,
-           encoder lifecycle) is not thread-safe; only one thread may
-           submit work to a given ``mx.Stream`` at a time. The prior
-           split — prefill on the executor, decode inline on the event
-           loop — meant ``_stream`` was touched by two threads
-           alternately, and Metal's driver asserted
+        1. **Correctness.** MLX's per-stream state is not thread-safe;
+           only one thread may submit work to the Metal device at a
+           time. Routing every step and every other MLX-touching code
+           path (embeddings, rerank, etc.) through the one shared
+           executor eliminates cross-thread Metal asserts such as
            ``'A command encoder is already encoding to this command
-           buffer'`` when the next thread created an encoder before the
-           previous thread's encoder state had fully settled (an
-           effect of ``mx.async_eval``'s pipelined submit).
-        2. **Responsiveness.** Inline decode blocks the event loop for
-           the full duration of the step (~3 ms of GPU work). Handing
-           every step off via ``run_in_executor`` releases the loop
-           while the executor thread runs the step, so HTTP handlers,
+           buffer'`` and ``'Completed handler provided after commit
+           call'`` that otherwise fire under concurrent load.
+        2. **Responsiveness.** Handing every step off via
+           ``run_in_executor`` releases the event loop for the full
+           duration of the step (~3 ms of GPU work), so HTTP handlers,
            metrics, disconnect detection, and background tasks are
-           free to schedule during the step. Submit overhead is on the
-           order of tens of µs, dwarfed by the step itself.
+           free to schedule. Submit overhead is on the order of tens
+           of µs.
         """
-        _executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mllm-step"
-        )
+        from .mlx_thread import get_executor
+
+        executor = get_executor()
         loop = asyncio.get_running_loop()
 
         while self._running:
             try:
                 if self.has_requests():
-                    await loop.run_in_executor(_executor, self.step)
+                    await loop.run_in_executor(executor, self.step)
                 else:
                     # No work, wait a bit
                     await asyncio.sleep(0.01)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -381,8 +381,18 @@ class MLLMScheduler:
             if hasattr(self.processor, "tokenizer")
             else self.processor
         )
+        # Serialize with the batch generator's tokenizer_lock — HF's fast
+        # tokenizer raises RuntimeError: Already borrowed under concurrent
+        # access, and this call runs from the async request handler thread.
+        lock = None
+        if self.batch_generator is not None:
+            lock = getattr(self.batch_generator, "tokenizer_lock", None)
         try:
-            request.num_prompt_tokens = len(tokenizer.encode(prompt))
+            if lock is not None:
+                with lock:
+                    request.num_prompt_tokens = len(tokenizer.encode(prompt))
+            else:
+                request.num_prompt_tokens = len(tokenizer.encode(prompt))
         except Exception:
             pass
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -279,12 +279,7 @@ class MLLMScheduler:
         if self.batch_generator is None:
             from .memory_cache import MemoryCacheConfig
 
-            # No global sampler — every request now builds its own sampler
-            # in ``MLLMBatchGenerator._process_prompts`` from its
-            # ``temperature`` / ``top_p`` / ``top_k`` / ``min_p`` and the
-            # result flows through to ``_step``. ``self.sampler`` is only
-            # consulted as a last-resort fallback, which is the
-            # MLLMBatchGenerator default (``argmax``).
+            # Per-request samplers are built in _process_prompts; no global.
             sampler = None
 
             # Configure KV prefix cache for text-only requests

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -277,12 +277,15 @@ class MLLMScheduler:
     def _ensure_batch_generator(self) -> None:
         """Ensure batch generator exists."""
         if self.batch_generator is None:
-            from mlx_lm.sample_utils import make_sampler
-
             from .memory_cache import MemoryCacheConfig
 
-            # Default sampler (can be overridden per-request in future)
-            sampler = make_sampler(temp=0.7, top_p=0.9)
+            # No global sampler — every request now builds its own sampler
+            # in ``MLLMBatchGenerator._process_prompts`` from its
+            # ``temperature`` / ``top_p`` / ``top_k`` / ``min_p`` and the
+            # result flows through to ``_step``. ``self.sampler`` is only
+            # consulted as a last-resort fallback, which is the
+            # MLLMBatchGenerator default (``argmax``).
+            sampler = None
 
             # Configure KV prefix cache for text-only requests
             # KV cache quantization reduces prefix cache memory ~4x (BF16→Q8).

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -80,6 +80,14 @@ class MLLMSchedulerConfig:
     kv_cache_quantization_group_size: int = 64
     # Interleaved prefill/decode budget per step (0 = disabled, blocking prefill)
     chunked_prefill_tokens: int = 0
+    # SSD cache tier — evict-and-spill destination for the prefix cache.
+    # When set, evicted RAM entries asynchronously spill to NVMe via the
+    # SQLite-indexed ``SSDCacheTier``, survive process restarts, and are
+    # promoted back on fetch. Gives incremental durability (no one-shot
+    # shutdown save required) and effectively unbounds the cache to the
+    # configured disk budget.
+    ssd_cache_dir: Optional[str] = None  # None = disabled
+    ssd_cache_max_gb: float = 10.0
 
 
 @dataclass
@@ -317,6 +325,30 @@ class MLLMScheduler:
                 prefill_step_size=self.config.prefill_step_size,
                 prefix_cache_config=prefix_cache_config,
             )
+
+            # Attach SSD cold tier to the prefix cache if configured. Evicted
+            # RAM entries spill to NVMe asynchronously, fetches fall through
+            # to SSD on RAM miss, and the SQLite-indexed tier survives
+            # restarts / crashes / OOMs — no reliance on lifespan shutdown.
+            self._ssd_tier = None
+            if (
+                self.config.ssd_cache_dir is not None
+                and self.batch_generator.prefix_cache is not None
+            ):
+                from .ssd_cache import SSDCacheConfig, SSDCacheTier
+
+                ssd_config = SSDCacheConfig(
+                    cache_dir=self.config.ssd_cache_dir,
+                    max_size_gb=self.config.ssd_cache_max_gb,
+                )
+                self._ssd_tier = SSDCacheTier(ssd_config)
+                self._ssd_tier.start_writer()
+                self._ssd_tier.reconcile()
+                self.batch_generator.prefix_cache.set_ssd_tier(self._ssd_tier)
+                logger.info(
+                    f"MLLM SSD cache tier enabled: dir={self.config.ssd_cache_dir}, "
+                    f"max={self.config.ssd_cache_max_gb}GB"
+                )
 
             # Install chunked prefill BEFORE MTP (MTP wraps _next,
             # chunked replaces it — MTP then wraps the chunked version).
@@ -839,6 +871,14 @@ class MLLMScheduler:
         if self.batch_generator is not None:
             self.batch_generator.close()
             self.batch_generator = None
+
+        ssd_tier = getattr(self, "_ssd_tier", None)
+        if ssd_tier is not None:
+            try:
+                ssd_tier.close()
+            except Exception as exc:
+                logger.warning(f"SSD tier close failed: {exc}")
+            self._ssd_tier = None
 
         logger.info("MLLM Scheduler stopped")
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -986,9 +986,16 @@ class MLLMScheduler:
                 if output is None:
                     finished_normally = True
                     break
-                yield output
+                # Mark finished BEFORE yield. If the consumer breaks out of
+                # its async-for loop right after seeing output.finished, the
+                # async generator gets aclose()'d and our finally runs while
+                # suspended at ``yield``. Setting the flag pre-yield avoids
+                # the false-positive "Aborting orphaned" log on what is
+                # actually a clean completion.
                 if output.finished:
                     finished_normally = True
+                yield output
+                if output.finished:
                     break
         finally:
             if not finished_normally:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -845,10 +845,26 @@ class MLLMScheduler:
     async def _process_loop(self) -> None:
         """Main async processing loop.
 
-        Uses a thread pool executor for steps that involve prefill
-        (waiting requests or partial prefill in progress) so that the
-        event loop stays responsive for health checks and other HTTP
-        endpoints.  Decode-only steps are fast (<3 ms) and run inline.
+        Every scheduler step runs on the single-worker ``mllm-step``
+        executor thread. Two invariants follow:
+
+        1. **Correctness.** MLX's per-stream state (command buffer,
+           encoder lifecycle) is not thread-safe; only one thread may
+           submit work to a given ``mx.Stream`` at a time. The prior
+           split — prefill on the executor, decode inline on the event
+           loop — meant ``_stream`` was touched by two threads
+           alternately, and Metal's driver asserted
+           ``'A command encoder is already encoding to this command
+           buffer'`` when the next thread created an encoder before the
+           previous thread's encoder state had fully settled (an
+           effect of ``mx.async_eval``'s pipelined submit).
+        2. **Responsiveness.** Inline decode blocks the event loop for
+           the full duration of the step (~3 ms of GPU work). Handing
+           every step off via ``run_in_executor`` releases the loop
+           while the executor thread runs the step, so HTTP handlers,
+           metrics, disconnect detection, and background tasks are
+           free to schedule during the step. Submit overhead is on the
+           order of tens of µs, dwarfed by the step itself.
         """
         _executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="mllm-step"
@@ -858,18 +874,7 @@ class MLLMScheduler:
         while self._running:
             try:
                 if self.has_requests():
-                    has_waiting = self.get_num_waiting() > 0
-                    has_partial = (
-                        self.batch_generator is not None
-                        and getattr(self.batch_generator, "_partial", None) is not None
-                    )
-                    needs_executor = has_waiting or has_partial
-
-                    if needs_executor:
-                        await loop.run_in_executor(_executor, self.step)
-                    else:
-                        self.step()
-                        await asyncio.sleep(0)
+                    await loop.run_in_executor(_executor, self.step)
                 else:
                     # No work, wait a bit
                     await asyncio.sleep(0.01)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -78,6 +78,8 @@ class MLLMSchedulerConfig:
     kv_cache_quantization: bool = False
     kv_cache_quantization_bits: int = 8
     kv_cache_quantization_group_size: int = 64
+    # Interleaved prefill/decode budget per step (0 = disabled, blocking prefill)
+    chunked_prefill_tokens: int = 0
 
 
 @dataclass
@@ -307,6 +309,16 @@ class MLLMScheduler:
                 prefill_step_size=self.config.prefill_step_size,
                 prefix_cache_config=prefix_cache_config,
             )
+
+            # Install chunked prefill BEFORE MTP (MTP wraps _next,
+            # chunked replaces it — MTP then wraps the chunked version)
+            if self.config.chunked_prefill_tokens > 0:
+                from .mllm_batch_generator import install_chunked_prefill_mllm
+
+                install_chunked_prefill_mllm(
+                    self.batch_generator,
+                    budget=self.config.chunked_prefill_tokens,
+                )
 
             # Install MTP if enabled and language model supports it
             if self.config.enable_mtp:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -783,6 +783,12 @@ class MLLMScheduler:
         if self._running:
             return
 
+        # Build the batch generator up front so its init (attention patches,
+        # _compute_think_suffix_len, prefix cache setup) completes before
+        # any request handler touches the tokenizer or model. Avoids a race
+        # between lazy init and the first concurrent request.
+        self._ensure_batch_generator()
+
         self._running = True
         self._processing_task = asyncio.create_task(self._process_loop())
         logger.info(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -399,17 +399,14 @@ class MLLMScheduler:
             if hasattr(self.processor, "tokenizer")
             else self.processor
         )
-        # Serialize with the batch generator's tokenizer_lock — HF's fast
-        # tokenizer raises RuntimeError: Already borrowed under concurrent
-        # access, and this call runs from the async request handler thread.
-        lock = None
-        if self.batch_generator is not None:
-            lock = getattr(self.batch_generator, "tokenizer_lock", None)
+        # Serialize with the module-level TOKENIZER_LOCK so we can't race
+        # with _preprocess_request or _apply_chat_template on HF's fast
+        # tokenizer (raises RuntimeError: Already borrowed under concurrent
+        # access).
+        from .mllm_batch_generator import TOKENIZER_LOCK
+
         try:
-            if lock is not None:
-                with lock:
-                    request.num_prompt_tokens = len(tokenizer.encode(prompt))
-            else:
+            with TOKENIZER_LOCK:
                 request.num_prompt_tokens = len(tokenizer.encode(prompt))
         except Exception:
             pass

--- a/vllm_mlx/mlx_thread.py
+++ b/vllm_mlx/mlx_thread.py
@@ -1,0 +1,76 @@
+"""Process-wide single-threaded executor for all MLX work.
+
+Metal's per-stream state (command buffers, encoder lifecycle, completion
+handlers) is not thread-safe. MLX does not guard it — the caller must
+ensure only one Python thread submits work against a given ``mx.Stream``
+(and in practice, against the whole Metal device) at a time.
+
+Under load, two Apple driver asserts surface when this invariant is
+broken:
+
+    "A command encoder is already encoding to this command buffer"
+    "Completed handler provided after commit call"
+
+Both are fatal (they abort the process).
+
+This module exposes a single-worker ``ThreadPoolExecutor`` that every
+MLX-submitting code path in vllm-mlx must use: the continuous-batching
+scheduler, the embeddings handler, the rerank handler, and any future
+add-on that calls into Metal. Routing all MLX work through one thread
+keeps the per-stream state consistent and eliminates the class of Metal
+races described above.
+
+The event loop is not blocked while work runs here — callers use
+``await run_mlx(fn, ...)``. Submit overhead is on the order of tens of
+microseconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import threading
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")
+
+_executor: concurrent.futures.ThreadPoolExecutor | None = None
+_lock = threading.Lock()
+
+
+def get_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return the process-wide single-threaded MLX executor.
+
+    Lazily constructed on first call. Safe to call from any thread.
+    """
+    global _executor
+    if _executor is None:
+        with _lock:
+            if _executor is None:
+                _executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="mlx"
+                )
+    return _executor
+
+
+async def run_mlx(fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run ``fn(*args, **kwargs)`` on the shared MLX thread and await its result.
+
+    The event loop is free to schedule other coroutines while the MLX
+    thread runs ``fn``. Any synchronous MLX-touching code path (model
+    forward, ``mx.eval``, ``mx.clear_cache``, etc.) should be wrapped
+    with this helper to keep all Metal submissions serialized on one
+    thread.
+    """
+    loop = asyncio.get_running_loop()
+    if kwargs:
+        return await loop.run_in_executor(get_executor(), lambda: fn(*args, **kwargs))
+    return await loop.run_in_executor(get_executor(), fn, *args)
+
+
+def shutdown() -> None:
+    """Tear down the MLX executor. Called from graceful-shutdown paths."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=True)
+        _executor = None

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1133,6 +1133,126 @@ class MLXMultimodalLM:
 
         return translated
 
+    def _prepare_chat_messages(
+        self,
+        messages: list[dict],
+        video_frame_counts: dict[int, int] | None = None,
+    ) -> tuple[list[dict], list]:
+        """Transform OpenAI-format messages into chat-template-ready form.
+
+        Preserves every message's full structure — ``role``, ``tool_calls``
+        (assistant side), ``tool_call_id`` + ``name`` (tool side), and
+        content in whatever shape it arrived (None, str, dict, list). For
+        list content, walks items in order and:
+
+        - Text parts: passed through as ``{type: text, text: ...}``.
+        - ``image_url`` / ``image`` parts: URL registered into
+          ``all_image_urls`` for the image pipeline; item replaced with
+          ``{type: image}`` so the chat template emits its model-specific
+          image placeholder at that position. Order inside the content
+          list is preserved.
+        - ``video``/``video_url`` and unknown part types: passed through
+          unchanged so specialised templates can render them.
+
+        ``video_frame_counts`` maps message index → number of frames that
+        the video-frame-fallback pipeline extracted from videos in that
+        message. Each frame is a real image already added to
+        ``all_video_frames`` by the caller; we append one ``{type: image}``
+        placeholder per frame so the template emits the matching count of
+        image tokens aligned with the frame pixels passed to the model.
+
+        Dict content on a message passes through unchanged — supports the
+        tool-parser adapter's wrap pattern (e.g. Gemma 4 wrapping string
+        tool responses as ``{"content": str}`` so the template's
+        mapping-branch renders them as
+        ``response:name{content:<|"|>str<|"|>}`` rather than the synthetic
+        ``{value:...}`` the model wasn't trained on).
+
+        Returns the rebuilt messages list plus the flat list of image URLs
+        that need downloading/decoding via ``_prepare_images``.
+        """
+        chat_messages: list[dict] = []
+        all_image_urls: list = []
+        video_frame_counts = video_frame_counts or {}
+
+        for msg_idx, msg in enumerate(messages):
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+
+            out: dict = {"role": role}
+            for k in ("tool_calls", "tool_call_id", "name"):
+                if k in msg and msg[k] is not None:
+                    out[k] = msg[k]
+
+            n_video_frames = video_frame_counts.get(msg_idx, 0)
+
+            if isinstance(content, list):
+                transformed: list = []
+                for item in content:
+                    if isinstance(item, str):
+                        transformed.append({"type": "text", "text": item})
+                        continue
+
+                    # Pydantic model conversion (drop None fields to avoid
+                    # e.g. `image_url: null` on text parts tripping templates)
+                    if hasattr(item, "model_dump"):
+                        item = item.model_dump(exclude_none=True)
+                    elif hasattr(item, "dict"):
+                        item = {k: v for k, v in item.dict().items() if v is not None}
+
+                    if not isinstance(item, dict):
+                        continue
+
+                    item_type = item.get("type", "")
+                    if item_type == "text":
+                        transformed.append(item)
+                    elif item_type == "image_url":
+                        url_obj = item.get("image_url", {})
+                        url = (
+                            url_obj.get("url", "")
+                            if isinstance(url_obj, dict)
+                            else url_obj
+                        )
+                        if url:
+                            all_image_urls.append(url)
+                            transformed.append({"type": "image"})
+                    elif item_type == "image":
+                        url = item.get("image", item.get("url", ""))
+                        if url:
+                            all_image_urls.append(url)
+                            transformed.append({"type": "image"})
+                    else:
+                        # video/video_url/audio/etc. — pass through so
+                        # specialised templates can render them.
+                        transformed.append(item)
+
+                # One image placeholder per extracted video frame, each
+                # corresponding to a real frame already in all_video_frames.
+                for _ in range(n_video_frames):
+                    transformed.append({"type": "image"})
+                out["content"] = transformed
+            elif n_video_frames:
+                # String / None / dict content alongside extracted video frames
+                # — promote to list so the frame placeholders sit next to text.
+                parts: list = []
+                for _ in range(n_video_frames):
+                    parts.append({"type": "image"})
+                if isinstance(content, str) and content:
+                    parts.append({"type": "text", "text": content})
+                elif isinstance(content, dict):
+                    # Rare but legal: preserve dict next to frame placeholders.
+                    parts.append(content)
+                out["content"] = parts
+            else:
+                # None, str, dict — pass through verbatim. Tool-call-only
+                # assistant turns (content=None) and tool-parser-wrapped
+                # dict content both fall through here.
+                out["content"] = content
+
+            chat_messages.append(out)
+
+        return chat_messages, all_image_urls
+
     def generate(
         self,
         prompt: str,
@@ -1397,11 +1517,6 @@ class MLXMultimodalLM:
         from mlx_vlm import generate
         from mlx_vlm.prompt_utils import get_chat_template
 
-        # Extract text and images from messages
-        # Build chat_messages for multi-turn support WITH proper image tokens per message
-        all_image_urls = []  # Raw URLs/paths to process later
-        chat_messages = []  # List of properly formatted messages for chat template
-
         logger.info(f"MLLM.chat() called with {len(messages)} messages")
 
         # Pop params early so they don't leak into mlx_vlm.generate()
@@ -1440,77 +1555,13 @@ class MLXMultimodalLM:
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
 
-        # Second pass: build chat messages with image counts that include video frames
-        for msg_idx, msg in enumerate(messages):
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            msg_text = ""  # Text content for this message
-            msg_image_count = 0  # Number of images in THIS message
-
-            if isinstance(content, str):
-                msg_text = content
-            elif isinstance(content, list):
-                # OpenAI multimodal format - extract text and count images for THIS message
-                for item in content:
-                    if isinstance(item, str):
-                        msg_text += item
-                        continue
-
-                    # Convert Pydantic models to dicts, excluding None fields
-                    # to avoid null keys like image_url: null on text parts
-                    if hasattr(item, "model_dump"):
-                        item = item.model_dump(exclude_none=True)
-                    elif hasattr(item, "dict"):
-                        item = {k: v for k, v in item.dict().items() if v is not None}
-
-                    if isinstance(item, dict):
-                        item_type = item.get("type", "")
-
-                        if item_type == "text":
-                            msg_text += item.get("text", "")
-
-                        elif item_type == "image_url":
-                            img_url = item.get("image_url", {})
-                            if isinstance(img_url, str):
-                                all_image_urls.append(img_url)
-                            else:
-                                all_image_urls.append(img_url.get("url", ""))
-                            msg_image_count += 1
-
-                        elif item_type == "image":
-                            all_image_urls.append(
-                                item.get("image", item.get("url", ""))
-                            )
-                            msg_image_count += 1
-
-            # Add video frame count to image count for this message
-            msg_image_count += _msg_video_frame_counts.get(msg_idx, 0)
-
-            # Build properly structured message for Qwen3-VL-MoE
-            # Format: {"role": "...", "content": [{"type": "image"}, ..., {"type": "text", "text": "..."}]}
-            if msg_text or msg_image_count > 0:
-                if role == "user" and msg_image_count > 0:
-                    # User message WITH images - build content array with image tokens FIRST
-                    content_list = []
-                    for _ in range(msg_image_count):
-                        content_list.append({"type": "image"})
-                    content_list.append(
-                        {"type": "text", "text": msg_text, "content": msg_text}
-                    )
-                    chat_messages.append({"role": role, "content": content_list})
-                elif role == "assistant":
-                    # Assistant messages - just text content (not array)
-                    chat_messages.append({"role": role, "content": msg_text})
-                else:
-                    # User/system message WITHOUT images - still use content array format
-                    chat_messages.append(
-                        {
-                            "role": role,
-                            "content": [
-                                {"type": "text", "text": msg_text, "content": msg_text}
-                            ],
-                        }
-                    )
+        # Rebuild messages for the template. Preserves tool_calls /
+        # tool_call_id / name / dict-content intact while extracting image
+        # URLs and inserting `{type: image}` placeholders inline at each
+        # image's original position.
+        chat_messages, all_image_urls = self._prepare_chat_messages(
+            messages, _msg_video_frame_counts
+        )
 
         # Process images
         all_images = []
@@ -1796,11 +1847,6 @@ class MLXMultimodalLM:
             yield output
             return
 
-        # Extract text and images from messages
-        # Build chat_messages for multi-turn support WITH proper image tokens per message
-        all_image_urls = []  # Raw URLs/paths to process later
-        chat_messages = []  # List of properly formatted messages for chat template
-
         # Pop params early so they don't leak into mlx_vlm.generate()
         video_fps = kwargs.pop("video_fps", DEFAULT_FPS)
         video_max_frames = kwargs.pop("video_max_frames", MAX_FRAMES)
@@ -1844,67 +1890,12 @@ class MLXMultimodalLM:
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
 
-        for msg_idx, msg in enumerate(messages):
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            msg_text = ""
-            msg_image_count = 0
-
-            if isinstance(content, str):
-                msg_text = content
-            elif isinstance(content, list):
-                for item in content:
-                    if isinstance(item, str):
-                        msg_text += item
-                        continue
-
-                    if hasattr(item, "model_dump"):
-                        item = item.model_dump(exclude_none=True)
-                    elif hasattr(item, "dict"):
-                        item = {k: v for k, v in item.dict().items() if v is not None}
-
-                    if isinstance(item, dict):
-                        item_type = item.get("type", "")
-
-                        if item_type == "text":
-                            msg_text += item.get("text", "")
-
-                        elif item_type == "image_url":
-                            img_url = item.get("image_url", {})
-                            if isinstance(img_url, str):
-                                all_image_urls.append(img_url)
-                            else:
-                                all_image_urls.append(img_url.get("url", ""))
-                            msg_image_count += 1
-
-                        elif item_type == "image":
-                            all_image_urls.append(
-                                item.get("image", item.get("url", ""))
-                            )
-                            msg_image_count += 1
-
-            msg_image_count += _msg_video_frame_counts.get(msg_idx, 0)
-
-            if msg_text or msg_image_count > 0:
-                if role == "user" and msg_image_count > 0:
-                    content_list = []
-                    for _ in range(msg_image_count):
-                        content_list.append({"type": "image"})
-                    content_list.append(
-                        {"type": "text", "text": msg_text, "content": msg_text}
-                    )
-                    chat_messages.append({"role": role, "content": content_list})
-                elif role == "assistant":
-                    chat_messages.append({"role": role, "content": msg_text})
-                else:
-                    chat_messages.append(
-                        {
-                            "role": role,
-                            "content": [
-                                {"type": "text", "text": msg_text, "content": msg_text}
-                            ],
-                        }
-                    )
+        # Rebuild messages for the template. Preserves tool_calls /
+        # tool_call_id / name / dict-content intact while extracting image
+        # URLs and inserting `{type: image}` placeholders inline.
+        chat_messages, all_image_urls = self._prepare_chat_messages(
+            messages, _msg_video_frame_counts
+        )
 
         all_images = []
         if all_image_urls:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1164,12 +1164,9 @@ class MLXMultimodalLM:
         placeholder per frame so the template emits the matching count of
         image tokens aligned with the frame pixels passed to the model.
 
-        Dict content on a message passes through unchanged — supports the
-        tool-parser adapter's wrap pattern (e.g. Gemma 4 wrapping string
-        tool responses as ``{"content": str}`` so the template's
-        mapping-branch renders them as
-        ``response:name{content:<|"|>str<|"|>}`` rather than the synthetic
-        ``{value:...}`` the model wasn't trained on).
+        Dict content on a message passes through unchanged so that tool
+        parsers' ``prepare_messages`` hook can wrap tool responses in a
+        template-specific shape.
 
         Returns the rebuilt messages list, the flat list of image URLs
         that need downloading/decoding via ``_prepare_images``, and the

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -589,8 +589,11 @@ def process_image_input(image: str | dict) -> str:
     Supports:
     - URL (http/https)
     - Base64 encoded string
+    - Local filesystem path (used for pre-extracted video frames)
     - OpenAI format dict: {"url": "..."} or {"url": "data:image/...;base64,..."}
     """
+    from pathlib import Path
+
     # Handle dict format (OpenAI style)
     if isinstance(image, dict):
         url = image.get("url", image.get("image_url", ""))
@@ -609,8 +612,19 @@ def process_image_input(image: str | dict) -> str:
     if is_url(image):
         return download_image(image)
 
+    # Local filesystem path (e.g. video frames pre-extracted by the engine).
+    # Bounded by length so we don't stat() a multi-MB base64 blob.
+    if len(image) < 4096:
+        try:
+            p = Path(image)
+            if p.is_file():
+                return str(p)
+        except (OSError, ValueError):
+            pass
+
     raise ValueError(
-        "Unsupported image input. Only http(s) URLs and data:image base64 payloads are allowed."
+        "Unsupported image input. Only http(s) URLs, data:image base64 "
+        "payloads, and local file paths are allowed."
     )
 
 

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -28,6 +28,11 @@ from .think_parser import BaseThinkingReasoningParser
 # Channel names that follow <|channel> — stripped from output
 _THOUGHT_PREFIX = "thought"
 _RESPONSE_MARKER = "<|channel>response"
+# Full "open-thinking" marker. Kept as a buffering target so that partial
+# prefixes arriving mid-stream (e.g. "<|channel>th", "<|channel>thoug") are
+# held back until the label completes, instead of leaking 'th', 'tho', etc.
+# into the reasoning output.
+_THOUGHT_MARKER = "<|channel>thought"
 
 
 def _strip_channel_name(text: str, prefix: str) -> str:
@@ -112,7 +117,7 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         when it appears AT THE END and is not followed by more text (i.e.,
         `response` or `thought` hasn't arrived yet).
         """
-        markers = (_RESPONSE_MARKER, self.end_token, self.start_token)
+        markers = (_RESPONSE_MARKER, _THOUGHT_MARKER, self.end_token, self.start_token)
         max_len = 0
         for marker in markers:
             # Scan from longest proper prefix downwards

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -77,11 +77,36 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         # Tracks whether we have emitted the first content delta past the
         # <|channel>response transition — used to strip the leading newline.
         self._content_seen: bool = False
+        # Gemma 4's chat template injects an empty `<|channel>thought\n<channel|>`
+        # preamble on every model turn when enable_thinking=false. The prompt
+        # thus already ends in the END marker, so the model's first emitted
+        # token is content, not reasoning. The base class would otherwise
+        # stay in pre_think and route everything into `reasoning_content`
+        # until a stray `<|channel>` shows up — then choke on the transition
+        # and leak the closing marker into content. Starting in "content"
+        # phase matches the template's actual behavior and still handles
+        # mid-stream thought blocks via the base class's content-phase
+        # re-entry path.
+        self._phase = "content"
+        # Counters used while eating the "thought\n" channel-name prefix at
+        # the start of each reasoning block. Works at delta granularity —
+        # the prefix can be split across arbitrary chunk boundaries
+        # ("tho" / "ught" / "\n") and we still consume it exactly once.
+        self._thought_prefix_consumed: int = 0
+        self._thought_newline_consumed: bool = False
 
     def reset_state(self):
         super().reset_state()
         self._pending = ""
         self._content_seen = False
+        self._phase = "content"
+        self._thought_prefix_consumed = 0
+        self._thought_newline_consumed = False
+
+    def _arm_thought_strip(self) -> None:
+        """Re-arm the thought-prefix stripper when entering a new thinking block."""
+        self._thought_prefix_consumed = 0
+        self._thought_newline_consumed = False
 
     def _trailing_partial_marker_len(self, text: str) -> int:
         """
@@ -243,30 +268,40 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
                     return DeltaMessage(content=stripped)
                 return DeltaMessage(content=delta_text)
 
+        # If the base class entered a new thinking block in this delta
+        # (start token appears somewhere inside delta_text), re-arm the
+        # thought-prefix stripper so we eat the next "thought\n" again.
+        if self.start_token in delta_text:
+            self._arm_thought_strip()
+
         # Delegate to base class for standard <|channel>/<channel|> handling
         result = super().extract_reasoning_streaming(
             previous_text, current_text, delta_text
         )
 
-        # Strip "thought" channel name from initial reasoning
+        # Strip the "thought" channel-name token (and its trailing newline)
+        # from the START of each reasoning block, chunk-by-chunk. We operate
+        # directly on ``result.reasoning`` — NOT on ``current_text`` — so
+        # any ``result.content`` the base class split off stays intact.
         if result is not None and result.reasoning is not None:
-            # First reasoning delta after <|channel> will be "thought" or "thought\n"
-            if self.start_token in current_text:
-                # Check if this is the very first reasoning content
-                after_channel = current_text.split(self.start_token, 1)[1]
-                if after_channel.startswith(_THOUGHT_PREFIX):
-                    # Remove "thought" prefix from the accumulated reasoning so far
-                    clean = after_channel[len(_THOUGHT_PREFIX) :].lstrip("\n")
-                    # Compute what portion of clean text is in this delta
-                    prev_after = ""
-                    if self.start_token in previous_text:
-                        prev_after = previous_text.split(self.start_token, 1)[1]
-                        if prev_after.startswith(_THOUGHT_PREFIX):
-                            prev_after = prev_after[len(_THOUGHT_PREFIX) :].lstrip("\n")
-                    # The new reasoning text is clean minus what was already emitted
-                    new_reasoning = clean[len(prev_after) :]
-                    if new_reasoning:
-                        return DeltaMessage(reasoning=new_reasoning)
-                    return None  # Suppress channel name token
+            r = result.reasoning
+            while (
+                self._thought_prefix_consumed < len(_THOUGHT_PREFIX)
+                and r
+                and r[0] == _THOUGHT_PREFIX[self._thought_prefix_consumed]
+            ):
+                r = r[1:]
+                self._thought_prefix_consumed += 1
+            if (
+                self._thought_prefix_consumed == len(_THOUGHT_PREFIX)
+                and not self._thought_newline_consumed
+                and r.startswith("\n")
+            ):
+                r = r.lstrip("\n")
+                self._thought_newline_consumed = True
+
+            if not r and not result.content:
+                return None
+            return DeltaMessage(reasoning=r or None, content=result.content)
 
         return result

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -77,21 +77,13 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         # Tracks whether we have emitted the first content delta past the
         # <|channel>response transition — used to strip the leading newline.
         self._content_seen: bool = False
-        # Gemma 4's chat template injects an empty `<|channel>thought\n<channel|>`
-        # preamble on every model turn when enable_thinking=false. The prompt
-        # thus already ends in the END marker, so the model's first emitted
-        # token is content, not reasoning. The base class would otherwise
-        # stay in pre_think and route everything into `reasoning_content`
-        # until a stray `<|channel>` shows up — then choke on the transition
-        # and leak the closing marker into content. Starting in "content"
-        # phase matches the template's actual behavior and still handles
-        # mid-stream thought blocks via the base class's content-phase
-        # re-entry path.
+        # Gemma 4's template injects `<|channel>thought\n<channel|>` as
+        # preamble, so the model starts emitting content, not reasoning.
+        # Start in "content" phase; mid-stream thought blocks re-enter via
+        # the base class's content-phase path.
         self._phase = "content"
-        # Counters used while eating the "thought\n" channel-name prefix at
-        # the start of each reasoning block. Works at delta granularity —
-        # the prefix can be split across arbitrary chunk boundaries
-        # ("tho" / "ught" / "\n") and we still consume it exactly once.
+        # Counters for eating the "thought\n" channel-name prefix at the
+        # start of each reasoning block, tolerant to chunk-boundary splits.
         self._thought_prefix_consumed: int = 0
         self._thought_newline_consumed: bool = False
 
@@ -268,21 +260,15 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
                     return DeltaMessage(content=stripped)
                 return DeltaMessage(content=delta_text)
 
-        # If the base class entered a new thinking block in this delta
-        # (start token appears somewhere inside delta_text), re-arm the
-        # thought-prefix stripper so we eat the next "thought\n" again.
+        # Re-arm the prefix stripper each time a new thought block opens.
         if self.start_token in delta_text:
             self._arm_thought_strip()
 
-        # Delegate to base class for standard <|channel>/<channel|> handling
         result = super().extract_reasoning_streaming(
             previous_text, current_text, delta_text
         )
 
-        # Strip the "thought" channel-name token (and its trailing newline)
-        # from the START of each reasoning block, chunk-by-chunk. We operate
-        # directly on ``result.reasoning`` — NOT on ``current_text`` — so
-        # any ``result.content`` the base class split off stays intact.
+        # Eat the "thought\n" label from the start of each reasoning block.
         if result is not None and result.reasoning is not None:
             r = result.reasoning
             while (

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -185,14 +185,9 @@ class BaseThinkingReasoningParser(ReasoningParser):
             return DeltaMessage(reasoning=delta_text)
 
         # ── Phase: thinking ───────────────────────────────────────
-        # Inside a reasoning block, waiting for end tag. The end-token
-        # detection uses a count comparison rather than
-        # ``end_tok in current_text and end_tok not in previous_text``
-        # so that models which emit multiple back-to-back reasoning
-        # blocks (e.g. Gemma 4 with its ``<|channel>thought<channel|>``
-        # pattern) correctly detect each new closing marker —
-        # ``previous_text`` already contains earlier end tokens from
-        # prior blocks.
+        # Inside a reasoning block. Count comparison (vs containment)
+        # detects each closing marker in streams with multiple
+        # back-to-back reasoning blocks.
         if self._phase == "thinking":
             if current_text.count(end_tok) > previous_text.count(end_tok):
                 self._phase = "content"
@@ -212,12 +207,9 @@ class BaseThinkingReasoningParser(ReasoningParser):
             return DeltaMessage(reasoning=delta_text)
 
         # ── Phase: content ────────────────────────────────────────
-        # Past the reasoning block. Some models (Gemma 4) emit multiple
-        # back-to-back reasoning blocks — detect a fresh start token in
-        # this delta and re-enter thinking so the markers don't leak as
-        # literal content. If both start AND end tags appear in the same
-        # delta, treat it as a full mini-block: content around it,
-        # reasoning between them, phase stays in content.
+        # Post-reasoning. Re-enter thinking if a fresh start token appears
+        # (back-to-back blocks). Start+end in one delta is a mini-block:
+        # content outside, reasoning inside, phase stays in content.
         if start_tok in delta_text:
             start_idx = delta_text.find(start_tok)
             pre_content = delta_text[:start_idx]

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -185,9 +185,16 @@ class BaseThinkingReasoningParser(ReasoningParser):
             return DeltaMessage(reasoning=delta_text)
 
         # ── Phase: thinking ───────────────────────────────────────
-        # Inside a reasoning block, waiting for end tag.
+        # Inside a reasoning block, waiting for end tag. The end-token
+        # detection uses a count comparison rather than
+        # ``end_tok in current_text and end_tok not in previous_text``
+        # so that models which emit multiple back-to-back reasoning
+        # blocks (e.g. Gemma 4 with its ``<|channel>thought<channel|>``
+        # pattern) correctly detect each new closing marker —
+        # ``previous_text`` already contains earlier end tokens from
+        # prior blocks.
         if self._phase == "thinking":
-            if end_tok in current_text and end_tok not in previous_text:
+            if current_text.count(end_tok) > previous_text.count(end_tok):
                 self._phase = "content"
                 idx = delta_text.find(end_tok)
                 if idx >= 0:
@@ -205,5 +212,30 @@ class BaseThinkingReasoningParser(ReasoningParser):
             return DeltaMessage(reasoning=delta_text)
 
         # ── Phase: content ────────────────────────────────────────
-        # Past the reasoning block — everything is content.
+        # Past the reasoning block. Some models (Gemma 4) emit multiple
+        # back-to-back reasoning blocks — detect a fresh start token in
+        # this delta and re-enter thinking so the markers don't leak as
+        # literal content. If both start AND end tags appear in the same
+        # delta, treat it as a full mini-block: content around it,
+        # reasoning between them, phase stays in content.
+        if start_tok in delta_text:
+            start_idx = delta_text.find(start_tok)
+            pre_content = delta_text[:start_idx]
+            after_start = delta_text[start_idx + len(start_tok) :]
+            if end_tok in after_start:
+                end_idx = after_start.find(end_tok)
+                reasoning = after_start[:end_idx]
+                post_content = after_start[end_idx + len(end_tok) :]
+                combined = pre_content + post_content
+                if not combined and not reasoning:
+                    return None
+                return DeltaMessage(
+                    content=combined or None,
+                    reasoning=reasoning or None,
+                )
+            self._phase = "thinking"
+            return DeltaMessage(
+                content=pre_content or None,
+                reasoning=after_start or None,
+            )
         return DeltaMessage(content=delta_text)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -243,13 +243,7 @@ def _resolve_repetition_penalty(request_value: float | None) -> float:
 
 
 def _log_resolved_sampling(kwargs: dict) -> None:
-    """Log the final sampling kwargs the sampler actually sees.
-
-    The [REQUEST] line prints raw ``request.*`` values, which are ``None``
-    whenever the client omits a field. Operators need to see what the
-    resolvers produced to tell at a glance whether generation_config /
-    CLI defaults landed.
-    """
+    """Log resolved sampling kwargs (post-resolver, pre-sampler)."""
     logger.info(
         "[SAMPLING] "
         f"temperature={kwargs.get('temperature')} "
@@ -262,21 +256,9 @@ def _log_resolved_sampling(kwargs: dict) -> None:
 
 
 def _apply_generation_config_defaults() -> None:
-    """Fill in any server sampling default the operator didn't pin via CLI
-    from the loaded model's ``generation_config.json``.
-
-    Many HF models ship reasonable sampling defaults in that file
-    (``temperature``, ``top_p``, ``top_k``, ``min_p``, ``repetition_penalty``).
-    Without this loader, clients that omit sampling params get mlx-lm's
-    generic fallbacks regardless of what the model was tuned for.
-
-    Resolution order at request time: request body > CLI flag >
-    generation_config.json > hardcoded fallback. CLI wins over the model
-    file because an operator override is an explicit choice.
-
-    The tokenizer's ``name_or_path`` is the authoritative source for the
-    resolved model directory post-load — same path ``mllm_scheduler`` uses
-    to fish out EOS tokens. Call only after ``load_model()``.
+    """Populate unset server sampling defaults from the loaded model's
+    ``generation_config.json``. Resolution order: request > CLI > this >
+    hardcoded fallback. Call after the engine is loaded.
     """
     global _default_temperature, _default_top_p, _default_top_k
     global _default_min_p, _default_repetition_penalty
@@ -285,42 +267,27 @@ def _apply_generation_config_defaults() -> None:
     from pathlib import Path
 
     if _engine is None:
-        logger.info(
-            "sampling defaults: engine not loaded, using CLI/fallbacks only"
-        )
         return
 
-    # For MLLM engines ``_engine.tokenizer`` returns the HF processor; the
-    # actual tokenizer hangs off that. mllm_scheduler unwraps the same way
-    # when collecting EOS token IDs.
     processor_or_tokenizer = getattr(_engine, "tokenizer", None)
     tokenizer = (
         getattr(processor_or_tokenizer, "tokenizer", None)
         or processor_or_tokenizer
     )
-    tok_path = getattr(tokenizer, "name_or_path", None)
+    tok_path = getattr(tokenizer, "name_or_path", None) or getattr(
+        processor_or_tokenizer, "name_or_path", None
+    )
     if not tok_path:
-        tok_path = getattr(processor_or_tokenizer, "name_or_path", None)
-
-    if not tok_path:
-        logger.info(
-            "sampling defaults: tokenizer has no name_or_path, using "
-            "CLI/fallbacks only"
-        )
         return
 
     gc_path = Path(tok_path) / "generation_config.json"
     if not gc_path.exists():
-        logger.info(
-            f"sampling defaults: no generation_config.json at {gc_path}, "
-            "using CLI/fallbacks only"
-        )
         return
 
     try:
         gc = json.loads(gc_path.read_text())
     except Exception as exc:
-        logger.warning(f"sampling defaults: could not read {gc_path}: {exc}")
+        logger.warning(f"generation_config.json unreadable at {gc_path}: {exc}")
         return
 
     if _default_temperature is None and "temperature" in gc:
@@ -335,7 +302,7 @@ def _apply_generation_config_defaults() -> None:
         _default_repetition_penalty = float(gc["repetition_penalty"])
 
     logger.info(
-        f"sampling defaults loaded from {gc_path}: "
+        f"sampling defaults from {gc_path.name}: "
         f"temperature={_default_temperature} top_p={_default_top_p} "
         f"top_k={_default_top_k} min_p={_default_min_p} "
         f"repetition_penalty={_default_repetition_penalty}"
@@ -1804,13 +1771,8 @@ def _tool_choice_disabled(request: ChatCompletionRequest | None) -> bool:
 def _apply_tool_parser_message_adapter(
     messages: list[dict],
 ) -> list[dict]:
-    """Run the configured tool parser's ``prepare_messages`` hook over
-    the message list. Per-model adaptation of OpenAI-shape messages to
-    what the model's chat template expects — see ToolParser.prepare_messages.
-
-    No-op when auto-tool-choice is off, no parser is configured, or the
-    parser hasn't yet been instantiated. Safe to call at any point in
-    the request pipeline.
+    """Run the configured tool parser's ``prepare_messages`` hook.
+    No-op when auto-tool-choice is off or no parser is configured.
     """
     if not _enable_auto_tool_choice or not _tool_call_parser:
         return messages
@@ -4902,8 +4864,7 @@ def main():
         trust_remote_code=args.trust_remote_code,
     )
 
-    # Fill in any sampling default the operator didn't pin via CLI from
-    # the loaded model's generation_config.json.
+    # Fill remaining sampling defaults from generation_config.json.
     _apply_generation_config_defaults()
 
     # Start server

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2713,19 +2713,25 @@ async def _ensure_sse_terminal(
     *generator*, even if the generator raises mid-stream.
 
     If the inner generator already yields the terminal frame on its happy path,
-    the wrapper detects it and avoids double-emission.  If the generator raises
-    before reaching the terminal, the wrapper emits it in the ``finally`` block.
+    the wrapper detects it and avoids double-emission. On a plain exception
+    we emit the terminal; on ``GeneratorExit`` (consumer closed us) we must
+    NOT yield — yielding inside finally while unwinding from GeneratorExit
+    produces Python's "async generator ignored GeneratorExit" warning.
     """
     emitted = False
+    closing = False
     try:
         async for chunk in generator:
             if chunk == terminal_frame:
                 emitted = True
             yield chunk
+    except GeneratorExit:
+        closing = True
+        raise
     except Exception as e:
         logger.error(f"Streaming error, ensuring terminal frame: {e}")
     finally:
-        if not emitted:
+        if not emitted and not closing:
             yield terminal_frame
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -155,7 +155,7 @@ from .endpoint_model_policies import (
     resolve_tts_model_name,
 )
 from .metrics import metrics as _metrics
-from .tool_parsers import ToolParserManager
+from .tool_parsers import ToolParserManager, get_parser_stop_tokens
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -3277,6 +3277,14 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     # Add tools if provided
     if request.tools and request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(request.tools)
+
+    # Merge stop sequences: user-supplied + parser-declared EOG tokens.
+    # Gemma 4's <|tool_response> is the canonical example — without it the
+    # model keeps generating text after a tool call (llama.cpp PR #21418).
+    parser_name = _tool_call_parser if _enable_auto_tool_choice else None
+    merged_stop = get_parser_stop_tokens(parser_name, request.stop)
+    if merged_stop:
+        chat_kwargs["stop"] = merged_stop
 
     # Wire constrained decoding logits processor if available.  Must be
     # appended after all other kwargs because the engine may merge it with

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -459,8 +459,17 @@ async def lifespan(app: FastAPI):
         # during start(), so sampling defaults can't resolve before this point.
         _apply_generation_config_defaults()
 
-    # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
-    if _engine is not None and hasattr(_engine, "load_cache_from_disk"):
+    # Load persisted cache from disk only when no SSD tier is wired. With an
+    # SSD tier attached, durability is already handled incrementally via the
+    # evict-and-spill path and the tier's own reconcile() on startup — this
+    # one-shot snapshot is a legacy fallback for deployments that don't run
+    # with --ssd-cache-dir.
+    _has_ssd = bool(getattr(_engine, "has_ssd_cache_tier", False))
+    if (
+        _engine is not None
+        and hasattr(_engine, "load_cache_from_disk")
+        and not _has_ssd
+    ):
         _load_prefix_cache_from_disk()
 
     # Warm up prefix cache with user-provided prompts (AFTER disk cache load, so
@@ -497,8 +506,14 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Shutdown: Save cache to disk BEFORE stopping engine
-    if _engine is not None and hasattr(_engine, "save_cache_to_disk"):
+    # Shutdown: Save cache to disk BEFORE stopping engine — fallback path
+    # only. With an SSD tier attached, durability was already handled
+    # incrementally and this one-shot save would just redo work.
+    if (
+        _engine is not None
+        and hasattr(_engine, "save_cache_to_disk")
+        and not bool(getattr(_engine, "has_ssd_cache_tier", False))
+    ):
         _save_prefix_cache_to_disk()
 
     # Shutdown: Close MCP connections and stop engine

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2839,19 +2839,31 @@ async def _disconnect_guard(
             f"[disconnect_guard] GeneratorExit after {chunk_count} chunks, elapsed={_elapsed()}"
         )
     finally:
-        if disconnect_task and not disconnect_task.done():
+        # Cancel AND await the helper tasks. Just cancelling leaves them
+        # suspended mid-await, which triggers Python's
+        # "async generator ignored GeneratorExit" finalizer warning when
+        # the consumer calls aclose() on us. Awaiting lets them unwind.
+        if disconnect_task is not None and not disconnect_task.done():
             disconnect_task.cancel()
-        if anext_task and not anext_task.done():
+            try:
+                await disconnect_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if anext_task is not None and not anext_task.done():
             anext_task.cancel()
+            try:
+                await anext_task
+            except (asyncio.CancelledError, StopAsyncIteration, Exception):
+                pass
         # NOTE: Do NOT call generator.aclose() here.  With run_in_executor,
         # scheduler.step() runs in a background thread.  aclose() would throw
         # GeneratorExit into the async-generator chain, which can trigger
         # mlx::core::eval on the main thread while the executor thread is also
         # mid-eval → Metal assertion failure → SIGABRT.
         #
-        # Instead, rely on the task cancellation propagation:
-        #   anext_task.cancel() → CancelledError in stream_outputs()
-        #   → finally block → abort_request() → request removed from scheduler
+        # Instead rely on task cancellation propagation:
+        #   anext_task.cancel() → CancelledError in stream_outputs() →
+        #   finally block → abort_request() → request removed from scheduler.
         logger.info(
             f"[disconnect_guard] CLEANUP done, {chunk_count} chunks, "
             f"{heartbeat_count} heartbeats, elapsed={_elapsed()}"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2783,26 +2783,25 @@ async def _disconnect_guard(
     import time as _time
 
     _t0 = _time.monotonic()
+    # Short tag for cross-referencing with upstream MLLM request IDs in
+    # the same log stream.
+    scope = getattr(raw_request, "scope", None) or {}
+    client = scope.get("client") or ("?", "?")
+    tag = f"{client[0]}:{client[1]}"
 
     def _elapsed():
         return f"{_time.monotonic() - _t0:.1f}s"
 
-    logger.info(
-        f"[disconnect_guard] START poll={poll_interval}s heartbeat={heartbeat_interval}s"
-    )
+    logger.info(f"[disconnect_guard {tag}] START elapsed=0.0s")
 
     async def _wait_disconnect():
-        poll_count = 0
         while True:
             await asyncio.sleep(poll_interval)
-            poll_count += 1
             is_disc = await raw_request.is_disconnected()
-            if poll_count % 10 == 0 or is_disc:
-                logger.info(
-                    f"[disconnect_guard] poll #{poll_count} "
-                    f"disconnected={is_disc} elapsed={_elapsed()}"
-                )
             if is_disc:
+                logger.info(
+                    f"[disconnect_guard {tag}] DISCONNECT elapsed={_elapsed()}"
+                )
                 return
 
     chunk_count = 0
@@ -2825,7 +2824,7 @@ async def _disconnect_guard(
 
             if disconnect_task in done:
                 logger.info(
-                    f"[disconnect_guard] CLIENT DISCONNECTED after "
+                    f"[disconnect_guard {tag}] CLIENT DISCONNECTED after "
                     f"{chunk_count} chunks, {heartbeat_count} heartbeats, "
                     f"elapsed={_elapsed()}"
                 )
@@ -2841,20 +2840,20 @@ async def _disconnect_guard(
                     chunk = anext_task.result()
                 except StopAsyncIteration:
                     logger.info(
-                        f"[disconnect_guard] generator exhausted normally, "
+                        f"[disconnect_guard {tag}] generator exhausted normally, "
                         f"{chunk_count} chunks, elapsed={_elapsed()}"
                     )
                     break
                 except Exception as exc:
                     logger.error(
-                        f"[disconnect_guard] generator raised {type(exc).__name__}: {exc}, "
+                        f"[disconnect_guard {tag}] generator raised {type(exc).__name__}: {exc}, "
                         f"after {chunk_count} chunks, elapsed={_elapsed()}"
                     )
                     break
                 chunk_count += 1
                 if chunk_count == 1:
                     logger.info(
-                        f"[disconnect_guard] first chunk arrived, elapsed={_elapsed()}"
+                        f"[disconnect_guard {tag}] first chunk arrived, elapsed={_elapsed()}"
                     )
                 yield chunk
                 anext_task = None
@@ -2869,7 +2868,7 @@ async def _disconnect_guard(
 
     except GeneratorExit:
         logger.info(
-            f"[disconnect_guard] GeneratorExit after {chunk_count} chunks, elapsed={_elapsed()}"
+            f"[disconnect_guard {tag}] GeneratorExit after {chunk_count} chunks, elapsed={_elapsed()}"
         )
     finally:
         # Cancel AND await the helper tasks. Just cancelling leaves them
@@ -2898,7 +2897,7 @@ async def _disconnect_guard(
         #   anext_task.cancel() → CancelledError in stream_outputs() →
         #   finally block → abort_request() → request removed from scheduler.
         logger.info(
-            f"[disconnect_guard] CLEANUP done, {chunk_count} chunks, "
+            f"[disconnect_guard {tag}] CLEANUP done, {chunk_count} chunks, "
             f"{heartbeat_count} heartbeats, elapsed={_elapsed()}"
         )
 
@@ -2918,21 +2917,21 @@ async def _wait_with_disconnect(
     import time as _time
 
     _t0 = _time.monotonic()
+    scope = getattr(raw_request, "scope", None) or {}
+    client = scope.get("client") or ("?", "?")
+    tag = f"{client[0]}:{client[1]}"
 
     task = asyncio.ensure_future(coro)
 
     async def _wait_disconnect():
-        poll_count = 0
         while True:
             await asyncio.sleep(poll_interval)
-            poll_count += 1
             is_disc = await raw_request.is_disconnected()
-            if poll_count % 10 == 0 or is_disc:
-                logger.info(
-                    f"[disconnect_guard] poll #{poll_count} "
-                    f"disconnected={is_disc} elapsed={_time.monotonic() - _t0:.1f}s"
-                )
             if is_disc:
+                logger.info(
+                    f"[disconnect_guard {tag}] DISCONNECT (non-stream) "
+                    f"elapsed={_time.monotonic() - _t0:.1f}s"
+                )
                 return
 
     disconnect_task = asyncio.create_task(_wait_disconnect())
@@ -2957,11 +2956,7 @@ async def _wait_with_disconnect(
             )
 
         if disconnect_task in done:
-            # Client disconnected
-            logger.info(
-                f"[disconnect_guard] CLIENT DISCONNECTED (non-stream) "
-                f"elapsed={_time.monotonic() - _t0:.1f}s"
-            )
+            # Client disconnected (already logged inside _wait_disconnect)
             task.cancel()
             try:
                 await task

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -242,73 +242,76 @@ def _resolve_repetition_penalty(request_value: float | None) -> float:
     return _FALLBACK_REPETITION_PENALTY
 
 
-def _apply_generation_config_defaults(model_path: str | None) -> None:
-    """Read the model's ``generation_config.json`` and fill in any server
-    sampling defaults the user didn't override via CLI.
+def _apply_generation_config_defaults() -> None:
+    """Fill in any server sampling default the operator didn't pin via CLI
+    from the loaded model's ``generation_config.json``.
 
-    Priority on request time: request body > CLI flag > generation_config.json
-    > hardcoded fallback. CLI flags get priority because operators explicitly
-    chose them; generation_config.json fills in only the blanks.
+    Many HF models ship reasonable sampling defaults in that file
+    (``temperature``, ``top_p``, ``top_k``, ``min_p``, ``repetition_penalty``).
+    Without this loader, clients that omit sampling params get mlx-lm's
+    generic fallbacks regardless of what the model was tuned for.
 
-    Gemma 4 is the motivating case: its generation_config.json ships
-    ``temperature=1.0, top_p=0.95, top_k=64`` — without this loader those
-    values went unused and clients omitting sampling params got mlx-lm's
-    fallbacks (temp 0.7, top_k 0), which destabilizes the model.
+    Resolution order at request time: request body > CLI flag >
+    generation_config.json > hardcoded fallback. CLI wins over the model
+    file because an operator override is an explicit choice.
+
+    The tokenizer's ``name_or_path`` is the authoritative source for the
+    resolved model directory post-load — same path ``mllm_scheduler`` uses
+    to fish out EOS tokens. Call only after ``load_model()``.
     """
     global _default_temperature, _default_top_p, _default_top_k
     global _default_min_p, _default_repetition_penalty
 
-    if not model_path:
-        return
-
     import json
     from pathlib import Path
 
-    # ``model_path`` may be a repo ID (not a filesystem path) if the user
-    # passed e.g. ``unsloth/gemma-4-31b-it-MLX-8bit``. In that case resolve
-    # it via the HF cache directory the model actually landed in.
-    candidate_paths: list[Path] = []
-    mp = Path(model_path)
-    if mp.exists():
-        candidate_paths.append(mp)
-    else:
-        try:
-            from huggingface_hub import snapshot_download
-
-            cache_path = Path(
-                snapshot_download(repo_id=model_path, local_files_only=True)
-            )
-            candidate_paths.append(cache_path)
-        except Exception:
-            return
-
-    for base in candidate_paths:
-        gc_path = base / "generation_config.json"
-        if not gc_path.exists():
-            continue
-        try:
-            gc = json.loads(gc_path.read_text())
-        except Exception:
-            continue
-
-        if _default_temperature is None and "temperature" in gc:
-            _default_temperature = float(gc["temperature"])
-        if _default_top_p is None and "top_p" in gc:
-            _default_top_p = float(gc["top_p"])
-        if _default_top_k is None and "top_k" in gc:
-            _default_top_k = int(gc["top_k"])
-        if _default_min_p is None and "min_p" in gc:
-            _default_min_p = float(gc["min_p"])
-        if _default_repetition_penalty is None and "repetition_penalty" in gc:
-            _default_repetition_penalty = float(gc["repetition_penalty"])
-
+    if _engine is None:
         logger.info(
-            "sampling defaults from generation_config.json: "
-            f"temperature={_default_temperature} top_p={_default_top_p} "
-            f"top_k={_default_top_k} min_p={_default_min_p} "
-            f"repetition_penalty={_default_repetition_penalty}"
+            "sampling defaults: engine not loaded, using CLI/fallbacks only"
         )
-        break
+        return
+
+    tokenizer = getattr(_engine, "tokenizer", None)
+    tok_path = getattr(tokenizer, "name_or_path", None) if tokenizer else None
+
+    if not tok_path:
+        logger.info(
+            "sampling defaults: tokenizer has no name_or_path, using "
+            "CLI/fallbacks only"
+        )
+        return
+
+    gc_path = Path(tok_path) / "generation_config.json"
+    if not gc_path.exists():
+        logger.info(
+            f"sampling defaults: no generation_config.json at {gc_path}, "
+            "using CLI/fallbacks only"
+        )
+        return
+
+    try:
+        gc = json.loads(gc_path.read_text())
+    except Exception as exc:
+        logger.warning(f"sampling defaults: could not read {gc_path}: {exc}")
+        return
+
+    if _default_temperature is None and "temperature" in gc:
+        _default_temperature = float(gc["temperature"])
+    if _default_top_p is None and "top_p" in gc:
+        _default_top_p = float(gc["top_p"])
+    if _default_top_k is None and "top_k" in gc:
+        _default_top_k = int(gc["top_k"])
+    if _default_min_p is None and "min_p" in gc:
+        _default_min_p = float(gc["min_p"])
+    if _default_repetition_penalty is None and "repetition_penalty" in gc:
+        _default_repetition_penalty = float(gc["repetition_penalty"])
+
+    logger.info(
+        f"sampling defaults loaded from {gc_path}: "
+        f"temperature={_default_temperature} top_p={_default_top_p} "
+        f"top_k={_default_top_k} min_p={_default_min_p} "
+        f"repetition_penalty={_default_repetition_penalty}"
+    )
 
 
 def _resolve_request_max_tokens(requested_value: int | None) -> int:
@@ -4823,11 +4826,9 @@ def main():
         trust_remote_code=args.trust_remote_code,
     )
 
-    # Fill in any sampling defaults the operator didn't pin via CLI from the
-    # model's generation_config.json. This is how Gemma 4's declared
-    # top_k=64 / top_p=0.95 / temperature=1.0 actually reach the sampler
-    # when clients omit these fields.
-    _apply_generation_config_defaults(_model_path)
+    # Fill in any sampling default the operator didn't pin via CLI from
+    # the loaded model's generation_config.json.
+    _apply_generation_config_defaults()
 
     # Start server
     uvicorn.run(app, host=args.host, port=args.port)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -271,8 +271,17 @@ def _apply_generation_config_defaults() -> None:
         )
         return
 
-    tokenizer = getattr(_engine, "tokenizer", None)
-    tok_path = getattr(tokenizer, "name_or_path", None) if tokenizer else None
+    # For MLLM engines ``_engine.tokenizer`` returns the HF processor; the
+    # actual tokenizer hangs off that. mllm_scheduler unwraps the same way
+    # when collecting EOS token IDs.
+    processor_or_tokenizer = getattr(_engine, "tokenizer", None)
+    tokenizer = (
+        getattr(processor_or_tokenizer, "tokenizer", None)
+        or processor_or_tokenizer
+    )
+    tok_path = getattr(tokenizer, "name_or_path", None)
+    if not tok_path:
+        tok_path = getattr(processor_or_tokenizer, "name_or_path", None)
 
     if not tok_path:
         logger.info(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -170,18 +170,26 @@ _warm_prompts_path: str | None = None  # Path to JSON of prompts to pre-warm at 
 _default_max_tokens: int = 32768
 _max_request_tokens: int = 32768
 _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes)
-_default_temperature: float | None = None  # Set via --default-temperature
-_default_top_p: float | None = None  # Set via --default-top-p
+_default_temperature: float | None = None  # Set via --default-temperature or generation_config.json
+_default_top_p: float | None = None  # Set via --default-top-p or generation_config.json
+_default_top_k: int | None = None  # Set via --default-top-k or generation_config.json
+_default_min_p: float | None = None  # Set via --default-min-p or generation_config.json
+_default_presence_penalty: float | None = None  # Set via --default-presence-penalty
+_default_repetition_penalty: float | None = None  # Set via --default-repetition-penalty or generation_config.json
 _metrics_enabled = False
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
 
 _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
+_FALLBACK_TOP_K = 0          # 0 disables top-k filtering in mlx-lm
+_FALLBACK_MIN_P = 0.0
+_FALLBACK_PRESENCE_PENALTY = 0.0
+_FALLBACK_REPETITION_PENALTY = 1.0
 
 
 def _resolve_temperature(request_value: float | None) -> float:
-    """Resolve temperature: request > CLI default > fallback."""
+    """Resolve temperature: request > CLI/generation_config > fallback."""
     if request_value is not None:
         return request_value
     if _default_temperature is not None:
@@ -190,12 +198,117 @@ def _resolve_temperature(request_value: float | None) -> float:
 
 
 def _resolve_top_p(request_value: float | None) -> float:
-    """Resolve top_p: request > CLI default > fallback."""
+    """Resolve top_p: request > CLI/generation_config > fallback."""
     if request_value is not None:
         return request_value
     if _default_top_p is not None:
         return _default_top_p
     return _FALLBACK_TOP_P
+
+
+def _resolve_top_k(request_value: int | None) -> int:
+    """Resolve top_k: request > CLI/generation_config > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_top_k is not None:
+        return _default_top_k
+    return _FALLBACK_TOP_K
+
+
+def _resolve_min_p(request_value: float | None) -> float:
+    """Resolve min_p: request > CLI/generation_config > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_min_p is not None:
+        return _default_min_p
+    return _FALLBACK_MIN_P
+
+
+def _resolve_presence_penalty(request_value: float | None) -> float:
+    """Resolve presence_penalty: request > CLI > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_presence_penalty is not None:
+        return _default_presence_penalty
+    return _FALLBACK_PRESENCE_PENALTY
+
+
+def _resolve_repetition_penalty(request_value: float | None) -> float:
+    """Resolve repetition_penalty: request > CLI/generation_config > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_repetition_penalty is not None:
+        return _default_repetition_penalty
+    return _FALLBACK_REPETITION_PENALTY
+
+
+def _apply_generation_config_defaults(model_path: str | None) -> None:
+    """Read the model's ``generation_config.json`` and fill in any server
+    sampling defaults the user didn't override via CLI.
+
+    Priority on request time: request body > CLI flag > generation_config.json
+    > hardcoded fallback. CLI flags get priority because operators explicitly
+    chose them; generation_config.json fills in only the blanks.
+
+    Gemma 4 is the motivating case: its generation_config.json ships
+    ``temperature=1.0, top_p=0.95, top_k=64`` — without this loader those
+    values went unused and clients omitting sampling params got mlx-lm's
+    fallbacks (temp 0.7, top_k 0), which destabilizes the model.
+    """
+    global _default_temperature, _default_top_p, _default_top_k
+    global _default_min_p, _default_repetition_penalty
+
+    if not model_path:
+        return
+
+    import json
+    from pathlib import Path
+
+    # ``model_path`` may be a repo ID (not a filesystem path) if the user
+    # passed e.g. ``unsloth/gemma-4-31b-it-MLX-8bit``. In that case resolve
+    # it via the HF cache directory the model actually landed in.
+    candidate_paths: list[Path] = []
+    mp = Path(model_path)
+    if mp.exists():
+        candidate_paths.append(mp)
+    else:
+        try:
+            from huggingface_hub import snapshot_download
+
+            cache_path = Path(
+                snapshot_download(repo_id=model_path, local_files_only=True)
+            )
+            candidate_paths.append(cache_path)
+        except Exception:
+            return
+
+    for base in candidate_paths:
+        gc_path = base / "generation_config.json"
+        if not gc_path.exists():
+            continue
+        try:
+            gc = json.loads(gc_path.read_text())
+        except Exception:
+            continue
+
+        if _default_temperature is None and "temperature" in gc:
+            _default_temperature = float(gc["temperature"])
+        if _default_top_p is None and "top_p" in gc:
+            _default_top_p = float(gc["top_p"])
+        if _default_top_k is None and "top_k" in gc:
+            _default_top_k = int(gc["top_k"])
+        if _default_min_p is None and "min_p" in gc:
+            _default_min_p = float(gc["min_p"])
+        if _default_repetition_penalty is None and "repetition_penalty" in gc:
+            _default_repetition_penalty = float(gc["repetition_penalty"])
+
+        logger.info(
+            "sampling defaults from generation_config.json: "
+            f"temperature={_default_temperature} top_p={_default_top_p} "
+            f"top_k={_default_top_k} min_p={_default_min_p} "
+            f"repetition_penalty={_default_repetition_penalty}"
+        )
+        break
 
 
 def _resolve_request_max_tokens(requested_value: int | None) -> int:
@@ -2851,13 +2964,15 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             "max_tokens": effective_max_tokens,
             "temperature": _resolve_temperature(request.temperature),
             "top_p": _resolve_top_p(request.top_p),
-            "top_k": request.top_k or 0,
-            "min_p": request.min_p or 0.0,
-            "presence_penalty": request.presence_penalty or 0.0,
+            "top_k": _resolve_top_k(request.top_k),
+            "min_p": _resolve_min_p(request.min_p),
+            "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
             "stop": request.stop,
         }
         if comp_rep_penalty is not None:
             generate_kwargs["repetition_penalty"] = comp_rep_penalty
+        else:
+            generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(None)
         if request.specprefill is not None:
             generate_kwargs["specprefill"] = request.specprefill
         if request.specprefill_keep_pct is not None:
@@ -3088,21 +3203,19 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         ),
                     )
 
-    # Resolve repetition penalty
-    rep_penalty = request.repetition_penalty
+    # Resolve repetition penalty (request > CLI default > generation_config.json > fallback)
+    rep_penalty = _resolve_repetition_penalty(request.repetition_penalty)
 
     # Prepare kwargs
     chat_kwargs = {
         "max_tokens": effective_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
-        "repetition_penalty": request.repetition_penalty or 1.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
+        "repetition_penalty": rep_penalty,
     }
-    if rep_penalty is not None:
-        chat_kwargs["repetition_penalty"] = rep_penalty
 
     # Add multimodal content
     if has_media:
@@ -3499,12 +3612,12 @@ async def create_anthropic_message(
 
     chat_kwargs = {
         "max_tokens": effective_max_tokens,
-        "temperature": openai_request.temperature,
-        "top_p": openai_request.top_p,
-        "top_k": openai_request.top_k or 0,
-        "min_p": openai_request.min_p or 0.0,
-        "presence_penalty": openai_request.presence_penalty or 0.0,
-        "repetition_penalty": openai_request.repetition_penalty or 1.0,
+        "temperature": _resolve_temperature(openai_request.temperature),
+        "top_p": _resolve_top_p(openai_request.top_p),
+        "top_k": _resolve_top_k(openai_request.top_k),
+        "min_p": _resolve_min_p(openai_request.min_p),
+        "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(openai_request.repetition_penalty),
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -3781,12 +3894,12 @@ async def _stream_anthropic_messages(
 
     chat_kwargs = {
         "max_tokens": max_tokens,
-        "temperature": openai_request.temperature,
-        "top_p": openai_request.top_p,
-        "top_k": openai_request.top_k or 0,
-        "min_p": openai_request.min_p or 0.0,
-        "presence_penalty": openai_request.presence_penalty or 0.0,
-        "repetition_penalty": openai_request.repetition_penalty or 1.0,
+        "temperature": _resolve_temperature(openai_request.temperature),
+        "top_p": _resolve_top_p(openai_request.top_p),
+        "top_k": _resolve_top_k(openai_request.top_k),
+        "min_p": _resolve_min_p(openai_request.min_p),
+        "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(openai_request.repetition_penalty),
     }
 
     if openai_request.tools and openai_request.tool_choice != "none":
@@ -4069,13 +4182,15 @@ async def stream_completion(
         "max_tokens": max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
         "stop": request.stop,
     }
     if repetition_penalty is not None:
         generate_kwargs["repetition_penalty"] = repetition_penalty
+    else:
+        generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(None)
     if request.specprefill is not None:
         generate_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
@@ -4627,7 +4742,8 @@ def main():
 
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
-    global _default_temperature, _default_top_p
+    global _default_temperature, _default_top_p, _default_top_k
+    global _default_min_p, _default_presence_penalty, _default_repetition_penalty
     global _max_audio_upload_bytes, _max_tts_input_chars
     _api_key = args.api_key
     _default_timeout = args.timeout
@@ -4637,6 +4753,14 @@ def main():
         _default_temperature = args.default_temperature
     if args.default_top_p is not None:
         _default_top_p = args.default_top_p
+    if args.default_top_k is not None:
+        _default_top_k = args.default_top_k
+    if args.default_min_p is not None:
+        _default_min_p = args.default_min_p
+    if args.default_presence_penalty is not None:
+        _default_presence_penalty = args.default_presence_penalty
+    if args.default_repetition_penalty is not None:
+        _default_repetition_penalty = args.default_repetition_penalty
     _max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     _max_tts_input_chars = args.max_tts_input_chars
 
@@ -4698,6 +4822,12 @@ def main():
         force_mllm=args.mllm,
         trust_remote_code=args.trust_remote_code,
     )
+
+    # Fill in any sampling defaults the operator didn't pin via CLI from the
+    # model's generation_config.json. This is how Gemma 4's declared
+    # top_k=64 / top_p=0.95 / temperature=1.0 actually reach the sampler
+    # when clients omit these fields.
+    _apply_generation_config_defaults(_model_path)
 
     # Start server
     uvicorn.run(app, host=args.host, port=args.port)
@@ -4818,13 +4948,43 @@ Examples:
         "--default-temperature",
         type=float,
         default=None,
-        help="Default temperature for generation when not specified in request",
+        help="Default temperature for generation when not specified in request "
+        "(falls back to generation_config.json, then to 0.7)",
     )
     parser.add_argument(
         "--default-top-p",
         type=float,
         default=None,
-        help="Default top_p for generation when not specified in request",
+        help="Default top_p for generation when not specified in request "
+        "(falls back to generation_config.json, then to 0.9)",
+    )
+    parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Default top_k for generation when not specified in request "
+        "(falls back to generation_config.json, then to 0 i.e. disabled)",
+    )
+    parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Default min_p for generation when not specified in request "
+        "(falls back to generation_config.json, then to 0.0 i.e. disabled)",
+    )
+    parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Default presence_penalty for generation when not specified in request "
+        "(falls back to 0.0)",
+    )
+    parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help="Default repetition_penalty for generation when not specified in request "
+        "(falls back to generation_config.json, then to 1.0)",
     )
     parser.add_argument(
         "--max-audio-upload-mb",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -242,6 +242,25 @@ def _resolve_repetition_penalty(request_value: float | None) -> float:
     return _FALLBACK_REPETITION_PENALTY
 
 
+def _log_resolved_sampling(kwargs: dict) -> None:
+    """Log the final sampling kwargs the sampler actually sees.
+
+    The [REQUEST] line prints raw ``request.*`` values, which are ``None``
+    whenever the client omits a field. Operators need to see what the
+    resolvers produced to tell at a glance whether generation_config /
+    CLI defaults landed.
+    """
+    logger.info(
+        "[SAMPLING] "
+        f"temperature={kwargs.get('temperature')} "
+        f"top_p={kwargs.get('top_p')} "
+        f"top_k={kwargs.get('top_k')} "
+        f"min_p={kwargs.get('min_p')} "
+        f"presence_penalty={kwargs.get('presence_penalty')} "
+        f"repetition_penalty={kwargs.get('repetition_penalty')}"
+    )
+
+
 def _apply_generation_config_defaults() -> None:
     """Fill in any server sampling default the operator didn't pin via CLI
     from the loaded model's ``generation_config.json``.
@@ -2985,6 +3004,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             generate_kwargs["repetition_penalty"] = comp_rep_penalty
         else:
             generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(None)
+        _log_resolved_sampling(generate_kwargs)
         if request.specprefill is not None:
             generate_kwargs["specprefill"] = request.specprefill
         if request.specprefill_keep_pct is not None:
@@ -3228,6 +3248,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
         "repetition_penalty": rep_penalty,
     }
+    _log_resolved_sampling(chat_kwargs)
 
     # Add multimodal content
     if has_media:
@@ -3631,6 +3652,7 @@ async def create_anthropic_message(
         "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
         "repetition_penalty": _resolve_repetition_penalty(openai_request.repetition_penalty),
     }
+    _log_resolved_sampling(chat_kwargs)
 
     if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
@@ -3913,6 +3935,7 @@ async def _stream_anthropic_messages(
         "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
         "repetition_penalty": _resolve_repetition_penalty(openai_request.repetition_penalty),
     }
+    _log_resolved_sampling(chat_kwargs)
 
     if openai_request.tools and openai_request.tool_choice != "none":
         chat_kwargs["tools"] = convert_tools_for_template(openai_request.tools)
@@ -4203,6 +4226,7 @@ async def stream_completion(
         generate_kwargs["repetition_penalty"] = repetition_penalty
     else:
         generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(None)
+    _log_resolved_sampling(generate_kwargs)
     if request.specprefill is not None:
         generate_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2279,8 +2279,12 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
             locked_model=_embedding_model_locked,
         )
 
-        # Lazy-load or swap embedding engine
-        load_embedding_model(model_name, lock=False, reuse_existing=True)
+        # Lazy-load or swap embedding engine on the shared MLX thread.
+        # load() submits Metal work; doing it on the event loop while
+        # the chat scheduler is running would race per-device state.
+        from .mlx_thread import run_mlx
+
+        await run_mlx(load_embedding_model, model_name, lock=False, reuse_existing=True)
 
         # Normalise input to list
         texts = request.input if isinstance(request.input, list) else [request.input]
@@ -2290,11 +2294,10 @@ async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
 
         start_time = time.perf_counter()
 
-        # Count tokens for usage reporting
-        prompt_tokens = _embedding_engine.count_tokens(texts)
-
-        # Generate embeddings (batch)
-        embeddings = _embedding_engine.embed(texts)
+        # Count tokens and embed on the shared MLX thread — same
+        # reason as the load_embedding_model call above.
+        prompt_tokens = await run_mlx(_embedding_engine.count_tokens, texts)
+        embeddings = await run_mlx(_embedding_engine.embed, texts)
 
         elapsed = time.perf_counter() - start_time
         logger.info(
@@ -2426,13 +2429,13 @@ async def rerank_documents(request: RerankRequest) -> RerankResponse:
 
         start_time = time.perf_counter()
 
-        # Run scoring off the event loop with concurrency limit.
-        # score_pairs returns (scores, total_tokens) from the same
-        # tokenization pass used for scoring — no double tokenization.
-        import asyncio
+        # Run scoring on the shared MLX thread so it serializes against
+        # chat + embeddings instead of racing on Metal command buffers.
+        # The engine's own _semaphore still gates concurrent entry.
+        from .mlx_thread import run_mlx
 
         async with _rerank_engine._semaphore:
-            scores, total_tokens = await asyncio.to_thread(
+            scores, total_tokens = await run_mlx(
                 _rerank_engine.score_pairs, request.query, doc_texts
             )
 
@@ -2583,10 +2586,14 @@ async def create_transcription(
 
         model_name = resolve_stt_model_name(model)
 
-        # Load engine if needed
+        # Load + transcribe on the shared MLX thread — both can submit
+        # Metal work and must stay off the event loop while chat /
+        # embeddings are running on the MLX executor.
+        from .mlx_thread import run_mlx
+
         if _stt_engine is None or _stt_engine.model_name != model_name:
             _stt_engine = STTEngine(model_name)
-            _stt_engine.load()
+            await run_mlx(_stt_engine.load)
 
         # Stream uploaded file to disk under a hard size cap.
         tmp_path = await save_upload_with_limit(
@@ -2596,7 +2603,9 @@ async def create_transcription(
         )
 
         try:
-            result = _stt_engine.transcribe(tmp_path, language=language)
+            result = await run_mlx(
+                _stt_engine.transcribe, tmp_path, language=language
+            )
         finally:
             os.unlink(tmp_path)
 
@@ -2655,12 +2664,15 @@ async def create_speech(
         model_name = resolve_tts_model_name(model)
         validate_tts_input_length(input, max_chars=_max_tts_input_chars)
 
-        # Load engine if needed
+        # Load + synthesize on the shared MLX thread so Metal submits
+        # serialize with chat / embeddings.
+        from .mlx_thread import run_mlx
+
         if _tts_engine is None or _tts_engine.model_name != model_name:
             _tts_engine = TTSEngine(model_name)
-            _tts_engine.load()
+            await run_mlx(_tts_engine.load)
 
-        audio = _tts_engine.generate(input, voice=voice, speed=speed)
+        audio = await run_mlx(_tts_engine.generate, input, voice=voice, speed=speed)
         audio_bytes = _tts_engine.to_bytes(audio, format=response_format)
 
         content_type = (

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -455,6 +455,9 @@ async def lifespan(app: FastAPI):
     # Startup: Start engine if loaded (needed for BatchedEngine in uvicorn's event loop)
     if _engine is not None and hasattr(_engine, "_loaded") and not _engine._loaded:
         await _engine.start()
+        # Must run AFTER start() — BatchedEngine only populates its processor
+        # during start(), so sampling defaults can't resolve before this point.
+        _apply_generation_config_defaults()
 
     # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
     if _engine is not None and hasattr(_engine, "load_cache_from_disk"):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1801,6 +1801,45 @@ def _tool_choice_disabled(request: ChatCompletionRequest | None) -> bool:
     return tool_choice == "none"
 
 
+def _apply_tool_parser_message_adapter(
+    messages: list[dict],
+) -> list[dict]:
+    """Run the configured tool parser's ``prepare_messages`` hook over
+    the message list. Per-model adaptation of OpenAI-shape messages to
+    what the model's chat template expects — see ToolParser.prepare_messages.
+
+    No-op when auto-tool-choice is off, no parser is configured, or the
+    parser hasn't yet been instantiated. Safe to call at any point in
+    the request pipeline.
+    """
+    if not _enable_auto_tool_choice or not _tool_call_parser:
+        return messages
+    global _tool_parser_instance
+    if _tool_parser_instance is None:
+        try:
+            parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
+            tokenizer = None
+            if _engine is not None and hasattr(_engine, "_tokenizer"):
+                tokenizer = _engine._tokenizer
+            _tool_parser_instance = parser_cls(tokenizer)
+        except Exception as exc:
+            logger.debug(
+                f"prepare_messages: parser init failed ({exc}); "
+                f"passing messages through unchanged"
+            )
+            return messages
+    try:
+        return _tool_parser_instance.prepare_messages(messages)
+    except Exception as exc:
+        logger.warning(
+            "prepare_messages: parser %r raised (%s); "
+            "passing messages through unchanged",
+            _tool_call_parser,
+            _sanitize_log_text(exc, limit=300),
+        )
+        return messages
+
+
 def _get_streaming_tool_parser(request: ChatCompletionRequest | None):
     """Get a streaming-capable tool parser for this request.
 
@@ -3171,6 +3210,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         except (json.JSONDecodeError, ValueError):
                             pass
         messages = _normalize_messages(messages)
+        messages = _apply_tool_parser_message_adapter(messages)
     else:
         # For LLM, extract text, images, and videos separately
         messages, images, videos = extract_multimodal_content(
@@ -3178,6 +3218,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             preserve_native_format=engine.preserve_native_tool_format,
         )
         messages = _normalize_messages(messages)
+        messages = _apply_tool_parser_message_adapter(messages)
 
     has_media = bool(images or videos)
     if engine.is_mllm and not has_media:
@@ -3612,6 +3653,7 @@ async def create_anthropic_message(
         preserve_native_format=engine.preserve_native_tool_format,
     )
     messages = _normalize_messages(messages)
+    messages = _apply_tool_parser_message_adapter(messages)
 
     # Handle response_format (propagated from Anthropic request via adapter):
     # inject prompt-level instruction AND wire a grammar-guided logits
@@ -3925,6 +3967,7 @@ async def _stream_anthropic_messages(
         preserve_native_format=engine.preserve_native_tool_format,
     )
     messages = _normalize_messages(messages)
+    messages = _apply_tool_parser_message_adapter(messages)
 
     chat_kwargs = {
         "max_tokens": max_tokens,

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -360,14 +360,56 @@ class SSDIndex:
             self._conn.close()
 
 
-# Support matrix: maps cache type names to their serializer status
+# Support matrix: maps cache type names to their serializer status.
+# All types are serialized in their native representation (quantized layers
+# stay quantized on disk) — dtype-conversion (notably bfloat16) is handled
+# bit-exactly via uint16 reinterpret on the calling thread.
 SERIALIZER_SUPPORT_MATRIX = {
     "KVCache": "supported",
     "RotatingKVCache": "supported",  # Serialized as KVCache (keys/values/offset)
     "ArraysCache": "supported",
     "MambaCache": "supported",  # Legacy name for ArraysCache
-    "_QuantizedCacheWrapper": "not_supported_spill_dequantized",
+    "_QuantizedCacheWrapper": "supported",
 }
+
+
+_BFLOAT16_MARKER = "bfloat16"
+
+
+def _mlx_array_to_numpy(arr):
+    """Convert a materialized MLX array to numpy, preserving bfloat16 bits.
+
+    numpy has no native bfloat16 dtype — the buffer-protocol conversion
+    raises ``RuntimeError: Item size 2 for PEP 3118 buffer format string
+    B does not match the dtype B item size 1`` otherwise. We reinterpret
+    bf16 as uint16 (same 2 bytes) so the write is lossless, and record
+    the original dtype in metadata so the load path can cast back.
+
+    Must be called on a thread that's allowed to submit MLX work — i.e.
+    the shared MLX executor thread. Callers from the SSD writer thread
+    must pre-pack on the MLX thread before handing arrays over.
+    """
+    import numpy as np
+    import mlx.core as mx
+
+    if arr is None:
+        return None, None
+    if arr.dtype == mx.bfloat16:
+        return np.array(arr.view(mx.uint16)), _BFLOAT16_MARKER
+    return np.array(arr), str(arr.dtype).split(".")[-1]
+
+
+def _numpy_to_mlx_array(np_arr, recorded_dtype):
+    """Inverse of ``_mlx_array_to_numpy`` — reconstruct an MLX array,
+    restoring bfloat16 from its uint16 bit-preserving view when needed."""
+    import mlx.core as mx
+
+    if np_arr is None:
+        return None
+    mx_arr = mx.array(np_arr)
+    if recorded_dtype == _BFLOAT16_MARKER:
+        mx_arr = mx_arr.view(mx.bfloat16)
+    return mx_arr
 
 
 class LayerSerializer(ABC):
@@ -412,6 +454,9 @@ class KVCacheSerializer(LayerSerializer):
 
     Handles layers with .keys, .values, .offset attributes.
     RotatingKVCache also has .max_size, .keep, .step, ._idx.
+
+    Input layers are *packed* dicts produced on the MLX thread — the
+    writer thread never touches an MLX array directly.
     """
 
     def serialize_layer(
@@ -419,24 +464,22 @@ class KVCacheSerializer(LayerSerializer):
     ) -> dict[str, Any]:
         from safetensors.numpy import save_file
 
-        keys_np = np.array(layer.keys)
-        values_np = np.array(layer.values)
-
         tensors = {
-            f"layer_{layer_idx}_keys": keys_np,
-            f"layer_{layer_idx}_values": values_np,
+            f"layer_{layer_idx}_keys": layer["arrays"]["keys"],
+            f"layer_{layer_idx}_values": layer["arrays"]["values"],
         }
         save_file(tensors, file_path)
 
         metadata = {
-            "layer_type": "KVCache",
+            "layer_type": layer["layer_type"],
             "layer_idx": layer_idx,
-            "offset": layer.offset,
+            "offset": layer["offset"],
+            "dtypes": layer["dtypes"],
         }
         # Preserve RotatingKVCache extra attributes
         for attr in ("max_size", "keep", "step", "_idx"):
-            if hasattr(layer, attr):
-                metadata[attr] = getattr(layer, attr)
+            if attr in layer:
+                metadata[attr] = layer[attr]
 
         return metadata
 
@@ -447,14 +490,79 @@ class KVCacheSerializer(LayerSerializer):
         tensors = load_file(file_path)
 
         result = {
+            "layer_type": metadata.get("layer_type", "KVCache"),
             "keys": tensors[f"layer_{layer_idx}_keys"],
             "values": tensors[f"layer_{layer_idx}_values"],
             "offset": metadata["offset"],
+            "dtypes": metadata.get("dtypes", {}),
         }
         for attr in ("max_size", "keep", "step", "_idx"):
             if attr in metadata:
                 result[attr] = metadata[attr]
         return result
+
+
+class QuantizedCacheSerializer(LayerSerializer):
+    """Serializer for ``_QuantizedCacheWrapper`` layers.
+
+    Quantized caches store keys and values as tuples of
+    ``(packed_weights, scales, biases)``. All three components are
+    written verbatim so the entry stays quantized on disk — no
+    dequantize round-trip, no 4x disk blow-up.
+    """
+
+    def serialize_layer(
+        self, layer: Any, layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        from safetensors.numpy import save_file
+
+        arrays = layer["arrays"]
+        tensors = {
+            f"layer_{layer_idx}_keys_wq": arrays["keys_wq"],
+            f"layer_{layer_idx}_keys_scales": arrays["keys_scales"],
+            f"layer_{layer_idx}_keys_biases": arrays["keys_biases"],
+            f"layer_{layer_idx}_values_wq": arrays["values_wq"],
+            f"layer_{layer_idx}_values_scales": arrays["values_scales"],
+            f"layer_{layer_idx}_values_biases": arrays["values_biases"],
+        }
+        save_file(tensors, file_path)
+
+        return {
+            "layer_type": "_QuantizedCacheWrapper",
+            "layer_idx": layer_idx,
+            "offset": layer["offset"],
+            "bits": layer["bits"],
+            "group_size": layer["group_size"],
+            "orig_type": layer["orig_type"],
+            "orig_attrs": layer["orig_attrs"],
+            "dtypes": layer["dtypes"],
+        }
+
+    def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
+        from safetensors.numpy import load_file
+
+        layer_idx = metadata["layer_idx"]
+        tensors = load_file(file_path)
+
+        return {
+            "layer_type": "_QuantizedCacheWrapper",
+            "keys": (
+                tensors[f"layer_{layer_idx}_keys_wq"],
+                tensors[f"layer_{layer_idx}_keys_scales"],
+                tensors[f"layer_{layer_idx}_keys_biases"],
+            ),
+            "values": (
+                tensors[f"layer_{layer_idx}_values_wq"],
+                tensors[f"layer_{layer_idx}_values_scales"],
+                tensors[f"layer_{layer_idx}_values_biases"],
+            ),
+            "offset": metadata["offset"],
+            "bits": metadata["bits"],
+            "group_size": metadata["group_size"],
+            "orig_type": metadata["orig_type"],
+            "orig_attrs": metadata["orig_attrs"],
+            "dtypes": metadata["dtypes"],
+        }
 
 
 class ArraysCacheSerializer(LayerSerializer):
@@ -495,21 +603,28 @@ class ArraysCacheSerializer(LayerSerializer):
 
 
 def get_serializer_for_layer(layer: Any) -> LayerSerializer:
-    """Return the appropriate serializer for a cache layer.
+    """Return the appropriate serializer for a *packed* cache layer dict.
 
-    Dispatches based on duck-typing:
-    - If layer has .keys and .values and .offset -> KVCacheSerializer
-    - If layer has .state and it's a list -> ArraysCacheSerializer
-
-    Raises ValueError for unsupported layer types.
+    Packed layers are produced on the MLX thread by
+    ``memory_cache._pack_cache_for_spill`` and arrive at the writer
+    thread as plain dicts. Dispatch is on the ``layer_type`` tag so the
+    writer never has to introspect an MLX object.
     """
-    if hasattr(layer, "keys") and hasattr(layer, "values") and hasattr(layer, "offset"):
-        return KVCacheSerializer()
-    if hasattr(layer, "state") and isinstance(getattr(layer, "state", None), list):
-        return ArraysCacheSerializer()
+    if isinstance(layer, dict):
+        layer_type = layer.get("layer_type")
+        if layer_type == "_QuantizedCacheWrapper":
+            return QuantizedCacheSerializer()
+        if layer_type in ("KVCache", "RotatingKVCache"):
+            return KVCacheSerializer()
+        if layer_type in ("ArraysCache", "MambaCache"):
+            return ArraysCacheSerializer()
+        raise ValueError(
+            f"Unsupported packed layer type: {layer_type!r}. "
+            f"Supported: {list(SERIALIZER_SUPPORT_MATRIX.keys())}"
+        )
     raise ValueError(
-        f"Unsupported cache layer type: {type(layer).__name__}. "
-        f"Supported: {list(SERIALIZER_SUPPORT_MATRIX.keys())}"
+        f"SSD writer expects packed dicts, got {type(layer).__name__} — "
+        "cache layers must be pre-packed on the MLX thread before spill"
     )
 
 
@@ -852,7 +967,9 @@ class SSDCacheTier:
             layer_type = layer_meta["layer_type"]
 
             try:
-                if layer_type in ("KVCache", "RotatingKVCache"):
+                if layer_type == "_QuantizedCacheWrapper":
+                    serializer = QuantizedCacheSerializer()
+                elif layer_type in ("KVCache", "RotatingKVCache"):
                     serializer = KVCacheSerializer()
                 elif layer_type in ("ArraysCache", "MambaCache"):
                     serializer = ArraysCacheSerializer()

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -62,6 +62,7 @@ from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 
+
 def get_parser_stop_tokens(
     parser_name: str | None,
     user_stops: list[str] | None,

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -62,11 +62,36 @@ from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
 from .minimax_tool_parser import MiniMaxToolParser
 
+def get_parser_stop_tokens(
+    parser_name: str | None,
+    user_stops: list[str] | None,
+) -> list[str]:
+    """Merge user-supplied stops with parser-declared extras (deduped).
+
+    Some models declare end-of-generation tokens beyond the tokenizer's default
+    eos set — e.g. Gemma 4's ``<|tool_response>`` which signals the runtime's
+    turn after a tool call. Parsers expose those via ``extra_stop_tokens``.
+    """
+    stops = list(user_stops or [])
+    if not parser_name:
+        return stops
+    try:
+        parser_cls = ToolParserManager.get_tool_parser(parser_name)
+    except (KeyError, ImportError):
+        return stops
+    for s in getattr(parser_cls, "extra_stop_tokens", []):
+        if s not in stops:
+            stops.append(s)
+    return stops
+
+
 __all__ = [
     # Base classes
     "ToolParser",
     "ToolParserManager",
     "ExtractedToolCallInformation",
+    # Helpers
+    "get_parser_stop_tokens",
     # Specific parsers
     "AutoToolParser",
     "Gemma4ToolParser",

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -50,6 +50,12 @@ class ToolParser(ABC):
     # without needing conversion to text format.
     SUPPORTS_NATIVE_TOOL_FORMAT: bool = False
 
+    # Extra stop tokens specific to this parser's model format. The server
+    # merges these into the request's `stop` list when the parser is active,
+    # so the model halts on format-specific EOG markers (e.g. Gemma 4's
+    # <|tool_response>) that are not part of the tokenizer's default eos set.
+    extra_stop_tokens: list[str] = []
+
     @classmethod
     def supports_native_format(cls) -> bool:
         """

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -168,22 +168,9 @@ class ToolParser(ABC):
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Per-model adaptation of OpenAI-style messages before the chat
-        template renders them.
-
-        Symmetric pair of ``extract_tool_calls`` (which adapts model
-        output → OpenAI shape going out). This method adapts OpenAI
-        shape → what the model was trained on going in, where the
-        generic ``SUPPORTS_NATIVE_TOOL_FORMAT`` conversions the server
-        already performs aren't enough.
-
-        Default is a no-op passthrough. Override in subclasses that
-        need massaging — e.g. Gemma 4 requires string tool-message
-        content to be wrapped as ``{"content": str}`` so the template's
-        dict-shape ``response:name{field:val}`` branch renders what the
-        model was trained to see.
-
-        Parsers MUST NOT mutate the input list in place — return a new
-        list with copied dicts when changes are made.
+        template renders them. Symmetric inverse of ``extract_tool_calls``.
+        Default is passthrough. Subclasses MUST NOT mutate ``messages``
+        in place — return a new list when changes are made.
         """
         return messages
 

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -164,6 +164,29 @@ class ToolParser(ABC):
         self.current_tool_id = -1
         self.prev_tool_call_arr = []
 
+    def prepare_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Per-model adaptation of OpenAI-style messages before the chat
+        template renders them.
+
+        Symmetric pair of ``extract_tool_calls`` (which adapts model
+        output → OpenAI shape going out). This method adapts OpenAI
+        shape → what the model was trained on going in, where the
+        generic ``SUPPORTS_NATIVE_TOOL_FORMAT`` conversions the server
+        already performs aren't enough.
+
+        Default is a no-op passthrough. Override in subclasses that
+        need massaging — e.g. Gemma 4 requires string tool-message
+        content to be wrapped as ``{"content": str}`` so the template's
+        dict-shape ``response:name{field:val}`` branch renders what the
+        model was trained to see.
+
+        Parsers MUST NOT mutate the input list in place — return a new
+        list with copied dicts when changes are made.
+        """
+        return messages
+
 
 class ToolParserManager:
     """

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -45,6 +45,15 @@ _CALL_PREFIX = re.compile(r"call:(\w+)\s*\{")
 # Pattern to quote bare keys: word followed by : at start or after , or {
 _BARE_KEY = re.compile(r"(?<=[{,])\s*(\w+)\s*:")
 
+# Pattern to quote bare string VALUES that the template omitted <|"|> around.
+# This fires when a schema uses a nullable type like ["string","null"] or an
+# enum field without explicit "type": the template takes the non-STRING branch
+# and emits the value raw. Preceded by a value-position separator (: [ ,), a
+# word starting with a letter, followed by ,/}/]. JSON literals true/false/null
+# are filtered out inside the substitution. Ref: llama.cpp PR #21327.
+_BARE_VALUE = re.compile(r"(?<=[:\[,])(\s*)([A-Za-z_][\w\-]*)(?=\s*[,}\]])")
+_JSON_LITERALS = frozenset({"true", "false", "null"})
+
 # Max arg block length to prevent runaway parsing on malformed input (1 MB)
 _MAX_ARG_BLOCK_LEN = 1_048_576
 
@@ -85,15 +94,27 @@ def _find_balanced_brace(text: str, start: int) -> int:
     return -1
 
 
+def _quote_bare_value(m: re.Match) -> str:
+    """Substitution callback for _BARE_VALUE — quotes bare identifiers that
+    are not JSON literals (true/false/null)."""
+    ws, word = m.group(1), m.group(2)
+    if word in _JSON_LITERALS:
+        return m.group(0)
+    return f'{ws}"{word}"'
+
+
 def _gemma4_args_to_json(text: str) -> str:
     """Convert Gemma 4 tool call args to valid JSON.
 
-    Three-step conversion (ORDER MATTERS):
+    Four-step conversion (ORDER MATTERS):
     1. Extract <|"|>-delimited strings into numbered \\x00N\\x00 placeholders.
        This protects string contents from step 2's bare-key quoting -- without
        this, a string value like "key: value" would be corrupted.
     2. Quote bare keys (word: -> "word":) now that strings are safe.
-    3. Restore placeholders as properly JSON-escaped strings via json.dumps().
+    3. Quote bare string VALUES that the template emitted without <|"|>
+       wrappers. Happens with nullable/enum schemas where the STRING branch
+       of the template isn't taken.
+    4. Restore placeholders as properly JSON-escaped strings via json.dumps().
        Uses a single re.sub pass (O(len(text))) instead of per-placeholder replace.
     """
     strings: list[str] = []
@@ -108,7 +129,10 @@ def _gemma4_args_to_json(text: str) -> str:
     # Step 2: Quote bare keys
     text = _BARE_KEY.sub(r'"\1":', text)
 
-    # Step 3: Restore captured strings as properly escaped JSON strings
+    # Step 3: Quote bare string values (nullable / enum-without-type schemas)
+    text = _BARE_VALUE.sub(_quote_bare_value, text)
+
+    # Step 4: Restore captured strings as properly escaped JSON strings
     def _restore(m: re.Match) -> str:
         idx = int(m.group(1))
         return json.dumps(strings[idx]) if idx < len(strings) else m.group(0)

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -143,6 +143,46 @@ class Gemma4ToolParser(ToolParser):
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 
+    def prepare_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Adapt OpenAI-style ``role: tool`` messages to Gemma 4's
+        expected dict-shape tool-response content.
+
+        OpenAI's Chat Completions API has ``role: tool`` messages
+        carrying string ``content`` (e.g. file contents, shell stdout).
+        Gemma 4's chat template's string-response branch wraps that as
+        ``response:name{value:<|"|>...<|"|>}``, which the model wasn't
+        trained on — it was trained on dict-shape responses matching
+        the tool's declared output schema (``response:name{field1:val1,
+        field2:val2}``). When the model sees the ``{value:...}`` synthetic
+        key, it doesn't recognize the tool call as complete, silently
+        ignores the response, and emits a fresh identical ``<|tool_call>``
+        on the next turn — infinite tool-call loop.
+
+        Wrapping the string as ``{"content": string}`` routes through
+        the template's mapping branch and produces
+        ``response:name{content:<|"|>string<|"|>}``. ``content`` matches
+        OpenAI's own field name for tool message bodies, and the model
+        recognizes the dict shape as a completed response.
+
+        Verified empirically: without the wrap, opencode + Gemma 4 loops
+        on every tool call; with the wrap, the model answers referencing
+        the tool output as expected.
+        """
+        adapted: list[dict[str, Any]] = []
+        for msg in messages:
+            if (
+                msg.get("role") == "tool"
+                and isinstance(msg.get("content"), str)
+            ):
+                new_msg = dict(msg)
+                new_msg["content"] = {"content": msg["content"]}
+                adapted.append(new_msg)
+            else:
+                adapted.append(msg)
+        return adapted
+
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -146,41 +146,133 @@ class Gemma4ToolParser(ToolParser):
     def prepare_messages(
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        """Adapt OpenAI-style ``role: tool`` messages to Gemma 4's
-        expected dict-shape tool-response content.
+        """Coalesce OpenAI ``role:tool`` messages into the preceding
+        assistant's ``tool_responses`` field — the Gemma-native layout
+        the chat template's legacy branch handles correctly.
 
-        OpenAI's Chat Completions API has ``role: tool`` messages
-        carrying string ``content`` (e.g. file contents, shell stdout).
-        Gemma 4's chat template's string-response branch wraps that as
-        ``response:name{value:<|"|>...<|"|>}``, which the model wasn't
-        trained on — it was trained on dict-shape responses matching
-        the tool's declared output schema (``response:name{field1:val1,
-        field2:val2}``). When the model sees the ``{value:...}`` synthetic
-        key, it doesn't recognize the tool call as complete, silently
-        ignores the response, and emits a fresh identical ``<|tool_call>``
-        on the next turn — infinite tool-call loop.
+        OpenAI's Chat Completions shape:
 
-        Wrapping the string as ``{"content": string}`` routes through
-        the template's mapping branch and produces
-        ``response:name{content:<|"|>string<|"|>}``. ``content`` matches
-        OpenAI's own field name for tool message bodies, and the model
-        recognizes the dict shape as a completed response.
+            [assistant{tool_calls:[A,B]}, tool{tool_call_id:A.id, content},
+             tool{tool_call_id:B.id, content}, ...]
 
-        Verified empirically: without the wrap, opencode + Gemma 4 loops
-        on every tool call; with the wrap, the model answers referencing
-        the tool output as expected.
+        Gemma 4 native shape (same data, different layout):
+
+            [assistant{tool_calls:[A,B],
+                       tool_responses:[{name:A.name, response:{content:"..."}},
+                                       {name:B.name, response:{content:"..."}}]}]
+
+        Why this matters: the chat template has two paths for tool
+        responses. The OpenAI forward-scan path (``elif tool_calls``)
+        reads each ``role:tool`` follow-up's ``content`` and dispatches
+        on type — and Jinja2's ``is sequence`` returns True for dicts,
+        so the dict-content branch falls into the sequence loop that
+        calls ``.get('type')`` on each dict *key* (string), which
+        crashes. The legacy ``if tool_responses`` path calls
+        ``format_tool_response_block`` directly with the dict response,
+        which routes through that macro's ``is mapping`` branch and
+        renders the Gemma-native ``response:name{field:value,...}``.
+
+        Wrapping the raw string as ``{"content": str}`` and placing the
+        pair inside ``tool_responses`` lets the template's legacy branch
+        do its job — the model sees
+        ``response:name{content:<|"|>str<|"|>}``, which matches its
+        training data and unblocks the tool loop. No template edits.
+
+        Verified empirically: a raw /v1/completions with this exact
+        shape produces coherent ``The README says ...`` output against
+        the same weights that loop on the template's default string
+        wrapper (``response:name{value:<|"|>...<|"|>}``).
         """
+        import json
+
         adapted: list[dict[str, Any]] = []
-        for msg in messages:
-            if (
-                msg.get("role") == "tool"
-                and isinstance(msg.get("content"), str)
-            ):
-                new_msg = dict(msg)
-                new_msg["content"] = {"content": msg["content"]}
-                adapted.append(new_msg)
-            else:
+        i = 0
+        while i < len(messages):
+            msg = messages[i]
+            role = msg.get("role")
+
+            # Pass-through for anything that isn't an assistant with
+            # tool_calls — the template already renders these correctly.
+            if role != "assistant" or not msg.get("tool_calls"):
                 adapted.append(msg)
+                i += 1
+                continue
+
+            tool_calls = msg.get("tool_calls") or []
+            # Parse arg strings into dicts (no-op when already dict).
+            # The template's tool-call rendering only works on dicts;
+            # server.py does the same for native-format parsers but
+            # this keeps the parser's prepare_messages self-contained
+            # for callers that skip the server-layer conversion.
+            normalized_calls = []
+            id_to_name: dict[str, str] = {}
+            for tc in tool_calls:
+                tc_copy = dict(tc)
+                func = dict(tc_copy.get("function") or {})
+                args = func.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        func["arguments"] = json.loads(args)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                tc_copy["function"] = func
+                normalized_calls.append(tc_copy)
+                if tc_copy.get("id") and func.get("name"):
+                    id_to_name[tc_copy["id"]] = func["name"]
+
+            # Forward-scan consecutive role:tool messages and convert
+            # each into a tool_responses entry keyed to the matching
+            # tool_call's name (so the rendered response:<name>{...}
+            # matches the call:<name>{...} above it).
+            tool_responses: list[dict[str, Any]] = []
+            j = i + 1
+            while j < len(messages) and messages[j].get("role") == "tool":
+                tool_msg = messages[j]
+                name = (
+                    id_to_name.get(tool_msg.get("tool_call_id") or "")
+                    or tool_msg.get("name")
+                    or "unknown"
+                )
+                content = tool_msg.get("content")
+                if isinstance(content, str):
+                    response = {"content": content}
+                elif isinstance(content, dict):
+                    response = content
+                elif isinstance(content, list):
+                    # Multimodal tool content (e.g. screenshot return). The
+                    # template's dict branch iterates keys, so coalesce any
+                    # text parts into a single string under ``content`` and
+                    # pass image/etc parts through under type-keyed fields
+                    # preserving order. For the common text-only case this
+                    # matches the string branch output.
+                    text_parts: list[str] = []
+                    extras: list[dict[str, Any]] = []
+                    for part in content:
+                        if hasattr(part, "model_dump"):
+                            part = part.model_dump(exclude_none=True)
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") == "text":
+                            text_parts.append(part.get("text", ""))
+                        else:
+                            extras.append(part)
+                    response = {"content": "".join(text_parts)}
+                    if extras:
+                        response["parts"] = extras
+                else:
+                    response = {"content": "" if content is None else str(content)}
+
+                tool_responses.append({"name": name, "response": response})
+                j += 1
+
+            # Rebuild the assistant message with the coalesced responses.
+            new_msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            new_msg["tool_calls"] = normalized_calls
+            if tool_responses:
+                new_msg["tool_responses"] = tool_responses
+            adapted.append(new_msg)
+            i = j  # skip past the consumed tool messages
+
         return adapted
 
     def extract_tool_calls(

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -239,28 +239,45 @@ class Gemma4ToolParser(ToolParser):
         delta_token_ids: Sequence[int] | None = None,
         request: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        """Extract tool calls from streaming Gemma 4 model output."""
-        has_start = TOOL_CALL_START in current_text
+        """Extract tool calls from streaming Gemma 4 model output.
 
-        if not has_start:
+        OpenAI delta semantics: each streamed ``tool_calls`` entry gets
+        a stable ``id`` that the client concatenates deltas into, keyed
+        by ``index``. This implementation emits newly-completed tool
+        call blocks once, in order, and uses ``self.prev_tool_call_arr``
+        (reset per stream by the base class) to avoid re-emitting
+        earlier blocks — which would otherwise regenerate fresh UUIDs
+        every time a later ``<tool_call|>`` arrived.
+        """
+        if TOOL_CALL_START not in current_text:
             return {"content": delta_text}
 
-        if TOOL_CALL_END in delta_text:
-            result = self.extract_tool_calls(current_text)
-            if result.tools_called:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(result.tool_calls)
-                    ]
-                }
+        # Only emit when at least one block has completed in this delta.
+        if TOOL_CALL_END not in delta_text:
+            return None
 
-        return None
+        result = self.extract_tool_calls(current_text)
+        if not result.tools_called:
+            return None
+
+        already_emitted = len(self.prev_tool_call_arr)
+        new_calls = result.tool_calls[already_emitted:]
+        if not new_calls:
+            return None
+
+        self.prev_tool_call_arr.extend(new_calls)
+
+        return {
+            "tool_calls": [
+                {
+                    "index": already_emitted + i,
+                    "id": tc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["arguments"],
+                    },
+                }
+                for i, tc in enumerate(new_calls)
+            ]
+        }

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -132,13 +132,9 @@ class Gemma4ToolParser(ToolParser):
 
     Used when --enable-auto-tool-choice --tool-call-parser gemma4 are set.
 
-    Native tool format is supported end-to-end: Gemma 4's chat template
-    renders ``role: tool`` messages via a forward-scan inside the
-    preceding assistant turn (``<|tool_response>response:name{...}<tool_response|>``)
-    and expects tool_call ``arguments`` as a dict (not a JSON-string) so
-    its mapping-render branch can emit ``key:<|"|>value<|"|>`` pairs
-    instead of leaking OpenAI's ``{"key":"value"}`` JSON verbatim —
-    which produces the double-brace ``{{"k":"v"}}`` pathology.
+    Native tool format: Gemma 4's template expects tool_call ``arguments``
+    as a dict (not a JSON string) so its mapping branch emits
+    ``key:<|"|>value<|"|>`` pairs — raw JSON leaks as ``{{"k":"v"}}``.
     """
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
@@ -147,41 +143,21 @@ class Gemma4ToolParser(ToolParser):
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Coalesce OpenAI ``role:tool`` messages into the preceding
-        assistant's ``tool_responses`` field — the Gemma-native layout
-        the chat template's legacy branch handles correctly.
+        assistant's ``tool_responses`` field — the Gemma-native layout.
 
-        OpenAI's Chat Completions shape:
+        OpenAI shape::
 
             [assistant{tool_calls:[A,B]}, tool{tool_call_id:A.id, content},
              tool{tool_call_id:B.id, content}, ...]
 
-        Gemma 4 native shape (same data, different layout):
+        Gemma 4 native::
 
             [assistant{tool_calls:[A,B],
-                       tool_responses:[{name:A.name, response:{content:"..."}},
-                                       {name:B.name, response:{content:"..."}}]}]
+                       tool_responses:[{name:A.name, response:{content:...}},
+                                       {name:B.name, response:{content:...}}]}]
 
-        Why this matters: the chat template has two paths for tool
-        responses. The OpenAI forward-scan path (``elif tool_calls``)
-        reads each ``role:tool`` follow-up's ``content`` and dispatches
-        on type — and Jinja2's ``is sequence`` returns True for dicts,
-        so the dict-content branch falls into the sequence loop that
-        calls ``.get('type')`` on each dict *key* (string), which
-        crashes. The legacy ``if tool_responses`` path calls
-        ``format_tool_response_block`` directly with the dict response,
-        which routes through that macro's ``is mapping`` branch and
-        renders the Gemma-native ``response:name{field:value,...}``.
-
-        Wrapping the raw string as ``{"content": str}`` and placing the
-        pair inside ``tool_responses`` lets the template's legacy branch
-        do its job — the model sees
-        ``response:name{content:<|"|>str<|"|>}``, which matches its
-        training data and unblocks the tool loop. No template edits.
-
-        Verified empirically: a raw /v1/completions with this exact
-        shape produces coherent ``The README says ...`` output against
-        the same weights that loop on the template's default string
-        wrapper (``response:name{value:<|"|>...<|"|>}``).
+        Routes through the template's ``is mapping`` branch, producing
+        ``response:name{content:<|"|>str<|"|>}`` which matches training.
         """
         import json
 
@@ -199,11 +175,7 @@ class Gemma4ToolParser(ToolParser):
                 continue
 
             tool_calls = msg.get("tool_calls") or []
-            # Parse arg strings into dicts (no-op when already dict).
-            # The template's tool-call rendering only works on dicts;
-            # server.py does the same for native-format parsers but
-            # this keeps the parser's prepare_messages self-contained
-            # for callers that skip the server-layer conversion.
+            # Template rendering requires dict arguments; parse JSON strings.
             normalized_calls = []
             id_to_name: dict[str, str] = {}
             for tc in tool_calls:
@@ -220,10 +192,8 @@ class Gemma4ToolParser(ToolParser):
                 if tc_copy.get("id") and func.get("name"):
                     id_to_name[tc_copy["id"]] = func["name"]
 
-            # Forward-scan consecutive role:tool messages and convert
-            # each into a tool_responses entry keyed to the matching
-            # tool_call's name (so the rendered response:<name>{...}
-            # matches the call:<name>{...} above it).
+            # Forward-scan consecutive role:tool messages into
+            # tool_responses entries keyed by matching tool_call name.
             tool_responses: list[dict[str, Any]] = []
             j = i + 1
             while j < len(messages) and messages[j].get("role") == "tool":
@@ -239,12 +209,8 @@ class Gemma4ToolParser(ToolParser):
                 elif isinstance(content, dict):
                     response = content
                 elif isinstance(content, list):
-                    # Multimodal tool content (e.g. screenshot return). The
-                    # template's dict branch iterates keys, so coalesce any
-                    # text parts into a single string under ``content`` and
-                    # pass image/etc parts through under type-keyed fields
-                    # preserving order. For the common text-only case this
-                    # matches the string branch output.
+                    # Multimodal tool content — coalesce text parts into
+                    # ``content``; non-text parts go to ``parts`` preserving order.
                     text_parts: list[str] = []
                     extras: list[dict[str, Any]] = []
                     for part in content:
@@ -280,18 +246,8 @@ class Gemma4ToolParser(ToolParser):
     ) -> ExtractedToolCallInformation:
         """Extract tool calls from a complete Gemma 4 model response.
 
-        Handles both layouts the wild can produce:
-
-        1. Single-block, multi-call (per the tool-parser docstring /
-           mlx-lm PR #1105): one ``<|tool_call>`` ... ``<tool_call|>``
-           enclosing several ``call:name{...}`` entries.
-        2. Multi-block (what the chat_template.jinja currently emits for
-           parallel tool calls): one ``<|tool_call>call:A{...}<tool_call|>``
-           immediately followed by ``<|tool_call>call:B{...}<tool_call|>``,
-           etc.
-
-        Iterating every delimited block means whichever shape the model
-        produces, we don't silently drop calls 2..N.
+        Handles both single-block (multi-call in one ``<|tool_call>...
+        <tool_call|>``) and multi-block (back-to-back blocks) layouts.
         """
         cleaned = self.strip_think_tags(model_output)
 
@@ -334,10 +290,7 @@ class Gemma4ToolParser(ToolParser):
     def _extract_calls_from_block(
         self, block: str, tool_calls: list[dict[str, Any]]
     ) -> None:
-        """Parse every ``call:name{...}`` sub-section inside a single
-        ``<|tool_call>...<tool_call|>`` block and append them to
-        ``tool_calls``.
-        """
+        """Parse every ``call:name{...}`` inside a single tool-call block."""
         pos = 0
         while pos < len(block):
             m = _CALL_PREFIX.search(block, pos)
@@ -381,15 +334,9 @@ class Gemma4ToolParser(ToolParser):
         delta_token_ids: Sequence[int] | None = None,
         request: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        """Extract tool calls from streaming Gemma 4 model output.
-
-        OpenAI delta semantics: each streamed ``tool_calls`` entry gets
-        a stable ``id`` that the client concatenates deltas into, keyed
-        by ``index``. This implementation emits newly-completed tool
-        call blocks once, in order, and uses ``self.prev_tool_call_arr``
-        (reset per stream by the base class) to avoid re-emitting
-        earlier blocks — which would otherwise regenerate fresh UUIDs
-        every time a later ``<tool_call|>`` arrived.
+        """Extract tool calls from streaming Gemma 4 output.
+        Emits each newly-completed block once with a stable ``id``,
+        using ``self.prev_tool_call_arr`` to track what was already sent.
         """
         if TOOL_CALL_START not in current_text:
             return {"content": delta_text}

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -136,26 +136,66 @@ class Gemma4ToolParser(ToolParser):
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
     ) -> ExtractedToolCallInformation:
-        """Extract tool calls from a complete Gemma 4 model response."""
+        """Extract tool calls from a complete Gemma 4 model response.
+
+        Handles both layouts the wild can produce:
+
+        1. Single-block, multi-call (per the tool-parser docstring /
+           mlx-lm PR #1105): one ``<|tool_call>`` ... ``<tool_call|>``
+           enclosing several ``call:name{...}`` entries.
+        2. Multi-block (what the chat_template.jinja currently emits for
+           parallel tool calls): one ``<|tool_call>call:A{...}<tool_call|>``
+           immediately followed by ``<|tool_call>call:B{...}<tool_call|>``,
+           etc.
+
+        Iterating every delimited block means whichever shape the model
+        produces, we don't silently drop calls 2..N.
+        """
         cleaned = self.strip_think_tags(model_output)
 
-        start_idx = cleaned.find(TOOL_CALL_START)
-        if start_idx == -1:
+        first_start = cleaned.find(TOOL_CALL_START)
+        if first_start == -1:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
 
-        content_before = cleaned[:start_idx].strip() or None
-
-        block_start = start_idx + len(TOOL_CALL_START)
-        end_idx = cleaned.find(TOOL_CALL_END, block_start)
-        if end_idx == -1:
-            block = cleaned[block_start:]
-        else:
-            block = cleaned[block_start:end_idx]
-
+        content_before = cleaned[:first_start].strip() or None
         tool_calls: list[dict[str, Any]] = []
 
+        cursor = first_start
+        while cursor < len(cleaned):
+            start_idx = cleaned.find(TOOL_CALL_START, cursor)
+            if start_idx == -1:
+                break
+            block_start = start_idx + len(TOOL_CALL_START)
+            end_idx = cleaned.find(TOOL_CALL_END, block_start)
+            if end_idx == -1:
+                # Unterminated block at the tail — parse what we have
+                # and stop iterating.
+                block = cleaned[block_start:]
+                cursor = len(cleaned)
+            else:
+                block = cleaned[block_start:end_idx]
+                cursor = end_idx + len(TOOL_CALL_END)
+            self._extract_calls_from_block(block, tool_calls)
+
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content_before,
+            )
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def _extract_calls_from_block(
+        self, block: str, tool_calls: list[dict[str, Any]]
+    ) -> None:
+        """Parse every ``call:name{...}`` sub-section inside a single
+        ``<|tool_call>...<tool_call|>`` block and append them to
+        ``tool_calls``.
+        """
         pos = 0
         while pos < len(block):
             m = _CALL_PREFIX.search(block, pos)
@@ -188,17 +228,6 @@ class Gemma4ToolParser(ToolParser):
                 )
 
             pos = brace_end + 1
-
-        if tool_calls:
-            return ExtractedToolCallInformation(
-                tools_called=True,
-                tool_calls=tool_calls,
-                content=content_before,
-            )
-        else:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
-            )
 
     def extract_tool_calls_streaming(
         self,

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -139,6 +139,12 @@ class Gemma4ToolParser(ToolParser):
 
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 
+    # The chat template renders <|tool_response> (token 50) when the assistant
+    # emits a tool call without its own tool_responses block — it's the signal
+    # that it's the runtime's turn, not the model's. Treat it as EOG so the
+    # model doesn't keep generating past the tool call (ref: llama.cpp #21418).
+    extra_stop_tokens = ["<|tool_response>"]
+
     def prepare_messages(
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -131,7 +131,17 @@ class Gemma4ToolParser(ToolParser):
     Parses: <|tool_call>call:func{<|"|>key<|"|>: <|"|>val<|"|>}<tool_call|>
 
     Used when --enable-auto-tool-choice --tool-call-parser gemma4 are set.
+
+    Native tool format is supported end-to-end: Gemma 4's chat template
+    renders ``role: tool`` messages via a forward-scan inside the
+    preceding assistant turn (``<|tool_response>response:name{...}<tool_response|>``)
+    and expects tool_call ``arguments`` as a dict (not a JSON-string) so
+    its mapping-render branch can emit ``key:<|"|>value<|"|>`` pairs
+    instead of leaking OpenAI's ``{"key":"value"}`` JSON verbatim —
+    which produces the double-brace ``{{"k":"v"}}`` pathology.
     """
+
+    SUPPORTS_NATIVE_TOOL_FORMAT = True
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None


### PR DESCRIPTION
Follow-up to #380, #383, #385. The bugs enumerated below were found by running `unsloth/gemma-4-31b-it-MLX-8bit` under `--continuous-batching --enable-auto-tool-choice --tool-call-parser gemma4 --reasoning-parser gemma4` against a realistic workload — Honcho as a concurrent load generator with dialectic, deriver, summary, and embeddings all firing per turn; opencode and Hermes Agent for tool-call and reasoning streaming; 14-16K-token agent system prompts with multi-turn history — and fixing each failure until Gemma 4 was stable under that workload.

The branch was developed locally while #383 and #385 were in review, so it carries re-implementations of a few of those commits. Rebasing onto current `main` to drop the duplicates is fine; the net diff in this PR is what's new beyond them.

## Bugs fixed

### Gemma 4 reasoning + tool parser

1. `<|tool_response>` was not declared as end-of-generation — the model kept generating past tool calls.
2. Bare string tool-call values produced by nullable / enum schemas (`["string","null"]`, enum-without-type) failed JSON parse because the template skipped the `<|"|>` wrap.
3. Streaming "thought" channel label leaked partial prefixes (`th`, `tho`, `thoug`) into `reasoning_content` when the label arrived split across deltas.
4. Reasoning parser leaked `<channel|>` marker into `content`.
5. Reasoning parser overwrote already-emitted content when the thought label completed mid-stream.
6. `BaseThinkingReasoningParser`'s containment check (`end_tok in current_text and end_tok not in previous_text`) missed a second end-token in streams with back-to-back reasoning blocks.
7. `BaseThinkingReasoningParser` didn't re-enter thinking from content on a fresh start token, so consecutive `<think>` blocks collapsed into one.
8. Multi-block tool-call responses only parsed the first `<|tool_call>...<tool_call|>` block; subsequent blocks were ignored.
9. Streaming tool-call emission lacked stable IDs and re-sent the full tool-call list on every delta that contained a closing marker.
10. `Gemma4ToolParser.SUPPORTS_NATIVE_TOOL_FORMAT` was False, so JSON-string `arguments` leaked through the template as `{{"k":"v"}}`.
11. OpenAI `role:tool` messages were not coalesced into the preceding assistant's `tool_responses` field, which is what the Gemma 4 template's `is mapping` branch actually expects.
12. String tool-response content was not wrapped as `{content: ...}` for that mapping branch.

### Prefix cache and KV correctness

13. `_trim_cache_offset` on plain `KVCache` shrank the offset pointer but left `keys`/`values` pointing at the full-size array. Gemma 4's KV-shared attention layers read `cache.state` directly and saw stale tokens from the previous owner past the new boundary.
14. `MemoryAwarePrefixCache` had no thread lock protecting `_entries` / `_sorted_keys` / `_current_memory` / `_stats`.
15. LCP scan only checked the two neighbors around the bisect insertion point. It missed valid LCP candidates when many entries shared a first token.
16. Non-quantized fetch returned references to the stored entry. The model's in-place `update_and_fetch` on `RotatingKVCache` buffers then corrupted that stored entry.
17. `_QuantizedCacheWrapper` dequantize did not slice the output to `layer.offset`. A post-trim wrapper whose quantized arrays still covered the pre-trim length leaked trailing slots.
18. `MLLMBatch.extract_cache` returned slice views into the shared batch KV tensor. Extracted caches mutated under their new owner as the batch kept generating for other slots.
19. `RotatingKVCache.offset` was being clamped to `max_size` after a sliding-window trim. The offset tracks the global token position and is consumed by RoPE; clamping it told RoPE a 12K-token prefill landed at position 1024, producing language mixing and repetition loops.
20. RotatingKVCache buffers that exceeded `max_size` after an LCP trim crashed `BatchRotatingKVCache.merge()` with "Negative dimensions not allowed".
21. Chunked prefill with `step > sliding_window` evicted the prior chunk wholesale at each boundary. Early queries in the next chunk saw no in-window context, breaking SWA layers.

### HF fast tokenizer concurrency

22. Concurrent async handlers calling `apply_chat_template` on the Rust-backed fast tokenizer raised `RuntimeError: Already borrowed`.
23. Same race on `add_request_async`'s prompt-token `encode`.
24. Same race on `_compute_think_suffix_len`.
25. Same race on `_preprocess_request`'s `prepare_inputs` call.
26. `prepare_inputs` persistently mutated `tokenizer.pad_token` as a side effect. The mutation leaked across requests.

### Sampling params and server defaults

27. Per-request samplers were built only when `top_k != 0 or min_p != 0`. Every other request silently dropped its per-request `temperature` / `top_p` / `top_k` / `min_p`.
28. The scheduler installed a hardcoded module-level `make_sampler(temp=0.7, top_p=0.9)` that overrode request values on the path that wasn't using per-request samplers.
29. `--default-top-k`, `--default-min-p`, `--default-presence-penalty`, and `--default-repetition-penalty` CLI flags didn't exist. Only `--default-temperature` and `--default-top-p` did.
30. Sampling defaults did not resolve from the loaded model's `generation_config.json`.
31. `_apply_generation_config_defaults()` ran before `BatchedEngine.start()` populated the processor. For MLLM the resolution was effectively a no-op.
32. `BatchedEngine.tokenizer` returned the wrapped tokenizer instead of the processor, so callers that needed `name_or_path` to find `generation_config.json` couldn't reach it for MLLM.
33. No per-request log line showed the resolved sampling kwargs. There was no way to verify what the server actually applied.

### Metal driver asserts under concurrent HTTP

34. The scheduler split `step()` between the event-loop thread (decode-only inline) and the `mllm-step` executor thread (prefill). `mx.async_eval` left encoder state on `mx.Stream` in a transitional state across the handoff, so the next thread's `with mx.stream(_stream):` created an encoder on the shared command buffer before the prior thread's submit had closed it — `'A command encoder is already encoding to this command buffer'`.
35. After fixing 34, the embedding / rerank / audio handlers still submitted MLX work from the event loop, which raced the scheduler's executor thread and surfaced as `'Completed handler provided after commit call'`.
36. `/v1/embeddings` called `_embedding_engine.count_tokens` and `.embed` synchronously on the event loop.
37. `/v1/rerank` used `asyncio.to_thread`, which picks arbitrary threadpool threads rather than the scheduler's executor.
38. `/v1/audio/transcriptions` ran `STTEngine.load` and `.transcribe` on the event loop.
39. `/v1/audio/speech` ran `TTSEngine.load` and `.generate` on the event loop.

### Scheduler and batch generator plumbing

40. The batch generator was built lazily on the first request. Concurrent first requests raced against the init path (attention patches, `_compute_think_suffix_len`, prefix cache setup) while it was still running.
41. `_preprocess_request` re-tokenized text-only requests when both chunked prefill interleaving and `_process_prompts` called it for the same request.
42. `_copy_prefix_cache` became a dead shallow-copy call site after `fetch()` was changed to deep-clone. Left the branch in a confused state.

### Multimodal / video

43. Video-native models could not flow through the batched scheduler. The processor's `<|image>...<|video|>...<image|>` timestamp interleave can't be reconstructed from a rendered chat-template string.
44. `_run_vision_encoding` called `self.model(input_ids, ..., attention_mask=...)` with the wrong kwarg name. Gemma 4's forward takes `mask=`; `attention_mask` fell into `**kwargs` and was ignored.
45. `_run_vision_encoding` dropped the embedding-time state returned by `get_input_embeddings` (M-RoPE deltas, position IDs, etc.). The language model didn't receive the state it needed for decode.
46. `process_image_input` rejected local filesystem paths. The video-frame extraction pipeline couldn't feed frames into the MLLM.

### Server and streaming lifecycle

47. `_ensure_sse_terminal` yielded the terminal frame during `GeneratorExit`. Yielding inside `finally` while unwinding from `GeneratorExit` produces Python's "async generator ignored GeneratorExit" warning.
48. `_disconnect_guard` cancelled helper tasks but never awaited them. Just cancelling leaves them suspended mid-await, which triggers the same warning when the consumer calls `aclose()` on us.
49. `MLXMultimodalLM.chat` and `stream_chat` each reimplemented a multi-turn message loop that dropped `tool_calls`, `tool_call_id`, and `name` fields and collapsed dict content.
50. `stream_chat` didn't forward `audio=all_audio_urls` to the mlx_vlm generator, so audio inputs were silently dropped from the streaming path.

## New features

`--chunked-prefill-tokens N` enables interleaved prefill/decode on the continuous-batching path. When a long text-only request arrives at an active batch, one chunk of its prefill runs per scheduler step, interleaved with generation for the active batch. In-flight throughput stays at 30-50 tok/s instead of collapsing to 1-5 tok/s for the full prefill duration. Handles abort-during-partial, post-prefill merge into the batch cache, and prefix-cache store on completion. Capped at `prefill_step_size` so the SWA safety cap applies.

Native video through the batched scheduler. `BatchedEngine._native_video_preprocess` runs `MLXMultimodalLM._prepare_native_video_inputs` under the tokenizer lock to produce `input_ids`, `pixel_values`, `mask`, and `video_grid_thw`. New `MLLMRequest.preprocessed_*` fields and a `MLLMBatchRequest.is_preprocessed` flag propagate the pre-tokenized inputs to the scheduler, which short-circuits its own preprocess pass. `_run_vision_encoding` mirrors upstream `mlx_vlm.generate.generate_step`: `model.get_input_embeddings(input_ids, pixel_values, mask=mask, **extras)` then `language_model(inputs_embeds=..., cache=..., **state)`.

## Tests

- `tests/test_memory_cache_mlx.py` (281 lines, from #385's cherry-pick; included here) — MLX-backed regression for `_trim_cache_offset` and end-to-end `MemoryAwarePrefixCache.fetch` on an LCP match. Covers dtype agnosticism (fp16 / bf16 / fp32), multiple layers, trim-exceeds-offset, source-entry preservation after trim, and quantized-wrapper slicing. Added to the apple-silicon CI matrix; excluded from the Linux `test-matrix` job because MLX has no Linux distribution.
- `tests/test_gemma4_tool_parser.py` — bare-value quoting, JSON-literal filtering, `<|tool_response>` in `extra_stop_tokens`, `get_parser_stop_tokens` merge / dedup / unknown-parser / None-parser passthrough.
- `tests/test_gemma4_streaming_edge.py` — streaming "thought" label split across deltas.

## Upstream references

- ggml-org/llama.cpp#21327 — Gemma 4 bare string tool-call values
- ggml-org/llama.cpp#21365 — Gemma 4 repetition bias
- ggml-org/llama.cpp#21418 — `<|tool_response>` as end-of-generation
