### PR TITLE
Fix MLLM batch extension for opaque caches

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -235,6 +235,51 @@ class TestMLLMBatch:
         assert batch.uids == [1, 3]
         assert batch.request_ids == ["req-1", "req-3"]
 
+    def test_batch_extend_handles_empty_protocol_caches_without_keys(self):
+        """Caches with empty()/extend() but no .keys still need batch extension."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatch, MLLMBatchRequest
+
+        class OpaqueCache:
+            def __init__(self):
+                self.extend_calls = 0
+                self.extended_with = None
+
+            def empty(self):
+                return False
+
+            def extend(self, other):
+                self.extend_calls += 1
+                self.extended_with = other
+
+        primary_cache = OpaqueCache()
+        other_cache = OpaqueCache()
+        primary = MLLMBatch(
+            uids=[1],
+            request_ids=["req-1"],
+            y=mx.array([100]),
+            logprobs=[mx.array([0.1])],
+            max_tokens=[100],
+            num_tokens=[0],
+            cache=[primary_cache],
+            requests=[MLLMBatchRequest(uid=1, request_id="req-1", prompt="one")],
+        )
+        other = MLLMBatch(
+            uids=[2],
+            request_ids=["req-2"],
+            y=mx.array([200]),
+            logprobs=[mx.array([0.2])],
+            max_tokens=[100],
+            num_tokens=[0],
+            cache=[other_cache],
+            requests=[MLLMBatchRequest(uid=2, request_id="req-2", prompt="two")],
+        )
+
+        primary.extend(other)
+
+        assert primary.y.shape == (2,)
+        assert primary_cache.extend_calls == 1
+        assert primary_cache.extended_with is other_cache
+
 
 class TestMLLMBatchStats:
     """Tests for MLLMBatchStats."""

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -208,13 +208,16 @@ class MLLMBatch:
             self.samplers = list(self_s) + list(other_s)
 
         # Extend cache - handle both BatchKVCache (.keys/.values) and
-        # ArraysCache (.cache list) from hybrid models like Qwen3.5
+        # ArraysCache (.cache list) from hybrid models like Qwen3.5. Some
+        # cache integrations, such as quantized SDPA caches, expose state only
+        # through empty()/extend() and do not publish .keys.
         for c, o in zip(self.cache, other.cache):
             if c is not None and o is not None and hasattr(c, "extend"):
                 try:
                     has_kv = hasattr(c, "keys") and c.keys is not None
                     has_arrays = hasattr(c, "cache")
-                    if has_kv or has_arrays:
+                    has_extendable_state = hasattr(c, "empty") and not c.empty()
+                    if has_kv or has_arrays or has_extendable_state:
                         c.extend(o)
                 except Exception as e:
                     logger.warning(f"Failed to extend cache: {e}")


### PR DESCRIPTION
## Summary
- extend MLLM batches for caches that expose empty()/extend() but not .keys
- add regression coverage with an opaque cache fake

## Why
I hit this in runtime qualification with a quantized SDPA cache: the request batch grew to two rows while the cache stayed at one row, causing a broadcast failure during decode. The fix is intentionally generic and does not depend on mlx-qsdpa.

## Tests
- /opt/ai-runtime/venv-live/bin/python -m pytest -q tests/test_mllm_continuous_batching.py
- /opt/ai-runtime/venv-live/bin/python -m black --check --target-version py312 vllm_mlx/mllm_batch_generator.py tests/test_mllm_continuous_batching.py
