### PR TITLE
Fix #131: work around models that don't supply a chat template

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -47,6 +47,33 @@ def test_batched_engine_applies_chat_template_kwargs():
         )
 
 
+def test_batched_engine_mllm_falls_back_to_tokenizer_when_processor_has_no_template():
+    with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=True):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine("test-mllm-model")
+        engine._is_mllm = True
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "prompt-from-tokenizer"
+
+        processor = MagicMock()
+        processor.tokenizer = tokenizer
+        processor.apply_chat_template.side_effect = ValueError(
+            "Cannot use apply_chat_template because this processor does not have a chat template."
+        )
+        engine._processor = processor
+
+        prompt = engine._apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+        assert prompt == "prompt-from-tokenizer"
+        processor.apply_chat_template.assert_called_once()
+        tokenizer.apply_chat_template.assert_called_once()
+
+
 def test_chat_completion_endpoint_forwards_chat_template_kwargs():
     captured = {}
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -490,10 +490,28 @@ class BatchedEngine(BaseEngine):
             if tools and "tools" not in template_kwargs:
                 template_kwargs["tools"] = tools
 
+            tokenizer_applicator = None
+            tokenizer = self.tokenizer
+            if template_applicator is not tokenizer and hasattr(
+                tokenizer, "apply_chat_template"
+            ):
+                tokenizer_applicator = tokenizer
+
             try:
                 return template_applicator.apply_chat_template(
                     messages, **template_kwargs
                 )
+            except ValueError as e:
+                # Some HF processors define apply_chat_template but do not carry
+                # a template (e.g. Gemma-3 processor). Retry on tokenizer.
+                if (
+                    tokenizer_applicator is not None
+                    and "does not have a chat template" in str(e)
+                ):
+                    return tokenizer_applicator.apply_chat_template(
+                        messages, **template_kwargs
+                    )
+                raise
             except TypeError as e:
                 # Some templates don't accept extra kwargs; retry without them.
                 logger.debug(f"Chat template TypeError, retrying without extras: {e}")


### PR DESCRIPTION
Fix #131: work around models that don't supply a chat template like Gemma3