### PR TITLE
fix: keep MLLM generation on model-load thread

### DIFF
--- a/tests/test_engine_core_thread_streams.py
+++ b/tests/test_engine_core_thread_streams.py
@@ -68,8 +68,8 @@ async def test_engine_core_runs_all_scheduler_steps_on_one_worker_thread(monkeyp
 
 
 @pytest.mark.anyio
-async def test_mllm_scheduler_runs_all_steps_on_one_worker_thread(monkeypatch):
-    """MLLM scheduler loop follows the same thread-local stream invariant."""
+async def test_mllm_scheduler_runs_steps_on_model_load_thread(monkeypatch):
+    """MLLM keeps generation on the event-loop thread that loaded the model."""
     from vllm_mlx.mllm_scheduler import MLLMScheduler
 
     scheduler = object.__new__(MLLMScheduler)
@@ -107,6 +107,6 @@ async def test_mllm_scheduler_runs_all_steps_on_one_worker_thread(monkeypatch):
 
     assert step_threads
     assert len(set(step_threads)) == 1
-    assert step_threads[0] != main_thread
-    assert bind_threads == [step_threads[0]]
-    assert close_threads == [step_threads[0]]
+    assert step_threads[0] == main_thread
+    assert bind_threads == [main_thread]
+    assert close_threads == []

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -804,13 +804,65 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert request_sampler.call_count == 1
         assert batch_gen.sampler.call_count == 0
 
-    def test_next_drops_retired_processors_and_makes_request_mtp_eligible(self):
+    def test_next_keeps_retired_processors_by_default(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatch,
             MLLMBatchGenerator,
             MLLMBatchRequest,
             MLLMBatchStats,
         )
+
+        monkeypatch.delenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME", raising=False)
+
+        class RetiredProcessor:
+            is_retired = True
+
+            def __call__(self, tokens, logits):
+                return logits
+
+        processor = RetiredProcessor()
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._stats = MLLMBatchStats()
+        generator.stop_tokens = set()
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator._maybe_store_prefix_cache = lambda batch, end_idx: None
+        generator._step = lambda *args, **kwargs: (
+            mx.array([11]),
+            [mx.array([0.2, 0.8])],
+        )
+
+        request = MLLMBatchRequest(uid=1, request_id="req-1", prompt="hello")
+        generator.active_batch = MLLMBatch(
+            uids=[1],
+            request_ids=["req-1"],
+            y=mx.array([7]),
+            logprobs=[mx.array([0.5, 0.5])],
+            max_tokens=[4],
+            num_tokens=[0],
+            cache=[],
+            requests=[request],
+            logits_processors=[[processor]],
+            samplers=None,
+        )
+
+        responses = MLLMBatchGenerator._next(generator)
+
+        assert len(responses) == 1
+        assert generator.active_batch is not None
+        assert generator.active_batch.logits_processors == [[processor]]
+
+    def test_next_drops_retired_processors_only_when_enabled(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        monkeypatch.setenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME", "1")
 
         class RetiredProcessor:
             is_retired = True

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -781,8 +781,10 @@ class TestSimpleEngineConcurrency:
         assert captured_kwargs["num_draft_tokens"] == 4
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_reenables_mtp_after_retired_processor(self):
-        """Retired thinking processors should hand off the content phase to MTP."""
+    async def test_stream_generate_text_reenables_mtp_after_retired_processor_when_enabled(
+        self,
+    ):
+        """Retired thinking processor handoff is an explicit opt-in path."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -825,6 +827,10 @@ class TestSimpleEngineConcurrency:
         engine._text_tokenizer = tokenizer
 
         with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME": "1"},
+            ),
             patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
             patch("mlx_lm.models.cache.trim_prompt_cache"),
@@ -852,7 +858,7 @@ class TestSimpleEngineConcurrency:
     async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(
         self,
     ):
-        """SpecPrefill continuation should resume with MTP once thinking retires."""
+        """SpecPrefill retirement-to-MTP continuation is explicit opt-in."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -898,6 +904,10 @@ class TestSimpleEngineConcurrency:
             return mx.array(11, dtype=mx.uint32), logits
 
         with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME": "1"},
+            ),
             patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
             patch(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -8,6 +8,7 @@ performance when serving a single user at a time.
 
 import asyncio
 import logging
+import os
 import time
 from collections.abc import AsyncIterator
 from typing import Any
@@ -81,6 +82,8 @@ def _sample_with_processors(
 
 def _processors_can_retire(processors: list[Any] | None) -> bool:
     """True when any processor advertises a retire-to-content transition."""
+    if os.getenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME") != "1":
+        return False
     return bool(processors) and any(
         isinstance(getattr(p, "is_retired", None), bool) for p in processors
     )
@@ -88,6 +91,8 @@ def _processors_can_retire(processors: list[Any] | None) -> bool:
 
 def _processors_retired(processors: list[Any] | None) -> bool:
     """True when any retire-capable processor has entered its retired state."""
+    if os.getenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME") != "1":
+        return False
     return bool(processors) and any(
         getattr(p, "is_retired", False) is True for p in processors
     )

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -17,6 +17,7 @@ Architecture:
 """
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -33,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 def _processors_can_retire(processors: Optional[List[Callable]]) -> bool:
     """True when any processor advertises a retire-to-content transition."""
+    if os.getenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME") != "1":
+        return False
     return bool(processors) and any(
         isinstance(getattr(p, "is_retired", None), bool) for p in processors
     )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -19,7 +19,6 @@ Architecture:
 """
 
 import asyncio
-import concurrent.futures
 import logging
 import time
 import uuid
@@ -786,56 +785,34 @@ class MLLMScheduler:
     async def _process_loop(self) -> None:
         """Main async processing loop.
 
-        All MLLM steps run on one worker thread. MLX generation streams are
-        thread-local, so prefill and decode must not bounce between the event
-        loop thread and a worker thread.
+        MLLM models are loaded on the server/event-loop thread, so their MLX
+        arrays and cache state must be consumed on that same thread.  Unlike
+        the text-only EngineCore path, moving MLLM prefill to a worker crosses
+        MLX stream ownership and can fail with "no Stream in current thread".
         """
-        _executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mllm-step"
-        )
-        loop = asyncio.get_running_loop()
-        worker_streams_bound = False
+        streams_bound = False
 
-        def _ensure_worker_streams_bound() -> None:
-            nonlocal worker_streams_bound
-            if not worker_streams_bound:
+        def _ensure_streams_bound() -> None:
+            nonlocal streams_bound
+            if not streams_bound:
                 bind_generation_streams()
-                worker_streams_bound = True
+                streams_bound = True
 
-        def _step_on_worker() -> None:
-            _ensure_worker_streams_bound()
-            self.step()
-
-        def _close_batch_generator_on_worker() -> None:
-            _ensure_worker_streams_bound()
-            if self.batch_generator is not None:
-                self.batch_generator.close()
-                self.batch_generator = None
-
-        try:
-            while self._running:
-                try:
-                    if self.has_requests():
-                        await loop.run_in_executor(_executor, _step_on_worker)
-                        await asyncio.sleep(0)
-                    else:
-                        # No work, wait a bit
-                        await asyncio.sleep(0.01)
-
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
-                    await asyncio.sleep(0.1)
-        finally:
-            close_future = loop.run_in_executor(
-                _executor, _close_batch_generator_on_worker
-            )
+        while self._running:
             try:
-                await asyncio.shield(close_future)
-            except BaseException:
-                pass
-            _executor.shutdown(wait=True)
+                if self.has_requests():
+                    _ensure_streams_bound()
+                    self.step()
+                    await asyncio.sleep(0)
+                else:
+                    # No work, wait a bit
+                    await asyncio.sleep(0.01)
+
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
+                await asyncio.sleep(0.1)
 
     async def add_request_async(
         self,


### PR DESCRIPTION
## Summary
- keeps MLLM scheduler steps on the model-load/event-loop thread to avoid MLX stream ownership failures from worker-thread prefill
- gates the thinking-processor retirement/MTP handoff behind VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME=1 so the default path keeps content-phase control-token masking
- updates regression coverage for MLLM threading and default-off thinking handoff

## Tests
- python -m pytest -q tests/test_engine_core_thread_streams.py tests/test_mllm_continuous_batching.py tests/test_simple_engine.py tests/test_constrained_decoding.py tests/test_reasoning_parser.py
- python -m black --check vllm_mlx/mllm_scheduler.py vllm_mlx/engine/simple.py vllm_mlx/mllm_batch_generator.py tests/test_engine_core_thread_streams.py tests/test_simple_engine.py tests/test_mllm_continuous_batching.py

## Local runtime evidence
- resident qwen3.5-35b-a3b non-thinking canary: ACK_STREAM_FIX_READY, finish_reason=stop
- resident qwen3.5-35b-a3b streaming thinking canary: ACK_THINK_READY, finish_reason=stop, no think-tag/content leakage