### PR TITLE
fix(simple): preserve mtp after successful specprefill

### DIFF
--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -92,3 +92,35 @@ class TestBatchedEngineGenerate:
         assert result.prompt_tokens == 7
         assert result.completion_tokens == 1
         assert result.finish_reason == "stop"
+
+
+class TestBatchedEngineCacheRestore:
+    def _make_mllm_engine(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=True):
+            engine = BatchedEngine("test-mllm")
+
+        engine._loaded = True
+        engine._is_mllm = True
+        return engine
+
+    def test_load_cache_from_disk_bootstraps_mllm_batch_generator(self):
+        engine = self._make_mllm_engine()
+
+        prefix_cache = MagicMock()
+        prefix_cache.load_from_disk.return_value = 2
+        scheduler = MagicMock()
+        scheduler.batch_generator = None
+
+        def ensure_batch_generator():
+            scheduler.batch_generator = MagicMock(prefix_cache=prefix_cache)
+
+        scheduler._ensure_batch_generator.side_effect = ensure_batch_generator
+        engine._mllm_scheduler = scheduler
+
+        loaded = engine.load_cache_from_disk("/tmp/cache")
+
+        assert loaded == 2
+        scheduler._ensure_batch_generator.assert_called_once_with()
+        prefix_cache.load_from_disk.assert_called_once_with("/tmp/cache")

--- a/tests/test_engine_core_thread_streams.py
+++ b/tests/test_engine_core_thread_streams.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for MLX stream/thread ownership in engine loops."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _SchedulerOutput:
+    outputs = []
+    finished_request_ids = []
+
+
+@pytest.mark.anyio
+async def test_engine_core_runs_all_scheduler_steps_on_one_worker_thread(monkeypatch):
+    """Continuous batching must not bounce MLX steps across threads."""
+    from vllm_mlx.engine_core import EngineConfig, EngineCore
+
+    engine = object.__new__(EngineCore)
+    engine.config = EngineConfig(step_interval=0, stream_interval=1)
+    engine._running = True
+    engine._steps_executed = 0
+    engine._output_collectors = {}
+    engine._stream_states = {}
+    engine._finished_events = {}
+
+    main_thread = threading.get_ident()
+    bind_threads: list[int] = []
+
+    class FakeScheduler:
+        batch_generator = SimpleNamespace(_partial=None)
+
+        def __init__(self):
+            self.calls = 0
+            self.step_threads: list[int] = []
+            self.close_threads: list[int] = []
+
+        def has_requests(self):
+            return self.calls < 3
+
+        def step(self):
+            self.step_threads.append(threading.get_ident())
+            self.calls += 1
+            if self.calls == 3:
+                engine._running = False
+            return _SchedulerOutput()
+
+        def _close_batch_generator(self):
+            self.close_threads.append(threading.get_ident())
+
+    scheduler = FakeScheduler()
+    engine.scheduler = scheduler
+
+    def bind_streams():
+        bind_threads.append(threading.get_ident())
+
+    monkeypatch.setattr("vllm_mlx.engine_core.bind_generation_streams", bind_streams)
+
+    await asyncio.wait_for(engine._engine_loop(), timeout=2)
+
+    assert scheduler.step_threads
+    assert len(set(scheduler.step_threads)) == 1
+    assert scheduler.step_threads[0] != main_thread
+    assert bind_threads == [scheduler.step_threads[0]]
+    assert scheduler.close_threads == [scheduler.step_threads[0]]
+
+
+@pytest.mark.anyio
+async def test_mllm_scheduler_runs_all_steps_on_one_worker_thread(monkeypatch):
+    """MLLM scheduler loop follows the same thread-local stream invariant."""
+    from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+    scheduler = object.__new__(MLLMScheduler)
+    scheduler._running = True
+
+    main_thread = threading.get_ident()
+    bind_threads: list[int] = []
+    step_threads: list[int] = []
+    close_threads: list[int] = []
+
+    class FakeBatchGenerator:
+        _partial = None
+
+        def close(self):
+            close_threads.append(threading.get_ident())
+
+    scheduler.batch_generator = FakeBatchGenerator()
+
+    def has_requests():
+        return len(step_threads) < 3
+
+    def step():
+        step_threads.append(threading.get_ident())
+        if len(step_threads) == 3:
+            scheduler._running = False
+
+    def bind_streams():
+        bind_threads.append(threading.get_ident())
+
+    scheduler.has_requests = has_requests
+    scheduler.step = step
+    monkeypatch.setattr("vllm_mlx.mllm_scheduler.bind_generation_streams", bind_streams)
+
+    await asyncio.wait_for(scheduler._process_loop(), timeout=2)
+
+    assert step_threads
+    assert len(set(step_threads)) == 1
+    assert step_threads[0] != main_thread
+    assert bind_threads == [step_threads[0]]
+    assert close_threads == [step_threads[0]]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,8 @@
 
 import platform
 import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -49,6 +51,31 @@ def test_model_repr():
     assert "MLXLanguageModel" in repr_str
     assert "test-model" in repr_str
     assert "not loaded" in repr_str
+
+
+def test_model_stream_generate_passes_num_draft_tokens():
+    """Native MTP path should forward configured draft depth to mlx_lm."""
+    from vllm_mlx.models.llm import MLXLanguageModel
+
+    model = MLXLanguageModel("test-model", mtp=True, mtp_num_draft_tokens=4)
+    model._loaded = True
+    model.model = object()
+    tokenizer = MagicMock()
+    tokenizer.encode.return_value = [1, 2, 3]
+    model.tokenizer = tokenizer
+
+    captured_kwargs = {}
+
+    def fake_stream_generate(_model, _tokenizer, **kwargs):
+        captured_kwargs.update(kwargs)
+        yield SimpleNamespace(text="Hello")
+
+    with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
+        chunks = list(model.stream_generate("Hello", max_tokens=8))
+
+    assert chunks[-1].text == "Hello"
+    assert captured_kwargs["mtp"] is True
+    assert captured_kwargs["num_draft_tokens"] == 4
 
 
 @pytest.mark.slow

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -13,6 +13,7 @@ Test Cases:
 - Mixed text-only and multimodal requests
 """
 
+import asyncio
 import base64
 import os
 import tempfile
@@ -738,10 +739,56 @@ class TestMLLMBatchGeneratorMTPGuards:
         language_model.assert_not_called()
         language_model.mtp_forward.assert_not_called()
 
+    def test_next_drops_retired_processors_and_makes_request_mtp_eligible(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class RetiredProcessor:
+            is_retired = True
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._stats = MLLMBatchStats()
+        generator.stop_tokens = set()
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator._maybe_store_prefix_cache = lambda batch, end_idx: None
+        generator._step = lambda *args, **kwargs: (
+            mx.array([11]),
+            [mx.array([0.2, 0.8])],
+        )
+
+        request = MLLMBatchRequest(uid=1, request_id="req-1", prompt="hello")
+        generator.active_batch = MLLMBatch(
+            uids=[1],
+            request_ids=["req-1"],
+            y=mx.array([7]),
+            logprobs=[mx.array([0.5, 0.5])],
+            max_tokens=[4],
+            num_tokens=[0],
+            cache=[],
+            requests=[request],
+            logits_processors=[[RetiredProcessor()]],
+            samplers=None,
+        )
+
+        responses = MLLMBatchGenerator._next(generator)
+
+        assert len(responses) == 1
+        assert generator.active_batch is not None
+        assert generator.active_batch.logits_processors == [None]
+
 
 class TestBatchedMLLMConfigWiring:
-    @pytest.mark.asyncio
-    async def test_batched_engine_forwards_prefill_step_size_to_mllm_scheduler(
+    def test_batched_engine_forwards_prefill_step_size_to_mllm_scheduler(
         self, monkeypatch
     ):
         from vllm_mlx.engine.batched import BatchedEngine
@@ -795,6 +842,6 @@ class TestBatchedMLLMConfigWiring:
             force_mllm=True,
         )
 
-        await engine._start_mllm()
+        asyncio.run(engine._start_mllm())
 
         assert captured["config_kwargs"]["prefill_step_size"] == 256

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -646,3 +646,155 @@ class TestMLLMSchedulerIntegration:
 # Run tests
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestMLLMBatchGeneratorMTPGuards:
+    def test_install_mtp_mllm_disables_mtp_when_logits_processors_active(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        expected_tokens = mx.array([7])
+        expected_logprobs = [mx.array([0.1, 0.9])]
+        original_step = MagicMock(return_value=(expected_tokens, expected_logprobs))
+
+        class FakeBatchGen:
+            def __init__(self):
+                self._step = original_step
+                self._next = MagicMock(return_value=[])
+                self.active_batch = MagicMock()
+                self.active_batch.__len__.return_value = 1
+                self.active_batch.requests = [
+                    MagicMock(
+                        temperature=0.0,
+                        top_p=1.0,
+                        top_k=0,
+                        min_p=0.0,
+                    )
+                ]
+                self.sampler = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        language_model = MagicMock()
+
+        install_mtp_mllm(batch_gen, language_model, num_draft_tokens=4)
+
+        logits_processor = MagicMock()
+        tokens, logprobs = batch_gen._step(
+            mx.array([[123]]),
+            cache=[],
+            logits_processors=[[logits_processor]],
+            output_tokens=[[1, 2]],
+            samplers=[None],
+        )
+
+        assert tokens.tolist() == expected_tokens.tolist()
+        assert [lp.tolist() for lp in logprobs] == [
+            lp.tolist() for lp in expected_logprobs
+        ]
+        original_step.assert_called_once()
+        language_model.assert_not_called()
+        language_model.mtp_forward.assert_not_called()
+
+    def test_install_mtp_mllm_disables_mtp_for_non_greedy_sampling(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        expected_tokens = mx.array([11])
+        expected_logprobs = [mx.array([0.3, 0.7])]
+        original_step = MagicMock(return_value=(expected_tokens, expected_logprobs))
+
+        class FakeBatchGen:
+            def __init__(self):
+                self._step = original_step
+                self._next = MagicMock(return_value=[])
+                self.active_batch = MagicMock()
+                self.active_batch.__len__.return_value = 1
+                self.active_batch.requests = [
+                    MagicMock(
+                        temperature=0.6,
+                        top_p=0.95,
+                        top_k=20,
+                        min_p=0.0,
+                    )
+                ]
+                self.sampler = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        language_model = MagicMock()
+
+        install_mtp_mllm(batch_gen, language_model, num_draft_tokens=4)
+
+        tokens, logprobs = batch_gen._step(
+            mx.array([[321]]),
+            cache=[],
+            logits_processors=None,
+            output_tokens=None,
+            samplers=[MagicMock()],
+        )
+
+        assert tokens.tolist() == expected_tokens.tolist()
+        assert [lp.tolist() for lp in logprobs] == [
+            lp.tolist() for lp in expected_logprobs
+        ]
+        original_step.assert_called_once()
+        language_model.assert_not_called()
+        language_model.mtp_forward.assert_not_called()
+
+
+class TestBatchedMLLMConfigWiring:
+    @pytest.mark.asyncio
+    async def test_batched_engine_forwards_prefill_step_size_to_mllm_scheduler(
+        self, monkeypatch
+    ):
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        captured = {}
+
+        class FakeMLXMultimodalLM:
+            def __init__(self, model_name, trust_remote_code=True):
+                self.model_name = model_name
+                self.model = object()
+                self.processor = object()
+
+            def load(self):
+                return None
+
+        class FakeMLLMSchedulerConfig:
+            def __init__(self, **kwargs):
+                captured["config_kwargs"] = kwargs
+                self.__dict__.update(kwargs)
+
+        class FakeMLLMScheduler:
+            def __init__(self, model, processor, config):
+                captured["scheduler_config"] = config
+
+            async def start(self):
+                return None
+
+        import vllm_mlx.engine.batched as batched_mod
+        import vllm_mlx.mllm_scheduler as mllm_sched_mod
+        import vllm_mlx.models.mllm as mllm_model_mod
+
+        monkeypatch.setattr(mllm_model_mod, "MLXMultimodalLM", FakeMLXMultimodalLM)
+        monkeypatch.setattr(mllm_sched_mod, "MLLMScheduler", FakeMLLMScheduler)
+        monkeypatch.setattr(
+            mllm_sched_mod, "MLLMSchedulerConfig", FakeMLLMSchedulerConfig
+        )
+        monkeypatch.setattr(
+            batched_mod.BatchedEngine, "_inject_mtp_mllm", lambda self: None
+        )
+
+        cfg = SchedulerConfig(
+            prefill_batch_size=4,
+            completion_batch_size=8,
+            prefill_step_size=256,
+            enable_mtp=False,
+        )
+        engine = BatchedEngine(
+            model_name="fake-qwen",
+            scheduler_config=cfg,
+            force_mllm=True,
+        )
+
+        await engine._start_mllm()
+
+        assert captured["config_kwargs"]["prefill_step_size"] == 256

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -739,6 +739,71 @@ class TestMLLMBatchGeneratorMTPGuards:
         language_model.assert_not_called()
         language_model.mtp_forward.assert_not_called()
 
+    def test_install_mtp_mllm_accepted_drafts_bypass_request_sampler(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, install_mtp_mllm
+
+        class FakeBatchGen:
+            def __init__(self):
+                self._step = MagicMock()
+                self._next = MagicMock(
+                    return_value=[
+                        MLLMBatchResponse(
+                            uid=7,
+                            request_id="req-7",
+                            token=1,
+                            logprobs=mx.array([0.0, 0.0, 0.0, 0.0, 0.0]),
+                            finish_reason=None,
+                        )
+                    ]
+                )
+                self.active_batch = MagicMock()
+                self.active_batch.__len__.return_value = 1
+                self.active_batch.uids = [7]
+                request = MagicMock(
+                    request_id="req-7",
+                    temperature=0.0,
+                    top_p=1.0,
+                    top_k=0,
+                    min_p=0.0,
+                    output_tokens=[],
+                )
+                self.active_batch.requests = [request]
+                self.active_batch.num_tokens = [0]
+                self.active_batch.max_tokens = [16]
+                self.stop_tokens = set()
+                self.sampler = MagicMock(return_value=mx.array([1], dtype=mx.uint32))
+                self._maybe_store_prefix_cache = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        request_sampler = MagicMock(return_value=mx.array([1], dtype=mx.uint32))
+
+        class FakeLanguageModel:
+            def mtp_forward(self, hidden_states, next_token_ids, mtp_cache=None):
+                logits = mx.full((1, 1, 5), -1000.0)
+                logits[:, :, 2] = 0.0
+                return logits
+
+            def __call__(self, verify_input, cache=None, return_hidden=False):
+                logits = mx.full((1, 2, 5), -1000.0)
+                logits[:, 0, 2] = 0.0
+                logits[:, 1, 3] = 0.0
+                return logits, mx.zeros((1, 2, 4))
+
+        install_mtp_mllm(batch_gen, FakeLanguageModel(), num_draft_tokens=1)
+
+        batch_gen._step(
+            mx.array([[123]], dtype=mx.uint32),
+            cache=[],
+            logits_processors=None,
+            output_tokens=[[]],
+            samplers=[request_sampler],
+        )
+        responses = batch_gen._next()
+
+        assert [r.token for r in responses] == [1, 2]
+        assert request_sampler.call_count == 1
+        assert batch_gen.sampler.call_count == 0
+
     def test_next_drops_retired_processors_and_makes_request_mtp_eligible(self):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatch,

--- a/tests/test_server_cache_controls.py
+++ b/tests/test_server_cache_controls.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for cache control endpoints."""
+
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+
+def test_cache_stats_includes_engine_cache(monkeypatch):
+    import vllm_mlx.server as server
+
+    fake_utils = types.ModuleType("mlx_vlm.utils")
+    fake_utils.get_multimodal_kv_cache_stats = lambda: {"entries": 1}
+    fake_utils.get_pixel_values_cache_stats = lambda: {"entries": 2}
+    fake_utils.get_pil_cache_stats = lambda: {"entries": 3}
+
+    class DummyEngine:
+        def get_cache_stats(self):
+            return {"prefix_cache": {"hits": 7, "misses": 2}}
+
+    original_engine = server._engine
+    original_api_key = server._api_key
+    original_module = sys.modules.get("mlx_vlm.utils")
+    try:
+        server._engine = DummyEngine()
+        server._api_key = None
+        sys.modules["mlx_vlm.utils"] = fake_utils
+        client = TestClient(server.app)
+
+        response = client.get("/v1/cache/stats")
+        assert response.status_code == 200
+        assert response.json()["engine_cache"] == {
+            "prefix_cache": {"hits": 7, "misses": 2}
+        }
+    finally:
+        server._engine = original_engine
+        server._api_key = original_api_key
+        if original_module is not None:
+            sys.modules["mlx_vlm.utils"] = original_module
+        else:
+            sys.modules.pop("mlx_vlm.utils", None)
+
+
+def test_clear_cache_clears_engine_managed_runtime_caches(monkeypatch):
+    import vllm_mlx.server as server
+
+    calls = {"multimodal": 0, "pixel": 0, "engine": 0}
+    fake_utils = types.ModuleType("mlx_vlm.utils")
+
+    def clear_multimodal():
+        calls["multimodal"] += 1
+
+    def clear_pixel():
+        calls["pixel"] += 1
+
+    fake_utils.clear_multimodal_kv_cache = clear_multimodal
+    fake_utils.clear_pixel_values_cache = clear_pixel
+
+    class DummyEngine:
+        def clear_runtime_caches(self):
+            calls["engine"] += 1
+            return {"prefix_cache": True}
+
+    original_engine = server._engine
+    original_api_key = server._api_key
+    original_module = sys.modules.get("mlx_vlm.utils")
+    try:
+        server._engine = DummyEngine()
+        server._api_key = None
+        sys.modules["mlx_vlm.utils"] = fake_utils
+        client = TestClient(server.app)
+
+        response = client.delete("/v1/cache")
+        assert response.status_code == 200
+        assert response.json()["engine_cache"] == {"prefix_cache": True}
+        assert calls == {"multimodal": 1, "pixel": 1, "engine": 1}
+    finally:
+        server._engine = original_engine
+        server._api_key = original_api_key
+        if original_module is not None:
+            sys.modules["mlx_vlm.utils"] = original_module
+        else:
+            sys.modules.pop("mlx_vlm.utils", None)

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -781,6 +781,152 @@ class TestSimpleEngineConcurrency:
         assert captured_kwargs["num_draft_tokens"] == 4
 
     @pytest.mark.anyio
+    async def test_stream_generate_text_reenables_mtp_after_retired_processor(self):
+        """Retired thinking processors should hand off the content phase to MTP."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        calls = []
+
+        class RetiringProcessor:
+            def __init__(self):
+                self.is_retired = False
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        processor = RetiringProcessor()
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            if len(calls) == 1:
+                processor.is_retired = True
+                yield SimpleNamespace(token=11, text="Hello", finish_reason=None)
+            else:
+                yield SimpleNamespace(token=12, text=" world", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+        tokenizer.encode.return_value = [11]
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            mtp=True,
+            mtp_num_draft_tokens=4,
+        )
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_model.make_mtp_cache.return_value = []
+        engine._text_tokenizer = tokenizer
+
+        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate), patch(
+            "mlx_lm.models.cache.make_prompt_cache", return_value=[]
+        ), patch("mlx_lm.models.cache.trim_prompt_cache"):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                    logits_processors=[processor],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello world"
+        assert len(calls) == 2
+        assert "mtp" not in calls[0]
+        assert calls[0]["logits_processors"][0] is processor
+        assert calls[1]["mtp"] is True
+        assert calls[1]["num_draft_tokens"] == 4
+        assert "logits_processors" not in calls[1]
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(self):
+        """SpecPrefill continuation should resume with MTP once thinking retires."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        calls = []
+
+        class RetiringProcessor:
+            def __init__(self):
+                self.is_retired = False
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        processor = RetiringProcessor()
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            calls.append({"prompt": prompt, **kwargs})
+            yield SimpleNamespace(token=12, text=" world", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+        tokenizer.encode.return_value = [1, 2, 3, 4]
+        tokenizer.decode.side_effect = lambda toks: "Hello" if toks == [11] else ""
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            mtp=True,
+            mtp_num_draft_tokens=4,
+            specprefill_enabled=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_model.make_mtp_cache.return_value = []
+        engine._text_tokenizer = tokenizer
+
+        def fake_sample(tokens, logits, sampler, logits_processors):
+            processor.is_retired = True
+            return mx.array(11, dtype=mx.uint32), logits
+
+        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate), patch(
+            "mlx_lm.models.cache.make_prompt_cache", return_value=[]
+        ), patch(
+            "vllm_mlx.specprefill.score_tokens", return_value=mx.array([0.1, 0.2])
+        ), patch(
+            "vllm_mlx.specprefill.select_chunks", return_value=mx.array([0, 1])
+        ), patch(
+            "vllm_mlx.specprefill.sparse_prefill",
+            return_value=mx.zeros((1, 1, 32)),
+        ), patch(
+            "vllm_mlx.specprefill.cleanup_rope"
+        ), patch(
+            "vllm_mlx.engine.simple._sample_with_processors",
+            side_effect=fake_sample,
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                    specprefill=True,
+                    logits_processors=[processor],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello world"
+        assert len(calls) == 1
+        assert calls[0]["mtp"] is True
+        assert calls[0]["num_draft_tokens"] == 4
+        assert "logits_processors" not in calls[0]
+
+    @pytest.mark.anyio
     async def test_cancellation_does_not_release_lock_before_worker_finishes(
         self, mock_llm_model
     ):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -270,6 +270,95 @@ class TestSimpleEngineConcurrency:
             assert isinstance(engine._generation_lock, asyncio.Lock)
 
     @pytest.mark.anyio
+    async def test_run_blocking_serialized_rebinds_worker_generation_streams(self):
+        """Worker-thread MLX generation should get fresh thread-local streams."""
+        import importlib
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        mlx_lm_generate = importlib.import_module("mlx_lm.generate")
+        sentinel_stream = object()
+
+        with (
+            patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False),
+            patch("vllm_mlx.engine.simple.mx.default_device", return_value="gpu"),
+            patch(
+                "vllm_mlx.engine.simple.mx.new_stream",
+                return_value=sentinel_stream,
+            ),
+            patch("vllm_mlx.engine.simple.mx.set_default_stream"),
+        ):
+            engine = SimpleEngine("test-model")
+            observed = await engine._run_blocking_serialized(
+                lambda: mlx_lm_generate.generation_stream
+            )
+
+        assert observed is sentinel_stream
+
+    @pytest.mark.anyio
+    async def test_start_keeps_text_routing_for_mllm_without_mtp(self):
+        """MLLM text-only routing must stay available when MTP is disabled."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        text_model = MagicMock()
+        text_model.mtp = None
+        tokenizer = MagicMock()
+        tokenizer.convert_tokens_to_ids.return_value = 42
+
+        mock_mllm = MagicMock()
+        mock_mllm.model = MagicMock()
+        mock_mllm.get_tokenizer.return_value = tokenizer
+
+        with (
+            patch(
+                "vllm_mlx.models.mllm.MLXMultimodalLM",
+                return_value=mock_mllm,
+            ),
+            patch(
+                "vllm_mlx.text_model_from_vlm.build_text_model",
+                return_value=text_model,
+            ),
+        ):
+            engine = SimpleEngine("qwen3.6-27b", force_mllm=True, mtp=False)
+            await engine.start()
+
+        assert engine._text_model is text_model
+        assert engine._text_tokenizer is tokenizer
+
+    @pytest.mark.anyio
+    async def test_mllm_nonstream_text_only_routes_without_mtp(self):
+        """Non-stream text-only MLLM chat must aggregate the TextModel route."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        async def fake_stream_chat(*args, **kwargs):
+            yield MagicMock(
+                text="Hello",
+                tokens=[1],
+                prompt_tokens=5,
+                completion_tokens=1,
+                finish_reason="stop",
+                finished=True,
+            )
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._model = MagicMock()
+        engine.stream_chat = fake_stream_chat  # type: ignore[method-assign]
+
+        output = await engine.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=16,
+        )
+
+        assert output.text == "Hello"
+        assert output.tokens == [1]
+        assert output.prompt_tokens == 5
+        assert output.completion_tokens == 1
+        assert output.finish_reason == "stop"
+        engine._model.chat.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_requests_complete_in_order(self, mock_model):
         """Test that concurrent requests complete (may be in any order due to lock)."""
         from vllm_mlx.engine.simple import SimpleEngine
@@ -374,6 +463,216 @@ class TestSimpleEngineConcurrency:
 
         assert output.text == ""
         assert output.finish_reason == "stop"
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_forwards_logits_processors_and_sampler_args(
+        self,
+    ):
+        """Text routing must preserve request-local decoding controls."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_kwargs = {}
+        sampler_calls = []
+        penalty_calls = []
+        user_processor = MagicMock()
+        penalty_processor = MagicMock()
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        def fake_make_sampler(**kwargs):
+            sampler_calls.append(kwargs)
+            return MagicMock()
+
+        def fake_make_logits_processors(**kwargs):
+            penalty_calls.append(kwargs)
+            return [penalty_processor]
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        engine._text_tokenizer = tokenizer
+
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("mlx_lm.sample_utils.make_sampler", side_effect=fake_make_sampler),
+            patch(
+                "mlx_lm.sample_utils.make_logits_processors",
+                side_effect=fake_make_logits_processors,
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.3,
+                    top_p=0.8,
+                    top_k=40,
+                    min_p=0.1,
+                    presence_penalty=1.5,
+                    repetition_penalty=1.2,
+                    logits_processors=[user_processor],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert sampler_calls == [
+            {"temp": 0.3, "top_p": 0.8, "top_k": 40, "min_p": 0.1}
+        ]
+        assert penalty_calls == [
+            {"repetition_penalty": 1.2, "presence_penalty": 1.5}
+        ]
+        assert captured_kwargs["logits_processors"] == [
+            user_processor,
+            penalty_processor,
+        ]
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_disables_mtp_when_logits_processors_active(
+        self,
+    ):
+        """Custom logits processors must fail closed to non-MTP decoding."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_kwargs = {}
+        user_processor = MagicMock()
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=True)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_tokenizer = tokenizer
+
+        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                    logits_processors=[user_processor],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert "mtp" not in captured_kwargs
+        assert captured_kwargs["logits_processors"][0] is user_processor
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_keeps_mtp_for_budget_only_thinking_processor(
+        self,
+    ):
+        """Budget-only ThinkingAwareLogitsProcessor should not disable MTP."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_kwargs = {}
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=True)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_tokenizer = tokenizer
+
+        thinking_proc = MagicMock()
+
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch(
+                "vllm_mlx.engine.simple._only_mtp_safe_thinking_processors",
+                return_value=True,
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                    logits_processors=[thinking_proc],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert captured_kwargs["mtp"] is True
+        assert captured_kwargs["logits_processors"][0] is thinking_proc
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_passes_num_draft_tokens(self):
+        """Text routing should forward configured MTP draft depth."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_kwargs = {}
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            mtp=True,
+            mtp_num_draft_tokens=4,
+        )
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_tokenizer = tokenizer
+
+        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert captured_kwargs["mtp"] is True
+        assert captured_kwargs["num_draft_tokens"] == 4
 
     @pytest.mark.anyio
     async def test_cancellation_does_not_release_lock_before_worker_finishes(

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -464,6 +464,122 @@ class TestSimpleEngineConcurrency:
         assert output.text == ""
         assert output.finish_reason == "stop"
 
+    def test_seed_logits_processors_prepends_prompt_tokens(self):
+        """Continuation decode processors must see the original prompt prefix."""
+        from vllm_mlx.engine.simple import _seed_logits_processors
+
+        seen = {}
+
+        def processor(tokens, logits):
+            seen["tokens"] = tokens.tolist()
+            return logits
+
+        seeded = _seed_logits_processors(
+            mx.array([10, 11], dtype=mx.uint32), [processor]
+        )
+
+        logits = mx.zeros((1, 8), dtype=mx.float32)
+        seeded[0](mx.array([12, 13], dtype=mx.uint32), logits)
+
+        assert seen["tokens"] == [10, 11, 12, 13]
+
+    @pytest.mark.anyio
+    async def test_specprefill_success_preserves_mtp_path(self):
+        """Successful sparse prefill should continue through the normal MTP path."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured = {}
+
+        def fake_make_sampler(**kwargs):
+            captured["sampler_kwargs"] = kwargs
+
+            def _sample(_logprobs):
+                return mx.array([17], dtype=mx.uint32)
+
+            return _sample
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured["prompt"] = prompt.tolist()
+            captured["kwargs"] = kwargs
+            yield SimpleNamespace(text="B", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 99
+        tokenizer.encode.return_value = [5, 6, 7]
+        tokenizer.decode.side_effect = lambda ids: "".join(
+            {17: "A", 99: ""}.get(tok, f"<{tok}>") for tok in ids
+        )
+
+        text_model = MagicMock()
+        text_model.mtp = object()
+        text_model.make_mtp_cache.return_value = ["mtp-cache"]
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            mtp=True,
+            mtp_num_draft_tokens=4,
+            specprefill_enabled=True,
+            specprefill_threshold=1,
+        )
+        engine._loaded = True
+        engine._text_model = text_model
+        engine._text_tokenizer = tokenizer
+        engine._draft_model = object()
+
+        with (
+            patch("vllm_mlx.engine.simple._bind_worker_generation_streams"),
+            patch(
+                "mlx_lm.models.cache.make_prompt_cache",
+                return_value=["backbone-cache"],
+            ),
+            patch("mlx_lm.sample_utils.make_sampler", side_effect=fake_make_sampler),
+            patch(
+                "mlx_lm.sample_utils.make_logits_processors",
+                return_value=[],
+            ),
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch(
+                "vllm_mlx.specprefill.score_tokens",
+                return_value=mx.array([1.0, 0.9, 0.8], dtype=mx.float32),
+            ),
+            patch(
+                "vllm_mlx.specprefill.select_chunks",
+                return_value=mx.array([0, 1, 2], dtype=mx.int32),
+            ),
+            patch(
+                "vllm_mlx.specprefill.sparse_prefill",
+                return_value=mx.zeros((1, 3, 32), dtype=mx.float32),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=4,
+                    temperature=0.6,
+                    top_p=0.95,
+                )
+            ]
+
+        assert [chunk.new_text for chunk in outputs] == ["A", "B"]
+        assert captured["sampler_kwargs"] == {
+            "temp": 0.6,
+            "top_p": 0.95,
+            "top_k": 0,
+            "min_p": 0.0,
+        }
+        assert captured["prompt"] == [17]
+        assert captured["kwargs"]["mtp"] is True
+        assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
+        assert captured["kwargs"]["max_tokens"] == 3
+        assert captured["kwargs"]["logits_processors"] is None
+
     @pytest.mark.anyio
     async def test_stream_generate_text_forwards_logits_processors_and_sampler_args(
         self,
@@ -526,12 +642,8 @@ class TestSimpleEngineConcurrency:
             ]
 
         assert outputs[-1].text == "Hello"
-        assert sampler_calls == [
-            {"temp": 0.3, "top_p": 0.8, "top_k": 40, "min_p": 0.1}
-        ]
-        assert penalty_calls == [
-            {"repetition_penalty": 1.2, "presence_penalty": 1.5}
-        ]
+        assert sampler_calls == [{"temp": 0.3, "top_p": 0.8, "top_k": 40, "min_p": 0.1}]
+        assert penalty_calls == [{"repetition_penalty": 1.2, "presence_penalty": 1.5}]
         assert captured_kwargs["logits_processors"] == [
             user_processor,
             penalty_processor,

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -281,12 +281,12 @@ class TestSimpleEngineConcurrency:
 
         with (
             patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False),
-            patch("vllm_mlx.engine.simple.mx.default_device", return_value="gpu"),
+            patch("vllm_mlx.mlx_streams.mx.default_device", return_value="gpu"),
             patch(
-                "vllm_mlx.engine.simple.mx.new_stream",
+                "vllm_mlx.mlx_streams.mx.new_stream",
                 return_value=sentinel_stream,
             ),
-            patch("vllm_mlx.engine.simple.mx.set_default_stream"),
+            patch("vllm_mlx.mlx_streams.mx.set_default_stream"),
         ):
             engine = SimpleEngine("test-model")
             observed = await engine._run_blocking_serialized(

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -824,9 +824,11 @@ class TestSimpleEngineConcurrency:
         engine._text_model.make_mtp_cache.return_value = []
         engine._text_tokenizer = tokenizer
 
-        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate), patch(
-            "mlx_lm.models.cache.make_prompt_cache", return_value=[]
-        ), patch("mlx_lm.models.cache.trim_prompt_cache"):
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch("mlx_lm.models.cache.trim_prompt_cache"),
+        ):
             outputs = [
                 chunk
                 async for chunk in engine._stream_generate_text(
@@ -847,7 +849,9 @@ class TestSimpleEngineConcurrency:
         assert "logits_processors" not in calls[1]
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(self):
+    async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(
+        self,
+    ):
         """SpecPrefill continuation should resume with MTP once thinking retires."""
         from types import SimpleNamespace
 
@@ -893,20 +897,22 @@ class TestSimpleEngineConcurrency:
             processor.is_retired = True
             return mx.array(11, dtype=mx.uint32), logits
 
-        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate), patch(
-            "mlx_lm.models.cache.make_prompt_cache", return_value=[]
-        ), patch(
-            "vllm_mlx.specprefill.score_tokens", return_value=mx.array([0.1, 0.2])
-        ), patch(
-            "vllm_mlx.specprefill.select_chunks", return_value=mx.array([0, 1])
-        ), patch(
-            "vllm_mlx.specprefill.sparse_prefill",
-            return_value=mx.zeros((1, 1, 32)),
-        ), patch(
-            "vllm_mlx.specprefill.cleanup_rope"
-        ), patch(
-            "vllm_mlx.engine.simple._sample_with_processors",
-            side_effect=fake_sample,
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "vllm_mlx.specprefill.score_tokens", return_value=mx.array([0.1, 0.2])
+            ),
+            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0, 1])),
+            patch(
+                "vllm_mlx.specprefill.sparse_prefill",
+                return_value=mx.zeros((1, 1, 32)),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch(
+                "vllm_mlx.engine.simple._sample_with_processors",
+                side_effect=fake_sample,
+            ),
         ):
             outputs = [
                 chunk

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -693,10 +693,10 @@ class TestSimpleEngineConcurrency:
         assert captured_kwargs["logits_processors"][0] is user_processor
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_keeps_mtp_for_budget_only_thinking_processor(
+    async def test_stream_generate_text_disables_mtp_for_thinking_processor(
         self,
     ):
-        """Budget-only thinking processors may keep MTP on the normal path."""
+        """Thinking-budget processors must fail closed to non-MTP decoding."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -718,17 +718,7 @@ class TestSimpleEngineConcurrency:
         engine._text_model.mtp = MagicMock()
         engine._text_tokenizer = tokenizer
 
-        class BudgetOnlyThinkingProcessor:
-            def __init__(self):
-                self.is_retired = False
-                self.thinking_tokens = 0
-                self.state = object()
-                self._inner = None
-
-            def __call__(self, tokens, logits):
-                return logits
-
-        thinking_proc = BudgetOnlyThinkingProcessor()
+        thinking_proc = MagicMock()
 
         with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
             outputs = [
@@ -743,8 +733,7 @@ class TestSimpleEngineConcurrency:
             ]
 
         assert outputs[-1].text == "Hello"
-        assert captured_kwargs["mtp"] is True
-        assert captured_kwargs["num_draft_tokens"] == 1
+        assert "mtp" not in captured_kwargs
         assert captured_kwargs["logits_processors"][0] is thinking_proc
 
     @pytest.mark.anyio
@@ -856,74 +845,6 @@ class TestSimpleEngineConcurrency:
         assert calls[1]["mtp"] is True
         assert calls[1]["num_draft_tokens"] == 4
         assert "logits_processors" not in calls[1]
-
-    @pytest.mark.anyio
-    async def test_stream_generate_text_budget_only_thinking_disables_specprefill(
-        self,
-    ):
-        """Budget-only thinking processors should force normal-path MTP, not SpecPrefill."""
-        from types import SimpleNamespace
-
-        from vllm_mlx.engine.simple import SimpleEngine
-
-        captured_kwargs = {}
-
-        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
-            captured_kwargs["prompt"] = prompt
-            captured_kwargs.update(kwargs)
-            yield SimpleNamespace(text="Hello", finish_reason="stop")
-
-        tokenizer = MagicMock()
-        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
-        tokenizer.bos_token = None
-        tokenizer.eos_token_id = 42
-        tokenizer.encode.return_value = [1, 2, 3, 4]
-
-        engine = SimpleEngine(
-            "test-model",
-            force_mllm=True,
-            mtp=True,
-            specprefill_enabled=True,
-        )
-        engine._loaded = True
-        engine._draft_model = MagicMock()
-        engine._text_model = MagicMock()
-        engine._text_model.mtp = MagicMock()
-        engine._text_tokenizer = tokenizer
-
-        class BudgetOnlyThinkingProcessor:
-            def __init__(self):
-                self.is_retired = False
-                self.thinking_tokens = 0
-                self.state = object()
-                self._inner = None
-
-            def __call__(self, tokens, logits):
-                return logits
-
-        thinking_proc = BudgetOnlyThinkingProcessor()
-
-        with (
-            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
-            patch("vllm_mlx.specprefill.score_tokens") as score_tokens,
-        ):
-            outputs = [
-                chunk
-                async for chunk in engine._stream_generate_text(
-                    messages=[{"role": "user", "content": "hello"}],
-                    max_tokens=16,
-                    temperature=0.7,
-                    top_p=0.9,
-                    specprefill=True,
-                    logits_processors=[thinking_proc],
-                )
-            ]
-
-        assert outputs[-1].text == "Hello"
-        score_tokens.assert_not_called()
-        assert captured_kwargs["mtp"] is True
-        assert captured_kwargs["logits_processors"][0] is thinking_proc
-        assert "prompt_cache" not in captured_kwargs
 
     @pytest.mark.anyio
     async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(self):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -693,10 +693,10 @@ class TestSimpleEngineConcurrency:
         assert captured_kwargs["logits_processors"][0] is user_processor
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_keeps_mtp_for_budget_only_thinking_processor(
+    async def test_stream_generate_text_disables_mtp_for_thinking_processor(
         self,
     ):
-        """Budget-only ThinkingAwareLogitsProcessor should not disable MTP."""
+        """Thinking-budget processors must fail closed to non-MTP decoding."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -720,13 +720,7 @@ class TestSimpleEngineConcurrency:
 
         thinking_proc = MagicMock()
 
-        with (
-            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
-            patch(
-                "vllm_mlx.engine.simple._only_mtp_safe_thinking_processors",
-                return_value=True,
-            ),
-        ):
+        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
             outputs = [
                 chunk
                 async for chunk in engine._stream_generate_text(
@@ -739,7 +733,7 @@ class TestSimpleEngineConcurrency:
             ]
 
         assert outputs[-1].text == "Hello"
-        assert captured_kwargs["mtp"] is True
+        assert "mtp" not in captured_kwargs
         assert captured_kwargs["logits_processors"][0] is thinking_proc
 
     @pytest.mark.anyio

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -693,10 +693,10 @@ class TestSimpleEngineConcurrency:
         assert captured_kwargs["logits_processors"][0] is user_processor
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_disables_mtp_for_thinking_processor(
+    async def test_stream_generate_text_keeps_mtp_for_budget_only_thinking_processor(
         self,
     ):
-        """Thinking-budget processors must fail closed to non-MTP decoding."""
+        """Budget-only thinking processors may keep MTP on the normal path."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -718,7 +718,17 @@ class TestSimpleEngineConcurrency:
         engine._text_model.mtp = MagicMock()
         engine._text_tokenizer = tokenizer
 
-        thinking_proc = MagicMock()
+        class BudgetOnlyThinkingProcessor:
+            def __init__(self):
+                self.is_retired = False
+                self.thinking_tokens = 0
+                self.state = object()
+                self._inner = None
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        thinking_proc = BudgetOnlyThinkingProcessor()
 
         with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
             outputs = [
@@ -733,7 +743,8 @@ class TestSimpleEngineConcurrency:
             ]
 
         assert outputs[-1].text == "Hello"
-        assert "mtp" not in captured_kwargs
+        assert captured_kwargs["mtp"] is True
+        assert captured_kwargs["num_draft_tokens"] == 1
         assert captured_kwargs["logits_processors"][0] is thinking_proc
 
     @pytest.mark.anyio
@@ -845,6 +856,74 @@ class TestSimpleEngineConcurrency:
         assert calls[1]["mtp"] is True
         assert calls[1]["num_draft_tokens"] == 4
         assert "logits_processors" not in calls[1]
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_budget_only_thinking_disables_specprefill(
+        self,
+    ):
+        """Budget-only thinking processors should force normal-path MTP, not SpecPrefill."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_kwargs = {}
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_kwargs["prompt"] = prompt
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+        tokenizer.encode.return_value = [1, 2, 3, 4]
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            mtp=True,
+            specprefill_enabled=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = MagicMock()
+        engine._text_tokenizer = tokenizer
+
+        class BudgetOnlyThinkingProcessor:
+            def __init__(self):
+                self.is_retired = False
+                self.thinking_tokens = 0
+                self.state = object()
+                self._inner = None
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        thinking_proc = BudgetOnlyThinkingProcessor()
+
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("vllm_mlx.specprefill.score_tokens") as score_tokens,
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=16,
+                    temperature=0.7,
+                    top_p=0.9,
+                    specprefill=True,
+                    logits_processors=[thinking_proc],
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        score_tokens.assert_not_called()
+        assert captured_kwargs["mtp"] is True
+        assert captured_kwargs["logits_processors"][0] is thinking_proc
+        assert "prompt_cache" not in captured_kwargs
 
     @pytest.mark.anyio
     async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(self):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -265,3 +265,7 @@ class BaseEngine(ABC):
     def get_cache_stats(self) -> dict[str, Any] | None:
         """Get cache statistics. Override in subclasses."""
         return None
+
+    def clear_runtime_caches(self) -> dict[str, Any] | None:
+        """Clear engine-managed runtime caches. Override in subclasses."""
+        return None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -297,7 +297,9 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "mllm_prefill_step_size", None
         )
         if prefill_step_size is None:
-            prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", None)
+            prefill_step_size = getattr(
+                self._scheduler_config, "prefill_step_size", None
+            )
         mllm_extra = {}
         if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
@@ -1022,9 +1024,20 @@ class BatchedEngine(BaseEngine):
     def get_cache_stats(self) -> dict[str, Any] | None:
         """Get cache statistics."""
         if self._mllm_scheduler and self._mllm_scheduler.batch_generator:
-            return self._mllm_scheduler.batch_generator.get_vision_cache_stats()
+            return {
+                "prefix_cache": self._mllm_scheduler.batch_generator.get_prefix_cache_stats(),
+                "vision_embedding_cache": self._mllm_scheduler.batch_generator.get_vision_cache_stats(),
+            }
         elif self._engine:
             return self._engine.get_cache_stats()
+        return None
+
+    def clear_runtime_caches(self) -> dict[str, Any] | None:
+        """Clear engine-managed runtime caches."""
+        if self._mllm_scheduler is not None:
+            return self._mllm_scheduler.clear_runtime_caches()
+        if self._engine is not None:
+            return self._engine.clear_runtime_caches()
         return None
 
     def save_cache_to_disk(self, cache_dir: str) -> bool:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -293,11 +293,11 @@ class BatchedEngine(BaseEngine):
             self._scheduler_config, "kv_cache_quantization_group_size", 64
         )
 
-        # Forward MLLM prefill-step override only when explicitly configured.
-        # This keeps default behavior unchanged for MLLM (1024) unless set.
         prefill_step_size = getattr(
             self._scheduler_config, "mllm_prefill_step_size", None
         )
+        if prefill_step_size is None:
+            prefill_step_size = getattr(self._scheduler_config, "prefill_step_size", None)
         mllm_extra = {}
         if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
@@ -1039,7 +1039,8 @@ class BatchedEngine(BaseEngine):
 
     def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk. Returns number of entries loaded."""
-        if self._mllm_scheduler and self._mllm_scheduler.batch_generator:
+        if self._mllm_scheduler:
+            self._mllm_scheduler._ensure_batch_generator()
             pc = self._mllm_scheduler.batch_generator.prefix_cache
             if pc is not None:
                 return pc.load_from_disk(cache_dir)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -101,20 +101,6 @@ def _processors_retired(processors: list[Any] | None) -> bool:
     )
 
 
-def _processors_are_budget_only_thinking(
-    external_processors: list[Any] | None,
-    penalty_processors: list[Any] | None,
-) -> bool:
-    """True when active request-local processors only enforce thinking budget."""
-    return bool(external_processors) and not penalty_processors and all(
-        isinstance(getattr(p, "is_retired", None), bool)
-        and hasattr(p, "thinking_tokens")
-        and hasattr(p, "state")
-        and getattr(p, "_inner", None) is None
-        for p in external_processors
-    )
-
-
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
@@ -1094,10 +1080,6 @@ class SimpleEngine(BaseEngine):
             presence_penalty=presence_penalty if presence_penalty != 0.0 else None,
         )
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
-        budget_only_thinking_processors = _processors_are_budget_only_thinking(
-            external_logits_processors,
-            penalty_processors,
-        )
         custom_logits_active = bool(all_processors)
         max_tokens = max_tokens or 4096
 
@@ -1248,12 +1230,6 @@ class SimpleEngine(BaseEngine):
         ):
             use_specprefill = False
 
-        if use_specprefill and budget_only_thinking_processors:
-            logger.info(
-                "Text route: disabling SpecPrefill for budget-only thinking processor"
-            )
-            use_specprefill = False
-
         # Upper bound: cap specprefill to avoid draft model OOM on very long prompts
         # 65536 tokens ~ 2GB draft KV cache on Qwen3.5-4B (32KB/token x 8 attn layers)
         _SPECPREFILL_MAX_TOKENS = 65536
@@ -1276,20 +1252,15 @@ class SimpleEngine(BaseEngine):
 
             model = self._text_model
             can_retire_processors = _processors_can_retire(all_processors)
-            allow_budget_only_mtp = budget_only_thinking_processors and not use_specprefill
             use_mtp = (
                 self._mtp
-                and (not custom_logits_active or allow_budget_only_mtp)
+                and not custom_logits_active
                 and hasattr(model, "mtp")
                 and model.mtp is not None
             )
-            if self._mtp and custom_logits_active and not allow_budget_only_mtp:
+            if self._mtp and custom_logits_active:
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
-                )
-            elif self._mtp and allow_budget_only_mtp:
-                logger.info(
-                    "Text route: keeping MTP enabled for budget-only thinking processor"
                 )
 
             # Cache MISS with valid prefix: prefill system tokens and snapshot

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -7,7 +7,6 @@ performance when serving a single user at a time.
 """
 
 import asyncio
-import importlib
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -23,21 +22,14 @@ from .base import (
     cleanup_startup_cancellation,
     run_blocking_startup_work,
 )
+from ..mlx_streams import bind_generation_streams
 
 logger = logging.getLogger(__name__)
 
 
 def _bind_worker_generation_streams() -> None:
     """Rebind mlx generation streams inside the current worker thread."""
-    default_stream = mx.new_stream(mx.default_device())
-    mx.set_default_stream(default_stream)
-    for module_name in ("mlx_lm.generate", "mlx_vlm.generate"):
-        try:
-            module = importlib.import_module(module_name)
-        except ImportError:
-            continue
-        if hasattr(module, "generation_stream"):
-            module.generation_stream = default_stream
+    bind_generation_streams()
 
 
 def _seed_logits_processors(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1258,6 +1258,44 @@ class SimpleEngine(BaseEngine):
             )
             use_specprefill = False
 
+        def _seed_from_last_response(prompt_cache, last_resp):
+            last_tok = getattr(last_resp, "token", None)
+            if last_tok is not None:
+                cache_module.trim_prompt_cache(prompt_cache, 1)
+                return mx.array([last_tok], dtype=mx.uint32)
+            return mx.array(
+                self._text_tokenizer.encode(getattr(last_resp, "text", "")),
+                dtype=mx.uint32,
+            )
+
+        def _resume_after_processor_retirement(
+            model,
+            prompt_cache,
+            prompt,
+            remaining_tokens: int,
+            results: list[Any],
+        ) -> None:
+            resume_kwargs = dict(
+                max_tokens=remaining_tokens,
+                sampler=sampler,
+                prefill_step_size=self._prefill_step_size,
+                prompt_cache=prompt_cache,
+            )
+            if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                # Resume speculative decode from the retained backbone cache with
+                # a fresh MTP cache so stale speculative state cannot survive the
+                # processor-to-content handoff.
+                resume_kwargs["prompt_cache"] = prompt_cache + model.make_mtp_cache()
+                resume_kwargs["mtp"] = True
+                resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+            for resp in mlx_stream_generate(
+                model,
+                self._text_tokenizer,
+                prompt=prompt,
+                **resume_kwargs,
+            ):
+                results.append(resp)
+
         # Run all Metal ops in a single serialized thread.
         def _run_all():
             nonlocal backbone_cache, prompt_to_send
@@ -1379,37 +1417,14 @@ class SimpleEngine(BaseEngine):
                         break
 
                 if retired and token_count < max_tokens and last_resp is not None:
-                    last_tok = getattr(last_resp, "token", None)
-                    if last_tok is not None:
-                        cache_module.trim_prompt_cache(shared_cache, 1)
-                        seed = mx.array([last_tok], dtype=mx.uint32)
-                    else:
-                        seed = mx.array(
-                            self._text_tokenizer.encode(getattr(last_resp, "text", "")),
-                            dtype=mx.uint32,
-                        )
-                    resume_kwargs = dict(
-                        max_tokens=max_tokens - token_count,
-                        sampler=sampler,
-                        prefill_step_size=self._prefill_step_size,
-                        prompt_cache=shared_cache,
-                    )
-                    if hasattr(model, "make_mtp_cache") and model.mtp is not None:
-                        # The processor phase ran without MTP. Resume from the
-                        # trimmed backbone cache with a fresh MTP cache so no
-                        # stale speculative state survives the seed handoff.
-                        resume_kwargs["prompt_cache"] = (
-                            shared_cache + model.make_mtp_cache()
-                        )
-                        resume_kwargs["mtp"] = True
-                        resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
-                    for resp in mlx_stream_generate(
+                    seed = _seed_from_last_response(shared_cache, last_resp)
+                    _resume_after_processor_retirement(
                         model,
-                        self._text_tokenizer,
-                        prompt=seed,
-                        **resume_kwargs,
-                    ):
-                        results.append(resp)
+                        shared_cache,
+                        seed,
+                        max_tokens - token_count,
+                        results,
+                    )
                 return results
             else:
                 results = []
@@ -1533,28 +1548,13 @@ class SimpleEngine(BaseEngine):
                             "resuming content phase with MTP=%s",
                             hasattr(model, "make_mtp_cache") and model.mtp is not None,
                         )
-                        resume_kwargs = dict(
-                            max_tokens=max_tokens - token_count,
-                            sampler=sampler,
-                            prefill_step_size=self._prefill_step_size,
-                            prompt_cache=bc,
-                        )
-                        if hasattr(model, "make_mtp_cache") and model.mtp is not None:
-                            # Resume speculative decode from the trimmed
-                            # backbone cache with a fresh MTP cache so no stale
-                            # speculative state survives the seed handoff.
-                            resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
-                            resume_kwargs["mtp"] = True
-                            resume_kwargs["num_draft_tokens"] = (
-                                self._mtp_num_draft_tokens
-                            )
-                        for resp in mlx_stream_generate(
+                        _resume_after_processor_retirement(
                             model,
-                            self._text_tokenizer,
-                            prompt=continuation_prompt,
-                            **resume_kwargs,
-                        ):
-                            results.append(resp)
+                            bc,
+                            continuation_prompt,
+                            max_tokens - token_count,
+                            results,
+                        )
                         return results
 
                     last_resp = None
@@ -1585,39 +1585,14 @@ class SimpleEngine(BaseEngine):
                             break
 
                     if retired and token_count < max_tokens and last_resp is not None:
-                        last_tok = getattr(last_resp, "token", None)
-                        if last_tok is not None:
-                            cache_module.trim_prompt_cache(bc, 1)
-                            seed = mx.array([last_tok], dtype=mx.uint32)
-                        else:
-                            seed = mx.array(
-                                self._text_tokenizer.encode(
-                                    getattr(last_resp, "text", "")
-                                ),
-                                dtype=mx.uint32,
-                            )
-                        resume_kwargs = dict(
-                            max_tokens=max_tokens - token_count,
-                            sampler=sampler,
-                            prefill_step_size=self._prefill_step_size,
-                            prompt_cache=bc,
-                        )
-                        if hasattr(model, "make_mtp_cache") and model.mtp is not None:
-                            # Resume speculative decode from the trimmed
-                            # backbone cache with a fresh MTP cache so no stale
-                            # speculative state survives the seed handoff.
-                            resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
-                            resume_kwargs["mtp"] = True
-                            resume_kwargs["num_draft_tokens"] = (
-                                self._mtp_num_draft_tokens
-                            )
-                        for resp in mlx_stream_generate(
+                        seed = _seed_from_last_response(bc, last_resp)
+                        _resume_after_processor_retirement(
                             model,
-                            self._text_tokenizer,
-                            prompt=seed,
-                            **resume_kwargs,
-                        ):
-                            results.append(resp)
+                            bc,
+                            seed,
+                            max_tokens - token_count,
+                            results,
+                        )
 
                 return results
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -56,6 +56,53 @@ def _only_mtp_safe_thinking_processors(processors: list[Any] | None) -> bool:
     )
 
 
+def _seed_logits_processors(
+    seed_tokens: mx.array | None,
+    processors: list[Any] | None,
+) -> list[Any] | None:
+    """Wrap logits processors so continuation decode sees the full prompt."""
+    if not processors:
+        return None
+    if seed_tokens is None or seed_tokens.size == 0:
+        return list(processors)
+
+    def _wrap(processor):
+        def _seeded(tokens, logits):
+            merged = seed_tokens
+            if tokens is not None:
+                if not isinstance(tokens, mx.array):
+                    tokens_arr = mx.array(tokens, dtype=mx.uint32)
+                else:
+                    tokens_arr = tokens
+                if tokens_arr.size > 0:
+                    merged = mx.concatenate([seed_tokens, tokens_arr])
+            return processor(merged, logits)
+
+        return _seeded
+
+    return [_wrap(processor) for processor in processors]
+
+
+def _sample_with_processors(
+    tokens: mx.array | None,
+    logits: mx.array,
+    sampler: Any,
+    logits_processors: list[Any] | None,
+) -> tuple[mx.array, mx.array]:
+    """Sample a token while honoring any active logits processors."""
+    if logits_processors:
+        is_1d = logits.ndim == 1
+        if is_1d:
+            logits = logits[None]
+        for processor in logits_processors:
+            logits = processor(tokens, logits)
+        if is_1d:
+            logits = logits.squeeze(0)
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    tok = sampler(logprobs)
+    return tok, logprobs
+
+
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
@@ -274,6 +321,7 @@ class SimpleEngine(BaseEngine):
         corrupt the command-buffer state.
         """
         async with self._generation_lock:
+
             def run_bound():
                 _bind_worker_generation_streams()
                 return func(*args, **kwargs)
@@ -656,7 +704,9 @@ class SimpleEngine(BaseEngine):
             and self._text_model is not None
             and not has_media_content(messages)
         ):
-            has_mtp = hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
+            has_mtp = (
+                hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
+            )
             logger.info("Text-only request → LLM path (MTP=%s)", has_mtp and self._mtp)
             if chat_template_kwargs:
                 kwargs["chat_template_kwargs"] = chat_template_kwargs
@@ -1256,7 +1306,7 @@ class SimpleEngine(BaseEngine):
             # --- SpecPrefill path (with fallback to normal on failure) ---
             if use_specprefill:
                 try:
-                    return _run_specprefill(model, backbone_cache)
+                    return _run_specprefill(model, backbone_cache, use_mtp)
                 except Exception as e:
                     logger.error(
                         "SpecPrefill failed, falling back to normal MTP path: %s",
@@ -1299,14 +1349,12 @@ class SimpleEngine(BaseEngine):
                 results.append(resp)
             return results
 
-        def _run_specprefill(model, bc):
-            """Score tokens, sparse prefill, generate without MTP."""
+        def _run_specprefill(model, bc, use_mtp):
+            """Score tokens, sparse prefill, then continue on the standard decode path."""
             from types import SimpleNamespace
 
-            import mlx.core as mx
             from mlx_lm import stream_generate as mlx_stream_generate
             from mlx_lm.models.cache import make_prompt_cache
-            from mlx_lm.sample_utils import make_sampler
 
             from ..specprefill import (
                 cleanup_rope,
@@ -1314,8 +1362,6 @@ class SimpleEngine(BaseEngine):
                 select_chunks,
                 sparse_prefill,
             )
-
-            sampler = make_sampler(temp=temperature, top_p=top_p)
 
             # Create backbone cache if not already from system KV
             if bc is None:
@@ -1365,26 +1411,58 @@ class SimpleEngine(BaseEngine):
                     effective_keep,
                 )
 
-                # Phase 4: Generate via mlx_lm pipelined path (no MTP)
+                # Phase 4: Sample the first token from the prefilled logits, then
+                # continue through mlx_lm's normal decode path so MTP and request-
+                # local logits processors remain active after sparse prefill.
                 eos_id = self._text_tokenizer.eos_token_id
-                first_token_id = sampler(logits[:, -1, :]).item()
-                first_text = self._text_tokenizer.decode([first_token_id])
+                seed_tokens = (
+                    mx.array(full_tokens_list, dtype=mx.uint32)
+                    if full_tokens_list is not None
+                    else None
+                )
+                seeded_processors = _seed_logits_processors(seed_tokens, all_processors)
+                y, _ = _sample_with_processors(
+                    None,
+                    logits[:, -1, :].squeeze(0),
+                    sampler,
+                    seeded_processors,
+                )
+                mx.eval(y)
 
+                generated_ids = []
+                prev_decoded = ""
+
+                tok_id = y.item()
+                generated_ids.append(tok_id)
+
+                decoded = self._text_tokenizer.decode(generated_ids)
+                new_text = decoded[len(prev_decoded) :]
+                prev_decoded = decoded
+
+                is_eos = tok_id == eos_id
                 results = [
                     SimpleNamespace(
-                        text=first_text,
-                        finish_reason="stop" if first_token_id == eos_id else None,
+                        text=new_text,
+                        finish_reason="stop" if is_eos else None,
                     )
                 ]
 
-                if first_token_id != eos_id:
+                if not is_eos and max_tokens > 1:
+                    prompt_cache = bc
+                    if use_mtp and hasattr(model, "make_mtp_cache"):
+                        prompt_cache = bc + model.make_mtp_cache()
+
+                    continuation_prompt = mx.array([tok_id], dtype=mx.uint32)
                     for resp in mlx_stream_generate(
                         model,
                         self._text_tokenizer,
-                        prompt=mx.array([first_token_id]),
+                        prompt=continuation_prompt,
                         max_tokens=max_tokens - 1,
                         sampler=sampler,
-                        prompt_cache=bc,
+                        prefill_step_size=self._prefill_step_size,
+                        logits_processors=seeded_processors,
+                        prompt_cache=prompt_cache,
+                        mtp=use_mtp,
                     ):
                         results.append(resp)
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -229,6 +229,13 @@ class SimpleEngine(BaseEngine):
                 await run_blocking_startup_work(self.prepare_for_start)
             self._loaded = True
 
+            if self._mtp and self._mtp_num_draft_tokens != 1:
+                logger.warning(
+                    "Native mlx_lm MTP currently ignores num_draft_tokens=%d; "
+                    "effective speculative draft depth remains 1",
+                    self._mtp_num_draft_tokens,
+                )
+
             # Build parallel mlx_lm TextModel for text-only routing.
             # Even when MTP is disabled, text-only requests should not be trapped
             # on the slower mlx_vlm multimodal path.
@@ -286,7 +293,12 @@ class SimpleEngine(BaseEngine):
                     logger.error("SpecPrefill: draft model load failed: %s", e)
                     self._draft_model = None
 
-            mtp_info = f", MTP={self._mtp}" if self._mtp else ""
+            mtp_info = ""
+            if self._mtp:
+                mtp_info = (
+                    f", MTP={self._mtp}(configured={self._mtp_num_draft_tokens}, "
+                    "effective=1)"
+                )
             routing = ", routing=per-request" if self._text_model is not None else ""
             specprefill_info = (
                 ", SpecPrefill=active" if self._draft_model is not None else ""
@@ -1373,9 +1385,7 @@ class SimpleEngine(BaseEngine):
                         seed = mx.array([last_tok], dtype=mx.uint32)
                     else:
                         seed = mx.array(
-                            self._text_tokenizer.encode(
-                                getattr(last_resp, "text", "")
-                            ),
+                            self._text_tokenizer.encode(getattr(last_resp, "text", "")),
                             dtype=mx.uint32,
                         )
                     resume_kwargs = dict(
@@ -1529,7 +1539,9 @@ class SimpleEngine(BaseEngine):
                         if hasattr(model, "make_mtp_cache") and model.mtp is not None:
                             resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
                             resume_kwargs["mtp"] = True
-                            resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                            resume_kwargs["num_draft_tokens"] = (
+                                self._mtp_num_draft_tokens
+                            )
                         for resp in mlx_stream_generate(
                             model,
                             self._text_tokenizer,
@@ -1561,7 +1573,8 @@ class SimpleEngine(BaseEngine):
                                 "SpecPrefill text route: request-local processor retired after %d tokens; "
                                 "resuming content phase with MTP=%s",
                                 token_count,
-                                hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                                hasattr(model, "make_mtp_cache")
+                                and model.mtp is not None,
                             )
                             break
 
@@ -1586,7 +1599,9 @@ class SimpleEngine(BaseEngine):
                         if hasattr(model, "make_mtp_cache") and model.mtp is not None:
                             resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
                             resume_kwargs["mtp"] = True
-                            resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                            resume_kwargs["num_draft_tokens"] = (
+                                self._mtp_num_draft_tokens
+                            )
                         for resp in mlx_stream_generate(
                             model,
                             self._text_tokenizer,
@@ -1687,4 +1702,11 @@ class SimpleEngine(BaseEngine):
         """Get cache statistics (for MLLM models)."""
         if self._is_mllm and self._model is not None:
             return self._model.get_cache_stats()
+        return None
+
+    def clear_runtime_caches(self) -> dict[str, Any] | None:
+        """Clear engine-managed runtime caches."""
+        if self._is_mllm and self._model is not None:
+            self._model.clear_cache()
+            return {"model_cache": True}
         return None

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -7,10 +7,13 @@ performance when serving a single user at a time.
 """
 
 import asyncio
+import importlib
 import logging
 import time
 from collections.abc import AsyncIterator
 from typing import Any
+
+import mlx.core as mx
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, has_media_content, is_mllm_model
@@ -22,6 +25,35 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _bind_worker_generation_streams() -> None:
+    """Rebind mlx generation streams inside the current worker thread."""
+    default_stream = mx.new_stream(mx.default_device())
+    mx.set_default_stream(default_stream)
+    for module_name in ("mlx_lm.generate", "mlx_vlm.generate"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        if hasattr(module, "generation_stream"):
+            module.generation_stream = default_stream
+
+
+def _only_mtp_safe_thinking_processors(processors: list[Any] | None) -> bool:
+    """Return True when processors are budget-only thinking controllers."""
+    if not processors:
+        return False
+    try:
+        from ..constrained import ThinkingAwareLogitsProcessor
+    except Exception:
+        return False
+
+    return all(
+        isinstance(proc, ThinkingAwareLogitsProcessor)
+        and getattr(proc, "_inner", None) is None
+        for proc in processors
+    )
 
 
 class _SpecPrefillCancelled(Exception):
@@ -43,6 +75,7 @@ class SimpleEngine(BaseEngine):
         enable_cache: bool = True,
         force_mllm: bool = False,
         mtp: bool = False,
+        mtp_num_draft_tokens: int = 1,
         prefill_step_size: int = 2048,
         specprefill_enabled: bool = False,
         specprefill_threshold: int = 8192,
@@ -58,6 +91,7 @@ class SimpleEngine(BaseEngine):
             enable_cache: Enable VLM cache for multimodal models
             force_mllm: Force loading as MLLM even if not auto-detected
             mtp: Enable native MTP speculative decoding (model must have MTP head)
+            mtp_num_draft_tokens: Draft tokens per speculative MTP step
             prefill_step_size: Chunk size for prompt prefill processing (default: 2048)
             specprefill_enabled: Enable SpecPrefill (attention-based sparse prefill)
             specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill
@@ -70,6 +104,7 @@ class SimpleEngine(BaseEngine):
         self._enable_cache = enable_cache
         self._is_mllm = force_mllm or is_mllm_model(model_name)
         self._mtp = mtp
+        self._mtp_num_draft_tokens = mtp_num_draft_tokens
         self._prefill_step_size = prefill_step_size
 
         # SpecPrefill config
@@ -135,6 +170,7 @@ class SimpleEngine(BaseEngine):
                 self._model_name,
                 trust_remote_code=self._trust_remote_code,
                 mtp=self._mtp,
+                mtp_num_draft_tokens=self._mtp_num_draft_tokens,
             )
 
         self._model.load()
@@ -148,8 +184,10 @@ class SimpleEngine(BaseEngine):
                 await run_blocking_startup_work(self.prepare_for_start)
             self._loaded = True
 
-            # Build parallel mlx_lm TextModel for text-only MTP routing
-            if self._is_mllm and self._mtp:
+            # Build parallel mlx_lm TextModel for text-only routing.
+            # Even when MTP is disabled, text-only requests should not be trapped
+            # on the slower mlx_vlm multimodal path.
+            if self._is_mllm:
                 try:
                     from ..text_model_from_vlm import build_text_model
 
@@ -157,11 +195,7 @@ class SimpleEngine(BaseEngine):
                         self._model.model, self._model_name
                     )
 
-                    if (
-                        self._text_model is not None
-                        and hasattr(self._text_model, "mtp")
-                        and self._text_model.mtp is not None
-                    ):
+                    if self._text_model is not None:
                         self._text_tokenizer = self._model.get_tokenizer()
 
                         # Apply Qwen3.5 eos_token fix (matches MLXLanguageModel.load)
@@ -171,18 +205,21 @@ class SimpleEngine(BaseEngine):
                                 self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
                             )
 
+                        has_mtp = (
+                            hasattr(self._text_model, "mtp")
+                            and self._text_model.mtp is not None
+                        )
                         logger.info(
-                            "MLLM+MTP routing: text-only -> mlx_lm TextModel "
-                            "(MTP=True), media -> mlx_vlm"
+                            "MLLM text routing: text-only -> mlx_lm TextModel "
+                            "(MTP=%s), media -> mlx_vlm",
+                            has_mtp and self._mtp,
                         )
                     else:
-                        logger.warning(
-                            "TextModel built but no MTP - text-only requests won't use MTP"
-                        )
                         self._text_model = None
+                        self._text_tokenizer = None
 
                 except Exception as e:
-                    logger.error("MLLM+MTP routing setup failed: %s", e)
+                    logger.error("MLLM text routing setup failed: %s", e)
                     self._text_model = None
                     self._text_tokenizer = None
 
@@ -237,7 +274,11 @@ class SimpleEngine(BaseEngine):
         corrupt the command-buffer state.
         """
         async with self._generation_lock:
-            task = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+            def run_bound():
+                _bind_worker_generation_streams()
+                return func(*args, **kwargs)
+
+            task = asyncio.create_task(asyncio.to_thread(run_bound))
             try:
                 return await asyncio.shield(task)
             except asyncio.CancelledError:
@@ -481,11 +522,7 @@ class SimpleEngine(BaseEngine):
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
 
-        # mlx-lm non-streaming chat with tools can stall indefinitely on some
-        # local models, while the streaming path completes normally. Reuse the
-        # streaming implementation and aggregate its final state so both chat
-        # APIs share the same tool-capable execution path.
-        if tools and not self._is_mllm:
+        async def aggregate_stream_chat() -> GenerationOutput:
             final_output = GenerationOutput(text="")
             async for output in self.stream_chat(
                 messages=messages,
@@ -507,6 +544,24 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=final_output.completion_tokens,
                 finish_reason=final_output.finish_reason,
             )
+
+        # mlx-lm non-streaming chat with tools can stall indefinitely on some
+        # local models, while the streaming path completes normally. Reuse the
+        # streaming implementation and aggregate its final state so both chat
+        # APIs share the same tool-capable execution path.
+        if tools and not self._is_mllm:
+            return await aggregate_stream_chat()
+
+        # Text-only requests on MLLM models should use the TextModel route even
+        # for non-streaming chat. Aggregating the streaming path keeps one
+        # execution seam for text-only requests and avoids thread-local mlx_vlm
+        # stream assumptions inside to_thread().
+        if (
+            self._is_mllm
+            and self._text_model is not None
+            and not has_media_content(messages)
+        ):
+            return await aggregate_stream_chat()
 
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -595,13 +650,14 @@ class SimpleEngine(BaseEngine):
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
 
-        # Per-request routing: text-only through mlx_lm with MTP
+        # Per-request routing: text-only through mlx_lm TextModel
         if (
             self._is_mllm
             and self._text_model is not None
             and not has_media_content(messages)
         ):
-            logger.info("Text-only request → LLM path (MTP=True)")
+            has_mtp = hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
+            logger.info("Text-only request → LLM path (MTP=%s)", has_mtp and self._mtp)
             if chat_template_kwargs:
                 kwargs["chat_template_kwargs"] = chat_template_kwargs
             async for chunk in self._stream_generate_text(
@@ -906,9 +962,9 @@ class SimpleEngine(BaseEngine):
         tools: list | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
-        """Text-only generation via mlx_lm TextModel with MTP.
+        """Text-only generation via mlx_lm TextModel.
 
-        Used when MLLM+MTP routing is active and the request has no media.
+        Used when text-only MLLM routing is active and the request has no media.
         Runs the full generation in a single thread to maintain Metal safety.
 
         System prompt KV caching: on the first request, prefills system tokens
@@ -918,10 +974,21 @@ class SimpleEngine(BaseEngine):
         import hashlib
         import os
 
+        import mlx.core as mx
+        from mlx_lm import stream_generate as mlx_stream_generate
+        from mlx_lm.models.cache import make_prompt_cache
+        from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct = kwargs.pop("specprefill_keep_pct", None)
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        top_k = kwargs.pop("top_k", 0)
+        min_p = kwargs.pop("min_p", 0.0)
+        presence_penalty = kwargs.pop("presence_penalty", 0.0)
+        repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
+        stop = kwargs.pop("stop", None)
+        external_logits_processors = kwargs.pop("logits_processors", None)
 
         # Per-request enable_thinking override; fall back to env var / default True.
         enable_thinking = kwargs.pop("enable_thinking", None)
@@ -951,6 +1018,21 @@ class SimpleEngine(BaseEngine):
                 messages, **template_kwargs
             )
 
+        sampler = make_sampler(
+            temp=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+        )
+        penalty_processors = make_logits_processors(
+            repetition_penalty=(
+                repetition_penalty if repetition_penalty != 1.0 else None
+            ),
+            presence_penalty=presence_penalty if presence_penalty != 0.0 else None,
+        )
+        all_processors = (external_logits_processors or []) + (penalty_processors or [])
+        custom_logits_active = bool(all_processors)
+        mtp_safe_processors = _only_mtp_safe_thinking_processors(all_processors)
         max_tokens = max_tokens or 4096
 
         # --- System prompt KV caching ---
@@ -1118,15 +1200,19 @@ class SimpleEngine(BaseEngine):
 
         # Run all Metal ops in a single serialized thread.
         def _run_all():
-            import mlx.core as mx
-            from mlx_lm import stream_generate as mlx_stream_generate
-            from mlx_lm.models.cache import make_prompt_cache
-            from mlx_lm.sample_utils import make_sampler
-
             nonlocal backbone_cache, prompt_to_send
 
-            sampler = make_sampler(temp=temperature, top_p=top_p)
             model = self._text_model
+            use_mtp = (
+                self._mtp
+                and (not custom_logits_active or mtp_safe_processors)
+                and hasattr(model, "mtp")
+                and model.mtp is not None
+            )
+            if self._mtp and custom_logits_active and not mtp_safe_processors:
+                logger.info(
+                    "Text route: disabling MTP for request-local logits processors"
+                )
 
             # Cache MISS with valid prefix: prefill system tokens and snapshot
             if (
@@ -1180,11 +1266,11 @@ class SimpleEngine(BaseEngine):
                     backbone_cache = None
                     prompt_to_send = full_prompt
 
-            # --- Normal path (MTP via mlx_lm stream_generate) ---
+            # --- Normal path (mlx_lm stream_generate) ---
             prompt_cache = None
             if backbone_cache is not None:
                 # Add MTP cache on top of backbone
-                if hasattr(model, "make_mtp_cache"):
+                if use_mtp and hasattr(model, "make_mtp_cache"):
                     mtp_cache = model.make_mtp_cache()
                     prompt_cache = backbone_cache + mtp_cache
                 else:
@@ -1194,9 +1280,13 @@ class SimpleEngine(BaseEngine):
             gen_kwargs = dict(
                 max_tokens=max_tokens,
                 sampler=sampler,
-                mtp=True,
                 prefill_step_size=self._prefill_step_size,
             )
+            if all_processors:
+                gen_kwargs["logits_processors"] = all_processors
+            if use_mtp:
+                gen_kwargs["mtp"] = True
+                gen_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
             if prompt_cache is not None:
                 gen_kwargs["prompt_cache"] = prompt_cache
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -101,6 +101,20 @@ def _processors_retired(processors: list[Any] | None) -> bool:
     )
 
 
+def _processors_are_budget_only_thinking(
+    external_processors: list[Any] | None,
+    penalty_processors: list[Any] | None,
+) -> bool:
+    """True when active request-local processors only enforce thinking budget."""
+    return bool(external_processors) and not penalty_processors and all(
+        isinstance(getattr(p, "is_retired", None), bool)
+        and hasattr(p, "thinking_tokens")
+        and hasattr(p, "state")
+        and getattr(p, "_inner", None) is None
+        for p in external_processors
+    )
+
+
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
@@ -1080,6 +1094,10 @@ class SimpleEngine(BaseEngine):
             presence_penalty=presence_penalty if presence_penalty != 0.0 else None,
         )
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
+        budget_only_thinking_processors = _processors_are_budget_only_thinking(
+            external_logits_processors,
+            penalty_processors,
+        )
         custom_logits_active = bool(all_processors)
         max_tokens = max_tokens or 4096
 
@@ -1230,6 +1248,12 @@ class SimpleEngine(BaseEngine):
         ):
             use_specprefill = False
 
+        if use_specprefill and budget_only_thinking_processors:
+            logger.info(
+                "Text route: disabling SpecPrefill for budget-only thinking processor"
+            )
+            use_specprefill = False
+
         # Upper bound: cap specprefill to avoid draft model OOM on very long prompts
         # 65536 tokens ~ 2GB draft KV cache on Qwen3.5-4B (32KB/token x 8 attn layers)
         _SPECPREFILL_MAX_TOKENS = 65536
@@ -1252,15 +1276,20 @@ class SimpleEngine(BaseEngine):
 
             model = self._text_model
             can_retire_processors = _processors_can_retire(all_processors)
+            allow_budget_only_mtp = budget_only_thinking_processors and not use_specprefill
             use_mtp = (
                 self._mtp
-                and not custom_logits_active
+                and (not custom_logits_active or allow_budget_only_mtp)
                 and hasattr(model, "mtp")
                 and model.mtp is not None
             )
-            if self._mtp and custom_logits_active:
+            if self._mtp and custom_logits_active and not allow_budget_only_mtp:
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
+                )
+            elif self._mtp and allow_budget_only_mtp:
+                logger.info(
+                    "Text route: keeping MTP enabled for budget-only thinking processor"
                 )
 
             # Cache MISS with valid prefix: prefill system tokens and snapshot

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1395,6 +1395,9 @@ class SimpleEngine(BaseEngine):
                         prompt_cache=shared_cache,
                     )
                     if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                        # The processor phase ran without MTP. Resume from the
+                        # trimmed backbone cache with a fresh MTP cache so no
+                        # stale speculative state survives the seed handoff.
                         resume_kwargs["prompt_cache"] = (
                             shared_cache + model.make_mtp_cache()
                         )
@@ -1537,6 +1540,9 @@ class SimpleEngine(BaseEngine):
                             prompt_cache=bc,
                         )
                         if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                            # Resume speculative decode from the trimmed
+                            # backbone cache with a fresh MTP cache so no stale
+                            # speculative state survives the seed handoff.
                             resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
                             resume_kwargs["mtp"] = True
                             resume_kwargs["num_draft_tokens"] = (
@@ -1597,6 +1603,9 @@ class SimpleEngine(BaseEngine):
                             prompt_cache=bc,
                         )
                         if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                            # Resume speculative decode from the trimmed
+                            # backbone cache with a fresh MTP cache so no stale
+                            # speculative state survives the seed handoff.
                             resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
                             resume_kwargs["mtp"] = True
                             resume_kwargs["num_draft_tokens"] = (

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -40,22 +40,6 @@ def _bind_worker_generation_streams() -> None:
             module.generation_stream = default_stream
 
 
-def _only_mtp_safe_thinking_processors(processors: list[Any] | None) -> bool:
-    """Return True when processors are budget-only thinking controllers."""
-    if not processors:
-        return False
-    try:
-        from ..constrained import ThinkingAwareLogitsProcessor
-    except Exception:
-        return False
-
-    return all(
-        isinstance(proc, ThinkingAwareLogitsProcessor)
-        and getattr(proc, "_inner", None) is None
-        for proc in processors
-    )
-
-
 def _seed_logits_processors(
     seed_tokens: mx.array | None,
     processors: list[Any] | None,
@@ -1082,7 +1066,6 @@ class SimpleEngine(BaseEngine):
         )
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
         custom_logits_active = bool(all_processors)
-        mtp_safe_processors = _only_mtp_safe_thinking_processors(all_processors)
         max_tokens = max_tokens or 4096
 
         # --- System prompt KV caching ---
@@ -1255,11 +1238,11 @@ class SimpleEngine(BaseEngine):
             model = self._text_model
             use_mtp = (
                 self._mtp
-                and (not custom_logits_active or mtp_safe_processors)
+                and not custom_logits_active
                 and hasattr(model, "mtp")
                 and model.mtp is not None
             )
-            if self._mtp and custom_logits_active and not mtp_safe_processors:
+            if self._mtp and custom_logits_active:
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
                 )

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -87,6 +87,20 @@ def _sample_with_processors(
     return tok, logprobs
 
 
+def _processors_can_retire(processors: list[Any] | None) -> bool:
+    """True when any processor advertises a retire-to-content transition."""
+    return bool(processors) and any(
+        isinstance(getattr(p, "is_retired", None), bool) for p in processors
+    )
+
+
+def _processors_retired(processors: list[Any] | None) -> bool:
+    """True when any retire-capable processor has entered its retired state."""
+    return bool(processors) and any(
+        getattr(p, "is_retired", False) is True for p in processors
+    )
+
+
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
@@ -1010,6 +1024,7 @@ class SimpleEngine(BaseEngine):
 
         import mlx.core as mx
         from mlx_lm import stream_generate as mlx_stream_generate
+        from mlx_lm.models import cache as cache_module
         from mlx_lm.models.cache import make_prompt_cache
         from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
@@ -1236,6 +1251,7 @@ class SimpleEngine(BaseEngine):
             nonlocal backbone_cache, prompt_to_send
 
             model = self._text_model
+            can_retire_processors = _processors_can_retire(all_processors)
             use_mtp = (
                 self._mtp
                 and not custom_logits_active
@@ -1309,7 +1325,6 @@ class SimpleEngine(BaseEngine):
                 else:
                     prompt_cache = backbone_cache
 
-            results = []
             gen_kwargs = dict(
                 max_tokens=max_tokens,
                 sampler=sampler,
@@ -1322,15 +1337,77 @@ class SimpleEngine(BaseEngine):
                 gen_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
             if prompt_cache is not None:
                 gen_kwargs["prompt_cache"] = prompt_cache
+            if can_retire_processors and not use_mtp:
+                shared_cache = prompt_cache
+                if shared_cache is None:
+                    shared_cache = make_prompt_cache(model)
+                gen_kwargs["prompt_cache"] = shared_cache
 
-            for resp in mlx_stream_generate(
-                model,
-                self._text_tokenizer,
-                prompt=prompt_to_send,
-                **gen_kwargs,
-            ):
-                results.append(resp)
-            return results
+                results = []
+                token_count = 0
+                last_resp = None
+                retired = False
+                for resp in mlx_stream_generate(
+                    model,
+                    self._text_tokenizer,
+                    prompt=prompt_to_send,
+                    **gen_kwargs,
+                ):
+                    results.append(resp)
+                    token_count += 1
+                    last_resp = resp
+                    retired = _processors_retired(all_processors)
+                    if retired:
+                        logger.info(
+                            "Text route: request-local processor retired after %d tokens; "
+                            "resuming content phase with MTP=%s",
+                            token_count,
+                            hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                        )
+                        break
+
+                if retired and token_count < max_tokens and last_resp is not None:
+                    last_tok = getattr(last_resp, "token", None)
+                    if last_tok is not None:
+                        cache_module.trim_prompt_cache(shared_cache, 1)
+                        seed = mx.array([last_tok], dtype=mx.uint32)
+                    else:
+                        seed = mx.array(
+                            self._text_tokenizer.encode(
+                                getattr(last_resp, "text", "")
+                            ),
+                            dtype=mx.uint32,
+                        )
+                    resume_kwargs = dict(
+                        max_tokens=max_tokens - token_count,
+                        sampler=sampler,
+                        prefill_step_size=self._prefill_step_size,
+                        prompt_cache=shared_cache,
+                    )
+                    if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                        resume_kwargs["prompt_cache"] = (
+                            shared_cache + model.make_mtp_cache()
+                        )
+                        resume_kwargs["mtp"] = True
+                        resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                    for resp in mlx_stream_generate(
+                        model,
+                        self._text_tokenizer,
+                        prompt=seed,
+                        **resume_kwargs,
+                    ):
+                        results.append(resp)
+                return results
+            else:
+                results = []
+                for resp in mlx_stream_generate(
+                    model,
+                    self._text_tokenizer,
+                    prompt=prompt_to_send,
+                    **gen_kwargs,
+                ):
+                    results.append(resp)
+                return results
 
         def _run_specprefill(model, bc, use_mtp):
             """Score tokens, sparse prefill, then continue on the standard decode path."""
@@ -1436,11 +1513,39 @@ class SimpleEngine(BaseEngine):
                         prompt_cache = bc + model.make_mtp_cache()
 
                     continuation_prompt = mx.array([tok_id], dtype=mx.uint32)
+                    token_count = 1
+                    if _processors_retired(all_processors) and token_count < max_tokens:
+                        logger.info(
+                            "SpecPrefill text route: request-local processor retired after seed token; "
+                            "resuming content phase with MTP=%s",
+                            hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                        )
+                        resume_kwargs = dict(
+                            max_tokens=max_tokens - token_count,
+                            sampler=sampler,
+                            prefill_step_size=self._prefill_step_size,
+                            prompt_cache=bc,
+                        )
+                        if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                            resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
+                            resume_kwargs["mtp"] = True
+                            resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                        for resp in mlx_stream_generate(
+                            model,
+                            self._text_tokenizer,
+                            prompt=continuation_prompt,
+                            **resume_kwargs,
+                        ):
+                            results.append(resp)
+                        return results
+
+                    last_resp = None
+                    retired = False
                     for resp in mlx_stream_generate(
                         model,
                         self._text_tokenizer,
                         prompt=continuation_prompt,
-                        max_tokens=max_tokens - 1,
+                        max_tokens=max_tokens - token_count,
                         sampler=sampler,
                         prefill_step_size=self._prefill_step_size,
                         logits_processors=seeded_processors,
@@ -1448,6 +1553,47 @@ class SimpleEngine(BaseEngine):
                         mtp=use_mtp,
                     ):
                         results.append(resp)
+                        token_count += 1
+                        last_resp = resp
+                        retired = _processors_retired(all_processors)
+                        if retired:
+                            logger.info(
+                                "SpecPrefill text route: request-local processor retired after %d tokens; "
+                                "resuming content phase with MTP=%s",
+                                token_count,
+                                hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                            )
+                            break
+
+                    if retired and token_count < max_tokens and last_resp is not None:
+                        last_tok = getattr(last_resp, "token", None)
+                        if last_tok is not None:
+                            cache_module.trim_prompt_cache(bc, 1)
+                            seed = mx.array([last_tok], dtype=mx.uint32)
+                        else:
+                            seed = mx.array(
+                                self._text_tokenizer.encode(
+                                    getattr(last_resp, "text", "")
+                                ),
+                                dtype=mx.uint32,
+                            )
+                        resume_kwargs = dict(
+                            max_tokens=max_tokens - token_count,
+                            sampler=sampler,
+                            prefill_step_size=self._prefill_step_size,
+                            prompt_cache=bc,
+                        )
+                        if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+                            resume_kwargs["prompt_cache"] = bc + model.make_mtp_cache()
+                            resume_kwargs["mtp"] = True
+                            resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                        for resp in mlx_stream_generate(
+                            model,
+                            self._text_tokenizer,
+                            prompt=seed,
+                            **resume_kwargs,
+                        ):
+                            results.append(resp)
 
                 return results
 

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -564,6 +564,10 @@ class EngineCore:
         """Load prefix cache from disk."""
         return self.scheduler.load_cache_from_disk(cache_dir)
 
+    def clear_runtime_caches(self) -> Dict[str, Any] | None:
+        """Clear scheduler-managed runtime caches."""
+        return self.scheduler.clear_runtime_caches()
+
     def clear_prefix_cache(self) -> None:
         """Clear the prefix cache (delegates to scheduler)."""
         if hasattr(self.scheduler, "clear_prefix_cache"):
@@ -713,3 +717,7 @@ class AsyncEngineCore:
     def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk."""
         return self.engine.load_cache_from_disk(cache_dir)
+
+    def clear_runtime_caches(self) -> Dict[str, Any] | None:
+        """Clear scheduler-managed runtime caches."""
+        return self.engine.clear_runtime_caches()

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -24,6 +24,7 @@ from .request import Request, RequestOutput, SamplingParams
 from .scheduler import Scheduler, SchedulerConfig
 from .output_collector import RequestOutputCollector, RequestStreamState
 from .model_registry import get_registry
+from .mlx_streams import bind_generation_streams
 
 logger = logging.getLogger(__name__)
 
@@ -136,20 +137,55 @@ class EngineCore:
         return self._running
 
     async def _engine_loop(self) -> None:
-        """Main engine loop - hybrid executor for prefill vs generation.
+        """Main engine loop.
 
-        Prefill steps (long prompts) are run in a thread executor to keep
-        the asyncio event loop responsive.  Generation-only steps (~1-3ms)
-        are called directly to avoid ~0.5-2ms context switch overhead,
-        giving ~5-10% throughput improvement during sustained generation.
+        All scheduler steps run on one worker thread. MLX generation streams
+        are thread-local, so mixing prefill on a worker with decode on the
+        event-loop thread can reuse stream handles on the wrong thread.
         """
         import concurrent.futures
 
-        # Single-thread executor ensures MLX calls are never concurrent
+        # Single-thread executor ensures MLX calls are never concurrent and
+        # keeps mlx-lm generation streams bound to one thread for this engine.
         _executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="mlx-step"
         )
         loop = asyncio.get_running_loop()
+        worker_streams_bound = False
+
+        def _ensure_worker_streams_bound() -> None:
+            nonlocal worker_streams_bound
+            if not worker_streams_bound:
+                bind_generation_streams()
+                worker_streams_bound = True
+
+        def _step_on_worker():
+            _ensure_worker_streams_bound()
+            output = self.scheduler.step()
+            self._steps_executed += 1
+
+            if self._steps_executed % _memory_check_interval == 0:
+                try:
+                    active_mem = mx.get_active_memory()
+                    if active_mem > _memory_pressure_threshold:
+                        mx.clear_cache()
+                        logger.warning(
+                            f"[Memory pressure] {active_mem / 1e9:.1f}GB > "
+                            f"{_memory_pressure_threshold / 1e9:.0f}GB threshold, "
+                            f"forced cache clear"
+                        )
+                except Exception:
+                    pass
+
+            return output
+
+        def _clear_cache_on_worker() -> None:
+            _ensure_worker_streams_bound()
+            mx.clear_cache()
+
+        def _close_batch_generator_on_worker() -> None:
+            _ensure_worker_streams_bound()
+            self.scheduler._close_batch_generator()
 
         step_interval = self.config.step_interval
         stream_interval = self.config.stream_interval
@@ -170,43 +206,9 @@ class EngineCore:
             while self._running:
                 try:
                     if self.scheduler.has_requests():
-                        # Hybrid approach: use executor only when prefill is likely.
-                        # Prefill happens when there are waiting requests that need
-                        # to be inserted into the batch (may block for seconds).
-                        # Generation-only steps are fast (<3ms) and can run inline.
-                        has_waiting = self.scheduler.get_num_waiting() > 0
-                        has_partial = (
-                            self.scheduler.batch_generator is not None
-                            and getattr(
-                                self.scheduler.batch_generator, "_partial", None
-                            )
-                            is not None
-                        )
-                        needs_executor = has_waiting or has_partial
-
-                        if needs_executor:
-                            output = await loop.run_in_executor(
-                                _executor, self.scheduler.step
-                            )
-                        else:
-                            output = self.scheduler.step()
-                            # Yield to event loop after inline step
-                            await asyncio.sleep(0)
-                        self._steps_executed += 1
-
-                        # Emergency memory pressure check
-                        if self._steps_executed % _memory_check_interval == 0:
-                            try:
-                                active_mem = mx.get_active_memory()
-                                if active_mem > _memory_pressure_threshold:
-                                    mx.clear_cache()
-                                    logger.warning(
-                                        f"[Memory pressure] {active_mem / 1e9:.1f}GB > "
-                                        f"{_memory_pressure_threshold / 1e9:.0f}GB threshold, "
-                                        f"forced cache clear"
-                                    )
-                            except Exception:
-                                pass
+                        output = await loop.run_in_executor(_executor, _step_on_worker)
+                        # Yield to event loop after each worker step.
+                        await asyncio.sleep(0)
 
                         # Fast path: distribute outputs to collectors
                         outputs = output.outputs
@@ -241,7 +243,9 @@ class EngineCore:
 
                             # Free Metal buffers after distributing finished outputs
                             if output.finished_request_ids:
-                                mx.clear_cache()
+                                await loop.run_in_executor(
+                                    _executor, _clear_cache_on_worker
+                                )
 
                             # Always yield to prevent event loop starvation.
                             # Without this, orphaned requests (client disconnected but
@@ -260,13 +264,16 @@ class EngineCore:
                     logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
                     await asyncio.sleep(0.1)
         finally:
-            # Shut down the executor and wait for any in-flight step() to finish
-            # before closing the batch generator.  This prevents the GC from
-            # collecting a stale BatchGenerator on the worker thread, whose
-            # __del__ → close() → mx.synchronize(generation_stream) would
-            # conflict with concurrent Metal operations and SIGABRT.
+            # Close the batch generator on the same worker thread that owns the
+            # generation streams, then wait for any in-flight work to finish.
+            close_future = loop.run_in_executor(
+                _executor, _close_batch_generator_on_worker
+            )
+            try:
+                await asyncio.shield(close_future)
+            except BaseException:
+                pass
             _executor.shutdown(wait=True)
-            self.scheduler._close_batch_generator()
 
     async def add_request(
         self,

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -31,6 +31,30 @@ from .vision_embedding_cache import VisionEmbeddingCache
 logger = logging.getLogger(__name__)
 
 
+def _processors_can_retire(processors: Optional[List[Callable]]) -> bool:
+    """True when any processor advertises a retire-to-content transition."""
+    return bool(processors) and any(
+        isinstance(getattr(p, "is_retired", None), bool) for p in processors
+    )
+
+
+def _drop_retired_processors(
+    processors: Optional[List[Callable]],
+) -> tuple[Optional[List[Callable]], int]:
+    """Drop retire-capable processors that have completed their work."""
+    if not processors:
+        return processors, 0
+
+    remaining = []
+    retired_count = 0
+    for processor in processors:
+        if getattr(processor, "is_retired", False) is True:
+            retired_count += 1
+            continue
+        remaining.append(processor)
+    return (remaining or None), retired_count
+
+
 class PrefillAbortedError(Exception):
     """Raised when a prefill is aborted due to client disconnect."""
 
@@ -1676,6 +1700,22 @@ class MLLMBatchGenerator:
             req.num_tokens = num_tok
             req.output_tokens.append(token)
 
+            if batch.logits_processors and _processors_can_retire(
+                batch.logits_processors[i]
+            ):
+                remaining_processors, retired_count = _drop_retired_processors(
+                    batch.logits_processors[i]
+                )
+                if retired_count > 0:
+                    batch.logits_processors[i] = remaining_processors
+                    logger.info(
+                        "[MTP-MLLM] request=%s retired %d processor(s); "
+                        "mtp_eligible_next_step=%s",
+                        request_id[:12],
+                        retired_count,
+                        remaining_processors is None,
+                    )
+
             finish_reason = None
             cache_fn = None
 
@@ -2150,8 +2190,14 @@ def install_mtp_mllm(
     batch_gen._step = _mtp_step
     batch_gen._next = _mtp_next
 
+    if num_draft_tokens != 1:
+        logger.warning(
+            "[MTP-MLLM] num_draft_tokens=%d requested, but the current batched "
+            "MLLM MTP path drafts exactly one token per verify step",
+            num_draft_tokens,
+        )
     total = _mtp_stats
     logger.info(
         f"[MTP-MLLM] installed with num_draft_tokens={num_draft_tokens}, "
-        f"always-advance verified mode"
+        f"effective_draft_tokens=1, always-advance verified mode"
     )

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1707,6 +1707,10 @@ class MLLMBatchGenerator:
                     batch.logits_processors[i]
                 )
                 if retired_count > 0:
+                    # Keep the per-request slot but replace an empty processor
+                    # stack with None. The next `_mtp_step` uses any([None]) ==
+                    # False, so a fully retired request becomes MTP-eligible
+                    # without changing batch alignment.
                     batch.logits_processors[i] = remaining_processors
                     logger.info(
                         "[MTP-MLLM] request=%s retired %d processor(s); "
@@ -1896,7 +1900,10 @@ def install_mtp_mllm(
         # Also skip MTP when batch has multiple active requests (MTP overhead
         # hurts aggregate throughput in concurrent scenarios). The current
         # verifier is only correctness-safe for greedy decoding with no
-        # request-local logits processors.
+        # request-local logits processors. Accepted drafts are emitted directly
+        # from the greedy draft/argmax verify path; they do not pass through the
+        # request-local sampler. Non-greedy decoding needs a sampler-aware
+        # verifier before this guard can be safely relaxed.
         if (
             input_tokens.shape[1] > 1
             or batch_gen.active_batch is None

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1839,14 +1839,30 @@ def install_mtp_mllm(
     ) -> Tuple[mx.array, List[mx.array]]:
         """Extended _step with MTP always-advance strategy."""
         batch_size = input_tokens.shape[0]
+        active_requests = (
+            list(batch_gen.active_batch.requests)
+            if batch_gen.active_batch is not None
+            else []
+        )
+        has_non_greedy_sampling = any(
+            getattr(req, "temperature", 0.0) not in (0, 0.0)
+            or getattr(req, "top_p", 1.0) < 1.0
+            or getattr(req, "top_k", 0) != 0
+            or getattr(req, "min_p", 0.0) != 0.0
+            for req in active_requests
+        )
 
         # Prefill guard: skip MTP for multi-token input or when no active batch
         # Also skip MTP when batch has multiple active requests (MTP overhead
-        # hurts aggregate throughput in concurrent scenarios)
+        # hurts aggregate throughput in concurrent scenarios). The current
+        # verifier is only correctness-safe for greedy decoding with no
+        # request-local logits processors.
         if (
             input_tokens.shape[1] > 1
             or batch_gen.active_batch is None
             or len(batch_gen.active_batch) > 1
+            or has_non_greedy_sampling
+            or (logits_processors is not None and any(logits_processors))
         ):
             _skip_state[0] = None
             return _orig_step(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -36,6 +36,7 @@ from .mllm_batch_generator import (
     MLLMBatchRequest,
     MLLMBatchResponse,
 )
+from .mlx_streams import bind_generation_streams
 from .multimodal_processor import MultimodalProcessor
 from .request import RequestOutput, RequestStatus, SamplingParams
 
@@ -785,40 +786,56 @@ class MLLMScheduler:
     async def _process_loop(self) -> None:
         """Main async processing loop.
 
-        Uses a thread pool executor for steps that involve prefill
-        (waiting requests or partial prefill in progress) so that the
-        event loop stays responsive for health checks and other HTTP
-        endpoints.  Decode-only steps are fast (<3 ms) and run inline.
+        All MLLM steps run on one worker thread. MLX generation streams are
+        thread-local, so prefill and decode must not bounce between the event
+        loop thread and a worker thread.
         """
         _executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="mllm-step"
         )
         loop = asyncio.get_running_loop()
+        worker_streams_bound = False
 
-        while self._running:
-            try:
-                if self.has_requests():
-                    has_waiting = self.get_num_waiting() > 0
-                    has_partial = (
-                        self.batch_generator is not None
-                        and getattr(self.batch_generator, "_partial", None) is not None
-                    )
-                    needs_executor = has_waiting or has_partial
+        def _ensure_worker_streams_bound() -> None:
+            nonlocal worker_streams_bound
+            if not worker_streams_bound:
+                bind_generation_streams()
+                worker_streams_bound = True
 
-                    if needs_executor:
-                        await loop.run_in_executor(_executor, self.step)
-                    else:
-                        self.step()
+        def _step_on_worker() -> None:
+            _ensure_worker_streams_bound()
+            self.step()
+
+        def _close_batch_generator_on_worker() -> None:
+            _ensure_worker_streams_bound()
+            if self.batch_generator is not None:
+                self.batch_generator.close()
+                self.batch_generator = None
+
+        try:
+            while self._running:
+                try:
+                    if self.has_requests():
+                        await loop.run_in_executor(_executor, _step_on_worker)
                         await asyncio.sleep(0)
-                else:
-                    # No work, wait a bit
-                    await asyncio.sleep(0.01)
+                    else:
+                        # No work, wait a bit
+                        await asyncio.sleep(0.01)
 
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
-                await asyncio.sleep(0.1)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
+                    await asyncio.sleep(0.1)
+        finally:
+            close_future = loop.run_in_executor(
+                _executor, _close_batch_generator_on_worker
+            )
+            try:
+                await asyncio.shield(close_future)
+            except BaseException:
+                pass
+            _executor.shutdown(wait=True)
 
     async def add_request_async(
         self,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1068,6 +1068,23 @@ class MLLMScheduler:
 
         return stats
 
+    def clear_runtime_caches(self) -> Dict[str, bool]:
+        """Clear runtime caches without resetting scheduler/request state."""
+        cleared = {
+            "vision_cache": False,
+            "prefix_cache": False,
+        }
+        if self.vision_cache:
+            self.vision_cache.clear()
+            cleared["vision_cache"] = True
+        if (
+            self.batch_generator is not None
+            and self.batch_generator.prefix_cache is not None
+        ):
+            self.batch_generator.prefix_cache.clear()
+            cleared["prefix_cache"] = True
+        return cleared
+
     def reset(self) -> None:
         """Reset the scheduler state."""
         # Abort all requests

--- a/vllm_mlx/mlx_streams.py
+++ b/vllm_mlx/mlx_streams.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for binding MLX generation streams to worker threads."""
+
+import importlib
+from collections.abc import Iterable
+
+import mlx.core as mx
+
+
+def bind_generation_streams(
+    module_names: Iterable[str] = ("mlx_lm.generate", "mlx_vlm.generate"),
+) -> object:
+    """Bind mlx-lm/mlx-vlm generation streams to the current thread.
+
+    MLX streams are thread-local. If a model is loaded on one thread and
+    generation runs on another, module-level generation streams created during
+    import can point at a stream that does not exist in the worker thread.
+    """
+    default_stream = mx.new_stream(mx.default_device())
+    mx.set_default_stream(default_stream)
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        if hasattr(module, "generation_stream"):
+            module.generation_stream = default_stream
+    return default_stream

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -56,6 +56,7 @@ class MLXLanguageModel:
         tokenizer_name: str | None = None,
         trust_remote_code: bool = False,
         mtp: bool = False,
+        mtp_num_draft_tokens: int = 1,
     ):
         """
         Initialize the MLX language model.
@@ -65,11 +66,13 @@ class MLXLanguageModel:
             tokenizer_name: Optional separate tokenizer name
             trust_remote_code: Whether to trust remote code
             mtp: Enable native MTP speculative decoding (model must have MTP head)
+            mtp_num_draft_tokens: Draft tokens per speculative MTP step
         """
         self.model_name = model_name
         self.tokenizer_name = tokenizer_name or model_name
         self.trust_remote_code = trust_remote_code
         self._mtp = mtp
+        self._mtp_num_draft_tokens = mtp_num_draft_tokens
 
         self.model = None
         self.tokenizer = None
@@ -274,6 +277,7 @@ class MLXLanguageModel:
         mtp_kwargs = {}
         if self._mtp:
             mtp_kwargs["mtp"] = True
+            mtp_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1091,9 +1091,16 @@ def _install_mtp(
     batch_gen._step = _mtp_step
     batch_gen._next = _mtp_next
 
+    if num_draft_tokens != 1:
+        logger.warning(
+            "[MTP] num_draft_tokens=%d requested, but the current batched MTP "
+            "path drafts exactly one token per verify step",
+            num_draft_tokens,
+        )
     mode_str = "optimistic (no verify)" if optimistic else "always-advance"
     logger.info(
-        f"[MTP] installed with num_draft_tokens={num_draft_tokens}, " f"{mode_str} mode"
+        f"[MTP] installed with num_draft_tokens={num_draft_tokens}, "
+        f"effective_draft_tokens=1, {mode_str} mode"
     )
 
 
@@ -2668,6 +2675,24 @@ class Scheduler:
             return self.prefix_cache.get_stats()
         return None
 
+    def clear_runtime_caches(self) -> Dict[str, bool]:
+        """Clear prefix-cache state without resetting scheduler/request state."""
+        cleared = {
+            "paged_cache": False,
+            "memory_aware_cache": False,
+            "prefix_cache": False,
+        }
+        if self.block_aware_cache is not None:
+            self.block_aware_cache.clear()
+            cleared["paged_cache"] = True
+        if self.memory_aware_cache is not None:
+            self.memory_aware_cache.clear()
+            cleared["memory_aware_cache"] = True
+        if self.prefix_cache is not None:
+            self.prefix_cache.clear()
+            cleared["prefix_cache"] = True
+        return cleared
+
     def reset(self) -> None:
         """Reset the scheduler state."""
         # Drain any pending deferred aborts
@@ -2688,12 +2713,7 @@ class Scheduler:
         self._current_sampler_params = None
 
         # Clear caches
-        if self.block_aware_cache is not None:
-            self.block_aware_cache.clear()
-        if self.memory_aware_cache is not None:
-            self.memory_aware_cache.clear()
-        if self.prefix_cache is not None:
-            self.prefix_cache.clear()
+        self.clear_runtime_caches()
 
         # Close SSD tier on reset
         self.close_ssd_tier()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2413,6 +2413,13 @@ async def status():
 @app.get("/v1/cache/stats", dependencies=[Depends(verify_api_key)])
 async def cache_stats():
     """Get cache statistics for debugging and monitoring."""
+    engine_cache = None
+    if _engine is not None and hasattr(_engine, "get_cache_stats"):
+        try:
+            engine_cache = _engine.get_cache_stats()
+        except Exception as exc:
+            engine_cache = {"error": f"engine cache stats failed: {exc}"}
+
     try:
         from mlx_vlm.utils import (
             get_multimodal_kv_cache_stats,
@@ -2421,17 +2428,29 @@ async def cache_stats():
         )
 
         return {
+            "engine_cache": engine_cache,
             "multimodal_kv_cache": get_multimodal_kv_cache_stats(),
             "pixel_values_cache": get_pixel_values_cache_stats(),
             "pil_image_cache": get_pil_cache_stats(),
         }
     except ImportError:
-        return {"error": "Cache stats not available (mlx_vlm not loaded)"}
+        return {
+            "engine_cache": engine_cache,
+            "error": "Cache stats not available (mlx_vlm not loaded)",
+        }
 
 
 @app.delete("/v1/cache", dependencies=[Depends(verify_api_key)])
 async def clear_cache():
     """Clear all caches."""
+    cleared_engine = None
+    if _engine is not None and hasattr(_engine, "clear_runtime_caches"):
+        try:
+            cleared_engine = _engine.clear_runtime_caches()
+        except Exception as exc:
+            logger.warning("Failed to clear engine caches: %s", exc, exc_info=True)
+            cleared_engine = {"error": str(exc)}
+
     try:
         from mlx_vlm.utils import (
             clear_multimodal_kv_cache,
@@ -2442,10 +2461,15 @@ async def clear_cache():
         clear_pixel_values_cache()
         return {
             "status": "cleared",
+            "engine_cache": cleared_engine,
             "caches": ["multimodal_kv", "pixel_values", "pil_image"],
         }
     except ImportError:
-        return {"error": "Cache clear not available (mlx_vlm not loaded)"}
+        return {
+            "status": "cleared",
+            "engine_cache": cleared_engine,
+            "error": "Cache clear not available (mlx_vlm not loaded)",
+        }
 
 
 @app.delete("/v1/cache/prefix", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
## Summary
- preserve text-route decoding controls after successful SimpleEngine SpecPrefill
- keep native MTP only on paths where request-local processors are speculation-safe or retired
- resume MTP after thinking-budget processor retirement through a shared continuation helper
- bind MLX generation streams inside the scheduler worker thread to fix cross-thread stream ownership failures

## Problem
Successful SimpleEngine SpecPrefill was not composing with the normal decode contract. The continuation could silently drop native MTP and request-local logits processors, making SpecPrefill+MTP measurements misleading and risking constrained-decoding violations.

Separately, continuous batching could run prefill on an executor thread and decode on the event-loop thread. MLX generation streams are thread-local, so that split can fail with `RuntimeError: There is no Stream(gpu, N) in current thread`.

## Fix
- seed request-local logits processors with the original prompt context before continuation
- sample the first post-prefill token through active processors
- continue through `mlx_lm.stream_generate()` with the backbone cache and MTP cache only when allowed
- fail closed for native MTP with active unsafe processors
- share processor-retirement resume logic between normal and SpecPrefill simple paths
- run continuous-batching and MLLM scheduler steps on one MLX worker thread and bind mlx-lm/mlx-vlm generation streams in that thread

## Validation
- `python -m pytest -q tests/test_engine_core_thread_streams.py tests/test_simple_engine.py tests/test_mllm_continuous_batching.py tests/test_batched_engine.py tests/test_llm.py tests/test_server_cache_controls.py`
- result: `66 passed, 9 deselected`
- `python -m black --check ...`
- result: `16 files would be left unchanged`
- GitHub Actions run `24860026718`: lint, type-check, test-matrix 3.10/3.11/3.12/3.13, Apple Silicon 3.11/3.13, and aggregate tests all passed

Fixes #398.
