### PR TITLE
[DOCS] README refresh and ES/FR/ZH translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,302 @@
+# vllm-mlx
+
+**Lee esto en otros idiomas:** [English](README.md) · [Español](README.es.md) · [Français](README.fr.md) · [中文](README.zh.md)
+
+**Continuous batching + APIs OpenAI y Anthropic en un solo servidor. Inferencia nativa en Apple Silicon.**
+
+[![PyPI version](https://img.shields.io/pypi/v/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Apple Silicon](https://img.shields.io/badge/Apple-Silicon-black.svg)](https://support.apple.com/en-us/HT211814)
+[![GitHub stars](https://img.shields.io/github/stars/waybarrios/vllm-mlx.svg?style=social)](https://github.com/waybarrios/vllm-mlx)
+
+---
+
+## ¿Qué es vllm-mlx?
+
+Un servidor de inferencia estilo vLLM para Macs con Apple Silicon. A diferencia de usar `Ollama` o `mlx-lm` directamente, incluye **continuous batching, paged KV cache, prefix caching y KV cache en SSD**, y expone **tanto OpenAI `/v1/*` como Anthropic `/v1/messages`** desde un solo proceso. Corre LLMs, modelos de visión, audio y embeddings sobre Metal con memoria unificada, sin paso de conversión.
+
+## Inicio rápido (30 segundos)
+
+```bash
+pip install vllm-mlx
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+**SDK de OpenAI:**
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+r = client.chat.completions.create(model="default", messages=[{"role": "user", "content": "Hola!"}])
+print(r.choices[0].message.content)
+```
+
+**SDK de Anthropic / Claude Code:**
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+## Características
+
+### APIs
+- **Compatible con OpenAI**: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/rerank`, `/v1/responses`
+- **Compatible con Anthropic**: `/v1/messages` (streaming, tool use, system prompts)
+- **MCP Tool Calling**: 12 parsers (OpenAI, Anthropic, Gemini, Qwen, DeepSeek, Gemma y más)
+- **Salida estructurada**: JSON Schema vía `response_format` (lm-format-enforcer)
+
+### Throughput y memoria
+- **Continuous batching**: alto throughput para requests concurrentes
+- **Paged KV cache**: eficiente en memoria con prefix sharing
+- **KV cache en SSD**: volcá el prefix cache a disco para agentes con contexto largo (`--ssd-cache-dir`)
+- **Warm prompts**: precargá prefixes populares al arrancar (`--warm-prompts`) para 1.3-2.25x de TTFT
+- **Prefix cache**: basado en trie, compartido entre requests
+
+### Multimodal
+- **Texto + imagen + video + audio** desde un solo servidor
+- Modelos de visión: Gemma 3, Gemma 4, Qwen3-VL, Pixtral, Llama vision
+- **Audio de entrada** en el chat (bloques `audio_url`)
+- **TTS nativo**: 11 voces, 15+ idiomas (Kokoro, Chatterbox, VibeVoice, VoxCPM)
+- **STT**: familia Whisper con RTF hasta 197x en M4 Max
+
+### Razonamiento y avanzado
+- **Extracción de razonamiento**: Qwen3, DeepSeek-R1 (`--reasoning-parser`)
+- **Reducción de expertos MoE**: `--moe-top-k` para +7-16% en Qwen3-30B-A3B
+- **Decodificación especulativa**: `--mtp` para Qwen3-Next
+- **Prefill disperso**: `--spec-prefill` basado en atención para reducir TTFT
+
+### Observabilidad
+- **Métricas Prometheus**: endpoint `/metrics` con `--metrics`
+- **Benchmarker incluido**: `vllm-mlx bench-serve` para barridos de prompts con salida CSV/JSON
+
+### Aceleración GPU nativa
+- Solo Apple Silicon (M1, M2, M3, M4) con kernels Metal vía MLX
+- Memoria unificada, sin conversión de modelos
+
+## Rendimiento
+
+**Decode de LLM (M4 Max, 128 GB, greedy, single stream):**
+
+| Modelo | Tok/s | Memoria |
+|--------|------:|--------:|
+| Qwen3-0.6B-8bit | 417.9 | 0.7 GB |
+| Llama-3.2-3B-Instruct-4bit | 205.6 | 1.8 GB |
+| Qwen3-30B-A3B-4bit | 127.7 | ~18 GB |
+
+**Audio speech-to-text (M4 Max, RTF = real-time factor):**
+
+| Modelo | RTF | Caso de uso |
+|--------|----:|-------------|
+| whisper-tiny | 197x | Tiempo real / baja latencia |
+| whisper-large-v3-turbo | 55x | Calidad + velocidad |
+| whisper-large-v3 | 24x | Máxima precisión |
+
+Ver [docs/benchmarks/](docs/benchmarks/) para resultados de continuous batching, cuantización de KV cache (4-bit / 8-bit / fp16) y barridos de MoE top-k.
+
+## Ejemplos
+
+### API Anthropic (Claude Code, OpenCode)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --port 8000
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### Modelos de razonamiento (Qwen3, DeepSeek-R1)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "¿Cuánto es 17 * 23?"}],
+)
+print("Pensamiento:", r.choices[0].message.reasoning)
+print("Respuesta:",   r.choices[0].message.content)
+```
+
+### Multimodal (imagen + texto)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "¿Qué hay en esta imagen?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+    ]}],
+)
+```
+
+### Salida estructurada (JSON Schema)
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Lista 3 colores."}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "schema": {"type": "object", "properties": {"colors": {"type": "array", "items": {"type": "string"}}}}
+        },
+    },
+)
+```
+
+### Reranking (`/v1/rerank`)
+
+```bash
+curl http://localhost:8000/v1/rerank -H 'Content-Type: application/json' -d '{
+  "model": "default",
+  "query": "inferencia en apple silicon",
+  "documents": ["MLX es el framework de Apple", "Kernels Metal en M-series", "CUDA en NVIDIA"]
+}'
+```
+
+### Embeddings
+
+```bash
+vllm-mlx serve <llm-model> --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+```python
+emb = client.embeddings.create(model="mlx-community/all-MiniLM-L6-v2-4bit", input=["Hola", "Mundo"])
+```
+
+### Audio (TTS / STT)
+
+```bash
+pip install vllm-mlx[audio]
+brew install espeak-ng        # macOS, necesario para TTS en idiomas no-inglés
+
+python examples/tts_example.py "Hello, how are you?" --play
+python examples/tts_multilingual.py "Hola mundo" --lang es --play
+```
+
+### Benchmarking incluido
+
+```bash
+vllm-mlx bench-serve --url http://localhost:8000 --concurrency 5 --prompts prompts.txt --output results.csv
+```
+
+### Métricas Prometheus
+
+```bash
+vllm-mlx serve <model> --metrics
+curl http://localhost:8000/metrics
+```
+
+## Instalación
+
+**Usando uv (recomendado):**
+
+```bash
+uv tool install vllm-mlx                 # CLI a nivel sistema
+# o dentro de un proyecto
+uv pip install vllm-mlx
+```
+
+**Usando pip:**
+
+```bash
+pip install vllm-mlx
+
+# Extras de audio
+pip install vllm-mlx[audio]
+brew install espeak-ng
+python -m spacy download en_core_web_sm
+```
+
+**Desde el código fuente:**
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+pip install -e .
+```
+
+Ver [Guía de instalación](docs/getting-started/installation.md) para todas las opciones.
+
+## Documentación
+
+- **Primeros pasos**: [Instalación](docs/getting-started/installation.md) · [Inicio rápido](docs/getting-started/quickstart.md)
+- **Servidores y APIs**: [Servidor OpenAI](docs/guides/server.md) · [API Anthropic Messages](docs/guides/server.md#anthropic-messages-api) · [API Python](docs/guides/python-api.md)
+- **Características**: [Multimodal](docs/guides/multimodal.md) · [Audio](docs/guides/audio.md) · [Embeddings](docs/guides/embeddings.md) · [Razonamiento](docs/guides/reasoning.md) · [MCP y Tool Calling](docs/guides/mcp-tools.md) · [Parsers de tools](docs/guides/tool-calling.md)
+- **Rendimiento**: [Continuous Batching](docs/guides/continuous-batching.md) · [Warm Prompts](docs/guides/warm-prompts.md) · [MoE Top-K](docs/guides/moe-top-k.md)
+- **Referencia**: [CLI](docs/reference/cli.md) · [Modelos](docs/reference/models.md) · [Configuración](docs/reference/configuration.md)
+- **Benchmarks**: [LLM](docs/benchmarks/llm.md) · [Imagen](docs/benchmarks/image.md) · [Video](docs/benchmarks/video.md) · [Audio](docs/benchmarks/audio.md)
+
+## Arquitectura
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         Servidor vllm-mlx                               │
+│   OpenAI /v1/*  ·  Anthropic /v1/messages  ·  /v1/rerank  ·  /metrics   │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Continuous batching · Paged KV cache · Prefix cache · SSD tiering      │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+        ┌─────────────┬────────────┴────────────┬─────────────┐
+        ▼             ▼                         ▼             ▼
+┌───────────────┐ ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+│    mlx-lm     │ │   mlx-vlm     │ │   mlx-audio   │ │mlx-embeddings │
+│    (LLMs)     │ │  (Visión)     │ │  (TTS + STT)  │ │ (Embeddings)  │
+└───────────────┘ └───────────────┘ └───────────────┘ └───────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                   MLX · kernels Metal · memoria unificada               │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Contribuir
+
+Bienvenidos bug fixes, trabajo de performance, docs y benchmarks en distintos chips de Apple Silicon. Ver [Guía de contribución](docs/development/contributing.md).
+
+## Licencia
+
+Apache 2.0. Ver [LICENSE](LICENSE).
+
+## Citación
+
+```bibtex
+@software{vllm_mlx2025,
+  author = {Barrios, Wayner},
+  title  = {vllm-mlx: Apple Silicon MLX Backend for vLLM},
+  year   = {2025},
+  url    = {https://github.com/waybarrios/vllm-mlx},
+  note   = {Native GPU-accelerated LLM and vision-language model inference on Apple Silicon}
+}
+```
+
+## Agradecimientos
+
+- [MLX](https://github.com/ml-explore/mlx). Framework de ML de Apple.
+- [mlx-lm](https://github.com/ml-explore/mlx-lm). Librería de inferencia de LLM.
+- [mlx-vlm](https://github.com/Blaizzy/mlx-vlm). Modelos de visión y lenguaje.
+- [mlx-audio](https://github.com/Blaizzy/mlx-audio). Text-to-Speech y Speech-to-Text.
+- [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings). Embeddings de texto.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX). Fork comunitario de vllm-mlx.
+- [vLLM](https://github.com/vllm-project/vllm). Servicio de LLM de alto throughput. vllm-mlx está inspirado en vLLM y adopta su diseño de continuous-batching y paged KV-cache para Apple Silicon vía MLX.
+
+## Historia de stars
+
+[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+
+---
+
+**Si vllm-mlx te sirvió, por favor dale una star al repo. Ayuda a que más devs de Apple Silicon lo encuentren.**

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,302 @@
+# vllm-mlx
+
+**Lire ceci dans d'autres langues :** [English](README.md) · [Español](README.es.md) · [Français](README.fr.md) · [中文](README.zh.md)
+
+**Continuous batching + API OpenAI et Anthropic dans un seul serveur. Inférence native sur Apple Silicon.**
+
+[![PyPI version](https://img.shields.io/pypi/v/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Apple Silicon](https://img.shields.io/badge/Apple-Silicon-black.svg)](https://support.apple.com/en-us/HT211814)
+[![GitHub stars](https://img.shields.io/github/stars/waybarrios/vllm-mlx.svg?style=social)](https://github.com/waybarrios/vllm-mlx)
+
+---
+
+## Qu'est-ce que vllm-mlx ?
+
+Un serveur d'inférence de type vLLM pour les Macs Apple Silicon. Contrairement à l'utilisation directe de `Ollama` ou `mlx-lm`, il embarque **continuous batching, paged KV cache, prefix caching et cache KV sur SSD**, et expose **à la fois OpenAI `/v1/*` et Anthropic `/v1/messages`** depuis un seul processus. Exécutez des LLMs, modèles de vision, audio et embeddings sur Metal avec mémoire unifiée, sans étape de conversion.
+
+## Démarrage rapide (30 secondes)
+
+```bash
+pip install vllm-mlx
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+**SDK OpenAI :**
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+r = client.chat.completions.create(model="default", messages=[{"role": "user", "content": "Salut !"}])
+print(r.choices[0].message.content)
+```
+
+**SDK Anthropic / Claude Code :**
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+## Fonctionnalités
+
+### APIs
+- **Compatible OpenAI** : `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/rerank`, `/v1/responses`
+- **Compatible Anthropic** : `/v1/messages` (streaming, tool use, system prompts)
+- **MCP Tool Calling** : 12 parsers (OpenAI, Anthropic, Gemini, Qwen, DeepSeek, Gemma et plus)
+- **Sortie structurée** : JSON Schema via `response_format` (lm-format-enforcer)
+
+### Débit et mémoire
+- **Continuous batching** : haut débit pour des requêtes concurrentes
+- **Paged KV cache** : efficace en mémoire avec prefix sharing
+- **Cache KV sur SSD** : déversez le prefix cache sur disque pour les agents à long contexte (`--ssd-cache-dir`)
+- **Warm prompts** : pré-chargez les préfixes populaires au démarrage (`--warm-prompts`) pour un TTFT 1.3-2.25x
+- **Prefix cache** : basé sur trie, partagé entre les requêtes
+
+### Multimodal
+- **Texte + image + vidéo + audio** depuis un seul serveur
+- Modèles de vision : Gemma 3, Gemma 4, Qwen3-VL, Pixtral, Llama vision
+- **Audio en entrée** dans le chat (blocs `audio_url`)
+- **TTS natif** : 11 voix, 15+ langues (Kokoro, Chatterbox, VibeVoice, VoxCPM)
+- **STT** : famille Whisper avec RTF jusqu'à 197x sur M4 Max
+
+### Raisonnement et avancé
+- **Extraction du raisonnement** : Qwen3, DeepSeek-R1 (`--reasoning-parser`)
+- **Réduction d'experts MoE** : `--moe-top-k` pour +7-16% sur Qwen3-30B-A3B
+- **Décodage spéculatif** : `--mtp` pour Qwen3-Next
+- **Prefill creux** : `--spec-prefill` basé sur l'attention pour réduire le TTFT
+
+### Observabilité
+- **Métriques Prometheus** : endpoint `/metrics` avec `--metrics`
+- **Benchmark intégré** : `vllm-mlx bench-serve` pour des balayages de prompts en CSV/JSON
+
+### Accélération GPU native
+- Apple Silicon uniquement (M1, M2, M3, M4) avec kernels Metal via MLX
+- Mémoire unifiée, sans conversion de modèles
+
+## Performance
+
+**Decode LLM (M4 Max, 128 Go, greedy, single stream) :**
+
+| Modèle | Tok/s | Mémoire |
+|--------|------:|--------:|
+| Qwen3-0.6B-8bit | 417.9 | 0.7 Go |
+| Llama-3.2-3B-Instruct-4bit | 205.6 | 1.8 Go |
+| Qwen3-30B-A3B-4bit | 127.7 | ~18 Go |
+
+**Audio speech-to-text (M4 Max, RTF = real-time factor) :**
+
+| Modèle | RTF | Cas d'usage |
+|--------|----:|-------------|
+| whisper-tiny | 197x | Temps réel / faible latence |
+| whisper-large-v3-turbo | 55x | Qualité + vitesse |
+| whisper-large-v3 | 24x | Précision maximale |
+
+Voir [docs/benchmarks/](docs/benchmarks/) pour les résultats continuous batching, la quantification du KV cache (4-bit / 8-bit / fp16) et les balayages MoE top-k.
+
+## Exemples
+
+### API Anthropic (Claude Code, OpenCode)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --port 8000
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### Modèles de raisonnement (Qwen3, DeepSeek-R1)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Combien font 17 * 23 ?"}],
+)
+print("Raisonnement :", r.choices[0].message.reasoning)
+print("Réponse :",      r.choices[0].message.content)
+```
+
+### Multimodal (image + texte)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "Qu'y a-t-il sur cette image ?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+    ]}],
+)
+```
+
+### Sortie structurée (JSON Schema)
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Liste 3 couleurs."}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "schema": {"type": "object", "properties": {"colors": {"type": "array", "items": {"type": "string"}}}}
+        },
+    },
+)
+```
+
+### Reranking (`/v1/rerank`)
+
+```bash
+curl http://localhost:8000/v1/rerank -H 'Content-Type: application/json' -d '{
+  "model": "default",
+  "query": "inférence apple silicon",
+  "documents": ["MLX est le framework d Apple", "Kernels Metal sur M-series", "CUDA sur NVIDIA"]
+}'
+```
+
+### Embeddings
+
+```bash
+vllm-mlx serve <llm-model> --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+```python
+emb = client.embeddings.create(model="mlx-community/all-MiniLM-L6-v2-4bit", input=["Bonjour", "Monde"])
+```
+
+### Audio (TTS / STT)
+
+```bash
+pip install vllm-mlx[audio]
+brew install espeak-ng        # macOS, nécessaire pour TTS non-anglais
+
+python examples/tts_example.py "Hello, how are you?" --play
+python examples/tts_multilingual.py "Bonjour le monde" --lang fr --play
+```
+
+### Benchmarking intégré
+
+```bash
+vllm-mlx bench-serve --url http://localhost:8000 --concurrency 5 --prompts prompts.txt --output results.csv
+```
+
+### Métriques Prometheus
+
+```bash
+vllm-mlx serve <model> --metrics
+curl http://localhost:8000/metrics
+```
+
+## Installation
+
+**Avec uv (recommandé) :**
+
+```bash
+uv tool install vllm-mlx                 # CLI global
+# ou dans un projet
+uv pip install vllm-mlx
+```
+
+**Avec pip :**
+
+```bash
+pip install vllm-mlx
+
+# Extras audio
+pip install vllm-mlx[audio]
+brew install espeak-ng
+python -m spacy download en_core_web_sm
+```
+
+**Depuis les sources :**
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+pip install -e .
+```
+
+Voir le [Guide d'installation](docs/getting-started/installation.md) pour toutes les options.
+
+## Documentation
+
+- **Premiers pas** : [Installation](docs/getting-started/installation.md) · [Démarrage rapide](docs/getting-started/quickstart.md)
+- **Serveurs et APIs** : [Serveur OpenAI](docs/guides/server.md) · [API Anthropic Messages](docs/guides/server.md#anthropic-messages-api) · [API Python](docs/guides/python-api.md)
+- **Fonctionnalités** : [Multimodal](docs/guides/multimodal.md) · [Audio](docs/guides/audio.md) · [Embeddings](docs/guides/embeddings.md) · [Raisonnement](docs/guides/reasoning.md) · [MCP et Tool Calling](docs/guides/mcp-tools.md) · [Parsers de tools](docs/guides/tool-calling.md)
+- **Performance** : [Continuous Batching](docs/guides/continuous-batching.md) · [Warm Prompts](docs/guides/warm-prompts.md) · [MoE Top-K](docs/guides/moe-top-k.md)
+- **Référence** : [CLI](docs/reference/cli.md) · [Modèles](docs/reference/models.md) · [Configuration](docs/reference/configuration.md)
+- **Benchmarks** : [LLM](docs/benchmarks/llm.md) · [Image](docs/benchmarks/image.md) · [Vidéo](docs/benchmarks/video.md) · [Audio](docs/benchmarks/audio.md)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         Serveur vllm-mlx                                │
+│   OpenAI /v1/*  ·  Anthropic /v1/messages  ·  /v1/rerank  ·  /metrics   │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Continuous batching · Paged KV cache · Prefix cache · SSD tiering      │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+        ┌─────────────┬────────────┴────────────┬─────────────┐
+        ▼             ▼                         ▼             ▼
+┌───────────────┐ ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+│    mlx-lm     │ │   mlx-vlm     │ │   mlx-audio   │ │mlx-embeddings │
+│    (LLMs)     │ │  (Vision)     │ │  (TTS + STT)  │ │ (Embeddings)  │
+└───────────────┘ └───────────────┘ └───────────────┘ └───────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                   MLX · kernels Metal · mémoire unifiée                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Contribuer
+
+Les corrections de bugs, travaux de performance, docs et benchmarks sur différentes puces Apple Silicon sont bienvenus. Voir le [Guide de contribution](docs/development/contributing.md).
+
+## Licence
+
+Apache 2.0. Voir [LICENSE](LICENSE).
+
+## Citation
+
+```bibtex
+@software{vllm_mlx2025,
+  author = {Barrios, Wayner},
+  title  = {vllm-mlx: Apple Silicon MLX Backend for vLLM},
+  year   = {2025},
+  url    = {https://github.com/waybarrios/vllm-mlx},
+  note   = {Native GPU-accelerated LLM and vision-language model inference on Apple Silicon}
+}
+```
+
+## Remerciements
+
+- [MLX](https://github.com/ml-explore/mlx). Framework ML d'Apple.
+- [mlx-lm](https://github.com/ml-explore/mlx-lm). Bibliothèque d'inférence LLM.
+- [mlx-vlm](https://github.com/Blaizzy/mlx-vlm). Modèles vision-langage.
+- [mlx-audio](https://github.com/Blaizzy/mlx-audio). Text-to-Speech et Speech-to-Text.
+- [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings). Embeddings de texte.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX). Fork communautaire de vllm-mlx.
+- [vLLM](https://github.com/vllm-project/vllm). Service LLM haut débit. vllm-mlx s'inspire de vLLM et adopte sa conception continuous-batching et paged KV-cache pour Apple Silicon via MLX.
+
+## Historique des stars
+
+[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+
+---
+
+**Si vllm-mlx vous a été utile, mettez une étoile au repo. Cela aide plus de développeurs Apple Silicon à le trouver.**

--- a/README.md
+++ b/README.md
@@ -1,110 +1,39 @@
-# vLLM-MLX
+# vllm-mlx
 
-**vLLM-like inference for Apple Silicon** - GPU-accelerated Text, Image, Video & Audio on Mac
+**Read this in other languages:** [English](README.md) · [Español](README.es.md) · [Français](README.fr.md) · [中文](README.zh.md)
 
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+**Continuous batching + OpenAI + Anthropic APIs in one server. Native Apple Silicon inference.**
+
+[![PyPI version](https://img.shields.io/pypi/v/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Apple Silicon](https://img.shields.io/badge/Apple-Silicon-black.svg)](https://support.apple.com/en-us/HT211814)
-[![GitHub](https://img.shields.io/badge/GitHub-waybarrios%2Fvllm--mlx-blue?logo=github)](https://github.com/waybarrios/vllm-mlx)
+[![GitHub stars](https://img.shields.io/github/stars/waybarrios/vllm-mlx.svg?style=social)](https://github.com/waybarrios/vllm-mlx)
 
-## Overview
+---
 
-vllm-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
+## What is vllm-mlx?
 
-- **[MLX](https://github.com/ml-explore/mlx)**: Apple's ML framework with unified memory and Metal kernels
-- **[mlx-lm](https://github.com/ml-explore/mlx-lm)**: Optimized LLM inference with KV cache and quantization
-- **[mlx-vlm](https://github.com/Blaizzy/mlx-vlm)**: Vision-language models for multimodal inference
-- **[mlx-audio](https://github.com/Blaizzy/mlx-audio)**: Speech-to-Text and Text-to-Speech with native voices
-- **[mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings)**: Text embeddings for semantic search and RAG
+A vLLM-style inference server for Apple Silicon Macs. Unlike `Ollama` or `mlx-lm` used directly, it ships **continuous batching, paged KV cache, prefix caching, and SSD-tiered cache**, and exposes **both OpenAI `/v1/*` and Anthropic `/v1/messages`** from a single process. Run LLMs, vision models, audio, and embeddings on Metal with unified memory, no conversion step.
 
-## Features
-
-- **Multimodal** - Text, Image, Video & Audio in one platform
-- **Native GPU acceleration** on Apple Silicon (M1, M2, M3, M4)
-- **Native TTS voices** - Spanish, French, Chinese, Japanese + 5 more languages
-- **OpenAI API compatible** - drop-in replacement for OpenAI client
-- **Anthropic Messages API** - native `/v1/messages` endpoint for Claude Code and OpenCode
-- **Embeddings** - OpenAI-compatible `/v1/embeddings` endpoint with mlx-embeddings
-- **Reasoning Models** - extract thinking process from Qwen3, DeepSeek-R1
-- **MCP Tool Calling** - integrate external tools via Model Context Protocol
-- **Paged KV Cache** - memory-efficient caching with prefix sharing
-- **Continuous Batching** - high throughput for multiple concurrent users
-
-## Quick Start
-
-### Installation
-
-**Using uv (recommended):**
+## Quick start (30 seconds)
 
 ```bash
-# Install as CLI tool (system-wide)
-uv tool install git+https://github.com/waybarrios/vllm-mlx.git
-
-# Or install in a project/virtual environment
-uv pip install git+https://github.com/waybarrios/vllm-mlx.git
-```
-
-**Using pip:**
-
-```bash
-# Install from GitHub
-pip install git+https://github.com/waybarrios/vllm-mlx.git
-
-# Or clone and install in development mode
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
-pip install -e .
-```
-
-### Start Server
-
-```bash
-# Simple mode (single user, max throughput)
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
-
-# Continuous batching (multiple users)
+pip install vllm-mlx
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
-
-# With API key authentication
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --api-key your-secret-key
 ```
 
-### Use with OpenAI SDK
+**OpenAI SDK:**
 
 ```python
 from openai import OpenAI
-
-# Without API key (local development)
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
-
-# With API key (production)
-client = OpenAI(base_url="http://localhost:8000/v1", api_key="your-secret-key")
-
-response = client.chat.completions.create(
-    model="default",
-    messages=[{"role": "user", "content": "Hello!"}],
-)
-print(response.choices[0].message.content)
+r = client.chat.completions.create(model="default", messages=[{"role": "user", "content": "Hi!"}])
+print(r.choices[0].message.content)
 ```
 
-### Use with Anthropic SDK
-
-vllm-mlx exposes an Anthropic-compatible `/v1/messages` endpoint, so tools like Claude Code and OpenCode can connect directly.
-
-```python
-from anthropic import Anthropic
-
-client = Anthropic(base_url="http://localhost:8000", api_key="not-needed")
-
-response = client.messages.create(
-    model="default",
-    max_tokens=256,
-    messages=[{"role": "user", "content": "Hello!"}]
-)
-print(response.content[0].text)
-```
-
-To use with Claude Code:
+**Anthropic SDK / Claude Code:**
 
 ```bash
 export ANTHROPIC_BASE_URL=http://localhost:8000
@@ -112,291 +41,262 @@ export ANTHROPIC_API_KEY=not-needed
 claude
 ```
 
-See [Anthropic Messages API docs](docs/guides/server.md#anthropic-messages-api) for streaming, tool calling, system messages, and token counting.
+## Features
 
-### Multimodal (Images & Video)
+### APIs
+- **OpenAI-compatible**: `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/rerank`, `/v1/responses`
+- **Anthropic-compatible**: `/v1/messages` (streaming, tool use, system prompts)
+- **MCP Tool Calling**: 12 parsers (OpenAI, Anthropic, Gemini, Qwen, DeepSeek, Gemma, and more)
+- **Structured output**: JSON Schema via `response_format` (lm-format-enforcer)
+
+### Throughput & memory
+- **Continuous batching**: high throughput for concurrent requests
+- **Paged KV cache**: memory-efficient with prefix sharing
+- **SSD-tiered KV cache**: spill prefix cache to disk for long-context agents (`--ssd-cache-dir`)
+- **Warm prompts**: preload popular prefixes at startup (`--warm-prompts`) for 1.3-2.25x TTFT
+- **Prefix cache**: trie-based, shared across requests
+
+### Multimodal
+- **Text + image + video + audio** from one server
+- Vision models: Gemma 3, Gemma 4, Qwen3-VL, Pixtral, Llama vision
+- **Audio input** in chat (`audio_url` content blocks)
+- **Native TTS**: 11 voices, 15+ languages (Kokoro, Chatterbox, VibeVoice, VoxCPM)
+- **STT**: Whisper family with RTF up to 197x on M4 Max
+
+### Reasoning & advanced
+- **Reasoning extraction**: Qwen3, DeepSeek-R1 (`--reasoning-parser`)
+- **MoE expert reduction**: `--moe-top-k` for +7-16% on Qwen3-30B-A3B
+- **Speculative decoding**: `--mtp` for Qwen3-Next
+- **Sparse prefill**: attention-based `--spec-prefill` for TTFT reduction
+
+### Observability
+- **Prometheus metrics**: `/metrics` endpoint with `--metrics`
+- **Built-in benchmarker**: `vllm-mlx bench-serve` for prompt sweeps with CSV/JSON output
+
+### Native GPU acceleration
+- Apple Silicon only (M1, M2, M3, M4) with Metal kernels via MLX
+- Unified memory, no model conversion
+
+## Performance
+
+**LLM decode (M4 Max, 128 GB, greedy, single stream):**
+
+| Model | Tok/s | Memory |
+|-------|------:|-------:|
+| Qwen3-0.6B-8bit | 417.9 | 0.7 GB |
+| Llama-3.2-3B-Instruct-4bit | 205.6 | 1.8 GB |
+| Qwen3-30B-A3B-4bit | 127.7 | ~18 GB |
+
+**Audio speech-to-text (M4 Max, RTF = real-time factor):**
+
+| Model | RTF | Use case |
+|-------|----:|----------|
+| whisper-tiny | 197x | Real-time / low latency |
+| whisper-large-v3-turbo | 55x | Quality + speed |
+| whisper-large-v3 | 24x | Highest accuracy |
+
+See [docs/benchmarks/](docs/benchmarks/) for continuous-batching results, KV-cache quantization (4-bit / 8-bit / fp16), and MoE top-k sweeps.
+
+## Examples
+
+### Anthropic API (Claude Code, OpenCode)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --port 8000
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### Reasoning models (Qwen3, DeepSeek-R1)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 * 23?"}],
+)
+print("Thinking:", r.choices[0].message.reasoning)
+print("Answer:",   r.choices[0].message.content)
+```
+
+### Multimodal (image + text)
 
 ```bash
 vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 ```
 
 ```python
-response = client.chat.completions.create(
+r = client.chat.completions.create(
     model="default",
-    messages=[{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "What's in this image?"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
-        ]
-    }]
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+    ]}],
 )
 ```
 
-### Audio (TTS/STT)
-
-```bash
-# Install audio dependencies
-pip install vllm-mlx[audio]
-python -m spacy download en_core_web_sm
-brew install espeak-ng  # macOS, for non-English languages
-```
-
-```bash
-# Text-to-Speech (English)
-python examples/tts_example.py "Hello, how are you?" --play
-
-# Text-to-Speech (Spanish)
-python examples/tts_multilingual.py "Hola mundo" --lang es --play
-
-# List available models and languages
-python examples/tts_multilingual.py --list-models
-python examples/tts_multilingual.py --list-languages
-```
-
-**Supported TTS Models:**
-| Model | Languages | Description |
-|-------|-----------|-------------|
-| Kokoro | EN, ES, FR, JA, ZH, IT, PT, HI | Fast, 82M params, 11 voices |
-| Chatterbox | 15+ languages | Expressive, voice cloning |
-| VibeVoice | EN | Realtime, low latency |
-| VoxCPM | ZH, EN | High quality Chinese/English |
-
-### Reasoning Models
-
-Extract the thinking process from reasoning models like Qwen3 and DeepSeek-R1:
-
-```bash
-# Start server with reasoning parser
-vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
-```
+### Structured output (JSON Schema)
 
 ```python
-response = client.chat.completions.create(
+r = client.chat.completions.create(
     model="default",
-    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+    messages=[{"role": "user", "content": "List 3 colors."}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "schema": {"type": "object", "properties": {"colors": {"type": "array", "items": {"type": "string"}}}}
+        },
+    },
 )
-
-# Access reasoning separately from the answer
-print("Thinking:", response.choices[0].message.reasoning)
-print("Answer:", response.choices[0].message.content)
 ```
 
-**Supported Parsers:**
-| Parser | Models | Description |
-|--------|--------|-------------|
-| `qwen3` | Qwen3 series | Requires both `<think>` and `</think>` tags |
-| `deepseek_r1` | DeepSeek-R1 | Handles implicit `<think>` tag |
+### Reranking (`/v1/rerank`)
+
+```bash
+curl http://localhost:8000/v1/rerank -H 'Content-Type: application/json' -d '{
+  "model": "default",
+  "query": "apple silicon inference",
+  "documents": ["MLX is Apples framework", "Metal kernels on M-series", "CUDA on NVIDIA"]
+}'
+```
 
 ### Embeddings
 
-Generate text embeddings for semantic search, RAG, and similarity:
-
 ```bash
-# Start server with an embedding model pre-loaded
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+vllm-mlx serve <llm-model> --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
 ```
 
 ```python
-# Generate embeddings using the OpenAI SDK
-embeddings = client.embeddings.create(
-    model="mlx-community/all-MiniLM-L6-v2-4bit",
-    input=["Hello world", "How are you?"]
-)
-print(f"Dimensions: {len(embeddings.data[0].embedding)}")
+emb = client.embeddings.create(model="mlx-community/all-MiniLM-L6-v2-4bit", input=["Hello", "World"])
 ```
 
-See [Embeddings Guide](docs/guides/embeddings.md) for details on supported models and lazy loading.
+### Audio (TTS / STT)
+
+```bash
+pip install vllm-mlx[audio]
+brew install espeak-ng        # macOS, needed for non-English TTS
+
+python examples/tts_example.py "Hello, how are you?" --play
+python examples/tts_multilingual.py "Hola mundo" --lang es --play
+```
+
+### Built-in benchmarking
+
+```bash
+vllm-mlx bench-serve --url http://localhost:8000 --concurrency 5 --prompts prompts.txt --output results.csv
+```
+
+### Prometheus metrics
+
+```bash
+vllm-mlx serve <model> --metrics
+curl http://localhost:8000/metrics
+```
+
+## Installation
+
+**Using uv (recommended):**
+
+```bash
+uv tool install vllm-mlx                 # CLI, system-wide
+# or in a project
+uv pip install vllm-mlx
+```
+
+**Using pip:**
+
+```bash
+pip install vllm-mlx
+
+# Audio extras
+pip install vllm-mlx[audio]
+brew install espeak-ng
+python -m spacy download en_core_web_sm
+```
+
+**From source:**
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+pip install -e .
+```
+
+See [Installation Guide](docs/getting-started/installation.md) for full options.
 
 ## Documentation
 
-For full documentation, see the [docs](docs/) directory:
-
-- **Getting Started**
-  - [Installation](docs/getting-started/installation.md)
-  - [Quick Start](docs/getting-started/quickstart.md)
-
-- **User Guides**
-  - [OpenAI-Compatible Server](docs/guides/server.md)
-  - [Anthropic Messages API](docs/guides/server.md#anthropic-messages-api)
-  - [Python API](docs/guides/python-api.md)
-  - [Multimodal (Images & Video)](docs/guides/multimodal.md)
-  - [Audio (STT/TTS)](docs/guides/audio.md)
-  - [Embeddings](docs/guides/embeddings.md)
-  - [Reasoning Models](docs/guides/reasoning.md)
-  - [MCP & Tool Calling](docs/guides/mcp-tools.md)
-  - [Continuous Batching](docs/guides/continuous-batching.md)
-
-- **Reference**
-  - [CLI Commands](docs/reference/cli.md)
-  - [Supported Models](docs/reference/models.md)
-  - [Configuration](docs/reference/configuration.md)
-
-- **Benchmarks**
-  - [LLM Benchmarks](docs/benchmarks/llm.md)
-  - [Image Benchmarks](docs/benchmarks/image.md)
-  - [Video Benchmarks](docs/benchmarks/video.md)
-  - [Audio Benchmarks](docs/benchmarks/audio.md)
+- **Getting started**: [Installation](docs/getting-started/installation.md) · [Quick Start](docs/getting-started/quickstart.md)
+- **Servers & APIs**: [OpenAI server](docs/guides/server.md) · [Anthropic Messages API](docs/guides/server.md#anthropic-messages-api) · [Python API](docs/guides/python-api.md)
+- **Features**: [Multimodal](docs/guides/multimodal.md) · [Audio](docs/guides/audio.md) · [Embeddings](docs/guides/embeddings.md) · [Reasoning](docs/guides/reasoning.md) · [MCP & Tool Calling](docs/guides/mcp-tools.md) · [Tool Parsers](docs/guides/tool-calling.md)
+- **Performance**: [Continuous Batching](docs/guides/continuous-batching.md) · [Warm Prompts](docs/guides/warm-prompts.md) · [MoE Top-K](docs/guides/moe-top-k.md)
+- **Reference**: [CLI](docs/reference/cli.md) · [Models](docs/reference/models.md) · [Configuration](docs/reference/configuration.md)
+- **Benchmarks**: [LLM](docs/benchmarks/llm.md) · [Image](docs/benchmarks/image.md) · [Video](docs/benchmarks/video.md) · [Audio](docs/benchmarks/audio.md)
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                           vLLM API Layer                                │
-│                    (OpenAI-compatible interface)                         │
+│                           vllm-mlx Server                               │
+│   OpenAI /v1/*  ·  Anthropic /v1/messages  ·  /v1/rerank  ·  /metrics   │
 └─────────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                            MLXPlatform                                  │
-│               (vLLM platform plugin for Apple Silicon)                  │
+│  Continuous batching · Paged KV cache · Prefix cache · SSD tiering      │
 └─────────────────────────────────────────────────────────────────────────┘
                                    │
         ┌─────────────┬────────────┴────────────┬─────────────┐
         ▼             ▼                         ▼             ▼
 ┌───────────────┐ ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
 │    mlx-lm     │ │   mlx-vlm     │ │   mlx-audio   │ │mlx-embeddings │
-│(LLM inference)│ │ (Vision+LLM)  │ │  (TTS + STT)  │ │ (Embeddings)  │
+│    (LLMs)     │ │  (Vision)     │ │  (TTS + STT)  │ │ (Embeddings)  │
 └───────────────┘ └───────────────┘ └───────────────┘ └───────────────┘
-        │             │                         │             │
-        └─────────────┴─────────────────────────┴─────────────┘
                                    │
                                    ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                              MLX                                        │
-│                (Apple ML Framework - Metal kernels)                      │
+│                   MLX · Metal kernels · Unified memory                  │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Performance
-
-**LLM Performance (M4 Max, 128GB):**
-
-| Model | Speed | Memory |
-|-------|-------|--------|
-| Qwen3-0.6B-8bit | 402 tok/s | 0.7 GB |
-| Llama-3.2-1B-4bit | 464 tok/s | 0.7 GB |
-| Llama-3.2-3B-4bit | 200 tok/s | 1.8 GB |
-
-**Continuous Batching (5 concurrent requests):**
-
-| Model | Single | Batched | Speedup |
-|-------|--------|---------|---------|
-| Qwen3-0.6B-8bit | 328 tok/s | 1112 tok/s | **3.4x** |
-| Llama-3.2-1B-4bit | 299 tok/s | 613 tok/s | **2.0x** |
-
-**Audio - Speech-to-Text (M4 Max, 128GB):**
-
-| Model | RTF* | Use Case |
-|-------|------|----------|
-| whisper-tiny | **197x** | Real-time, low latency |
-| whisper-large-v3-turbo | **55x** | Best quality/speed balance |
-| whisper-large-v3 | **24x** | Highest accuracy |
-
-*RTF = Real-Time Factor. RTF of 100x means 1 minute transcribes in ~0.6 seconds.
-
-See [benchmarks](docs/benchmarks/) for detailed results.
-
-## Gemma 3 Support
-
-vllm-mlx includes native support for Gemma 3 vision models. Gemma 3 is automatically detected as MLLM.
-
-### Usage
-
-```bash
-# Start server with Gemma 3
-vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
-
-# Verify it loaded as MLLM (not LLM)
-curl http://localhost:8000/health
-# Should show: "model_type": "mllm"
-```
-
-### Long Context Patch (mlx-vlm)
-
-Gemma 3's default `sliding_window=1024` limits context to ~10K tokens on Apple Silicon (Metal GPU timeout at higher context). To enable longer context (up to ~50K tokens), patch mlx-vlm:
-
-**Location:** `~/.../site-packages/mlx_vlm/models/gemma3/language.py`
-
-Find the `make_cache` method and replace with:
-
-```python
-def make_cache(self):
-    import os
-    # Set GEMMA3_SLIDING_WINDOW=8192 for ~40K context
-    # Set GEMMA3_SLIDING_WINDOW=0 for ~50K context (full KVCache)
-    sliding_window = int(os.environ.get('GEMMA3_SLIDING_WINDOW', self.config.sliding_window))
-
-    caches = []
-    for i in range(self.config.num_hidden_layers):
-        if (
-            i % self.config.sliding_window_pattern
-            == self.config.sliding_window_pattern - 1
-        ):
-            caches.append(KVCache())
-        elif sliding_window == 0:
-            caches.append(KVCache())  # Full context for all layers
-        else:
-            caches.append(RotatingKVCache(max_size=sliding_window, keep=0))
-    return caches
-```
-
-**Usage:**
-
-```bash
-# Default (~10K max context)
-vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
-
-# Extended context (~40K max)
-GEMMA3_SLIDING_WINDOW=8192 vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
-
-# Maximum context (~50K max)
-GEMMA3_SLIDING_WINDOW=0 vllm-mlx serve mlx-community/gemma-3-27b-it-4bit --port 8000
-```
-
-**Benchmark Results (M4 Max 128GB):**
-
-| Setting | Max Context | Memory |
-|---------|-------------|--------|
-| Default (1024) | ~10K tokens | ~16GB |
-| `GEMMA3_SLIDING_WINDOW=8192` | ~40K tokens | ~25GB |
-| `GEMMA3_SLIDING_WINDOW=0` | ~50K tokens | ~35GB |
-
 ## Contributing
 
-We welcome contributions! See [Contributing Guide](docs/development/contributing.md) for details.
-
-- Bug fixes and improvements
-- Performance optimizations
-- Documentation improvements
-- Benchmarks on different Apple Silicon chips
-
-Submit PRs to: [https://github.com/waybarrios/vllm-mlx](https://github.com/waybarrios/vllm-mlx)
+Bug fixes, perf work, docs, and benchmarks on different Apple Silicon chips all welcome. See the [Contributing Guide](docs/development/contributing.md).
 
 ## License
 
-Apache 2.0 - see [LICENSE](LICENSE) for details.
+Apache 2.0. See [LICENSE](LICENSE).
 
 ## Citation
-
-If you use vLLM-MLX in your research or project, please cite:
 
 ```bibtex
 @software{vllm_mlx2025,
   author = {Barrios, Wayner},
-  title = {vLLM-MLX: Apple Silicon MLX Backend for vLLM},
-  year = {2025},
-  url = {https://github.com/waybarrios/vllm-mlx},
-  note = {Native GPU-accelerated LLM and vision-language model inference on Apple Silicon}
+  title  = {vllm-mlx: Apple Silicon MLX Backend for vLLM},
+  year   = {2025},
+  url    = {https://github.com/waybarrios/vllm-mlx},
+  note   = {Native GPU-accelerated LLM and vision-language model inference on Apple Silicon}
 }
 ```
 
 ## Acknowledgments
 
-- [MLX](https://github.com/ml-explore/mlx) - Apple's ML framework
-- [mlx-lm](https://github.com/ml-explore/mlx-lm) - LLM inference library
-- [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) - Vision-language models
-- [mlx-audio](https://github.com/Blaizzy/mlx-audio) - Text-to-Speech and Speech-to-Text
-- [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) - Text embeddings
-- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) - Community fork of vllm-mlx
-- [vLLM](https://github.com/vllm-project/vllm) - High-throughput LLM serving
+- [MLX](https://github.com/ml-explore/mlx). Apple's ML framework.
+- [mlx-lm](https://github.com/ml-explore/mlx-lm). LLM inference library.
+- [mlx-vlm](https://github.com/Blaizzy/mlx-vlm). Vision-language models.
+- [mlx-audio](https://github.com/Blaizzy/mlx-audio). Text-to-Speech and Speech-to-Text.
+- [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings). Text embeddings.
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX). Community fork of vllm-mlx.
+- [vLLM](https://github.com/vllm-project/vllm). High-throughput LLM serving. vllm-mlx is inspired by vLLM and adopts its continuous-batching and paged KV-cache design for Apple Silicon via MLX.
+
+## Star history
+
+[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+
+---
+
+**If vllm-mlx helped you, please star the repo. It helps more Apple Silicon devs find it.**

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,302 @@
+# vllm-mlx
+
+**其他语言版本：** [English](README.md) · [Español](README.es.md) · [Français](README.fr.md) · [中文](README.zh.md)
+
+**连续批处理 + OpenAI 和 Anthropic API 集成于一个服务。Apple Silicon 原生推理。**
+
+[![PyPI version](https://img.shields.io/pypi/v/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/vllm-mlx.svg)](https://pypi.org/project/vllm-mlx/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Apple Silicon](https://img.shields.io/badge/Apple-Silicon-black.svg)](https://support.apple.com/en-us/HT211814)
+[![GitHub stars](https://img.shields.io/github/stars/waybarrios/vllm-mlx.svg?style=social)](https://github.com/waybarrios/vllm-mlx)
+
+---
+
+## vllm-mlx 是什么？
+
+面向 Apple Silicon Mac 的 vLLM 风格推理服务器。与直接使用 `Ollama` 或 `mlx-lm` 不同，vllm-mlx 内置了**连续批处理（continuous batching）、分页 KV cache、prefix caching 以及 SSD 分层 KV cache**，并在同一个进程中同时暴露 **OpenAI `/v1/*` 和 Anthropic `/v1/messages`** 接口。可在 Metal 上通过统一内存运行 LLM、视觉模型、音频模型和嵌入模型，无需任何格式转换步骤。
+
+## 快速开始（30 秒）
+
+```bash
+pip install vllm-mlx
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+**OpenAI SDK：**
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+r = client.chat.completions.create(model="default", messages=[{"role": "user", "content": "你好！"}])
+print(r.choices[0].message.content)
+```
+
+**Anthropic SDK / Claude Code：**
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+## 功能特性
+
+### API
+- **兼容 OpenAI**：`/v1/chat/completions`、`/v1/completions`、`/v1/embeddings`、`/v1/rerank`、`/v1/responses`
+- **兼容 Anthropic**：`/v1/messages`（流式、工具调用、system prompts）
+- **MCP 工具调用**：12 种解析器（OpenAI、Anthropic、Gemini、Qwen、DeepSeek、Gemma 等）
+- **结构化输出**：通过 `response_format` 的 JSON Schema（基于 lm-format-enforcer）
+
+### 吞吐与内存
+- **连续批处理**：高并发下的高吞吐
+- **分页 KV cache**：内存高效，支持 prefix 共享
+- **SSD 分层 KV cache**：为长上下文 agent 场景将 prefix cache 溢出到磁盘（`--ssd-cache-dir`）
+- **Warm prompts**：启动时预加载热门 prefix（`--warm-prompts`），TTFT 提升 1.3-2.25 倍
+- **Prefix cache**：基于 trie，跨请求共享
+
+### 多模态
+- **文本 + 图像 + 视频 + 音频** 集成于一个服务
+- 视觉模型：Gemma 3、Gemma 4、Qwen3-VL、Pixtral、Llama vision
+- **聊天中的音频输入**（`audio_url` 内容块）
+- **原生 TTS**：11 种声音，15+ 种语言（Kokoro、Chatterbox、VibeVoice、VoxCPM）
+- **STT**：Whisper 系列，M4 Max 上 RTF 最高可达 197 倍
+
+### 推理与高级功能
+- **思维链提取**：Qwen3、DeepSeek-R1（`--reasoning-parser`）
+- **MoE 专家裁剪**：`--moe-top-k`，Qwen3-30B-A3B 上 +7-16%
+- **投机解码**：`--mtp`，用于 Qwen3-Next
+- **稀疏 prefill**：基于注意力的 `--spec-prefill`，降低 TTFT
+
+### 可观测性
+- **Prometheus 指标**：使用 `--metrics` 开启 `/metrics` 端点
+- **内置基准测试**：`vllm-mlx bench-serve`，支持 prompt 扫描及 CSV/JSON 输出
+
+### 原生 GPU 加速
+- 仅支持 Apple Silicon（M1、M2、M3、M4），通过 MLX 使用 Metal kernel
+- 统一内存，无需模型转换
+
+## 性能
+
+**LLM 解码（M4 Max，128 GB，greedy，单流）：**
+
+| 模型 | Tok/s | 内存 |
+|------|------:|-----:|
+| Qwen3-0.6B-8bit | 417.9 | 0.7 GB |
+| Llama-3.2-3B-Instruct-4bit | 205.6 | 1.8 GB |
+| Qwen3-30B-A3B-4bit | 127.7 | ~18 GB |
+
+**音频 speech-to-text（M4 Max，RTF = real-time factor）：**
+
+| 模型 | RTF | 适用场景 |
+|------|----:|---------|
+| whisper-tiny | 197x | 实时 / 低延迟 |
+| whisper-large-v3-turbo | 55x | 质量与速度兼顾 |
+| whisper-large-v3 | 24x | 最高精度 |
+
+完整结果（包括连续批处理、KV cache 量化 4-bit / 8-bit / fp16、MoE top-k 扫描）见 [docs/benchmarks/](docs/benchmarks/)。
+
+## 示例
+
+### Anthropic API（Claude Code、OpenCode）
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --port 8000
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### 推理模型（Qwen3、DeepSeek-R1）
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "17 乘以 23 等于多少？"}],
+)
+print("思考过程：", r.choices[0].message.reasoning)
+print("答案：",     r.choices[0].message.content)
+```
+
+### 多模态（图像 + 文本）
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "这张图里有什么？"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+    ]}],
+)
+```
+
+### 结构化输出（JSON Schema）
+
+```python
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "列出 3 种颜色。"}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "schema": {"type": "object", "properties": {"colors": {"type": "array", "items": {"type": "string"}}}}
+        },
+    },
+)
+```
+
+### 重排序（`/v1/rerank`）
+
+```bash
+curl http://localhost:8000/v1/rerank -H 'Content-Type: application/json' -d '{
+  "model": "default",
+  "query": "apple silicon 推理",
+  "documents": ["MLX 是苹果的框架", "M 系列芯片上的 Metal kernel", "NVIDIA 上的 CUDA"]
+}'
+```
+
+### 嵌入（Embeddings）
+
+```bash
+vllm-mlx serve <llm-model> --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+```python
+emb = client.embeddings.create(model="mlx-community/all-MiniLM-L6-v2-4bit", input=["你好", "世界"])
+```
+
+### 音频（TTS / STT）
+
+```bash
+pip install vllm-mlx[audio]
+brew install espeak-ng        # macOS，非英语 TTS 需要
+
+python examples/tts_example.py "Hello, how are you?" --play
+python examples/tts_multilingual.py "你好，世界" --lang zh --play
+```
+
+### 内置基准测试
+
+```bash
+vllm-mlx bench-serve --url http://localhost:8000 --concurrency 5 --prompts prompts.txt --output results.csv
+```
+
+### Prometheus 指标
+
+```bash
+vllm-mlx serve <model> --metrics
+curl http://localhost:8000/metrics
+```
+
+## 安装
+
+**使用 uv（推荐）：**
+
+```bash
+uv tool install vllm-mlx                 # 作为系统级 CLI
+# 或在项目中
+uv pip install vllm-mlx
+```
+
+**使用 pip：**
+
+```bash
+pip install vllm-mlx
+
+# 音频扩展
+pip install vllm-mlx[audio]
+brew install espeak-ng
+python -m spacy download en_core_web_sm
+```
+
+**从源码安装：**
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+pip install -e .
+```
+
+更多选项见 [安装指南](docs/getting-started/installation.md)。
+
+## 文档
+
+- **入门**：[安装](docs/getting-started/installation.md) · [快速开始](docs/getting-started/quickstart.md)
+- **服务器与 API**：[OpenAI 服务器](docs/guides/server.md) · [Anthropic Messages API](docs/guides/server.md#anthropic-messages-api) · [Python API](docs/guides/python-api.md)
+- **功能**：[多模态](docs/guides/multimodal.md) · [音频](docs/guides/audio.md) · [嵌入](docs/guides/embeddings.md) · [推理模型](docs/guides/reasoning.md) · [MCP 与工具调用](docs/guides/mcp-tools.md) · [工具解析器](docs/guides/tool-calling.md)
+- **性能**：[连续批处理](docs/guides/continuous-batching.md) · [Warm Prompts](docs/guides/warm-prompts.md) · [MoE Top-K](docs/guides/moe-top-k.md)
+- **参考**：[CLI](docs/reference/cli.md) · [模型](docs/reference/models.md) · [配置](docs/reference/configuration.md)
+- **基准测试**：[LLM](docs/benchmarks/llm.md) · [图像](docs/benchmarks/image.md) · [视频](docs/benchmarks/video.md) · [音频](docs/benchmarks/audio.md)
+
+## 架构
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          vllm-mlx 服务器                                │
+│   OpenAI /v1/*  ·  Anthropic /v1/messages  ·  /v1/rerank  ·  /metrics   │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  连续批处理 · 分页 KV cache · Prefix cache · SSD 分层                   │
+└─────────────────────────────────────────────────────────────────────────┘
+                                   │
+        ┌─────────────┬────────────┴────────────┬─────────────┐
+        ▼             ▼                         ▼             ▼
+┌───────────────┐ ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+│    mlx-lm     │ │   mlx-vlm     │ │   mlx-audio   │ │mlx-embeddings │
+│    (LLMs)     │ │   (视觉)      │ │  (TTS + STT)  │ │  (嵌入向量)   │
+└───────────────┘ └───────────────┘ └───────────────┘ └───────────────┘
+                                   │
+                                   ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                  MLX · Metal kernel · 统一内存                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## 贡献
+
+欢迎提交 bug 修复、性能优化、文档改进以及在不同 Apple Silicon 芯片上的 benchmark。详见 [贡献指南](docs/development/contributing.md)。
+
+## 许可证
+
+Apache 2.0。详见 [LICENSE](LICENSE)。
+
+## 引用
+
+```bibtex
+@software{vllm_mlx2025,
+  author = {Barrios, Wayner},
+  title  = {vllm-mlx: Apple Silicon MLX Backend for vLLM},
+  year   = {2025},
+  url    = {https://github.com/waybarrios/vllm-mlx},
+  note   = {Native GPU-accelerated LLM and vision-language model inference on Apple Silicon}
+}
+```
+
+## 致谢
+
+- [MLX](https://github.com/ml-explore/mlx)。Apple 的 ML 框架。
+- [mlx-lm](https://github.com/ml-explore/mlx-lm)。LLM 推理库。
+- [mlx-vlm](https://github.com/Blaizzy/mlx-vlm)。视觉语言模型。
+- [mlx-audio](https://github.com/Blaizzy/mlx-audio)。Text-to-Speech 与 Speech-to-Text。
+- [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings)。文本嵌入。
+- [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX)。vllm-mlx 的社区分支。
+- [vLLM](https://github.com/vllm-project/vllm)。高吞吐 LLM 推理服务。vllm-mlx 受 vLLM 启发，借鉴了其连续批处理和分页 KV cache 的设计，通过 MLX 适配到 Apple Silicon。
+
+## Star 历史
+
+[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+
+---
+
+**如果 vllm-mlx 对你有帮助，请给仓库点一个 star。这能帮助更多 Apple Silicon 开发者发现它。**

--- a/docs/es/benchmarks/README.md
+++ b/docs/es/benchmarks/README.md
@@ -1,0 +1,63 @@
+# Benchmarks
+
+Benchmarks de rendimiento para vllm-mlx en Apple Silicon.
+
+## Tipos de benchmark
+
+- [Benchmarks de LLM](llm.md) - Rendimiento de generación de texto
+- [Benchmarks de imagen](image.md) - Rendimiento de comprension de imagenes
+- [Benchmarks de video](video.md) - Rendimiento de comprension de video
+
+## Comandos rápidos
+
+```bash
+# LLM benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# Image benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+```
+
+## Valores predeterminados de los scripts de prueba
+
+Los scripts de benchmark independientes tienen modelos predeterminados integrados, por lo que puedes ejecutar:
+
+```bash
+python tests/test_continuous_batching.py
+python tests/test_prefix_cache.py
+```
+
+Valores predeterminados:
+- `tests/test_continuous_batching.py` → `mlx-community/Qwen3-8B-6bit`
+- `tests/test_prefix_cache.py` → `mlx-community/Qwen3-0.6B-8bit`
+
+Para probar con otros modelos, usa el parámetro opcional `--model`:
+
+```bash
+python tests/test_continuous_batching.py --model mlx-community/Qwen3-0.6B-8bit
+python tests/test_prefix_cache.py --model mlx-community/Qwen3-8B-6bit
+```
+
+## Hardware
+
+Los benchmarks se recopilaron en las siguientes configuraciones de Apple Silicon:
+
+| Chip | Memoria | Python |
+|------|---------|--------|
+| Apple M4 Max | 128 GB unificada | 3.13 |
+| Apple M1 Max | 64 GB unificada | 3.12 |
+
+Los resultados pueden variar en distintos chips de Apple Silicon.
+
+## Contribuir benchmarks
+
+Si tienes un chip de Apple Silicon diferente, comparte tus resultados:
+
+```bash
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+```
+
+Abre un issue con tus resultados en [GitHub Issues](https://github.com/waybarrios/vllm-mlx/issues).

--- a/docs/es/benchmarks/audio.md
+++ b/docs/es/benchmarks/audio.md
@@ -1,0 +1,158 @@
+# Benchmarks de Audio
+
+## Benchmarks de Speech-to-Text (STT)
+
+### Ejecutar benchmarks de STT
+
+```bash
+# Run with default test audio
+python examples/benchmark_audio.py --stt
+
+# Run with your own audio file
+python examples/benchmark_audio.py --stt --audio path/to/audio.wav
+```
+
+### Resultados (M4 Max, 128GB)
+
+**Audio de prueba:** 46.7 segundos de voz sintetizada
+
+| Model | Parameters | Load Time | Transcribe Time | RTF* |
+|-------|------------|-----------|-----------------|------|
+| whisper-tiny | 39M | 0.34s | 0.24s | **197x** |
+| whisper-small | 244M | 0.18s | 0.47s | **98x** |
+| whisper-medium | 769M | 0.35s | 1.15s | **41x** |
+| whisper-large-v3 | 1.5B | 0.50s | 1.96s | **24x** |
+| whisper-large-v3-turbo | 809M | 0.12s | 0.86s | **55x** |
+
+*RTF = Real-Time Factor (mayor es más rápido). Un RTF de 100x significa que 1 minuto de audio se transcribe en aprox. 0.6 segundos.*
+
+### Resultados (M1 Max, 64GB)
+
+STT con Parakeet (entorno predeterminado, Whisper no disponible por incompatibilidad de dependencia con numpy):
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| parakeet-tdt-0.6b-v2 | 0.28s | 1.01s | **9.9x** |
+| parakeet-tdt-0.6b-v3 | 0.30s | 0.19s | **52.7x** |
+
+STT con Whisper (`numpy==2.3.5` explícito + `uv run --no-sync`):
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| whisper-tiny | 4.02s | 1.05s | **9.5x** |
+| whisper-small | 10.15s | 1.03s | **9.7x** |
+| whisper-medium | 22.96s | 2.20s | **4.6x** |
+| whisper-large-v3 | 38.34s | 0.96s | **10.5x** |
+| whisper-large-v3-turbo | 21.79s | 0.70s | **14.3x** |
+| parakeet-tdt-0.6b-v2 | 0.47s | 0.18s | **54.4x** |
+| parakeet-tdt-0.6b-v3 | 1.13s | 0.18s | **54.6x** |
+
+### Recomendaciones de modelos
+
+| Use Case | Recommended Model | Why |
+|----------|-------------------|-----|
+| **Transcripcion en tiempo real** | whisper-tiny | El más rápido (197x RTF), baja latencia |
+| **Uso general** | whisper-large-v3-turbo | Mejor equilibrio entre velocidad (55x) y calidad |
+| **Mayor precision** | whisper-large-v3 | El más preciso, soporta más de 99 idiomas |
+| **Memoria reducida** | whisper-small | Buena calidad con 244M parámetros |
+
+### Calidad de transcripción
+
+Todos los modelos transcribieron correctamente el audio de prueba. Ejemplo de salida:
+
+```
+Input text:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..."
+
+Whisper-large-v3 output:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..." (identical)
+```
+
+### Idiomas soportados
+
+Los modelos Whisper soportan más de 99 idiomas, entre ellos:
+- Inglés, español, francés, alemán, italiano, portugués
+- Chino (mandarín, cantonés), japonés, coreano
+- Árabe, hindi, ruso, turco, ucraniano
+- Y muchos más
+
+## Benchmarks de Text-to-Speech (TTS)
+
+### Ejecutar benchmarks de TTS
+
+```bash
+python examples/benchmark_audio.py --tts
+```
+
+### Resultados (M4 Max, 128GB)
+
+**Prueba:** Generar audio para 3 muestras de texto (corta, media, larga)
+
+| Model | Load Time | Chars/sec | RTF* |
+|-------|-----------|-----------|------|
+| Kokoro-82M-bf16 | 0.8s | 350+ | **22x** |
+| Kokoro-82M-4bit | 0.4s | 320+ | **20x** |
+
+*RTF = Real-Time Factor. Un RTF de 22x significa que 1 segundo de audio se genera en aprox. 0.045 segundos.*
+
+### Resultados de TTS (M1 Max, 64GB)
+
+| Model | Load Time | Avg Chars/s | Avg RTF |
+|-------|-----------|-------------|---------|
+| Kokoro-82M-bf16 | 2.81s | 176.0 | **11.9x** |
+| Kokoro-82M-4bit | 0.22s | 225.6 | **15.5x** |
+
+### Calidad de TTS
+
+Kokoro produce voz con sonido natural, con:
+- 11 voces integradas (masculinas y femeninas)
+- Soporte para 8 idiomas (inglés, español, francés, japonés, chino, italiano, portugués, hindi)
+- 82M parámetros, rápido y liviano
+
+## Benchmarks de procesamiento de audio
+
+### SAM-Audio (separacion de fuentes)
+
+**Prueba:** Separar la bateria de una cancion de rock de 30 segundos
+
+| Metric | Value |
+|--------|-------|
+| Model | sam-audio-large-fp16 |
+| Processing time | ~20s |
+| Peak memory | ~27 GB |
+| Output sample rate | 48000 Hz |
+
+## Ejecutar todos los benchmarks de audio
+
+```bash
+# Run all benchmarks
+python examples/benchmark_audio.py --all
+
+# Or run individually
+python examples/benchmark_audio.py --stt
+python examples/benchmark_audio.py --tts
+```
+
+## Modelos disponibles en mlx-community
+
+### Modelos STT
+- `mlx-community/whisper-tiny-mlx`
+- `mlx-community/whisper-small-mlx`
+- `mlx-community/whisper-medium-mlx`
+- `mlx-community/whisper-large-v3-mlx`
+- `mlx-community/whisper-large-v3-turbo`
+- `mlx-community/parakeet-tdt-0.6b-v2`
+- `mlx-community/parakeet-tdt-0.6b-v3`
+
+### Modelos TTS
+- `mlx-community/Kokoro-82M-bf16` (recommended)
+- `mlx-community/Kokoro-82M-4bit`
+- `mlx-community/chatterbox-turbo-fp16`
+- `mlx-community/VibeVoice-Realtime-0.5B-4bit`
+
+### Procesamiento de audio
+- `mlx-community/sam-audio-large-fp16`

--- a/docs/es/benchmarks/image.md
+++ b/docs/es/benchmarks/image.md
@@ -1,0 +1,138 @@
+# Benchmarks de Imágenes
+
+## Ejecutar Benchmarks de Imágenes
+
+```bash
+# Benchmark completo (10 resoluciones)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Benchmark rápido (4 resoluciones)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --quick
+```
+
+## Resultados - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.04s | 78 | 74.8 tok/s |
+| 336x336 | 113K | 0.94s | 64 | 68.3 tok/s |
+| 448x448 | 201K | 1.45s | 70 | 48.1 tok/s |
+| 512x512 | 262K | 1.58s | 99 | 62.8 tok/s |
+| 672x672 | 452K | 1.83s | 83 | 45.3 tok/s |
+| 768x768 | 590K | 2.05s | 91 | 44.3 tok/s |
+| 896x896 | 803K | 2.61s | 90 | 34.5 tok/s |
+| 1024x1024 | 1.0M | 2.79s | 76 | 27.2 tok/s |
+| 1280x720 | 922K | 2.97s | 96 | 32.4 tok/s |
+| 1920x1080 | 2.1M | 6.30s | 89 | 14.1 tok/s |
+
+**Resumen:** Promedio de 45.2 tok/s en todas las resoluciones. Más rápido en 224x224 (74.8 tok/s), más lento en 1920x1080 (14.1 tok/s)
+
+## Resultados - Qwen3-VL-8B-Instruct-4bit (M1 Max, 64GB)
+
+Benchmark MLLM local:
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.84s | 78 | 42.5 tok/s |
+| 448x448 | 201K | 2.28s | 70 | 30.7 tok/s |
+| 768x768 | 590K | 4.39s | 91 | 20.7 tok/s |
+| 1024x1024 | 1.0M | 6.41s | 76 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 14.92 | 315 | 21.1 |
+
+## Resultados - Qwen3-VL-4B-Instruct-3bit Server (M1 Max, 64GB)
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.65s | 113 | 68.4 tok/s |
+| 448x448 | 201K | 2.09s | 120 | 57.5 tok/s |
+| 768x768 | 590K | 2.93s | 106 | 36.2 tok/s |
+| 1024x1024 | 1.0M | 4.12s | 100 | 24.3 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 10.79 | 439 | 40.7 |
+
+## Resultados del Prefix Cache MLLM
+
+```
+======================================================================
+  MLLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-VL-4B-Instruct-3bit
+  Test: Verify KV cache reuse for repeated image/video + prompt combinations
+  Expected behavior:
+    - Same image + same prompt → cache HIT
+    - Same image + different prompt → cache MISS
+    - Different image + same prompt → cache MISS
+----------------------------------------------------------------------
+  SETUP: Loading Model
+----------------------------------------------------------------------
+    Model loaded in 0.11s
+
+----------------------------------------------------------------------
+  SETUP: Creating Test Images
+----------------------------------------------------------------------
+    Resized: 224x224, 336x336, 512x512, 768x768
+
+----------------------------------------------------------------------
+  TEST 1: Image Cache - Basic Hit/Miss
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    1a     | First image+prompt        | MISS     | MISS   | 0.10ms | ✓
+    1b     | Same image+prompt         | HIT      | HIT    | 0.18ms | ✓
+    1c     | Different prompt          | MISS     | MISS   | 0.01ms | ✓
+    1d     | Return to original        | HIT      | HIT    | 0.18ms | ✓
+
+----------------------------------------------------------------------
+  TEST 2: Different Images
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    2a     | Image A first request     | MISS     | MISS   | 0.01ms | ✓
+    2b     | Image B first request     | MISS     | MISS   | 0.01ms | ✓
+    2c     | Image A cached            | HIT      | HIT    | 0.13ms | ✓
+
+----------------------------------------------------------------------
+  TEST 3: Image Resolutions
+----------------------------------------------------------------------
+    Results:
+    Step   | Description           | Expected | Actual | Time   | Status
+    -------+-----------------------+----------+--------+--------+-------
+    3.1a | 224x224 first         | MISS     | MISS   | 0.01ms | ✓
+    3.1b | 224x224 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.2a | 336x336 first         | MISS     | MISS   | 0.01ms | ✓
+    3.2b | 336x336 cached        | HIT      | HIT    | 0.21ms | ✓
+    3.3a | 512x512 first         | MISS     | MISS   | 0.12ms | ✓
+    3.3b | 512x512 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.4a | 768x768 first         | MISS     | MISS   | 0.12ms | ✓
+    3.4b | 768x768 cached        | HIT      | HIT    | 0.24ms | ✓
+======================================================================
+```
+
+## Estrategia de Clave de Cache
+
+- **Images**: `hash(image_content) + hash(prompt)`
+
+La misma imagen con el mismo prompt siempre generara un acierto en el cache. Una imagen diferente o un prompt diferente generara un fallo.
+
+## Consejos de Rendimiento
+
+- Las resoluciones menores se procesan más rápido (224x224 vs 1920x1080)
+- Usa la resolucion adecuada para tu tarea
+- Agrupa imagenes de tamanio similar para un rendimiento consistente
+
+## Referencia de Métricas
+
+| Metric | Description |
+|--------|-------------|
+| Resolution | Dimensiones de la imagen (ancho x alto) |
+| Pixels | Total pixel count |
+| Time | Tiempo de generación |
+| Tokens | Tokens de salida generados |
+| Speed | Tokens por segundo (tok/s) |

--- a/docs/es/benchmarks/llm.md
+++ b/docs/es/benchmarks/llm.md
@@ -1,0 +1,271 @@
+# Benchmarks de LLM
+
+## Ejecutar benchmarks de LLM
+
+```bash
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 5 --max-tokens 256
+```
+
+## Resultados (M4 Max, 128GB)
+
+| Model | Gen Speed | TTFT* | Memory |
+|-------|-----------|-------|--------|
+| Qwen3-0.6B-8bit | 402.3 tok/s | 58.6 ms | 0.68 GB |
+| Llama-3.2-1B-Instruct-4bit | 463.6 tok/s | 49.2 ms | 0.69 GB |
+| Qwen2.5-1.5B-Instruct-4bit | 308.5 tok/s | 86.2 ms | 0.84 GB |
+| Llama-3.2-3B-Instruct-4bit | 200.1 tok/s | 81.4 ms | 1.79 GB |
+| Qwen3-30B-A3B-4bit | 123.9 tok/s | 126.9 ms | 16.05 GB |
+| NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit | 122.9 tok/s | 72.3 ms | 23.98 GB |
+
+*TTFT = Time to First Token (latencia hasta que el modelo comienza a generar)
+
+## Resultados (M1 Max, 64GB)
+
+| Model | Runs | Prompt Tok | Gen Tok | Total Time (s) | TTFT Mean (ms) | TPOT Mean (ms) | Gen Speed (tok/s) | Total Throughput (tok/s) |
+|-------|------|------------|---------|-----------------|-----------------|-----------------|-------------------|--------------------------|
+| Qwen3-0.6B-8bit | 5 | 56 | 1280 | 5.66 | 119.0 | 3.97 | 251.9 | 236.1 |
+
+## Resultados de continuous batching
+
+| Model | Single Request | Batch (5 req) | Speedup |
+|-------|----------------|---------------|---------|
+| Llama-3.2-1B-Instruct-4bit | 299.1 tok/s | 613.0 tok/s | **2.05x** |
+| Llama-3.2-3B-Instruct-4bit | 137.6 tok/s | 208.1 tok/s | **1.51x** |
+| Qwen3-0.6B-8bit | 328.1 tok/s | 1111.8 tok/s | **3.39x** |
+| Qwen3-30B-A3B-4bit | 98.1 tok/s | 233.3 tok/s | **2.38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196.9 tok/s | 322.2 tok/s | **1.64x** |
+
+*Con 5 solicitudes concurrentes se observa una mejora de throughput de 1.5x a 3x.*
+
+### Continuous batching (M1 Max, 64GB)
+
+| Requests | Total Tokens | Total Time (s) | Throughput (tok/s) | Requests/sec |
+|----------|--------------|-----------------|--------------------|--------------|
+| 5 | 315 | 0.64 | 492.5 | 7.82 |
+
+## Rendimiento de streaming
+
+| Model | TTFT | Generation Speed |
+|-------|------|------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4.6ms | 218.9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10.7ms | 93.6 tok/s |
+| Qwen3-0.6B-8bit | ~3.0ms | 328.5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10.2ms | 98.4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7.1ms | 140.3 tok/s |
+
+### Detokenizador en streaming (M1 Max, 64GB)
+
+`vllm-mlx bench-detok`:
+
+| Tokens | Iterations | Naive Time | Streaming Time | Speedup |
+|--------|------------|------------|----------------|---------|
+| 742 | 5 | 1.69ms | 0.71ms | 2.39x |
+
+`examples/benchmark_detokenizer.py`:
+
+| Sequence | Tokens | decode() | Streaming | Speedup |
+|----------|--------|----------|-----------|---------|
+| Short | 8 | 0.029ms | 0.028ms | 1.04x |
+| Medium | 103 | 0.206ms | 0.129ms | 1.59x |
+| Long | 511 | 1.040ms | 0.502ms | 2.07x |
+| 1K | 1191 | 2.446ms | 1.178ms | 2.08x |
+| 2K | 2381 | 4.949ms | 2.356ms | 2.10x |
+| 4K | 4761 | 9.887ms | 5.398ms | 1.83x |
+
+Speedup promedio: 1.79x
+
+## Resultados del prefix cache
+
+### Prefix cache (M4 Max, 128GB)
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | ✓
+  1b     | Same prompt         | HIT      | HIT    | ✓
+  1c     | Different prompt    | MISS     | MISS   | ✓
+  1d     | Return to prompt 1  | HIT      | HIT    | ✓
+======================================================================
+```
+
+### Prefix cache (M1 Max, 64GB)
+
+| Test | Expected | Actual | Time | Status |
+|------|----------|--------|------|--------|
+| First request | MISS | MISS | 203.5ms | PASS |
+| Same prompt | HIT | HIT | 131.6ms | PASS |
+| Different prompt | MISS or PREFIX_HIT | PREFIX_HIT (5 tok) | 135.3ms | PASS |
+
+Estadísticas finales del cache:
+
+| Cache Hits | Cache Misses | Hit Rate | Tokens Saved | Cached Speedup |
+|------------|--------------|----------|--------------|----------------|
+| 2 | 1 | 66.7% | 20 | 1.55x |
+
+## Resultados del paged cache
+
+*Prueba: 20 solicitudes de inferencia reales en 2 rondas con un system prompt compartido de aproximadamente 286 tokens*
+
+```
+======================================================================
+  PAGED KV CACHE - REAL INFERENCE TEST
+======================================================================
+
+--------------------------------------------------
+Test 1: WITHOUT Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.47s
+  Throughput: 681.2 tok/s
+  Cache hits: 0
+  Tokens saved: 0
+
+--------------------------------------------------
+Test 2: WITH Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.31s
+  Throughput: 765.8 tok/s
+
+  Paged Cache Stats:
+    Blocks allocated: 25
+    Shared blocks: 4
+    Cache hits: 10
+    Tokens saved: 2560
+
+==================================================
+SUMMARY
+==================================================
+  Without paged cache: 681.2 tok/s
+  With paged cache:    765.8 tok/s
+
+  Speedup: 1.12x
+  Cache hits: 10 (all Round 2 requests)
+  Tokens saved: 2,560 (~256 tokens × 10 requests)
+==================================================
+```
+
+### Paged KV cache (M1 Max, 64GB)
+
+Benchmark de inferencia (20 solicitudes):
+
+| Mode | Time (s) | Throughput (tok/s) |
+|------|----------|--------------------|
+| Without paged cache | 3.43 | 291.8 |
+| With paged cache | 3.42 | 292.2 |
+
+| Speedup | Blocks Allocated | Shared Blocks | Cache Hits | Tokens Saved |
+|---------|------------------|---------------|------------|--------------|
+| 1.00x | 45 | 4 | 10 | 2560 |
+
+Inferencia concurrente real (20 solicitudes):
+
+| Mode | Time (s) | Throughput (tok/s) |
+|------|----------|--------------------|
+| Without paged cache | 4.32 | 231.7 |
+| With paged cache | 4.35 | 229.7 |
+
+| Speedup | Blocks Allocated | Shared Blocks | Cache Hits | Tokens Saved |
+|---------|------------------|---------------|------------|--------------|
+| 0.99x | 49 | 8 | 10 | 5120 |
+
+Demostración de ahorro de memoria:
+
+| Scenario | Memory Savings |
+|----------|----------------|
+| Shared system prompts | 70.8% |
+| Concurrent memory efficiency | 83.5% |
+| Prefix sharing branches | 38.5% |
+
+## Análisis del detokenizador en streaming
+
+*Investigación Fase 9.1: `BPEStreamingDetokenizer` de mlx-lm vs `tokenizer.decode()` naive*
+
+### Contexto
+
+El enfoque naive llama a `decode([token])` por cada token. En teoria, los detokenizadores en streaming ofrecen complejidad O(T) frente a O(T²) del decode naive.
+
+### Resultados del benchmark aislado
+
+```bash
+vllm-mlx bench-detok
+```
+
+Al reutilizar la misma instancia del detokenizador (con `reset()` entre usos):
+
+| Sequence | Tokens | Naive decode() | Streaming | Speedup |
+|----------|--------|----------------|-----------|---------|
+| Short | 8 | 0.020ms | 0.019ms | 1.05x |
+| Medium | 103 | 0.155ms | 0.097ms | 1.59x |
+| Long | 511 | 0.752ms | 0.371ms | **2.03x** |
+| 1K tokens | 1191 | 1.743ms | 0.833ms | **2.09x** |
+| 2K tokens | 2381 | 3.493ms | 1.737ms | **2.01x** |
+
+### Hallazgo clave: costo de creación de instancias
+
+Crear una nueva instancia de `BPEStreamingDetokenizer` es **extremadamente costoso**:
+
+```
+100 tokenizer.detokenizer calls: 5.266s (52.7ms each!)
+```
+
+Esto significa que crear un nuevo detokenizador por solicitud agrega **aproximadamente 52ms de sobrecarga**, anulando cualquier beneficio.
+
+### Impacto en uso real
+
+Al integrarlo en el scheduler (un detokenizador por solicitud):
+
+| Metric | Naive decode() | Streaming (new instance) |
+|--------|----------------|--------------------------|
+| Throughput (20 req) | 681 tok/s | 275 tok/s |
+| Impact | - | **-60% slower** |
+
+### Conclusión
+
+El detokenizador en streaming **no es viable actualmente** para uso por solicitud, debido al costo de creación de instancias. El enfoque naive con `decode([token])` sigue siendo más rápido en la práctica.
+
+**Optimizacion futura**: crear un pool de instancias de detokenizador al inicio y reutilizarlas entre solicitudes.
+
+## Referencia de métricas
+
+| Metric | Description |
+|--------|-------------|
+| **TTFT** | Time to First Token: latencia hasta que el modelo comienza a responder (ms) |
+| **TPOT** | Time Per Output Token: tiempo entre cada token generado (ms/token) |
+| **Generation TPS** | Tokens de salida por segundo (tok/s) |
+| **Processing TPS** | Tokens de entrada/prompt procesados por segundo (tok/s) |
+| **End-to-End Latency** | Tiempo total desde la solicitud hasta la respuesta completa |
+| **Total Throughput** | Tokens totales (entrada + salida) por segundo |
+
+## Ejecutar benchmarks
+
+```bash
+# Basic benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# With more prompts
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --prompts 10
+
+# Save results
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+
+# Continuous batching test
+python tests/test_continuous_batching.py
+
+# Prefix cache test
+python tests/test_prefix_cache.py
+
+# Paged cache test
+python tests/test_paged_cache_real_inference.py
+
+# Streaming detokenizer benchmark
+vllm-mlx bench-detok
+vllm-mlx bench-detok mlx-community/Llama-3.2-1B-Instruct-4bit --iterations 5
+```

--- a/docs/es/benchmarks/video.md
+++ b/docs/es/benchmarks/video.md
@@ -1,0 +1,128 @@
+# Benchmarks de Video
+
+## Ejecutar Benchmarks de Video
+
+```bash
+# Benchmark completo (10 configuraciones, 2-64 fotogramas)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# Benchmark rápido (3 conteos de fotogramas)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --quick
+
+# Video personalizado
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --video-url https://example.com/video.mp4
+```
+
+## Resultados - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)
+
+| Configuration | Frames | Time | Tokens | Speed | Memory |
+|---------------|--------|------|--------|-------|--------|
+| 2 frames @ 0.5fps | 2 | 4.48s | 256 | 57.1 tok/s | 6.4 GB |
+| 4 frames @ 1fps | 4 | 4.65s | 256 | 55.0 tok/s | 6.4 GB |
+| 6 frames @ 1fps | 6 | 5.15s | 197 | 38.2 tok/s | 6.6 GB |
+| 8 frames @ 2fps | 8 | 6.45s | 240 | 37.2 tok/s | 6.8 GB |
+| 12 frames @ 2fps | 12 | 8.73s | 256 | 29.3 tok/s | 7.1 GB |
+| 16 frames @ 2fps | 16 | 10.96s | 256 | 23.4 tok/s | 7.6 GB |
+| 24 frames @ 4fps | 24 | 14.95s | 226 | 15.1 tok/s | 8.4 GB |
+| 32 frames @ 4fps | 32 | 20.00s | 256 | 12.8 tok/s | 9.2 GB |
+| 48 frames @ 8fps | 48 | 31.11s | 246 | 7.9 tok/s | 11.1 GB |
+| 64 frames @ 8fps | 64 | 59.81s | 256 | 4.3 tok/s | 12.9 GB |
+
+**Resumen:** Más rápido con 2 fotogramas (57.1 tok/s), más lento con 64 fotogramas (4.3 tok/s). La memoria escala de 6.4 GB a 12.9 GB.
+
+> **Nota:** 96 fotogramas o más provoca un timeout de GPU en la mayoría del hardware debido a los límites de memoria y cómputo.
+
+## Resultados - Qwen3-VL-8B-Instruct-4bit (M1 Max, 64GB)
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 8.84s | 256 | 29.0 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 13.05s | 256 | 19.6 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 21.60s | 256 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 43.48 | 768 | 17.7 |
+
+## Resultados - Qwen3-VL-4B-Instruct-3bit (M1 Max, 64GB)
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 5.09s | 150 | 29.5 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 8.36s | 150 | 17.9 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 15.21s | 150 | 9.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 28.66 | 450 | 15.7 |
+
+## Resultados de Caché de Video
+
+```
+----------------------------------------------------------------------
+  TEST 4: Video Cache - fps/max_frames in Cache Key
+----------------------------------------------------------------------
+    Config: fps=2.0, max_frames=16
+
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    4a     | Video first request       | MISS     | MISS   | 0.03ms | ✓
+    4b     | Same video+params         | HIT      | HIT    | 0.14ms | ✓
+    4c     | Different fps (4.0)       | MISS     | MISS   | 0.01ms | ✓
+    4d     | Different max_frames (32) | MISS     | MISS   | 0.01ms | ✓
+    4.0.5a | fps=0.5 first             | MISS     | MISS   | 0.01ms | ✓
+    4.0.5b | fps=0.5 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.1.0a | fps=1.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.1.0b | fps=1.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.2.0a | fps=2.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.2.0b | fps=2.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.4.0a | fps=4.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.4.0b | fps=4.0 cached            | HIT      | HIT    | 0.14ms | ✓
+
+----------------------------------------------------------------------
+  TEST 5: Additional Videos
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    5a     | Video 1 first             | MISS     | MISS   | 0.01ms | ✓
+    5b     | Video 2 first             | MISS     | MISS   | 0.01ms | ✓
+    5c     | Video 1 cached            | HIT      | HIT    | 0.13ms | ✓
+    5d     | Video 2 cached            | HIT      | HIT    | 0.13ms | ✓
+```
+
+## Estrategia de Clave de Caché
+
+- **Videos**: `hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+El mismo video con los mismos valores de fps, max_frames y prompt utilizará la caché. Cambiar cualquier parámetro genera un miss.
+
+## Consejos de Rendimiento
+
+- Menor FPS = procesamiento más rápido
+- Menos fotogramas = menor uso de memoria
+- 64 fotogramas es el máximo práctico
+- 96 fotogramas o más provoca un timeout de GPU
+
+## Extracción de Fotogramas
+
+| FPS | 10s Video | 30s Video | 60s Video |
+|-----|-----------|-----------|-----------|
+| 0.5 | 5 frames | 15 frames | 30 frames |
+| 1.0 | 10 frames | 30 frames | 60 frames |
+| 2.0 | 20 frames | 60 frames | 120 frames* |
+| 4.0 | 40 frames | 120 frames* | 240 frames* |
+
+*Puede alcanzar el límite de `max_frames`
+
+## Referencia de Métricas
+
+| Metric | Description |
+|--------|-------------|
+| Configuration | Configuración de FPS y fotogramas máximos |
+| Frames | Fotogramas extraídos realmente |
+| Time | Tiempo total de generación |
+| Tokens | Tokens de salida generados |
+| Speed | Tokens por segundo (tok/s) |
+| Memory | Uso de memoria GPU |

--- a/docs/es/getting-started/installation.md
+++ b/docs/es/getting-started/installation.md
@@ -1,0 +1,89 @@
+# Instalacion
+
+## Requisitos
+
+- macOS en Apple Silicon (M1/M2/M3/M4)
+- Python 3.10+
+
+## Instalar con uv (Recomendado)
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+uv pip install -e .
+```
+
+## Instalar con pip
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+pip install -e .
+```
+
+### Opcional: Soporte para vision
+
+Para procesamiento de video con transformers:
+
+```bash
+pip install -e ".[vision]"
+```
+
+### Opcional: Soporte de audio (STT/TTS)
+
+```bash
+pip install mlx-audio
+```
+
+### Opcional: Embeddings
+
+```bash
+pip install mlx-embeddings
+```
+
+## Que se instala
+
+- `mlx`, `mlx-lm`, `mlx-vlm` - Framework MLX y bibliotecas de modelos
+- `transformers`, `tokenizers` - Bibliotecas de HuggingFace
+- `opencv-python` - Procesamiento de video
+- `gradio` - Interfaz de chat
+- `psutil` - Monitoreo de recursos
+- `mlx-audio` (opcional) - Speech-to-Text y Text-to-Speech
+- `mlx-embeddings` (opcional) - Text embeddings
+
+## Verificar la instalacion
+
+```bash
+# Verificar comandos CLI
+vllm-mlx --help
+vllm-mlx-bench --help
+vllm-mlx-chat --help
+
+# Probar con un modelo pequeño
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 1
+```
+
+## Solucion de problemas
+
+### MLX no encontrado
+
+Asegurate de estar en Apple Silicon:
+```bash
+uname -m  # Should output "arm64"
+```
+
+### Fallo en la descarga del modelo
+
+Verifica tu conexion a internet y el acceso a HuggingFace. Algunos modelos requieren autenticacion:
+```bash
+huggingface-cli login
+```
+
+### Sin memoria
+
+Usa un modelo cuantizado más pequeno:
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
+```

--- a/docs/es/getting-started/quickstart.md
+++ b/docs/es/getting-started/quickstart.md
@@ -1,0 +1,133 @@
+# Inicio rápido
+
+## Opción 1: Servidor compatible con OpenAI
+
+Inicia el servidor:
+
+```bash
+# Simple mode - maximum throughput for single user
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# Continuous batching - for multiple concurrent users
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+Úsalo con el SDK de Python de OpenAI:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="mlx-community/Llama-3.2-3B-Instruct-4bit",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+O con curl:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## Opción 2: API de Python directa
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+
+# Streaming
+for chunk in model.stream_generate("Tell me a story"):
+    print(chunk.text, end="", flush=True)
+```
+
+## Opción 3: Interfaz de chat con Gradio
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+Abre una interfaz web en http://localhost:7860
+
+## Modelos multimodales
+
+Para comprensión de imágenes y video, usa un modelo VLM:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+```
+
+## Modelos de razonamiento
+
+Separa el proceso de pensamiento del modelo de la respuesta final:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+print(response.choices[0].message.content)  # Final answer
+```
+
+## Embeddings
+
+Genera embeddings de texto para búsqueda semántica y RAG:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+```
+
+## Tool Calling
+
+Habilita la llamada a funciones con cualquier modelo compatible:
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+## Próximos pasos
+
+- [Guía del servidor](../guides/server.md) - Configuración completa del servidor
+- [API de Python](../guides/python-api.md) - Uso directo de la API
+- [Guía multimodal](../guides/multimodal.md) - Imágenes y video
+- [Guía de audio](../guides/audio.md) - Speech-to-Text y Text-to-Speech
+- [Guía de embeddings](../guides/embeddings.md) - Embeddings de texto
+- [Modelos de razonamiento](../guides/reasoning.md) - Modelos con pensamiento
+- [Tool Calling](../guides/tool-calling.md) - Llamada a funciones
+- [Modelos compatibles](../reference/models.md) - Modelos disponibles

--- a/docs/es/guides/audio.md
+++ b/docs/es/guides/audio.md
@@ -1,0 +1,524 @@
+# Soporte de Audio
+
+vllm-mlx soporta el procesamiento de audio mediante [mlx-audio](https://github.com/Blaizzy/mlx-audio), y ofrece:
+
+- **STT (Speech-to-Text)**: Whisper, Parakeet
+- **TTS (Text-to-Speech)**: Kokoro, Chatterbox, VibeVoice, VoxCPM
+- **Procesamiento de audio**: SAM-Audio (separación de voz)
+
+## Instalación
+
+```bash
+# Soporte de audio principal
+pip install mlx-audio>=0.2.9
+
+# Dependencias requeridas para TTS
+pip install sounddevice soundfile scipy numba tiktoken misaki spacy num2words loguru phonemizer
+
+# Descargar el modelo de inglés de spacy
+python -m spacy download en_core_web_sm
+
+# Para TTS en idiomas distintos al inglés (español, francés, etc.), instalar espeak-ng:
+# macOS
+brew install espeak-ng
+
+# Ubuntu/Debian
+# sudo apt-get install espeak-ng
+```
+
+O instalar todas las dependencias de audio de una sola vez:
+
+```bash
+pip install vllm-mlx[audio]
+python -m spacy download en_core_web_sm
+brew install espeak-ng  # macOS, para idiomas distintos al inglés
+```
+
+## Inicio Rápido
+
+### Speech-to-Text (Transcripción)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Transcribir un archivo de audio
+with open("audio.mp3", "rb") as f:
+    transcript = client.audio.transcriptions.create(
+        model="whisper-large-v3",
+        file=f,
+        language="en"  # opcional
+    )
+print(transcript.text)
+```
+
+### Text-to-Speech (Generación)
+
+```python
+# Generar voz
+audio = client.audio.speech.create(
+    model="kokoro",
+    input="Hello, how are you?",
+    voice="af_heart",
+    speed=1.0
+)
+
+# Guardar en archivo
+with open("output.wav", "wb") as f:
+    f.write(audio.content)
+```
+
+### Separación de Voz (SAM-Audio)
+
+Aislar la voz del ruido de fondo, música u otros sonidos:
+
+```python
+from vllm_mlx.audio import AudioProcessor
+
+# Cargar el modelo SAM-Audio
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+
+# Separar el habla del audio
+result = processor.separate("meeting_with_music.mp3", description="speech")
+
+# Guardar la voz aislada y el fondo
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background_only.wav")
+```
+
+**Ejemplo de CLI:**
+```bash
+python examples/audio_separation_example.py meeting.mp3 --play
+python examples/audio_separation_example.py song.mp3 --description music -o music.wav
+```
+
+### Demo de Separación de Batería
+
+Aislar la batería de una canción de rock usando SAM-Audio:
+
+| Audio | Descripción | Escuchar |
+|-------|-------------|----------|
+| Original | "Get Ready" de David Fesliyan (30s, libre de regalías) | [🎵 rock_get_ready.mp3](../../../examples/rock_get_ready.mp3) |
+| Batería aislada | Batería extraída por SAM-Audio | [🥁 drums_isolated.wav](../../../examples/drums_isolated.wav) |
+| Sin batería | Pista con la batería eliminada | [🎸 rock_no_drums.wav](../../../examples/rock_no_drums.wav) |
+
+```bash
+# Aislar la batería de una canción de rock
+python examples/audio_separation_example.py examples/rock_get_ready.mp3 \
+  --description "drums" \
+  --output drums_isolated.wav \
+  --background rock_no_drums.wav
+```
+
+**Rendimiento:** 30 segundos de audio procesados en ~20 segundos en M4 Max.
+
+## Modelos Soportados
+
+### Modelos STT (Speech-to-Text)
+
+| Modelo | Alias | Idiomas | Velocidad | Calidad |
+|--------|-------|---------|-----------|---------|
+| `mlx-community/whisper-large-v3-mlx` | `whisper-large-v3` | 99+ | Media | Mejor |
+| `mlx-community/whisper-large-v3-turbo` | `whisper-large-v3-turbo` | 99+ | Rápida | Muy buena |
+| `mlx-community/whisper-medium-mlx` | `whisper-medium` | 99+ | Rápida | Buena |
+| `mlx-community/whisper-small-mlx` | `whisper-small` | 99+ | Muy rápida | Aceptable |
+| `mlx-community/parakeet-tdt-0.6b-v2` | `parakeet` | Inglés | La más rápida | Muy buena |
+| `mlx-community/parakeet-tdt-0.6b-v3` | `parakeet-v3` | Inglés | La más rápida | Mejor |
+
+**Recomendación:**
+- Multilingüe: `whisper-large-v3`
+- Solo inglés: `parakeet` (3x más rápido)
+
+### Modelos TTS (Text-to-Speech)
+
+#### Kokoro (Rápido y ligero) - Recomendado
+
+| Modelo | Alias | Tamaño | Idiomas |
+|--------|-------|--------|---------|
+| `mlx-community/Kokoro-82M-bf16` | `kokoro` | 82M | EN, ES, FR, JA, ZH, HI, IT, PT |
+| `mlx-community/Kokoro-82M-4bit` | `kokoro-4bit` | 82M | EN, ES, FR, JA, ZH, HI, IT, PT |
+
+**Voces (11):**
+- Femenino estadounidense: `af_heart`, `af_bella`, `af_nicole`, `af_sarah`, `af_sky`
+- Masculino estadounidense: `am_adam`, `am_michael`
+- Femenino británico: `bf_emma`, `bf_isabella`
+- Masculino británico: `bm_george`, `bm_lewis`
+
+**Códigos de idioma:**
+| Código | Idioma | Código | Idioma |
+|--------|--------|--------|--------|
+| `a` / `en` | English (US) | `e` / `es` | Español |
+| `b` / `en-gb` | English (UK) | `f` / `fr` | Français |
+| `j` / `ja` | 日本語 | `z` / `zh` | 中文 |
+| `i` / `it` | Italiano | `p` / `pt` | Português |
+| `h` / `hi` | हिन्दी | | |
+
+#### Chatterbox (Multilingüe y expresivo)
+
+| Modelo | Alias | Tamaño | Idiomas |
+|--------|-------|--------|---------|
+| `mlx-community/chatterbox-turbo-fp16` | `chatterbox` | 134M | 15+ idiomas |
+| `mlx-community/chatterbox-turbo-4bit` | `chatterbox-4bit` | 134M | 15+ idiomas |
+
+**Idiomas soportados:** EN, ES, FR, DE, IT, PT, RU, JA, ZH, KO, AR, HI, NL, PL, TR
+
+#### VibeVoice (Tiempo real)
+
+| Modelo | Alias | Tamaño | Caso de uso |
+|--------|-------|--------|-------------|
+| `mlx-community/VibeVoice-Realtime-0.5B-4bit` | `vibevoice` | 200M | Baja latencia, inglés |
+
+#### VoxCPM (Chino/Inglés)
+
+| Modelo | Alias | Tamaño | Idiomas |
+|--------|-------|--------|---------|
+| `mlx-community/VoxCPM1.5` | `voxcpm` | 0.9B | ZH, EN |
+| `mlx-community/VoxCPM1.5-4bit` | `voxcpm-4bit` | 200M | ZH, EN |
+
+### Modelos de Procesamiento de Audio
+
+#### SAM-Audio (Separación de Voz)
+
+| Modelo | Tamaño | Caso de uso |
+|--------|--------|-------------|
+| `mlx-community/sam-audio-large-fp16` | 3B | Mejor calidad |
+| `mlx-community/sam-audio-large` | 3B | Estándar |
+| `mlx-community/sam-audio-small-fp16` | 0.6B | Rápido |
+| `mlx-community/sam-audio-small` | 0.6B | Ligero |
+
+## Referencia de API
+
+### POST /v1/audio/transcriptions
+
+Transcribir audio a texto (compatible con la API OpenAI Whisper).
+
+**Parámetros:**
+- `file`: Archivo de audio (mp3, wav, m4a, webm)
+- `model`: Nombre o alias del modelo
+- `language`: Código de idioma (opcional, se detecta automáticamente)
+- `response_format`: `json` o `text`
+
+**Límites:**
+- Tamaño máximo de carga por defecto: 25 MiB
+- Se puede ajustar con `--max-audio-upload-mb`
+
+**Ejemplo:**
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@audio.mp3 \
+  -F model=whisper-large-v3
+```
+
+### POST /v1/audio/speech
+
+Generar voz a partir de texto (compatible con la API OpenAI TTS).
+
+**Parámetros:**
+- `model`: Nombre o alias del modelo
+- `input`: Texto a sintetizar
+- `voice`: ID de la voz
+- `speed`: Velocidad del habla (0.5 a 2.0)
+- `response_format`: `wav`, `mp3`
+
+**Límites:**
+- Límite de entrada por defecto: 4096 caracteres
+- Se puede ajustar con `--max-tts-input-chars`
+
+**Ejemplo:**
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart"}' \
+  -H "Content-Type: application/json" \
+  --output speech.wav
+```
+
+### GET /v1/audio/voices
+
+Listar las voces disponibles para un modelo.
+
+**Ejemplo:**
+```bash
+curl http://localhost:8000/v1/audio/voices?model=kokoro
+```
+
+## Ejemplos de CLI
+
+### Transcripción en Vivo / Subtítulos
+
+Transcripción de voz a texto en tiempo real desde el micrófono:
+
+```bash
+# Subtítulos con whisper-large-v3 (mejor calidad)
+python examples/closed_captions.py --language es --chunk 5
+
+# Modelo más rápido para menor latencia
+python examples/closed_captions.py --language en --model whisper-turbo --chunk 3
+
+# Transcripción básica por micrófono (grabar y luego transcribir)
+python examples/mic_transcribe.py --language es
+
+# Transcripción en fragmentos en tiempo real
+python examples/mic_realtime.py --language es --chunk 3
+
+# Transcripción en vivo con detección de actividad de voz
+python examples/mic_live.py --language es
+```
+
+**Requisitos:**
+```bash
+pip install sounddevice soundfile numpy
+```
+
+### TTS Básico
+
+```bash
+# Ejemplo simple de TTS
+python examples/tts_example.py "Hello, how are you?" --play
+
+# Con una voz diferente
+python examples/tts_example.py "Hello!" --voice am_michael --play
+
+# Guardar en archivo
+python examples/tts_example.py "Welcome to the demo" -o greeting.wav
+
+# Listar las voces disponibles
+python examples/tts_example.py --list-voices
+```
+
+### TTS Multilingüe
+
+```bash
+# Inglés (selecciona automáticamente el mejor modelo)
+python examples/tts_multilingual.py "Hello world" --play
+
+# Español
+python examples/tts_multilingual.py "Hola mundo" --lang es --play
+
+# Francés
+python examples/tts_multilingual.py "Bonjour le monde" --lang fr --play
+
+# Japonés
+python examples/tts_multilingual.py "こんにちは" --lang ja --play
+
+# Chino
+python examples/tts_multilingual.py "你好世界" --lang zh --play
+
+# Usar un modelo específico
+python examples/tts_multilingual.py "Hello" --model chatterbox --play
+
+# Listar todos los modelos
+python examples/tts_multilingual.py --list-models
+
+# Listar todos los idiomas
+python examples/tts_multilingual.py --list-languages
+```
+
+### Ejemplos de Asistente de Voz para Negocios
+
+Muestras de voz pregeneradas con **voces nativas** para casos de uso empresariales comunes:
+
+| Idioma | Voz | Mensaje | Escuchar |
+|--------|-----|---------|----------|
+| 🇺🇸 Inglés | af_heart | "Welcome to First National Bank. How may I assist you today?" | [▶️ assistant_bank_en.wav](../../../examples/assistant_bank_en.wav) |
+| 🇪🇸 Español | ef_dora | "Gracias por llamar a servicio al cliente. Un agente le atenderá pronto." | [▶️ assistant_service_es.wav](../../../examples/assistant_service_es.wav) |
+| 🇫🇷 Francés | ff_siwis | "Bienvenue. Votre appel est important pour nous." | [▶️ assistant_callcenter_fr.wav](../../../examples/assistant_callcenter_fr.wav) |
+| 🇨🇳 Chino | zf_xiaobei | "欢迎致电技术支持中心。我们将竭诚为您服务。" | [▶️ assistant_support_zh.wav](../../../examples/assistant_support_zh.wav) |
+
+**Genera tus propias muestras con voces nativas:**
+```bash
+# Inglés - Asistente bancario (voz nativa: af_heart)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Welcome to First National Bank. How may I assist you today?" \
+  --voice af_heart --lang_code a --file_prefix assistant_bank_en
+
+# Español - Atención al cliente (voz nativa: ef_dora)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Gracias por llamar a servicio al cliente. Un agente le atendera pronto." \
+  --voice ef_dora --lang_code e --file_prefix assistant_service_es
+
+# Francés - Centro de llamadas (voz nativa: ff_siwis)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Bienvenue. Votre appel est important pour nous." \
+  --voice ff_siwis --lang_code f --file_prefix assistant_callcenter_fr
+
+# Chino - Soporte técnico (voz nativa: zf_xiaobei)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "欢迎致电技术支持中心。我们将竭诚为您服务。" \
+  --voice zf_xiaobei --lang_code z --file_prefix assistant_support_zh
+```
+
+### Referencia de Voces Nativas
+
+| Idioma | Código | Voces |
+|--------|--------|-------|
+| English (US) | `a` | af_heart, af_bella, af_nicole, am_adam, am_michael |
+| English (UK) | `b` | bf_emma, bf_isabella, bm_george, bm_lewis |
+| Español | `e` | ef_dora, em_alex, em_santa |
+| Français | `f` | ff_siwis |
+| 中文 | `z` | zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zm_yunjian, zm_yunxi |
+| 日本語 | `j` | jf_alpha, jf_gongitsune, jm_kumo |
+| Italiano | `i` | if_sara, im_nicola |
+| Português | `p` | pf_dora, pm_alex |
+| हिन्दी | `h` | hf_alpha, hf_beta, hm_omega |
+
+## API de Python
+
+### Uso Directo (sin servidor)
+
+```python
+from vllm_mlx.audio import STTEngine, TTSEngine, AudioProcessor
+
+# Speech-to-Text
+stt = STTEngine("mlx-community/whisper-large-v3-mlx")
+stt.load()
+result = stt.transcribe("audio.mp3")
+print(result.text)
+
+# Text-to-Speech
+tts = TTSEngine("mlx-community/Kokoro-82M-bf16")
+tts.load()
+audio = tts.generate("Hello world", voice="af_heart")
+tts.save(audio, "output.wav")
+
+# Separación de voz
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+result = processor.separate("mixed_audio.mp3", description="speech")
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background.wav")
+```
+
+### Funciones de Conveniencia
+
+```python
+from vllm_mlx.audio import transcribe_audio, generate_speech, separate_voice
+
+# Transcripción rápida
+result = transcribe_audio("audio.mp3")
+print(result.text)
+
+# TTS rápido
+audio = generate_speech("Hello world", voice="af_heart")
+
+# Separación de voz rápida
+voice, background = separate_voice("mixed.mp3")
+```
+
+## Audio en el Chat
+
+Incluir audio en mensajes de chat (se transcribe automáticamente):
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Summarize this audio"},
+            {"type": "audio_url", "audio_url": {"url": "file://meeting.mp3"}}
+        ]
+    }]
+)
+```
+
+## Benchmarks
+
+Probado en Apple M2 Max (32GB).
+
+### Benchmarks de TTS (Kokoro-82M-bf16)
+
+| Longitud del texto | Duración del audio | Tiempo de generación | RTF | Chars/seg |
+|--------------------|--------------------|----------------------|-----|-----------|
+| 25 chars | 1.95s | 0.43s | 4.6x | 58.5 |
+| 88 chars | 6.00s | 0.32s | 18.6x | 272.4 |
+| 117 chars | 7.92s | 0.27s | 29.0x | 427.4 |
+
+**Resumen:**
+- Tiempo de carga del modelo: ~1.0s
+- RTF promedio: **17.4x** (17 veces más rápido que en tiempo real)
+- Chars/seg promedio: **252.8**
+
+### Benchmarks de STT
+
+| Modelo | Tiempo de carga | Transcripción (audio de 6s) | RTF |
+|--------|-----------------|------------------------------|-----|
+| whisper-small | 0.25s | 0.20s | 30.2x |
+| whisper-medium | 18.1s | 0.38s | 15.5x |
+| whisper-large-v3 | ~30s | ~0.6s | ~10x |
+| parakeet | ~0.5s | ~0.15s | ~40x |
+
+**Notas:**
+- RTF (Real-Time Factor) indica cuántas veces más rápido que en tiempo real es el procesamiento
+- La primera carga incluye la descarga del modelo desde HuggingFace
+- Las cargas siguientes usan los modelos en caché
+
+### Recomendaciones por Caso de Uso
+
+| Caso de uso | Modelo recomendado | Motivo |
+|-------------|-------------------|--------|
+| STT en inglés rápido | `parakeet` | RTF de 40x, bajo consumo de memoria |
+| STT multilingüe | `whisper-large-v3` | 99+ idiomas |
+| STT de baja latencia | `whisper-small` | RTF de 30x, carga rápida |
+| TTS general | `kokoro` | RTF de 17x, buena calidad |
+| TTS con poca memoria | `kokoro-4bit` | Cuantizado a 4 bits |
+
+## Consejos de Rendimiento
+
+1. **Usa Parakeet para inglés**: 40x más rápido que en tiempo real
+2. **Usa modelos de 4 bits** para menor uso de memoria
+3. **Usa SAM-Audio small** para una separación de voz más rápida
+4. **Guarda los modelos en caché**: los motores se cargan de forma diferida y quedan en caché
+5. **Descarga los modelos previamente** para evitar la latencia en la primera ejecución
+
+## Solución de Problemas
+
+### mlx-audio no está instalado
+```
+pip install mlx-audio>=0.2.9
+```
+
+### La descarga del modelo es lenta
+Los modelos se descargan desde HuggingFace en el primer uso. Usa `huggingface-cli download` para descargarlos previamente:
+```bash
+huggingface-cli download mlx-community/whisper-large-v3-mlx
+huggingface-cli download mlx-community/Kokoro-82M-bf16
+```
+
+### Sin memoria suficiente
+Usa modelos más pequeños o versiones cuantizadas a 4 bits:
+- `whisper-small-mlx` en lugar de `whisper-large-v3-mlx`
+- `Kokoro-82M-4bit` en lugar de `Kokoro-82M-bf16`
+- `sam-audio-small` en lugar de `sam-audio-large`
+
+### Error multilingüe de Kokoro (mlx-audio 0.2.9)
+
+Si obtienes `ValueError: too many values to unpack` al usar idiomas distintos al inglés (español, chino, japonés, etc.) con Kokoro, aplica esta corrección:
+
+```python
+# Corrección para mlx_audio/tts/models/kokoro/pipeline.py línea 443
+# Cambia:
+#     ps, _ = self.g2p(chunk)
+# Por:
+g2p_result = self.g2p(chunk)
+ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result
+```
+
+**Corrección en una sola línea:**
+```bash
+python -c "
+import os
+path = os.path.join(os.path.dirname(__import__('mlx_audio').__file__), 'tts/models/kokoro/pipeline.py')
+with open(path, 'r') as f: content = f.read()
+old = '                    ps, _ = self.g2p(chunk)'
+new = '''                    # Fix: handle both tuple (en) and string (zh/ja/es) returns from g2p
+                    g2p_result = self.g2p(chunk)
+                    ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result'''
+if old in content:
+    with open(path, 'w') as f: f.write(content.replace(old, new))
+    print('Fix applied!')
+"
+```
+
+Este error ocurre porque el g2p para inglés devuelve una tupla `(phonemes, tokens)` mientras que otros idiomas devuelven solo una cadena de texto.

--- a/docs/es/guides/continuous-batching.md
+++ b/docs/es/guides/continuous-batching.md
@@ -1,0 +1,174 @@
+# Continuous Batching
+
+El continuous batching permite mayor throughput al servir múltiples usuarios concurrentes.
+
+## Activar Continuous Batching
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
+```
+
+## Con Paged Cache
+
+Para compartir prefijos de forma eficiente en memoria:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
+```
+
+## Cómo Funciona
+
+### Modo Simple (Predeterminado)
+- Una solicitud a la vez
+- Máximo throughput para un solo usuario
+- Sin sobrecarga por batching
+
+### Modo Continuous Batching
+- Múltiples solicitudes procesadas en conjunto
+- Mejor throughput para usuarios concurrentes
+- Pequeña sobrecarga por solicitud
+
+### Paged Cache
+- KV cache almacenado en bloques de tamaño fijo
+- Los system prompts compartidos usan los mismos bloques
+- Ahorro de memoria: 80% o más con 10 o más usuarios concurrentes
+
+## Resultados de Rendimiento
+
+**Resultados de Continuous Batching (M4 Max, 128GB):**
+
+| Modelo | Solicitud Individual | Batch (5 req) | Mejora |
+|--------|----------------------|---------------|--------|
+| Llama-3.2-1B-Instruct-4bit | 299.1 tok/s | 613.0 tok/s | **2.05x** |
+| Llama-3.2-3B-Instruct-4bit | 137.6 tok/s | 208.1 tok/s | **1.51x** |
+| Qwen3-0.6B-8bit | 328.1 tok/s | 1111.8 tok/s | **3.39x** |
+| Qwen3-30B-A3B-4bit | 98.1 tok/s | 233.3 tok/s | **2.38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196.9 tok/s | 322.2 tok/s | **1.64x** |
+
+*El batching de 5 solicitudes concurrentes muestra una mejora de throughput de 1.5 a 3 veces.*
+
+## Rendimiento en Streaming
+
+**Rendimiento de Streaming (M4 Max, 128GB):**
+
+| Modelo | TTFT | Velocidad de Generación |
+|--------|------|-------------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4.6ms | 218.9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10.7ms | 93.6 tok/s |
+| Qwen3-0.6B-8bit | ~3.0ms | 328.5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10.2ms | 98.4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7.1ms | 140.3 tok/s |
+
+*TTFT = Time to First Token*
+
+## Configuración de Streaming
+
+Controla la entrega de tokens con `--stream-interval`:
+
+```bash
+# Cada token (más fluido)
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# Tokens en batch (mejor para alta latencia)
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+| Valor | Comportamiento |
+|-------|----------------|
+| `1` | Envía cada token de inmediato |
+| `2-5` | Agrupa tokens antes de enviar |
+| `10+` | Máximo throughput, salida en fragmentos más grandes |
+
+## Gestión de Memoria
+
+En modelos grandes, el prefix cache puede consumir una cantidad significativa de memoria. El cache con gestión automática de memoria administra esto de forma transparente:
+
+```bash
+# Detección automática (usa el 20% de la RAM disponible)
+vllm-mlx serve model --continuous-batching
+
+# Límite explícito
+vllm-mlx serve model --continuous-batching --cache-memory-mb 2048
+
+# Porcentaje personalizado
+vllm-mlx serve model --continuous-batching --cache-memory-percent 0.10
+```
+
+| Opción | Descripción |
+|--------|-------------|
+| `--cache-memory-mb` | Establece un límite explícito en MB |
+| `--cache-memory-percent` | Fracción de la RAM disponible (predeterminado: 0.20) |
+| `--no-memory-aware-cache` | Usa el cache heredado basado en conteo de entradas |
+
+## Prefix Cache
+
+El prefix caching reutiliza el KV cache para prompts repetidos.
+
+### Cómo Funciona
+
+```
+User 1: System prompt (500 tokens) → Creates 8 blocks
+User 2: Same system prompt → Shares 8 blocks (ref_count++)
+User N: Same system prompt → Shares 8 blocks (ref_count++)
+
+Memory savings: 80%+ for 10+ concurrent users
+```
+
+### Estrategia de Clave de Cache
+
+- **LLM**: `hash(prompt)`
+- **Images**: `hash(image_content) + hash(prompt)`
+- **Videos**: `hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+### Probar el Prefix Cache
+
+```bash
+python tests/test_prefix_cache.py
+```
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS or PREFIX_HIT (shared template tokens)
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | PASS
+  1b     | Same prompt         | HIT      | HIT    | PASS
+  1c     | Different prompt    | MISS     | MISS   | PASS
+  1d     | Return to prompt 1  | HIT      | HIT    | PASS
+======================================================================
+```
+
+## Ejecutar Benchmarks
+
+```bash
+# Benchmark de continuous batching
+python tests/test_continuous_batching.py
+
+# Prueba de prefix cache
+python tests/test_prefix_cache.py
+```
+
+## Cuándo Usarlo
+
+| Escenario | Modo |
+|-----------|------|
+| Usuario individual, máxima velocidad | Simple (predeterminado) |
+| Múltiples usuarios concurrentes | `--continuous-batching` |
+| Modelos grandes (7B+) | `--continuous-batching --cache-memory-mb 2048` |
+| Producción con prompts compartidos | `--continuous-batching --use-paged-cache` |
+
+## Configuración para Producción
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+```

--- a/docs/es/guides/embeddings.md
+++ b/docs/es/guides/embeddings.md
@@ -1,0 +1,150 @@
+# Embeddings
+
+vllm-mlx soporta embeddings de texto usando [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings), y expone un endpoint `/v1/embeddings` compatible con OpenAI.
+
+## Instalacion
+
+```bash
+pip install mlx-embeddings>=0.0.5
+```
+
+## Inicio rápido
+
+### Iniciar el servidor con un modelo de embeddings
+
+```bash
+# Precarga un modelo de embeddings especifico al inicio
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+Si no se usa `--embedding-model`, el modelo de embeddings se carga de forma diferida en la primera solicitud, pero solo desde la lista de modelos permitidos en tiempo de solicitud.
+
+### Generar embeddings con el SDK de OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Texto individual
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+
+# Lote de textos
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input=[
+        "I love machine learning",
+        "Deep learning is fascinating",
+        "Natural language processing rocks"
+    ]
+)
+for item in response.data:
+    print(f"Text {item.index}: {len(item.embedding)} dimensions")
+```
+
+### Usando curl
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+    "input": ["Hello world", "How are you?"]
+  }'
+```
+
+## Modelos soportados
+
+Modelos disponibles en tiempo de solicitud:
+
+| Model | Use Case | Size |
+|-------|----------|------|
+| `mlx-community/all-MiniLM-L6-v2-4bit` | Fast, compact | Small |
+| `mlx-community/embeddinggemma-300m-6bit` | High quality | 300M |
+| `mlx-community/bge-large-en-v1.5-4bit` | Best for English | Large |
+| `mlx-community/multilingual-e5-small-mlx` | Multilingual retrieval | Small |
+| `mlx-community/multilingual-e5-large-mlx` | Multilingual retrieval | Large |
+| `mlx-community/bert-base-uncased-mlx` | General BERT baseline | Base |
+| `mlx-community/ModernBERT-base-mlx` | ModernBERT baseline | Base |
+
+Otros modelos de embeddings requieren `--embedding-model` al iniciar el servidor.
+
+## Gestion de modelos
+
+### Carga diferida
+
+Por defecto, el modelo de embeddings se carga en la primera solicitud a `/v1/embeddings`. Es posible cambiar entre los modelos permitidos en tiempo de solicitud, y el modelo anterior se descarga automaticamente.
+
+### Precarga al inicio
+
+Usa `--embedding-model` para cargar un modelo al iniciar el servidor. Cuando se establece esta opcion, solo ese modelo puede usarse para embeddings:
+
+```bash
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+Solicitar un modelo diferente devolvera un error 400.
+
+## Referencia de la API
+
+### POST /v1/embeddings
+
+Crea embeddings para los textos de entrada proporcionados.
+
+**Cuerpo de la solicitud:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | Yes | Supported embedding model ID, or the startup-pinned model when `--embedding-model` is used |
+| `input` | string or list[string] | Yes | Text(s) to embed |
+
+**Respuesta:**
+
+```json
+{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "index": 0, "embedding": [0.023, -0.982, ...]},
+    {"object": "embedding", "index": 1, "embedding": [0.112, -0.543, ...]}
+  ],
+  "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+  "usage": {"prompt_tokens": 12, "total_tokens": 12}
+}
+```
+
+## API de Python
+
+### Uso directo sin servidor
+
+```python
+from vllm_mlx.embedding import EmbeddingEngine
+
+engine = EmbeddingEngine("mlx-community/all-MiniLM-L6-v2-4bit")
+engine.load()
+
+vectors = engine.embed(["Hello world", "How are you?"])
+print(f"Dimensions: {len(vectors[0])}")
+
+tokens = engine.count_tokens(["Hello world"])
+print(f"Token count: {tokens}")
+```
+
+## Solucion de problemas
+
+### mlx-embeddings no esta instalado
+
+```
+pip install mlx-embeddings>=0.0.5
+```
+
+### Modelo no encontrado
+
+Asegurate de que el nombre del modelo coincida con alguno de los IDs permitidos en tiempo de solicitud, o inicia el servidor con `--embedding-model` para fijar un modelo personalizado. Puedes descargar los modelos soportados con anticipacion:
+
+```bash
+huggingface-cli download mlx-community/all-MiniLM-L6-v2-4bit
+```

--- a/docs/es/guides/mcp-tools.md
+++ b/docs/es/guides/mcp-tools.md
@@ -1,0 +1,405 @@
+# MCP y Tool Calling
+
+vllm-mlx soporta el Model Context Protocol (MCP) para integrar herramientas externas con LLMs.
+
+## Como funciona el tool calling
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Tool Calling Flow                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  1. User Request                                                    │
+│     ─────────────────►  "List files in /tmp"                       │
+│                                                                     │
+│  2. LLM Generates Tool Call                                         │
+│     ─────────────────►  tool_calls: [{                             │
+│                           name: "list_directory",                   │
+│                           arguments: {path: "/tmp"}                 │
+│                         }]                                          │
+│                                                                     │
+│  3. App Executes Tool via MCP                                       │
+│     ─────────────────►  MCP Server executes list_directory         │
+│                         Returns: ["file1.txt", "file2.txt"]        │
+│                                                                     │
+│  4. Tool Result Sent Back to LLM                                    │
+│     ─────────────────►  role: "tool", content: [...]               │
+│                                                                     │
+│  5. LLM Generates Final Response                                    │
+│     ─────────────────►  "The /tmp directory contains 2 files..."   │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Inicio rápido
+
+### 1. Crear la configuración de MCP
+
+Crea el archivo `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### 2. Iniciar el servidor con MCP
+
+```bash
+# Modo simple
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# Continuous batching
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
+```
+
+### 3. Verificar el estado de MCP
+
+```bash
+# Verificar estado de MCP
+curl http://localhost:8000/v1/mcp/status
+
+# Listar las herramientas disponibles
+curl http://localhost:8000/v1/mcp/tools
+```
+
+## Ejemplo de tool calling
+
+```python
+import json
+import httpx
+
+BASE_URL = "http://localhost:8000"
+
+# 1. Get available tools
+tools_response = httpx.get(f"{BASE_URL}/v1/mcp/tools")
+tools = tools_response.json()["tools"]
+
+# 2. Send request with tools
+response = httpx.post(
+    f"{BASE_URL}/v1/chat/completions",
+    json={
+        "model": "default",
+        "messages": [{"role": "user", "content": "List files in /tmp"}],
+        "tools": tools,
+        "max_tokens": 1024
+    }
+)
+
+result = response.json()
+message = result["choices"][0]["message"]
+
+# 3. Check for tool calls
+if message.get("tool_calls"):
+    tool_call = message["tool_calls"][0]
+
+    # 4. Execute tool via MCP
+    exec_response = httpx.post(
+        f"{BASE_URL}/v1/mcp/execute",
+        json={
+            "server": "filesystem",
+            "tool": tool_call["function"]["name"],
+            "arguments": json.loads(tool_call["function"]["arguments"])
+        }
+    )
+    tool_result = exec_response.json()
+
+    # 5. Send result back to LLM
+    messages = [
+        {"role": "user", "content": "List files in /tmp"},
+        message,
+        {
+            "role": "tool",
+            "tool_call_id": tool_call["id"],
+            "content": json.dumps(tool_result["result"])
+        }
+    ]
+
+    final_response = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        json={"model": "default", "messages": messages}
+    )
+    print(final_response.json()["choices"][0]["message"]["content"])
+```
+
+## Endpoints de MCP
+
+| Endpoint | Metodo | Descripcion |
+|----------|--------|-------------|
+| `/v1/mcp/status` | GET | Verificar el estado de MCP |
+| `/v1/mcp/tools` | GET | Listar las herramientas disponibles |
+| `/v1/mcp/execute` | POST | Ejecutar una herramienta |
+
+## Ejemplos de servidores MCP
+
+### Sistema de archivos
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### GitHub
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+### PostgreSQL
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost/db"
+      }
+    }
+  }
+}
+```
+
+### Brave Search
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "your-key"
+      }
+    }
+  }
+}
+```
+
+## Multiples servidores MCP
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+## Chat MCP interactivo
+
+Para probar MCP de forma interactiva:
+
+```bash
+python examples/mcp_chat.py
+```
+
+## Formatos de herramientas soportados
+
+vllm-mlx soporta 12 tool call parsers que cubren todas las familias de modelos principales. Consulta [Tool Calling](tool-calling.md) para ver la lista completa de parsers, alias y ejemplos.
+
+## Seguridad
+
+vllm-mlx incluye medidas de seguridad para prevenir ataques de inyeccion de comandos a traves de servidores MCP.
+
+### Lista blanca de comandos
+
+Solo se permiten comandos de confianza por defecto:
+
+| Categoria | Comandos permitidos |
+|----------|-----------------|
+| Node.js | `npx`, `npm`, `node` |
+| Python | `uvx`, `uv`, `python`, `python3`, `pip`, `pipx` |
+| Docker | `docker` |
+| Servidores MCP | `mcp-server-*` (servidores oficiales) |
+
+### Patrones bloqueados
+
+Los siguientes patrones estan bloqueados para prevenir ataques de inyeccion:
+
+- Encadenamiento de comandos: `;`, `&&`, `||`, `|`
+- Sustitucion de comandos: `` ` ``, `$()`
+- Recorrido de rutas: `../`
+- Variables de entorno peligrosas: `LD_PRELOAD`, `PATH`, `PYTHONPATH`
+
+### Ejemplo: ataque bloqueado
+
+```json
+{
+  "mcpServers": {
+    "malicious": {
+      "command": "bash",
+      "args": ["-c", "rm -rf /"]
+    }
+  }
+}
+```
+
+Esta configuración sera rechazada:
+```
+ValueError: MCP server 'malicious': Command 'bash' is not in the allowed commands whitelist.
+```
+
+### Modo de desarrollo (inseguro)
+
+Solo para desarrollo, es posible omitir la validación de seguridad:
+
+```json
+{
+  "mcpServers": {
+    "custom": {
+      "command": "my-custom-server",
+      "skip_security_validation": true
+    }
+  }
+}
+```
+
+**ADVERTENCIA**: nunca uses `skip_security_validation` en produccion.
+
+### Lista blanca personalizada
+
+Para agregar comandos personalizados a la lista blanca mediante código:
+
+```python
+from vllm_mlx.mcp import MCPCommandValidator, set_validator
+
+# Add custom commands
+validator = MCPCommandValidator(
+    custom_whitelist={"my-trusted-server", "another-server"}
+)
+set_validator(validator)
+```
+
+## Sandboxing de ejecución de herramientas
+
+Ademas de la validación de comandos, vllm-mlx ofrece sandboxing en tiempo de ejecución para las herramientas:
+
+### Caracteristicas del sandbox
+
+| Caracteristica | Descripcion |
+|---------|-------------|
+| Lista blanca de herramientas | Permite ejecutar solo herramientas especificas |
+| Lista negra de herramientas | Bloquea herramientas peligrosas especificas |
+| Validacion de argumentos | Bloquea patrones peligrosos en los argumentos de las herramientas |
+| Limite de frecuencia | Limita las llamadas a herramientas por minuto |
+| Registro de auditoria | Registra todas las ejecuciones de herramientas |
+
+### Patrones de argumentos bloqueados
+
+Los argumentos de las herramientas son validados para detectar patrones peligrosos:
+
+- Recorrido de rutas: `../`
+- Directorios del sistema: `/etc/`, `/proc/`, `/sys/`
+- Acceso root: `/root/`, `~root`
+
+### Deteccion de herramientas de alto riesgo
+
+Las herramientas que coincidan con estos patrones generan advertencias de seguridad:
+
+- `execute`, `run_command`, `shell`, `eval`, `exec`, `system`, `subprocess`
+
+### Configuracion personalizada del sandbox
+
+```python
+from vllm_mlx.mcp import ToolSandbox, set_sandbox
+
+# Create sandbox with custom settings
+sandbox = ToolSandbox(
+    # Only allow specific tools (whitelist mode)
+    allowed_tools={"read_file", "list_directory"},
+
+    # Block specific tools (blacklist mode)
+    blocked_tools={"execute_command", "run_shell"},
+
+    # Rate limit: max 30 calls per minute
+    max_calls_per_minute=30,
+
+    # Optional audit callback
+    audit_callback=lambda audit: print(f"Tool: {audit.tool_name}, Success: {audit.success}"),
+)
+set_sandbox(sandbox)
+```
+
+### Acceso a los registros de auditoria
+
+```python
+from vllm_mlx.mcp import get_sandbox
+
+sandbox = get_sandbox()
+
+# Get recent audit entries
+entries = sandbox.get_audit_log(limit=50)
+
+# Filter by tool name
+file_ops = sandbox.get_audit_log(tool_filter="file")
+
+# Get only errors
+errors = sandbox.get_audit_log(errors_only=True)
+
+# Clear audit log
+sandbox.clear_audit_log()
+```
+
+### Redaccion de datos sensibles
+
+Los registros de auditoria redactan automaticamente los campos sensibles (password, token, secret, key, credential, auth) y truncan los valores de gran tamano.
+
+## Solucion de problemas
+
+### El servidor MCP no se conecta
+
+Verifica que el comando del servidor MCP sea correcto:
+```bash
+npx -y @modelcontextprotocol/server-filesystem /tmp
+```
+
+### La herramienta no se ejecuta
+
+Verifica que la herramienta este disponible:
+```bash
+curl http://localhost:8000/v1/mcp/tools | jq '.tools[].name'
+```
+
+### La llamada a la herramienta no se analiza
+
+Asegurate de usar un modelo que soporte llamadas a funciones (Qwen3, Llama-3.2-Instruct).
+
+### El comando no esta en la lista blanca
+
+Si ves "Command X is not in the allowed commands whitelist", puedes:
+1. Usar un comando permitido (ver lista blanca arriba)
+2. Agregar el comando a una lista blanca personalizada
+3. Usar `skip_security_validation: true` (solo para desarrollo)

--- a/docs/es/guides/moe-top-k.md
+++ b/docs/es/guides/moe-top-k.md
@@ -1,0 +1,125 @@
+# MoE top_k override (`--moe-top-k`)
+
+Reduce el numero de experts activados por token en modelos Mixture of Experts
+como Qwen3-30B-A3B, intercambiando una pequeña cantidad de calidad por un
+aumento significativo en el throughput de decodificacion.
+
+> **Estado:** flag opt-in. El comportamiento por defecto no cambia. Los numeros
+> de calidad que se muestran son para Qwen3-30B-A3B-4bit en M4 Max 128 GB.
+> Verifica con tu modelo antes de usarlo en cargas de produccion.
+
+## Que hace
+
+Qwen3-30B-A3B se entrena con `top_k=8`. cada token selecciona 8 de 128
+experts. En Apple Silicon con batch=1 durante la decodificacion, la multiplicacion
+de matrices de experts (`SwitchGLU`) es la parte más costosa del computo por capa,
+y ese costo escala de forma aproximadamente lineal con `top_k`. Reducir `top_k`
+en tiempo de inferencia ha demostrado (LExI 2025, Lynx 2024) preservar la mayor
+parte de la calidad entrenada mientras reduce materialmente el tiempo de
+decodificacion.
+
+`--moe-top-k N` itera cada capa del modelo cargado y, en cada capa que tenga
+`.mlp.switch_mlp` (es decir, un bloque sparse-MoE), establece `top_k = N`. Las
+capas densas y los modelos densos no se modifican: el flag es un no-op para ellos.
+
+## Uso
+
+```bash
+# Server
+vllm-mlx serve mlx-community/Qwen3-30B-A3B-4bit \
+  --continuous-batching \
+  --moe-top-k 4
+
+# Bench
+vllm-mlx bench mlx-community/Qwen3-30B-A3B-4bit --moe-top-k 4
+```
+
+El flag se rechaza si `N` es mayor que el `top_k` entrenado del modelo
+(solo tiene sentido reducirlo, nunca aumentarlo).
+
+## Impacto medido
+
+### Throughput de decodificacion (M4 Max 128 GB, batch=1, greedy)
+
+| top_k | tok/s | vs baseline |
+|---:|---:|---:|
+| 8 (baseline) | 126.5 | - |
+| 6 | 136.1 | +7.6% |
+| 5 | 140.3 | +10.9% |
+| 4 | 147.3 | +16.5% |
+
+### Calidad (Qwen3-30B-A3B-4bit, lm-evaluation-harness, MLX backend)
+
+<!-- se completa cuando finaliza la evaluacion -->
+
+| top_k | MMLU (acc) | GSM8K (exact match) | Delta vs baseline |
+|---:|---:|---:|---:|
+| 8 | TBD | TBD | - |
+| 6 | TBD | TBD | TBD |
+| 5 | TBD | TBD | TBD |
+| 4 | TBD | TBD | TBD |
+
+MMLU: 200 muestras seleccionadas aleatoriamente, 0-shot.
+GSM8K: 100 muestras seleccionadas aleatoriamente, 0-shot, exact-match estricto.
+
+Estos numeros son **indicativos**: los conjuntos de evaluacion completos son
+más grandes y desplazarian la precision absoluta, pero no el delta relativo
+entre configuraciones de forma significativa.
+
+### Paridad de salida greedy
+
+Con `top_k=4` en el checkpoint de 4 bits observamos **los primeros 16 tokens
+generados identicos** al baseline en todos los prompts de prueba que usamos.
+Esto sugiere que top_k=4 no cambia el argmax en los pasos iniciales de
+decodificacion: el modelo es internamente robusto a eliminar la mitad de sus
+experts activados.
+
+Con `top_k=3` o menor, la calidad comenzaria a degradarse de forma visible
+(no medido aquí; inferido del paper LExI), por lo que el flag no permite bajar
+por debajo de 1 en la capa de validación de configuración. Sin embargo, el
+piso recomendado para produccion es `top_k=4`.
+
+## Cuando usarlo y cuando no
+
+Usalo cuando:
+- Ejecutas un Qwen3 MoE (o compatible: Qwen3.5 MoE, Gemma-MoE) y el throughput
+  de decodificacion con un solo usuario es tu cuello de botella.
+- Tienes una carga de trabajo donde una pequeña perdida de calidad es aceptable
+  a cambio de una mejora visible en latencia.
+- Despliegas en hardware limitado por ancho de banda de memoria (Apple Silicon
+  serie M) donde el gather de experts domina el tiempo de decodificacion por paso.
+
+No lo uses cuando:
+- Sirves modelos densos: el flag es un no-op y no aporta nada.
+- Te importa la precision en el top-1% de suites de evaluacion de leaderboard.
+- Ejecutas generaciones largas de chain-of-thought o "modo thinking", donde el
+  acantilado de calidad puede ser más pronunciado que lo que sugiere MMLU en 0-shot.
+
+## Combinacion con otras optimizaciones
+
+Este flag se compone con la cuantizacion. En Qwen3-30B-A3B-4bit nuestra
+combinacion medida es:
+
+- 4-bit + top_k=8: 126.5 tok/s (baseline)
+- 4-bit + top_k=4: 147.3 tok/s (+16.5%)
+- 3-bit + top_k=8: 138.6 tok/s (+9.6%)
+- 3-bit + top_k=6: 147.1 tok/s (+16.3%) . divergencia de calidad medible
+- 3-bit + top_k=4: 157.3 tok/s (+24%) . **la calidad de salida se rompe** (el modelo respondió una pregunta diferente en nuestra prueba de humo)
+
+3-bit + top_k=4 acumulo el error numérico más alla del punto donde el argmax
+es estable. Usa a lo sumo un parámetro agresivo: ya sea 4-bit + top_k=4
+o 3-bit + top_k=6. Ambos dan aproximadamente el mismo tok/s (~147) con perfiles
+de calidad muy distintos.
+
+## Internos
+
+- Helper de parcheo: `vllm_mlx.scheduler.apply_moe_top_k_override(model, k)`
+- Se aplica en `Scheduler.__init__` despues de cargar el modelo.
+- Tests: `tests/test_moe_top_k.py`. cubre modelos densos, arquitecturas mixtas
+  y rutas de validación.
+
+## Referencias
+
+- LExI: Layer-Adaptive Active Experts, [arXiv 2509.02753](https://arxiv.org/html/2509.02753)
+- Not All Experts are Equal (NAEE), [ACL 2024](https://aclanthology.org/2024.acl-long.334.pdf)
+- SwiftLM (`SWIFTLM_TOP_K` env knob prior art), [github.com/SharpAI/SwiftLM](https://github.com/SharpAI/SwiftLM)

--- a/docs/es/guides/multimodal.md
+++ b/docs/es/guides/multimodal.md
@@ -1,0 +1,315 @@
+# Modelos Multimodales (Imágenes y Video)
+
+vllm-mlx soporta modelos de visión y lenguaje (VLM) para el análisis de imágenes y video.
+
+## Modelos Soportados
+
+- Qwen3-VL (recomendado)
+- Qwen2-VL
+- Gemma 3
+- LLaVA
+- Idefics
+- PaliGemma
+- Pixtral
+- Molmo
+- DeepSeek-VL
+
+## Iniciar un Servidor Multimodal
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+Los modelos que contienen "VL", "Vision" o "mllm" en el nombre se detectan automáticamente como multimodales.
+
+## Análisis de Imágenes
+
+### Mediante el SDK de OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Imagen desde URL
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+print(response.choices[0].message.content)
+```
+
+### Imágenes en Base64
+
+```python
+import base64
+
+def encode_image(path):
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+base64_image = encode_image("photo.jpg")
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}}
+        ]
+    }]
+)
+```
+
+### Mediante curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+      ]
+    }],
+    "max_tokens": 256
+  }'
+```
+
+## Análisis de Video
+
+### Mediante el SDK de OpenAI
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What happens in this video?"},
+            {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+        ]
+    }],
+    max_tokens=512
+)
+```
+
+### Parámetros de Video
+
+Controla la extracción de fotogramas mediante parámetros adicionales en el cuerpo de la solicitud:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this video"},
+            {"type": "video_url", "video_url": {"url": "video.mp4"}}
+        ]
+    }],
+    extra_body={
+        "video_fps": 2.0,
+        "video_max_frames": 32
+    }
+)
+```
+
+### Mediante curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this video"},
+        {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+      ]
+    }],
+    "video_fps": 2.0,
+    "video_max_frames": 16
+  }'
+```
+
+## Formatos Soportados
+
+### Imágenes
+
+| Formato | Ejemplo |
+|--------|---------|
+| URL | `{"type": "image_url", "image_url": {"url": "https://..."}}` |
+| Archivo local | `{"type": "image_url", "image_url": {"url": "/path/to/image.jpg"}}` |
+| Base64 | `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}` |
+
+### Videos
+
+| Formato | Ejemplo |
+|--------|---------|
+| URL | `{"type": "video_url", "video_url": {"url": "https://..."}}` |
+| Archivo local | `{"type": "video", "video": "/path/to/video.mp4"}` |
+| Base64 | `{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}` |
+
+## API de Python
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Imagen
+description = mllm.describe_image("photo.jpg")
+
+# Video
+description = mllm.describe_video("video.mp4", fps=2.0)
+
+# Prompt personalizado
+output = mllm.generate(
+    prompt="Compare these images",
+    images=["img1.jpg", "img2.jpg"]
+)
+```
+
+## Consejos de Rendimiento
+
+### Imágenes
+- Las resoluciones menores se procesan más rápido (224x224 vs 1920x1080)
+- Usa la resolución adecuada para tu tarea
+
+### Videos
+- Menor FPS = procesamiento más rápido
+- Menos fotogramas = menor uso de memoria
+- 64 fotogramas es el máximo práctico (96 o más causa timeout en la GPU)
+
+## Benchmarks
+
+Probado en Apple M4 Max con 128 GB de memoria unificada.
+
+### Qwen3-VL-4B-Instruct-3bit
+
+| Resolución | Tiempo | Tokens | Velocidad | Memoria |
+|------------|------|--------|-------|--------|
+| 224x224 | 0.87s | 124 | 143 tok/s | 2.6 GB |
+| 448x448 | 1.01s | 107 | 106 tok/s | 3.1 GB |
+| 768x768 | 1.42s | 127 | 89 tok/s | 3.4 GB |
+| 1024x1024 | 1.85s | 116 | 63 tok/s | 3.6 GB |
+
+### Qwen3-VL-8B-Instruct-4bit
+
+| Resolución | Tiempo | Tokens | Velocidad | Memoria |
+|------------|------|--------|-------|--------|
+| 224x224 | 1.08s | 78 | 73 tok/s | 5.6 GB |
+| 448x448 | 1.41s | 70 | 50 tok/s | 6.1 GB |
+| 768x768 | 2.06s | 91 | 44 tok/s | 6.5 GB |
+| 1024x1024 | 3.02s | 76 | 25 tok/s | 7.6 GB |
+
+### Gemma 3 4B 4bit
+
+| Resolución | Tiempo | Tokens | Velocidad | Memoria |
+|------------|------|--------|-------|--------|
+| 224x224 | 0.95s | 30 | 32 tok/s | 5.2 GB |
+| 448x448 | 0.99s | 34 | 34 tok/s | 5.2 GB |
+| 768x768 | 0.99s | 32 | 32 tok/s | 5.2 GB |
+| 1024x1024 | 0.95s | 28 | 29 tok/s | 5.2 GB |
+
+### Ejecutar Benchmarks
+
+```bash
+# Benchmark rápido
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --quick
+
+# Benchmark completo con más resoluciones
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Benchmark de video
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --video
+```
+
+## MLLM Cache
+
+vllm-mlx incluye un sistema de prefix cache para modelos multimodales que puede acelerar significativamente las solicitudes repetidas con las mismas imágenes.
+
+### Cómo Funciona
+
+Cuando envías una imagen al modelo, el encoder de visión la procesa y genera embeddings. Este procesamiento toma entre 1 y 2 segundos. El MLLM cache almacena esos embeddings junto con el estado del KV cache, de modo que las solicitudes posteriores con la misma imagen omiten el encoder de visión por completo.
+
+El cache utiliza hashing basado en contenido (similar a LMCache) para identificar imágenes idénticas sin importar cómo se proporcionen (URL, base64 o ruta de archivo).
+
+### Habilitar el Cache
+
+```bash
+# Habilitar con configuración predeterminada (512 MB máximo)
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
+
+# Con límite de memoria personalizado
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
+    --enable-mllm-cache \
+    --mllm-cache-max-mb 1024
+```
+
+### API de Python
+
+```python
+from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
+
+# Crear el gestor de cache
+cache = MLLMPrefixCacheManager(max_memory_mb=512)
+
+# Almacenar embeddings y KV cache tras el procesamiento
+cache.store(
+    images=["photo.jpg"],
+    prompt="Describe this image",
+    vision_embeddings=embeddings,
+    kv_cache=kv_state,
+    num_tokens=128
+)
+
+# Recuperar del cache en solicitudes posteriores
+entry, match_len = cache.fetch(images=["photo.jpg"], prompt="Describe this image")
+if entry:
+    # Usar embeddings en cache, omitir el encoder de visión
+    embeddings = entry.vision_embeddings
+    kv_state = entry.kv_cache
+```
+
+### Estadísticas del Cache
+
+```python
+stats = cache.get_stats()
+print(f"Hit rate: {stats.hit_rate:.1%}")
+print(f"Memory used: {stats.memory_used_mb:.1f} MB")
+print(f"Tokens saved: {stats.tokens_saved}")
+```
+
+### Gestión de Memoria
+
+El cache utiliza evicción LRU (Least Recently Used) cuando se alcanza el límite de memoria. Cada entrada registra:
+
+- Tamaño de los embeddings de visión
+- Tamaño del KV cache por capa
+- Frecuencia de acceso para el ordenamiento LRU
+
+Cuando hay presión de memoria, las entradas con acceso menos reciente se evictan primero.
+
+## Gradio Chat UI
+
+Para chat multimodal interactivo:
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+```
+
+Soporta arrastrar y soltar imágenes y videos.

--- a/docs/es/guides/python-api.md
+++ b/docs/es/guides/python-api.md
@@ -1,0 +1,182 @@
+# Python API
+
+API de Python directa para acceso programático a vllm-mlx.
+
+## Modelos de lenguaje
+
+### Uso básico
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+# Load model
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+```
+
+### Generación con streaming
+
+```python
+for chunk in model.stream_generate("Tell me a story about a robot"):
+    print(chunk.text, end="", flush=True)
+```
+
+### Interfaz de chat
+
+```python
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello, who are you?"}
+]
+response = model.chat(messages)
+print(response.text)
+```
+
+### Parámetros de generación
+
+```python
+output = model.generate(
+    prompt="Write a poem",
+    max_tokens=256,
+    temperature=0.7,
+    top_p=0.9,
+    stop=["END", "\n\n"]
+)
+```
+
+| Parámetro | Descripción | Valor por defecto |
+|-----------|-------------|---------|
+| `max_tokens` | Cantidad máxima de tokens a generar | 256 |
+| `temperature` | Temperatura de muestreo (0-2) | 0.7 |
+| `top_p` | Nucleus sampling | 0.9 |
+| `stop` | Secuencias de parada | None |
+
+## Modelos de visión y lenguaje (VLM)
+
+### Uso básico
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+# Load model
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Describe an image
+description = mllm.describe_image("photo.jpg")
+print(description)
+```
+
+### Preguntas sobre imágenes
+
+```python
+answer = mllm.answer_about_image("photo.jpg", "What color is the car?")
+print(answer)
+```
+
+### Varias imágenes
+
+```python
+output = mllm.generate(
+    prompt="Compare these two images",
+    images=["image1.jpg", "image2.jpg"]
+)
+print(output.text)
+```
+
+### Comprensión de video
+
+```python
+# From local file
+output = mllm.generate(
+    prompt="What is happening in this video?",
+    videos=["video.mp4"],
+    video_fps=2.0,
+    video_max_frames=16
+)
+print(output.text)
+
+# From URL
+output = mllm.generate(
+    prompt="Describe this video",
+    videos=["https://example.com/video.mp4"],
+    video_fps=2.0
+)
+
+# Convenience method
+description = mllm.describe_video("video.mp4", fps=2.0)
+```
+
+### Parámetros de video
+
+| Parámetro | Descripción | Valor por defecto |
+|-----------|-------------|---------|
+| `video_fps` | Fotogramas por segundo a extraer | 2.0 |
+| `video_max_frames` | Cantidad máxima de fotogramas a procesar | 32 |
+
+## Engine API
+
+Para casos de uso avanzados, se puede usar el engine directamente:
+
+### Engine simple
+
+```python
+from vllm_mlx.engine import SimpleEngine
+
+engine = SimpleEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+print(output.text)
+
+await engine.stop()
+```
+
+### Engine con batching
+
+```python
+from vllm_mlx.engine import BatchedEngine
+
+engine = BatchedEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+# Multiple concurrent requests
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+
+await engine.stop()
+```
+
+## Formato de salida
+
+Todos los métodos de generación retornan un objeto `GenerationOutput`:
+
+```python
+output = model.generate("Hello")
+
+print(output.text)              # Generated text
+print(output.prompt_tokens)     # Input token count
+print(output.completion_tokens) # Output token count
+print(output.finish_reason)     # "stop" or "length"
+```
+
+## Manejo de errores
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+try:
+    model = MLXLanguageModel("invalid-model")
+    model.load()
+except Exception as e:
+    print(f"Failed to load model: {e}")
+```

--- a/docs/es/guides/reasoning.md
+++ b/docs/es/guides/reasoning.md
@@ -1,0 +1,267 @@
+# Modelos de reasoning
+
+vllm-mlx admite modelos de reasoning que muestran su proceso de thinking antes de dar una respuesta. Modelos como Qwen3 y DeepSeek-R1 envuelven su reasoning en etiquetas `<think>...</think>`, y vllm-mlx puede analizar estas etiquetas para separar el reasoning de la respuesta final.
+
+## Por que usar el reasoning parser?
+
+Cuando un modelo de reasoning genera salida, normalmente luce asi:
+
+```
+<think>
+Let me analyze this step by step.
+First, I need to consider the constraints.
+The answer should be a prime number less than 10.
+Checking: 2, 3, 5, 7 are all prime and less than 10.
+</think>
+The prime numbers less than 10 are: 2, 3, 5, 7.
+```
+
+Sin el reasoning parser, obtienes la salida cruda con las etiquetas incluidas. Con el reasoning parser habilitado, el proceso de thinking y la respuesta final se separan en campos distintos dentro de la respuesta de la API.
+
+## Primeros pasos
+
+### Iniciar el servidor con el reasoning parser
+
+```bash
+# For Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# For DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+### Formato de respuesta de la API
+
+Cuando el reasoning parser esta habilitado, la respuesta de la API incluye un campo `reasoning`:
+
+**Respuesta sin streaming:**
+
+```json
+{
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": "The prime numbers less than 10 are: 2, 3, 5, 7.",
+      "reasoning": "Let me analyze this step by step.\nFirst, I need to consider the constraints.\nThe answer should be a prime number less than 10.\nChecking: 2, 3, 5, 7 are all prime and less than 10."
+    }
+  }]
+}
+```
+
+**Respuesta con streaming:**
+
+Los fragmentos se envian por separado para el reasoning y el contenido. Durante la fase de reasoning, los fragmentos tienen `reasoning` con valor. Cuando el modelo pasa a la respuesta final, los fragmentos tienen `content` con valor:
+
+```json
+{"delta": {"reasoning": "Let me analyze"}}
+{"delta": {"reasoning": " this step by step."}}
+{"delta": {"reasoning": "\nFirst, I need to"}}
+...
+{"delta": {"content": "The prime"}}
+{"delta": {"content": " numbers less than 10"}}
+{"delta": {"content": " are: 2, 3, 5, 7."}}
+```
+
+## Uso con el SDK de OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Non-streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What are the prime numbers less than 10?"}]
+)
+
+message = response.choices[0].message
+print("Reasoning:", message.reasoning)  # The thinking process
+print("Answer:", message.content)        # The final answer
+```
+
+### Streaming con reasoning
+
+```python
+reasoning_text = ""
+content_text = ""
+
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Solve: 2 + 2 = ?"}],
+    stream=True
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if hasattr(delta, 'reasoning') and delta.reasoning:
+        reasoning_text += delta.reasoning
+        print(f"[Thinking] {delta.reasoning}", end="")
+    if delta.content:
+        content_text += delta.content
+        print(delta.content, end="")
+
+print(f"\n\nFinal reasoning: {reasoning_text}")
+print(f"Final answer: {content_text}")
+```
+
+## Parsers disponibles
+
+### Parser de Qwen3 (`qwen3`)
+
+Para modelos Qwen3 que usan etiquetas explicitas `<think>` y `</think>`.
+
+- Requiere **ambas** etiquetas, la de apertura y la de cierre
+- Si faltan las etiquetas, la salida se trata como contenido regular
+- Recomendado para: Qwen3-0.6B, Qwen3-4B, Qwen3-8B y modelos similares
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+### Parser de DeepSeek-R1 (`deepseek_r1`)
+
+Para modelos DeepSeek-R1 que pueden omitir la etiqueta de apertura `<think>`.
+
+- Mas permisivo que el parser de Qwen3
+- Maneja casos donde `<think>` es implicita
+- El contenido antes de `</think>` se trata como reasoning incluso sin `<think>`
+
+```bash
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+## Como funciona
+
+El reasoning parser usa deteccion basada en texto para identificar etiquetas de thinking en la salida del modelo. Durante el streaming, rastrea la posicion actual en la salida para enrutar correctamente cada token a `reasoning` o a `content`.
+
+```
+Model Output:        <think>Step 1: analyze...</think>The answer is 42.
+                     ├─────────────────────┤├─────────────────────┤
+Parsed:              │     reasoning       ││       content       │
+                     └─────────────────────┘└─────────────────────┘
+```
+
+El parsing no tiene estado y usa el texto acumulado para determinar el contexto, lo que lo hace robusto para escenarios de streaming donde los tokens pueden llegar en fragmentos arbitrarios.
+
+## Consejos para mejores resultados
+
+### Prompting
+
+Los modelos de reasoning funcionan mejor cuando se les anima a pensar paso a paso:
+
+```python
+messages = [
+    {"role": "system", "content": "Think through problems step by step before answering."},
+    {"role": "user", "content": "What is 17 × 23?"}
+]
+```
+
+### Manejo del reasoning ausente
+
+Algunos prompts pueden no activar el reasoning. En esos casos, `reasoning` sera `None` y toda la salida va a `content`:
+
+```python
+message = response.choices[0].message
+if message.reasoning:
+    print(f"Model's thought process: {message.reasoning}")
+print(f"Answer: {message.content}")
+```
+
+### Temperatura y reasoning
+
+Las temperaturas más bajas tienden a producir patrones de reasoning más consistentes:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Explain quantum entanglement"}],
+    temperature=0.3  # More focused reasoning
+)
+```
+
+## Compatibilidad con versiones anteriores
+
+Cuando no se especifica `--reasoning-parser`, el servidor se comporta como antes:
+- Las etiquetas de thinking se incluyen en el campo `content`
+- No se agrega el campo `reasoning` a las respuestas
+
+Esto garantiza que las aplicaciones existentes sigan funcionando sin cambios.
+
+## Ejemplo: solucionador de problemas matematicos
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+def solve_math(problem: str) -> dict:
+    """Solve a math problem and return reasoning + answer."""
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": "You are a math tutor. Show your work."},
+            {"role": "user", "content": problem}
+        ],
+        temperature=0.2
+    )
+
+    message = response.choices[0].message
+    return {
+        "problem": problem,
+        "work": message.reasoning,
+        "answer": message.content
+    }
+
+result = solve_math("If a train travels 120 km in 2 hours, what is its average speed?")
+print(f"Problem: {result['problem']}")
+print(f"\nWork shown:\n{result['work']}")
+print(f"\nFinal answer: {result['answer']}")
+```
+
+## Ejemplos con curl
+
+### Sin streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}]
+  }'
+```
+
+### Con streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}],
+    "stream": true
+  }'
+```
+
+## Solucion de problemas
+
+### No aparece el campo reasoning en la respuesta
+
+- Asegurate de haber iniciado el servidor con `--reasoning-parser`
+- Verifica que el modelo realmente use etiquetas de thinking (no todos los prompts activan el reasoning)
+
+### El reasoning aparece en content
+
+- Es posible que el modelo no este usando el formato de etiquetas esperado
+- Prueba un parser diferente (`qwen3` vs `deepseek_r1`)
+
+### Reasoning truncado
+
+- Aumenta `--max-tokens` si el modelo esta alcanzando el limite de tokens a mitad del thinking
+
+## Relacionado
+
+- [Modelos admitidos](../reference/models.md) - Modelos que admiten reasoning
+- [Configuracion del servidor](server.md) - Todas las opciones del servidor
+- [Referencia de CLI](../reference/cli.md) - Opciones de línea de comandos

--- a/docs/es/guides/server.md
+++ b/docs/es/guides/server.md
@@ -1,0 +1,781 @@
+# Servidor compatible con OpenAI
+
+vllm-mlx provee un servidor FastAPI con compatibilidad completa con la API de OpenAI.
+
+Por defecto, el servidor escucha solo en `127.0.0.1`. Usa `--host 0.0.0.0` solo cuando quieras exponerlo fuera de la máquina local de forma intencional.
+
+## Iniciar el servidor
+
+### Modo simple (por defecto)
+
+Máximo rendimiento para un solo usuario:
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+```
+
+### Modo continuous batching
+
+Para múltiples usuarios concurrentes:
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+### Con paged cache
+
+Caché eficiente en memoria para producción:
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
+```
+
+## Opciones del servidor
+
+| Opción | Descripción | Valor por defecto |
+|--------|-------------|---------|
+| `--port` | Puerto del servidor | 8000 |
+| `--host` | Host del servidor | 127.0.0.1 |
+| `--api-key` | Clave de API para autenticación | None |
+| `--rate-limit` | Solicitudes por minuto por cliente (0 = desactivado) | 0 |
+| `--timeout` | Tiempo límite de solicitud en segundos | 300 |
+| `--enable-metrics` | Expone métricas de Prometheus en `/metrics` | False |
+| `--continuous-batching` | Activa batching para múltiples usuarios | False |
+| `--use-paged-cache` | Activa paged KV cache | False |
+| `--cache-memory-mb` | Límite de memoria de caché en MB | Auto |
+| `--cache-memory-percent` | Fracción de RAM para caché | 0.20 |
+| `--max-tokens` | Máximo de tokens por defecto | 32768 |
+| `--max-request-tokens` | Máximo de `max_tokens` aceptado de clientes de la API | 32768 |
+| `--default-temperature` | Temperatura por defecto cuando no se especifica | None |
+| `--default-top-p` | top_p por defecto cuando no se especifica | None |
+| `--stream-interval` | Tokens por fragmento de streaming | 1 |
+| `--mcp-config` | Ruta al archivo de configuración de MCP | None |
+| `--reasoning-parser` | Parser para modelos de reasoning (`qwen3`, `deepseek_r1`) | None |
+| `--embedding-model` | Pre-carga un modelo de embeddings al iniciar | None |
+| `--enable-auto-tool-choice` | Activa tool calling automático | False |
+| `--tool-call-parser` | Parser de tool calls (ver [Tool Calling](tool-calling.md)) | None |
+
+## Endpoints de la API
+
+### Chat completions
+
+```bash
+POST /v1/chat/completions
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Sin streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=100
+)
+
+# Con streaming
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### Completions
+
+```bash
+POST /v1/completions
+```
+
+```python
+response = client.completions.create(
+    model="default",
+    prompt="The capital of France is",
+    max_tokens=50
+)
+```
+
+### Models
+
+```bash
+GET /v1/models
+```
+
+Retorna los modelos disponibles.
+
+### Embeddings
+
+```bash
+POST /v1/embeddings
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+```
+
+Consulta la [Guía de Embeddings](embeddings.md) para más detalles.
+
+### Health check
+
+```bash
+GET /health
+```
+
+Retorna el estado del servidor.
+
+### Métricas
+
+```bash
+GET /metrics
+```
+
+Endpoint de scrape de Prometheus con métricas del servidor, caché, scheduler y solicitudes.
+El endpoint está desactivado por defecto y se habilita con `--enable-metrics`.
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-metrics
+```
+
+`/metrics` no requiere autenticación de forma intencional. Exponlo solo en una red de confianza o detrás de un proxy inverso o firewall que limite quién puede consultarlo.
+
+### API de mensajes de Anthropic
+
+```bash
+POST /v1/messages
+```
+
+Endpoint compatible con Anthropic que permite que herramientas como Claude Code y OpenCode se conecten directamente a vllm-mlx. Internamente traduce las solicitudes de Anthropic al formato de OpenAI, ejecuta la inferencia a través del motor y convierte la respuesta de vuelta al formato de Anthropic.
+
+Capacidades:
+- Respuestas sin streaming y con streaming (SSE)
+- Mensajes de sistema (cadena de texto simple o lista de bloques de contenido)
+- Conversaciones multi-turno con mensajes de usuario y asistente
+- Tool calling con bloques de contenido `tool_use` / `tool_result`
+- Conteo de tokens para seguimiento de presupuesto
+- Contenido multimodal (imágenes mediante bloques `source`)
+- Detección de desconexión del cliente (retorna HTTP 499)
+- Filtrado automático de tokens especiales en la salida en streaming
+
+#### Sin streaming
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(base_url="http://localhost:8000", api_key="not-needed")
+
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.content[0].text)
+# Response includes: response.id, response.model, response.stop_reason,
+# response.usage.input_tokens, response.usage.output_tokens
+```
+
+#### Streaming
+
+El streaming sigue el protocolo de eventos SSE de Anthropic. Los eventos se emiten en este orden:
+`message_start` -> `content_block_start` -> `content_block_delta` (repetido) -> `content_block_stop` -> `message_delta` -> `message_stop`
+
+```python
+with client.messages.stream(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Tell me a story"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="")
+```
+
+#### Mensajes de sistema
+
+Los mensajes de sistema pueden ser una cadena de texto simple o una lista de bloques de contenido:
+
+```python
+# Plain string
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system="You are a helpful coding assistant.",
+    messages=[{"role": "user", "content": "Write a hello world in Python"}]
+)
+
+# List of content blocks
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system=[
+        {"type": "text", "text": "You are a helpful assistant."},
+        {"type": "text", "text": "Be concise in your answers."},
+    ],
+    messages=[{"role": "user", "content": "What is 2+2?"}]
+)
+```
+
+#### Tool calling
+
+Define las herramientas con `name`, `description` e `input_schema`. El modelo retorna bloques de contenido `tool_use` cuando desea llamar a una herramienta. Envía los resultados de vuelta como bloques `tool_result`.
+
+```python
+# Step 1: Send request with tools
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+
+# Step 2: Check if model wants to use tools
+for block in response.content:
+    if block.type == "tool_use":
+        print(f"Tool: {block.name}, Input: {block.input}, ID: {block.id}")
+        # response.stop_reason will be "tool_use"
+
+# Step 3: Send tool result back
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {"role": "assistant", "content": response.content},
+        {"role": "user", "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": "Sunny, 22C"
+            }
+        ]}
+    ],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+print(response.content[0].text)  # "The weather in Paris is sunny, 22C."
+```
+
+Modos de selección de herramientas:
+
+| `tool_choice` | Comportamiento |
+|---------------|----------|
+| `{"type": "auto"}` | El modelo decide si llamar herramientas (por defecto) |
+| `{"type": "any"}` | El modelo debe llamar al menos una herramienta |
+| `{"type": "tool", "name": "get_weather"}` | El modelo debe llamar la herramienta especificada |
+| `{"type": "none"}` | El modelo no llamará ninguna herramienta |
+
+#### Conversaciones multi-turno
+
+```python
+messages = [
+    {"role": "user", "content": "My name is Alice."},
+    {"role": "assistant", "content": "Nice to meet you, Alice!"},
+    {"role": "user", "content": "What's my name?"},
+]
+
+response = client.messages.create(
+    model="default",
+    max_tokens=100,
+    messages=messages
+)
+```
+
+#### Conteo de tokens
+
+```bash
+POST /v1/messages/count_tokens
+```
+
+Cuenta los tokens de entrada para una solicitud de Anthropic usando el tokenizador del modelo. Útil para el seguimiento de presupuesto antes de enviar una solicitud. Cuenta tokens de mensajes de sistema, mensajes de conversación, entradas de tool_use, contenido de tool_result y definiciones de herramientas (name, description, input_schema).
+
+```python
+import requests
+
+resp = requests.post("http://localhost:8000/v1/messages/count_tokens", json={
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello, how are you?"}],
+    "system": "You are helpful.",
+    "tools": [{
+        "name": "search",
+        "description": "Search the web",
+        "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+    }]
+})
+print(resp.json())  # {"input_tokens": 42}
+```
+
+#### Ejemplos con curl
+
+Sin streaming:
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+Con streaming:
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Tell me a joke"}]
+  }'
+```
+
+Conteo de tokens:
+
+```bash
+curl http://localhost:8000/v1/messages/count_tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+# {"input_tokens": 12}
+```
+
+#### Campos de la solicitud
+
+| Campo | Tipo | Requerido | Valor por defecto | Descripción |
+|-------|------|----------|---------|-------------|
+| `model` | string | sí | - | Nombre del modelo (usa `"default"` para el modelo cargado) |
+| `messages` | list | sí | - | Mensajes de conversación con `role` y `content` |
+| `max_tokens` | int | sí | - | Número máximo de tokens a generar |
+| `system` | string o list | no | null | Prompt de sistema (cadena o lista de bloques `{"type": "text", "text": "..."}`) |
+| `stream` | bool | no | false | Activa el streaming SSE |
+| `temperature` | float | no | 0.7 | Temperatura de muestreo (0.0 = determinista, 1.0 = creativo) |
+| `top_p` | float | no | 0.9 | Umbral de nucleus sampling |
+| `top_k` | int | no | null | Top-k sampling |
+| `stop_sequences` | list | no | null | Secuencias que detienen la generación |
+| `tools` | list | no | null | Definiciones de herramientas con `name`, `description`, `input_schema` |
+| `tool_choice` | dict | no | null | Modo de selección de herramientas (`auto`, `any`, `tool`, `none`) |
+| `metadata` | dict | no | null | Metadatos arbitrarios (se pasan sin ser usados por el servidor) |
+
+#### Formato de respuesta
+
+Respuesta sin streaming:
+
+```json
+{
+  "id": "msg_abc123...",
+  "type": "message",
+  "role": "assistant",
+  "model": "default",
+  "content": [
+    {"type": "text", "text": "Hello! How can I help?"}
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 8
+  }
+}
+```
+
+Cuando se llaman herramientas, `content` incluye bloques `tool_use` y `stop_reason` es `"tool_use"`:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "Let me check the weather."},
+    {
+      "type": "tool_use",
+      "id": "call_abc123",
+      "name": "get_weather",
+      "input": {"city": "Paris"}
+    }
+  ],
+  "stop_reason": "tool_use"
+}
+```
+
+Razones de parada:
+
+| `stop_reason` | Significado |
+|---------------|---------|
+| `end_turn` | El modelo terminó de forma natural |
+| `tool_use` | El modelo quiere llamar una herramienta |
+| `max_tokens` | Se alcanzó el límite de `max_tokens` |
+
+#### Uso con Claude Code
+
+Apunta Claude Code directamente a tu servidor vllm-mlx:
+
+```bash
+# Start the server
+vllm-mlx serve mlx-community/Qwen3-Coder-Next-235B-A22B-4bit \
+  --continuous-batching \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+
+# In another terminal, configure Claude Code
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### Estado del servidor
+
+```bash
+GET /v1/status
+```
+
+Endpoint de monitoreo en tiempo real que retorna estadísticas generales del servidor y detalles por solicitud. Útil para depurar el rendimiento, rastrear la eficiencia de la caché y monitorear la memoria GPU Metal.
+
+```bash
+curl -s http://localhost:8000/v1/status | python -m json.tool
+```
+
+Respuesta de ejemplo:
+
+```json
+{
+  "status": "running",
+  "model": "mlx-community/Qwen3-8B-4bit",
+  "uptime_s": 342.5,
+  "steps_executed": 1247,
+  "num_running": 1,
+  "num_waiting": 0,
+  "total_requests_processed": 15,
+  "total_prompt_tokens": 28450,
+  "total_completion_tokens": 3200,
+  "metal": {
+    "active_memory_gb": 5.2,
+    "peak_memory_gb": 8.1,
+    "cache_memory_gb": 2.3
+  },
+  "cache": {
+    "type": "memory_aware_cache",
+    "entries": 5,
+    "hit_rate": 0.87,
+    "memory_mb": 2350
+  },
+  "requests": [
+    {
+      "request_id": "req_abc123",
+      "phase": "generation",
+      "tokens_per_second": 45.2,
+      "ttft_s": 0.8,
+      "progress": 0.35,
+      "cache_hit_type": "prefix",
+      "cached_tokens": 1200,
+      "generated_tokens": 85,
+      "max_tokens": 256
+    }
+  ]
+}
+```
+
+Campos de la respuesta:
+
+| Campo | Descripción |
+|-------|-------------|
+| `status` | Estado del servidor: `running`, `stopped` o `not_loaded` |
+| `model` | Nombre del modelo cargado |
+| `uptime_s` | Segundos desde que el servidor inició |
+| `steps_executed` | Total de pasos de inferencia ejecutados |
+| `num_running` | Número de solicitudes generando tokens actualmente |
+| `num_waiting` | Número de solicitudes en cola para prefill |
+| `total_requests_processed` | Total de solicitudes completadas desde el inicio |
+| `total_prompt_tokens` | Total de tokens de prompt procesados desde el inicio |
+| `total_completion_tokens` | Total de tokens de completion generados desde el inicio |
+| `metal.active_memory_gb` | Memoria GPU Metal en uso actualmente (GB) |
+| `metal.peak_memory_gb` | Uso pico de memoria GPU Metal (GB) |
+| `metal.cache_memory_gb` | Uso de memoria de caché Metal (GB) |
+| `cache` | Estadísticas de caché (tipo, entradas, tasa de aciertos, uso de memoria) |
+| `requests` | Lista de solicitudes activas con detalles por solicitud |
+
+Campos por solicitud en `requests`:
+
+| Campo | Descripción |
+|-------|-------------|
+| `request_id` | Identificador único de la solicitud |
+| `phase` | Fase actual: `queued`, `prefill` o `generation` |
+| `tokens_per_second` | Rendimiento de generación para esta solicitud |
+| `ttft_s` | Tiempo hasta el primer token (segundos) |
+| `progress` | Porcentaje de completado (0.0 a 1.0) |
+| `cache_hit_type` | Tipo de coincidencia en caché: `exact`, `prefix`, `supersequence`, `lcp` o `miss` |
+| `cached_tokens` | Número de tokens servidos desde caché |
+| `generated_tokens` | Tokens generados hasta ahora |
+| `max_tokens` | Máximo de tokens solicitados |
+
+## Tool Calling
+
+Activa tool calling compatible con OpenAI con `--enable-auto-tool-choice`:
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+Usa la opción `--tool-call-parser` para seleccionar el parser adecuado para tu modelo:
+
+| Parser | Modelos |
+|--------|--------|
+| `auto` | Detección automática (prueba todos los parsers) |
+| `mistral` | Mistral, Devstral |
+| `qwen` | Qwen, Qwen3 |
+| `llama` | Llama 3.x, 4.x |
+| `hermes` | Hermes, NousResearch |
+| `deepseek` | DeepSeek V3, R1 |
+| `kimi` | Kimi K2, Moonshot |
+| `granite` | IBM Granite 3.x, 4.x |
+| `nemotron` | NVIDIA Nemotron |
+| `xlam` | Salesforce xLAM |
+| `functionary` | MeetKai Functionary |
+| `glm47` | GLM-4.7, GLM-4.7-Flash |
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"{tc.function.name}: {tc.function.arguments}")
+```
+
+Consulta la [Guía de Tool Calling](tool-calling.md) para la documentación completa.
+
+## Modelos de reasoning
+
+Para modelos que muestran su proceso de pensamiento (Qwen3, DeepSeek-R1), usa `--reasoning-parser` para separar el reasoning de la respuesta final:
+
+```bash
+# Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+La respuesta de la API incluye un campo `reasoning` con el proceso de pensamiento del modelo:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+
+print(response.choices[0].message.reasoning)  # Step-by-step thinking
+print(response.choices[0].message.content)    # Final answer
+```
+
+En streaming, los fragmentos de reasoning llegan primero, seguidos de los fragmentos de contenido:
+
+```python
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.reasoning:
+        print(f"[Thinking] {delta.reasoning}")
+    if delta.content:
+        print(delta.content, end="")
+```
+
+Consulta la [Guía de Modelos de Reasoning](reasoning.md) para todos los detalles.
+
+## Salida estructurada (modo JSON)
+
+Obliga al modelo a retornar JSON válido usando `response_format`:
+
+### Modo JSON Object
+
+Retorna cualquier JSON válido:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={"type": "json_object"}
+)
+# Output: {"colors": ["red", "blue", "green"]}
+```
+
+### Modo JSON Schema
+
+Retorna JSON que coincide con un esquema específico:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "colors",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "colors": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["colors"]
+            }
+        }
+    }
+)
+# Output validated against schema
+data = json.loads(response.choices[0].message.content)
+assert "colors" in data
+```
+
+### Ejemplo con curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "List 3 colors"}],
+    "response_format": {"type": "json_object"}
+  }'
+```
+
+## Ejemplos con curl
+
+### Chat
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 100
+  }'
+```
+
+### Streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+  }'
+```
+
+## Configuración de streaming
+
+Controla el comportamiento del streaming con `--stream-interval`:
+
+| Valor | Comportamiento |
+|-------|----------|
+| `1` (por defecto) | Envía cada token inmediatamente |
+| `2-5` | Agrupa tokens antes de enviar |
+| `10+` | Máximo rendimiento, salida en fragmentos más grandes |
+
+```bash
+# Smooth streaming
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# Batched streaming (better for high-latency networks)
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+## Integración con Open WebUI
+
+```bash
+# 1. Start vllm-mlx server
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# 2. Start Open WebUI
+docker run -d -p 3000:8080 \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
+  -e OPENAI_API_KEY=not-needed \
+  --name open-webui \
+  ghcr.io/open-webui/open-webui:main
+
+# 3. Open http://localhost:3000
+```
+
+## Despliegue en producción
+
+### Con systemd
+
+Crea `/etc/systemd/system/vllm-mlx.service`:
+
+```ini
+[Unit]
+Description=vLLM-MLX Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching --use-paged-cache --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable vllm-mlx
+sudo systemctl start vllm-mlx
+```
+
+### Configuración recomendada
+
+Para producción con 50 o más usuarios concurrentes:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --port 8000
+```

--- a/docs/es/guides/tool-calling.md
+++ b/docs/es/guides/tool-calling.md
@@ -1,0 +1,244 @@
+# Tool Calling
+
+vllm-mlx soporta tool calling compatible con OpenAI (function calling) con análisis automático para muchas familias de modelos populares.
+
+## Inicio rápido
+
+Activa el tool calling agregando la bandera `--enable-auto-tool-choice` al iniciar el servidor:
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+Luego usa herramientas con la API estándar de OpenAI:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+# Check for tool calls
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"Function: {tc.function.name}")
+        print(f"Arguments: {tc.function.arguments}")
+```
+
+## Parsers disponibles
+
+Usa `--tool-call-parser` para seleccionar un tool parser según tu familia de modelos:
+
+| Parser | Alias | Modelos | Formato |
+|--------|-------|---------|---------|
+| `auto` | | Cualquier modelo | Detecta el formato automáticamente (prueba todos los parsers) |
+| `mistral` | | Mistral, Devstral | Arreglo JSON con `[TOOL_CALLS]` |
+| `qwen` | `qwen3` | Qwen, Qwen3 | XML `<tool_call>` o `[Calling tool:]` |
+| `llama` | `llama3`, `llama4` | Llama 3.x, 4.x | Etiquetas `<function=name>` |
+| `hermes` | `nous` | Hermes, NousResearch | JSON `<tool_call>` dentro de XML |
+| `deepseek` | `deepseek_v3`, `deepseek_r1` | DeepSeek V3, R1 | Delimitadores Unicode |
+| `kimi` | `kimi_k2`, `moonshot` | Kimi K2, Moonshot | Tokens `<\|tool_call_begin\|>` |
+| `granite` | `granite3` | IBM Granite 3.x, 4.x | `<\|tool_call\|>` o `<tool_call>` |
+| `nemotron` | `nemotron3` | NVIDIA Nemotron | `<tool_call><function=...><parameter=...>` |
+| `xlam` | | Salesforce xLAM | JSON con arreglo `tool_calls` |
+| `functionary` | `meetkai` | MeetKai Functionary | Múltiples bloques de función |
+| `glm47` | `glm4` | GLM-4.7, GLM-4.7-Flash | `<tool_call>` con XML `<arg_key>`/`<arg_value>` |
+
+## Ejemplos por modelo
+
+### Mistral / Devstral
+
+```bash
+# Devstral Small (optimizado para código y tool use)
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Mistral Instruct
+vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+### Qwen
+
+```bash
+# Qwen3
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser qwen
+```
+
+### Llama
+
+```bash
+# Llama 3.2
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser llama
+```
+
+### DeepSeek
+
+```bash
+# DeepSeek V3
+vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
+  --enable-auto-tool-choice --tool-call-parser deepseek
+```
+
+### IBM Granite
+
+```bash
+# Granite 4.0
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+```
+
+### NVIDIA Nemotron
+
+```bash
+# Nemotron 3 Nano
+vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
+  --enable-auto-tool-choice --tool-call-parser nemotron
+```
+
+### GLM-4.7
+
+```bash
+# GLM-4.7 Flash
+vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
+  --enable-auto-tool-choice --tool-call-parser glm47
+```
+
+### Kimi K2
+
+```bash
+# Kimi K2
+vllm-mlx serve mlx-community/Kimi-K2-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser kimi
+```
+
+### Salesforce xLAM
+
+```bash
+# xLAM
+vllm-mlx serve mlx-community/xLAM-2-fc-r-4bit \
+  --enable-auto-tool-choice --tool-call-parser xlam
+```
+
+## Parser automático
+
+Si no sabes qué parser usar, el parser `auto` intenta detectar el formato de forma automática:
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser auto
+```
+
+El parser automático prueba los formatos en este orden:
+1. Mistral (`[TOOL_CALLS]`)
+2. Qwen con corchetes (`[Calling tool:]`)
+3. Nemotron (`<tool_call><function=...><parameter=...>`)
+4. XML de Qwen/Hermes (`<tool_call>{...}</tool_call>`)
+5. Llama (`<function=name>{...}</function>`)
+6. JSON sin formato
+
+## Streaming de tool calls
+
+Los tool calls funcionan con streaming. La información del tool call se envía cuando el modelo termina de generarla:
+
+```python
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's 25 * 17?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Calculate math expressions",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string"}
+                },
+                "required": ["expression"]
+            }
+        }
+    }],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.tool_calls:
+        for tc in chunk.choices[0].delta.tool_calls:
+            print(f"Tool call: {tc.function.name}({tc.function.arguments})")
+```
+
+## Manejo de resultados de herramientas
+
+Después de recibir un tool call, ejecuta la función y devuelve el resultado:
+
+```python
+import json
+
+# Primera solicitud: el modelo decide llamar a una herramienta
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=[weather_tool]
+)
+
+# Obtener el tool call
+tool_call = response.choices[0].message.tool_calls[0]
+tool_call_id = tool_call.id
+function_name = tool_call.function.name
+arguments = json.loads(tool_call.function.arguments)
+
+# Ejecutar la función (implementación propia)
+result = get_weather(**arguments)  # {"temperature": 22, "condition": "sunny"}
+
+# Enviar el resultado de vuelta al modelo
+response = client.chat.completions.create(
+    model="default",
+    messages=[
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {"role": "assistant", "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": tool_call_id, "content": json.dumps(result)}
+    ],
+    tools=[weather_tool]
+)
+
+print(response.choices[0].message.content)
+# "The weather in Tokyo is sunny with a temperature of 22C."
+```
+
+## Manejo de etiquetas de razonamiento
+
+Los modelos que producen etiquetas de razonamiento `<think>...</think>` (como DeepSeek-R1, Qwen3, GLM-4.7) se manejan de forma automática. El parser elimina el contenido de reasoning antes de extraer los tool calls, por lo que las etiquetas de razonamiento nunca interfieren con el análisis de tool calls.
+
+Esto funciona incluso cuando `<think>` fue inyectado en el prompt (etiquetas implícitas con solo un cierre `</think>`).
+
+## Referencia de CLI
+
+| Opción | Descripción |
+|--------|-------------|
+| `--enable-auto-tool-choice` | Activa el tool calling automático |
+| `--tool-call-parser` | Selecciona el parser (ver tabla anterior) |
+
+Consulta la [Referencia de CLI](../reference/cli.md) para todas las opciones.

--- a/docs/es/guides/warm-prompts.md
+++ b/docs/es/guides/warm-prompts.md
@@ -1,0 +1,192 @@
+# Warm Prompts
+
+Pre-pobla el prefix cache al iniciar el servidor para que la **primera** solicitud
+que envie un agent encuentre un cache caliente en lugar de pagar el prefill completo
+de su system prompt de varios kilobytes.
+
+## Cuándo usar esto
+
+Las cargas de trabajo de agents, proxies hacia asistentes de código o razonamiento,
+servidores MCP, orquestadores multi-agent, siempre envian el mismo system prompt.
+Hoy, la primera solicitud desde un servidor frio paga el prefill completo de ese
+sistema. En un modelo de miles de millones de parámetros eso equivale a varios
+segundos de TTFT, justo cuando un usuario espera que su nuevo agent responda por
+primera vez.
+
+Si ya conoces los system prompts de tus agents al momento del despliegue, escríbelos
+en un archivo JSON y apunta `--warm-prompts` hacia él. El servidor ejecuta un chat
+completion de `max_tokens=1` para cada uno al inicio, el estado del KV cache queda
+en el prefix cache, y la primera solicitud real coincide via strict-prefix.
+
+Requiere `--continuous-batching` (el prefix cache vive ahí).
+
+## Ejemplo rápido
+
+```bash
+# Write the agents you care about once
+cat > ~/.config/vllm-mlx/agents.json <<'JSON'
+[
+  [{"role": "system", "content": "You are a code assistant..."}]
+]
+JSON
+
+# Point the server at it
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json
+```
+
+Al iniciar verás:
+
+```
+[lifespan] Warm-up done (strict-prefix): 1 completed, 0 skipped,
+           1431 prompt tokens in 0.2s
+```
+
+La primera solicitud real que comparte el system prompt calentado accede al cache
+con `tokens_saved` cercano a la longitud del prompt de calentamiento.
+
+## Formato del archivo
+
+Una lista JSON de nivel superior. Cada entrada es a su vez una lista de mensajes
+de chat, con la misma forma que `messages` en `/v1/chat/completions`.
+
+```json
+[
+  [
+    {"role": "system", "content": "You are a code assistant..."}
+  ],
+  [
+    {"role": "system", "content": "You are a senior code reviewer..."}
+  ],
+  [
+    {"role": "system", "content": "You are a planner..."},
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "Hello, what are we planning?"}
+  ]
+]
+```
+
+Los system prompts de un solo mensaje son el caso más común. Los historiales
+multi-turno son compatibles para escenarios en los que quieres calentar un inicio
+de conversación específico (ejemplos few-shot, una persona de asistente fija).
+
+## Dimensionamiento
+
+Los warm prompts se procesan **de forma concurrente** via `asyncio.gather`, por lo
+que N entradas lanzan N prefills concurrentes al inicio. Cada prefill asigna KV
+cache según la longitud de su prompt.
+
+**Recomendado: 1 a 3 entradas.** Eso cubre los caminos calientes de despliegues
+típicos de agents (una persona por entrada). Un archivo warm-prompts muy grande en
+un modelo con poca memoria puede agotar el espacio disponible en el arranque.
+
+Si necesitas calentar decenas de personas, abre un issue con tu carga de trabajo y
+podemos agregar un limite `--warm-prompts-concurrency=N`.
+
+## Benchmarks
+
+**Configuración.** M4 Max, 128 GB de memoria unificada. Dos servidores separados por
+medición (frio vs caliente), arranque frio aislado. Conjunto de prompts `long`
+(aprox. 2.5k tokens de usuario) antepuesto con un system prompt de aprox. 1.7k
+tokens para coincidir con el warm prompt. `max_tokens=128`. bench-serve con
+`--skip-preflight-token-count` para que el preflight de count_prompt_tokens no
+contamine el cache.
+
+| Model | conc | cold TTFT | warm TTFT | Speedup |
+|-------|-----:|----------:|----------:|--------:|
+| Qwen3-0.6B-8bit | 1 | 563 ms | 419 ms | 1.34x |
+| Qwen3-0.6B-8bit | 4 | 1 723 ms | 1 282 ms | 1.34x |
+| Qwen3-0.6B-8bit | 8 | 3 708 ms | 2 661 ms | 1.39x |
+| Llama-3.2-3B-Instruct-4bit | 1 | 1 754 ms | 1 060 ms | 1.65x |
+| Llama-3.2-3B-Instruct-4bit | 4 | 5 926 ms | 3 945 ms | 1.50x |
+| Llama-3.2-3B-Instruct-4bit | 8 | 15 161 ms | 9 820 ms | 1.54x |
+| Qwen3-4B-4bit | 1 | 4 937 ms | 2 191 ms | 2.25x |
+| Qwen3-4B-4bit | 4 | 12 535 ms | 9 623 ms | 1.30x |
+| Qwen3-4B-4bit | 8 | 38 148 ms | 23 878 ms | 1.60x |
+| Qwen3.6-35B-A3B-4bit (MoE/hybrid) | 1 | 2 400 ms | 1 603 ms | 1.50x |
+| Qwen3.6-35B-A3B-4bit | 4 | 8 735 ms | 6 054 ms | 1.44x |
+| Qwen3.6-35B-A3B-4bit | 8 | 22 419 ms | 14 409 ms | 1.56x |
+
+Las 12 configuraciones mejoran. Los ahorros de TTFT son mayores cuando la relación
+prompt/total es más alta (conc=1, system prompt largo) y siguen siendo significativos
+bajo carga concurrente.
+
+**Generation tok/s** es neutral (dentro de +-5%) para los modelos densos.
+Qwen3.6-35B-A3B (MoE) muestra una caida en decode del 20 al 35% con conc >= 4,
+que parece ser una interacción del enrutamiento MoE con el scheduling en batch. Los
+ahorros de TTFT siguen dominando la latencia extremo a extremo en cargas de trabajo
+de agents, pero toma nota de esto si tu flujo es fuertemente decode-bound a alta
+concurrencia.
+
+## Cómo funciona
+
+El calentamiento naive, renderizar la plantilla de chat con un mensaje de usuario de
+relleno y cachear los tokens, no funciona para modelos híbridos SSM+attention
+(Qwen3.5-MoE, Qwen3.6-MoE). Sus capas de cache incluyen estado SSM que no puede
+recortarse, por lo que `memory_cache.py` deshabilita la coincidencia LCP. El
+contenido de usuario de relleno diverge del contenido real del usuario y una entrada
+cacheada a nivel de tokens ya no es un strict-prefix de ninguna solicitud real.
+
+El calentador aquí renderiza la plantilla de chat **dos veces** con dos contenidos de
+usuario distintos (`"__PROBE_A__"` y `"__PROBE_B__"`), encuentra la posición de
+carácter donde las dos cadenas divergen y trunca el primer renderizado en ese limite.
+Esa cadena truncada, todo lo que precede al punto donde se inserta el contenido del
+usuario, es lo que se envía al motor.
+
+Dado que el flujo de solicitudes reales del motor también renderiza la plantilla con
+`tokenize=False` y luego deja que el tokenizador codifique el resultado, los tokens
+del calentamiento tienen garantia de ser un strict-prefix de cualquier solicitud real
+con un sistema coincidente e historial de chat vacío. Las coincidencias strict-prefix
+funcionan en todo tipo de capas de cache, incluidos los flujos híbridos donde el LCP
+está deshabilitado.
+
+## Administración
+
+### Limpiar el prefix cache en memoria
+
+```bash
+curl -X DELETE http://localhost:8000/v1/cache/prefix
+```
+
+Si el servidor se inició con `--warm-prompts`, el calentamiento se vuelve a ejecutar
+en segundo plano después de la limpieza. La respuesta se devuelve de inmediato sin
+esperar a que termine el re-calentamiento.
+
+Respuesta:
+
+```json
+{"status": "cleared", "rewarm_scheduled": true}
+```
+
+### Inspeccionar el estado del cache
+
+```bash
+curl http://localhost:8000/v1/status | jq '.cache'
+```
+
+Tras el arranque con warm-prompts verás `entry_count > 0` antes de la primera
+solicitud del usuario.
+
+## Benchmark de tu propia configuración
+
+Para medir el impacto en tu modelo y tus prompts, usa `bench-serve`:
+
+```bash
+# Cold: no warm-prompts
+vllm-mlx serve MODEL --continuous-batching &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag cold \
+  --output cold.csv --format csv
+
+# Warm: same server config + --warm-prompts
+vllm-mlx serve MODEL --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag warm \
+  --output warm.csv --format csv
+```
+
+`--skip-preflight-token-count` se habilita automáticamente cuando se usa
+`--system-prompt-file`, por lo que el preflight de `count_prompt_tokens` no
+contamina el cache. Compara `cold.csv` y `warm.csv` para tu carga de trabajo.

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -1,0 +1,66 @@
+# Documentación de vLLM-MLX
+
+**Backend MLX para Apple Silicon en vLLM** - Aceleración GPU para texto, imagen, video y audio en Mac
+
+## ¿Qué es vLLM-MLX?
+
+vllm-mlx incorpora aceleración GPU nativa de Apple Silicon a vLLM mediante la integración de:
+
+- **[MLX](https://github.com/ml-explore/mlx)**: El framework de ML de Apple con memoria unificada y kernels Metal
+- **[mlx-lm](https://github.com/ml-explore/mlx-lm)**: Inferencia LLM optimizada con KV cache y cuantización
+- **[mlx-vlm](https://github.com/Blaizzy/mlx-vlm)**: Modelos visión-lenguaje para inferencia multimodal
+- **[mlx-audio](https://github.com/Blaizzy/mlx-audio)**: TTS y STT con voces nativas
+- **[mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings)**: Embeddings de texto para búsqueda semántica y RAG
+
+## Características principales
+
+- **Multimodal** - Texto, imagen, video y audio en una sola plataforma
+- **Aceleración GPU nativa** en Apple Silicon (M1, M2, M3, M4)
+- **Voces TTS nativas** - Español, francés, chino, japonés y 5 idiomas más
+- **Compatible con la API de OpenAI** - reemplazo directo del cliente de OpenAI
+- **Embeddings** - Endpoint `/v1/embeddings` compatible con OpenAI
+- **MCP Tool Calling** - integración de herramientas externas mediante el Model Context Protocol
+- **Paged KV Cache** - almacenamiento en caché eficiente en memoria con prefix sharing
+- **Continuous Batching** - alto rendimiento para múltiples usuarios concurrentes
+
+## Enlaces rápidos
+
+### Primeros pasos
+- [Instalación](getting-started/installation.md)
+- [Inicio rápido](getting-started/quickstart.md)
+
+### Guías de usuario
+- [Servidor compatible con OpenAI](guides/server.md)
+- [API de Python](guides/python-api.md)
+- [Multimodal (imágenes y video)](guides/multimodal.md)
+- [Audio (STT/TTS)](guides/audio.md)
+- [Embeddings](guides/embeddings.md)
+- [Modelos de reasoning](guides/reasoning.md)
+- [Tool Calling](guides/tool-calling.md)
+- [MCP y Tool Calling](guides/mcp-tools.md)
+- [Continuous Batching](guides/continuous-batching.md)
+
+### Referencia
+- [Comandos CLI](reference/cli.md)
+- [Modelos compatibles](reference/models.md)
+- [Configuración](reference/configuration.md)
+
+### Benchmarks
+- [Benchmarks LLM](benchmarks/llm.md)
+- [Benchmarks de imagen](benchmarks/image.md)
+- [Benchmarks de video](benchmarks/video.md)
+- [Benchmarks de audio](benchmarks/audio.md)
+
+### Desarrollo
+- [Arquitectura](../development/architecture.md)
+- [Contribuir](../development/contributing.md)
+
+## Requisitos
+
+- macOS en Apple Silicon (M1/M2/M3/M4)
+- Python 3.10+
+- Se recomiendan 8 GB de RAM o más
+
+## Licencia
+
+Apache 2.0 - Consulta [LICENSE](../../LICENSE) para más detalles.

--- a/docs/es/reference/cli.md
+++ b/docs/es/reference/cli.md
@@ -1,0 +1,210 @@
+# Referencia de CLI
+
+## Resumen de comandos
+
+| Comando | Descripcion |
+|---------|-------------|
+| `vllm-mlx serve` | Inicia el servidor compatible con OpenAI |
+| `vllm-mlx-bench` | Ejecuta benchmarks de rendimiento |
+| `vllm-mlx-chat` | Inicia la interfaz de chat con Gradio |
+
+## `vllm-mlx serve`
+
+Inicia el servidor de API compatible con OpenAI.
+
+### Uso
+
+```bash
+vllm-mlx serve <model> [options]
+```
+
+### Opciones
+
+| Opcion | Descripcion | Por defecto |
+|--------|-------------|-------------|
+| `--served-model-name` | Nombre personalizado del modelo expuesto a traves de la API de OpenAI. Si no se especifica, se usa la ruta del modelo como nombre. | None |
+| `--port` | Puerto del servidor | 8000 |
+| `--host` | Host del servidor | 127.0.0.1 |
+| `--api-key` | Clave de API para autenticacion | None |
+| `--rate-limit` | Solicitudes por minuto por cliente (0 = desactivado) | 0 |
+| `--timeout` | Tiempo limite de solicitud en segundos | 300 |
+| `--enable-metrics` | Expone métricas de Prometheus en `/metrics` | False |
+| `--continuous-batching` | Activa continuous batching para multiples usuarios | False |
+| `--cache-memory-mb` | Limite de memoria para cache en MB | Auto |
+| `--cache-memory-percent` | Fraccion de RAM para cache | 0.20 |
+| `--no-memory-aware-cache` | Usa cache legacy basado en conteo de entradas | False |
+| `--use-paged-cache` | Activa el KV cache paginado | False |
+| `--max-tokens` | Maximo de tokens por defecto | 32768 |
+| `--max-request-tokens` | Maximo de `max_tokens` aceptado desde clientes de la API | 32768 |
+| `--stream-interval` | Tokens por fragmento de streaming | 1 |
+| `--mcp-config` | Ruta al archivo de configuración de MCP | None |
+| `--paged-cache-block-size` | Tokens por bloque de cache | 64 |
+| `--max-cache-blocks` | Maximos bloques de cache | 1000 |
+| `--max-num-seqs` | Maximo de secuencias concurrentes | 256 |
+| `--default-temperature` | Temperatura por defecto cuando no se especifica en la solicitud | None |
+| `--default-top-p` | top_p por defecto cuando no se especifica en la solicitud | None |
+| `--max-audio-upload-mb` | Tamano máximo de audio subido para `/v1/audio/transcriptions` | 25 |
+| `--max-tts-input-chars` | Longitud máxima de texto aceptada por `/v1/audio/speech` | 4096 |
+| `--reasoning-parser` | Parser para modelos de reasoning (`qwen3`, `deepseek_r1`) | None |
+| `--embedding-model` | Pre-carga un modelo de embeddings al iniciar | None |
+| `--enable-auto-tool-choice` | Activa tool calling automático | False |
+| `--tool-call-parser` | Parser de tool calling (`auto`, `mistral`, `qwen`, `llama`, `hermes`, `deepseek`, `kimi`, `granite`, `nemotron`, `xlam`, `functionary`, `glm47`) | None |
+
+### Ejemplos
+
+```bash
+# Modo simple (usuario único, máximo rendimiento)
+# La ruta del modelo se usa como nombre en la API de OpenAI (ej. model="mlx-community/Llama-3.2-3B-Instruct-4bit")
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+
+Model will show up as 'mlx-community/Llama-3.2-3B-Instruct-4bit' in the `/v1/models` API endpoint. View with `curl http://localhost:8000/v1/models` or similar.
+
+# Con un nombre de modelo personalizado en la API (el modelo se accede como "my-model" via la API de OpenAI)
+# --served-model-name establece el nombre que los clientes deben usar al llamar a la API (ej. model="my-model")
+vllm-mlx serve --served-model-name my-model mlx-community/Llama-3.2-3B-Instruct-4bit
+# Note: Model will show up as 'my-model' in the `/v1/models` API endpoint.
+
+# Continuous batching (multiples usuarios)
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
+
+# Con limite de memoria para modelos grandes
+vllm-mlx serve mlx-community/GLM-4.7-Flash-4bit \
+  --continuous-batching \
+  --cache-memory-mb 2048
+
+# Produccion con paged cache
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+
+# Con herramientas MCP
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# Modelo multimodal
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Modelo de reasoning (separa el pensamiento de la respuesta)
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# Modelo de reasoning DeepSeek
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+
+# Tool calling con Mistral/Devstral
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Tool calling con Granite
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+
+# Con autenticacion por clave de API
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
+
+# Exponer métricas de Prometheus
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics
+
+# Configuracion de produccion con opciones de seguridad
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --continuous-batching
+```
+
+### Seguridad
+
+Cuando se establece `--api-key`, todas las solicitudes a la API requieren el encabezado `Authorization: Bearer <api-key>`:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="your-secret-key"  # Must match --api-key
+)
+```
+
+O con curl:
+
+```bash
+curl http://localhost:8000/v1/models \
+  -H "Authorization: Bearer your-secret-key"
+```
+
+## `vllm-mlx-bench`
+
+Ejecuta benchmarks de rendimiento.
+
+### Uso
+
+```bash
+vllm-mlx-bench --model <model> [options]
+```
+
+### Opciones
+
+| Opcion | Descripcion | Por defecto |
+|--------|-------------|-------------|
+| `--model` | Nombre del modelo | Requerido |
+| `--prompts` | Numero de prompts | 5 |
+| `--max-tokens` | Maximo de tokens por prompt | 256 |
+| `--quick` | Modo de benchmark rápido | False |
+| `--video` | Ejecutar benchmark de video | False |
+| `--video-url` | URL de video personalizada | None |
+| `--video-path` | Ruta de video personalizada | None |
+
+### Ejemplos
+
+```bash
+# Benchmark de LLM
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit
+
+# Benchmark rápido
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --quick
+
+# Benchmark de imagenes (deteccion automática para modelos VLM)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Benchmark de video
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# Video personalizado
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit \
+  --video --video-url https://example.com/video.mp4
+```
+
+## `vllm-mlx-chat`
+
+Inicia la interfaz de chat con Gradio.
+
+### Uso
+
+```bash
+vllm-mlx-chat --served-model-name <model-name> [options]
+```
+
+### Opciones
+
+| Opcion | Descripcion | Por defecto |
+|--------|-------------|-------------|
+| `--model` | Nombre del modelo | Requerido |
+| `--port` | Puerto de Gradio | 7860 |
+| `--text-only` | Desactiva el modo multimodal | False |
+
+### Ejemplos
+
+```bash
+# Chat multimodal (texto + imagenes + video)
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Chat solo de texto
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit --text-only
+```
+
+## Variables de entorno
+
+| Variable | Descripcion |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | Modelo para pruebas |
+| `HF_TOKEN` | Token de HuggingFace |

--- a/docs/es/reference/configuration.md
+++ b/docs/es/reference/configuration.md
@@ -1,0 +1,189 @@
+# Referencia de configuración
+
+## Configuracion del servidor
+
+### Opciones basicas
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--host` | Direccion del host del servidor | `127.0.0.1` |
+| `--port` | Puerto del servidor | `8000` |
+| `--max-tokens` | Maximo de tokens por defecto | `32768` |
+| `--max-request-tokens` | Maximo de `max_tokens` aceptado de clientes de la API | `32768` |
+| `--default-temperature` | Temperatura por defecto cuando no se especifica en la solicitud | None |
+| `--default-top-p` | top_p por defecto cuando no se especifica en la solicitud | None |
+
+### Opciones de seguridad
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--api-key` | Clave de API para autenticacion | None |
+| `--rate-limit` | Solicitudes por minuto por cliente (0 = deshabilitado) | `0` |
+| `--timeout` | Tiempo de espera de la solicitud en segundos | `300` |
+| `--enable-metrics` | Expone métricas de Prometheus en `/metrics` | `false` |
+| `--max-audio-upload-mb` | Tamano máximo de audio subido para `/v1/audio/transcriptions` | `25` |
+| `--max-tts-input-chars` | Longitud máxima de texto aceptada por `/v1/audio/speech` | `4096` |
+
+### Opciones de batching
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--continuous-batching` | Habilita el continuous batching | `false` |
+| `--stream-interval` | Tokens por fragmento de streaming | `1` |
+| `--max-num-seqs` | Maximo de secuencias concurrentes | `256` |
+
+### Opciones de cache
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--cache-memory-mb` | Limite de memoria de cache en MB | Auto |
+| `--cache-memory-percent` | Fraccion de RAM para cache | `0.20` |
+| `--no-memory-aware-cache` | Usa cache de conteo de entradas heredado | `false` |
+| `--use-paged-cache` | Habilita el KV cache paginado | `false` |
+| `--paged-cache-block-size` | Tokens por bloque | `64` |
+| `--max-cache-blocks` | Maximo de bloques | `1000` |
+
+### Opciones de llamado a herramientas
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--enable-auto-tool-choice` | Habilita el llamado automático a herramientas | `false` |
+| `--tool-call-parser` | Parser de llamados a herramientas (ver [Tool Calling](../guides/tool-calling.md)) | None |
+
+### Opciones de razonamiento
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--reasoning-parser` | Parser para modelos de razonamiento (`qwen3`, `deepseek_r1`) | None |
+
+### Opciones de embeddings
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--embedding-model` | Precarga un modelo de embeddings al iniciar | None |
+
+### Opciones de MCP
+
+| Opcion | Descripcion | Valor por defecto |
+|--------|-------------|---------|
+| `--mcp-config` | Ruta al archivo de configuración MCP | None |
+
+## Configuracion de MCP
+
+Crear `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-name", "arg1"],
+      "env": {
+        "ENV_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+### Opciones del servidor MCP
+
+| Campo | Descripcion | Requerido |
+|-------|-------------|----------|
+| `command` | Comando ejecutable | Si |
+| `args` | Argumentos del comando | Si |
+| `env` | Variables de entorno | No |
+
+## Opciones de solicitudes a la API
+
+### Chat Completions
+
+| Parametro | Descripcion | Valor por defecto |
+|-----------|-------------|---------|
+| `model` | Nombre del modelo | Requerido |
+| `messages` | Mensajes del chat | Requerido |
+| `max_tokens` | Maximo de tokens a generar | 256 |
+| `temperature` | Temperatura de muestreo | Valor por defecto del modelo |
+| `top_p` | Nucleus sampling | Valor por defecto del modelo |
+| `stream` | Habilita el streaming | `true` |
+| `stop` | Secuencias de detencion | None |
+| `tools` | Definiciones de herramientas | None |
+| `response_format` | Formato de salida (`json_object`, `json_schema`) | None |
+
+### Opciones multimodales
+
+| Parametro | Descripcion | Valor por defecto |
+|-----------|-------------|---------|
+| `video_fps` | Fotogramas por segundo | 2.0 |
+| `video_max_frames` | Maximo de fotogramas | 32 |
+
+## Variables de entorno
+
+| Variable | Descripcion |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | Modelo por defecto para pruebas |
+| `HF_TOKEN` | Token de autenticacion de HuggingFace |
+| `OPENAI_API_KEY` | Establecer a cualquier valor para compatibilidad con el SDK |
+
+## Configuraciones de ejemplo
+
+### Desarrollo (usuario único)
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### Produccion (multiples usuarios)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --port 8000
+```
+
+### Con llamado a herramientas
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral \
+  --continuous-batching
+```
+
+### Con herramientas MCP
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --mcp-config mcp.json \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen \
+  --continuous-batching
+```
+
+### Modelo de razonamiento
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit \
+  --reasoning-parser qwen3 \
+  --continuous-batching
+```
+
+### Con embeddings
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --embedding-model mlx-community/multilingual-e5-small-mlx \
+  --continuous-batching
+```
+
+### Alto rendimiento
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --stream-interval 5 \
+  --max-num-seqs 256
+```

--- a/docs/es/reference/models.md
+++ b/docs/es/reference/models.md
@@ -1,0 +1,99 @@
+# Modelos compatibles
+
+Todos los modelos cuantizados de [mlx-community en HuggingFace](https://huggingface.co/mlx-community/models) son compatibles.
+
+Explora miles de modelos preoptimizados en: **https://huggingface.co/mlx-community/models**
+
+## Modelos de lenguaje (vía mlx-lm)
+
+| Familia de modelos | Tamaños | Cuantización |
+|--------------------|---------|--------------|
+| Llama 3.x, 4.x | 1B, 3B, 8B, 70B | 4-bit |
+| Mistral / Devstral | 7B, Mixtral 8x7B | 4-bit, 8-bit |
+| Qwen2/Qwen3 | 0.5B a 72B | Varios |
+| DeepSeek V3, R1 | 7B, 33B, 67B | 4-bit |
+| Gemma 2, 3, 4 | 2B, 9B, 27B | 4-bit |
+| GLM-4.7 | Flash, Base | 4-bit, 8-bit |
+| Kimi K2 | Varios | 4-bit |
+| Phi-3 | 3.8B, 14B | 4-bit |
+| Granite 3.x, 4.x | Varios | 4-bit |
+| Nemotron | 3 Nano 30B | 6-bit |
+
+### Modelos recomendados
+
+| Caso de uso | Modelo | Memoria |
+|-------------|--------|---------|
+| Rápido / Liviano | `mlx-community/Qwen3-0.6B-8bit` | ~0.7 GB |
+| Equilibrado | `mlx-community/Llama-3.2-3B-Instruct-4bit` | ~1.8 GB |
+| Calidad | `mlx-community/Llama-3.1-8B-Instruct-4bit` | ~4.5 GB |
+| Grande | `mlx-community/Qwen3-30B-A3B-4bit` | ~16 GB |
+
+## Modelos multimodales (vía mlx-vlm)
+
+| Familia de modelos | Modelos de ejemplo |
+|--------------------|--------------------|
+| **Qwen-VL** | `Qwen3-VL-4B-Instruct-3bit`, `Qwen3-VL-8B-Instruct-4bit`, `Qwen2-VL-2B/7B-Instruct-4bit` |
+| **LLaVA** | `llava-1.5-7b-4bit`, `llava-v1.6-mistral-7b-4bit`, `llava-llama-3-8b-v1_1-4bit` |
+| **Idefics** | `Idefics3-8B-Llama3-4bit`, `idefics2-8b-4bit` |
+| **Gemma 4** | `gemma-4-e2b-it-mxfp4` (visión + audio) |
+| **PaliGemma** | `paligemma2-3b-mix-224-4bit`, `paligemma-3b-mix-224-8bit` |
+| **Pixtral** | `pixtral-12b-4bit`, `pixtral-12b-8bit` |
+| **Molmo** | `Molmo-7B-D-0924-4bit`, `Molmo-7B-D-0924-8bit` |
+| **Phi-3 Vision** | `Phi-3-vision-128k-instruct-4bit` |
+| **DeepSeek-VL** | `deepseek-vl-7b-chat-4bit`, `deepseek-vl2-small-4bit` |
+
+### Modelos VLM recomendados
+
+| Caso de uso | Modelo | Memoria |
+|-------------|--------|---------|
+| Rápido / Liviano | `mlx-community/Qwen3-VL-4B-Instruct-3bit` | ~3 GB |
+| Equilibrado | `mlx-community/Qwen3-VL-8B-Instruct-4bit` | ~6 GB |
+| Calidad | `mlx-community/Qwen3-VL-30B-A3B-Instruct-6bit` | ~20 GB |
+
+## Modelos de embeddings (vía mlx-embeddings)
+
+| Familia de modelos | Modelos de ejemplo |
+|--------------------|--------------------|
+| **BERT** | `mlx-community/bert-base-uncased-mlx` |
+| **XLM-RoBERTa** | `mlx-community/multilingual-e5-small-mlx`, `mlx-community/multilingual-e5-large-mlx` |
+| **ModernBERT** | `mlx-community/ModernBERT-base-mlx` |
+
+## Modelos de audio (vía mlx-audio)
+
+| Tipo | Familia de modelos | Modelos de ejemplo |
+|------|--------------------|--------------------|
+| **STT** | Whisper | `mlx-community/whisper-large-v3-turbo` |
+| **STT** | Parakeet | `mlx-community/parakeet-tdt-0.6b-v2` |
+| **TTS** | Kokoro | `prince-canuma/Kokoro-82M` |
+| **TTS** | Chatterbox | `chatterbox/chatterbox-tts-0.1` |
+
+## Detección de modelos
+
+vllm-mlx detecta automáticamente los modelos multimodales por patrones en el nombre:
+- Contiene "VL", "Vision", "vision"
+- Contiene "llava", "idefics", "paligemma"
+- Contiene "pixtral", "molmo", "deepseek-vl"
+- Contiene "MedGemma", "Gemma-3", "Gemma-4" (variantes multimodales)
+
+## Usar modelos
+
+### Desde HuggingFace
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### Ruta local
+
+```bash
+vllm-mlx serve /path/to/local/model
+```
+
+## Buscar modelos
+
+Filtra los modelos de mlx-community por:
+- **LLM**: `Llama`, `Qwen`, `Mistral`, `Phi`, `Gemma`, `DeepSeek`, `GLM`, `Kimi`, `Granite`, `Nemotron`
+- **VLM**: `-VL-`, `llava`, `paligemma`, `pixtral`, `molmo`, `idefics`, `deepseek-vl`, `MedGemma`
+- **Embedding**: `e5`, `bert`, `ModernBERT`
+- **Tamaño**: `1B`, `3B`, `7B`, `8B`, `70B`
+- **Cuantización**: `4bit`, `8bit`, `bf16`

--- a/docs/fr/benchmarks/README.md
+++ b/docs/fr/benchmarks/README.md
@@ -1,0 +1,63 @@
+# Benchmarks
+
+Benchmarks de performance pour vllm-mlx sur Apple Silicon.
+
+## Types de benchmarks
+
+- [Benchmarks LLM](llm.md) - Performance de génération de texte
+- [Benchmarks image](image.md) - Performance de compréhension d'images
+- [Benchmarks vidéo](video.md) - Performance de compréhension de vidéos
+
+## Commandes rapides
+
+```bash
+# LLM benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# Image benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+```
+
+## Valeurs par défaut des scripts de test autonomes
+
+Les scripts de benchmark autonomes disposent de modèles par défaut intégrés, ce qui permet de les lancer directement :
+
+```bash
+python tests/test_continuous_batching.py
+python tests/test_prefix_cache.py
+```
+
+Valeurs par défaut :
+- `tests/test_continuous_batching.py` → `mlx-community/Qwen3-8B-6bit`
+- `tests/test_prefix_cache.py` → `mlx-community/Qwen3-0.6B-8bit`
+
+Pour tester d'autres modèles, utilisez l'option `--model` :
+
+```bash
+python tests/test_continuous_batching.py --model mlx-community/Qwen3-0.6B-8bit
+python tests/test_prefix_cache.py --model mlx-community/Qwen3-8B-6bit
+```
+
+## Matériel
+
+Les benchmarks ont été collectés sur les configurations Apple Silicon suivantes :
+
+| Puce | Mémoire | Python |
+|------|---------|--------|
+| Apple M4 Max | 128 Go unifiée | 3.13 |
+| Apple M1 Max | 64 Go unifiée | 3.12 |
+
+Les résultats varieront selon la puce Apple Silicon utilisée.
+
+## Contribuer des benchmarks
+
+Si vous disposez d'une puce Apple Silicon différente, partagez vos résultats :
+
+```bash
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+```
+
+Ouvrez un ticket avec vos résultats sur [GitHub Issues](https://github.com/waybarrios/vllm-mlx/issues).

--- a/docs/fr/benchmarks/audio.md
+++ b/docs/fr/benchmarks/audio.md
@@ -1,0 +1,158 @@
+# Benchmarks Audio
+
+## Benchmarks STT (Speech-to-Text)
+
+### Lancer les benchmarks STT
+
+```bash
+# Run with default test audio
+python examples/benchmark_audio.py --stt
+
+# Run with your own audio file
+python examples/benchmark_audio.py --stt --audio path/to/audio.wav
+```
+
+### Résultats (M4 Max, 128 Go)
+
+**Audio de test :** 46,7 secondes de synthèse vocale
+
+| Model | Parameters | Load Time | Transcribe Time | RTF* |
+|-------|------------|-----------|-----------------|------|
+| whisper-tiny | 39M | 0.34s | 0.24s | **197x** |
+| whisper-small | 244M | 0.18s | 0.47s | **98x** |
+| whisper-medium | 769M | 0.35s | 1.15s | **41x** |
+| whisper-large-v3 | 1.5B | 0.50s | 1.96s | **24x** |
+| whisper-large-v3-turbo | 809M | 0.12s | 0.86s | **55x** |
+
+*RTF = Real-Time Factor (plus la valeur est élevée, plus c'est rapide). Un RTF de 100x signifie qu'une minute d'audio est transcrite en environ 0,6 secondes.*
+
+### Résultats (M1 Max, 64 Go)
+
+STT avec Parakeet (environnement par défaut, Whisper indisponible en raison d'une incompatibilité de dépendance numpy) :
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| parakeet-tdt-0.6b-v2 | 0.28s | 1.01s | **9.9x** |
+| parakeet-tdt-0.6b-v3 | 0.30s | 0.19s | **52.7x** |
+
+STT avec Whisper (`numpy==2.3.5` explicite + `uv run --no-sync`) :
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| whisper-tiny | 4.02s | 1.05s | **9.5x** |
+| whisper-small | 10.15s | 1.03s | **9.7x** |
+| whisper-medium | 22.96s | 2.20s | **4.6x** |
+| whisper-large-v3 | 38.34s | 0.96s | **10.5x** |
+| whisper-large-v3-turbo | 21.79s | 0.70s | **14.3x** |
+| parakeet-tdt-0.6b-v2 | 0.47s | 0.18s | **54.4x** |
+| parakeet-tdt-0.6b-v3 | 1.13s | 0.18s | **54.6x** |
+
+### Recommandations de modèles
+
+| Use Case | Recommended Model | Why |
+|----------|-------------------|-----|
+| **Transcription en temps réel** | whisper-tiny | Le plus rapide (RTF 197x), faible latence |
+| **Usage général** | whisper-large-v3-turbo | Meilleur compromis vitesse (55x) et qualité |
+| **Précision maximale** | whisper-large-v3 | Le plus précis, prend en charge plus de 99 langues |
+| **Mémoire limitée** | whisper-small | Bonne qualité à 244M paramètres |
+
+### Qualité de transcription
+
+Tous les modèles ont correctement transcrit l'audio de test. Exemple de sortie :
+
+```
+Input text:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..."
+
+Whisper-large-v3 output:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..." (identical)
+```
+
+### Langues prises en charge
+
+Les modèles Whisper prennent en charge plus de 99 langues, notamment :
+- Anglais, espagnol, français, allemand, italien, portugais
+- Chinois (mandarin, cantonais), japonais, coréen
+- Arabe, hindi, russe, turc, ukrainien
+- Et bien d'autres
+
+## Benchmarks TTS (Text-to-Speech)
+
+### Lancer les benchmarks TTS
+
+```bash
+python examples/benchmark_audio.py --tts
+```
+
+### Résultats (M4 Max, 128 Go)
+
+**Test :** Génération audio pour 3 échantillons de texte (court, moyen, long)
+
+| Model | Load Time | Chars/sec | RTF* |
+|-------|-----------|-----------|------|
+| Kokoro-82M-bf16 | 0.8s | 350+ | **22x** |
+| Kokoro-82M-4bit | 0.4s | 320+ | **20x** |
+
+*RTF = Real-Time Factor. Un RTF de 22x signifie qu'une seconde d'audio est générée en environ 0,045 secondes.*
+
+### Résultats TTS (M1 Max, 64 Go)
+
+| Model | Load Time | Avg Chars/s | Avg RTF |
+|-------|-----------|-------------|---------|
+| Kokoro-82M-bf16 | 2.81s | 176.0 | **11.9x** |
+| Kokoro-82M-4bit | 0.22s | 225.6 | **15.5x** |
+
+### Qualité TTS
+
+Kokoro produit une synthèse vocale au son naturel avec :
+- 11 voix intégrées (masculines et féminines)
+- Prise en charge de 8 langues (anglais, espagnol, français, japonais, chinois, italien, portugais, hindi)
+- 82M paramètres, rapide et léger
+
+## Benchmarks de traitement audio
+
+### SAM-Audio (séparation de sources)
+
+**Test :** Séparation de la batterie dans un morceau de rock de 30 secondes
+
+| Metric | Value |
+|--------|-------|
+| Model | sam-audio-large-fp16 |
+| Processing time | ~20s |
+| Peak memory | ~27 GB |
+| Output sample rate | 48000 Hz |
+
+## Lancer tous les benchmarks audio
+
+```bash
+# Run all benchmarks
+python examples/benchmark_audio.py --all
+
+# Or run individually
+python examples/benchmark_audio.py --stt
+python examples/benchmark_audio.py --tts
+```
+
+## Modèles disponibles sur mlx-community
+
+### Modèles STT
+- `mlx-community/whisper-tiny-mlx`
+- `mlx-community/whisper-small-mlx`
+- `mlx-community/whisper-medium-mlx`
+- `mlx-community/whisper-large-v3-mlx`
+- `mlx-community/whisper-large-v3-turbo`
+- `mlx-community/parakeet-tdt-0.6b-v2`
+- `mlx-community/parakeet-tdt-0.6b-v3`
+
+### Modèles TTS
+- `mlx-community/Kokoro-82M-bf16` (recommandé)
+- `mlx-community/Kokoro-82M-4bit`
+- `mlx-community/chatterbox-turbo-fp16`
+- `mlx-community/VibeVoice-Realtime-0.5B-4bit`
+
+### Traitement audio
+- `mlx-community/sam-audio-large-fp16`

--- a/docs/fr/benchmarks/image.md
+++ b/docs/fr/benchmarks/image.md
@@ -1,0 +1,138 @@
+# Benchmarks d'images
+
+## Lancer les benchmarks d'images
+
+```bash
+# Benchmark complet (10 résolutions)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Benchmark rapide (4 résolutions)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --quick
+```
+
+## Résultats - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.04s | 78 | 74.8 tok/s |
+| 336x336 | 113K | 0.94s | 64 | 68.3 tok/s |
+| 448x448 | 201K | 1.45s | 70 | 48.1 tok/s |
+| 512x512 | 262K | 1.58s | 99 | 62.8 tok/s |
+| 672x672 | 452K | 1.83s | 83 | 45.3 tok/s |
+| 768x768 | 590K | 2.05s | 91 | 44.3 tok/s |
+| 896x896 | 803K | 2.61s | 90 | 34.5 tok/s |
+| 1024x1024 | 1.0M | 2.79s | 76 | 27.2 tok/s |
+| 1280x720 | 922K | 2.97s | 96 | 32.4 tok/s |
+| 1920x1080 | 2.1M | 6.30s | 89 | 14.1 tok/s |
+
+**Résumé :** Moyenne de 45.2 tok/s sur toutes les résolutions. Le plus rapide à 224x224 (74.8 tok/s), le plus lent à 1920x1080 (14.1 tok/s)
+
+## Résultats - Qwen3-VL-8B-Instruct-4bit (M1 Max, 64GB)
+
+Benchmark MLLM local :
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.84s | 78 | 42.5 tok/s |
+| 448x448 | 201K | 2.28s | 70 | 30.7 tok/s |
+| 768x768 | 590K | 4.39s | 91 | 20.7 tok/s |
+| 1024x1024 | 1.0M | 6.41s | 76 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 14.92 | 315 | 21.1 |
+
+## Résultats - Qwen3-VL-4B-Instruct-3bit Serveur (M1 Max, 64GB)
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.65s | 113 | 68.4 tok/s |
+| 448x448 | 201K | 2.09s | 120 | 57.5 tok/s |
+| 768x768 | 590K | 2.93s | 106 | 36.2 tok/s |
+| 1024x1024 | 1.0M | 4.12s | 100 | 24.3 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 10.79 | 439 | 40.7 |
+
+## Résultats du cache de préfixe MLLM
+
+```
+======================================================================
+  MLLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-VL-4B-Instruct-3bit
+  Test: Verify KV cache reuse for repeated image/video + prompt combinations
+  Expected behavior:
+    - Same image + same prompt → cache HIT
+    - Same image + different prompt → cache MISS
+    - Different image + same prompt → cache MISS
+----------------------------------------------------------------------
+  SETUP: Loading Model
+----------------------------------------------------------------------
+    Model loaded in 0.11s
+
+----------------------------------------------------------------------
+  SETUP: Creating Test Images
+----------------------------------------------------------------------
+    Resized: 224x224, 336x336, 512x512, 768x768
+
+----------------------------------------------------------------------
+  TEST 1: Image Cache - Basic Hit/Miss
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    1a     | First image+prompt        | MISS     | MISS   | 0.10ms | ✓
+    1b     | Same image+prompt         | HIT      | HIT    | 0.18ms | ✓
+    1c     | Different prompt          | MISS     | MISS   | 0.01ms | ✓
+    1d     | Return to original        | HIT      | HIT    | 0.18ms | ✓
+
+----------------------------------------------------------------------
+  TEST 2: Different Images
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    2a     | Image A first request     | MISS     | MISS   | 0.01ms | ✓
+    2b     | Image B first request     | MISS     | MISS   | 0.01ms | ✓
+    2c     | Image A cached            | HIT      | HIT    | 0.13ms | ✓
+
+----------------------------------------------------------------------
+  TEST 3: Image Resolutions
+----------------------------------------------------------------------
+    Results:
+    Step   | Description           | Expected | Actual | Time   | Status
+    -------+-----------------------+----------+--------+--------+-------
+    3.1a | 224x224 first         | MISS     | MISS   | 0.01ms | ✓
+    3.1b | 224x224 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.2a | 336x336 first         | MISS     | MISS   | 0.01ms | ✓
+    3.2b | 336x336 cached        | HIT      | HIT    | 0.21ms | ✓
+    3.3a | 512x512 first         | MISS     | MISS   | 0.12ms | ✓
+    3.3b | 512x512 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.4a | 768x768 first         | MISS     | MISS   | 0.12ms | ✓
+    3.4b | 768x768 cached        | HIT      | HIT    | 0.24ms | ✓
+======================================================================
+```
+
+## Stratégie de clé de cache
+
+- **Images :** `hash(image_content) + hash(prompt)`
+
+Une même image avec le même prompt touchera toujours le cache. Une image différente ou un prompt différent provoquera un cache miss.
+
+## Conseils de performance
+
+- Les résolutions plus petites sont traitées plus rapidement (224x224 contre 1920x1080)
+- Utilisez la résolution adaptée à votre tâche
+- Regroupez les images de taille similaire pour un débit constant
+
+## Référence des métriques
+
+| Metric | Description |
+|--------|-------------|
+| Resolution | Dimensions de l'image (largeur x hauteur) |
+| Pixels | Nombre total de pixels |
+| Time | Durée de génération |
+| Tokens | Tokens de sortie générés |
+| Speed | Tokens par seconde (tok/s) |

--- a/docs/fr/benchmarks/llm.md
+++ b/docs/fr/benchmarks/llm.md
@@ -1,0 +1,271 @@
+# Benchmarks LLM
+
+## Lancer les benchmarks LLM
+
+```bash
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 5 --max-tokens 256
+```
+
+## Résultats (M4 Max, 128 Go)
+
+| Modèle | Vitesse de génération | TTFT* | Mémoire |
+|--------|-----------------------|-------|---------|
+| Qwen3-0.6B-8bit | 402,3 tok/s | 58,6 ms | 0,68 Go |
+| Llama-3.2-1B-Instruct-4bit | 463,6 tok/s | 49,2 ms | 0,69 Go |
+| Qwen2.5-1.5B-Instruct-4bit | 308,5 tok/s | 86,2 ms | 0,84 Go |
+| Llama-3.2-3B-Instruct-4bit | 200,1 tok/s | 81,4 ms | 1,79 Go |
+| Qwen3-30B-A3B-4bit | 123,9 tok/s | 126,9 ms | 16,05 Go |
+| NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit | 122,9 tok/s | 72,3 ms | 23,98 Go |
+
+*TTFT = Time to First Token (latence jusqu'au premier token généré)
+
+## Résultats (M1 Max, 64 Go)
+
+| Modèle | Requêtes | Tok. prompt | Tok. générés | Temps total (s) | TTFT moyen (ms) | TPOT moyen (ms) | Vitesse génération (tok/s) | Débit total (tok/s) |
+|--------|----------|-------------|--------------|-----------------|-----------------|-----------------|---------------------------|---------------------|
+| Qwen3-0.6B-8bit | 5 | 56 | 1280 | 5,66 | 119,0 | 3,97 | 251,9 | 236,1 |
+
+## Résultats du continuous batching
+
+| Modèle | Requête unique | Batch (5 req) | Accélération |
+|--------|----------------|---------------|--------------|
+| Llama-3.2-1B-Instruct-4bit | 299,1 tok/s | 613,0 tok/s | **2,05x** |
+| Llama-3.2-3B-Instruct-4bit | 137,6 tok/s | 208,1 tok/s | **1,51x** |
+| Qwen3-0.6B-8bit | 328,1 tok/s | 1111,8 tok/s | **3,39x** |
+| Qwen3-30B-A3B-4bit | 98,1 tok/s | 233,3 tok/s | **2,38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196,9 tok/s | 322,2 tok/s | **1,64x** |
+
+*Le batching de 5 requêtes simultanées apporte une amélioration du throughput de 1,5 à 3x.*
+
+### Continuous batching (M1 Max, 64 Go)
+
+| Requêtes | Tokens totaux | Temps total (s) | Throughput (tok/s) | Requêtes/sec |
+|----------|---------------|-----------------|--------------------|--------------|
+| 5 | 315 | 0,64 | 492,5 | 7,82 |
+
+## Performances en streaming
+
+| Modèle | TTFT | Vitesse de génération |
+|--------|------|-----------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4,6 ms | 218,9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10,7 ms | 93,6 tok/s |
+| Qwen3-0.6B-8bit | ~3,0 ms | 328,5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10,2 ms | 98,4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7,1 ms | 140,3 tok/s |
+
+### Détokeniseur en streaming (M1 Max, 64 Go)
+
+`vllm-mlx bench-detok` :
+
+| Tokens | Itérations | Temps naïf | Temps streaming | Accélération |
+|--------|------------|------------|-----------------|--------------|
+| 742 | 5 | 1,69 ms | 0,71 ms | 2,39x |
+
+`examples/benchmark_detokenizer.py` :
+
+| Séquence | Tokens | decode() | Streaming | Accélération |
+|----------|--------|----------|-----------|--------------|
+| Courte | 8 | 0,029 ms | 0,028 ms | 1,04x |
+| Moyenne | 103 | 0,206 ms | 0,129 ms | 1,59x |
+| Longue | 511 | 1,040 ms | 0,502 ms | 2,07x |
+| 1K | 1191 | 2,446 ms | 1,178 ms | 2,08x |
+| 2K | 2381 | 4,949 ms | 2,356 ms | 2,10x |
+| 4K | 4761 | 9,887 ms | 5,398 ms | 1,83x |
+
+Accélération moyenne : 1,79x
+
+## Résultats du prefix cache
+
+### Prefix cache (M4 Max, 128 Go)
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | ✓
+  1b     | Same prompt         | HIT      | HIT    | ✓
+  1c     | Different prompt    | MISS     | MISS   | ✓
+  1d     | Return to prompt 1  | HIT      | HIT    | ✓
+======================================================================
+```
+
+### Prefix cache (M1 Max, 64 Go)
+
+| Test | Attendu | Réel | Temps | Statut |
+|------|---------|------|-------|--------|
+| Première requête | MISS | MISS | 203,5 ms | PASS |
+| Même prompt | HIT | HIT | 131,6 ms | PASS |
+| Prompt différent | MISS ou PREFIX_HIT | PREFIX_HIT (5 tok) | 135,3 ms | PASS |
+
+Statistiques finales du cache :
+
+| Hits cache | Misses cache | Taux de hit | Tokens économisés | Accélération avec cache |
+|------------|--------------|-------------|-------------------|------------------------|
+| 2 | 1 | 66,7 % | 20 | 1,55x |
+
+## Résultats du paged cache
+
+*Test : 20 requêtes d'inférence réelles en 2 rounds avec un prompt système partagé d'environ 286 tokens*
+
+```
+======================================================================
+  PAGED KV CACHE - REAL INFERENCE TEST
+======================================================================
+
+--------------------------------------------------
+Test 1: WITHOUT Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.47s
+  Throughput: 681.2 tok/s
+  Cache hits: 0
+  Tokens saved: 0
+
+--------------------------------------------------
+Test 2: WITH Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.31s
+  Throughput: 765.8 tok/s
+
+  Paged Cache Stats:
+    Blocks allocated: 25
+    Shared blocks: 4
+    Cache hits: 10
+    Tokens saved: 2560
+
+==================================================
+SUMMARY
+==================================================
+  Without paged cache: 681.2 tok/s
+  With paged cache:    765.8 tok/s
+
+  Speedup: 1.12x
+  Cache hits: 10 (all Round 2 requests)
+  Tokens saved: 2,560 (~256 tokens × 10 requests)
+==================================================
+```
+
+### KV cache paginé (M1 Max, 64 Go)
+
+Benchmark d'inférence (20 requêtes) :
+
+| Mode | Temps (s) | Throughput (tok/s) |
+|------|-----------|--------------------|
+| Sans paged cache | 3,43 | 291,8 |
+| Avec paged cache | 3,42 | 292,2 |
+
+| Accélération | Blocs alloués | Blocs partagés | Hits cache | Tokens économisés |
+|--------------|---------------|----------------|------------|-------------------|
+| 1,00x | 45 | 4 | 10 | 2560 |
+
+Inférence concurrente réelle (20 requêtes) :
+
+| Mode | Temps (s) | Throughput (tok/s) |
+|------|-----------|--------------------|
+| Sans paged cache | 4,32 | 231,7 |
+| Avec paged cache | 4,35 | 229,7 |
+
+| Accélération | Blocs alloués | Blocs partagés | Hits cache | Tokens économisés |
+|--------------|---------------|----------------|------------|-------------------|
+| 0,99x | 49 | 8 | 10 | 5120 |
+
+Démonstration des économies mémoire :
+
+| Scénario | Économies mémoire |
+|----------|-------------------|
+| Prompts système partagés | 70,8 % |
+| Efficacité mémoire concurrente | 83,5 % |
+| Branches avec partage de préfixe | 38,5 % |
+
+## Analyse du détokeniseur en streaming
+
+*Investigation phase 9.1 : `BPEStreamingDetokenizer` de mlx-lm vs `tokenizer.decode()` naïf*
+
+### Contexte
+
+L'approche naïve appelle `decode([token])` pour chaque token. En théorie, les détokeniseurs en streaming offrent une complexité O(T) contre O(T²) pour le décodage naïf.
+
+### Résultats du benchmark isolé
+
+```bash
+vllm-mlx bench-detok
+```
+
+En réutilisant la même instance de détokeniseur (avec `reset()` entre les utilisations) :
+
+| Séquence | Tokens | decode() naïf | Streaming | Accélération |
+|----------|--------|---------------|-----------|--------------|
+| Courte | 8 | 0,020 ms | 0,019 ms | 1,05x |
+| Moyenne | 103 | 0,155 ms | 0,097 ms | 1,59x |
+| Longue | 511 | 0,752 ms | 0,371 ms | **2,03x** |
+| 1K tokens | 1191 | 1,743 ms | 0,833 ms | **2,09x** |
+| 2K tokens | 2381 | 3,493 ms | 1,737 ms | **2,01x** |
+
+### Constat critique : surcoût de création d'instance
+
+La création d'une nouvelle instance de `BPEStreamingDetokenizer` est **extrêmement coûteuse** :
+
+```
+100 tokenizer.detokenizer calls: 5.266s (52.7ms each!)
+```
+
+Cela signifie que créer un nouveau détokeniseur par requête ajoute **environ 52 ms de surcoût**, annulant tout bénéfice.
+
+### Impact en conditions réelles
+
+Intégré dans le scheduler (un détokeniseur par requête) :
+
+| Métrique | decode() naïf | Streaming (nouvelle instance) |
+|----------|---------------|-------------------------------|
+| Throughput (20 req) | 681 tok/s | 275 tok/s |
+| Impact | - | **-60 % plus lent** |
+
+### Conclusion
+
+Le détokeniseur en streaming n'est **pas viable actuellement** pour un usage par requête, en raison du coût de création d'instance. L'approche naïve `decode([token])` reste plus rapide en pratique.
+
+**Optimisation future** : pré-créer un pool d'instances de détokeniseur au démarrage et les réutiliser entre les requêtes.
+
+## Référence des métriques
+
+| Métrique | Description |
+|----------|-------------|
+| **TTFT** | Time to First Token - latence jusqu'à ce que le modèle commence à répondre (ms) |
+| **TPOT** | Time Per Output Token - temps entre chaque token généré (ms/token) |
+| **Generation TPS** | Tokens de sortie par seconde (tok/s) |
+| **Processing TPS** | Tokens d'entrée/prompt traités par seconde (tok/s) |
+| **End-to-End Latency** | Temps total de la requête à la réponse complète |
+| **Total Throughput** | Tokens totaux (entrée + sortie) par seconde |
+
+## Lancer les benchmarks
+
+```bash
+# Benchmark de base
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# Avec davantage de prompts
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --prompts 10
+
+# Sauvegarder les résultats
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+
+# Test de continuous batching
+python tests/test_continuous_batching.py
+
+# Test de prefix cache
+python tests/test_prefix_cache.py
+
+# Test de paged cache
+python tests/test_paged_cache_real_inference.py
+
+# Benchmark du détokeniseur en streaming
+vllm-mlx bench-detok
+vllm-mlx bench-detok mlx-community/Llama-3.2-1B-Instruct-4bit --iterations 5
+```

--- a/docs/fr/benchmarks/video.md
+++ b/docs/fr/benchmarks/video.md
@@ -1,0 +1,128 @@
+# Benchmarks vidéo
+
+## Lancer les benchmarks vidéo
+
+```bash
+# Benchmark complet (10 configurations, 2-64 frames)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# Benchmark rapide (3 nombres de frames)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --quick
+
+# Vidéo personnalisée
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --video-url https://example.com/video.mp4
+```
+
+## Résultats - Qwen3-VL-8B-Instruct-4bit (M4 Max, 128GB)
+
+| Configuration | Frames | Time | Tokens | Speed | Memory |
+|---------------|--------|------|--------|-------|--------|
+| 2 frames @ 0.5fps | 2 | 4.48s | 256 | 57.1 tok/s | 6.4 GB |
+| 4 frames @ 1fps | 4 | 4.65s | 256 | 55.0 tok/s | 6.4 GB |
+| 6 frames @ 1fps | 6 | 5.15s | 197 | 38.2 tok/s | 6.6 GB |
+| 8 frames @ 2fps | 8 | 6.45s | 240 | 37.2 tok/s | 6.8 GB |
+| 12 frames @ 2fps | 12 | 8.73s | 256 | 29.3 tok/s | 7.1 GB |
+| 16 frames @ 2fps | 16 | 10.96s | 256 | 23.4 tok/s | 7.6 GB |
+| 24 frames @ 4fps | 24 | 14.95s | 226 | 15.1 tok/s | 8.4 GB |
+| 32 frames @ 4fps | 32 | 20.00s | 256 | 12.8 tok/s | 9.2 GB |
+| 48 frames @ 8fps | 48 | 31.11s | 246 | 7.9 tok/s | 11.1 GB |
+| 64 frames @ 8fps | 64 | 59.81s | 256 | 4.3 tok/s | 12.9 GB |
+
+**Résumé :** Le plus rapide à 2 frames (57.1 tok/s), le plus lent à 64 frames (4.3 tok/s). La mémoire varie de 6.4 GB à 12.9 GB.
+
+> **Note :** 96 frames et plus provoque un timeout GPU sur la plupart des machines en raison des limites de mémoire et de calcul.
+
+## Résultats - Qwen3-VL-8B-Instruct-4bit (M1 Max, 64GB)
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 8.84s | 256 | 29.0 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 13.05s | 256 | 19.6 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 21.60s | 256 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 43.48 | 768 | 17.7 |
+
+## Résultats - Qwen3-VL-4B-Instruct-3bit (M1 Max, 64GB)
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 5.09s | 150 | 29.5 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 8.36s | 150 | 17.9 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 15.21s | 150 | 9.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 28.66 | 450 | 15.7 |
+
+## Résultats du cache vidéo
+
+```
+----------------------------------------------------------------------
+  TEST 4: Video Cache - fps/max_frames in Cache Key
+----------------------------------------------------------------------
+    Config: fps=2.0, max_frames=16
+
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    4a     | Video first request       | MISS     | MISS   | 0.03ms | ✓
+    4b     | Same video+params         | HIT      | HIT    | 0.14ms | ✓
+    4c     | Different fps (4.0)       | MISS     | MISS   | 0.01ms | ✓
+    4d     | Different max_frames (32) | MISS     | MISS   | 0.01ms | ✓
+    4.0.5a | fps=0.5 first             | MISS     | MISS   | 0.01ms | ✓
+    4.0.5b | fps=0.5 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.1.0a | fps=1.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.1.0b | fps=1.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.2.0a | fps=2.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.2.0b | fps=2.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.4.0a | fps=4.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.4.0b | fps=4.0 cached            | HIT      | HIT    | 0.14ms | ✓
+
+----------------------------------------------------------------------
+  TEST 5: Additional Videos
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    5a     | Video 1 first             | MISS     | MISS   | 0.01ms | ✓
+    5b     | Video 2 first             | MISS     | MISS   | 0.01ms | ✓
+    5c     | Video 1 cached            | HIT      | HIT    | 0.13ms | ✓
+    5d     | Video 2 cached            | HIT      | HIT    | 0.13ms | ✓
+```
+
+## Stratégie de clé de cache
+
+- **Vidéos :** `hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+La même vidéo avec les mêmes paramètres fps, max_frames et prompt donnera un HIT dans le cache. La modification de l'un quelconque de ces paramètres provoque un MISS.
+
+## Conseils de performance
+
+- Un FPS plus faible accélère le traitement
+- Moins de frames réduit l'utilisation mémoire
+- 64 frames est le maximum pratique
+- 96 frames et plus provoque un timeout GPU
+
+## Extraction de frames
+
+| FPS | Vidéo 10s | Vidéo 30s | Vidéo 60s |
+|-----|-----------|-----------|-----------|
+| 0.5 | 5 frames | 15 frames | 30 frames |
+| 1.0 | 10 frames | 30 frames | 60 frames |
+| 2.0 | 20 frames | 60 frames | 120 frames* |
+| 4.0 | 40 frames | 120 frames* | 240 frames* |
+
+*Peut atteindre la limite `max_frames`
+
+## Référence des métriques
+
+| Metric | Description |
+|--------|-------------|
+| Configuration | Paramètres FPS et nombre maximum de frames |
+| Frames | Nombre réel de frames extraites |
+| Time | Temps total de génération |
+| Tokens | Tokens de sortie générés |
+| Speed | Tokens par seconde (tok/s) |
+| Memory | Utilisation de la mémoire GPU |

--- a/docs/fr/getting-started/installation.md
+++ b/docs/fr/getting-started/installation.md
@@ -1,0 +1,89 @@
+# Installation
+
+## Prérequis
+
+- macOS sur Apple Silicon (M1/M2/M3/M4)
+- Python 3.10+
+
+## Installation avec uv (recommandée)
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+uv pip install -e .
+```
+
+## Installation avec pip
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+pip install -e .
+```
+
+### Optionnel : support vidéo
+
+Pour le traitement vidéo avec transformers :
+
+```bash
+pip install -e ".[vision]"
+```
+
+### Optionnel : support audio (STT/TTS)
+
+```bash
+pip install mlx-audio
+```
+
+### Optionnel : embeddings
+
+```bash
+pip install mlx-embeddings
+```
+
+## Ce qui est installé
+
+- `mlx`, `mlx-lm`, `mlx-vlm` - framework MLX et bibliothèques de modèles
+- `transformers`, `tokenizers` - bibliothèques HuggingFace
+- `opencv-python` - traitement vidéo
+- `gradio` - interface de chat
+- `psutil` - surveillance des ressources
+- `mlx-audio` (optionnel) - Speech-to-Text et Text-to-Speech
+- `mlx-embeddings` (optionnel) - embeddings de texte
+
+## Vérifier l'installation
+
+```bash
+# Check CLI commands
+vllm-mlx --help
+vllm-mlx-bench --help
+vllm-mlx-chat --help
+
+# Test with a small model
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 1
+```
+
+## Dépannage
+
+### MLX introuvable
+
+Vérifiez que vous êtes sur Apple Silicon :
+```bash
+uname -m  # Should output "arm64"
+```
+
+### Échec du téléchargement du modèle
+
+Vérifiez votre connexion internet et vos accès HuggingFace. Certains modèles nécessitent une authentification :
+```bash
+huggingface-cli login
+```
+
+### Mémoire insuffisante
+
+Utilisez un modèle quantifié plus petit :
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
+```

--- a/docs/fr/getting-started/quickstart.md
+++ b/docs/fr/getting-started/quickstart.md
@@ -1,0 +1,133 @@
+# Démarrage rapide
+
+## Option 1 : serveur compatible OpenAI
+
+Démarrez le serveur :
+
+```bash
+# Simple mode - maximum throughput for single user
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# Continuous batching - for multiple concurrent users
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+Utilisation avec le SDK Python OpenAI :
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="mlx-community/Llama-3.2-3B-Instruct-4bit",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+Ou avec curl :
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## Option 2 : API Python directe
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+
+# Streaming
+for chunk in model.stream_generate("Tell me a story"):
+    print(chunk.text, end="", flush=True)
+```
+
+## Option 3 : interface de chat Gradio
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+Ouvre une interface web à l'adresse http://localhost:7860
+
+## Modèles multimodaux
+
+Pour la compréhension d'images et de vidéos, utilisez un modèle VLM :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+```
+
+## Modèles de raisonnement
+
+Séparez le processus de réflexion du modèle de la réponse finale :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+print(response.choices[0].message.content)  # Final answer
+```
+
+## Embeddings
+
+Générez des embeddings textuels pour la recherche sémantique et le RAG :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+```
+
+## Tool Calling
+
+Activez l'appel de fonctions avec tout modèle compatible :
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+## Étapes suivantes
+
+- [Server Guide](../guides/server.md) - Configuration complète du serveur
+- [Python API](../guides/python-api.md) - Utilisation directe de l'API
+- [Multimodal Guide](../guides/multimodal.md) - Images et vidéos
+- [Audio Guide](../guides/audio.md) - Speech-to-Text et Text-to-Speech
+- [Embeddings Guide](../guides/embeddings.md) - Embeddings textuels
+- [Reasoning Models](../guides/reasoning.md) - Modèles de réflexion
+- [Tool Calling](../guides/tool-calling.md) - Appel de fonctions
+- [Supported Models](../reference/models.md) - Modèles disponibles

--- a/docs/fr/guides/audio.md
+++ b/docs/fr/guides/audio.md
@@ -1,0 +1,524 @@
+# Support Audio
+
+vllm-mlx prend en charge le traitement audio via [mlx-audio](https://github.com/Blaizzy/mlx-audio), offrant :
+
+- **STT (Speech-to-Text)** : Whisper, Parakeet
+- **TTS (Text-to-Speech)** : Kokoro, Chatterbox, VibeVoice, VoxCPM
+- **Traitement audio** : SAM-Audio (séparation vocale)
+
+## Installation
+
+```bash
+# Support audio de base
+pip install mlx-audio>=0.2.9
+
+# Required dependencies for TTS
+pip install sounddevice soundfile scipy numba tiktoken misaki spacy num2words loguru phonemizer
+
+# Download spacy English model
+python -m spacy download en_core_web_sm
+
+# For non-English TTS (Spanish, French, etc.), install espeak-ng:
+# macOS
+brew install espeak-ng
+
+# Ubuntu/Debian
+# sudo apt-get install espeak-ng
+```
+
+Ou installez toutes les dépendances audio en une seule commande :
+
+```bash
+pip install vllm-mlx[audio]
+python -m spacy download en_core_web_sm
+brew install espeak-ng  # macOS, for non-English languages
+```
+
+## Démarrage rapide
+
+### Speech-to-Text (Transcription)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Transcribe audio file
+with open("audio.mp3", "rb") as f:
+    transcript = client.audio.transcriptions.create(
+        model="whisper-large-v3",
+        file=f,
+        language="en"  # optional
+    )
+print(transcript.text)
+```
+
+### Text-to-Speech (Génération)
+
+```python
+# Generate speech
+audio = client.audio.speech.create(
+    model="kokoro",
+    input="Hello, how are you?",
+    voice="af_heart",
+    speed=1.0
+)
+
+# Save to file
+with open("output.wav", "wb") as f:
+    f.write(audio.content)
+```
+
+### Séparation vocale (SAM-Audio)
+
+Isolez une voix du bruit de fond, de la musique ou d'autres sons :
+
+```python
+from vllm_mlx.audio import AudioProcessor
+
+# Load SAM-Audio model
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+
+# Separate speech from audio
+result = processor.separate("meeting_with_music.mp3", description="speech")
+
+# Save isolated voice and background
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background_only.wav")
+```
+
+**Exemple en ligne de commande :**
+```bash
+python examples/audio_separation_example.py meeting.mp3 --play
+python examples/audio_separation_example.py song.mp3 --description music -o music.wav
+```
+
+### Démo de séparation de batterie
+
+Isolez la batterie d'une chanson rock avec SAM-Audio :
+
+| Audio | Description | Écouter |
+|-------|-------------|---------|
+| Original | "Get Ready" de David Fesliyan (30s, libre de droits) | [rock_get_ready.mp3](../../../examples/rock_get_ready.mp3) |
+| Batterie isolée | Batterie extraite par SAM-Audio | [drums_isolated.wav](../../../examples/drums_isolated.wav) |
+| Sans batterie | Piste sans batterie | [rock_no_drums.wav](../../../examples/rock_no_drums.wav) |
+
+```bash
+# Isolate drums from rock song
+python examples/audio_separation_example.py examples/rock_get_ready.mp3 \
+  --description "drums" \
+  --output drums_isolated.wav \
+  --background rock_no_drums.wav
+```
+
+**Performance :** 30 secondes d'audio traitées en environ 20 secondes sur M4 Max.
+
+## Modèles pris en charge
+
+### Modèles STT (Speech-to-Text)
+
+| Modèle | Alias | Langues | Vitesse | Qualité |
+|--------|-------|---------|---------|---------|
+| `mlx-community/whisper-large-v3-mlx` | `whisper-large-v3` | 99+ | Moyenne | Meilleure |
+| `mlx-community/whisper-large-v3-turbo` | `whisper-large-v3-turbo` | 99+ | Rapide | Excellente |
+| `mlx-community/whisper-medium-mlx` | `whisper-medium` | 99+ | Rapide | Bonne |
+| `mlx-community/whisper-small-mlx` | `whisper-small` | 99+ | Très rapide | Correcte |
+| `mlx-community/parakeet-tdt-0.6b-v2` | `parakeet` | Anglais | La plus rapide | Excellente |
+| `mlx-community/parakeet-tdt-0.6b-v3` | `parakeet-v3` | Anglais | La plus rapide | Meilleure |
+
+**Recommandations :**
+- Multilingue : `whisper-large-v3`
+- Anglais uniquement : `parakeet` (3 fois plus rapide)
+
+### Modèles TTS (Text-to-Speech)
+
+#### Kokoro (Rapide, Léger) - Recommandé
+
+| Modèle | Alias | Taille | Langues |
+|--------|-------|--------|---------|
+| `mlx-community/Kokoro-82M-bf16` | `kokoro` | 82M | EN, ES, FR, JA, ZH, HI, IT, PT |
+| `mlx-community/Kokoro-82M-4bit` | `kokoro-4bit` | 82M | EN, ES, FR, JA, ZH, HI, IT, PT |
+
+**Voix (11) :**
+- Femme américaine : `af_heart`, `af_bella`, `af_nicole`, `af_sarah`, `af_sky`
+- Homme américain : `am_adam`, `am_michael`
+- Femme britannique : `bf_emma`, `bf_isabella`
+- Homme britannique : `bm_george`, `bm_lewis`
+
+**Codes de langue :**
+| Code | Langue | Code | Langue |
+|------|--------|------|--------|
+| `a` / `en` | English (US) | `e` / `es` | Español |
+| `b` / `en-gb` | English (UK) | `f` / `fr` | Français |
+| `j` / `ja` | 日本語 | `z` / `zh` | 中文 |
+| `i` / `it` | Italiano | `p` / `pt` | Português |
+| `h` / `hi` | हिन्दी | | |
+
+#### Chatterbox (Multilingue, Expressif)
+
+| Modèle | Alias | Taille | Langues |
+|--------|-------|--------|---------|
+| `mlx-community/chatterbox-turbo-fp16` | `chatterbox` | 134M | 15+ langues |
+| `mlx-community/chatterbox-turbo-4bit` | `chatterbox-4bit` | 134M | 15+ langues |
+
+**Langues prises en charge :** EN, ES, FR, DE, IT, PT, RU, JA, ZH, KO, AR, HI, NL, PL, TR
+
+#### VibeVoice (Temps réel)
+
+| Modèle | Alias | Taille | Cas d'usage |
+|--------|-------|--------|-------------|
+| `mlx-community/VibeVoice-Realtime-0.5B-4bit` | `vibevoice` | 200M | Faible latence, anglais |
+
+#### VoxCPM (Chinois/Anglais)
+
+| Modèle | Alias | Taille | Langues |
+|--------|-------|--------|---------|
+| `mlx-community/VoxCPM1.5` | `voxcpm` | 0.9B | ZH, EN |
+| `mlx-community/VoxCPM1.5-4bit` | `voxcpm-4bit` | 200M | ZH, EN |
+
+### Modèles de traitement audio
+
+#### SAM-Audio (Séparation vocale)
+
+| Modèle | Taille | Cas d'usage |
+|--------|--------|-------------|
+| `mlx-community/sam-audio-large-fp16` | 3B | Meilleure qualité |
+| `mlx-community/sam-audio-large` | 3B | Standard |
+| `mlx-community/sam-audio-small-fp16` | 0.6B | Rapide |
+| `mlx-community/sam-audio-small` | 0.6B | Léger |
+
+## Référence API
+
+### POST /v1/audio/transcriptions
+
+Transcrit un fichier audio en texte (compatible API OpenAI Whisper).
+
+**Paramètres :**
+- `file` : Fichier audio (mp3, wav, m4a, webm)
+- `model` : Nom ou alias du modèle
+- `language` : Code de langue (optionnel, détection automatique)
+- `response_format` : `json` ou `text`
+
+**Limites :**
+- Taille maximale par défaut : 25 MiB
+- Modifiable avec `--max-audio-upload-mb`
+
+**Exemple :**
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@audio.mp3 \
+  -F model=whisper-large-v3
+```
+
+### POST /v1/audio/speech
+
+Génère de la parole à partir de texte (compatible API OpenAI TTS).
+
+**Paramètres :**
+- `model` : Nom ou alias du modèle
+- `input` : Texte à synthétiser
+- `voice` : Identifiant de la voix
+- `speed` : Vitesse de parole (0,5 à 2,0)
+- `response_format` : `wav`, `mp3`
+
+**Limites :**
+- Nombre de caractères maximal par défaut : 4096
+- Modifiable avec `--max-tts-input-chars`
+
+**Exemple :**
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart"}' \
+  -H "Content-Type: application/json" \
+  --output speech.wav
+```
+
+### GET /v1/audio/voices
+
+Liste les voix disponibles pour un modèle.
+
+**Exemple :**
+```bash
+curl http://localhost:8000/v1/audio/voices?model=kokoro
+```
+
+## Exemples en ligne de commande
+
+### Transcription en direct / Sous-titres en temps réel
+
+Transcription STT en temps réel depuis votre microphone :
+
+```bash
+# Closed captions with whisper-large-v3 (best quality)
+python examples/closed_captions.py --language es --chunk 5
+
+# Faster model for lower latency
+python examples/closed_captions.py --language en --model whisper-turbo --chunk 3
+
+# Basic mic transcription (record then transcribe)
+python examples/mic_transcribe.py --language es
+
+# Real-time chunked transcription
+python examples/mic_realtime.py --language es --chunk 3
+
+# Live transcription with voice activity detection
+python examples/mic_live.py --language es
+```
+
+**Prérequis :**
+```bash
+pip install sounddevice soundfile numpy
+```
+
+### TTS de base
+
+```bash
+# Simple TTS example
+python examples/tts_example.py "Hello, how are you?" --play
+
+# With different voice
+python examples/tts_example.py "Hello!" --voice am_michael --play
+
+# Save to file
+python examples/tts_example.py "Welcome to the demo" -o greeting.wav
+
+# List available voices
+python examples/tts_example.py --list-voices
+```
+
+### TTS multilingue
+
+```bash
+# English (auto-selects best model)
+python examples/tts_multilingual.py "Hello world" --play
+
+# Spanish
+python examples/tts_multilingual.py "Hola mundo" --lang es --play
+
+# French
+python examples/tts_multilingual.py "Bonjour le monde" --lang fr --play
+
+# Japanese
+python examples/tts_multilingual.py "こんにちは" --lang ja --play
+
+# Chinese
+python examples/tts_multilingual.py "你好世界" --lang zh --play
+
+# Use specific model
+python examples/tts_multilingual.py "Hello" --model chatterbox --play
+
+# List all models
+python examples/tts_multilingual.py --list-models
+
+# List all languages
+python examples/tts_multilingual.py --list-languages
+```
+
+### Exemples d'assistant vocal professionnel
+
+Exemples vocaux prégénérés avec des **voix natives** pour des cas d'usage professionnels courants :
+
+| Langue | Voix | Message | Écouter |
+|--------|------|---------|---------|
+| Anglais | af_heart | "Welcome to First National Bank. How may I assist you today?" | [assistant_bank_en.wav](../../../examples/assistant_bank_en.wav) |
+| Espagnol | ef_dora | "Gracias por llamar a servicio al cliente. Un agente le atenderá pronto." | [assistant_service_es.wav](../../../examples/assistant_service_es.wav) |
+| Français | ff_siwis | "Bienvenue. Votre appel est important pour nous." | [assistant_callcenter_fr.wav](../../../examples/assistant_callcenter_fr.wav) |
+| Chinois | zf_xiaobei | "欢迎致电技术支持中心。我们将竭诚为您服务。" | [assistant_support_zh.wav](../../../examples/assistant_support_zh.wav) |
+
+**Générez vos propres exemples avec des voix natives :**
+```bash
+# English - Bank assistant (native voice: af_heart)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Welcome to First National Bank. How may I assist you today?" \
+  --voice af_heart --lang_code a --file_prefix assistant_bank_en
+
+# Spanish - Customer service (native voice: ef_dora)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Gracias por llamar a servicio al cliente. Un agente le atendera pronto." \
+  --voice ef_dora --lang_code e --file_prefix assistant_service_es
+
+# French - Call center (native voice: ff_siwis)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Bienvenue. Votre appel est important pour nous." \
+  --voice ff_siwis --lang_code f --file_prefix assistant_callcenter_fr
+
+# Chinese - Tech support (native voice: zf_xiaobei)
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "欢迎致电技术支持中心。我们将竭诚为您服务。" \
+  --voice zf_xiaobei --lang_code z --file_prefix assistant_support_zh
+```
+
+### Référence des voix natives
+
+| Langue | Code | Voix |
+|--------|------|------|
+| English (US) | `a` | af_heart, af_bella, af_nicole, am_adam, am_michael |
+| English (UK) | `b` | bf_emma, bf_isabella, bm_george, bm_lewis |
+| Espagnol | `e` | ef_dora, em_alex, em_santa |
+| Français | `f` | ff_siwis |
+| Chinois | `z` | zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zm_yunjian, zm_yunxi |
+| Japonais | `j` | jf_alpha, jf_gongitsune, jm_kumo |
+| Italien | `i` | if_sara, im_nicola |
+| Portugais | `p` | pf_dora, pm_alex |
+| Hindi | `h` | hf_alpha, hf_beta, hm_omega |
+
+## API Python
+
+### Utilisation directe (sans serveur)
+
+```python
+from vllm_mlx.audio import STTEngine, TTSEngine, AudioProcessor
+
+# Speech-to-Text
+stt = STTEngine("mlx-community/whisper-large-v3-mlx")
+stt.load()
+result = stt.transcribe("audio.mp3")
+print(result.text)
+
+# Text-to-Speech
+tts = TTSEngine("mlx-community/Kokoro-82M-bf16")
+tts.load()
+audio = tts.generate("Hello world", voice="af_heart")
+tts.save(audio, "output.wav")
+
+# Voice Separation
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+result = processor.separate("mixed_audio.mp3", description="speech")
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background.wav")
+```
+
+### Fonctions utilitaires
+
+```python
+from vllm_mlx.audio import transcribe_audio, generate_speech, separate_voice
+
+# Quick transcription
+result = transcribe_audio("audio.mp3")
+print(result.text)
+
+# Quick TTS
+audio = generate_speech("Hello world", voice="af_heart")
+
+# Quick voice separation
+voice, background = separate_voice("mixed.mp3")
+```
+
+## Audio dans le chat
+
+Incluez de l'audio dans les messages du chat (transcrit automatiquement) :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Summarize this audio"},
+            {"type": "audio_url", "audio_url": {"url": "file://meeting.mp3"}}
+        ]
+    }]
+)
+```
+
+## Benchmarks
+
+Testé sur Apple M2 Max (32 Go).
+
+### Benchmarks TTS (Kokoro-82M-bf16)
+
+| Longueur du texte | Durée audio | Temps de génération | RTF | Caractères/s |
+|-------------------|-------------|---------------------|-----|--------------|
+| 25 caractères | 1,95 s | 0,43 s | 4,6x | 58,5 |
+| 88 caractères | 6,00 s | 0,32 s | 18,6x | 272,4 |
+| 117 caractères | 7,92 s | 0,27 s | 29,0x | 427,4 |
+
+**Résumé :**
+- Temps de chargement du modèle : environ 1,0 s
+- RTF moyen : **17,4x** (17 fois plus rapide que le temps réel)
+- Caractères/s moyens : **252,8**
+
+### Benchmarks STT
+
+| Modèle | Temps de chargement | Transcription (6 s audio) | RTF |
+|--------|---------------------|---------------------------|-----|
+| whisper-small | 0,25 s | 0,20 s | 30,2x |
+| whisper-medium | 18,1 s | 0,38 s | 15,5x |
+| whisper-large-v3 | environ 30 s | environ 0,6 s | environ 10x |
+| parakeet | environ 0,5 s | environ 0,15 s | environ 40x |
+
+**Notes :**
+- Le RTF (Real-Time Factor) indique combien de fois plus rapide que le temps réel
+- Le premier chargement inclut le téléchargement du modèle depuis HuggingFace
+- Les chargements suivants utilisent les modèles mis en cache
+
+### Recommandations par cas d'usage
+
+| Cas d'usage | Modèle recommandé | Pourquoi |
+|-------------|------------------|----------|
+| STT anglais rapide | `parakeet` | RTF 40x, faible consommation mémoire |
+| STT multilingue | `whisper-large-v3` | 99+ langues |
+| STT faible latence | `whisper-small` | RTF 30x, chargement rapide |
+| TTS général | `kokoro` | RTF 17x, bonne qualité |
+| TTS faible mémoire | `kokoro-4bit` | Quantification 4 bits |
+
+## Conseils de performance
+
+1. **Utilisez Parakeet pour l'anglais** : 40 fois plus rapide que le temps réel
+2. **Utilisez les modèles 4 bits** pour réduire la consommation mémoire
+3. **Utilisez SAM-Audio small** pour une séparation vocale plus rapide
+4. **Mettez les modèles en cache** : les moteurs sont chargés à la demande et mis en cache
+5. **Pré-téléchargez les modèles** pour éviter la latence au premier démarrage
+
+## Dépannage
+
+### mlx-audio non installé
+```
+pip install mlx-audio>=0.2.9
+```
+
+### Téléchargement du modèle lent
+Les modèles sont téléchargés depuis HuggingFace lors de la première utilisation. Utilisez `huggingface-cli download` pour les pré-télécharger :
+```bash
+huggingface-cli download mlx-community/whisper-large-v3-mlx
+huggingface-cli download mlx-community/Kokoro-82M-bf16
+```
+
+### Mémoire insuffisante
+Utilisez des modèles plus petits ou des versions quantifiées en 4 bits :
+- `whisper-small-mlx` plutôt que `whisper-large-v3-mlx`
+- `Kokoro-82M-4bit` plutôt que `Kokoro-82M-bf16`
+- `sam-audio-small` plutôt que `sam-audio-large`
+
+### Bug multilingue Kokoro (mlx-audio 0.2.9)
+
+Si vous obtenez `ValueError: too many values to unpack` en utilisant des langues autres que l'anglais (espagnol, chinois, japonais, etc.) avec Kokoro, appliquez ce correctif :
+
+```python
+# Fix for mlx_audio/tts/models/kokoro/pipeline.py line 443
+# Change:
+#     ps, _ = self.g2p(chunk)
+# To:
+g2p_result = self.g2p(chunk)
+ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result
+```
+
+**Correctif en une ligne :**
+```bash
+python -c "
+import os
+path = os.path.join(os.path.dirname(__import__('mlx_audio').__file__), 'tts/models/kokoro/pipeline.py')
+with open(path, 'r') as f: content = f.read()
+old = '                    ps, _ = self.g2p(chunk)'
+new = '''                    # Fix: handle both tuple (en) and string (zh/ja/es) returns from g2p
+                    g2p_result = self.g2p(chunk)
+                    ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result'''
+if old in content:
+    with open(path, 'w') as f: f.write(content.replace(old, new))
+    print('Fix applied!')
+"
+```
+
+Ce bug survient car le g2p anglais retourne un tuple `(phonemes, tokens)` tandis que les autres langues retournent uniquement une chaîne de caractères.

--- a/docs/fr/guides/continuous-batching.md
+++ b/docs/fr/guides/continuous-batching.md
@@ -1,0 +1,174 @@
+# Continuous Batching
+
+Le continuous batching permet d'augmenter le throughput lors du traitement de plusieurs utilisateurs simultanés.
+
+## Activer le Continuous Batching
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
+```
+
+## Avec le Paged Cache
+
+Pour un partage mémoire efficace des préfixes :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
+```
+
+## Fonctionnement
+
+### Mode simple (par défaut)
+- Une seule requête à la fois
+- Throughput maximal pour un utilisateur unique
+- Aucune surcharge liée au batching
+
+### Mode Continuous Batching
+- Plusieurs requêtes traitées simultanément
+- Meilleur throughput pour les utilisateurs concurrents
+- Légère surcharge par requête
+
+### Paged Cache
+- Le KV cache est stocké en blocs de taille fixe
+- Les prompts système identiques partagent les mêmes blocs
+- Économies mémoire : 80 % et plus pour 10 utilisateurs simultanés ou davantage
+
+## Résultats de performance
+
+**Résultats du Continuous Batching (M4 Max, 128 Go) :**
+
+| Modèle | Requête unique | Batch (5 req) | Accélération |
+|--------|----------------|---------------|--------------|
+| Llama-3.2-1B-Instruct-4bit | 299.1 tok/s | 613.0 tok/s | **2.05x** |
+| Llama-3.2-3B-Instruct-4bit | 137.6 tok/s | 208.1 tok/s | **1.51x** |
+| Qwen3-0.6B-8bit | 328.1 tok/s | 1111.8 tok/s | **3.39x** |
+| Qwen3-30B-A3B-4bit | 98.1 tok/s | 233.3 tok/s | **2.38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196.9 tok/s | 322.2 tok/s | **1.64x** |
+
+*Le batching de 5 requêtes simultanées améliore le throughput d'un facteur 1,5 à 3.*
+
+## Performance en Streaming
+
+**Performance en streaming (M4 Max, 128 Go) :**
+
+| Modèle | TTFT | Vitesse de génération |
+|--------|------|-----------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4.6 ms | 218.9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10.7 ms | 93.6 tok/s |
+| Qwen3-0.6B-8bit | ~3.0 ms | 328.5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10.2 ms | 98.4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7.1 ms | 140.3 tok/s |
+
+*TTFT = Time to First Token*
+
+## Configuration du Streaming
+
+Contrôlez la cadence d'envoi des tokens avec `--stream-interval` :
+
+```bash
+# Chaque token (le plus fluide)
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# Tokens groupés (préférable pour les connexions à latence élevée)
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+| Valeur | Comportement |
+|--------|-------------|
+| `1` | Envoie chaque token immédiatement |
+| `2-5` | Regroupe les tokens avant l'envoi |
+| `10+` | Throughput maximal, sortie plus fragmentée |
+
+## Gestion de la mémoire
+
+Pour les grands modèles, le prefix cache peut consommer une quantité significative de mémoire. Le cache adaptatif la gère automatiquement :
+
+```bash
+# Détection automatique (utilise 20 % de la RAM disponible)
+vllm-mlx serve model --continuous-batching
+
+# Limite explicite
+vllm-mlx serve model --continuous-batching --cache-memory-mb 2048
+
+# Pourcentage personnalisé
+vllm-mlx serve model --continuous-batching --cache-memory-percent 0.10
+```
+
+| Option | Description |
+|--------|-------------|
+| `--cache-memory-mb` | Définit une limite explicite en Mo |
+| `--cache-memory-percent` | Fraction de la RAM disponible (par défaut : 0,20) |
+| `--no-memory-aware-cache` | Utilise le cache historique basé sur le nombre d'entrées |
+
+## Prefix Cache
+
+Le prefix caching réutilise le KV cache pour les prompts répétés.
+
+### Fonctionnement
+
+```
+User 1: System prompt (500 tokens) → Creates 8 blocks
+User 2: Same system prompt → Shares 8 blocks (ref_count++)
+User N: Same system prompt → Shares 8 blocks (ref_count++)
+
+Memory savings: 80%+ for 10+ concurrent users
+```
+
+### Stratégie de clé de cache
+
+- **LLM** : `hash(prompt)`
+- **Images** : `hash(image_content) + hash(prompt)`
+- **Vidéos** : `hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+### Tester le Prefix Cache
+
+```bash
+python tests/test_prefix_cache.py
+```
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS or PREFIX_HIT (shared template tokens)
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | PASS
+  1b     | Same prompt         | HIT      | HIT    | PASS
+  1c     | Different prompt    | MISS     | MISS   | PASS
+  1d     | Return to prompt 1  | HIT      | HIT    | PASS
+======================================================================
+```
+
+## Exécuter les benchmarks
+
+```bash
+# Benchmark du continuous batching
+python tests/test_continuous_batching.py
+
+# Test du prefix cache
+python tests/test_prefix_cache.py
+```
+
+## Quand l'utiliser
+
+| Scénario | Mode |
+|----------|------|
+| Utilisateur unique, vitesse maximale | Simple (par défaut) |
+| Plusieurs utilisateurs simultanés | `--continuous-batching` |
+| Grands modèles (7B et plus) | `--continuous-batching --cache-memory-mb 2048` |
+| Production avec prompts partagés | `--continuous-batching --use-paged-cache` |
+
+## Configuration en production
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+```

--- a/docs/fr/guides/embeddings.md
+++ b/docs/fr/guides/embeddings.md
@@ -1,0 +1,150 @@
+# Embeddings
+
+vllm-mlx prend en charge les embeddings de texte via [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings), en exposant un point d'accès `/v1/embeddings` compatible OpenAI.
+
+## Installation
+
+```bash
+pip install mlx-embeddings>=0.0.5
+```
+
+## Démarrage rapide
+
+### Lancer le serveur avec un modèle d'embeddings
+
+```bash
+# Précharger un modèle d'embeddings spécifique au démarrage
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+Si vous n'utilisez pas `--embedding-model`, le modèle d'embeddings est chargé à la demande lors de la première requête, mais uniquement parmi les modèles autorisés par défaut.
+
+### Générer des embeddings avec le SDK OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Texte unique
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+
+# Lot de textes
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input=[
+        "I love machine learning",
+        "Deep learning is fascinating",
+        "Natural language processing rocks"
+    ]
+)
+for item in response.data:
+    print(f"Text {item.index}: {len(item.embedding)} dimensions")
+```
+
+### Utilisation avec curl
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+    "input": ["Hello world", "How are you?"]
+  }'
+```
+
+## Modèles pris en charge
+
+Modèles disponibles à la demande :
+
+| Modèle | Cas d'usage | Taille |
+|--------|-------------|--------|
+| `mlx-community/all-MiniLM-L6-v2-4bit` | Rapide et compact | Small |
+| `mlx-community/embeddinggemma-300m-6bit` | Haute qualité | 300M |
+| `mlx-community/bge-large-en-v1.5-4bit` | Optimal pour l'anglais | Large |
+| `mlx-community/multilingual-e5-small-mlx` | Récupération multilingue | Small |
+| `mlx-community/multilingual-e5-large-mlx` | Récupération multilingue | Large |
+| `mlx-community/bert-base-uncased-mlx` | Référence BERT générale | Base |
+| `mlx-community/ModernBERT-base-mlx` | Référence ModernBERT | Base |
+
+Les autres modèles d'embeddings nécessitent l'option `--embedding-model` au démarrage du serveur.
+
+## Gestion des modèles
+
+### Chargement à la demande
+
+Par défaut, le modèle d'embeddings est chargé lors de la première requête sur `/v1/embeddings`. Vous pouvez alterner entre les modèles autorisés listés ci-dessus ; le modèle précédent est déchargé automatiquement.
+
+### Préchargement au démarrage
+
+Utilisez `--embedding-model` pour charger un modèle au démarrage. Lorsque cette option est définie, seul ce modèle peut être utilisé pour les embeddings :
+
+```bash
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+Toute requête utilisant un modèle différent renverra une erreur 400.
+
+## Référence de l'API
+
+### POST /v1/embeddings
+
+Génère des embeddings pour le ou les textes fournis.
+
+**Corps de la requête :**
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `model` | string | Oui | Identifiant d'un modèle d'embeddings pris en charge, ou le modèle fixé au démarrage si `--embedding-model` est utilisé |
+| `input` | string ou list[string] | Oui | Texte(s) à encoder |
+
+**Réponse :**
+
+```json
+{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "index": 0, "embedding": [0.023, -0.982, ...]},
+    {"object": "embedding", "index": 1, "embedding": [0.112, -0.543, ...]}
+  ],
+  "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+  "usage": {"prompt_tokens": 12, "total_tokens": 12}
+}
+```
+
+## API Python
+
+### Utilisation directe sans serveur
+
+```python
+from vllm_mlx.embedding import EmbeddingEngine
+
+engine = EmbeddingEngine("mlx-community/all-MiniLM-L6-v2-4bit")
+engine.load()
+
+vectors = engine.embed(["Hello world", "How are you?"])
+print(f"Dimensions: {len(vectors[0])}")
+
+tokens = engine.count_tokens(["Hello world"])
+print(f"Token count: {tokens}")
+```
+
+## Résolution des problèmes
+
+### mlx-embeddings non installé
+
+```
+pip install mlx-embeddings>=0.0.5
+```
+
+### Modèle introuvable
+
+Vérifiez que le nom du modèle correspond à l'un des identifiants autorisés listés ci-dessus, ou lancez le serveur avec `--embedding-model` pour fixer un modèle personnalisé. Vous pouvez télécharger les modèles pris en charge à l'avance :
+
+```bash
+huggingface-cli download mlx-community/all-MiniLM-L6-v2-4bit
+```

--- a/docs/fr/guides/mcp-tools.md
+++ b/docs/fr/guides/mcp-tools.md
@@ -1,0 +1,405 @@
+# MCP & Tool Calling
+
+vllm-mlx prend en charge le Model Context Protocol (MCP) pour intégrer des outils externes avec des LLM.
+
+## Fonctionnement du tool calling
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Tool Calling Flow                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  1. User Request                                                    │
+│     ─────────────────►  "List files in /tmp"                       │
+│                                                                     │
+│  2. LLM Generates Tool Call                                         │
+│     ─────────────────►  tool_calls: [{                             │
+│                           name: "list_directory",                   │
+│                           arguments: {path: "/tmp"}                 │
+│                         }]                                          │
+│                                                                     │
+│  3. App Executes Tool via MCP                                       │
+│     ─────────────────►  MCP Server executes list_directory         │
+│                         Returns: ["file1.txt", "file2.txt"]        │
+│                                                                     │
+│  4. Tool Result Sent Back to LLM                                    │
+│     ─────────────────►  role: "tool", content: [...]               │
+│                                                                     │
+│  5. LLM Generates Final Response                                    │
+│     ─────────────────►  "The /tmp directory contains 2 files..."   │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Démarrage rapide
+
+### 1. Créer la configuration MCP
+
+Créez `mcp.json` :
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### 2. Démarrer le serveur avec MCP
+
+```bash
+# Mode simple
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# Continuous batching
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
+```
+
+### 3. Vérifier l'état du MCP
+
+```bash
+# Vérifier l'état du MCP
+curl http://localhost:8000/v1/mcp/status
+
+# Lister les outils disponibles
+curl http://localhost:8000/v1/mcp/tools
+```
+
+## Exemple de tool calling
+
+```python
+import json
+import httpx
+
+BASE_URL = "http://localhost:8000"
+
+# 1. Get available tools
+tools_response = httpx.get(f"{BASE_URL}/v1/mcp/tools")
+tools = tools_response.json()["tools"]
+
+# 2. Send request with tools
+response = httpx.post(
+    f"{BASE_URL}/v1/chat/completions",
+    json={
+        "model": "default",
+        "messages": [{"role": "user", "content": "List files in /tmp"}],
+        "tools": tools,
+        "max_tokens": 1024
+    }
+)
+
+result = response.json()
+message = result["choices"][0]["message"]
+
+# 3. Check for tool calls
+if message.get("tool_calls"):
+    tool_call = message["tool_calls"][0]
+
+    # 4. Execute tool via MCP
+    exec_response = httpx.post(
+        f"{BASE_URL}/v1/mcp/execute",
+        json={
+            "server": "filesystem",
+            "tool": tool_call["function"]["name"],
+            "arguments": json.loads(tool_call["function"]["arguments"])
+        }
+    )
+    tool_result = exec_response.json()
+
+    # 5. Send result back to LLM
+    messages = [
+        {"role": "user", "content": "List files in /tmp"},
+        message,
+        {
+            "role": "tool",
+            "tool_call_id": tool_call["id"],
+            "content": json.dumps(tool_result["result"])
+        }
+    ]
+
+    final_response = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        json={"model": "default", "messages": messages}
+    )
+    print(final_response.json()["choices"][0]["message"]["content"])
+```
+
+## Points de terminaison MCP
+
+| Point de terminaison | Méthode | Description |
+|----------------------|---------|-------------|
+| `/v1/mcp/status` | GET | Vérifier l'état du MCP |
+| `/v1/mcp/tools` | GET | Lister les outils disponibles |
+| `/v1/mcp/execute` | POST | Exécuter un outil |
+
+## Exemples de serveurs MCP
+
+### Système de fichiers
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### GitHub
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+### PostgreSQL
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost/db"
+      }
+    }
+  }
+}
+```
+
+### Brave Search
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "your-key"
+      }
+    }
+  }
+}
+```
+
+## Plusieurs serveurs MCP
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+## Chat MCP interactif
+
+Pour tester MCP de manière interactive :
+
+```bash
+python examples/mcp_chat.py
+```
+
+## Formats d'outils pris en charge
+
+vllm-mlx prend en charge 12 tool call parsers couvrant toutes les grandes familles de modèles. Voir [Tool Calling](tool-calling.md) pour la liste complète des parsers, alias et exemples.
+
+## Sécurité
+
+vllm-mlx inclut des mesures de sécurité pour prévenir les attaques par injection de commandes via les serveurs MCP.
+
+### Liste blanche de commandes
+
+Seules les commandes de confiance sont autorisées par défaut :
+
+| Catégorie | Commandes autorisées |
+|-----------|----------------------|
+| Node.js | `npx`, `npm`, `node` |
+| Python | `uvx`, `uv`, `python`, `python3`, `pip`, `pipx` |
+| Docker | `docker` |
+| Serveurs MCP | `mcp-server-*` (serveurs officiels) |
+
+### Motifs bloqués
+
+Les motifs suivants sont bloqués pour prévenir les attaques par injection :
+
+- Enchaînement de commandes : `;`, `&&`, `||`, `|`
+- Substitution de commandes : `` ` ``, `$()`
+- Traversée de répertoires : `../`
+- Variables d'environnement dangereuses : `LD_PRELOAD`, `PATH`, `PYTHONPATH`
+
+### Exemple : attaque bloquée
+
+```json
+{
+  "mcpServers": {
+    "malicious": {
+      "command": "bash",
+      "args": ["-c", "rm -rf /"]
+    }
+  }
+}
+```
+
+Cette configuration sera rejetée :
+```
+ValueError: MCP server 'malicious': Command 'bash' is not in the allowed commands whitelist.
+```
+
+### Mode développement (non sécurisé)
+
+Pour le développement uniquement, il est possible de contourner la validation de sécurité :
+
+```json
+{
+  "mcpServers": {
+    "custom": {
+      "command": "my-custom-server",
+      "skip_security_validation": true
+    }
+  }
+}
+```
+
+**AVERTISSEMENT** : N'utilisez jamais `skip_security_validation` en production !
+
+### Liste blanche personnalisée
+
+Pour ajouter des commandes personnalisées à la liste blanche par programmation :
+
+```python
+from vllm_mlx.mcp import MCPCommandValidator, set_validator
+
+# Add custom commands
+validator = MCPCommandValidator(
+    custom_whitelist={"my-trusted-server", "another-server"}
+)
+set_validator(validator)
+```
+
+## Sandboxing de l'exécution des outils
+
+Au-delà de la validation des commandes, vllm-mlx fournit un sandboxing à l'exécution pour les exécutions d'outils.
+
+### Fonctionnalités du sandbox
+
+| Fonctionnalité | Description |
+|----------------|-------------|
+| Liste blanche d'outils | Autoriser uniquement des outils spécifiques à s'exécuter |
+| Liste noire d'outils | Bloquer des outils dangereux spécifiques |
+| Validation des arguments | Bloquer les motifs dangereux dans les arguments des outils |
+| Limitation du débit | Limiter les appels d'outils par minute |
+| Journal d'audit | Suivre toutes les exécutions d'outils |
+
+### Motifs d'arguments bloqués
+
+Les arguments des outils sont validés pour détecter les motifs dangereux :
+
+- Traversée de répertoires : `../`
+- Répertoires système : `/etc/`, `/proc/`, `/sys/`
+- Accès root : `/root/`, `~root`
+
+### Détection des outils à haut risque
+
+Les outils correspondant à ces motifs déclenchent des avertissements de sécurité :
+
+- `execute`, `run_command`, `shell`, `eval`, `exec`, `system`, `subprocess`
+
+### Configuration personnalisée du sandbox
+
+```python
+from vllm_mlx.mcp import ToolSandbox, set_sandbox
+
+# Create sandbox with custom settings
+sandbox = ToolSandbox(
+    # Only allow specific tools (whitelist mode)
+    allowed_tools={"read_file", "list_directory"},
+
+    # Block specific tools (blacklist mode)
+    blocked_tools={"execute_command", "run_shell"},
+
+    # Rate limit: max 30 calls per minute
+    max_calls_per_minute=30,
+
+    # Optional audit callback
+    audit_callback=lambda audit: print(f"Tool: {audit.tool_name}, Success: {audit.success}"),
+)
+set_sandbox(sandbox)
+```
+
+### Accès aux journaux d'audit
+
+```python
+from vllm_mlx.mcp import get_sandbox
+
+sandbox = get_sandbox()
+
+# Get recent audit entries
+entries = sandbox.get_audit_log(limit=50)
+
+# Filter by tool name
+file_ops = sandbox.get_audit_log(tool_filter="file")
+
+# Get only errors
+errors = sandbox.get_audit_log(errors_only=True)
+
+# Clear audit log
+sandbox.clear_audit_log()
+```
+
+### Expurgation des données sensibles
+
+Les journaux d'audit expurgent automatiquement les champs sensibles (password, token, secret, key, credential, auth) et tronquent les valeurs volumineuses.
+
+## Dépannage
+
+### Le serveur MCP ne se connecte pas
+
+Vérifiez que la commande du serveur MCP est correcte :
+```bash
+npx -y @modelcontextprotocol/server-filesystem /tmp
+```
+
+### L'outil ne s'exécute pas
+
+Vérifiez que l'outil est disponible :
+```bash
+curl http://localhost:8000/v1/mcp/tools | jq '.tools[].name'
+```
+
+### L'appel d'outil n'est pas analysé
+
+Assurez-vous d'utiliser un modèle qui prend en charge le function calling (Qwen3, Llama-3.2-Instruct).
+
+### La commande n'est pas dans la liste blanche
+
+Si vous voyez « Command X is not in the allowed commands whitelist », vous pouvez :
+1. Utiliser une commande autorisée (voir la liste blanche ci-dessus)
+2. Ajouter la commande à une liste blanche personnalisée
+3. Utiliser `skip_security_validation: true` (développement uniquement)

--- a/docs/fr/guides/moe-top-k.md
+++ b/docs/fr/guides/moe-top-k.md
@@ -1,0 +1,124 @@
+# MoE top_k override (`--moe-top-k`)
+
+Réduit le nombre d'experts activés par token dans les modèles Mixture of Experts
+comme Qwen3-30B-A3B, en échangeant une légère perte de qualité contre un gain
+sensible de débit au décodage.
+
+> **Statut :** option à activer explicitement. Le comportement par défaut est inchangé. Les chiffres de qualité
+> ci-dessous concernent Qwen3-30B-A3B-4bit sur M4 Max 128 Go ; vérifiez sur votre modèle
+> avant de déployer en production.
+
+## Ce que ça fait
+
+Qwen3-30B-A3B est entraîné avec `top_k=8` : chaque token sélectionne 8 experts parmi 128.
+Sur Apple Silicon en décodage batch=1, le produit matriciel des experts (`SwitchGLU`)
+représente la plus grande part du calcul de chaque couche, et ce coût évolue
+approximativement de façon linéaire avec `top_k`. Abaisser `top_k` à l'inférence a
+été démontré (LExI 2025, Lynx 2024) comme préservant l'essentiel de la qualité
+entraînée tout en réduisant significativement le temps de décodage.
+
+`--moe-top-k N` parcourt toutes les couches du modèle chargé et, pour chaque couche
+qui possède `.mlp.switch_mlp` (c'est-à-dire un bloc sparse-MoE), définit `top_k = N`.
+Les couches denses et les modèles denses ne sont pas modifiés ; le flag n'a aucun effet pour eux.
+
+## Utilisation
+
+```bash
+# Server
+vllm-mlx serve mlx-community/Qwen3-30B-A3B-4bit \
+  --continuous-batching \
+  --moe-top-k 4
+
+# Bench
+vllm-mlx bench mlx-community/Qwen3-30B-A3B-4bit --moe-top-k 4
+```
+
+Le flag est rejeté si `N` est supérieur au `top_k` d'entraînement du modèle
+(il ne peut que diminuer, jamais augmenter).
+
+## Impact mesuré
+
+### Débit de décodage (M4 Max 128 Go, batch=1, greedy)
+
+| top_k | tok/s | vs baseline |
+|---:|---:|---:|
+| 8 (baseline) | 126.5 | - |
+| 6 | 136.1 | +7.6% |
+| 5 | 140.3 | +10.9% |
+| 4 | 147.3 | +16.5% |
+
+### Qualité (Qwen3-30B-A3B-4bit, lm-evaluation-harness, MLX backend)
+
+<!-- populated after eval completes -->
+
+| top_k | MMLU (acc) | GSM8K (exact match) | Delta vs baseline |
+|---:|---:|---:|---:|
+| 8 | TBD | TBD | - |
+| 6 | TBD | TBD | TBD |
+| 5 | TBD | TBD | TBD |
+| 4 | TBD | TBD | TBD |
+
+MMLU : 200 échantillons sélectionnés aléatoirement, 0-shot.
+GSM8K : 100 échantillons sélectionnés aléatoirement, 0-shot, exact-match strict.
+
+Ces chiffres sont **indicatifs** ; les suites complètes sont plus grandes et
+feraient légèrement varier la précision absolue, mais pas le delta relatif entre
+configurations.
+
+### Parité des sorties greedy
+
+Avec `top_k=4` sur le checkpoint 4-bit, nous avons observé des **16 premiers tokens
+générés identiques** par rapport à la baseline sur toutes les requêtes de test.
+Cela suggère que top_k=4 ne modifie pas l'argmax dans les premières étapes de
+décodage : le modèle est intrinsèquement robuste à la suppression de la moitié
+de ses experts activés.
+
+À `top_k=3` ou moins, la qualité commencerait à se dégrader visiblement (non mesuré
+ici ; déduit du papier LExI). Le flag ne peut donc pas descendre en dessous de 1
+au niveau de la validation de configuration, mais le seuil recommandé pour la
+production est `top_k=4`.
+
+## Quand l'utiliser, quand ne pas l'utiliser
+
+Utilisez-le quand :
+- Vous faites tourner un MoE Qwen3 (ou compatible : Qwen3.5 MoE, Gemma-MoE) et le
+  débit de décodage en usage single-user est votre goulot d'étranglement.
+- Votre cas d'usage tolère une légère dégradation de qualité en échange d'une
+  amélioration visible de la latence.
+- Vous déployez sur du matériel limité par la bande passante mémoire (Apple Silicon
+  série M) où le gather des experts domine le temps de décodage par étape.
+
+Ne l'utilisez pas quand :
+- Vous servez des modèles denses : le flag n'a aucun effet.
+- La précision maximale sur les suites d'évaluation est une exigence.
+- Vous exécutez des générations longues en chaîne de pensée (mode "thinking") où
+  la chute de qualité peut être plus prononcée que ce que suggèrent les scores MMLU 0-shot.
+
+## Combinaison avec d'autres optimisations
+
+Ce flag se compose avec la quantification. Sur Qwen3-30B-A3B-4bit, nos mesures
+de combinaison sont :
+
+- 4-bit + top_k=8 : 126.5 tok/s (baseline)
+- 4-bit + top_k=4 : 147.3 tok/s (+16.5%)
+- 3-bit + top_k=8 : 138.6 tok/s (+9.6%)
+- 3-bit + top_k=6 : 147.1 tok/s (+16.3%) . divergence de qualité mesurable
+- 3-bit + top_k=4 : 157.3 tok/s (+24%) . **la qualité des sorties s'effondre** (le modèle a répondu à une question différente lors de notre test de fumée)
+
+3-bit + top_k=4 cumule l'erreur numérique au point où l'argmax n'est plus stable.
+Limitez-vous à un seul réglage agressif à la fois : soit 4-bit + top_k=4, soit
+3-bit + top_k=6. Les deux donnent approximativement le même tok/s (environ 147)
+avec des profils de qualité très différents.
+
+## Fonctionnement interne
+
+- Fonction de patch : `vllm_mlx.scheduler.apply_moe_top_k_override(model, k)`
+- Appliquée dans `Scheduler.__init__` après le chargement du modèle.
+- Tests : `tests/test_moe_top_k.py`. couvre les modèles denses, les architectures
+  mixtes et les chemins de validation.
+
+## Références
+
+- LExI : Layer-Adaptive Active Experts, [arXiv 2509.02753](https://arxiv.org/html/2509.02753)
+- Not All Experts are Equal (NAEE), [ACL 2024](https://aclanthology.org/2024.acl-long.334.pdf)
+- SwiftLM (`SWIFTLM_TOP_K` env knob prior art), [github.com/SharpAI/SwiftLM](https://github.com/SharpAI/SwiftLM)

--- a/docs/fr/guides/multimodal.md
+++ b/docs/fr/guides/multimodal.md
@@ -1,0 +1,315 @@
+# Modèles multimodaux (images et vidéos)
+
+vllm-mlx prend en charge les VLM pour la compréhension des images et des vidéos.
+
+## Modèles pris en charge
+
+- Qwen3-VL (recommandé)
+- Qwen2-VL
+- Gemma 3
+- LLaVA
+- Idefics
+- PaliGemma
+- Pixtral
+- Molmo
+- DeepSeek-VL
+
+## Démarrer un serveur multimodal
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+Les modèles dont le nom contient « VL », « Vision » ou « mllm » sont automatiquement détectés comme multimodaux.
+
+## Analyse d'images
+
+### Via le SDK OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Image depuis une URL
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+print(response.choices[0].message.content)
+```
+
+### Images en Base64
+
+```python
+import base64
+
+def encode_image(path):
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+base64_image = encode_image("photo.jpg")
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}}
+        ]
+    }]
+)
+```
+
+### Via curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+      ]
+    }],
+    "max_tokens": 256
+  }'
+```
+
+## Analyse de vidéos
+
+### Via le SDK OpenAI
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What happens in this video?"},
+            {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+        ]
+    }],
+    max_tokens=512
+)
+```
+
+### Paramètres vidéo
+
+Contrôlez l'extraction des images via les paramètres du corps étendu :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this video"},
+            {"type": "video_url", "video_url": {"url": "video.mp4"}}
+        ]
+    }],
+    extra_body={
+        "video_fps": 2.0,
+        "video_max_frames": 32
+    }
+)
+```
+
+### Via curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this video"},
+        {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+      ]
+    }],
+    "video_fps": 2.0,
+    "video_max_frames": 16
+  }'
+```
+
+## Formats pris en charge
+
+### Images
+
+| Format | Exemple |
+|--------|---------|
+| URL | `{"type": "image_url", "image_url": {"url": "https://..."}}` |
+| Fichier local | `{"type": "image_url", "image_url": {"url": "/path/to/image.jpg"}}` |
+| Base64 | `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}` |
+
+### Vidéos
+
+| Format | Exemple |
+|--------|---------|
+| URL | `{"type": "video_url", "video_url": {"url": "https://..."}}` |
+| Fichier local | `{"type": "video", "video": "/path/to/video.mp4"}` |
+| Base64 | `{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}` |
+
+## API Python
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Image
+description = mllm.describe_image("photo.jpg")
+
+# Vidéo
+description = mllm.describe_video("video.mp4", fps=2.0)
+
+# Prompt personnalisé
+output = mllm.generate(
+    prompt="Compare these images",
+    images=["img1.jpg", "img2.jpg"]
+)
+```
+
+## Conseils de performance
+
+### Images
+- Les résolutions plus petites sont traitées plus rapidement (224x224 vs 1920x1080)
+- Utilisez la résolution adaptée à votre tâche
+
+### Vidéos
+- Un FPS plus bas accélère le traitement
+- Moins d'images signifie moins de mémoire utilisée
+- 64 images est le maximum pratique (96 et plus provoque un timeout GPU)
+
+## Benchmarks
+
+Testés sur Apple M4 Max avec 128 Go de mémoire unifiée.
+
+### Qwen3-VL-4B-Instruct-3bit
+
+| Résolution | Temps | Tokens | Vitesse | Mémoire |
+|------------|-------|--------|---------|---------|
+| 224x224 | 0.87s | 124 | 143 tok/s | 2.6 Go |
+| 448x448 | 1.01s | 107 | 106 tok/s | 3.1 Go |
+| 768x768 | 1.42s | 127 | 89 tok/s | 3.4 Go |
+| 1024x1024 | 1.85s | 116 | 63 tok/s | 3.6 Go |
+
+### Qwen3-VL-8B-Instruct-4bit
+
+| Résolution | Temps | Tokens | Vitesse | Mémoire |
+|------------|-------|--------|---------|---------|
+| 224x224 | 1.08s | 78 | 73 tok/s | 5.6 Go |
+| 448x448 | 1.41s | 70 | 50 tok/s | 6.1 Go |
+| 768x768 | 2.06s | 91 | 44 tok/s | 6.5 Go |
+| 1024x1024 | 3.02s | 76 | 25 tok/s | 7.6 Go |
+
+### Gemma 3 4B 4bit
+
+| Résolution | Temps | Tokens | Vitesse | Mémoire |
+|------------|-------|--------|---------|---------|
+| 224x224 | 0.95s | 30 | 32 tok/s | 5.2 Go |
+| 448x448 | 0.99s | 34 | 34 tok/s | 5.2 Go |
+| 768x768 | 0.99s | 32 | 32 tok/s | 5.2 Go |
+| 1024x1024 | 0.95s | 28 | 29 tok/s | 5.2 Go |
+
+### Lancer les benchmarks
+
+```bash
+# Benchmark rapide
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --quick
+
+# Benchmark complet avec plus de résolutions
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Benchmark vidéo
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --video
+```
+
+## Cache MLLM
+
+vllm-mlx inclut un système de prefix cache pour les modèles multimodaux, capable d'accélérer significativement les requêtes répétées utilisant les mêmes images.
+
+### Fonctionnement
+
+Lorsque vous envoyez une image au modèle, l'encodeur de vision la traite en embeddings. Ce traitement prend 1 à 2 secondes. Le cache MLLM stocke ces embeddings ainsi que l'état du KV cache, de sorte que les requêtes ultérieures avec la même image contournent entièrement l'encodeur de vision.
+
+Le cache utilise un hachage basé sur le contenu (similaire à LMCache) pour identifier les images identiques, quelle que soit leur forme de transmission (URL, base64 ou chemin de fichier).
+
+### Activer le cache
+
+```bash
+# Activer avec les paramètres par défaut (512 Mo maximum)
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
+
+# Avec une limite mémoire personnalisée
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
+    --enable-mllm-cache \
+    --mllm-cache-max-mb 1024
+```
+
+### API Python
+
+```python
+from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
+
+# Créer le gestionnaire de cache
+cache = MLLMPrefixCacheManager(max_memory_mb=512)
+
+# Stocker les embeddings et le KV cache après traitement
+cache.store(
+    images=["photo.jpg"],
+    prompt="Describe this image",
+    vision_embeddings=embeddings,
+    kv_cache=kv_state,
+    num_tokens=128
+)
+
+# Récupérer depuis le cache lors des requêtes suivantes
+entry, match_len = cache.fetch(images=["photo.jpg"], prompt="Describe this image")
+if entry:
+    # Utiliser les embeddings mis en cache, contourner l'encodeur de vision
+    embeddings = entry.vision_embeddings
+    kv_state = entry.kv_cache
+```
+
+### Statistiques du cache
+
+```python
+stats = cache.get_stats()
+print(f"Hit rate: {stats.hit_rate:.1%}")
+print(f"Memory used: {stats.memory_used_mb:.1f} MB")
+print(f"Tokens saved: {stats.tokens_saved}")
+```
+
+### Gestion de la mémoire
+
+Le cache utilise une éviction LRU (Least Recently Used) lorsque la limite mémoire est atteinte. Chaque entrée suit :
+
+- La taille des embeddings de vision
+- La taille du KV cache par couche
+- La fréquence d'accès pour l'ordonnancement LRU
+
+En cas de pression mémoire, les entrées les moins récemment consultées sont évincées en premier.
+
+## Interface de chat Gradio
+
+Pour un chat multimodal interactif :
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+```
+
+Prend en charge le glisser-déposer d'images et de vidéos.

--- a/docs/fr/guides/python-api.md
+++ b/docs/fr/guides/python-api.md
@@ -1,0 +1,182 @@
+# Python API
+
+API Python directe pour un accès programmatique à vllm-mlx.
+
+## Modèles de langage
+
+### Utilisation de base
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+# Load model
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+```
+
+### Génération en streaming
+
+```python
+for chunk in model.stream_generate("Tell me a story about a robot"):
+    print(chunk.text, end="", flush=True)
+```
+
+### Interface de chat
+
+```python
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello, who are you?"}
+]
+response = model.chat(messages)
+print(response.text)
+```
+
+### Paramètres de génération
+
+```python
+output = model.generate(
+    prompt="Write a poem",
+    max_tokens=256,
+    temperature=0.7,
+    top_p=0.9,
+    stop=["END", "\n\n"]
+)
+```
+
+| Paramètre | Description | Défaut |
+|-----------|-------------|--------|
+| `max_tokens` | Nombre maximum de tokens à générer | 256 |
+| `temperature` | Température d'échantillonnage (0-2) | 0.7 |
+| `top_p` | Nucleus sampling | 0.9 |
+| `stop` | Séquences d'arrêt | None |
+
+## Modèles vision-langage
+
+### Utilisation de base
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+# Load model
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Describe an image
+description = mllm.describe_image("photo.jpg")
+print(description)
+```
+
+### Questions-réponses sur une image
+
+```python
+answer = mllm.answer_about_image("photo.jpg", "What color is the car?")
+print(answer)
+```
+
+### Plusieurs images
+
+```python
+output = mllm.generate(
+    prompt="Compare these two images",
+    images=["image1.jpg", "image2.jpg"]
+)
+print(output.text)
+```
+
+### Compréhension vidéo
+
+```python
+# From local file
+output = mllm.generate(
+    prompt="What is happening in this video?",
+    videos=["video.mp4"],
+    video_fps=2.0,
+    video_max_frames=16
+)
+print(output.text)
+
+# From URL
+output = mllm.generate(
+    prompt="Describe this video",
+    videos=["https://example.com/video.mp4"],
+    video_fps=2.0
+)
+
+# Convenience method
+description = mllm.describe_video("video.mp4", fps=2.0)
+```
+
+### Paramètres vidéo
+
+| Paramètre | Description | Défaut |
+|-----------|-------------|--------|
+| `video_fps` | Images par seconde à extraire | 2.0 |
+| `video_max_frames` | Nombre maximum d'images à traiter | 32 |
+
+## API du moteur
+
+Pour les cas d'utilisation avancés, utilisez le moteur directement :
+
+### Moteur simple
+
+```python
+from vllm_mlx.engine import SimpleEngine
+
+engine = SimpleEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+print(output.text)
+
+await engine.stop()
+```
+
+### Moteur avec batching
+
+```python
+from vllm_mlx.engine import BatchedEngine
+
+engine = BatchedEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+# Multiple concurrent requests
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+
+await engine.stop()
+```
+
+## Format de sortie
+
+Toutes les méthodes de génération retournent un objet `GenerationOutput` :
+
+```python
+output = model.generate("Hello")
+
+print(output.text)              # Generated text
+print(output.prompt_tokens)     # Input token count
+print(output.completion_tokens) # Output token count
+print(output.finish_reason)     # "stop" or "length"
+```
+
+## Gestion des erreurs
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+try:
+    model = MLXLanguageModel("invalid-model")
+    model.load()
+except Exception as e:
+    print(f"Failed to load model: {e}")
+```

--- a/docs/fr/guides/reasoning.md
+++ b/docs/fr/guides/reasoning.md
@@ -1,0 +1,267 @@
+# Reasoning Models
+
+vllm-mlx prend en charge les reasoning models qui affichent leur processus de thinking avant de fournir une réponse. Des modèles comme Qwen3 et DeepSeek-R1 encapsulent leur reasoning dans des balises `<think>...</think>`, et vllm-mlx peut analyser ces balises pour séparer le reasoning de la réponse finale.
+
+## Pourquoi utiliser le reasoning parsing ?
+
+Lorsqu'un reasoning model génère une sortie, elle ressemble généralement à ceci :
+
+```
+<think>
+Let me analyze this step by step.
+First, I need to consider the constraints.
+The answer should be a prime number less than 10.
+Checking: 2, 3, 5, 7 are all prime and less than 10.
+</think>
+The prime numbers less than 10 are: 2, 3, 5, 7.
+```
+
+Sans reasoning parsing, vous obtenez la sortie brute avec les balises incluses. Avec le reasoning parsing activé, le processus de thinking et la réponse finale sont séparés dans des champs distincts de la réponse de l'API.
+
+## Démarrage rapide
+
+### Démarrer le serveur avec un reasoning parser
+
+```bash
+# For Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# For DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+### Format de réponse de l'API
+
+Lorsque le reasoning parsing est activé, la réponse de l'API inclut un champ `reasoning` :
+
+**Réponse sans streaming :**
+
+```json
+{
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": "The prime numbers less than 10 are: 2, 3, 5, 7.",
+      "reasoning": "Let me analyze this step by step.\nFirst, I need to consider the constraints.\nThe answer should be a prime number less than 10.\nChecking: 2, 3, 5, 7 are all prime and less than 10."
+    }
+  }]
+}
+```
+
+**Réponse en streaming :**
+
+Les fragments sont envoyés séparément pour le reasoning et le contenu. Pendant la phase de reasoning, les fragments ont le champ `reasoning` renseigné. Lorsque le modèle passe à la réponse finale, les fragments ont le champ `content` renseigné :
+
+```json
+{"delta": {"reasoning": "Let me analyze"}}
+{"delta": {"reasoning": " this step by step."}}
+{"delta": {"reasoning": "\nFirst, I need to"}}
+...
+{"delta": {"content": "The prime"}}
+{"delta": {"content": " numbers less than 10"}}
+{"delta": {"content": " are: 2, 3, 5, 7."}}
+```
+
+## Utilisation avec le SDK OpenAI
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Non-streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What are the prime numbers less than 10?"}]
+)
+
+message = response.choices[0].message
+print("Reasoning:", message.reasoning)  # The thinking process
+print("Answer:", message.content)        # The final answer
+```
+
+### Streaming avec Reasoning
+
+```python
+reasoning_text = ""
+content_text = ""
+
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Solve: 2 + 2 = ?"}],
+    stream=True
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if hasattr(delta, 'reasoning') and delta.reasoning:
+        reasoning_text += delta.reasoning
+        print(f"[Thinking] {delta.reasoning}", end="")
+    if delta.content:
+        content_text += delta.content
+        print(delta.content, end="")
+
+print(f"\n\nFinal reasoning: {reasoning_text}")
+print(f"Final answer: {content_text}")
+```
+
+## Parsers disponibles
+
+### Parser Qwen3 (`qwen3`)
+
+Pour les modèles Qwen3 qui utilisent explicitement les balises `<think>` et `</think>`.
+
+- Nécessite **les deux** balises ouvrante et fermante
+- Si les balises sont absentes, la sortie est traitée comme du contenu ordinaire
+- Recommandé pour : Qwen3-0.6B, Qwen3-4B, Qwen3-8B et les modèles similaires
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+### Parser DeepSeek-R1 (`deepseek_r1`)
+
+Pour les modèles DeepSeek-R1 qui peuvent omettre la balise ouvrante `<think>`.
+
+- Plus permissif que le parser Qwen3
+- Gère les cas où `<think>` est implicite
+- Le contenu avant `</think>` est traité comme du reasoning même en l'absence de `<think>`
+
+```bash
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+## Fonctionnement
+
+Le reasoning parser utilise une détection textuelle pour identifier les balises de thinking dans la sortie du modèle. Pendant le streaming, il suit la position courante dans la sortie afin d'acheminer chaque token vers `reasoning` ou `content`.
+
+```
+Model Output:        <think>Step 1: analyze...</think>The answer is 42.
+                     ├─────────────────────┤├─────────────────────┤
+Parsed:              │     reasoning       ││       content       │
+                     └─────────────────────┘└─────────────────────┘
+```
+
+L'analyse est sans état et s'appuie sur le texte accumulé pour déterminer le contexte, ce qui la rend robuste dans les scénarios de streaming où les tokens peuvent arriver en fragments arbitraires.
+
+## Conseils pour de meilleurs résultats
+
+### Rédaction des prompts
+
+Les reasoning models fonctionnent mieux lorsque vous encouragez une réflexion étape par étape :
+
+```python
+messages = [
+    {"role": "system", "content": "Think through problems step by step before answering."},
+    {"role": "user", "content": "What is 17 × 23?"}
+]
+```
+
+### Gestion de l'absence de reasoning
+
+Certains prompts peuvent ne pas déclencher de reasoning. Dans ce cas, `reasoning` vaut `None` et toute la sortie va dans `content` :
+
+```python
+message = response.choices[0].message
+if message.reasoning:
+    print(f"Model's thought process: {message.reasoning}")
+print(f"Answer: {message.content}")
+```
+
+### Température et reasoning
+
+Les températures basses tendent à produire des schémas de reasoning plus cohérents :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Explain quantum entanglement"}],
+    temperature=0.3  # More focused reasoning
+)
+```
+
+## Compatibilité ascendante
+
+Lorsque `--reasoning-parser` n'est pas spécifié, le serveur se comporte comme avant :
+- Les balises de thinking sont incluses dans le champ `content`
+- Aucun champ `reasoning` n'est ajouté aux réponses
+
+Cela garantit que les applications existantes continuent de fonctionner sans modification.
+
+## Exemple : résolveur de problèmes mathématiques
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+def solve_math(problem: str) -> dict:
+    """Solve a math problem and return reasoning + answer."""
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": "You are a math tutor. Show your work."},
+            {"role": "user", "content": problem}
+        ],
+        temperature=0.2
+    )
+
+    message = response.choices[0].message
+    return {
+        "problem": problem,
+        "work": message.reasoning,
+        "answer": message.content
+    }
+
+result = solve_math("If a train travels 120 km in 2 hours, what is its average speed?")
+print(f"Problem: {result['problem']}")
+print(f"\nWork shown:\n{result['work']}")
+print(f"\nFinal answer: {result['answer']}")
+```
+
+## Exemples avec curl
+
+### Sans streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}]
+  }'
+```
+
+### Avec streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}],
+    "stream": true
+  }'
+```
+
+## Résolution de problèmes
+
+### Champ reasoning absent de la réponse
+
+- Vérifiez que le serveur a bien été démarré avec `--reasoning-parser`
+- Vérifiez que le modèle utilise effectivement des balises de thinking (tous les prompts ne déclenchent pas le reasoning)
+
+### Le reasoning apparaît dans le contenu
+
+- Le modèle n'utilise peut-être pas le format de balises attendu
+- Essayez un autre parser (`qwen3` ou `deepseek_r1`)
+
+### Reasoning tronqué
+
+- Augmentez `--max-tokens` si le modèle atteint la limite de tokens en plein milieu de sa réflexion
+
+## Voir aussi
+
+- [Modèles pris en charge](../reference/models.md) - Modèles qui prennent en charge le reasoning
+- [Configuration du serveur](server.md) - Toutes les options du serveur
+- [Référence CLI](../reference/cli.md) - Options de la ligne de commande

--- a/docs/fr/guides/server.md
+++ b/docs/fr/guides/server.md
@@ -1,0 +1,781 @@
+# Serveur compatible OpenAI
+
+vllm-mlx fournit un serveur FastAPI avec une compatibilité complète avec l'API OpenAI.
+
+Par défaut, le serveur n'écoute que sur `127.0.0.1`. Utilisez `--host 0.0.0.0` uniquement si vous souhaitez délibérément l'exposer au-delà de la machine locale.
+
+## Démarrage du serveur
+
+### Mode simple (par défaut)
+
+Débit maximal pour un utilisateur unique :
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+```
+
+### Mode continuous batching
+
+Pour plusieurs utilisateurs simultanés :
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+### Avec paged cache
+
+Mise en cache efficace en mémoire pour la production :
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
+```
+
+## Options du serveur
+
+| Option | Description | Défaut |
+|--------|-------------|--------|
+| `--port` | Port du serveur | 8000 |
+| `--host` | Hôte du serveur | 127.0.0.1 |
+| `--api-key` | Clé API pour l'authentification | None |
+| `--rate-limit` | Requêtes par minute par client (0 = désactivé) | 0 |
+| `--timeout` | Délai d'expiration des requêtes en secondes | 300 |
+| `--enable-metrics` | Expose les métriques Prometheus sur `/metrics` | False |
+| `--continuous-batching` | Active le batching pour plusieurs utilisateurs | False |
+| `--use-paged-cache` | Active le paged KV cache | False |
+| `--cache-memory-mb` | Limite mémoire du cache en Mo | Auto |
+| `--cache-memory-percent` | Fraction de la RAM réservée au cache | 0.20 |
+| `--max-tokens` | Nombre maximal de tokens par défaut | 32768 |
+| `--max-request-tokens` | Valeur maximale de `max_tokens` acceptée des clients API | 32768 |
+| `--default-temperature` | Température par défaut si non spécifiée | None |
+| `--default-top-p` | Valeur top_p par défaut si non spécifiée | None |
+| `--stream-interval` | Tokens par fragment de streaming | 1 |
+| `--mcp-config` | Chemin vers le fichier de configuration MCP | None |
+| `--reasoning-parser` | Parser pour les modèles reasoning (`qwen3`, `deepseek_r1`) | None |
+| `--embedding-model` | Précharge un modèle d'embeddings au démarrage | None |
+| `--enable-auto-tool-choice` | Active le tool calling automatique | False |
+| `--tool-call-parser` | Parser de tool calling (voir [Tool Calling](tool-calling.md)) | None |
+
+## Points de terminaison de l'API
+
+### Chat Completions
+
+```bash
+POST /v1/chat/completions
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Non-streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=100
+)
+
+# Streaming
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### Completions
+
+```bash
+POST /v1/completions
+```
+
+```python
+response = client.completions.create(
+    model="default",
+    prompt="The capital of France is",
+    max_tokens=50
+)
+```
+
+### Modèles
+
+```bash
+GET /v1/models
+```
+
+Retourne les modèles disponibles.
+
+### Embeddings
+
+```bash
+POST /v1/embeddings
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+```
+
+Voir le [Guide des embeddings](embeddings.md) pour plus de détails.
+
+### Vérification de l'état
+
+```bash
+GET /health
+```
+
+Retourne l'état du serveur.
+
+### Métriques
+
+```bash
+GET /metrics
+```
+
+Point de terminaison de collecte Prometheus pour les métriques du serveur, du cache, du scheduler et des requêtes.
+Le point de terminaison est désactivé par défaut et s'active avec `--enable-metrics`.
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-metrics
+```
+
+`/metrics` est intentionnellement non authentifié. Exposez-le uniquement sur un réseau de confiance ou derrière un reverse proxy ou un pare-feu qui limite les accès.
+
+### API Anthropic Messages
+
+```bash
+POST /v1/messages
+```
+
+Point de terminaison compatible Anthropic qui permet à des outils comme Claude Code et OpenCode de se connecter directement à vllm-mlx. En interne, il traduit les requêtes Anthropic au format OpenAI, exécute l'inférence via le moteur, puis convertit la réponse au format Anthropic.
+
+Fonctionnalités :
+- Réponses non-streaming et streaming (SSE)
+- Messages système (chaîne simple ou liste de blocs de contenu)
+- Conversations multi-tours avec messages utilisateur et assistant
+- Tool calling avec blocs de contenu `tool_use` et `tool_result`
+- Comptage de tokens pour le suivi du budget
+- Contenu multimodal (images via blocs `source`)
+- Détection de déconnexion client (retourne HTTP 499)
+- Filtrage automatique des tokens spéciaux dans la sortie en streaming
+
+#### Non-streaming
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(base_url="http://localhost:8000", api_key="not-needed")
+
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.content[0].text)
+# Response includes: response.id, response.model, response.stop_reason,
+# response.usage.input_tokens, response.usage.output_tokens
+```
+
+#### Streaming
+
+Le streaming suit le protocole d'événements SSE d'Anthropic. Les événements sont émis dans cet ordre :
+`message_start` -> `content_block_start` -> `content_block_delta` (répété) -> `content_block_stop` -> `message_delta` -> `message_stop`
+
+```python
+with client.messages.stream(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Tell me a story"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="")
+```
+
+#### Messages système
+
+Les messages système peuvent être une chaîne simple ou une liste de blocs de contenu :
+
+```python
+# Plain string
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system="You are a helpful coding assistant.",
+    messages=[{"role": "user", "content": "Write a hello world in Python"}]
+)
+
+# List of content blocks
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system=[
+        {"type": "text", "text": "You are a helpful assistant."},
+        {"type": "text", "text": "Be concise in your answers."},
+    ],
+    messages=[{"role": "user", "content": "What is 2+2?"}]
+)
+```
+
+#### Tool calling
+
+Définissez les outils avec `name`, `description` et `input_schema`. Le modèle retourne des blocs de contenu `tool_use` lorsqu'il souhaite appeler un outil. Renvoyez les résultats sous forme de blocs `tool_result`.
+
+```python
+# Step 1: Send request with tools
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+
+# Step 2: Check if model wants to use tools
+for block in response.content:
+    if block.type == "tool_use":
+        print(f"Tool: {block.name}, Input: {block.input}, ID: {block.id}")
+        # response.stop_reason will be "tool_use"
+
+# Step 3: Send tool result back
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {"role": "assistant", "content": response.content},
+        {"role": "user", "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": "Sunny, 22C"
+            }
+        ]}
+    ],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+print(response.content[0].text)  # "The weather in Paris is sunny, 22C."
+```
+
+Modes de sélection d'outil :
+
+| `tool_choice` | Comportement |
+|---------------|--------------|
+| `{"type": "auto"}` | Le modèle décide d'appeler ou non des outils (par défaut) |
+| `{"type": "any"}` | Le modèle doit appeler au moins un outil |
+| `{"type": "tool", "name": "get_weather"}` | Le modèle doit appeler l'outil spécifié |
+| `{"type": "none"}` | Le modèle n'appellera aucun outil |
+
+#### Conversations multi-tours
+
+```python
+messages = [
+    {"role": "user", "content": "My name is Alice."},
+    {"role": "assistant", "content": "Nice to meet you, Alice!"},
+    {"role": "user", "content": "What's my name?"},
+]
+
+response = client.messages.create(
+    model="default",
+    max_tokens=100,
+    messages=messages
+)
+```
+
+#### Comptage de tokens
+
+```bash
+POST /v1/messages/count_tokens
+```
+
+Compte les tokens d'entrée d'une requête Anthropic en utilisant le tokenizer du modèle. Utile pour le suivi du budget avant d'envoyer une requête. Comptabilise les tokens des messages système, des messages de conversation, des entrées `tool_use`, du contenu `tool_result` et des définitions d'outils (name, description, input_schema).
+
+```python
+import requests
+
+resp = requests.post("http://localhost:8000/v1/messages/count_tokens", json={
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello, how are you?"}],
+    "system": "You are helpful.",
+    "tools": [{
+        "name": "search",
+        "description": "Search the web",
+        "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+    }]
+})
+print(resp.json())  # {"input_tokens": 42}
+```
+
+#### Exemples curl
+
+Non-streaming :
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+Streaming :
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Tell me a joke"}]
+  }'
+```
+
+Comptage de tokens :
+
+```bash
+curl http://localhost:8000/v1/messages/count_tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+# {"input_tokens": 12}
+```
+
+#### Champs de la requête
+
+| Champ | Type | Requis | Défaut | Description |
+|-------|------|--------|--------|-------------|
+| `model` | string | oui | - | Nom du modèle (utilisez `"default"` pour le modèle chargé) |
+| `messages` | list | oui | - | Messages de conversation avec `role` et `content` |
+| `max_tokens` | int | oui | - | Nombre maximal de tokens à générer |
+| `system` | string or list | non | null | Invite système (chaîne ou liste de blocs `{"type": "text", "text": "..."}`) |
+| `stream` | bool | non | false | Active le streaming SSE |
+| `temperature` | float | non | 0.7 | Température d'échantillonnage (0.0 = déterministe, 1.0 = créatif) |
+| `top_p` | float | non | 0.9 | Seuil d'échantillonnage nucleus |
+| `top_k` | int | non | null | Échantillonnage top-k |
+| `stop_sequences` | list | non | null | Séquences qui arrêtent la génération |
+| `tools` | list | non | null | Définitions d'outils avec `name`, `description`, `input_schema` |
+| `tool_choice` | dict | non | null | Mode de sélection d'outil (`auto`, `any`, `tool`, `none`) |
+| `metadata` | dict | non | null | Métadonnées arbitraires (transmises telles quelles, non utilisées par le serveur) |
+
+#### Format de réponse
+
+Réponse non-streaming :
+
+```json
+{
+  "id": "msg_abc123...",
+  "type": "message",
+  "role": "assistant",
+  "model": "default",
+  "content": [
+    {"type": "text", "text": "Hello! How can I help?"}
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 8
+  }
+}
+```
+
+Lorsque des outils sont appelés, `content` inclut des blocs `tool_use` et `stop_reason` vaut `"tool_use"` :
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "Let me check the weather."},
+    {
+      "type": "tool_use",
+      "id": "call_abc123",
+      "name": "get_weather",
+      "input": {"city": "Paris"}
+    }
+  ],
+  "stop_reason": "tool_use"
+}
+```
+
+Raisons d'arrêt :
+
+| `stop_reason` | Signification |
+|---------------|---------------|
+| `end_turn` | Le modèle a terminé naturellement |
+| `tool_use` | Le modèle souhaite appeler un outil |
+| `max_tokens` | La limite `max_tokens` a été atteinte |
+
+#### Utilisation avec Claude Code
+
+Pointez Claude Code directement vers votre serveur vllm-mlx :
+
+```bash
+# Start the server
+vllm-mlx serve mlx-community/Qwen3-Coder-Next-235B-A22B-4bit \
+  --continuous-batching \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+
+# In another terminal, configure Claude Code
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### État du serveur
+
+```bash
+GET /v1/status
+```
+
+Point de terminaison de surveillance en temps réel qui retourne des statistiques globales du serveur et des détails par requête. Utile pour déboguer les performances, suivre l'efficacité du cache et surveiller la mémoire Metal GPU.
+
+```bash
+curl -s http://localhost:8000/v1/status | python -m json.tool
+```
+
+Exemple de réponse :
+
+```json
+{
+  "status": "running",
+  "model": "mlx-community/Qwen3-8B-4bit",
+  "uptime_s": 342.5,
+  "steps_executed": 1247,
+  "num_running": 1,
+  "num_waiting": 0,
+  "total_requests_processed": 15,
+  "total_prompt_tokens": 28450,
+  "total_completion_tokens": 3200,
+  "metal": {
+    "active_memory_gb": 5.2,
+    "peak_memory_gb": 8.1,
+    "cache_memory_gb": 2.3
+  },
+  "cache": {
+    "type": "memory_aware_cache",
+    "entries": 5,
+    "hit_rate": 0.87,
+    "memory_mb": 2350
+  },
+  "requests": [
+    {
+      "request_id": "req_abc123",
+      "phase": "generation",
+      "tokens_per_second": 45.2,
+      "ttft_s": 0.8,
+      "progress": 0.35,
+      "cache_hit_type": "prefix",
+      "cached_tokens": 1200,
+      "generated_tokens": 85,
+      "max_tokens": 256
+    }
+  ]
+}
+```
+
+Champs de la réponse :
+
+| Champ | Description |
+|-------|-------------|
+| `status` | État du serveur : `running`, `stopped` ou `not_loaded` |
+| `model` | Nom du modèle chargé |
+| `uptime_s` | Secondes écoulées depuis le démarrage du serveur |
+| `steps_executed` | Nombre total d'étapes d'inférence exécutées |
+| `num_running` | Nombre de requêtes en cours de génération de tokens |
+| `num_waiting` | Nombre de requêtes en attente de prefill |
+| `total_requests_processed` | Total des requêtes traitées depuis le démarrage |
+| `total_prompt_tokens` | Total des tokens de prompt traités depuis le démarrage |
+| `total_completion_tokens` | Total des tokens de complétion générés depuis le démarrage |
+| `metal.active_memory_gb` | Mémoire Metal GPU actuellement utilisée (Go) |
+| `metal.peak_memory_gb` | Pic d'utilisation de la mémoire Metal GPU (Go) |
+| `metal.cache_memory_gb` | Utilisation de la mémoire cache Metal (Go) |
+| `cache` | Statistiques du cache (type, entrées, taux de hit, utilisation mémoire) |
+| `requests` | Liste des requêtes actives avec détails par requête |
+
+Champs par requête dans `requests` :
+
+| Champ | Description |
+|-------|-------------|
+| `request_id` | Identifiant unique de la requête |
+| `phase` | Phase actuelle : `queued`, `prefill` ou `generation` |
+| `tokens_per_second` | Débit de génération pour cette requête |
+| `ttft_s` | TTFT (secondes) |
+| `progress` | Pourcentage de complétion (0.0 à 1.0) |
+| `cache_hit_type` | Type de correspondance dans le cache : `exact`, `prefix`, `supersequence`, `lcp` ou `miss` |
+| `cached_tokens` | Nombre de tokens servis depuis le cache |
+| `generated_tokens` | Tokens générés jusqu'à présent |
+| `max_tokens` | Nombre maximal de tokens demandés |
+
+## Tool Calling
+
+Activez le tool calling compatible OpenAI avec `--enable-auto-tool-choice` :
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+Utilisez l'option `--tool-call-parser` pour sélectionner le parser adapté à votre modèle :
+
+| Parser | Modèles |
+|--------|---------|
+| `auto` | Détection automatique (essaie tous les parsers) |
+| `mistral` | Mistral, Devstral |
+| `qwen` | Qwen, Qwen3 |
+| `llama` | Llama 3.x, 4.x |
+| `hermes` | Hermes, NousResearch |
+| `deepseek` | DeepSeek V3, R1 |
+| `kimi` | Kimi K2, Moonshot |
+| `granite` | IBM Granite 3.x, 4.x |
+| `nemotron` | NVIDIA Nemotron |
+| `xlam` | Salesforce xLAM |
+| `functionary` | MeetKai Functionary |
+| `glm47` | GLM-4.7, GLM-4.7-Flash |
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"{tc.function.name}: {tc.function.arguments}")
+```
+
+Voir le [Guide du tool calling](tool-calling.md) pour la documentation complète.
+
+## Modèles reasoning
+
+Pour les modèles qui exposent leur processus de réflexion (Qwen3, DeepSeek-R1), utilisez `--reasoning-parser` pour séparer le reasoning de la réponse finale :
+
+```bash
+# Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+La réponse de l'API inclut un champ `reasoning` avec le processus de réflexion du modèle :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+
+print(response.choices[0].message.reasoning)  # Step-by-step thinking
+print(response.choices[0].message.content)    # Final answer
+```
+
+En streaming, les fragments de reasoning arrivent en premier, suivis des fragments de contenu :
+
+```python
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.reasoning:
+        print(f"[Thinking] {delta.reasoning}")
+    if delta.content:
+        print(delta.content, end="")
+```
+
+Voir le [Guide des modèles reasoning](reasoning.md) pour tous les détails.
+
+## Sortie structurée (mode JSON)
+
+Forcez le modèle à retourner du JSON valide en utilisant `response_format` :
+
+### Mode JSON Object
+
+Retourne n'importe quel JSON valide :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={"type": "json_object"}
+)
+# Output: {"colors": ["red", "blue", "green"]}
+```
+
+### Mode JSON Schema
+
+Retourne du JSON conforme à un schéma spécifique :
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "colors",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "colors": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["colors"]
+            }
+        }
+    }
+)
+# Output validated against schema
+data = json.loads(response.choices[0].message.content)
+assert "colors" in data
+```
+
+### Exemple curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "List 3 colors"}],
+    "response_format": {"type": "json_object"}
+  }'
+```
+
+## Exemples curl
+
+### Chat
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 100
+  }'
+```
+
+### Streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+  }'
+```
+
+## Configuration du streaming
+
+Contrôlez le comportement du streaming avec `--stream-interval` :
+
+| Valeur | Comportement |
+|--------|--------------|
+| `1` (par défaut) | Envoie chaque token immédiatement |
+| `2-5` | Regroupe les tokens avant envoi |
+| `10+` | Débit maximal, sortie plus fragmentée |
+
+```bash
+# Smooth streaming
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# Batched streaming (better for high-latency networks)
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+## Intégration Open WebUI
+
+```bash
+# 1. Start vllm-mlx server
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# 2. Start Open WebUI
+docker run -d -p 3000:8080 \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
+  -e OPENAI_API_KEY=not-needed \
+  --name open-webui \
+  ghcr.io/open-webui/open-webui:main
+
+# 3. Open http://localhost:3000
+```
+
+## Déploiement en production
+
+### Avec systemd
+
+Créez `/etc/systemd/system/vllm-mlx.service` :
+
+```ini
+[Unit]
+Description=vLLM-MLX Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching --use-paged-cache --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable vllm-mlx
+sudo systemctl start vllm-mlx
+```
+
+### Paramètres recommandés
+
+Pour une production avec 50 utilisateurs simultanés ou plus :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --port 8000
+```

--- a/docs/fr/guides/tool-calling.md
+++ b/docs/fr/guides/tool-calling.md
@@ -1,0 +1,244 @@
+# Tool Calling
+
+vllm-mlx prend en charge le tool calling compatible OpenAI (function calling) avec un parsing automatique pour de nombreuses familles de modèles populaires.
+
+## Démarrage rapide
+
+Activez le tool calling en ajoutant le flag `--enable-auto-tool-choice` au démarrage du serveur :
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+Utilisez ensuite les outils avec l'API OpenAI standard :
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+# Check for tool calls
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"Function: {tc.function.name}")
+        print(f"Arguments: {tc.function.arguments}")
+```
+
+## Parsers disponibles
+
+Utilisez `--tool-call-parser` pour sélectionner un tool parser adapté à votre famille de modèles :
+
+| Parser | Alias | Modèles | Format |
+|--------|-------|---------|--------|
+| `auto` | | N'importe quel modèle | Détection automatique du format (essaie tous les parsers) |
+| `mistral` | | Mistral, Devstral | Tableau JSON `[TOOL_CALLS]` |
+| `qwen` | `qwen3` | Qwen, Qwen3 | XML `<tool_call>` ou `[Calling tool:]` |
+| `llama` | `llama3`, `llama4` | Llama 3.x, 4.x | Balises `<function=name>` |
+| `hermes` | `nous` | Hermes, NousResearch | JSON `<tool_call>` dans XML |
+| `deepseek` | `deepseek_v3`, `deepseek_r1` | DeepSeek V3, R1 | Délimiteurs Unicode |
+| `kimi` | `kimi_k2`, `moonshot` | Kimi K2, Moonshot | Tokens `<\|tool_call_begin\|>` |
+| `granite` | `granite3` | IBM Granite 3.x, 4.x | `<\|tool_call\|>` ou `<tool_call>` |
+| `nemotron` | `nemotron3` | NVIDIA Nemotron | `<tool_call><function=...><parameter=...>` |
+| `xlam` | | Salesforce xLAM | JSON avec tableau `tool_calls` |
+| `functionary` | `meetkai` | MeetKai Functionary | Plusieurs blocs de fonctions |
+| `glm47` | `glm4` | GLM-4.7, GLM-4.7-Flash | `<tool_call>` avec XML `<arg_key>`/`<arg_value>` |
+
+## Exemples par modèle
+
+### Mistral / Devstral
+
+```bash
+# Devstral Small (optimized for coding and tool use)
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Mistral Instruct
+vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+### Qwen
+
+```bash
+# Qwen3
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser qwen
+```
+
+### Llama
+
+```bash
+# Llama 3.2
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser llama
+```
+
+### DeepSeek
+
+```bash
+# DeepSeek V3
+vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
+  --enable-auto-tool-choice --tool-call-parser deepseek
+```
+
+### IBM Granite
+
+```bash
+# Granite 4.0
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+```
+
+### NVIDIA Nemotron
+
+```bash
+# Nemotron 3 Nano
+vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
+  --enable-auto-tool-choice --tool-call-parser nemotron
+```
+
+### GLM-4.7
+
+```bash
+# GLM-4.7 Flash
+vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
+  --enable-auto-tool-choice --tool-call-parser glm47
+```
+
+### Kimi K2
+
+```bash
+# Kimi K2
+vllm-mlx serve mlx-community/Kimi-K2-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser kimi
+```
+
+### Salesforce xLAM
+
+```bash
+# xLAM
+vllm-mlx serve mlx-community/xLAM-2-fc-r-4bit \
+  --enable-auto-tool-choice --tool-call-parser xlam
+```
+
+## Parser automatique
+
+Si vous n'êtes pas sûr du parser à utiliser, le parser `auto` tente de détecter le format automatiquement :
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser auto
+```
+
+Le parser automatique essaie les formats dans cet ordre :
+1. Mistral (`[TOOL_CALLS]`)
+2. Qwen bracket (`[Calling tool:]`)
+3. Nemotron (`<tool_call><function=...><parameter=...>`)
+4. Qwen/Hermes XML (`<tool_call>{...}</tool_call>`)
+5. Llama (`<function=name>{...}</function>`)
+6. JSON brut
+
+## Streaming tool calls
+
+Le tool calling fonctionne avec le streaming. Les informations du tool call sont envoyées lorsque le modèle a terminé de générer :
+
+```python
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's 25 * 17?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Calculate math expressions",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string"}
+                },
+                "required": ["expression"]
+            }
+        }
+    }],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.tool_calls:
+        for tc in chunk.choices[0].delta.tool_calls:
+            print(f"Tool call: {tc.function.name}({tc.function.arguments})")
+```
+
+## Gestion des résultats de tool calls
+
+Après avoir reçu un tool call, exécutez la fonction et renvoyez le résultat :
+
+```python
+import json
+
+# First request - model decides to call a tool
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=[weather_tool]
+)
+
+# Get the tool call
+tool_call = response.choices[0].message.tool_calls[0]
+tool_call_id = tool_call.id
+function_name = tool_call.function.name
+arguments = json.loads(tool_call.function.arguments)
+
+# Execute the function (your implementation)
+result = get_weather(**arguments)  # {"temperature": 22, "condition": "sunny"}
+
+# Send result back to model
+response = client.chat.completions.create(
+    model="default",
+    messages=[
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {"role": "assistant", "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": tool_call_id, "content": json.dumps(result)}
+    ],
+    tools=[weather_tool]
+)
+
+print(response.choices[0].message.content)
+# "The weather in Tokyo is sunny with a temperature of 22C."
+```
+
+## Gestion des balises think
+
+Les modèles qui produisent des balises de reasoning `<think>...</think>` (comme DeepSeek-R1, Qwen3, GLM-4.7) sont gérés automatiquement. Le parser supprime le contenu de la réflexion avant d'extraire les tool calls, de sorte que les balises de reasoning n'interfèrent jamais avec le parsing des tool calls.
+
+Cela fonctionne même lorsque `<think>` a été injecté dans le prompt (balises think implicites avec uniquement un `</think>` fermant).
+
+## Référence CLI
+
+| Option | Description |
+|--------|-------------|
+| `--enable-auto-tool-choice` | Active le tool calling automatique |
+| `--tool-call-parser` | Sélectionne le parser (voir tableau ci-dessus) |
+
+Voir [Référence CLI](../reference/cli.md) pour toutes les options.

--- a/docs/fr/guides/warm-prompts.md
+++ b/docs/fr/guides/warm-prompts.md
@@ -1,0 +1,187 @@
+# Warm Prompts
+
+Pré-remplissez le prefix cache au démarrage du serveur afin que la **première** requête
+envoyée par un agent trouve un cache déjà chaud, sans payer le coût complet du prefill
+pour son system prompt de plusieurs kilo-octets.
+
+## Quand utiliser cette fonctionnalité
+
+Les charges de travail agent. proxies vers des assistants de code ou de raisonnement, serveurs MCP,
+orchestrateurs multi-agents. envoient toujours le même system prompt. Aujourd'hui,
+la première requête d'un serveur froid paie le prefill complet pour ce system prompt.
+Sur un modèle de plusieurs milliards de paramètres, cela représente plusieurs secondes de
+TTFT, précisément au moment où un utilisateur attend la première réponse de son nouvel agent.
+
+Si vous connaissez les system prompts de vos agents au moment du déploiement, écrivez-les
+dans un fichier JSON et pointez `--warm-prompts` dessus. Le serveur exécute une complétion
+de chat avec `max_tokens=1` pour chacun au démarrage, l'état KV cache est chargé dans le
+prefix cache, et la première vraie requête correspond via strict-prefix.
+
+Nécessite `--continuous-batching` (le prefix cache y est hébergé).
+
+## Exemple rapide
+
+```bash
+# Écrivez une seule fois les agents qui vous intéressent
+cat > ~/.config/vllm-mlx/agents.json <<'JSON'
+[
+  [{"role": "system", "content": "You are a code assistant..."}]
+]
+JSON
+
+# Pointez le serveur dessus
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json
+```
+
+Au démarrage vous verrez :
+
+```
+[lifespan] Warm-up done (strict-prefix): 1 completed, 0 skipped,
+           1431 prompt tokens in 0.2s
+```
+
+La première vraie requête partageant le system prompt réchauffé atteint le cache
+avec `tokens_saved` proche de la longueur du prompt de warm-up.
+
+## Format de fichier
+
+Une liste JSON de premier niveau. Chaque entrée est elle-même une liste de messages de chat,
+de même forme que `messages` dans `/v1/chat/completions`.
+
+```json
+[
+  [
+    {"role": "system", "content": "You are a code assistant..."}
+  ],
+  [
+    {"role": "system", "content": "You are a senior code reviewer..."}
+  ],
+  [
+    {"role": "system", "content": "You are a planner..."},
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "Hello, what are we planning?"}
+  ]
+]
+```
+
+Les system prompts à message unique sont le cas le plus courant. Les historiques multi-tours
+sont pris en charge pour les scénarios où vous souhaitez réchauffer un début de conversation
+spécifique (exemples few-shot, persona d'assistant récurrente).
+
+## Dimensionnement
+
+Les warm prompts sont traités **en parallèle** via `asyncio.gather`, donc N entrées
+déclenchent N prefills simultanés au démarrage. Chaque prefill alloue du KV cache
+pour la longueur de son prompt.
+
+**Recommandation : 1 à 3 entrées.** Cela couvre les chemins critiques des déploiements
+agent typiques (une persona par entrée). Un fichier warm-prompts très grand sur un modèle
+à mémoire limitée peut épuiser la marge disponible au démarrage.
+
+Si vous devez réchauffer des dizaines de personas, ouvrez une issue en décrivant votre
+charge de travail et nous pourrons ajouter un paramètre `--warm-prompts-concurrency=N`.
+
+## Benchmarks
+
+**Configuration.** M4 Max, 128 Go de mémoire unifiée. Deux serveurs séparés par mesure
+(froid et chaud), démarrage à froid isolé. Jeu de prompts `long` (~2 500 tokens utilisateur)
+précédé d'un system prompt d'environ 1 700 tokens correspondant au prompt de warm-up.
+`max_tokens=128`. bench-serve avec `--skip-preflight-token-count` afin que le preflight
+`count_prompt_tokens` ne pollue pas le cache.
+
+| Modèle | conc | TTFT froid | TTFT chaud | Accélération |
+|--------|-----:|-----------:|-----------:|-------------:|
+| Qwen3-0.6B-8bit | 1 | 563 ms | 419 ms | 1.34x |
+| Qwen3-0.6B-8bit | 4 | 1 723 ms | 1 282 ms | 1.34x |
+| Qwen3-0.6B-8bit | 8 | 3 708 ms | 2 661 ms | 1.39x |
+| Llama-3.2-3B-Instruct-4bit | 1 | 1 754 ms | 1 060 ms | 1.65x |
+| Llama-3.2-3B-Instruct-4bit | 4 | 5 926 ms | 3 945 ms | 1.50x |
+| Llama-3.2-3B-Instruct-4bit | 8 | 15 161 ms | 9 820 ms | 1.54x |
+| Qwen3-4B-4bit | 1 | 4 937 ms | 2 191 ms | 2.25x |
+| Qwen3-4B-4bit | 4 | 12 535 ms | 9 623 ms | 1.30x |
+| Qwen3-4B-4bit | 8 | 38 148 ms | 23 878 ms | 1.60x |
+| Qwen3.6-35B-A3B-4bit (MoE/hybrid) | 1 | 2 400 ms | 1 603 ms | 1.50x |
+| Qwen3.6-35B-A3B-4bit | 4 | 8 735 ms | 6 054 ms | 1.44x |
+| Qwen3.6-35B-A3B-4bit | 8 | 22 419 ms | 14 409 ms | 1.56x |
+
+Les 12 configurations s'améliorent toutes. Les gains de TTFT sont les plus importants
+quand le ratio prompt/total est le plus élevé (conc=1, long system prompt) et restent
+significatifs sous charge concurrente.
+
+**La génération tok/s** est neutre (dans ±5 %) pour les modèles denses.
+Qwen3.6-35B-A3B (MoE) affiche une baisse de décodage de 20 à 35 % à conc >= 4, qui semble
+liée à l'interaction du routage MoE avec la planification en batch. Les gains de TTFT
+dominent néanmoins la latence de bout en bout sur les charges agent, mais tenez-en compte
+si votre flux de travail est fortement limité par le décodage à forte concurrence.
+
+## Fonctionnement interne
+
+Le warm-up naïf. rendu du template de chat avec un message utilisateur fictif et mise en
+cache des tokens. ne fonctionne pas pour les modèles hybrides SSM+attention
+(Qwen3.5-MoE, Qwen3.6-MoE). Leurs couches de cache incluent un état SSM qui ne peut pas
+être tronqué, si bien que `memory_cache.py` désactive la correspondance LCP. Le contenu
+utilisateur fictif diverge du vrai contenu utilisateur, et une entrée mise en cache au
+niveau des tokens n'est plus un strict prefix d'aucune vraie requête.
+
+Le warmer ici rend le template de chat **deux fois** avec deux contenus utilisateur
+distincts (`"__PROBE_A__"` et `"__PROBE_B__"`), trouve la position de caractère où les deux
+chaînes divergent, puis tronque le premier rendu à cette frontière. Cette chaîne tronquée.
+tout ce qui précède l'insertion du contenu utilisateur. est ce qui est envoyé au moteur.
+
+Comme le chemin de vraie requête du moteur rend aussi le template avec `tokenize=False` puis
+laisse le tokenizer encoder le résultat, les tokens du warm-up sont garantis d'être un strict
+prefix de toute vraie requête avec un system prompt correspondant et un historique de chat
+vide. Les correspondances strict-prefix fonctionnent sur tous les types de couche de cache,
+y compris les chemins hybrides où LCP est désactivé.
+
+## Administration
+
+### Vider le prefix cache en mémoire
+
+```bash
+curl -X DELETE http://localhost:8000/v1/cache/prefix
+```
+
+Si le serveur a été démarré avec `--warm-prompts`, le warm-up se relance en arrière-plan
+après la suppression. La réponse est retournée immédiatement sans attendre la fin du
+re-warm.
+
+Réponse :
+
+```json
+{"status": "cleared", "rewarm_scheduled": true}
+```
+
+### Inspecter l'état du cache
+
+```bash
+curl http://localhost:8000/v1/status | jq '.cache'
+```
+
+Après le démarrage avec warm-prompts, vous verrez `entry_count > 0` avant la première
+requête utilisateur.
+
+## Mesurer l'impact sur votre configuration
+
+Pour mesurer l'impact sur votre modèle et vos prompts, utilisez `bench-serve` :
+
+```bash
+# Froid : sans warm-prompts
+vllm-mlx serve MODEL --continuous-batching &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag cold \
+  --output cold.csv --format csv
+
+# Chaud : même configuration + --warm-prompts
+vllm-mlx serve MODEL --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag warm \
+  --output warm.csv --format csv
+```
+
+`--skip-preflight-token-count` est activé automatiquement quand
+`--system-prompt-file` est fourni, afin que le preflight `count_prompt_tokens`
+ne pollue pas le cache. Comparez `cold.csv` et `warm.csv` pour votre charge de travail.

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,0 +1,71 @@
+# Documentation vLLM-MLX
+
+**Backend MLX pour Apple Silicon sur vLLM** - Accélération GPU pour le texte, les images, la vidéo et l'audio sur Mac
+
+## Qu'est-ce que vLLM-MLX ?
+
+vllm-mlx apporte l'accélération GPU native d'Apple Silicon à vLLM en intégrant :
+
+- **[MLX](https://github.com/ml-explore/mlx)** : le framework ML d'Apple avec mémoire unifiée et noyaux Metal
+- **[mlx-lm](https://github.com/ml-explore/mlx-lm)** : inférence LLM optimisée avec KV cache et quantification
+- **[mlx-vlm](https://github.com/Blaizzy/mlx-vlm)** : modèles vision-langage (VLM) pour l'inférence multimodale
+- **[mlx-audio](https://github.com/Blaizzy/mlx-audio)** : Text-to-Speech et Speech-to-Text avec des voix natives
+- **[mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings)** : embeddings textuels pour la recherche sémantique et le RAG
+
+## Fonctionnalités principales
+
+- **Multimodal** - Texte, image, vidéo et audio sur une seule plateforme
+- **Accélération GPU native** sur Apple Silicon (M1, M2, M3, M4)
+- **Voix TTS natives** - espagnol, français, chinois, japonais et 5 autres langues
+- **Compatible API OpenAI** - remplacement direct du client OpenAI
+- **Embeddings** - point de terminaison `/v1/embeddings` compatible OpenAI
+- **MCP Tool Calling** - intégration d'outils externes via le Model Context Protocol
+- **Paged KV Cache** - mise en cache efficace en mémoire avec partage de préfixe
+- **Continuous Batching** - débit élevé pour plusieurs utilisateurs simultanés
+
+## Liens rapides
+
+### Démarrage
+
+- [Installation](getting-started/installation.md)
+- [Démarrage rapide](getting-started/quickstart.md)
+
+### Guides utilisateur
+
+- [Serveur compatible OpenAI](guides/server.md)
+- [API Python](guides/python-api.md)
+- [Multimodal (images et vidéo)](guides/multimodal.md)
+- [Audio (STT/TTS)](guides/audio.md)
+- [Embeddings](guides/embeddings.md)
+- [Modèles de reasoning](guides/reasoning.md)
+- [Tool Calling](guides/tool-calling.md)
+- [MCP et Tool Calling](guides/mcp-tools.md)
+- [Continuous Batching](guides/continuous-batching.md)
+
+### Référence
+
+- [Commandes CLI](reference/cli.md)
+- [Modèles pris en charge](reference/models.md)
+- [Configuration](reference/configuration.md)
+
+### Benchmarks
+
+- [Benchmarks LLM](benchmarks/llm.md)
+- [Benchmarks image](benchmarks/image.md)
+- [Benchmarks vidéo](benchmarks/video.md)
+- [Benchmarks audio](benchmarks/audio.md)
+
+### Développement
+
+- [Architecture](../development/architecture.md)
+- [Contribuer](../development/contributing.md)
+
+## Prérequis
+
+- macOS sur Apple Silicon (M1/M2/M3/M4)
+- Python 3.10+
+- 8 Go de RAM recommandés
+
+## Licence
+
+Apache 2.0 - Consultez [LICENSE](../../LICENSE) pour les détails.

--- a/docs/fr/reference/cli.md
+++ b/docs/fr/reference/cli.md
@@ -1,0 +1,210 @@
+# Référence CLI
+
+## Vue d'ensemble des commandes
+
+| Commande | Description |
+|---------|-------------|
+| `vllm-mlx serve` | Démarrer le serveur compatible OpenAI |
+| `vllm-mlx-bench` | Exécuter des benchmarks de performance |
+| `vllm-mlx-chat` | Démarrer l'interface de chat Gradio |
+
+## `vllm-mlx serve`
+
+Démarrer le serveur API compatible OpenAI.
+
+### Utilisation
+
+```bash
+vllm-mlx serve <model> [options]
+```
+
+### Options
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--served-model-name` | Nom de modèle personnalisé exposé via l'API OpenAI. Si non défini, le chemin du modèle est utilisé comme nom. | None |
+| `--port` | Port du serveur | 8000 |
+| `--host` | Hôte du serveur | 127.0.0.1 |
+| `--api-key` | Clé API pour l'authentification | None |
+| `--rate-limit` | Requêtes par minute par client (0 = désactivé) | 0 |
+| `--timeout` | Délai d'attente des requêtes en secondes | 300 |
+| `--enable-metrics` | Exposer les métriques Prometheus sur `/metrics` | False |
+| `--continuous-batching` | Activer le continuous batching pour plusieurs utilisateurs | False |
+| `--cache-memory-mb` | Limite mémoire du cache en Mo | Auto |
+| `--cache-memory-percent` | Fraction de la RAM réservée au cache | 0.20 |
+| `--no-memory-aware-cache` | Utiliser le cache legacy basé sur le nombre d'entrées | False |
+| `--use-paged-cache` | Activer le KV cache paginé | False |
+| `--max-tokens` | Nombre maximum de tokens par défaut | 32768 |
+| `--max-request-tokens` | Valeur maximale de `max_tokens` acceptée depuis les clients API | 32768 |
+| `--stream-interval` | Tokens par fragment de streaming | 1 |
+| `--mcp-config` | Chemin vers le fichier de configuration MCP | None |
+| `--paged-cache-block-size` | Tokens par bloc de cache | 64 |
+| `--max-cache-blocks` | Nombre maximum de blocs de cache | 1000 |
+| `--max-num-seqs` | Nombre maximum de séquences simultanées | 256 |
+| `--default-temperature` | Température par défaut si non spécifiée dans la requête | None |
+| `--default-top-p` | Valeur top_p par défaut si non spécifiée dans la requête | None |
+| `--max-audio-upload-mb` | Taille maximale des fichiers audio téléversés pour `/v1/audio/transcriptions` | 25 |
+| `--max-tts-input-chars` | Longueur maximale du texte acceptée par `/v1/audio/speech` | 4096 |
+| `--reasoning-parser` | Analyseur pour les modèles de reasoning (`qwen3`, `deepseek_r1`) | None |
+| `--embedding-model` | Pré-charger un modèle d'embeddings au démarrage | None |
+| `--enable-auto-tool-choice` | Activer le tool calling automatique | False |
+| `--tool-call-parser` | Analyseur d'appels d'outils (`auto`, `mistral`, `qwen`, `llama`, `hermes`, `deepseek`, `kimi`, `granite`, `nemotron`, `xlam`, `functionary`, `glm47`) | None |
+
+### Exemples
+
+```bash
+# Simple mode (single user, max throughput)
+# Model path is used as the model name in the OpenAI API (e.g. model="mlx-community/Llama-3.2-3B-Instruct-4bit")
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+
+Model will show up as 'mlx-community/Llama-3.2-3B-Instruct-4bit' in the `/v1/models` API endpoint. View with `curl http://localhost:8000/v1/models` or similar.
+
+# With a custom API model name (model is accessed as "my-model" via the OpenAI API)
+# --served-model-name sets the name clients must use when calling the API (e.g. model="my-model")
+vllm-mlx serve --served-model-name my-model mlx-community/Llama-3.2-3B-Instruct-4bit
+# Note: Model will show up as 'my-model' in the `/v1/models` API endpoint.
+
+# Continuous batching (multiple users)
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
+
+# With memory limit for large models
+vllm-mlx serve mlx-community/GLM-4.7-Flash-4bit \
+  --continuous-batching \
+  --cache-memory-mb 2048
+
+# Production with paged cache
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+
+# With MCP tools
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# Multimodal model
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Reasoning model (separates thinking from answer)
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek reasoning model
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+
+# Tool calling with Mistral/Devstral
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Tool calling with Granite
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+
+# With API key authentication
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
+
+# Expose Prometheus metrics
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics
+
+# Production setup with security options
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --continuous-batching
+```
+
+### Sécurité
+
+Lorsque `--api-key` est défini, toutes les requêtes API requièrent l'en-tête `Authorization: Bearer <api-key>` :
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="your-secret-key"  # Must match --api-key
+)
+```
+
+Ou avec curl :
+
+```bash
+curl http://localhost:8000/v1/models \
+  -H "Authorization: Bearer your-secret-key"
+```
+
+## `vllm-mlx-bench`
+
+Exécuter des benchmarks de performance.
+
+### Utilisation
+
+```bash
+vllm-mlx-bench --model <model> [options]
+```
+
+### Options
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--model` | Nom du modèle | Requis |
+| `--prompts` | Nombre de prompts | 5 |
+| `--max-tokens` | Nombre maximum de tokens par prompt | 256 |
+| `--quick` | Mode benchmark rapide | False |
+| `--video` | Exécuter le benchmark vidéo | False |
+| `--video-url` | URL vidéo personnalisée | None |
+| `--video-path` | Chemin vidéo personnalisé | None |
+
+### Exemples
+
+```bash
+# LLM benchmark
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit
+
+# Quick benchmark
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --quick
+
+# Image benchmark (auto-detected for VLM models)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# Custom video
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit \
+  --video --video-url https://example.com/video.mp4
+```
+
+## `vllm-mlx-chat`
+
+Démarrer l'interface de chat Gradio.
+
+### Utilisation
+
+```bash
+vllm-mlx-chat --served-model-name <model-name> [options]
+```
+
+### Options
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--model` | Nom du modèle | Requis |
+| `--port` | Port Gradio | 7860 |
+| `--text-only` | Désactiver le multimodal | False |
+
+### Exemples
+
+```bash
+# Multimodal chat (text + images + video)
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Text-only chat
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit --text-only
+```
+
+## Variables d'environnement
+
+| Variable | Description |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | Modèle utilisé pour les tests |
+| `HF_TOKEN` | Jeton HuggingFace |

--- a/docs/fr/reference/configuration.md
+++ b/docs/fr/reference/configuration.md
@@ -1,0 +1,189 @@
+# Référence de configuration
+
+## Configuration du serveur
+
+### Options de base
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--host` | Adresse hôte du serveur | `127.0.0.1` |
+| `--port` | Port du serveur | `8000` |
+| `--max-tokens` | Nombre maximum de tokens par défaut | `32768` |
+| `--max-request-tokens` | Valeur maximale de `max_tokens` acceptée depuis les clients API | `32768` |
+| `--default-temperature` | Température par défaut si non spécifiée dans la requête | None |
+| `--default-top-p` | top_p par défaut si non spécifié dans la requête | None |
+
+### Options de sécurité
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--api-key` | Clé API pour l'authentification | None |
+| `--rate-limit` | Requêtes par minute par client (0 = désactivé) | `0` |
+| `--timeout` | Délai d'expiration des requêtes en secondes | `300` |
+| `--enable-metrics` | Expose les métriques Prometheus sur `/metrics` | `false` |
+| `--max-audio-upload-mb` | Taille maximale du fichier audio téléversé pour `/v1/audio/transcriptions` | `25` |
+| `--max-tts-input-chars` | Longueur maximale du texte acceptée par `/v1/audio/speech` | `4096` |
+
+### Options de batching
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--continuous-batching` | Active le continuous batching | `false` |
+| `--stream-interval` | Tokens par fragment de streaming | `1` |
+| `--max-num-seqs` | Nombre maximum de séquences simultanées | `256` |
+
+### Options de cache
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--cache-memory-mb` | Limite mémoire du cache en Mo | Auto |
+| `--cache-memory-percent` | Fraction de la RAM allouée au cache | `0.20` |
+| `--no-memory-aware-cache` | Utilise le cache legacy basé sur le nombre d'entrées | `false` |
+| `--use-paged-cache` | Active le KV cache paginé | `false` |
+| `--paged-cache-block-size` | Tokens par bloc | `64` |
+| `--max-cache-blocks` | Nombre maximum de blocs | `1000` |
+
+### Options d'appel d'outils
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--enable-auto-tool-choice` | Active l'appel automatique d'outils | `false` |
+| `--tool-call-parser` | Parseur d'appels d'outils (voir [Appel d'outils](../guides/tool-calling.md)) | None |
+
+### Options de raisonnement
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--reasoning-parser` | Parseur pour les modèles de raisonnement (`qwen3`, `deepseek_r1`) | None |
+
+### Options d'embeddings
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--embedding-model` | Précharge un modèle d'embedding au démarrage | None |
+
+### Options MCP
+
+| Option | Description | Défaut |
+|--------|-------------|---------|
+| `--mcp-config` | Chemin vers le fichier de configuration MCP | None |
+
+## Configuration MCP
+
+Créez le fichier `mcp.json` :
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-name", "arg1"],
+      "env": {
+        "ENV_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+### Options du serveur MCP
+
+| Champ | Description | Obligatoire |
+|-------|-------------|-------------|
+| `command` | Commande exécutable | Oui |
+| `args` | Arguments de la commande | Oui |
+| `env` | Variables d'environnement | Non |
+
+## Options des requêtes API
+
+### Complétions de chat
+
+| Paramètre | Description | Défaut |
+|-----------|-------------|---------|
+| `model` | Nom du modèle | Obligatoire |
+| `messages` | Messages du chat | Obligatoire |
+| `max_tokens` | Nombre maximum de tokens à générer | 256 |
+| `temperature` | Température d'échantillonnage | Défaut du modèle |
+| `top_p` | Échantillonnage par noyau | Défaut du modèle |
+| `stream` | Active le streaming | `true` |
+| `stop` | Séquences d'arrêt | None |
+| `tools` | Définitions des outils | None |
+| `response_format` | Format de sortie (`json_object`, `json_schema`) | None |
+
+### Options multimodales
+
+| Paramètre | Description | Défaut |
+|-----------|-------------|---------|
+| `video_fps` | Images par seconde | 2.0 |
+| `video_max_frames` | Nombre maximum d'images | 32 |
+
+## Variables d'environnement
+
+| Variable | Description |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | Modèle par défaut pour les tests |
+| `HF_TOKEN` | Token d'authentification HuggingFace |
+| `OPENAI_API_KEY` | À définir avec n'importe quelle valeur pour la compatibilité SDK |
+
+## Exemples de configurations
+
+### Développement (utilisateur unique)
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### Production (utilisateurs multiples)
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --port 8000
+```
+
+### Avec appel d'outils
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral \
+  --continuous-batching
+```
+
+### Avec les outils MCP
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --mcp-config mcp.json \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen \
+  --continuous-batching
+```
+
+### Modèle de raisonnement
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit \
+  --reasoning-parser qwen3 \
+  --continuous-batching
+```
+
+### Avec embeddings
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --embedding-model mlx-community/multilingual-e5-small-mlx \
+  --continuous-batching
+```
+
+### Débit élevé
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --stream-interval 5 \
+  --max-num-seqs 256
+```

--- a/docs/fr/reference/models.md
+++ b/docs/fr/reference/models.md
@@ -1,0 +1,99 @@
+# Modèles pris en charge
+
+Tous les modèles quantifiés de [mlx-community sur HuggingFace](https://huggingface.co/mlx-community/models) sont compatibles.
+
+Parcourez des milliers de modèles pré-optimisés à l'adresse : **https://huggingface.co/mlx-community/models**
+
+## Modèles de langage (via mlx-lm)
+
+| Famille de modèles | Tailles | Quantification |
+|--------------------|---------|----------------|
+| Llama 3.x, 4.x | 1B, 3B, 8B, 70B | 4-bit |
+| Mistral / Devstral | 7B, Mixtral 8x7B | 4-bit, 8-bit |
+| Qwen2/Qwen3 | 0.5B à 72B | Variable |
+| DeepSeek V3, R1 | 7B, 33B, 67B | 4-bit |
+| Gemma 2, 3, 4 | 2B, 9B, 27B | 4-bit |
+| GLM-4.7 | Flash, Base | 4-bit, 8-bit |
+| Kimi K2 | Variable | 4-bit |
+| Phi-3 | 3.8B, 14B | 4-bit |
+| Granite 3.x, 4.x | Variable | 4-bit |
+| Nemotron | 3 Nano 30B | 6-bit |
+
+### Modèles recommandés
+
+| Cas d'utilisation | Modèle | Mémoire |
+|-------------------|--------|---------|
+| Rapide / léger | `mlx-community/Qwen3-0.6B-8bit` | ~0,7 Go |
+| Équilibré | `mlx-community/Llama-3.2-3B-Instruct-4bit` | ~1,8 Go |
+| Qualité | `mlx-community/Llama-3.1-8B-Instruct-4bit` | ~4,5 Go |
+| Grand modèle | `mlx-community/Qwen3-30B-A3B-4bit` | ~16 Go |
+
+## Modèles multimodaux (via mlx-vlm)
+
+| Famille de modèles | Exemples de modèles |
+|--------------------|---------------------|
+| **Qwen-VL** | `Qwen3-VL-4B-Instruct-3bit`, `Qwen3-VL-8B-Instruct-4bit`, `Qwen2-VL-2B/7B-Instruct-4bit` |
+| **LLaVA** | `llava-1.5-7b-4bit`, `llava-v1.6-mistral-7b-4bit`, `llava-llama-3-8b-v1_1-4bit` |
+| **Idefics** | `Idefics3-8B-Llama3-4bit`, `idefics2-8b-4bit` |
+| **Gemma 4** | `gemma-4-e2b-it-mxfp4` (vision + audio) |
+| **PaliGemma** | `paligemma2-3b-mix-224-4bit`, `paligemma-3b-mix-224-8bit` |
+| **Pixtral** | `pixtral-12b-4bit`, `pixtral-12b-8bit` |
+| **Molmo** | `Molmo-7B-D-0924-4bit`, `Molmo-7B-D-0924-8bit` |
+| **Phi-3 Vision** | `Phi-3-vision-128k-instruct-4bit` |
+| **DeepSeek-VL** | `deepseek-vl-7b-chat-4bit`, `deepseek-vl2-small-4bit` |
+
+### Modèles VLM recommandés
+
+| Cas d'utilisation | Modèle | Mémoire |
+|-------------------|--------|---------|
+| Rapide / léger | `mlx-community/Qwen3-VL-4B-Instruct-3bit` | ~3 Go |
+| Équilibré | `mlx-community/Qwen3-VL-8B-Instruct-4bit` | ~6 Go |
+| Qualité | `mlx-community/Qwen3-VL-30B-A3B-Instruct-6bit` | ~20 Go |
+
+## Modèles d'embeddings (via mlx-embeddings)
+
+| Famille de modèles | Exemples de modèles |
+|--------------------|---------------------|
+| **BERT** | `mlx-community/bert-base-uncased-mlx` |
+| **XLM-RoBERTa** | `mlx-community/multilingual-e5-small-mlx`, `mlx-community/multilingual-e5-large-mlx` |
+| **ModernBERT** | `mlx-community/ModernBERT-base-mlx` |
+
+## Modèles audio (via mlx-audio)
+
+| Type | Famille de modèles | Exemples de modèles |
+|------|--------------------|---------------------|
+| **STT** | Whisper | `mlx-community/whisper-large-v3-turbo` |
+| **STT** | Parakeet | `mlx-community/parakeet-tdt-0.6b-v2` |
+| **TTS** | Kokoro | `prince-canuma/Kokoro-82M` |
+| **TTS** | Chatterbox | `chatterbox/chatterbox-tts-0.1` |
+
+## Détection automatique des modèles
+
+vllm-mlx détecte automatiquement les modèles multimodaux selon des motifs dans leur nom :
+- Contient "VL", "Vision", "vision"
+- Contient "llava", "idefics", "paligemma"
+- Contient "pixtral", "molmo", "deepseek-vl"
+- Contient "MedGemma", "Gemma-3", "Gemma-4" (variantes multimodales)
+
+## Utilisation des modèles
+
+### Depuis HuggingFace
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### Chemin local
+
+```bash
+vllm-mlx serve /path/to/local/model
+```
+
+## Recherche de modèles
+
+Filtrez les modèles mlx-community par :
+- **LLM** : `Llama`, `Qwen`, `Mistral`, `Phi`, `Gemma`, `DeepSeek`, `GLM`, `Kimi`, `Granite`, `Nemotron`
+- **VLM** : `-VL-`, `llava`, `paligemma`, `pixtral`, `molmo`, `idefics`, `deepseek-vl`, `MedGemma`
+- **Embedding** : `e5`, `bert`, `ModernBERT`
+- **Taille** : `1B`, `3B`, `7B`, `8B`, `70B`
+- **Quantification** : `4bit`, `8bit`, `bf16`

--- a/docs/guides/moe-top-k.md
+++ b/docs/guides/moe-top-k.md
@@ -1,0 +1,122 @@
+# MoE top_k override (`--moe-top-k`)
+
+Reduces the number of experts activated per token in Mixture-of-Experts models
+like Qwen3-30B-A3B, trading a small amount of quality for meaningfully higher
+decode throughput.
+
+> **Status:** opt-in flag. Default behaviour is unchanged. Quality numbers
+> below are for Qwen3-30B-A3B-4bit on M4 Max 128 GB — verify on your model
+> before shipping this to production workloads.
+
+## What it does
+
+Qwen3-30B-A3B is trained with `top_k=8` — every token picks 8 out of 128
+experts. On Apple Silicon at batch=1 decode the expert matmul (`SwitchGLU`)
+is the single biggest chunk of each layer's compute, and that cost scales
+roughly linearly with `top_k`. Lowering `top_k` at inference time has been
+shown (LExI 2025, Lynx 2024) to preserve most of the trained quality while
+cutting decode time materially.
+
+`--moe-top-k N` iterates every layer of the loaded model, and on each layer
+that has `.mlp.switch_mlp` (i.e. a sparse-MoE block) sets `top_k = N`. Dense
+layers and dense models are untouched — the flag is a no-op for them.
+
+## Usage
+
+```bash
+# Server
+vllm-mlx serve mlx-community/Qwen3-30B-A3B-4bit \
+  --continuous-batching \
+  --moe-top-k 4
+
+# Bench
+vllm-mlx bench mlx-community/Qwen3-30B-A3B-4bit --moe-top-k 4
+```
+
+The flag is rejected if `N` is greater than the model's trained `top_k`
+(it only makes sense to lower, never to raise).
+
+## Measured impact
+
+### Decode throughput (M4 Max 128 GB, batch=1, greedy)
+
+| top_k | tok/s | vs baseline |
+|---:|---:|---:|
+| 8 (baseline) | 126.5 | — |
+| 6 | 136.1 | +7.6% |
+| 5 | 140.3 | +10.9% |
+| 4 | 147.3 | +16.5% |
+
+### Quality (Qwen3-30B-A3B-4bit, lm-evaluation-harness, MLX backend)
+
+<!-- populated after eval completes -->
+
+| top_k | MMLU (acc) | GSM8K (exact match) | Δ vs baseline |
+|---:|---:|---:|---:|
+| 8 | TBD | TBD | — |
+| 6 | TBD | TBD | TBD |
+| 5 | TBD | TBD | TBD |
+| 4 | TBD | TBD | TBD |
+
+MMLU: 200 randomly-selected samples, 0-shot.
+GSM8K: 100 randomly-selected samples, 0-shot, exact-match strict.
+
+These numbers are **directional** — full suites are larger and would shift
+the absolute accuracy but not the relative delta between configs by much.
+
+### Greedy output parity
+
+With `top_k=4` on the 4-bit checkpoint we observed **identical first 16
+generated tokens** vs the baseline across every probe prompt we tried. This
+suggests top_k=4 does not change the argmax in the early decode steps — the
+model is internally robust to dropping half its activated experts.
+
+At `top_k=3` or lower quality would start to degrade visibly (not measured
+here; inferred from LExI paper), so the flag is intentionally not lowered
+below 1 at the config validation layer but the recommended floor for
+production is `top_k=4`.
+
+## When to use it, when not to
+
+Use it when:
+- You run a Qwen3 MoE (or compatible: Qwen3.5 MoE, Gemma-MoE) and single-user
+  decode throughput is your bottleneck.
+- You have a workload where a small quality drop is acceptable in exchange
+  for a visible latency improvement.
+- You're deploying on memory-bandwidth-bound hardware (M-series Apple Silicon)
+  where expert gather dominates per-step decode time.
+
+Skip it when:
+- You serve dense models — flag is a no-op, adds nothing.
+- You care about top-1% leaderboard accuracy on eval suites.
+- You run long chain-of-thought / "thinking mode" generations where the
+  quality cliff may be steeper than 0-shot MMLU suggests.
+
+## Stacking with other optimizations
+
+This flag composes with quantization. On Qwen3-30B-A3B-4bit our measured
+stack is:
+
+- 4-bit + top_k=8: 126.5 tok/s (baseline)
+- 4-bit + top_k=4: 147.3 tok/s (+16.5%)
+- 3-bit + top_k=8: 138.6 tok/s (+9.6%)
+- 3-bit + top_k=6: 147.1 tok/s (+16.3%)  — quality divergence measurable
+- 3-bit + top_k=4: 157.3 tok/s (+24%)  — **output quality breaks** (model answered a different question in our smoke test)
+
+3-bit + top_k=4 compounded the numerical error past the point where the
+argmax is stable. Stick to at most one aggressive knob: either 4-bit + top_k=4
+or 3-bit + top_k=6. Both give approximately the same tok/s (~147) with very
+different quality profiles.
+
+## Internals
+
+- Patch helper: `vllm_mlx.scheduler.apply_moe_top_k_override(model, k)`
+- Applied in `Scheduler.__init__` after the model is loaded.
+- Tests: `tests/test_moe_top_k.py` — covers dense models, mixed architectures,
+  and validation paths.
+
+## References
+
+- LExI: Layer-Adaptive Active Experts, [arXiv 2509.02753](https://arxiv.org/html/2509.02753)
+- Not All Experts are Equal (NAEE), [ACL 2024](https://aclanthology.org/2024.acl-long.334.pdf)
+- SwiftLM (`SWIFTLM_TOP_K` env knob prior art), [github.com/SharpAI/SwiftLM](https://github.com/SharpAI/SwiftLM)

--- a/docs/zh/benchmarks/README.md
+++ b/docs/zh/benchmarks/README.md
@@ -1,0 +1,63 @@
+# 基准测试
+
+vllm-mlx 在 Apple Silicon 上的性能基准测试。
+
+## 基准测试类型
+
+- [LLM 基准测试](llm.md) - 文本生成性能
+- [图像基准测试](image.md) - 图像理解性能
+- [视频基准测试](video.md) - 视频理解性能
+
+## 常用命令
+
+```bash
+# LLM benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# Image benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+```
+
+## 独立测试默认值
+
+独立基准测试脚本内置了默认模型，可以直接运行：
+
+```bash
+python tests/test_continuous_batching.py
+python tests/test_prefix_cache.py
+```
+
+默认模型：
+- `tests/test_continuous_batching.py` 对应 `mlx-community/Qwen3-8B-6bit`
+- `tests/test_prefix_cache.py` 对应 `mlx-community/Qwen3-0.6B-8bit`
+
+如需测试其他模型，使用可选的 `--model` 参数：
+
+```bash
+python tests/test_continuous_batching.py --model mlx-community/Qwen3-0.6B-8bit
+python tests/test_prefix_cache.py --model mlx-community/Qwen3-8B-6bit
+```
+
+## 硬件配置
+
+以下 Apple Silicon 配置已收录基准测试结果：
+
+| 芯片 | 内存 | Python |
+|------|--------|--------|
+| Apple M4 Max | 128 GB unified | 3.13 |
+| Apple M1 Max | 64 GB unified | 3.12 |
+
+不同 Apple Silicon 芯片的测试结果会有所差异。
+
+## 贡献基准测试
+
+如果您使用的是其他 Apple Silicon 芯片，欢迎分享您的测试结果：
+
+```bash
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+```
+
+请在 [GitHub Issues](https://github.com/waybarrios/vllm-mlx/issues) 中提交您的结果。

--- a/docs/zh/benchmarks/audio.md
+++ b/docs/zh/benchmarks/audio.md
@@ -1,0 +1,158 @@
+# 音频基准测试
+
+## 语音转文本 (STT) 基准测试
+
+### 运行 STT 基准测试
+
+```bash
+# Run with default test audio
+python examples/benchmark_audio.py --stt
+
+# Run with your own audio file
+python examples/benchmark_audio.py --stt --audio path/to/audio.wav
+```
+
+### 测试结果（M4 Max，128GB）
+
+**测试音频：** 46.7 秒的合成语音
+
+| Model | Parameters | Load Time | Transcribe Time | RTF* |
+|-------|------------|-----------|-----------------|------|
+| whisper-tiny | 39M | 0.34s | 0.24s | **197x** |
+| whisper-small | 244M | 0.18s | 0.47s | **98x** |
+| whisper-medium | 769M | 0.35s | 1.15s | **41x** |
+| whisper-large-v3 | 1.5B | 0.50s | 1.96s | **24x** |
+| whisper-large-v3-turbo | 809M | 0.12s | 0.86s | **55x** |
+
+*RTF = 实时倍率（值越高速度越快）。RTF 为 100x 表示 1 分钟的音频约在 0.6 秒内转录完成。*
+
+### 测试结果（M1 Max，64GB）
+
+使用 Parakeet 进行 STT（默认环境，Whisper 因 numpy 依赖版本不匹配而不可用）：
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| parakeet-tdt-0.6b-v2 | 0.28s | 1.01s | **9.9x** |
+| parakeet-tdt-0.6b-v3 | 0.30s | 0.19s | **52.7x** |
+
+使用 Whisper 进行 STT（显式指定 `numpy==2.3.5` 并搭配 `uv run --no-sync`）：
+
+| Model | Load Time | Transcribe Time | RTF |
+|-------|-----------|-----------------|-----|
+| whisper-tiny | 4.02s | 1.05s | **9.5x** |
+| whisper-small | 10.15s | 1.03s | **9.7x** |
+| whisper-medium | 22.96s | 2.20s | **4.6x** |
+| whisper-large-v3 | 38.34s | 0.96s | **10.5x** |
+| whisper-large-v3-turbo | 21.79s | 0.70s | **14.3x** |
+| parakeet-tdt-0.6b-v2 | 0.47s | 0.18s | **54.4x** |
+| parakeet-tdt-0.6b-v3 | 1.13s | 0.18s | **54.6x** |
+
+### 模型推荐
+
+| 使用场景 | 推荐模型 | 原因 |
+|----------|----------|------|
+| **实时转录** | whisper-tiny | 速度最快（197x RTF），延迟低 |
+| **通用场景** | whisper-large-v3-turbo | 速度（55x）与质量兼顾，综合表现最佳 |
+| **最高精度** | whisper-large-v3 | 准确率最高，支持 99 种以上语言 |
+| **低内存** | whisper-small | 244M 参数，质量良好 |
+
+### 转录质量
+
+所有模型均能正确转录测试音频。示例输出：
+
+```
+Input text:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..."
+
+Whisper-large-v3 output:
+"Welcome to this comprehensive speech to text demonstration.
+This audio sample is designed to test the accuracy and speed of various speech recognition models.
+The quick brown fox jumps over the lazy dog..." (identical)
+```
+
+### 支持的语言
+
+Whisper 模型支持 99 种以上语言，包括：
+- 英语、西班牙语、法语、德语、意大利语、葡萄牙语
+- 中文（普通话、粤语）、日语、韩语
+- 阿拉伯语、印地语、俄语、土耳其语、乌克兰语
+- 以及更多语言
+
+## 文本转语音 (TTS) 基准测试
+
+### 运行 TTS 基准测试
+
+```bash
+python examples/benchmark_audio.py --tts
+```
+
+### 测试结果（M4 Max，128GB）
+
+**测试内容：** 为 3 段文本样本（短、中、长）生成音频
+
+| Model | Load Time | Chars/sec | RTF* |
+|-------|-----------|-----------|------|
+| Kokoro-82M-bf16 | 0.8s | 350+ | **22x** |
+| Kokoro-82M-4bit | 0.4s | 320+ | **20x** |
+
+*RTF = 实时倍率。RTF 为 22x 表示 1 秒的音频约在 0.045 秒内生成完毕。*
+
+### TTS 测试结果（M1 Max，64GB）
+
+| Model | Load Time | Avg Chars/s | Avg RTF |
+|-------|-----------|-------------|---------|
+| Kokoro-82M-bf16 | 2.81s | 176.0 | **11.9x** |
+| Kokoro-82M-4bit | 0.22s | 225.6 | **15.5x** |
+
+### TTS 质量
+
+Kokoro 可生成自然流畅的语音，具备以下特性：
+- 11 种内置音色（男声与女声）
+- 支持 8 种语言（英语、西班牙语、法语、日语、中文、意大利语、葡萄牙语、印地语）
+- 82M 参数，轻量且高效
+
+## 音频处理基准测试
+
+### SAM-Audio（音源分离）
+
+**测试内容：** 从 30 秒摇滚歌曲中分离鼓声
+
+| Metric | Value |
+|--------|-------|
+| Model | sam-audio-large-fp16 |
+| Processing time | ~20s |
+| Peak memory | ~27 GB |
+| Output sample rate | 48000 Hz |
+
+## 运行全部音频基准测试
+
+```bash
+# Run all benchmarks
+python examples/benchmark_audio.py --all
+
+# Or run individually
+python examples/benchmark_audio.py --stt
+python examples/benchmark_audio.py --tts
+```
+
+## mlx-community 上的可用模型
+
+### STT 模型
+- `mlx-community/whisper-tiny-mlx`
+- `mlx-community/whisper-small-mlx`
+- `mlx-community/whisper-medium-mlx`
+- `mlx-community/whisper-large-v3-mlx`
+- `mlx-community/whisper-large-v3-turbo`
+- `mlx-community/parakeet-tdt-0.6b-v2`
+- `mlx-community/parakeet-tdt-0.6b-v3`
+
+### TTS 模型
+- `mlx-community/Kokoro-82M-bf16`（推荐）
+- `mlx-community/Kokoro-82M-4bit`
+- `mlx-community/chatterbox-turbo-fp16`
+- `mlx-community/VibeVoice-Realtime-0.5B-4bit`
+
+### 音频处理
+- `mlx-community/sam-audio-large-fp16`

--- a/docs/zh/benchmarks/image.md
+++ b/docs/zh/benchmarks/image.md
@@ -1,0 +1,138 @@
+# 图像基准测试
+
+## 运行图像基准测试
+
+```bash
+# 完整基准测试（10 种分辨率）
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# 快速基准测试（4 种分辨率）
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --quick
+```
+
+## 测试结果 - Qwen3-VL-8B-Instruct-4bit（M4 Max，128GB）
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.04s | 78 | 74.8 tok/s |
+| 336x336 | 113K | 0.94s | 64 | 68.3 tok/s |
+| 448x448 | 201K | 1.45s | 70 | 48.1 tok/s |
+| 512x512 | 262K | 1.58s | 99 | 62.8 tok/s |
+| 672x672 | 452K | 1.83s | 83 | 45.3 tok/s |
+| 768x768 | 590K | 2.05s | 91 | 44.3 tok/s |
+| 896x896 | 803K | 2.61s | 90 | 34.5 tok/s |
+| 1024x1024 | 1.0M | 2.79s | 76 | 27.2 tok/s |
+| 1280x720 | 922K | 2.97s | 96 | 32.4 tok/s |
+| 1920x1080 | 2.1M | 6.30s | 89 | 14.1 tok/s |
+
+**摘要：** 所有分辨率的平均速度为 45.2 tok/s。最快为 224x224（74.8 tok/s），最慢为 1920x1080（14.1 tok/s）。
+
+## 测试结果 - Qwen3-VL-8B-Instruct-4bit（M1 Max，64GB）
+
+本地 MLLM 基准测试：
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.84s | 78 | 42.5 tok/s |
+| 448x448 | 201K | 2.28s | 70 | 30.7 tok/s |
+| 768x768 | 590K | 4.39s | 91 | 20.7 tok/s |
+| 1024x1024 | 1.0M | 6.41s | 76 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 14.92 | 315 | 21.1 |
+
+## 测试结果 - Qwen3-VL-4B-Instruct-3bit 服务端（M1 Max，64GB）
+
+| Resolution | Pixels | Time | Tokens | Speed |
+|------------|--------|------|--------|-------|
+| 224x224 | 50K | 1.65s | 113 | 68.4 tok/s |
+| 448x448 | 201K | 2.09s | 120 | 57.5 tok/s |
+| 768x768 | 590K | 2.93s | 106 | 36.2 tok/s |
+| 1024x1024 | 1.0M | 4.12s | 100 | 24.3 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 4 | 10.79 | 439 | 40.7 |
+
+## MLLM 前缀缓存测试结果
+
+```
+======================================================================
+  MLLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-VL-4B-Instruct-3bit
+  Test: Verify KV cache reuse for repeated image/video + prompt combinations
+  Expected behavior:
+    - Same image + same prompt → cache HIT
+    - Same image + different prompt → cache MISS
+    - Different image + same prompt → cache MISS
+----------------------------------------------------------------------
+  SETUP: Loading Model
+----------------------------------------------------------------------
+    Model loaded in 0.11s
+
+----------------------------------------------------------------------
+  SETUP: Creating Test Images
+----------------------------------------------------------------------
+    Resized: 224x224, 336x336, 512x512, 768x768
+
+----------------------------------------------------------------------
+  TEST 1: Image Cache - Basic Hit/Miss
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    1a     | First image+prompt        | MISS     | MISS   | 0.10ms | ✓
+    1b     | Same image+prompt         | HIT      | HIT    | 0.18ms | ✓
+    1c     | Different prompt          | MISS     | MISS   | 0.01ms | ✓
+    1d     | Return to original        | HIT      | HIT    | 0.18ms | ✓
+
+----------------------------------------------------------------------
+  TEST 2: Different Images
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    2a     | Image A first request     | MISS     | MISS   | 0.01ms | ✓
+    2b     | Image B first request     | MISS     | MISS   | 0.01ms | ✓
+    2c     | Image A cached            | HIT      | HIT    | 0.13ms | ✓
+
+----------------------------------------------------------------------
+  TEST 3: Image Resolutions
+----------------------------------------------------------------------
+    Results:
+    Step   | Description           | Expected | Actual | Time   | Status
+    -------+-----------------------+----------+--------+--------+-------
+    3.1a | 224x224 first         | MISS     | MISS   | 0.01ms | ✓
+    3.1b | 224x224 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.2a | 336x336 first         | MISS     | MISS   | 0.01ms | ✓
+    3.2b | 336x336 cached        | HIT      | HIT    | 0.21ms | ✓
+    3.3a | 512x512 first         | MISS     | MISS   | 0.12ms | ✓
+    3.3b | 512x512 cached        | HIT      | HIT    | 0.20ms | ✓
+    3.4a | 768x768 first         | MISS     | MISS   | 0.12ms | ✓
+    3.4b | 768x768 cached        | HIT      | HIT    | 0.24ms | ✓
+======================================================================
+```
+
+## 缓存键策略
+
+- **图像：** `hash(image_content) + hash(prompt)`
+
+相同图像与相同提示词始终命中缓存。不同图像或不同提示词将不命中缓存。
+
+## 性能提示
+
+- 分辨率越小，处理速度越快（如 224x224 对比 1920x1080）
+- 请根据任务需求选择合适的分辨率
+- 批量处理尺寸相近的图像，以获得稳定的吞吐量
+
+## 指标说明
+
+| Metric | Description |
+|--------|-------------|
+| Resolution | 图像尺寸（宽 x 高） |
+| Pixels | 总像素数 |
+| Time | 生成时间 |
+| Tokens | 生成的输出 token 数量 |
+| Speed | 每秒 token 数（tok/s） |

--- a/docs/zh/benchmarks/llm.md
+++ b/docs/zh/benchmarks/llm.md
@@ -1,0 +1,271 @@
+# LLM 基准测试
+
+## 运行 LLM 基准测试
+
+```bash
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 5 --max-tokens 256
+```
+
+## 测试结果 (M4 Max, 128GB)
+
+| Model | Gen Speed | TTFT* | Memory |
+|-------|-----------|-------|--------|
+| Qwen3-0.6B-8bit | 402.3 tok/s | 58.6 ms | 0.68 GB |
+| Llama-3.2-1B-Instruct-4bit | 463.6 tok/s | 49.2 ms | 0.69 GB |
+| Qwen2.5-1.5B-Instruct-4bit | 308.5 tok/s | 86.2 ms | 0.84 GB |
+| Llama-3.2-3B-Instruct-4bit | 200.1 tok/s | 81.4 ms | 1.79 GB |
+| Qwen3-30B-A3B-4bit | 123.9 tok/s | 126.9 ms | 16.05 GB |
+| NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit | 122.9 tok/s | 72.3 ms | 23.98 GB |
+
+*TTFT = 首个 token 的生成时间（模型开始输出前的延迟）
+
+## 测试结果 (M1 Max, 64GB)
+
+| Model | Runs | Prompt Tok | Gen Tok | Total Time (s) | TTFT Mean (ms) | TPOT Mean (ms) | Gen Speed (tok/s) | Total Throughput (tok/s) |
+|-------|------|------------|---------|-----------------|-----------------|-----------------|-------------------|--------------------------|
+| Qwen3-0.6B-8bit | 5 | 56 | 1280 | 5.66 | 119.0 | 3.97 | 251.9 | 236.1 |
+
+## Continuous Batching 测试结果
+
+| Model | Single Request | Batch (5 req) | Speedup |
+|-------|----------------|---------------|---------|
+| Llama-3.2-1B-Instruct-4bit | 299.1 tok/s | 613.0 tok/s | **2.05x** |
+| Llama-3.2-3B-Instruct-4bit | 137.6 tok/s | 208.1 tok/s | **1.51x** |
+| Qwen3-0.6B-8bit | 328.1 tok/s | 1111.8 tok/s | **3.39x** |
+| Qwen3-30B-A3B-4bit | 98.1 tok/s | 233.3 tok/s | **2.38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196.9 tok/s | 322.2 tok/s | **1.64x** |
+
+*批量处理 5 个并发请求可将 throughput 提升 1.5 到 3 倍。*
+
+### Continuous Batching (M1 Max, 64GB)
+
+| Requests | Total Tokens | Total Time (s) | Throughput (tok/s) | Requests/sec |
+|----------|--------------|-----------------|--------------------|--------------|
+| 5 | 315 | 0.64 | 492.5 | 7.82 |
+
+## Streaming 性能
+
+| Model | TTFT | Generation Speed |
+|-------|------|------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4.6ms | 218.9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10.7ms | 93.6 tok/s |
+| Qwen3-0.6B-8bit | ~3.0ms | 328.5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10.2ms | 98.4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7.1ms | 140.3 tok/s |
+
+### Streaming 解码器 (M1 Max, 64GB)
+
+`vllm-mlx bench-detok`:
+
+| Tokens | Iterations | Naive Time | Streaming Time | Speedup |
+|--------|------------|------------|----------------|---------|
+| 742 | 5 | 1.69ms | 0.71ms | 2.39x |
+
+`examples/benchmark_detokenizer.py`:
+
+| Sequence | Tokens | decode() | Streaming | Speedup |
+|----------|--------|----------|-----------|---------|
+| Short | 8 | 0.029ms | 0.028ms | 1.04x |
+| Medium | 103 | 0.206ms | 0.129ms | 1.59x |
+| Long | 511 | 1.040ms | 0.502ms | 2.07x |
+| 1K | 1191 | 2.446ms | 1.178ms | 2.08x |
+| 2K | 2381 | 4.949ms | 2.356ms | 2.10x |
+| 4K | 4761 | 9.887ms | 5.398ms | 1.83x |
+
+平均加速比：1.79x
+
+## Prefix Cache 测试结果
+
+### Prefix Cache (M4 Max, 128GB)
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | ✓
+  1b     | Same prompt         | HIT      | HIT    | ✓
+  1c     | Different prompt    | MISS     | MISS   | ✓
+  1d     | Return to prompt 1  | HIT      | HIT    | ✓
+======================================================================
+```
+
+### Prefix Cache (M1 Max, 64GB)
+
+| Test | Expected | Actual | Time | Status |
+|------|----------|--------|------|--------|
+| First request | MISS | MISS | 203.5ms | PASS |
+| Same prompt | HIT | HIT | 131.6ms | PASS |
+| Different prompt | MISS or PREFIX_HIT | PREFIX_HIT (5 tok) | 135.3ms | PASS |
+
+最终缓存统计：
+
+| Cache Hits | Cache Misses | Hit Rate | Tokens Saved | Cached Speedup |
+|------------|--------------|----------|--------------|----------------|
+| 2 | 1 | 66.7% | 20 | 1.55x |
+
+## Paged Cache 测试结果
+
+*测试：2 轮共 20 个真实推理请求，系统提示约 286 个 token*
+
+```
+======================================================================
+  PAGED KV CACHE - REAL INFERENCE TEST
+======================================================================
+
+--------------------------------------------------
+Test 1: WITHOUT Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.47s
+  Throughput: 681.2 tok/s
+  Cache hits: 0
+  Tokens saved: 0
+
+--------------------------------------------------
+Test 2: WITH Paged Cache (2 rounds of 10)
+--------------------------------------------------
+  Time: 1.31s
+  Throughput: 765.8 tok/s
+
+  Paged Cache Stats:
+    Blocks allocated: 25
+    Shared blocks: 4
+    Cache hits: 10
+    Tokens saved: 2560
+
+==================================================
+SUMMARY
+==================================================
+  Without paged cache: 681.2 tok/s
+  With paged cache:    765.8 tok/s
+
+  Speedup: 1.12x
+  Cache hits: 10 (all Round 2 requests)
+  Tokens saved: 2,560 (~256 tokens × 10 requests)
+==================================================
+```
+
+### Paged KV Cache (M1 Max, 64GB)
+
+推理基准测试（20 个请求）：
+
+| Mode | Time (s) | Throughput (tok/s) |
+|------|----------|--------------------|
+| Without paged cache | 3.43 | 291.8 |
+| With paged cache | 3.42 | 292.2 |
+
+| Speedup | Blocks Allocated | Shared Blocks | Cache Hits | Tokens Saved |
+|---------|------------------|---------------|------------|--------------|
+| 1.00x | 45 | 4 | 10 | 2560 |
+
+真实并发推理（20 个请求）：
+
+| Mode | Time (s) | Throughput (tok/s) |
+|------|----------|--------------------|
+| Without paged cache | 4.32 | 231.7 |
+| With paged cache | 4.35 | 229.7 |
+
+| Speedup | Blocks Allocated | Shared Blocks | Cache Hits | Tokens Saved |
+|---------|------------------|---------------|------------|--------------|
+| 0.99x | 49 | 8 | 10 | 5120 |
+
+内存节省示例：
+
+| Scenario | Memory Savings |
+|----------|----------------|
+| Shared system prompts | 70.8% |
+| Concurrent memory efficiency | 83.5% |
+| Prefix sharing branches | 38.5% |
+
+## Streaming 解码器分析
+
+*第 9.1 阶段调查：mlx-lm 的 `BPEStreamingDetokenizer` 与朴素 `tokenizer.decode()` 对比*
+
+### 背景
+
+朴素方法对每个 token 调用 `decode([token])`。理论上，streaming 解码器的时间复杂度为 O(T)，而朴素解码为 O(T²)。
+
+### 孤立基准测试结果
+
+```bash
+vllm-mlx bench-detok
+```
+
+复用同一解码器实例时（每次使用前调用 `reset()`）：
+
+| Sequence | Tokens | Naive decode() | Streaming | Speedup |
+|----------|--------|----------------|-----------|---------|
+| Short | 8 | 0.020ms | 0.019ms | 1.05x |
+| Medium | 103 | 0.155ms | 0.097ms | 1.59x |
+| Long | 511 | 0.752ms | 0.371ms | **2.03x** |
+| 1K tokens | 1191 | 1.743ms | 0.833ms | **2.09x** |
+| 2K tokens | 2381 | 3.493ms | 1.737ms | **2.01x** |
+
+### 关键发现：实例创建开销
+
+创建新的 `BPEStreamingDetokenizer` 实例**极其昂贵**：
+
+```
+100 tokenizer.detokenizer calls: 5.266s (52.7ms each!)
+```
+
+这意味着每个请求新建一个解码器实例会增加约 **52ms 的额外开销**，从而抵消所有性能收益。
+
+### 实际影响
+
+集成到调度器后（每个请求一个解码器实例）：
+
+| Metric | Naive decode() | Streaming (new instance) |
+|--------|----------------|--------------------------|
+| Throughput (20 req) | 681 tok/s | 275 tok/s |
+| Impact | - | **慢 60%** |
+
+### 结论
+
+由于实例创建成本过高，streaming 解码器**目前不适合**在每个请求中独立使用。朴素的 `decode([token])` 方法在实践中仍然更快。
+
+**未来优化方向**：在启动时预先创建一个解码器实例池，并在请求间复用这些实例。
+
+## 指标参考
+
+| Metric | Description |
+|--------|-------------|
+| **TTFT** | Time to First Token，模型开始响应前的延迟 (ms) |
+| **TPOT** | Time Per Output Token，每个生成 token 之间的间隔 (ms/token) |
+| **Generation TPS** | 每秒输出 token 数 (tok/s) |
+| **Processing TPS** | 每秒处理输入或提示词 token 数 (tok/s) |
+| **End-to-End Latency** | 从请求发出到收到完整响应的总时间 |
+| **Total Throughput** | 每秒处理的总 token 数（输入加输出） |
+
+## 运行基准测试
+
+```bash
+# Basic benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+
+# With more prompts
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --prompts 10
+
+# Save results
+vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit --output results.json
+
+# Continuous batching test
+python tests/test_continuous_batching.py
+
+# Prefix cache test
+python tests/test_prefix_cache.py
+
+# Paged cache test
+python tests/test_paged_cache_real_inference.py
+
+# Streaming detokenizer benchmark
+vllm-mlx bench-detok
+vllm-mlx bench-detok mlx-community/Llama-3.2-1B-Instruct-4bit --iterations 5
+```

--- a/docs/zh/benchmarks/video.md
+++ b/docs/zh/benchmarks/video.md
@@ -1,0 +1,128 @@
+# 视频基准测试
+
+## 运行视频基准测试
+
+```bash
+# 完整基准测试（10 种配置，2-64 帧）
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# 快速基准测试（3 种帧数）
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --quick
+
+# 自定义视频
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video --video-url https://example.com/video.mp4
+```
+
+## 结果 - Qwen3-VL-8B-Instruct-4bit（M4 Max，128GB）
+
+| Configuration | Frames | Time | Tokens | Speed | Memory |
+|---------------|--------|------|--------|-------|--------|
+| 2 frames @ 0.5fps | 2 | 4.48s | 256 | 57.1 tok/s | 6.4 GB |
+| 4 frames @ 1fps | 4 | 4.65s | 256 | 55.0 tok/s | 6.4 GB |
+| 6 frames @ 1fps | 6 | 5.15s | 197 | 38.2 tok/s | 6.6 GB |
+| 8 frames @ 2fps | 8 | 6.45s | 240 | 37.2 tok/s | 6.8 GB |
+| 12 frames @ 2fps | 12 | 8.73s | 256 | 29.3 tok/s | 7.1 GB |
+| 16 frames @ 2fps | 16 | 10.96s | 256 | 23.4 tok/s | 7.6 GB |
+| 24 frames @ 4fps | 24 | 14.95s | 226 | 15.1 tok/s | 8.4 GB |
+| 32 frames @ 4fps | 32 | 20.00s | 256 | 12.8 tok/s | 9.2 GB |
+| 48 frames @ 8fps | 48 | 31.11s | 246 | 7.9 tok/s | 11.1 GB |
+| 64 frames @ 8fps | 64 | 59.81s | 256 | 4.3 tok/s | 12.9 GB |
+
+**总结：** 2 帧时速度最快（57.1 tok/s），64 帧时速度最慢（4.3 tok/s）。内存占用从 6.4 GB 增长至 12.9 GB。
+
+> **注意：** 96 帧及以上会因内存或计算资源限制，在大多数硬件上导致 GPU 超时。
+
+## 结果 - Qwen3-VL-8B-Instruct-4bit（M1 Max，64GB）
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 8.84s | 256 | 29.0 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 13.05s | 256 | 19.6 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 21.60s | 256 | 11.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 43.48 | 768 | 17.7 |
+
+## 结果 - Qwen3-VL-4B-Instruct-3bit（M1 Max，64GB）
+
+| Configuration | Frames | FPS | Time | Tokens | Speed |
+|---------------|--------|-----|------|--------|-------|
+| 4 frames @ 1fps | 4 | 1.0 | 5.09s | 150 | 29.5 tok/s |
+| 8 frames @ 2fps | 8 | 2.0 | 8.36s | 150 | 17.9 tok/s |
+| 16 frames @ 2fps | 16 | 2.0 | 15.21s | 150 | 9.9 tok/s |
+
+| Configs | Total Time (s) | Total Tokens | Aggregate Tok/s |
+|---------|-----------------|--------------|-----------------|
+| 3 | 28.66 | 450 | 15.7 |
+
+## 视频缓存结果
+
+```
+----------------------------------------------------------------------
+  TEST 4: Video Cache - fps/max_frames in Cache Key
+----------------------------------------------------------------------
+    Config: fps=2.0, max_frames=16
+
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    4a     | Video first request       | MISS     | MISS   | 0.03ms | ✓
+    4b     | Same video+params         | HIT      | HIT    | 0.14ms | ✓
+    4c     | Different fps (4.0)       | MISS     | MISS   | 0.01ms | ✓
+    4d     | Different max_frames (32) | MISS     | MISS   | 0.01ms | ✓
+    4.0.5a | fps=0.5 first             | MISS     | MISS   | 0.01ms | ✓
+    4.0.5b | fps=0.5 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.1.0a | fps=1.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.1.0b | fps=1.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.2.0a | fps=2.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.2.0b | fps=2.0 cached            | HIT      | HIT    | 0.14ms | ✓
+    4.4.0a | fps=4.0 first             | MISS     | MISS   | 0.01ms | ✓
+    4.4.0b | fps=4.0 cached            | HIT      | HIT    | 0.14ms | ✓
+
+----------------------------------------------------------------------
+  TEST 5: Additional Videos
+----------------------------------------------------------------------
+    Results:
+    Step   | Description               | Expected | Actual | Time   | Status
+    -------+---------------------------+----------+--------+--------+-------
+    5a     | Video 1 first             | MISS     | MISS   | 0.01ms | ✓
+    5b     | Video 2 first             | MISS     | MISS   | 0.01ms | ✓
+    5c     | Video 1 cached            | HIT      | HIT    | 0.13ms | ✓
+    5d     | Video 2 cached            | HIT      | HIT    | 0.13ms | ✓
+```
+
+## 缓存键策略
+
+- **视频：** `hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+相同视频在 fps、max_frames 和 prompt 均相同时会命中缓存。任意参数发生变化则导致缓存未命中。
+
+## 性能建议
+
+- FPS 越低，处理速度越快。
+- 帧数越少，内存占用越小。
+- 64 帧是实际可用的最大值。
+- 96 帧及以上会导致 GPU 超时。
+
+## 帧提取参考
+
+| FPS | 10s 视频 | 30s 视频 | 60s 视频 |
+|-----|-----------|-----------|-----------|
+| 0.5 | 5 frames | 15 frames | 30 frames |
+| 1.0 | 10 frames | 30 frames | 60 frames |
+| 2.0 | 20 frames | 60 frames | 120 frames* |
+| 4.0 | 40 frames | 120 frames* | 240 frames* |
+
+*可能触及 `max_frames` 上限
+
+## 指标说明
+
+| Metric | 说明 |
+|--------|-------------|
+| Configuration | FPS 与最大帧数设置 |
+| Frames | 实际提取的帧数 |
+| Time | 总生成时长 |
+| Tokens | 生成的输出 token 数 |
+| Speed | 每秒 token 数（tok/s） |
+| Memory | GPU 内存占用 |

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -1,0 +1,89 @@
+# 安装
+
+## 系统要求
+
+- 搭载 Apple Silicon（M1/M2/M3/M4）的 macOS
+- Python 3.10+
+
+## 使用 uv 安装（推荐）
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+uv pip install -e .
+```
+
+## 使用 pip 安装
+
+```bash
+git clone https://github.com/waybarrios/vllm-mlx.git
+cd vllm-mlx
+
+pip install -e .
+```
+
+### 可选：视觉支持
+
+使用 transformers 进行视频处理：
+
+```bash
+pip install -e ".[vision]"
+```
+
+### 可选：音频支持（STT/TTS）
+
+```bash
+pip install mlx-audio
+```
+
+### 可选：向量嵌入
+
+```bash
+pip install mlx-embeddings
+```
+
+## 安装内容说明
+
+- `mlx`, `mlx-lm`, `mlx-vlm` - MLX 框架及模型库
+- `transformers`, `tokenizers` - HuggingFace 库
+- `opencv-python` - 视频处理
+- `gradio` - 对话界面
+- `psutil` - 资源监控
+- `mlx-audio`（可选）- 语音转文字与文字转语音
+- `mlx-embeddings`（可选）- 文本向量嵌入
+
+## 验证安装
+
+```bash
+# Check CLI commands
+vllm-mlx --help
+vllm-mlx-bench --help
+vllm-mlx-chat --help
+
+# Test with a small model
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 1
+```
+
+## 故障排查
+
+### 找不到 MLX
+
+请确认您使用的是 Apple Silicon 设备：
+```bash
+uname -m  # Should output "arm64"
+```
+
+### 模型下载失败
+
+请检查网络连接及 HuggingFace 访问权限。部分模型需要身份验证：
+```bash
+huggingface-cli login
+```
+
+### 内存不足
+
+请使用更小的量化模型：
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
+```

--- a/docs/zh/getting-started/quickstart.md
+++ b/docs/zh/getting-started/quickstart.md
@@ -1,0 +1,133 @@
+# 快速开始
+
+## 选项 1：兼容 OpenAI 的服务器
+
+启动服务器：
+
+```bash
+# Simple mode - maximum throughput for single user
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# Continuous batching - for multiple concurrent users
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+使用 OpenAI Python SDK：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="mlx-community/Llama-3.2-3B-Instruct-4bit",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+或使用 curl：
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## 选项 2：直接使用 Python API
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+
+# Streaming
+for chunk in model.stream_generate("Tell me a story"):
+    print(chunk.text, end="", flush=True)
+```
+
+## 选项 3：Gradio 聊天界面
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+在 http://localhost:7860 打开网页界面。
+
+## 多模态模型
+
+如需图像或视频理解，请使用 VLM 模型：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+```
+
+## 推理模型
+
+将模型的思考过程与最终答案分离：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+print(response.choices[0].message.content)  # Final answer
+```
+
+## Embeddings
+
+为语义搜索和 RAG 生成文本 embeddings：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --embedding-model mlx-community/multilingual-e5-small-mlx
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+```
+
+## 工具调用
+
+为任意支持的模型启用函数调用：
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+## 下一步
+
+- [服务器指南](../guides/server.md) - 完整的服务器配置
+- [Python API](../guides/python-api.md) - 直接使用 API
+- [多模态指南](../guides/multimodal.md) - 图像与视频
+- [音频指南](../guides/audio.md) - STT 与 TTS
+- [Embeddings 指南](../guides/embeddings.md) - 文本 embeddings
+- [推理模型](../guides/reasoning.md) - 思考模型
+- [工具调用](../guides/tool-calling.md) - 函数调用
+- [支持的模型](../reference/models.md) - 可用模型

--- a/docs/zh/guides/audio.md
+++ b/docs/zh/guides/audio.md
@@ -1,0 +1,524 @@
+# 音频支持
+
+vllm-mlx 通过 [mlx-audio](https://github.com/Blaizzy/mlx-audio) 支持音频处理，提供以下功能：
+
+- **STT（语音转文字）**：whisper、Parakeet
+- **TTS（文字转语音）**：Kokoro、Chatterbox、VibeVoice、VoxCPM
+- **音频处理**：SAM-Audio（人声分离）
+
+## 安装
+
+```bash
+# 核心音频支持
+pip install mlx-audio>=0.2.9
+
+# TTS 所需依赖
+pip install sounddevice soundfile scipy numba tiktoken misaki spacy num2words loguru phonemizer
+
+# 下载 spacy 英文模型
+python -m spacy download en_core_web_sm
+
+# 非英语 TTS（西班牙语、法语等）需安装 espeak-ng：
+# macOS
+brew install espeak-ng
+
+# Ubuntu/Debian
+# sudo apt-get install espeak-ng
+```
+
+或一次性安装所有音频依赖：
+
+```bash
+pip install vllm-mlx[audio]
+python -m spacy download en_core_web_sm
+brew install espeak-ng  # macOS，用于非英语语言
+```
+
+## 快速开始
+
+### STT（语音转录）
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# 转录音频文件
+with open("audio.mp3", "rb") as f:
+    transcript = client.audio.transcriptions.create(
+        model="whisper-large-v3",
+        file=f,
+        language="en"  # optional
+    )
+print(transcript.text)
+```
+
+### TTS（语音合成）
+
+```python
+# 生成语音
+audio = client.audio.speech.create(
+    model="kokoro",
+    input="Hello, how are you?",
+    voice="af_heart",
+    speed=1.0
+)
+
+# 保存到文件
+with open("output.wav", "wb") as f:
+    f.write(audio.content)
+```
+
+### 人声分离（SAM-Audio）
+
+从背景噪声、音乐或其他声音中提取人声：
+
+```python
+from vllm_mlx.audio import AudioProcessor
+
+# 加载 SAM-Audio 模型
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+
+# 从音频中分离语音
+result = processor.separate("meeting_with_music.mp3", description="speech")
+
+# 保存分离后的人声和背景音
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background_only.wav")
+```
+
+**命令行示例：**
+```bash
+python examples/audio_separation_example.py meeting.mp3 --play
+python examples/audio_separation_example.py song.mp3 --description music -o music.wav
+```
+
+### 鼓声分离演示
+
+使用 SAM-Audio 从摇滚歌曲中分离鼓声：
+
+| 音频 | 说明 | 收听 |
+|-------|-------------|--------|
+| 原始音频 | David Fesliyan 的"Get Ready"（30 秒，免版权） | [rock_get_ready.mp3](../../../examples/rock_get_ready.mp3) |
+| 分离鼓声 | SAM-Audio 提取的鼓声 | [drums_isolated.wav](../../../examples/drums_isolated.wav) |
+| 去除鼓声 | 移除鼓声后的音轨 | [rock_no_drums.wav](../../../examples/rock_no_drums.wav) |
+
+```bash
+# 从摇滚歌曲中分离鼓声
+python examples/audio_separation_example.py examples/rock_get_ready.mp3 \
+  --description "drums" \
+  --output drums_isolated.wav \
+  --background rock_no_drums.wav
+```
+
+**性能：** 在 M4 Max 上处理 30 秒音频约需 20 秒。
+
+## 支持的模型
+
+### STT 模型（语音转文字）
+
+| 模型 | 别名 | 语言数 | 速度 | 质量 |
+|-------|-------|-----------|-------|---------|
+| `mlx-community/whisper-large-v3-mlx` | `whisper-large-v3` | 99+ | 中等 | 最佳 |
+| `mlx-community/whisper-large-v3-turbo` | `whisper-large-v3-turbo` | 99+ | 快速 | 优秀 |
+| `mlx-community/whisper-medium-mlx` | `whisper-medium` | 99+ | 快速 | 良好 |
+| `mlx-community/whisper-small-mlx` | `whisper-small` | 99+ | 极快 | 一般 |
+| `mlx-community/parakeet-tdt-0.6b-v2` | `parakeet` | 仅英语 | 最快 | 优秀 |
+| `mlx-community/parakeet-tdt-0.6b-v3` | `parakeet-v3` | 仅英语 | 最快 | 最佳 |
+
+**推荐方案：**
+- 多语言场景：`whisper-large-v3`
+- 仅英语场景：`parakeet`（速度快 3 倍）
+
+### TTS 模型（文字转语音）
+
+#### Kokoro（快速、轻量）- 推荐
+
+| 模型 | 别名 | 参数量 | 支持语言 |
+|-------|-------|------|-----------|
+| `mlx-community/Kokoro-82M-bf16` | `kokoro` | 82M | EN、ES、FR、JA、ZH、HI、IT、PT |
+| `mlx-community/Kokoro-82M-4bit` | `kokoro-4bit` | 82M | EN、ES、FR、JA、ZH、HI、IT、PT |
+
+**声音（11 种）：**
+- 美式女声：`af_heart`、`af_bella`、`af_nicole`、`af_sarah`、`af_sky`
+- 美式男声：`am_adam`、`am_michael`
+- 英式女声：`bf_emma`、`bf_isabella`
+- 英式男声：`bm_george`、`bm_lewis`
+
+**语言代码：**
+| 代码 | 语言 | 代码 | 语言 |
+|------|----------|------|----------|
+| `a` / `en` | 英语（美国） | `e` / `es` | Español |
+| `b` / `en-gb` | 英语（英国） | `f` / `fr` | Français |
+| `j` / `ja` | 日本語 | `z` / `zh` | 中文 |
+| `i` / `it` | Italiano | `p` / `pt` | Português |
+| `h` / `hi` | हिन्दी | | |
+
+#### Chatterbox（多语言、表现力强）
+
+| 模型 | 别名 | 参数量 | 支持语言 |
+|-------|-------|------|-----------|
+| `mlx-community/chatterbox-turbo-fp16` | `chatterbox` | 134M | 15+ 种语言 |
+| `mlx-community/chatterbox-turbo-4bit` | `chatterbox-4bit` | 134M | 15+ 种语言 |
+
+**支持语言：** EN、ES、FR、DE、IT、PT、RU、JA、ZH、KO、AR、HI、NL、PL、TR
+
+#### VibeVoice（实时）
+
+| 模型 | 别名 | 参数量 | 适用场景 |
+|-------|-------|------|----------|
+| `mlx-community/VibeVoice-Realtime-0.5B-4bit` | `vibevoice` | 200M | 低延迟、仅英语 |
+
+#### VoxCPM（中英双语）
+
+| 模型 | 别名 | 参数量 | 支持语言 |
+|-------|-------|------|-----------|
+| `mlx-community/VoxCPM1.5` | `voxcpm` | 0.9B | ZH、EN |
+| `mlx-community/VoxCPM1.5-4bit` | `voxcpm-4bit` | 200M | ZH、EN |
+
+### 音频处理模型
+
+#### SAM-Audio（人声分离）
+
+| 模型 | 参数量 | 适用场景 |
+|-------|------|----------|
+| `mlx-community/sam-audio-large-fp16` | 3B | 最佳质量 |
+| `mlx-community/sam-audio-large` | 3B | 标准 |
+| `mlx-community/sam-audio-small-fp16` | 0.6B | 快速 |
+| `mlx-community/sam-audio-small` | 0.6B | 轻量 |
+
+## API 参考
+
+### POST /v1/audio/transcriptions
+
+将音频转录为文字（兼容 OpenAI Whisper API）。
+
+**参数：**
+- `file`：音频文件（mp3、wav、m4a、webm）
+- `model`：模型名称或别名
+- `language`：语言代码（可选，自动检测）
+- `response_format`：`json` 或 `text`
+
+**限制：**
+- 默认上传上限：25 MiB
+- 可通过 `--max-audio-upload-mb` 修改
+
+**示例：**
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F file=@audio.mp3 \
+  -F model=whisper-large-v3
+```
+
+### POST /v1/audio/speech
+
+从文字生成语音（兼容 OpenAI TTS API）。
+
+**参数：**
+- `model`：模型名称或别名
+- `input`：待合成文本
+- `voice`：声音 ID
+- `speed`：语速（0.5 到 2.0）
+- `response_format`：`wav`、`mp3`
+
+**限制：**
+- 默认输入上限：4096 个字符
+- 可通过 `--max-tts-input-chars` 修改
+
+**示例：**
+```bash
+curl http://localhost:8000/v1/audio/speech \
+  -d '{"model": "kokoro", "input": "Hello world", "voice": "af_heart"}' \
+  -H "Content-Type: application/json" \
+  --output speech.wav
+```
+
+### GET /v1/audio/voices
+
+列出模型可用的声音。
+
+**示例：**
+```bash
+curl http://localhost:8000/v1/audio/voices?model=kokoro
+```
+
+## 命令行示例
+
+### 实时转录与字幕
+
+从麦克风进行实时 STT 转录：
+
+```bash
+# 使用 whisper-large-v3 生成字幕（最佳质量）
+python examples/closed_captions.py --language es --chunk 5
+
+# 使用更快的模型降低延迟
+python examples/closed_captions.py --language en --model whisper-turbo --chunk 3
+
+# 基础麦克风转录（先录音再转录）
+python examples/mic_transcribe.py --language es
+
+# 实时分块转录
+python examples/mic_realtime.py --language es --chunk 3
+
+# 带语音活动检测的实时转录
+python examples/mic_live.py --language es
+```
+
+**依赖安装：**
+```bash
+pip install sounddevice soundfile numpy
+```
+
+### 基础 TTS
+
+```bash
+# 简单 TTS 示例
+python examples/tts_example.py "Hello, how are you?" --play
+
+# 使用不同声音
+python examples/tts_example.py "Hello!" --voice am_michael --play
+
+# 保存到文件
+python examples/tts_example.py "Welcome to the demo" -o greeting.wav
+
+# 列出可用声音
+python examples/tts_example.py --list-voices
+```
+
+### 多语言 TTS
+
+```bash
+# 英语（自动选择最佳模型）
+python examples/tts_multilingual.py "Hello world" --play
+
+# 西班牙语
+python examples/tts_multilingual.py "Hola mundo" --lang es --play
+
+# 法语
+python examples/tts_multilingual.py "Bonjour le monde" --lang fr --play
+
+# 日语
+python examples/tts_multilingual.py "こんにちは" --lang ja --play
+
+# 中文
+python examples/tts_multilingual.py "你好世界" --lang zh --play
+
+# 指定模型
+python examples/tts_multilingual.py "Hello" --model chatterbox --play
+
+# 列出所有模型
+python examples/tts_multilingual.py --list-models
+
+# 列出所有语言
+python examples/tts_multilingual.py --list-languages
+```
+
+### 商务助手语音示例
+
+使用**原生声音**预生成的常见商务场景语音样本：
+
+| 语言 | 声音 | 内容 | 收听 |
+|----------|-------|---------|--------|
+| 英语 | af_heart | "Welcome to First National Bank. How may I assist you today?" | [assistant_bank_en.wav](../../../examples/assistant_bank_en.wav) |
+| 西班牙语 | ef_dora | "Gracias por llamar a servicio al cliente. Un agente le atenderá pronto." | [assistant_service_es.wav](../../../examples/assistant_service_es.wav) |
+| 法语 | ff_siwis | "Bienvenue. Votre appel est important pour nous." | [assistant_callcenter_fr.wav](../../../examples/assistant_callcenter_fr.wav) |
+| 中文 | zf_xiaobei | "欢迎致电技术支持中心。我们将竭诚为您服务。" | [assistant_support_zh.wav](../../../examples/assistant_support_zh.wav) |
+
+**使用原生声音自行生成：**
+```bash
+# 英语 - 银行助手（原生声音：af_heart）
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Welcome to First National Bank. How may I assist you today?" \
+  --voice af_heart --lang_code a --file_prefix assistant_bank_en
+
+# 西班牙语 - 客服（原生声音：ef_dora）
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Gracias por llamar a servicio al cliente. Un agente le atendera pronto." \
+  --voice ef_dora --lang_code e --file_prefix assistant_service_es
+
+# 法语 - 呼叫中心（原生声音：ff_siwis）
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "Bienvenue. Votre appel est important pour nous." \
+  --voice ff_siwis --lang_code f --file_prefix assistant_callcenter_fr
+
+# 中文 - 技术支持（原生声音：zf_xiaobei）
+python -m mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 \
+  --text "欢迎致电技术支持中心。我们将竭诚为您服务。" \
+  --voice zf_xiaobei --lang_code z --file_prefix assistant_support_zh
+```
+
+### 原生声音参考
+
+| 语言 | 代码 | 声音 |
+|----------|------|--------|
+| 英语（美国） | `a` | af_heart、af_bella、af_nicole、am_adam、am_michael |
+| 英语（英国） | `b` | bf_emma、bf_isabella、bm_george、bm_lewis |
+| 西班牙语 | `e` | ef_dora、em_alex、em_santa |
+| 法语 | `f` | ff_siwis |
+| 中文 | `z` | zf_xiaobei、zf_xiaoni、zf_xiaoxiao、zm_yunjian、zm_yunxi |
+| 日语 | `j` | jf_alpha、jf_gongitsune、jm_kumo |
+| 意大利语 | `i` | if_sara、im_nicola |
+| 葡萄牙语 | `p` | pf_dora、pm_alex |
+| 印地语 | `h` | hf_alpha、hf_beta、hm_omega |
+
+## Python API
+
+### 直接调用（不启动服务器）
+
+```python
+from vllm_mlx.audio import STTEngine, TTSEngine, AudioProcessor
+
+# Speech-to-Text
+stt = STTEngine("mlx-community/whisper-large-v3-mlx")
+stt.load()
+result = stt.transcribe("audio.mp3")
+print(result.text)
+
+# Text-to-Speech
+tts = TTSEngine("mlx-community/Kokoro-82M-bf16")
+tts.load()
+audio = tts.generate("Hello world", voice="af_heart")
+tts.save(audio, "output.wav")
+
+# Voice Separation
+processor = AudioProcessor("mlx-community/sam-audio-large-fp16")
+processor.load()
+result = processor.separate("mixed_audio.mp3", description="speech")
+processor.save(result.target, "voice_only.wav")
+processor.save(result.residual, "background.wav")
+```
+
+### 便捷函数
+
+```python
+from vllm_mlx.audio import transcribe_audio, generate_speech, separate_voice
+
+# 快速转录
+result = transcribe_audio("audio.mp3")
+print(result.text)
+
+# 快速 TTS
+audio = generate_speech("Hello world", voice="af_heart")
+
+# 快速人声分离
+voice, background = separate_voice("mixed.mp3")
+```
+
+## 在对话中使用音频
+
+在对话消息中附带音频（自动转录）：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Summarize this audio"},
+            {"type": "audio_url", "audio_url": {"url": "file://meeting.mp3"}}
+        ]
+    }]
+)
+```
+
+## 基准测试
+
+测试环境：Apple M2 Max（32GB）。
+
+### TTS 基准测试（Kokoro-82M-bf16）
+
+| 文本长度 | 音频时长 | 生成耗时 | RTF | 字符/秒 |
+|-------------|----------------|----------|-----|-----------|
+| 25 字符 | 1.95s | 0.43s | 4.6x | 58.5 |
+| 88 字符 | 6.00s | 0.32s | 18.6x | 272.4 |
+| 117 字符 | 7.92s | 0.27s | 29.0x | 427.4 |
+
+**汇总：**
+- 模型加载时间：约 1.0 秒
+- 平均 RTF：**17.4x**（比实时快 17 倍）
+- 平均字符/秒：**252.8**
+
+### STT 基准测试
+
+| 模型 | 加载时间 | 转录耗时（6 秒音频） | RTF |
+|-------|-----------|----------------------|-----|
+| whisper-small | 0.25s | 0.20s | 30.2x |
+| whisper-medium | 18.1s | 0.38s | 15.5x |
+| whisper-large-v3 | ~30s | ~0.6s | ~10x |
+| parakeet | ~0.5s | ~0.15s | ~40x |
+
+**说明：**
+- RTF（实时倍率）表示处理速度相对于实时的倍数
+- 首次加载包含从 HuggingFace 下载模型的时间
+- 后续加载使用已缓存的模型
+
+### 按场景推荐
+
+| 场景 | 推荐模型 | 原因 |
+|----------|------------------|-----|
+| 英语 STT（快速） | `parakeet` | RTF 40x，内存占用低 |
+| 多语言 STT | `whisper-large-v3` | 支持 99+ 种语言 |
+| 低延迟 STT | `whisper-small` | RTF 30x，加载快 |
+| 通用 TTS | `kokoro` | RTF 17x，质量良好 |
+| 低内存 TTS | `kokoro-4bit` | 4-bit 量化 |
+
+## 性能建议
+
+1. **英语场景使用 Parakeet**，比实时快 40 倍
+2. **使用 4-bit 模型**降低内存占用
+3. **使用 SAM-Audio small**加快人声分离速度
+4. **模型缓存**，引擎采用懒加载并自动缓存
+5. **提前下载模型**，避免首次运行时的延迟
+
+## 常见问题
+
+### mlx-audio 未安装
+```
+pip install mlx-audio>=0.2.9
+```
+
+### 模型下载缓慢
+模型首次使用时从 HuggingFace 下载。可使用 `huggingface-cli download` 提前下载：
+```bash
+huggingface-cli download mlx-community/whisper-large-v3-mlx
+huggingface-cli download mlx-community/Kokoro-82M-bf16
+```
+
+### 内存不足
+请使用较小的模型或 4-bit 量化版本：
+- 用 `whisper-small-mlx` 替代 `whisper-large-v3-mlx`
+- 用 `Kokoro-82M-4bit` 替代 `Kokoro-82M-bf16`
+- 用 `sam-audio-small` 替代 `sam-audio-large`
+
+### Kokoro 多语言问题（mlx-audio 0.2.9）
+
+使用非英语语言（西班牙语、中文、日语等）时若出现 `ValueError: too many values to unpack`，请应用以下修复：
+
+```python
+# Fix for mlx_audio/tts/models/kokoro/pipeline.py line 443
+# Change:
+#     ps, _ = self.g2p(chunk)
+# To:
+g2p_result = self.g2p(chunk)
+ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result
+```
+
+**一键修复：**
+```bash
+python -c "
+import os
+path = os.path.join(os.path.dirname(__import__('mlx_audio').__file__), 'tts/models/kokoro/pipeline.py')
+with open(path, 'r') as f: content = f.read()
+old = '                    ps, _ = self.g2p(chunk)'
+new = '''                    # Fix: handle both tuple (en) and string (zh/ja/es) returns from g2p
+                    g2p_result = self.g2p(chunk)
+                    ps = g2p_result[0] if isinstance(g2p_result, tuple) else g2p_result'''
+if old in content:
+    with open(path, 'w') as f: f.write(content.replace(old, new))
+    print('Fix applied!')
+"
+```
+
+此问题的原因是英语 g2p 返回元组 `(phonemes, tokens)`，而其他语言仅返回字符串。

--- a/docs/zh/guides/continuous-batching.md
+++ b/docs/zh/guides/continuous-batching.md
@@ -1,0 +1,174 @@
+# Continuous Batching
+
+Continuous batching 在同时服务多个用户时能显著提升 throughput。
+
+## 启用 Continuous Batching
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching
+```
+
+## 与 Paged Cache 配合使用
+
+启用高效内存的前缀共享：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --continuous-batching --use-paged-cache
+```
+
+## 工作原理
+
+### 简单模式（默认）
+- 每次处理一个请求
+- 单用户场景下 throughput 最高
+- 无 batching 额外开销
+
+### Continuous Batching 模式
+- 多个请求同时处理
+- 并发用户场景下 throughput 更高
+- 每个请求存在少量额外开销
+
+### Paged Cache
+- KV cache 以固定大小的块存储
+- 相同的系统提示词共享同一批块
+- 10 个以上并发用户时节省 80% 以上内存
+
+## 性能测试结果
+
+**Continuous Batching 测试结果（M4 Max，128GB）：**
+
+| 模型 | 单请求 | Batch（5 个请求） | 加速比 |
+|-------|----------------|---------------|---------|
+| Llama-3.2-1B-Instruct-4bit | 299.1 tok/s | 613.0 tok/s | **2.05x** |
+| Llama-3.2-3B-Instruct-4bit | 137.6 tok/s | 208.1 tok/s | **1.51x** |
+| Qwen3-0.6B-8bit | 328.1 tok/s | 1111.8 tok/s | **3.39x** |
+| Qwen3-30B-A3B-4bit | 98.1 tok/s | 233.3 tok/s | **2.38x** |
+| Qwen2.5-1.5B-Instruct-4bit | 196.9 tok/s | 322.2 tok/s | **1.64x** |
+
+*5 个并发请求的 batching 可将 throughput 提升 1.5 到 3 倍。*
+
+## Streaming 性能
+
+**Streaming 性能（M4 Max，128GB）：**
+
+| 模型 | TTFT | 生成速度 |
+|-------|------|------------------|
+| Llama-3.2-1B-Instruct-4bit | ~4.6ms | 218.9 tok/s |
+| Llama-3.2-3B-Instruct-4bit | ~10.7ms | 93.6 tok/s |
+| Qwen3-0.6B-8bit | ~3.0ms | 328.5 tok/s |
+| Qwen3-30B-A3B-4bit | ~10.2ms | 98.4 tok/s |
+| Qwen2.5-1.5B-Instruct-4bit | ~7.1ms | 140.3 tok/s |
+
+*TTFT = Time to First Token（首 token 延迟）*
+
+## Streaming 配置
+
+使用 `--stream-interval` 控制 token 发送频率：
+
+```bash
+# 每个 token 立即发送（最流畅）
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# 批量发送 token（适合高延迟场景）
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+| 值 | 行为 |
+|-------|----------|
+| `1` | 每个 token 立即发送 |
+| `2-5` | 攒批后再发送 |
+| `10+` | 最大化 throughput，输出颗粒度更大 |
+
+## 内存管理
+
+对于大型模型，prefix cache 可能占用大量内存。内存感知缓存会自动进行管理：
+
+```bash
+# 自动检测（使用可用内存的 20%）
+vllm-mlx serve model --continuous-batching
+
+# 显式限制
+vllm-mlx serve model --continuous-batching --cache-memory-mb 2048
+
+# 自定义百分比
+vllm-mlx serve model --continuous-batching --cache-memory-percent 0.10
+```
+
+| 选项 | 说明 |
+|--------|-------------|
+| `--cache-memory-mb` | 以 MB 为单位设置显式上限 |
+| `--cache-memory-percent` | 可用内存的占比（默认值：0.20） |
+| `--no-memory-aware-cache` | 使用基于条目数量的旧式缓存 |
+
+## Prefix Cache
+
+Prefix caching 对重复提示词复用 KV cache。
+
+### 工作原理
+
+```
+User 1: System prompt (500 tokens) → Creates 8 blocks
+User 2: Same system prompt → Shares 8 blocks (ref_count++)
+User N: Same system prompt → Shares 8 blocks (ref_count++)
+
+Memory savings: 80%+ for 10+ concurrent users
+```
+
+### 缓存键策略
+
+- **LLM**：`hash(prompt)`
+- **图片**：`hash(image_content) + hash(prompt)`
+- **视频**：`hash(video_path) + hash(fps) + hash(max_frames) + hash(prompt)`
+
+### 测试 Prefix Cache
+
+```bash
+python tests/test_prefix_cache.py
+```
+
+```
+======================================================================
+  LLM PREFIX CACHE TEST
+======================================================================
+  Model: mlx-community/Qwen3-0.6B-8bit
+  Expected behavior:
+    - Same prompt → cache HIT
+    - Different prompt → cache MISS or PREFIX_HIT (shared template tokens)
+----------------------------------------------------------------------
+  Results:
+  Step   | Description         | Expected | Actual | Status
+  -------+---------------------+----------+--------+-------
+  1a     | First request       | MISS     | MISS   | PASS
+  1b     | Same prompt         | HIT      | HIT    | PASS
+  1c     | Different prompt    | MISS     | MISS   | PASS
+  1d     | Return to prompt 1  | HIT      | HIT    | PASS
+======================================================================
+```
+
+## 运行基准测试
+
+```bash
+# Continuous batching 基准测试
+python tests/test_continuous_batching.py
+
+# Prefix cache 测试
+python tests/test_prefix_cache.py
+```
+
+## 适用场景
+
+| 场景 | 模式 |
+|----------|------|
+| 单用户，追求最高速度 | 简单模式（默认） |
+| 多用户并发 | `--continuous-batching` |
+| 大型模型（7B+） | `--continuous-batching --cache-memory-mb 2048` |
+| 生产环境，提示词共享 | `--continuous-batching --use-paged-cache` |
+
+## 生产环境配置
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+```

--- a/docs/zh/guides/embeddings.md
+++ b/docs/zh/guides/embeddings.md
@@ -1,0 +1,150 @@
+# Embeddings
+
+vllm-mlx 通过 [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) 支持文本 embeddings，提供与 OpenAI 兼容的 `/v1/embeddings` 接口。
+
+## 安装
+
+```bash
+pip install mlx-embeddings>=0.0.5
+```
+
+## 快速入门
+
+### 启动带有 embedding 模型的服务器
+
+```bash
+# 启动时预加载指定的 embedding 模型
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+如果不使用 `--embedding-model`，embedding 模型会在第一次请求时按需加载，但仅限于内置的请求时许可列表中的模型。
+
+### 使用 OpenAI SDK 生成 embeddings
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# 单条文本
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+
+# 批量文本
+response = client.embeddings.create(
+    model="mlx-community/all-MiniLM-L6-v2-4bit",
+    input=[
+        "I love machine learning",
+        "Deep learning is fascinating",
+        "Natural language processing rocks"
+    ]
+)
+for item in response.data:
+    print(f"Text {item.index}: {len(item.embedding)} dimensions")
+```
+
+### 使用 curl
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+    "input": ["Hello world", "How are you?"]
+  }'
+```
+
+## 支持的模型
+
+请求时支持的模型：
+
+| 模型 | 适用场景 | 规模 |
+|-------|----------|------|
+| `mlx-community/all-MiniLM-L6-v2-4bit` | 快速、轻量 | 小 |
+| `mlx-community/embeddinggemma-300m-6bit` | 高质量 | 300M |
+| `mlx-community/bge-large-en-v1.5-4bit` | 英文效果最佳 | 大 |
+| `mlx-community/multilingual-e5-small-mlx` | 多语言检索 | 小 |
+| `mlx-community/multilingual-e5-large-mlx` | 多语言检索 | 大 |
+| `mlx-community/bert-base-uncased-mlx` | 通用 BERT 基准 | 基础 |
+| `mlx-community/ModernBERT-base-mlx` | ModernBERT 基准 | 基础 |
+
+其他 embedding 模型需要在启动服务器时通过 `--embedding-model` 指定。
+
+## 模型管理
+
+### 按需加载
+
+默认情况下，embedding 模型在第一次收到 `/v1/embeddings` 请求时加载。你可以在上述请求时支持的模型之间切换，切换后旧模型会自动卸载。
+
+### 启动时预加载
+
+使用 `--embedding-model` 可在启动时加载模型。设置该参数后，只有该指定模型可用于 embeddings：
+
+```bash
+vllm-mlx serve my-llm-model --embedding-model mlx-community/all-MiniLM-L6-v2-4bit
+```
+
+请求其他模型将返回 400 错误。
+
+## API 参考
+
+### POST /v1/embeddings
+
+为给定的输入文本生成 embeddings。
+
+**请求体：**
+
+| 字段 | 类型 | 是否必填 | 描述 |
+|-------|------|----------|-------------|
+| `model` | string | 是 | 支持的 embedding 模型 ID，或使用 `--embedding-model` 时启动时固定的模型 |
+| `input` | string 或 list[string] | 是 | 待嵌入的文本 |
+
+**响应：**
+
+```json
+{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "index": 0, "embedding": [0.023, -0.982, ...]},
+    {"object": "embedding", "index": 1, "embedding": [0.112, -0.543, ...]}
+  ],
+  "model": "mlx-community/all-MiniLM-L6-v2-4bit",
+  "usage": {"prompt_tokens": 12, "total_tokens": 12}
+}
+```
+
+## Python API
+
+### 不启动服务器直接使用
+
+```python
+from vllm_mlx.embedding import EmbeddingEngine
+
+engine = EmbeddingEngine("mlx-community/all-MiniLM-L6-v2-4bit")
+engine.load()
+
+vectors = engine.embed(["Hello world", "How are you?"])
+print(f"Dimensions: {len(vectors[0])}")
+
+tokens = engine.count_tokens(["Hello world"])
+print(f"Token count: {tokens}")
+```
+
+## 常见问题
+
+### mlx-embeddings 未安装
+
+```
+pip install mlx-embeddings>=0.0.5
+```
+
+### 找不到模型
+
+请确认模型名称与上方请求时支持的 ID 之一匹配，或在启动服务器时通过 `--embedding-model` 指定自定义模型。你也可以提前下载支持的模型：
+
+```bash
+huggingface-cli download mlx-community/all-MiniLM-L6-v2-4bit
+```

--- a/docs/zh/guides/mcp-tools.md
+++ b/docs/zh/guides/mcp-tools.md
@@ -1,0 +1,405 @@
+# MCP 与 tool calling
+
+vllm-mlx 支持 Model Context Protocol (MCP)，用于将外部工具与 LLM 集成。
+
+## tool calling 工作原理
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Tool Calling Flow                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  1. User Request                                                    │
+│     ─────────────────►  "List files in /tmp"                       │
+│                                                                     │
+│  2. LLM Generates Tool Call                                         │
+│     ─────────────────►  tool_calls: [{                             │
+│                           name: "list_directory",                   │
+│                           arguments: {path: "/tmp"}                 │
+│                         }]                                          │
+│                                                                     │
+│  3. App Executes Tool via MCP                                       │
+│     ─────────────────►  MCP Server executes list_directory         │
+│                         Returns: ["file1.txt", "file2.txt"]        │
+│                                                                     │
+│  4. Tool Result Sent Back to LLM                                    │
+│     ─────────────────►  role: "tool", content: [...]               │
+│                                                                     │
+│  5. LLM Generates Final Response                                    │
+│     ─────────────────►  "The /tmp directory contains 2 files..."   │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## 快速开始
+
+### 1. 创建 MCP 配置
+
+创建 `mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### 2. 启动带 MCP 的服务器
+
+```bash
+# 简单模式
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# 连续批处理
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json --continuous-batching
+```
+
+### 3. 验证 MCP 状态
+
+```bash
+# 查看 MCP 状态
+curl http://localhost:8000/v1/mcp/status
+
+# 列出可用工具
+curl http://localhost:8000/v1/mcp/tools
+```
+
+## tool calling 示例
+
+```python
+import json
+import httpx
+
+BASE_URL = "http://localhost:8000"
+
+# 1. Get available tools
+tools_response = httpx.get(f"{BASE_URL}/v1/mcp/tools")
+tools = tools_response.json()["tools"]
+
+# 2. Send request with tools
+response = httpx.post(
+    f"{BASE_URL}/v1/chat/completions",
+    json={
+        "model": "default",
+        "messages": [{"role": "user", "content": "List files in /tmp"}],
+        "tools": tools,
+        "max_tokens": 1024
+    }
+)
+
+result = response.json()
+message = result["choices"][0]["message"]
+
+# 3. Check for tool calls
+if message.get("tool_calls"):
+    tool_call = message["tool_calls"][0]
+
+    # 4. Execute tool via MCP
+    exec_response = httpx.post(
+        f"{BASE_URL}/v1/mcp/execute",
+        json={
+            "server": "filesystem",
+            "tool": tool_call["function"]["name"],
+            "arguments": json.loads(tool_call["function"]["arguments"])
+        }
+    )
+    tool_result = exec_response.json()
+
+    # 5. Send result back to LLM
+    messages = [
+        {"role": "user", "content": "List files in /tmp"},
+        message,
+        {
+            "role": "tool",
+            "tool_call_id": tool_call["id"],
+            "content": json.dumps(tool_result["result"])
+        }
+    ]
+
+    final_response = httpx.post(
+        f"{BASE_URL}/v1/chat/completions",
+        json={"model": "default", "messages": messages}
+    )
+    print(final_response.json()["choices"][0]["message"]["content"])
+```
+
+## MCP 接口端点
+
+| 端点 | 方法 | 说明 |
+|----------|--------|-------------|
+| `/v1/mcp/status` | GET | 查看 MCP 状态 |
+| `/v1/mcp/tools` | GET | 列出可用工具 |
+| `/v1/mcp/execute` | POST | 执行工具 |
+
+## MCP 服务器示例
+
+### 文件系统
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+### GitHub
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+### PostgreSQL
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@localhost/db"
+      }
+    }
+  }
+}
+```
+
+### Brave Search
+
+```json
+{
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "your-key"
+      }
+    }
+  }
+}
+```
+
+## 使用多个 MCP 服务器
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+## 交互式 MCP 聊天
+
+如需交互式测试 MCP：
+
+```bash
+python examples/mcp_chat.py
+```
+
+## 支持的工具格式
+
+vllm-mlx 支持 12 种 tool call parser，覆盖所有主流模型系列。完整的 parser 列表、别名及示例请参见 [Tool Calling](tool-calling.md)。
+
+## 安全性
+
+vllm-mlx 内置安全措施，防止通过 MCP 服务器进行命令注入攻击。
+
+### 命令白名单
+
+默认情况下，仅允许可信命令：
+
+| 类别 | 允许的命令 |
+|----------|-----------------|
+| Node.js | `npx`、`npm`、`node` |
+| Python | `uvx`、`uv`、`python`、`python3`、`pip`、`pipx` |
+| Docker | `docker` |
+| MCP 服务器 | `mcp-server-*`（官方服务器） |
+
+### 屏蔽模式
+
+以下模式会被屏蔽以防止注入攻击：
+
+- 命令链接：`;`、`&&`、`||`、`|`
+- 命令替换：`` ` ``、`$()`
+- 路径穿越：`../`
+- 危险环境变量：`LD_PRELOAD`、`PATH`、`PYTHONPATH`
+
+### 示例：被屏蔽的攻击
+
+```json
+{
+  "mcpServers": {
+    "malicious": {
+      "command": "bash",
+      "args": ["-c", "rm -rf /"]
+    }
+  }
+}
+```
+
+此配置将被拒绝：
+```
+ValueError: MCP server 'malicious': Command 'bash' is not in the allowed commands whitelist.
+```
+
+### 开发模式（不安全）
+
+仅限开发环境，可绕过安全校验：
+
+```json
+{
+  "mcpServers": {
+    "custom": {
+      "command": "my-custom-server",
+      "skip_security_validation": true
+    }
+  }
+}
+```
+
+**警告**：切勿在生产环境中使用 `skip_security_validation`。
+
+### 自定义白名单
+
+如需通过编程方式向白名单添加自定义命令：
+
+```python
+from vllm_mlx.mcp import MCPCommandValidator, set_validator
+
+# Add custom commands
+validator = MCPCommandValidator(
+    custom_whitelist={"my-trusted-server", "another-server"}
+)
+set_validator(validator)
+```
+
+## 工具执行沙箱
+
+除命令校验外，vllm-mlx 还为工具执行提供运行时沙箱。
+
+### 沙箱功能
+
+| 功能 | 说明 |
+|---------|-------------|
+| 工具白名单 | 仅允许特定工具执行 |
+| 工具黑名单 | 屏蔽特定危险工具 |
+| 参数校验 | 屏蔽工具参数中的危险模式 |
+| 频率限制 | 限制每分钟的工具调用次数 |
+| 审计日志 | 记录所有工具执行情况 |
+
+### 屏蔽的参数模式
+
+工具参数会针对以下危险模式进行校验：
+
+- 路径穿越：`../`
+- 系统目录：`/etc/`、`/proc/`、`/sys/`
+- root 访问：`/root/`、`~root`
+
+### 高风险工具检测
+
+匹配以下模式的工具会触发安全警告：
+
+- `execute`、`run_command`、`shell`、`eval`、`exec`、`system`、`subprocess`
+
+### 自定义沙箱配置
+
+```python
+from vllm_mlx.mcp import ToolSandbox, set_sandbox
+
+# Create sandbox with custom settings
+sandbox = ToolSandbox(
+    # Only allow specific tools (whitelist mode)
+    allowed_tools={"read_file", "list_directory"},
+
+    # Block specific tools (blacklist mode)
+    blocked_tools={"execute_command", "run_shell"},
+
+    # Rate limit: max 30 calls per minute
+    max_calls_per_minute=30,
+
+    # Optional audit callback
+    audit_callback=lambda audit: print(f"Tool: {audit.tool_name}, Success: {audit.success}"),
+)
+set_sandbox(sandbox)
+```
+
+### 访问审计日志
+
+```python
+from vllm_mlx.mcp import get_sandbox
+
+sandbox = get_sandbox()
+
+# Get recent audit entries
+entries = sandbox.get_audit_log(limit=50)
+
+# Filter by tool name
+file_ops = sandbox.get_audit_log(tool_filter="file")
+
+# Get only errors
+errors = sandbox.get_audit_log(errors_only=True)
+
+# Clear audit log
+sandbox.clear_audit_log()
+```
+
+### 敏感数据脱敏
+
+审计日志会自动对敏感字段（password、token、secret、key、credential、auth）进行脱敏处理，并对过大的值进行截断。
+
+## 故障排查
+
+### MCP 服务器无法连接
+
+检查 MCP 服务器命令是否正确：
+```bash
+npx -y @modelcontextprotocol/server-filesystem /tmp
+```
+
+### 工具无法执行
+
+验证工具是否可用：
+```bash
+curl http://localhost:8000/v1/mcp/tools | jq '.tools[].name'
+```
+
+### tool call 未被解析
+
+请确保所用模型支持函数调用（如 Qwen3、Llama-3.2-Instruct）。
+
+### 命令不在白名单中
+
+如果看到 "Command X is not in the allowed commands whitelist"，可采取以下措施之一：
+1. 使用允许的命令（参见上方白名单）
+2. 将该命令添加到自定义白名单
+3. 使用 `skip_security_validation: true`（仅限开发环境）

--- a/docs/zh/guides/moe-top-k.md
+++ b/docs/zh/guides/moe-top-k.md
@@ -1,0 +1,94 @@
+# MoE top_k 覆盖参数（`--moe-top-k`）
+
+减少 Mixture of Experts 模型（如 Qwen3-30B-A3B）每个 token 激活的 expert 数量，以少量质量损失换取明显更高的解码吞吐量。
+
+> **状态：** 可选参数，默认行为不变。以下质量数据基于 Qwen3-30B-A3B-4bit 在 M4 Max 128 GB 上的测试结果，在将其用于生产环境前请在你的模型上自行验证。
+
+## 功能说明
+
+Qwen3-30B-A3B 使用 `top_k=8` 训练，即每个 token 从 128 个 expert 中选取 8 个。在 Apple Silicon 上进行 batch=1 解码时，expert 矩阵乘法（`SwitchGLU`）是每层计算中占比最大的部分，其开销与 `top_k` 大致呈线性关系。在推理阶段降低 `top_k` 已被证明（LExI 2025，Lynx 2024）能在保留大部分训练质量的同时，有效缩短解码时间。
+
+`--moe-top-k N` 会遍历已加载模型的每一层，对含有 `.mlp.switch_mlp`（即稀疏 MoE 块）的层将 `top_k` 设置为 N。密集层和密集模型不受影响，该参数对它们是空操作。
+
+## 用法
+
+```bash
+# Server
+vllm-mlx serve mlx-community/Qwen3-30B-A3B-4bit \
+  --continuous-batching \
+  --moe-top-k 4
+
+# Bench
+vllm-mlx bench mlx-community/Qwen3-30B-A3B-4bit --moe-top-k 4
+```
+
+若 N 大于模型训练时的 `top_k`，该参数会被拒绝，因为只有降低才有意义，不支持提高。
+
+## 实测影响
+
+### 解码吞吐量（M4 Max 128 GB，batch=1，贪心解码）
+
+| top_k | tok/s | 对比基线 |
+|---:|---:|---:|
+| 8（基线） | 126.5 | - |
+| 6 | 136.1 | +7.6% |
+| 5 | 140.3 | +10.9% |
+| 4 | 147.3 | +16.5% |
+
+### 质量评估（Qwen3-30B-A3B-4bit，lm-evaluation-harness，MLX backend）
+
+<!-- populated after eval completes -->
+
+| top_k | MMLU (acc) | GSM8K (exact match) | Δ vs baseline |
+|---:|---:|---:|---:|
+| 8 | TBD | TBD | - |
+| 6 | TBD | TBD | TBD |
+| 5 | TBD | TBD | TBD |
+| 4 | TBD | TBD | TBD |
+
+MMLU：随机抽取 200 个样本，0-shot。
+GSM8K：随机抽取 100 个样本，0-shot，严格 exact-match。
+
+以上数据具有**方向性参考价值**，完整评测集规模更大，会改变绝对精度数值，但各配置间的相对差距不会有太大变化。
+
+### 贪心输出一致性
+
+在 4-bit 检查点上使用 `top_k=4` 时，我们测试的所有探针提示中，生成的**前 16 个 token 与基线完全一致**。这表明 top_k=4 不会改变早期解码步骤中的 argmax，模型对减少一半激活 expert 具有内在的鲁棒性。
+
+当 `top_k=3` 或更低时，质量会出现可见的下降（此处未测量，基于 LExI 论文推断），因此该参数在配置校验层刻意不允许低于 1，但生产环境推荐的最低值为 `top_k=4`。
+
+## 适用场景与不适用场景
+
+适合使用的情况：
+- 运行 Qwen3 MoE（或兼容模型：Qwen3.5 MoE、Gemma-MoE），且单用户解码吞吐量是瓶颈。
+- 工作负载允许少量质量损失，以换取明显的延迟改善。
+- 部署在受内存带宽限制的硬件上（M 系列 Apple Silicon），expert gather 主导每步解码时间。
+
+不适合使用的情况：
+- 运行密集模型，该参数是空操作，没有任何效果。
+- 对评测集排行榜精度有顶尖要求。
+- 运行长链式推理或"思考模式"生成，质量下降幅度可能比 0-shot MMLU 所示更陡。
+
+## 与其他优化叠加使用
+
+该参数可与量化叠加使用。在 Qwen3-30B-A3B-4bit 上的实测叠加结果如下：
+
+- 4-bit + top_k=8：126.5 tok/s（基线）
+- 4-bit + top_k=4：147.3 tok/s（+16.5%）
+- 3-bit + top_k=8：138.6 tok/s（+9.6%）
+- 3-bit + top_k=6：147.1 tok/s（+16.3%），质量差异可测量
+- 3-bit + top_k=4：157.3 tok/s（+24%），**输出质量严重下降**（在冒烟测试中模型回答了不同的问题）
+
+3-bit + top_k=4 的数值误差累积超出了 argmax 稳定的临界点。最多只应使用一个激进参数：4-bit + top_k=4 或 3-bit + top_k=6。两者的 tok/s 大致相同（约 147），但质量表现差异显著。
+
+## 内部实现
+
+- 补丁辅助函数：`vllm_mlx.scheduler.apply_moe_top_k_override(model, k)`
+- 在 `Scheduler.__init__` 中于模型加载完成后执行。
+- 测试：`tests/test_moe_top_k.py`，覆盖密集模型、混合架构及校验路径。
+
+## 参考资料
+
+- LExI: Layer-Adaptive Active Experts, [arXiv 2509.02753](https://arxiv.org/html/2509.02753)
+- Not All Experts are Equal (NAEE), [ACL 2024](https://aclanthology.org/2024.acl-long.334.pdf)
+- SwiftLM (`SWIFTLM_TOP_K` env knob prior art), [github.com/SharpAI/SwiftLM](https://github.com/SharpAI/SwiftLM)

--- a/docs/zh/guides/multimodal.md
+++ b/docs/zh/guides/multimodal.md
@@ -1,0 +1,315 @@
+# 多模态模型（图像与视频）
+
+vllm-mlx 支持用于图像和视频理解的视觉语言模型。
+
+## 支持的模型
+
+- Qwen3-VL（推荐）
+- Qwen2-VL
+- Gemma 3
+- LLaVA
+- Idefics
+- PaliGemma
+- Pixtral
+- Molmo
+- DeepSeek-VL
+
+## 启动多模态服务器
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
+```
+
+名称中包含 "VL"、"Vision" 或 "mllm" 的模型会被自动识别为多模态模型。
+
+## 图像分析
+
+### 通过 OpenAI SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Image from URL
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+    }],
+    max_tokens=256
+)
+print(response.choices[0].message.content)
+```
+
+### Base64 图像
+
+```python
+import base64
+
+def encode_image(path):
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+base64_image = encode_image("photo.jpg")
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}}
+        ]
+    }]
+)
+```
+
+### 通过 curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+      ]
+    }],
+    "max_tokens": 256
+  }'
+```
+
+## 视频分析
+
+### 通过 OpenAI SDK
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What happens in this video?"},
+            {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+        ]
+    }],
+    max_tokens=512
+)
+```
+
+### 视频参数
+
+通过额外的请求体参数控制帧提取：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this video"},
+            {"type": "video_url", "video_url": {"url": "video.mp4"}}
+        ]
+    }],
+    extra_body={
+        "video_fps": 2.0,
+        "video_max_frames": 32
+    }
+)
+```
+
+### 通过 curl
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this video"},
+        {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+      ]
+    }],
+    "video_fps": 2.0,
+    "video_max_frames": 16
+  }'
+```
+
+## 支持的格式
+
+### 图像
+
+| 格式 | 示例 |
+|------|------|
+| URL | `{"type": "image_url", "image_url": {"url": "https://..."}}` |
+| 本地文件 | `{"type": "image_url", "image_url": {"url": "/path/to/image.jpg"}}` |
+| Base64 | `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}` |
+
+### 视频
+
+| 格式 | 示例 |
+|------|------|
+| URL | `{"type": "video_url", "video_url": {"url": "https://..."}}` |
+| 本地文件 | `{"type": "video", "video": "/path/to/video.mp4"}` |
+| Base64 | `{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}` |
+
+## Python API
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Image
+description = mllm.describe_image("photo.jpg")
+
+# Video
+description = mllm.describe_video("video.mp4", fps=2.0)
+
+# Custom prompt
+output = mllm.generate(
+    prompt="Compare these images",
+    images=["img1.jpg", "img2.jpg"]
+)
+```
+
+## 性能建议
+
+### 图像
+- 分辨率越小，处理速度越快（224x224 对比 1920x1080）
+- 根据任务选择合适的分辨率
+
+### 视频
+- 帧率越低，处理速度越快
+- 帧数越少，内存占用越低
+- 64 帧是实际可用的最大值（96 帧及以上会导致 GPU 超时）
+
+## 基准测试
+
+在配备 128 GB 统一内存的 Apple M4 Max 上测试。
+
+### Qwen3-VL-4B-Instruct-3bit
+
+| 分辨率 | 耗时 | token 数 | 速度 | 内存 |
+|--------|------|----------|------|------|
+| 224x224 | 0.87s | 124 | 143 tok/s | 2.6 GB |
+| 448x448 | 1.01s | 107 | 106 tok/s | 3.1 GB |
+| 768x768 | 1.42s | 127 | 89 tok/s | 3.4 GB |
+| 1024x1024 | 1.85s | 116 | 63 tok/s | 3.6 GB |
+
+### Qwen3-VL-8B-Instruct-4bit
+
+| 分辨率 | 耗时 | token 数 | 速度 | 内存 |
+|--------|------|----------|------|------|
+| 224x224 | 1.08s | 78 | 73 tok/s | 5.6 GB |
+| 448x448 | 1.41s | 70 | 50 tok/s | 6.1 GB |
+| 768x768 | 2.06s | 91 | 44 tok/s | 6.5 GB |
+| 1024x1024 | 3.02s | 76 | 25 tok/s | 7.6 GB |
+
+### Gemma 3 4B 4bit
+
+| 分辨率 | 耗时 | token 数 | 速度 | 内存 |
+|--------|------|----------|------|------|
+| 224x224 | 0.95s | 30 | 32 tok/s | 5.2 GB |
+| 448x448 | 0.99s | 34 | 34 tok/s | 5.2 GB |
+| 768x768 | 0.99s | 32 | 32 tok/s | 5.2 GB |
+| 1024x1024 | 0.95s | 28 | 29 tok/s | 5.2 GB |
+
+### 运行基准测试
+
+```bash
+# Quick benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --quick
+
+# Full benchmark with more resolutions
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-4B-Instruct-3bit --video
+```
+
+## MLLM Cache
+
+vllm-mlx 为多模态模型内置了 prefix cache 系统，可以显著加速对相同图像的重复请求。
+
+### 工作原理
+
+向模型发送图像时，视觉编码器会将其处理为嵌入向量，该过程通常需要 1 到 2 秒。MLLM Cache 会同时存储这些嵌入向量和 KV cache 状态，因此后续使用相同图像的请求可以完全跳过视觉编码器。
+
+该缓存采用基于内容的哈希（类似 LMCache）来识别相同图像，无论图像以何种方式提供（URL、base64 还是文件路径）。
+
+### 启用缓存
+
+```bash
+# Enable with default settings (512 MB max)
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --enable-mllm-cache
+
+# With custom memory limit
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit \
+    --enable-mllm-cache \
+    --mllm-cache-max-mb 1024
+```
+
+### Python API
+
+```python
+from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
+
+# Create cache manager
+cache = MLLMPrefixCacheManager(max_memory_mb=512)
+
+# Store embeddings and KV cache after processing
+cache.store(
+    images=["photo.jpg"],
+    prompt="Describe this image",
+    vision_embeddings=embeddings,
+    kv_cache=kv_state,
+    num_tokens=128
+)
+
+# Fetch from cache on subsequent requests
+entry, match_len = cache.fetch(images=["photo.jpg"], prompt="Describe this image")
+if entry:
+    # Use cached embeddings, skip vision encoder
+    embeddings = entry.vision_embeddings
+    kv_state = entry.kv_cache
+```
+
+### 缓存统计
+
+```python
+stats = cache.get_stats()
+print(f"Hit rate: {stats.hit_rate:.1%}")
+print(f"Memory used: {stats.memory_used_mb:.1f} MB")
+print(f"Tokens saved: {stats.tokens_saved}")
+```
+
+### 内存管理
+
+当达到内存上限时，缓存采用 LRU（最近最少使用）策略进行淘汰。每个缓存条目记录以下信息：
+
+- 视觉嵌入向量大小
+- 每层 KV cache 大小
+- 用于 LRU 排序的访问频率
+
+当内存压力出现时，最近最少访问的条目会被优先淘汰。
+
+## Gradio 聊天界面
+
+如需交互式多模态对话：
+
+```bash
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+```
+
+支持拖放图像和视频。

--- a/docs/zh/guides/python-api.md
+++ b/docs/zh/guides/python-api.md
@@ -1,0 +1,182 @@
+# Python API
+
+通过 Python API 直接以编程方式访问 vllm-mlx。
+
+## Language Models
+
+### 基本用法
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+# Load model
+model = MLXLanguageModel("mlx-community/Llama-3.2-3B-Instruct-4bit")
+model.load()
+
+# Generate text
+output = model.generate("What is the capital of France?", max_tokens=100)
+print(output.text)
+```
+
+### Streaming Generation
+
+```python
+for chunk in model.stream_generate("Tell me a story about a robot"):
+    print(chunk.text, end="", flush=True)
+```
+
+### Chat 接口
+
+```python
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello, who are you?"}
+]
+response = model.chat(messages)
+print(response.text)
+```
+
+### 生成参数
+
+```python
+output = model.generate(
+    prompt="Write a poem",
+    max_tokens=256,
+    temperature=0.7,
+    top_p=0.9,
+    stop=["END", "\n\n"]
+)
+```
+
+| 参数 | 描述 | 默认值 |
+|-----------|-------------|---------|
+| `max_tokens` | 最大生成 token 数量 | 256 |
+| `temperature` | 采样温度（0-2） | 0.7 |
+| `top_p` | Nucleus sampling | 0.9 |
+| `stop` | 停止序列 | None |
+
+## Vision-Language Models
+
+### 基本用法
+
+```python
+from vllm_mlx.models import MLXMultimodalLM
+
+# Load model
+mllm = MLXMultimodalLM("mlx-community/Qwen3-VL-4B-Instruct-3bit")
+mllm.load()
+
+# Describe an image
+description = mllm.describe_image("photo.jpg")
+print(description)
+```
+
+### 问答
+
+```python
+answer = mllm.answer_about_image("photo.jpg", "What color is the car?")
+print(answer)
+```
+
+### 多图片输入
+
+```python
+output = mllm.generate(
+    prompt="Compare these two images",
+    images=["image1.jpg", "image2.jpg"]
+)
+print(output.text)
+```
+
+### 视频理解
+
+```python
+# From local file
+output = mllm.generate(
+    prompt="What is happening in this video?",
+    videos=["video.mp4"],
+    video_fps=2.0,
+    video_max_frames=16
+)
+print(output.text)
+
+# From URL
+output = mllm.generate(
+    prompt="Describe this video",
+    videos=["https://example.com/video.mp4"],
+    video_fps=2.0
+)
+
+# Convenience method
+description = mllm.describe_video("video.mp4", fps=2.0)
+```
+
+### 视频参数
+
+| 参数 | 描述 | 默认值 |
+|-----------|-------------|---------|
+| `video_fps` | 每秒提取帧数 | 2.0 |
+| `video_max_frames` | 最大处理帧数 | 32 |
+
+## Engine API
+
+针对高级使用场景，可直接使用 engine：
+
+### Simple Engine
+
+```python
+from vllm_mlx.engine import SimpleEngine
+
+engine = SimpleEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+print(output.text)
+
+await engine.stop()
+```
+
+### Batched Engine
+
+```python
+from vllm_mlx.engine import BatchedEngine
+
+engine = BatchedEngine("mlx-community/Llama-3.2-3B-Instruct-4bit")
+await engine.start()
+
+# Multiple concurrent requests
+output = await engine.generate(
+    prompt="Hello world",
+    max_tokens=100
+)
+
+await engine.stop()
+```
+
+## 输出格式
+
+所有生成方法均返回 `GenerationOutput`：
+
+```python
+output = model.generate("Hello")
+
+print(output.text)              # Generated text
+print(output.prompt_tokens)     # Input token count
+print(output.completion_tokens) # Output token count
+print(output.finish_reason)     # "stop" or "length"
+```
+
+## 错误处理
+
+```python
+from vllm_mlx.models import MLXLanguageModel
+
+try:
+    model = MLXLanguageModel("invalid-model")
+    model.load()
+except Exception as e:
+    print(f"Failed to load model: {e}")
+```

--- a/docs/zh/guides/reasoning.md
+++ b/docs/zh/guides/reasoning.md
@@ -1,0 +1,263 @@
+# Reasoning 模型
+
+vllm-mlx 支持在给出答案之前展示 thinking 过程的 reasoning 模型。Qwen3 和 DeepSeek-R1 等模型会将 reasoning 内容包裹在 `<think>...</think>` 标签中，vllm-mlx 可以解析这些标签，将 reasoning 与最终回答分离。
+
+## 为什么使用 Reasoning 解析？
+
+reasoning 模型生成的原始输出通常如下所示：
+
+```
+<think>
+Let me analyze this step by step.
+First, I need to consider the constraints.
+The answer should be a prime number less than 10.
+Checking: 2, 3, 5, 7 are all prime and less than 10.
+</think>
+The prime numbers less than 10 are: 2, 3, 5, 7.
+```
+
+不启用 reasoning 解析时，响应中会包含原始标签。启用 reasoning parsing 后，thinking 过程与最终回答会被分离到 API 响应的不同字段中。
+
+## 快速开始
+
+### 启动服务器并指定 Reasoning Parser
+
+```bash
+# For Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# For DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+### API 响应格式
+
+启用 reasoning parsing 后，API 响应中会包含 `reasoning` 字段。
+
+**非 streaming 响应：**
+
+```json
+{
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": "The prime numbers less than 10 are: 2, 3, 5, 7.",
+      "reasoning": "Let me analyze this step by step.\nFirst, I need to consider the constraints.\nThe answer should be a prime number less than 10.\nChecking: 2, 3, 5, 7 are all prime and less than 10."
+    }
+  }]
+}
+```
+
+**Streaming 响应：**
+
+reasoning 和正文内容分块独立发送。在 reasoning 阶段，数据块的 `reasoning` 字段有内容；当模型进入最终回答阶段后，数据块的 `content` 字段有内容：
+
+```json
+{"delta": {"reasoning": "Let me analyze"}}
+{"delta": {"reasoning": " this step by step."}}
+{"delta": {"reasoning": "\nFirst, I need to"}}
+...
+{"delta": {"content": "The prime"}}
+{"delta": {"content": " numbers less than 10"}}
+{"delta": {"content": " are: 2, 3, 5, 7."}}
+```
+
+## 与 OpenAI SDK 配合使用
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Non-streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What are the prime numbers less than 10?"}]
+)
+
+message = response.choices[0].message
+print("Reasoning:", message.reasoning)  # The thinking process
+print("Answer:", message.content)        # The final answer
+```
+
+### Streaming 与 Reasoning
+
+```python
+reasoning_text = ""
+content_text = ""
+
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Solve: 2 + 2 = ?"}],
+    stream=True
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if hasattr(delta, 'reasoning') and delta.reasoning:
+        reasoning_text += delta.reasoning
+        print(f"[Thinking] {delta.reasoning}", end="")
+    if delta.content:
+        content_text += delta.content
+        print(delta.content, end="")
+
+print(f"\n\nFinal reasoning: {reasoning_text}")
+print(f"Final answer: {content_text}")
+```
+
+## 支持的 Parser
+
+### Qwen3 Parser（`qwen3`）
+
+适用于使用显式 `<think>` 和 `</think>` 标签的 Qwen3 模型。
+
+- 需要开标签和闭标签**同时存在**
+- 如果标签缺失，输出将被视为普通内容
+- 适合：Qwen3-0.6B、Qwen3-4B、Qwen3-8B 及同系列模型
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+```
+
+### DeepSeek-R1 Parser（`deepseek_r1`）
+
+适用于可能省略开标签 `<think>` 的 DeepSeek-R1 模型。
+
+- 比 Qwen3 parser 更宽松
+- 能处理 `<think>` 为隐式的情况
+- 即使没有 `<think>`，`</think>` 之前的内容也会被视为 reasoning
+
+```bash
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+## 工作原理
+
+reasoning parser 通过基于文本的检测来识别模型输出中的 thinking 标签。在 streaming 过程中，它会追踪当前在输出中的位置，将每个 token 正确路由到 `reasoning` 或 `content` 字段。
+
+```
+Model Output:        <think>Step 1: analyze...</think>The answer is 42.
+                     ├─────────────────────┤├─────────────────────┤
+Parsed:              │     reasoning       ││       content       │
+                     └─────────────────────┘└─────────────────────┘
+```
+
+解析过程是无状态的，通过累积文本来判断上下文，在 token 以任意分块到达的 streaming 场景下也能稳定工作。
+
+## 最佳使用建议
+
+### 提示词写法
+
+引导模型逐步思考，reasoning 模型的效果更好：
+
+```python
+messages = [
+    {"role": "system", "content": "Think through problems step by step before answering."},
+    {"role": "user", "content": "What is 17 × 23?"}
+]
+```
+
+### 处理缺失的 Reasoning
+
+某些提示词可能不会触发 reasoning。此时 `reasoning` 值为 `None`，所有输出都进入 `content`：
+
+```python
+message = response.choices[0].message
+if message.reasoning:
+    print(f"Model's thought process: {message.reasoning}")
+print(f"Answer: {message.content}")
+```
+
+### 温度参数与 Reasoning
+
+较低的温度通常会产生更稳定的 reasoning 模式：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Explain quantum entanglement"}],
+    temperature=0.3  # More focused reasoning
+)
+```
+
+## 向后兼容性
+
+未指定 `--reasoning-parser` 时，服务器行为与之前一致：thinking 标签包含在 `content` 字段中，响应中不会添加 `reasoning` 字段。这确保现有应用无需修改即可继续正常使用。
+
+## 示例：数学题求解器
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+def solve_math(problem: str) -> dict:
+    """Solve a math problem and return reasoning + answer."""
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": "You are a math tutor. Show your work."},
+            {"role": "user", "content": problem}
+        ],
+        temperature=0.2
+    )
+
+    message = response.choices[0].message
+    return {
+        "problem": problem,
+        "work": message.reasoning,
+        "answer": message.content
+    }
+
+result = solve_math("If a train travels 120 km in 2 hours, what is its average speed?")
+print(f"Problem: {result['problem']}")
+print(f"\nWork shown:\n{result['work']}")
+print(f"\nFinal answer: {result['answer']}")
+```
+
+## Curl 示例
+
+### 非 Streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}]
+  }'
+```
+
+### Streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "What is 15% of 80?"}],
+    "stream": true
+  }'
+```
+
+## 常见问题排查
+
+### 响应中没有 reasoning 字段
+
+- 确认启动服务器时指定了 `--reasoning-parser`
+- 检查模型是否实际使用了 thinking 标签（并非所有提示词都会触发 reasoning）
+
+### Reasoning 出现在 content 中
+
+- 模型可能没有使用预期的标签格式
+- 尝试换用其他 parser（`qwen3` 或 `deepseek_r1`）
+
+### Reasoning 被截断
+
+- 如果模型在 thinking 过程中触及了 token 上限，请增大 `--max-tokens`
+
+## 相关链接
+
+- [支持的模型](../reference/models.md). 支持 reasoning 的模型列表
+- [服务器配置](server.md). 所有服务器选项
+- [CLI 参考](../reference/cli.md). 命令行选项

--- a/docs/zh/guides/server.md
+++ b/docs/zh/guides/server.md
@@ -1,0 +1,780 @@
+# OpenAI 兼容服务器
+
+vllm-mlx 提供一个具备完整 OpenAI API 兼容性的 FastAPI 服务器。
+
+默认情况下，服务器仅绑定到 `127.0.0.1`。只有在明确需要将其暴露到本机以外的网络时，才使用 `--host 0.0.0.0`。
+
+## 启动服务器
+
+### 简单模式（默认）
+
+单用户最大吞吐量：
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+```
+
+### continuous batching 模式
+
+适用于多个并发用户：
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+```
+
+### 启用 paged cache
+
+适用于生产环境的高效内存缓存：
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching --use-paged-cache
+```
+
+## 服务器选项
+
+| 选项 | 说明 | 默认值 |
+|------|------|--------|
+| `--port` | 服务器端口 | 8000 |
+| `--host` | 服务器主机 | 127.0.0.1 |
+| `--api-key` | 身份验证用 API key | None |
+| `--rate-limit` | 每客户端每分钟请求数（0 表示禁用） | 0 |
+| `--timeout` | 请求超时时间（秒） | 300 |
+| `--enable-metrics` | 在 `/metrics` 上暴露 Prometheus 指标 | False |
+| `--continuous-batching` | 为多用户启用 batching | False |
+| `--use-paged-cache` | 启用 paged KV cache | False |
+| `--cache-memory-mb` | 缓存内存上限（MB） | Auto |
+| `--cache-memory-percent` | 用于缓存的 RAM 比例 | 0.20 |
+| `--max-tokens` | 默认最大 token 数 | 32768 |
+| `--max-request-tokens` | API 客户端可传入的 `max_tokens` 最大值 | 32768 |
+| `--default-temperature` | 未指定时的默认 temperature | None |
+| `--default-top-p` | 未指定时的默认 top_p | None |
+| `--stream-interval` | 每个 streaming chunk 包含的 token 数 | 1 |
+| `--mcp-config` | MCP 配置文件路径 | None |
+| `--reasoning-parser` | reasoning 模型解析器（`qwen3`、`deepseek_r1`） | None |
+| `--embedding-model` | 启动时预加载 embeddings 模型 | None |
+| `--enable-auto-tool-choice` | 启用自动 tool calling | False |
+| `--tool-call-parser` | tool call 解析器（参见 [Tool Calling](tool-calling.md)） | None |
+
+## API 端点
+
+### Chat Completions
+
+```bash
+POST /v1/chat/completions
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+# Non-streaming
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=100
+)
+
+# Streaming
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### Completions
+
+```bash
+POST /v1/completions
+```
+
+```python
+response = client.completions.create(
+    model="default",
+    prompt="The capital of France is",
+    max_tokens=50
+)
+```
+
+### Models
+
+```bash
+GET /v1/models
+```
+
+返回可用模型列表。
+
+### Embeddings
+
+```bash
+POST /v1/embeddings
+```
+
+```python
+response = client.embeddings.create(
+    model="mlx-community/multilingual-e5-small-mlx",
+    input="Hello world"
+)
+print(response.data[0].embedding[:5])  # First 5 dimensions
+```
+
+详情参见 [Embeddings 指南](embeddings.md)。
+
+### 健康检查
+
+```bash
+GET /health
+```
+
+返回服务器状态。
+
+### 指标
+
+```bash
+GET /metrics
+```
+
+Prometheus 抓取端点，提供服务器、缓存、scheduler 及请求指标。该端点默认禁用，需通过 `--enable-metrics` 启用。
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-metrics
+```
+
+`/metrics` 端点有意不做身份验证。请仅在受信任的网络中暴露，或通过反向代理、防火墙限制访问来源。
+
+### Anthropic Messages API
+
+```bash
+POST /v1/messages
+```
+
+兼容 Anthropic 协议的端点，允许 Claude Code、OpenCode 等工具直接连接 vllm-mlx。内部将 Anthropic 请求转换为 OpenAI 格式，经引擎推理后再将响应转换回 Anthropic 格式。
+
+功能：
+- 非 streaming 与 streaming 响应（SSE）
+- 系统消息（纯字符串或内容块列表）
+- 包含用户和助手消息的多轮对话
+- 使用 `tool_use` / `tool_result` 内容块进行 tool calling
+- 用于预算追踪的 token 计数
+- 多模态内容（通过 `source` 块传入图片）
+- 客户端断开检测（返回 HTTP 499）
+- streaming 输出中的特殊 token 自动过滤
+
+#### 非 streaming
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(base_url="http://localhost:8000", api_key="not-needed")
+
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.content[0].text)
+# Response includes: response.id, response.model, response.stop_reason,
+# response.usage.input_tokens, response.usage.output_tokens
+```
+
+#### Streaming
+
+streaming 遵循 Anthropic SSE 事件协议，事件按以下顺序发出：
+`message_start` -> `content_block_start` -> `content_block_delta`（重复）-> `content_block_stop` -> `message_delta` -> `message_stop`
+
+```python
+with client.messages.stream(
+    model="default",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Tell me a story"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="")
+```
+
+#### 系统消息
+
+系统消息可以是纯字符串，也可以是内容块列表：
+
+```python
+# Plain string
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system="You are a helpful coding assistant.",
+    messages=[{"role": "user", "content": "Write a hello world in Python"}]
+)
+
+# List of content blocks
+response = client.messages.create(
+    model="default",
+    max_tokens=256,
+    system=[
+        {"type": "text", "text": "You are a helpful assistant."},
+        {"type": "text", "text": "Be concise in your answers."},
+    ],
+    messages=[{"role": "user", "content": "What is 2+2?"}]
+)
+```
+
+#### Tool calling
+
+使用 `name`、`description` 和 `input_schema` 定义工具。模型在需要调用工具时会返回 `tool_use` 内容块。将结果以 `tool_result` 块的形式返回。
+
+```python
+# Step 1: Send request with tools
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+
+# Step 2: Check if model wants to use tools
+for block in response.content:
+    if block.type == "tool_use":
+        print(f"Tool: {block.name}, Input: {block.input}, ID: {block.id}")
+        # response.stop_reason will be "tool_use"
+
+# Step 3: Send tool result back
+response = client.messages.create(
+    model="default",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {"role": "assistant", "content": response.content},
+        {"role": "user", "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": "Sunny, 22C"
+            }
+        ]}
+    ],
+    tools=[{
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }
+    }]
+)
+print(response.content[0].text)  # "The weather in Paris is sunny, 22C."
+```
+
+Tool choice 模式：
+
+| `tool_choice` | 行为 |
+|---------------|------|
+| `{"type": "auto"}` | 由模型决定是否调用工具（默认） |
+| `{"type": "any"}` | 模型必须至少调用一个工具 |
+| `{"type": "tool", "name": "get_weather"}` | 模型必须调用指定工具 |
+| `{"type": "none"}` | 模型不调用任何工具 |
+
+#### 多轮对话
+
+```python
+messages = [
+    {"role": "user", "content": "My name is Alice."},
+    {"role": "assistant", "content": "Nice to meet you, Alice!"},
+    {"role": "user", "content": "What's my name?"},
+]
+
+response = client.messages.create(
+    model="default",
+    max_tokens=100,
+    messages=messages
+)
+```
+
+#### Token 计数
+
+```bash
+POST /v1/messages/count_tokens
+```
+
+使用模型的 tokenizer 统计 Anthropic 请求的输入 token 数。适用于在发送请求前进行预算追踪。可统计系统消息、对话消息、tool_use 输入、tool_result 内容及工具定义（name、description、input_schema）中的 token。
+
+```python
+import requests
+
+resp = requests.post("http://localhost:8000/v1/messages/count_tokens", json={
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello, how are you?"}],
+    "system": "You are helpful.",
+    "tools": [{
+        "name": "search",
+        "description": "Search the web",
+        "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+    }]
+})
+print(resp.json())  # {"input_tokens": 42}
+```
+
+#### curl 示例
+
+非 streaming：
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+Streaming：
+
+```bash
+curl http://localhost:8000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "max_tokens": 256,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Tell me a joke"}]
+  }'
+```
+
+Token 计数：
+
+```bash
+curl http://localhost:8000/v1/messages/count_tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+# {"input_tokens": 12}
+```
+
+#### 请求字段
+
+| 字段 | 类型 | 是否必填 | 默认值 | 说明 |
+|------|------|----------|--------|------|
+| `model` | string | 是 | - | 模型名称（使用 `"default"` 指向已加载的模型） |
+| `messages` | list | 是 | - | 包含 `role` 和 `content` 的对话消息 |
+| `max_tokens` | int | 是 | - | 最大生成 token 数 |
+| `system` | string 或 list | 否 | null | 系统提示（字符串或 `{"type": "text", "text": "..."}` 块列表） |
+| `stream` | bool | 否 | false | 启用 SSE streaming |
+| `temperature` | float | 否 | 0.7 | 采样 temperature（0.0 为确定性，1.0 为创意性） |
+| `top_p` | float | 否 | 0.9 | nucleus sampling 阈值 |
+| `top_k` | int | 否 | null | top-k sampling |
+| `stop_sequences` | list | 否 | null | 触发停止生成的序列 |
+| `tools` | list | 否 | null | 包含 `name`、`description`、`input_schema` 的工具定义 |
+| `tool_choice` | dict | 否 | null | 工具选择模式（`auto`、`any`、`tool`、`none`） |
+| `metadata` | dict | 否 | null | 任意元数据（透传，服务器不使用） |
+
+#### 响应格式
+
+非 streaming 响应：
+
+```json
+{
+  "id": "msg_abc123...",
+  "type": "message",
+  "role": "assistant",
+  "model": "default",
+  "content": [
+    {"type": "text", "text": "Hello! How can I help?"}
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 8
+  }
+}
+```
+
+调用工具时，`content` 包含 `tool_use` 块，且 `stop_reason` 为 `"tool_use"`：
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "Let me check the weather."},
+    {
+      "type": "tool_use",
+      "id": "call_abc123",
+      "name": "get_weather",
+      "input": {"city": "Paris"}
+    }
+  ],
+  "stop_reason": "tool_use"
+}
+```
+
+停止原因：
+
+| `stop_reason` | 含义 |
+|---------------|------|
+| `end_turn` | 模型自然完成生成 |
+| `tool_use` | 模型需要调用工具 |
+| `max_tokens` | 达到 `max_tokens` 上限 |
+
+#### 与 Claude Code 配合使用
+
+将 Claude Code 直接指向你的 vllm-mlx 服务器：
+
+```bash
+# Start the server
+vllm-mlx serve mlx-community/Qwen3-Coder-Next-235B-A22B-4bit \
+  --continuous-batching \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+
+# In another terminal, configure Claude Code
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=not-needed
+claude
+```
+
+### 服务器状态
+
+```bash
+GET /v1/status
+```
+
+实时监控端点，返回服务器全局统计信息及每个请求的详情。适用于调试性能、追踪缓存效率以及监控 Metal GPU 内存。
+
+```bash
+curl -s http://localhost:8000/v1/status | python -m json.tool
+```
+
+示例响应：
+
+```json
+{
+  "status": "running",
+  "model": "mlx-community/Qwen3-8B-4bit",
+  "uptime_s": 342.5,
+  "steps_executed": 1247,
+  "num_running": 1,
+  "num_waiting": 0,
+  "total_requests_processed": 15,
+  "total_prompt_tokens": 28450,
+  "total_completion_tokens": 3200,
+  "metal": {
+    "active_memory_gb": 5.2,
+    "peak_memory_gb": 8.1,
+    "cache_memory_gb": 2.3
+  },
+  "cache": {
+    "type": "memory_aware_cache",
+    "entries": 5,
+    "hit_rate": 0.87,
+    "memory_mb": 2350
+  },
+  "requests": [
+    {
+      "request_id": "req_abc123",
+      "phase": "generation",
+      "tokens_per_second": 45.2,
+      "ttft_s": 0.8,
+      "progress": 0.35,
+      "cache_hit_type": "prefix",
+      "cached_tokens": 1200,
+      "generated_tokens": 85,
+      "max_tokens": 256
+    }
+  ]
+}
+```
+
+响应字段：
+
+| 字段 | 说明 |
+|------|------|
+| `status` | 服务器状态：`running`、`stopped` 或 `not_loaded` |
+| `model` | 已加载模型的名称 |
+| `uptime_s` | 服务器启动后经过的秒数 |
+| `steps_executed` | 已执行的推理步骤总数 |
+| `num_running` | 当前正在生成 token 的请求数 |
+| `num_waiting` | 排队等待 prefill 的请求数 |
+| `total_requests_processed` | 启动以来已完成的请求总数 |
+| `total_prompt_tokens` | 启动以来处理的 prompt token 总数 |
+| `total_completion_tokens` | 启动以来生成的 completion token 总数 |
+| `metal.active_memory_gb` | 当前使用的 Metal GPU 内存（GB） |
+| `metal.peak_memory_gb` | Metal GPU 内存峰值用量（GB） |
+| `metal.cache_memory_gb` | Metal 缓存内存用量（GB） |
+| `cache` | 缓存统计信息（类型、条目数、命中率、内存用量） |
+| `requests` | 活跃请求列表，包含每个请求的详细信息 |
+
+`requests` 中的每请求字段：
+
+| 字段 | 说明 |
+|------|------|
+| `request_id` | 唯一请求标识符 |
+| `phase` | 当前阶段：`queued`、`prefill` 或 `generation` |
+| `tokens_per_second` | 该请求的生成吞吐量 |
+| `ttft_s` | 首 token 时间（秒），即 TTFT |
+| `progress` | 完成进度（0.0 到 1.0） |
+| `cache_hit_type` | 缓存匹配类型：`exact`、`prefix`、`supersequence`、`lcp` 或 `miss` |
+| `cached_tokens` | 从缓存中命中的 token 数 |
+| `generated_tokens` | 已生成的 token 数 |
+| `max_tokens` | 请求的最大 token 数 |
+
+## Tool Calling
+
+使用 `--enable-auto-tool-choice` 启用兼容 OpenAI 的 tool calling：
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+使用 `--tool-call-parser` 选项为你的模型选择对应的解析器：
+
+| 解析器 | 适用模型 |
+|--------|----------|
+| `auto` | 自动检测（依次尝试所有解析器） |
+| `mistral` | Mistral、Devstral |
+| `qwen` | Qwen、Qwen3 |
+| `llama` | Llama 3.x、4.x |
+| `hermes` | Hermes、NousResearch |
+| `deepseek` | DeepSeek V3、R1 |
+| `kimi` | Kimi K2、Moonshot |
+| `granite` | IBM Granite 3.x、4.x |
+| `nemotron` | NVIDIA Nemotron |
+| `xlam` | Salesforce xLAM |
+| `functionary` | MeetKai Functionary |
+| `glm47` | GLM-4.7、GLM-4.7-Flash |
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"{tc.function.name}: {tc.function.arguments}")
+```
+
+完整文档参见 [Tool Calling 指南](tool-calling.md)。
+
+## Reasoning 模型
+
+对于展示思考过程的模型（Qwen3、DeepSeek-R1），使用 `--reasoning-parser` 将 reasoning 内容与最终答案分离：
+
+```bash
+# Qwen3 models
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek-R1 models
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+```
+
+API 响应中包含 `reasoning` 字段，用于展示模型的思考过程：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What is 17 × 23?"}]
+)
+
+print(response.choices[0].message.reasoning)  # Step-by-step thinking
+print(response.choices[0].message.content)    # Final answer
+```
+
+streaming 时，reasoning chunk 先于 content chunk 到达：
+
+```python
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.reasoning:
+        print(f"[Thinking] {delta.reasoning}")
+    if delta.content:
+        print(delta.content, end="")
+```
+
+完整说明参见 [Reasoning 模型指南](reasoning.md)。
+
+## 结构化输出（JSON 模式）
+
+使用 `response_format` 强制模型返回合法 JSON。
+
+### JSON Object 模式
+
+返回任意合法 JSON：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={"type": "json_object"}
+)
+# Output: {"colors": ["red", "blue", "green"]}
+```
+
+### JSON Schema 模式
+
+返回符合指定 schema 的 JSON：
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "List 3 colors"}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "colors",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "colors": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "required": ["colors"]
+            }
+        }
+    }
+)
+# Output validated against schema
+data = json.loads(response.choices[0].message.content)
+assert "colors" in data
+```
+
+### curl 示例
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "List 3 colors"}],
+    "response_format": {"type": "json_object"}
+  }'
+```
+
+## curl 示例
+
+### Chat
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 100
+  }'
+```
+
+### Streaming
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
+  }'
+```
+
+## Streaming 配置
+
+使用 `--stream-interval` 控制 streaming 行为：
+
+| 值 | 行为 |
+|----|------|
+| `1`（默认） | 每个 token 立即发送 |
+| `2-5` | 积攒若干 token 后再发送 |
+| `10+` | 最大吞吐量，输出分块较大 |
+
+```bash
+# Smooth streaming
+vllm-mlx serve model --continuous-batching --stream-interval 1
+
+# Batched streaming (better for high-latency networks)
+vllm-mlx serve model --continuous-batching --stream-interval 5
+```
+
+## Open WebUI 集成
+
+```bash
+# 1. Start vllm-mlx server
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
+
+# 2. Start Open WebUI
+docker run -d -p 3000:8080 \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 \
+  -e OPENAI_API_KEY=not-needed \
+  --name open-webui \
+  ghcr.io/open-webui/open-webui:main
+
+# 3. Open http://localhost:3000
+```
+
+## 生产部署
+
+### 使用 systemd
+
+创建 `/etc/systemd/system/vllm-mlx.service`：
+
+```ini
+[Unit]
+Description=vLLM-MLX Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching --use-paged-cache --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable vllm-mlx
+sudo systemctl start vllm-mlx
+```
+
+### 推荐配置
+
+适用于 50 个以上并发用户的生产环境：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --port 8000
+```

--- a/docs/zh/guides/tool-calling.md
+++ b/docs/zh/guides/tool-calling.md
@@ -1,0 +1,245 @@
+# Tool Calling
+
+vllm-mlx 支持与 OpenAI 兼容的 tool calling（function calling），并为多种主流模型系列提供自动解析。
+
+## 快速开始
+
+启动服务器时添加 `--enable-auto-tool-choice` 标志即可启用 tool calling：
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral
+```
+
+然后通过标准 OpenAI API 使用工具：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"]
+            }
+        }
+    }]
+)
+
+# Check for tool calls
+if response.choices[0].message.tool_calls:
+    for tc in response.choices[0].message.tool_calls:
+        print(f"Function: {tc.function.name}")
+        print(f"Arguments: {tc.function.arguments}")
+```
+
+## 支持的 tool parser
+
+使用 `--tool-call-parser` 为您的模型系列选择对应的 tool parser：
+
+| Parser | 别名 | 模型 | 格式 |
+|--------|------|------|------|
+| `auto` | | 任意模型 | 自动检测格式（依次尝试所有 parser） |
+| `mistral` | | Mistral、Devstral | `[TOOL_CALLS]` JSON 数组 |
+| `qwen` | `qwen3` | Qwen、Qwen3 | `<tool_call>` XML 或 `[Calling tool:]` |
+| `llama` | `llama3`、`llama4` | Llama 3.x、4.x | `<function=name>` 标签 |
+| `hermes` | `nous` | Hermes、NousResearch | `<tool_call>` XML 包裹的 JSON |
+| `deepseek` | `deepseek_v3`、`deepseek_r1` | DeepSeek V3、R1 | Unicode 分隔符 |
+| `kimi` | `kimi_k2`、`moonshot` | Kimi K2、Moonshot | `<\|tool_call_begin\|>` 标记 |
+| `granite` | `granite3` | IBM Granite 3.x、4.x | `<\|tool_call\|>` 或 `<tool_call>` |
+| `nemotron` | `nemotron3` | NVIDIA Nemotron | `<tool_call><function=...><parameter=...>` |
+| `xlam` | | Salesforce xLAM | 含 `tool_calls` 数组的 JSON |
+| `functionary` | `meetkai` | MeetKai Functionary | 多个 function 块 |
+| `glm47` | `glm4` | GLM-4.7、GLM-4.7-Flash | `<tool_call>` 配合 `<arg_key>`/`<arg_value>` XML |
+
+## 模型示例
+
+### Mistral / Devstral
+
+```bash
+# Devstral Small（针对编程和 tool use 优化）
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Mistral Instruct
+vllm-mlx serve mlx-community/Mistral-7B-Instruct-v0.3-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+```
+
+### Qwen
+
+```bash
+# Qwen3
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser qwen
+```
+
+### Llama
+
+```bash
+# Llama 3.2
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser llama
+```
+
+### DeepSeek
+
+```bash
+# DeepSeek V3
+vllm-mlx serve mlx-community/DeepSeek-V3-0324-4bit \
+  --enable-auto-tool-choice --tool-call-parser deepseek
+```
+
+### IBM Granite
+
+```bash
+# Granite 4.0
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+```
+
+### NVIDIA Nemotron
+
+```bash
+# Nemotron 3 Nano
+vllm-mlx serve mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit \
+  --enable-auto-tool-choice --tool-call-parser nemotron
+```
+
+### GLM-4.7
+
+```bash
+# GLM-4.7 Flash
+vllm-mlx serve lmstudio-community/GLM-4.7-Flash-MLX-8bit \
+  --enable-auto-tool-choice --tool-call-parser glm47
+```
+
+### Kimi K2
+
+```bash
+# Kimi K2
+vllm-mlx serve mlx-community/Kimi-K2-Instruct-4bit \
+  --enable-auto-tool-choice --tool-call-parser kimi
+```
+
+### Salesforce xLAM
+
+```bash
+# xLAM
+vllm-mlx serve mlx-community/xLAM-2-fc-r-4bit \
+  --enable-auto-tool-choice --tool-call-parser xlam
+```
+
+## Auto Parser
+
+如果不确定使用哪个 tool parser，`auto` parser 会尝试自动检测格式：
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --enable-auto-tool-choice --tool-call-parser auto
+```
+
+auto parser 按以下顺序依次尝试各种格式：
+
+1. Mistral（`[TOOL_CALLS]`）
+2. Qwen 括号格式（`[Calling tool:]`）
+3. Nemotron（`<tool_call><function=...><parameter=...>`）
+4. Qwen/Hermes XML（`<tool_call>{...}</tool_call>`）
+5. Llama（`<function=name>{...}</function>`）
+6. 原始 JSON
+
+## Streaming Tool Calls
+
+Tool calling 支持 streaming。模型生成完毕后发送 tool call 信息：
+
+```python
+stream = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's 25 * 17?"}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Calculate math expressions",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string"}
+                },
+                "required": ["expression"]
+            }
+        }
+    }],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.tool_calls:
+        for tc in chunk.choices[0].delta.tool_calls:
+            print(f"Tool call: {tc.function.name}({tc.function.arguments})")
+```
+
+## 处理工具返回结果
+
+收到 tool call 后，执行对应函数并将结果返回给模型：
+
+```python
+import json
+
+# 第一次请求，模型决定调用工具
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=[weather_tool]
+)
+
+# 获取 tool call
+tool_call = response.choices[0].message.tool_calls[0]
+tool_call_id = tool_call.id
+function_name = tool_call.function.name
+arguments = json.loads(tool_call.function.arguments)
+
+# 执行函数（由您自行实现）
+result = get_weather(**arguments)  # {"temperature": 22, "condition": "sunny"}
+
+# 将结果返回给模型
+response = client.chat.completions.create(
+    model="default",
+    messages=[
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {"role": "assistant", "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": tool_call_id, "content": json.dumps(result)}
+    ],
+    tools=[weather_tool]
+)
+
+print(response.choices[0].message.content)
+# "The weather in Tokyo is sunny with a temperature of 22C."
+```
+
+## Think 标签处理
+
+会产生 `<think>...</think>` reasoning 标签的模型（如 DeepSeek-R1、Qwen3、GLM-4.7）均可自动处理。tool parser 会在提取 tool call 前剥离 thinking 内容，因此 reasoning 标签不会干扰 tool call 解析。
+
+即使 `<think>` 是通过提示词注入的（即仅有闭合标签 `</think>` 的隐式 think 标签），也同样适用。
+
+## CLI 参数参考
+
+| 选项 | 说明 |
+|------|------|
+| `--enable-auto-tool-choice` | 启用自动 tool calling |
+| `--tool-call-parser` | 选择 tool parser（见上表） |
+
+完整选项请参阅 [CLI Reference](../reference/cli.md)。

--- a/docs/zh/guides/warm-prompts.md
+++ b/docs/zh/guides/warm-prompts.md
@@ -1,0 +1,142 @@
+# Warm Prompts
+
+在服务器启动时预先填充 prefix cache，使 agent 发送的**第一个**请求命中已预热的缓存，而无需为其数千字节的系统提示支付完整的 prefill 开销。
+
+## 适用场景
+
+Agent 工作负载，如代理编码助手或推理助手的代理、MCP 服务器、多 agent 编排器，始终会发送相同的系统提示。在当前实现中，冷启动服务器收到的第一个请求需要为该系统提示支付完整的 prefill 代价。对于数十亿参数的模型，这意味着数秒的 TTFT，而此时用户正在等待其新 agent 首次响应。
+
+如果您在部署时已知道各 agent 的系统提示，可将其写入一个 JSON 文件并通过 `--warm-prompts` 指向它。服务器会在启动时对每条提示执行一次 `max_tokens=1` 的聊天补全，KV cache 状态随即落入 prefix cache，后续真实请求即可通过严格前缀匹配命中缓存。
+
+此功能需要 `--continuous-batching`（prefix cache 依赖该模式）。
+
+## 快速示例
+
+```bash
+# 一次性写入您关心的 agent
+cat > ~/.config/vllm-mlx/agents.json <<'JSON'
+[
+  [{"role": "system", "content": "You are a code assistant..."}]
+]
+JSON
+
+# 将服务器指向该文件
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json
+```
+
+启动时您将看到：
+
+```
+[lifespan] Warm-up done (strict-prefix): 1 completed, 0 skipped,
+           1431 prompt tokens in 0.2s
+```
+
+第一个共享已预热系统提示的真实请求将命中缓存，其 `tokens_saved` 接近预热提示的长度。
+
+## 文件格式
+
+顶层为一个 JSON 列表，每个条目本身也是一个聊天消息列表，结构与 `/v1/chat/completions` 中的 `messages` 字段相同。
+
+```json
+[
+  [
+    {"role": "system", "content": "You are a code assistant..."}
+  ],
+  [
+    {"role": "system", "content": "You are a senior code reviewer..."}
+  ],
+  [
+    {"role": "system", "content": "You are a planner..."},
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "Hello, what are we planning?"}
+  ]
+]
+```
+
+单条系统提示是最常见的用法。多轮历史也受支持，适用于需要预热特定对话开头的场景（少样本示例、持续运行的助手角色等）。
+
+## 规模建议
+
+预热提示通过 `asyncio.gather` **并发**处理，因此 N 条条目会在启动时触发 N 个并发 prefill，每个 prefill 会为其提示长度分配 KV cache。
+
+**建议条目数为 1 至 3 条**，足以覆盖典型 agent 部署的热路径（每个角色一条）。在内存紧张的模型上，过大的 warm-prompts 文件可能在启动时耗尽可用空间。
+
+如需预热数十个角色，请提交一个 issue 并说明您的工作负载，我们可以添加 `--warm-prompts-concurrency=N` 上限参数。
+
+## 基准测试
+
+**测试环境：** M4 Max，128 GB 统一内存。每次测量使用两个独立服务器（冷启动与预热），隔离冷启动。`long` 提示集（约 2500 个用户 token）前置约 1700 token 的系统提示以匹配预热提示。`max_tokens=128`。bench-serve 使用 `--skip-preflight-token-count`，避免 count_prompt_tokens 预检污染缓存。
+
+| 模型 | 并发 | 冷启动 TTFT | 预热 TTFT | 加速比 |
+|------|-----:|----------:|----------:|------:|
+| Qwen3-0.6B-8bit | 1 | 563 ms | 419 ms | 1.34x |
+| Qwen3-0.6B-8bit | 4 | 1 723 ms | 1 282 ms | 1.34x |
+| Qwen3-0.6B-8bit | 8 | 3 708 ms | 2 661 ms | 1.39x |
+| Llama-3.2-3B-Instruct-4bit | 1 | 1 754 ms | 1 060 ms | 1.65x |
+| Llama-3.2-3B-Instruct-4bit | 4 | 5 926 ms | 3 945 ms | 1.50x |
+| Llama-3.2-3B-Instruct-4bit | 8 | 15 161 ms | 9 820 ms | 1.54x |
+| Qwen3-4B-4bit | 1 | 4 937 ms | 2 191 ms | 2.25x |
+| Qwen3-4B-4bit | 4 | 12 535 ms | 9 623 ms | 1.30x |
+| Qwen3-4B-4bit | 8 | 38 148 ms | 23 878 ms | 1.60x |
+| Qwen3.6-35B-A3B-4bit (MoE/hybrid) | 1 | 2 400 ms | 1 603 ms | 1.50x |
+| Qwen3.6-35B-A3B-4bit | 4 | 8 735 ms | 6 054 ms | 1.44x |
+| Qwen3.6-35B-A3B-4bit | 8 | 22 419 ms | 14 409 ms | 1.56x |
+
+全部 12 项配置均有提升。当提示占总长度比例最高时（并发=1，长系统提示），TTFT 节省最为显著，在并发负载下仍有实质性收益。
+
+**生成 tok/s** 对于稠密模型基本持平（误差在 ±5% 以内）。Qwen3.6-35B-A3B（MoE）在并发数大于等于 4 时出现 20 至 35% 的解码速度下降，原因似乎是 MoE 路由与批量调度之间的交互。对于 agent 工作负载，TTFT 节省仍主导端到端延迟，但若您的工作流在高并发下以解码为瓶颈，请注意这一点。
+
+## 工作原理
+
+朴素的预热方式，即用占位用户消息渲染聊天模板并缓存 token，对于混合 SSM+attention 模型（Qwen3.5-MoE、Qwen3.6-MoE）不适用。这类模型的缓存层包含无法裁剪的 SSM 状态，因此 `memory_cache.py` 禁用了 LCP 匹配。占位用户内容与真实用户内容不同，基于 token 的缓存条目不再是任何真实请求的严格前缀。
+
+本预热器会用两个不同的用户内容（`"__PROBE_A__"` 和 `"__PROBE_B__"`）**两次**渲染聊天模板，找到两个字符串开始发散的字符位置，并在该边界处截断第一次渲染的结果。这段截断后的字符串，即用户内容被插入之前的全部内容，是发送给引擎的内容。
+
+由于引擎的真实请求路径同样使用 `tokenize=False` 渲染模板，再由分词器对结果进行编码，因此预热生成的 token 保证是任何具有匹配系统提示且聊天历史为空的真实请求的严格前缀。严格前缀匹配适用于所有缓存层类型，包括禁用 LCP 的混合路径。
+
+## 管理操作
+
+### 清除内存中的 prefix cache
+
+```bash
+curl -X DELETE http://localhost:8000/v1/cache/prefix
+```
+
+若服务器以 `--warm-prompts` 启动，清除后会在后台重新执行预热。响应会立即返回，不等待重新预热完成。
+
+响应：
+
+```json
+{"status": "cleared", "rewarm_scheduled": true}
+```
+
+### 查看缓存状态
+
+```bash
+curl http://localhost:8000/v1/status | jq '.cache'
+```
+
+使用 warm-prompts 启动后，在第一个用户请求到来之前，您将看到 `entry_count > 0`。
+
+## 针对您自己的场景进行基准测试
+
+如需测量对您的模型和提示的实际影响，请使用 `bench-serve`：
+
+```bash
+# 冷启动：不使用 warm-prompts
+vllm-mlx serve MODEL --continuous-batching &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag cold \
+  --output cold.csv --format csv
+
+# 预热：相同服务器配置 + --warm-prompts
+vllm-mlx serve MODEL --continuous-batching \
+  --warm-prompts ~/.config/vllm-mlx/agents.json &
+vllm-mlx bench-serve --prompts long --concurrency 1,4 \
+  --system-prompt-file my-system.txt --tag warm \
+  --output warm.csv --format csv
+```
+
+设置 `--system-prompt-file` 时会自动启用 `--skip-preflight-token-count`，防止 `count_prompt_tokens` 预检污染缓存。比较 `cold.csv` 与 `warm.csv` 即可评估您工作负载的实际效果。

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,0 +1,66 @@
+# vLLM-MLX 文档
+
+**Apple Silicon 的 MLX 推理后端** - 在 Mac 上对文本、图像、视频和音频进行 GPU 加速推理
+
+## 什么是 vLLM-MLX？
+
+vllm-mlx 通过集成以下组件，为 vLLM 带来原生 Apple Silicon GPU 加速：
+
+- **[MLX](https://github.com/ml-explore/mlx)**：Apple 的机器学习框架，具有统一内存和 Metal 内核
+- **[mlx-lm](https://github.com/ml-explore/mlx-lm)**：经过优化的 LLM 推理，支持 KV cache 和量化
+- **[mlx-vlm](https://github.com/Blaizzy/mlx-vlm)**：用于多模态推理的视觉语言模型 VLM
+- **[mlx-audio](https://github.com/Blaizzy/mlx-audio)**：基于原生语音的 TTS 和 STT
+- **[mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings)**：用于语义搜索和 RAG 的文本 embeddings
+
+## 主要特性
+
+- **多模态** - 在同一平台上处理文本、图像、视频和音频
+- **原生 GPU 加速**，支持 Apple Silicon（M1、M2、M3、M4）
+- **原生 TTS 语音** - 支持西班牙语、法语、中文、日语及其他 5 种语言
+- **OpenAI API 兼容** - 可直接替换 OpenAI 客户端
+- **Embeddings** - 兼容 OpenAI 的 `/v1/embeddings` 端点
+- **MCP Tool Calling** - 通过 Model Context Protocol 集成外部工具
+- **Paged KV Cache** - 支持前缀共享的高效内存缓存
+- **Continuous Batching** - 为多并发用户提供高吞吐量
+
+## 快速链接
+
+### 入门指南
+- [安装](getting-started/installation.md)
+- [快速开始](getting-started/quickstart.md)
+
+### 用户指南
+- [兼容 OpenAI 的服务器](guides/server.md)
+- [Python API](guides/python-api.md)
+- [多模态（图像与视频）](guides/multimodal.md)
+- [音频（STT/TTS）](guides/audio.md)
+- [Embeddings](guides/embeddings.md)
+- [Reasoning 模型](guides/reasoning.md)
+- [Tool Calling](guides/tool-calling.md)
+- [MCP 与 Tool Calling](guides/mcp-tools.md)
+- [Continuous Batching](guides/continuous-batching.md)
+
+### 参考文档
+- [CLI 命令](reference/cli.md)
+- [支持的模型](reference/models.md)
+- [配置说明](reference/configuration.md)
+
+### 基准测试
+- [LLM 基准测试](benchmarks/llm.md)
+- [图像基准测试](benchmarks/image.md)
+- [视频基准测试](benchmarks/video.md)
+- [音频基准测试](benchmarks/audio.md)
+
+### 开发者文档
+- [架构设计](../development/architecture.md)
+- [贡献指南](../development/contributing.md)
+
+## 环境要求
+
+- 搭载 Apple Silicon 的 macOS（M1/M2/M3/M4）
+- Python 3.10 及以上
+- 推荐 8GB 及以上内存
+
+## 许可证
+
+Apache 2.0，详情请参阅 [LICENSE](../../LICENSE)。

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -1,0 +1,210 @@
+# CLI 参考
+
+## 命令概览
+
+| 命令 | 说明 |
+|---------|-------------|
+| `vllm-mlx serve` | 启动兼容 OpenAI 的服务器 |
+| `vllm-mlx-bench` | 运行性能基准测试 |
+| `vllm-mlx-chat` | 启动 Gradio 对话界面 |
+
+## `vllm-mlx serve`
+
+启动兼容 OpenAI 的 API 服务器。
+
+### 用法
+
+```bash
+vllm-mlx serve <model> [options]
+```
+
+### 选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--served-model-name` | 通过 OpenAI API 暴露的自定义模型名称。未设置时使用模型路径作为名称。 | None |
+| `--port` | 服务器端口 | 8000 |
+| `--host` | 服务器主机 | 127.0.0.1 |
+| `--api-key` | 用于身份验证的 API 密钥 | None |
+| `--rate-limit` | 每个客户端每分钟的请求数（0 表示禁用） | 0 |
+| `--timeout` | 请求超时时间，单位为秒 | 300 |
+| `--enable-metrics` | 在 `/metrics` 上暴露 Prometheus 指标 | False |
+| `--continuous-batching` | 为多用户启用 continuous batching | False |
+| `--cache-memory-mb` | 缓存内存上限，单位为 MB | Auto |
+| `--cache-memory-percent` | 用于缓存的内存占比 | 0.20 |
+| `--no-memory-aware-cache` | 使用旧版按条目数计数的缓存 | False |
+| `--use-paged-cache` | 启用 paged KV cache | False |
+| `--max-tokens` | 默认最大 token 数 | 32768 |
+| `--max-request-tokens` | API 客户端可传入的最大 `max_tokens` | 32768 |
+| `--stream-interval` | 每个 streaming 分块包含的 token 数 | 1 |
+| `--mcp-config` | MCP 配置文件路径 | None |
+| `--paged-cache-block-size` | 每个缓存块包含的 token 数 | 64 |
+| `--max-cache-blocks` | 最大缓存块数 | 1000 |
+| `--max-num-seqs` | 最大并发序列数 | 256 |
+| `--default-temperature` | 请求未指定时的默认 temperature | None |
+| `--default-top-p` | 请求未指定时的默认 top_p | None |
+| `--max-audio-upload-mb` | `/v1/audio/transcriptions` 接受的最大音频上传大小 | 25 |
+| `--max-tts-input-chars` | `/v1/audio/speech` 接受的最大文本长度 | 4096 |
+| `--reasoning-parser` | reasoning 模型的解析器（`qwen3`、`deepseek_r1`） | None |
+| `--embedding-model` | 启动时预加载 embeddings 模型 | None |
+| `--enable-auto-tool-choice` | 启用自动 tool calling | False |
+| `--tool-call-parser` | tool call 解析器（`auto`、`mistral`、`qwen`、`llama`、`hermes`、`deepseek`、`kimi`、`granite`、`nemotron`、`xlam`、`functionary`、`glm47`） | None |
+
+### 示例
+
+```bash
+# Simple mode (single user, max throughput)
+# Model path is used as the model name in the OpenAI API (e.g. model="mlx-community/Llama-3.2-3B-Instruct-4bit")
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+
+Model will show up as 'mlx-community/Llama-3.2-3B-Instruct-4bit' in the `/v1/models` API endpoint. View with `curl http://localhost:8000/v1/models` or similar.
+
+# With a custom API model name (model is accessed as "my-model" via the OpenAI API)
+# --served-model-name sets the name clients must use when calling the API (e.g. model="my-model")
+vllm-mlx serve --served-model-name my-model mlx-community/Llama-3.2-3B-Instruct-4bit
+# Note: Model will show up as 'my-model' in the `/v1/models` API endpoint.
+
+# Continuous batching (multiple users)
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --continuous-batching
+
+# With memory limit for large models
+vllm-mlx serve mlx-community/GLM-4.7-Flash-4bit \
+  --continuous-batching \
+  --cache-memory-mb 2048
+
+# Production with paged cache
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --port 8000
+
+# With MCP tools
+vllm-mlx serve mlx-community/Qwen3-4B-4bit --mcp-config mcp.json
+
+# Multimodal model
+vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Reasoning model (separates thinking from answer)
+vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
+
+# DeepSeek reasoning model
+vllm-mlx serve mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit --reasoning-parser deepseek_r1
+
+# Tool calling with Mistral/Devstral
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice --tool-call-parser mistral
+
+# Tool calling with Granite
+vllm-mlx serve mlx-community/granite-4.0-tiny-preview-4bit \
+  --enable-auto-tool-choice --tool-call-parser granite
+
+# With API key authentication
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-key
+
+# Expose Prometheus metrics
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics
+
+# Production setup with security options
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --timeout 120 \
+  --continuous-batching
+```
+
+### 安全
+
+设置 `--api-key` 后，所有 API 请求都需要携带 `Authorization: Bearer <api-key>` 请求头：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="your-secret-key"  # Must match --api-key
+)
+```
+
+或使用 curl：
+
+```bash
+curl http://localhost:8000/v1/models \
+  -H "Authorization: Bearer your-secret-key"
+```
+
+## `vllm-mlx-bench`
+
+运行性能基准测试。
+
+### 用法
+
+```bash
+vllm-mlx-bench --model <model> [options]
+```
+
+### 选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--model` | 模型名称 | 必填 |
+| `--prompts` | 提示词数量 | 5 |
+| `--max-tokens` | 每条提示词的最大 token 数 | 256 |
+| `--quick` | 快速基准测试模式 | False |
+| `--video` | 运行视频基准测试 | False |
+| `--video-url` | 自定义视频 URL | None |
+| `--video-path` | 自定义视频路径 | None |
+
+### 示例
+
+```bash
+# LLM benchmark
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit
+
+# Quick benchmark
+vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --quick
+
+# Image benchmark (auto-detected for VLM models)
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit
+
+# Video benchmark
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit --video
+
+# Custom video
+vllm-mlx-bench --model mlx-community/Qwen3-VL-8B-Instruct-4bit \
+  --video --video-url https://example.com/video.mp4
+```
+
+## `vllm-mlx-chat`
+
+启动 Gradio 对话界面。
+
+### 用法
+
+```bash
+vllm-mlx-chat --served-model-name <model-name> [options]
+```
+
+### 选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--model` | 模型名称 | 必填 |
+| `--port` | Gradio 端口 | 7860 |
+| `--text-only` | 禁用多模态功能 | False |
+
+### 示例
+
+```bash
+# Multimodal chat (text + images + video)
+vllm-mlx-chat --served-model-name mlx-community/Qwen3-VL-4B-Instruct-3bit
+
+# Text-only chat
+vllm-mlx-chat --served-model-name mlx-community/Llama-3.2-3B-Instruct-4bit --text-only
+```
+
+## 环境变量
+
+| 变量 | 说明 |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | 测试使用的模型 |
+| `HF_TOKEN` | HuggingFace token |

--- a/docs/zh/reference/configuration.md
+++ b/docs/zh/reference/configuration.md
@@ -1,0 +1,189 @@
+# 配置参考
+
+## 服务器配置
+
+### 基本选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--host` | 服务器主机地址 | `127.0.0.1` |
+| `--port` | 服务器端口 | `8000` |
+| `--max-tokens` | 默认最大 token 数 | `32768` |
+| `--max-request-tokens` | API 客户端可传入的最大 `max_tokens` 值 | `32768` |
+| `--default-temperature` | 请求未指定时使用的默认 temperature | None |
+| `--default-top-p` | 请求未指定时使用的默认 top_p | None |
+
+### 安全选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--api-key` | 用于身份验证的 API key | None |
+| `--rate-limit` | 每个客户端每分钟的请求数（0 表示禁用） | `0` |
+| `--timeout` | 请求超时时间（秒） | `300` |
+| `--enable-metrics` | 在 `/metrics` 上暴露 Prometheus 指标 | `false` |
+| `--max-audio-upload-mb` | `/v1/audio/transcriptions` 接受的最大音频上传大小 | `25` |
+| `--max-tts-input-chars` | `/v1/audio/speech` 接受的最大文本长度 | `4096` |
+
+### 批处理选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--continuous-batching` | 启用 continuous batching | `false` |
+| `--stream-interval` | 每个 streaming 分块包含的 token 数 | `1` |
+| `--max-num-seqs` | 最大并发序列数 | `256` |
+
+### 缓存选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--cache-memory-mb` | 缓存内存上限（MB） | 自动 |
+| `--cache-memory-percent` | 分配给缓存的内存比例 | `0.20` |
+| `--no-memory-aware-cache` | 使用旧版基于条目数量的缓存 | `false` |
+| `--use-paged-cache` | 启用 paged KV cache | `false` |
+| `--paged-cache-block-size` | 每个块包含的 token 数 | `64` |
+| `--max-cache-blocks` | 最大块数量 | `1000` |
+
+### 工具调用选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--enable-auto-tool-choice` | 启用自动工具调用 | `false` |
+| `--tool-call-parser` | 工具调用解析器（参见 [工具调用](../guides/tool-calling.md)） | None |
+
+### 推理选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--reasoning-parser` | 推理模型解析器（`qwen3`、`deepseek_r1`） | None |
+
+### 嵌入选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--embedding-model` | 启动时预加载嵌入模型 | None |
+
+### MCP 选项
+
+| 选项 | 说明 | 默认值 |
+|--------|-------------|---------|
+| `--mcp-config` | MCP 配置文件路径 | None |
+
+## MCP 配置
+
+创建 `mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-name", "arg1"],
+      "env": {
+        "ENV_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+### MCP 服务器字段
+
+| 字段 | 说明 | 是否必填 |
+|-------|-------------|----------|
+| `command` | 可执行命令 | 是 |
+| `args` | 命令参数 | 是 |
+| `env` | 环境变量 | 否 |
+
+## API 请求选项
+
+### 聊天补全
+
+| 参数 | 说明 | 默认值 |
+|-----------|-------------|---------|
+| `model` | 模型名称 | 必填 |
+| `messages` | 聊天消息 | 必填 |
+| `max_tokens` | 最大生成 token 数 | 256 |
+| `temperature` | 采样 temperature | 模型默认值 |
+| `top_p` | Nucleus sampling | 模型默认值 |
+| `stream` | 启用 streaming | `true` |
+| `stop` | 停止序列 | None |
+| `tools` | 工具定义 | None |
+| `response_format` | 输出格式（`json_object`、`json_schema`） | None |
+
+### 多模态选项
+
+| 参数 | 说明 | 默认值 |
+|-----------|-------------|---------|
+| `video_fps` | 每秒帧数 | 2.0 |
+| `video_max_frames` | 最大帧数 | 32 |
+
+## 环境变量
+
+| 变量 | 说明 |
+|----------|-------------|
+| `VLLM_MLX_TEST_MODEL` | 测试使用的默认模型 |
+| `HF_TOKEN` | HuggingFace 身份验证 token |
+| `OPENAI_API_KEY` | 设为任意值以兼容 SDK |
+
+## 配置示例
+
+### 开发环境（单用户）
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### 生产环境（多用户）
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --use-paged-cache \
+  --api-key your-secret-key \
+  --rate-limit 60 \
+  --port 8000
+```
+
+### 使用工具调用
+
+```bash
+vllm-mlx serve mlx-community/Devstral-Small-2507-4bit \
+  --enable-auto-tool-choice \
+  --tool-call-parser mistral \
+  --continuous-batching
+```
+
+### 使用 MCP 工具
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --mcp-config mcp.json \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen \
+  --continuous-batching
+```
+
+### 推理模型
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-8B-4bit \
+  --reasoning-parser qwen3 \
+  --continuous-batching
+```
+
+### 使用嵌入
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-4B-4bit \
+  --embedding-model mlx-community/multilingual-e5-small-mlx \
+  --continuous-batching
+```
+
+### 高吞吐量
+
+```bash
+vllm-mlx serve mlx-community/Qwen3-0.6B-8bit \
+  --continuous-batching \
+  --stream-interval 5 \
+  --max-num-seqs 256
+```

--- a/docs/zh/reference/models.md
+++ b/docs/zh/reference/models.md
@@ -1,0 +1,99 @@
+# 支持的模型
+
+所有来自 [mlx-community on HuggingFace](https://huggingface.co/mlx-community/models) 的量化模型均兼容。
+
+在以下地址浏览数千个预优化模型：**https://huggingface.co/mlx-community/models**
+
+## 语言模型（通过 mlx-lm）
+
+| 模型系列 | 规格 | 量化方式 |
+|--------------|-------|--------------|
+| Llama 3.x, 4.x | 1B, 3B, 8B, 70B | 4-bit |
+| Mistral / Devstral | 7B, Mixtral 8x7B | 4-bit, 8-bit |
+| Qwen2/Qwen3 | 0.5B 至 72B | 多种 |
+| DeepSeek V3, R1 | 7B, 33B, 67B | 4-bit |
+| Gemma 2, 3, 4 | 2B, 9B, 27B | 4-bit |
+| GLM-4.7 | Flash, Base | 4-bit, 8-bit |
+| Kimi K2 | 多种 | 4-bit |
+| Phi-3 | 3.8B, 14B | 4-bit |
+| Granite 3.x, 4.x | 多种 | 4-bit |
+| Nemotron | 3 Nano 30B | 6-bit |
+
+### 推荐模型
+
+| 使用场景 | 模型 | 内存 |
+|----------|-------|--------|
+| 快速/轻量 | `mlx-community/Qwen3-0.6B-8bit` | ~0.7 GB |
+| 均衡 | `mlx-community/Llama-3.2-3B-Instruct-4bit` | ~1.8 GB |
+| 高质量 | `mlx-community/Llama-3.1-8B-Instruct-4bit` | ~4.5 GB |
+| 大型 | `mlx-community/Qwen3-30B-A3B-4bit` | ~16 GB |
+
+## 多模态模型（通过 mlx-vlm）
+
+| 模型系列 | 示例模型 |
+|--------------|----------------|
+| **Qwen-VL** | `Qwen3-VL-4B-Instruct-3bit`, `Qwen3-VL-8B-Instruct-4bit`, `Qwen2-VL-2B/7B-Instruct-4bit` |
+| **LLaVA** | `llava-1.5-7b-4bit`, `llava-v1.6-mistral-7b-4bit`, `llava-llama-3-8b-v1_1-4bit` |
+| **Idefics** | `Idefics3-8B-Llama3-4bit`, `idefics2-8b-4bit` |
+| **Gemma 4** | `gemma-4-e2b-it-mxfp4`（视觉 + 音频） |
+| **PaliGemma** | `paligemma2-3b-mix-224-4bit`, `paligemma-3b-mix-224-8bit` |
+| **Pixtral** | `pixtral-12b-4bit`, `pixtral-12b-8bit` |
+| **Molmo** | `Molmo-7B-D-0924-4bit`, `Molmo-7B-D-0924-8bit` |
+| **Phi-3 Vision** | `Phi-3-vision-128k-instruct-4bit` |
+| **DeepSeek-VL** | `deepseek-vl-7b-chat-4bit`, `deepseek-vl2-small-4bit` |
+
+### 推荐 VLM 模型
+
+| 使用场景 | 模型 | 内存 |
+|----------|-------|--------|
+| 快速/轻量 | `mlx-community/Qwen3-VL-4B-Instruct-3bit` | ~3 GB |
+| 均衡 | `mlx-community/Qwen3-VL-8B-Instruct-4bit` | ~6 GB |
+| 高质量 | `mlx-community/Qwen3-VL-30B-A3B-Instruct-6bit` | ~20 GB |
+
+## Embedding 模型（通过 mlx-embeddings）
+
+| 模型系列 | 示例模型 |
+|--------------|----------------|
+| **BERT** | `mlx-community/bert-base-uncased-mlx` |
+| **XLM-RoBERTa** | `mlx-community/multilingual-e5-small-mlx`, `mlx-community/multilingual-e5-large-mlx` |
+| **ModernBERT** | `mlx-community/ModernBERT-base-mlx` |
+
+## 音频模型（通过 mlx-audio）
+
+| 类型 | 模型系列 | 示例模型 |
+|------|--------------|----------------|
+| **STT** | Whisper | `mlx-community/whisper-large-v3-turbo` |
+| **STT** | Parakeet | `mlx-community/parakeet-tdt-0.6b-v2` |
+| **TTS** | Kokoro | `prince-canuma/Kokoro-82M` |
+| **TTS** | Chatterbox | `chatterbox/chatterbox-tts-0.1` |
+
+## 模型自动检测
+
+vllm-mlx 通过名称模式自动检测多模态模型：
+- 包含 "VL"、"Vision"、"vision"
+- 包含 "llava"、"idefics"、"paligemma"
+- 包含 "pixtral"、"molmo"、"deepseek-vl"
+- 包含 "MedGemma"、"Gemma-3"、"Gemma-4"（多模态变体）
+
+## 使用模型
+
+### 从 HuggingFace 加载
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit
+```
+
+### 本地路径
+
+```bash
+vllm-mlx serve /path/to/local/model
+```
+
+## 查找模型
+
+按以下关键词筛选 mlx-community 模型：
+- **LLM**：`Llama`、`Qwen`、`Mistral`、`Phi`、`Gemma`、`DeepSeek`、`GLM`、`Kimi`、`Granite`、`Nemotron`
+- **VLM**：`-VL-`、`llava`、`paligemma`、`pixtral`、`molmo`、`idefics`、`deepseek-vl`、`MedGemma`
+- **Embedding**：`e5`、`bert`、`ModernBERT`
+- **规格**：`1B`、`3B`、`7B`、`8B`、`70B`
+- **量化方式**：`4bit`、`8bit`、`bf16`


### PR DESCRIPTION
## What

Refresh the English README and translate the entire documentation tree into Spanish, French, and Simplified Chinese. English stays as the default language; each translation lives in a sibling folder that mirrors the original structure. The language switcher appears at the top of every README and `index.md` across all four versions.

## Why

The previous README lagged the codebase by about 15 features shipped since the last edit (rerank endpoint, SSD KV cache tiering, bench-serve, structured output, Prometheus metrics, Gemma 4, warm-prompts, MoE top-k, MTP, SpecPrefill, and more). Benchmark numbers also drifted from the profiles recorded on 2026-04-18. At the same time, a large portion of the user base on Apple Silicon is outside the English-first Anglophone market (MLX adoption is strong in China, Japan, LatAm, and France), and the documentation was English-only. Translating the full docs tree raises conversion for Spanish, French, and Chinese audiences while the refreshed README gives new visitors a more accurate and compelling first impression.

## By the numbers

| Item | Count |
|------|------:|
| Files created | 69 |
| Files modified | 1 (README.md) |
| Languages supported | 4 (EN, ES, FR, ZH) |
| Features surfaced for the first time in the README | 15 |
| Benchmark rows refreshed | 3 |
| Previously unlinked guides now linked | 3 |
| Sections removed from the README | 1 (Gemma 3 monkey-patch, belongs in a dedicated guide) |
| Total translated lines | ~14,700 |
| Em dashes in any translated file | 0 (enforced) |
| Non-English content leaking into code blocks | 0 (verified) |

## README changes

### New tagline

> Continuous batching + OpenAI + Anthropic APIs in one server. Native Apple Silicon inference.

(Previous: *"vLLM-like inference for Apple Silicon - GPU-accelerated Text, Image, Video & Audio on Mac"*.)

### Badges

Replaced hand-rolled badges with real PyPI badges so version and monthly downloads update automatically.

| Kind | Status |
|------|--------|
| PyPI version | New, live |
| PyPI monthly downloads | New, live |
| Python 3.10+ | Kept |
| Apache 2.0 | Kept |
| Apple Silicon | Kept |
| GitHub stars | Kept |

### Features documented for the first time

| Area | Feature | Flag / Endpoint | Impact |
|------|---------|-----------------|--------|
| API | `/v1/rerank` | endpoint | Enables RAG reranking in-process |
| API | OpenAI `/v1/responses` | endpoint | OpenAI Responses API support |
| Throughput | SSD KV cache tiering | `--ssd-cache-dir`, `--ssd-cache-max-gb` | Prefix cache spills to disk for long-context agents |
| Throughput | Warm prompts | `--warm-prompts` | 1.3-2.25x TTFT speedup |
| Throughput | MoE expert reduction | `--moe-top-k` | +7 to +16% decode on Qwen3-30B-A3B |
| Decoding | Speculative decoding | `--mtp` | Supports Qwen3-Next |
| Decoding | Attention-based sparse prefill | `--spec-prefill` | Reduces TTFT |
| Decoding | Default sampling params | `--default-temperature`, `--default-top-p` | Server-level defaults |
| Decoding | Prefill chunk size | `--prefill-step-size` | Perf tuning |
| Output | Structured output | `response_format: json_schema` | JSON Schema via `lm-format-enforcer` |
| Multimodal | Audio input in chat | `audio_url` content block | Mirrors `image_url` |
| Multimodal | Gemma 4 vision | auto-detected | MLLM routing |
| Observability | Prometheus metrics | `--metrics` + `/metrics` | Production observability |
| Tooling | Built-in benchmarker | `vllm-mlx bench-serve` | Prompt sweeps with CSV/JSON output |
| Parsers | Tool-calling parsers (12) | `--tool-call-parser` | Full list now in README |

### Benchmark numbers refreshed

Source: `benchmarks/profile_*_20260418.md` (M4 Max, 128 GB, greedy, single stream).

| Model | Before | After | Memory |
|-------|-------:|------:|-------:|
| Qwen3-0.6B-8bit | 402 tok/s | **417.9 tok/s** | 0.7 GB |
| Llama-3.2-3B-Instruct-4bit | 200 tok/s | **205.6 tok/s** | 1.8 GB |
| Qwen3-30B-A3B-4bit | *missing* | **127.7 tok/s** | ~18 GB |

Audio STT row (whisper RTF on M4 Max) kept and retitled for clarity.

### Other edits

- **Architecture diagram** updated to surface SSD tiering and `/v1/rerank` in the service layer.
- **vLLM acknowledgment** clarified. The line now reads: *vllm-mlx is inspired by vLLM and adopts its continuous-batching and paged KV-cache design for Apple Silicon via MLX*. This was requested to make the design lineage explicit rather than implicit in the project name.
- **Gemma 3 long-context monkey-patch** section removed (~55 lines). The instructions to edit `mlx-vlm` internals belong in a focused guide, not on the landing page. No functional loss; the env var (`GEMMA3_SLIDING_WINDOW`) is still honored by the code.
- **Star history chart** and a star CTA added at the bottom.
- **Docs cross-links:** three previously unlinked guides are now reachable from the README:
  - `docs/guides/tool-calling.md`
  - `docs/guides/warm-prompts.md`
  - `docs/guides/moe-top-k.md`
- **Badges** and **quickstart** moved up so the 30-second install flow is visible without scrolling.

## Translations

### Folder layout

```
README.md           English (default)
README.es.md        Spanish
README.fr.md        French
README.zh.md        Simplified Chinese

docs/               English (default, unchanged)
docs/es/            Spanish mirror
docs/fr/            French mirror
docs/zh/            Simplified Chinese mirror
```

`docs/development/` and `docs/plans/` are intentionally not translated: the former is internal contributor docs, the latter is gitignored.

### Per-folder coverage

Each language folder contains 22 files in five groups:

| Subfolder | Files | Notes |
|-----------|------:|-------|
| `getting-started/` | 2 | installation, quickstart |
| `guides/` | 11 | server, python-api, multimodal, reasoning, audio, embeddings, mcp-tools, tool-calling, continuous-batching, warm-prompts, moe-top-k |
| `reference/` | 3 | cli, configuration, models |
| `benchmarks/` | 5 | README, llm, audio, image, video |
| root | 1 | index |

### Translation rules applied (enforced across all 69 files)

1. **Code blocks are byte-for-byte identical to the English source.** No translation of commands, flags, environment variables, JSON keys, model names, Python APIs, or shell scripts.
2. **URLs and relative link paths are preserved.** An image URL like `https://example.com/cat.jpg` stays `cat.jpg`, not a translated variant.
3. **JSON Schema property keys and CLI flags stay in English.** `"colors"` is not translated to `"colores"` or `"couleurs"`; `--continuous-batching` is not translated.
4. **Tech terms kept in English** where they are the established form in each language's ML community: `continuous batching`, `prefix cache`, `paged KV cache`, `KV cache`, `streaming`, `tool use`, `tool calling`, `embeddings`, `reasoning`, `LLM`, `VLM`, `MoE`, `TTS`, `STT`, `RTF`, `tok/s`, `TTFT`, `greedy`, `Metal`, `MLX`, `throughput`.
5. **No em dashes** and no double-hyphen joiners. Replaced with periods, commas, or colons.
6. **No emojis added** to the content.
7. **Prose string literals** inside illustrative code examples (e.g. `"Hello!"` to `"Hola!"`) may be localized because they are pedagogical, never configuration values.

### Per-language specifics

**Spanish (ES).** Neutral Latin American register (no `vosotros`, no regional slang). Proper accents restored everywhere after an automated cleanup pass fixed stripped accents (`rápido`, `más`, `también`, `función`, `análisis`, `conclusión`, `configuración`, `métricas`, `parámetros`, `código`, etc.).

**French (FR).** Typographic spacing before `:`, `;`, `?`, `!` applied throughout prose. A cleanup pass replaced every double-hyphen used as a sentence joiner with a period or comma.

**Simplified Chinese (ZH).** Full-width punctuation (`。，：；、`) used in prose; half-width kept in code blocks, CLI examples, and numeric tables. Tech terms kept in English per the Chinese ML community's norm.

### Quality control

- Every English source was read by the translating agent in full, not summarized.
- Each translation was verified by an independent agent against the English source for: completeness, URL integrity, JSON-key integrity, code-block identity, em dashes, emojis, and tech-term preservation.
- Issues found and fixed in this PR:
  - ES: URL `gato.jpg` reverted to `cat.jpg` (accidental translation).
  - ES: JSON key `"colores"` reverted to `"colors"`.
  - FR: URL `chat.jpg` reverted to `cat.jpg`.
  - FR: JSON key `"couleurs"` reverted to `"colors"`.
  - ES: Stripped accents restored by automated pass across 12 files.
  - FR: Double-hyphen joiners replaced with periods across 2 files.
  - ES / ZH: Stray long dashes replaced with a regular hyphen in tables or a period in prose.

### Known nuances left as-is

- `docs/fr/benchmarks/llm.md` and `docs/fr/benchmarks/audio.md` keep French decimal commas (`46,7` instead of `46.7`) in a couple of cells. This is correct French typography. If copy-paste compatibility with the English source is preferred here, a follow-up PR can normalize these to English decimals.
- A few ZH files (`moe-top-k.md`, `warm-prompts.md`) render with fewer lines than the English source because Chinese prose is more compact; content is complete and markdown renders identically.

## Layout change

```
 README.md              (modified: full rewrite, ~302 lines)
+README.es.md           (new)
+README.fr.md           (new)
+README.zh.md           (new)
+docs/es/               (new folder, 22 files)
+docs/fr/               (new folder, 22 files)
+docs/zh/               (new folder, 22 files)
```

No source code, tests, benchmarks, or configuration files are touched.

## Before merge

Recommended quick checks on GitHub after the PR is open:
1. Open `README.es.md`, `README.fr.md`, `README.zh.md` and confirm the language-switcher links resolve.
2. Copy the `pip install` and `vllm-mlx serve` commands from any non-English README and verify they run.
3. Spot-check one file per language (e.g. `docs/es/guides/server.md`, `docs/fr/guides/server.md`, `docs/zh/guides/server.md`) for rendering.