### PR TITLE
Fix MLLM request-local sampling controls

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -722,9 +722,7 @@ if __name__ == "__main__":
 
 
 class TestMLLMBatchGeneratorMTPGuards:
-    def test_process_prompts_applies_request_sampling_to_first_token(
-        self, monkeypatch
-    ):
+    def test_process_prompts_applies_request_sampling_to_first_token(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchGenerator,
             MLLMBatchRequest,
@@ -757,7 +755,9 @@ class TestMLLMBatchGeneratorMTPGuards:
             "mlx_lm.models.cache.make_prompt_cache", lambda model: [FakeCache()]
         )
         monkeypatch.setattr("mlx_lm.sample_utils.make_sampler", fake_make_sampler)
-        monkeypatch.setattr("mlx_lm.sample_utils.make_logits_processors", lambda **_: [])
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
 
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator._stats = MLLMBatchStats()
@@ -796,9 +796,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert processor.calls == [[]]
         assert request_sampler.call_count == 1
         fallback_sampler.assert_not_called()
-        assert sampler_calls == [
-            {"temp": 0.3, "top_p": 0.8, "top_k": 0, "min_p": 0.0}
-        ]
+        assert sampler_calls == [{"temp": 0.3, "top_p": 0.8, "top_k": 0, "min_p": 0.0}]
 
     def test_next_passes_current_token_to_logits_processor_prefix(self):
         from vllm_mlx.mllm_batch_generator import (

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -17,6 +17,7 @@ import asyncio
 import base64
 import os
 import tempfile
+from contextlib import nullcontext
 from unittest.mock import MagicMock
 
 import pytest
@@ -721,6 +722,132 @@ if __name__ == "__main__":
 
 
 class TestMLLMBatchGeneratorMTPGuards:
+    def test_process_prompts_applies_request_sampling_to_first_token(
+        self, monkeypatch
+    ):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FakeCache:
+            def merge(self, caches):
+                return self
+
+        class RecordingProcessor:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, tokens, logits):
+                self.calls.append(tokens.tolist())
+                return logits
+
+        processor = RecordingProcessor()
+        request_sampler = MagicMock(return_value=mx.array([3], dtype=mx.uint32))
+        fallback_sampler = MagicMock(return_value=mx.array([1], dtype=mx.uint32))
+        sampler_calls = []
+
+        def fake_make_sampler(**kwargs):
+            sampler_calls.append(kwargs)
+            return request_sampler
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda model: [FakeCache()]
+        )
+        monkeypatch.setattr("mlx_lm.sample_utils.make_sampler", fake_make_sampler)
+        monkeypatch.setattr("mlx_lm.sample_utils.make_logits_processors", lambda **_: [])
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator.prefill_step_size = 512
+        generator.language_model = object()
+        generator.model = MagicMock()
+        generator.sampler = fallback_sampler
+        generator._trim_rotating_caches = lambda cache: None
+        generator._preprocess_request = lambda req: None
+        generator._run_chunked_text_prefill = lambda req, cache: mx.array(
+            [[[0.0, 1.0, 2.0, 3.0]]]
+        )
+
+        request = MLLMBatchRequest(
+            uid=7,
+            request_id="req-7",
+            prompt="hello",
+            temperature=0.3,
+            top_p=0.8,
+            top_k=0,
+            min_p=0.0,
+            logits_processors=[processor],
+        )
+        request.input_ids = mx.array([[42]], dtype=mx.uint32)
+        request.is_text_only = True
+
+        batch = MLLMBatchGenerator._process_prompts(generator, [request])
+
+        assert batch.y.tolist() == [3]
+        assert batch.samplers == [request_sampler]
+        assert batch.logits_processors == [[processor]]
+        assert processor.calls == [[]]
+        assert request_sampler.call_count == 1
+        fallback_sampler.assert_not_called()
+        assert sampler_calls == [
+            {"temp": 0.3, "top_p": 0.8, "top_k": 0, "min_p": 0.0}
+        ]
+
+    def test_next_passes_current_token_to_logits_processor_prefix(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        captured = {}
+
+        def fake_step(input_tokens, cache, logits_processors, output_tokens, samplers):
+            captured["input_tokens"] = input_tokens.tolist()
+            captured["output_tokens"] = output_tokens
+            return mx.array([11]), [mx.array([0.2, 0.8])]
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._stats = MLLMBatchStats()
+        generator.stop_tokens = set()
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator._maybe_store_prefix_cache = lambda batch, end_idx: None
+        generator._step = fake_step
+
+        processor = MagicMock()
+        request = MLLMBatchRequest(uid=1, request_id="req-1", prompt="hello")
+        request.output_tokens = [5]
+        generator.active_batch = MLLMBatch(
+            uids=[1],
+            request_ids=["req-1"],
+            y=mx.array([7]),
+            logprobs=[mx.array([0.5, 0.5])],
+            max_tokens=[8],
+            num_tokens=[1],
+            cache=[],
+            requests=[request],
+            logits_processors=[[processor]],
+            samplers=None,
+        )
+
+        responses = MLLMBatchGenerator._next(generator)
+
+        assert [r.token for r in responses] == [7]
+        assert captured["input_tokens"] == [[7]]
+        assert captured["output_tokens"] == [[5, 7]]
+        assert request.output_tokens == [5, 7]
+
     def test_install_mtp_mllm_disables_mtp_when_logits_processors_active(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
 

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1060,6 +1060,7 @@ class MLLMBatchGenerator:
             MLLMBatch ready for generation
         """
         from mlx_lm.models.cache import make_prompt_cache
+        from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
         tic = time.perf_counter()
 
@@ -1092,6 +1093,60 @@ class MLLMBatchGenerator:
         if not requests:
             # All requests failed
             return None
+
+        logits_processors_by_request: dict[str, Optional[List[Callable]]] = {}
+        samplers_by_request: dict[str, Optional[Callable]] = {}
+        for req in requests:
+            need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
+            need_pres = req.presence_penalty and req.presence_penalty != 0.0
+            combined: List[Callable] = []
+            if need_rep or need_pres:
+                lp_kwargs = {}
+                if need_rep:
+                    lp_kwargs["repetition_penalty"] = req.repetition_penalty
+                if need_pres:
+                    lp_kwargs["presence_penalty"] = req.presence_penalty
+                combined.extend(make_logits_processors(**lp_kwargs))
+                logger.info(
+                    f"[sampling] request={req.request_id[:12]} "
+                    f"rep_penalty={req.repetition_penalty} "
+                    f"pres_penalty={req.presence_penalty}"
+                )
+            if req.logits_processors:
+                combined.extend(req.logits_processors)
+                logger.info(
+                    f"[sampling] request={req.request_id[:12]} "
+                    f"extra_logits_processors={len(req.logits_processors)}"
+                )
+            logits_processors_by_request[req.request_id] = combined or None
+
+            samplers_by_request[req.request_id] = make_sampler(
+                temp=req.temperature,
+                top_p=req.top_p,
+                top_k=req.top_k,
+                min_p=req.min_p,
+            )
+            logger.info(
+                f"[sampling] request={req.request_id[:12]} "
+                f"temp={req.temperature} top_p={req.top_p} "
+                f"top_k={req.top_k} min_p={req.min_p}"
+            )
+
+        def _sample_first_token(req: MLLMBatchRequest, logits: mx.array):
+            sample_logits = logits
+            processors = logits_processors_by_request.get(req.request_id)
+            if processors:
+                empty_tokens = mx.array([], dtype=mx.uint32)
+                for processor in processors:
+                    sample_logits = processor(empty_tokens, sample_logits)
+
+            logprobs = sample_logits - mx.logsumexp(
+                sample_logits, axis=-1, keepdims=True
+            )
+            sampler = samplers_by_request.get(req.request_id) or self.sampler
+            sampled = sampler(logprobs)
+            mx.eval(sampled, logprobs)
+            return sampled, logprobs
 
         total_prompt_tokens = sum(
             req.input_ids.size if req.input_ids is not None else 1 for req in requests
@@ -1233,18 +1288,7 @@ class MLLMBatchGenerator:
 
                         last_logits = logits[:, -1, :]
 
-                        # Apply per-request logits processors BEFORE sampler
-                        # for first-token sampling (prefix cache hit path).
-                        if getattr(req, "logits_processors", None):
-                            empty_tokens = mx.array([], dtype=mx.int32)
-                            for processor in req.logits_processors:
-                                last_logits = processor(empty_tokens, last_logits)
-
-                        logprobs = last_logits - mx.logsumexp(
-                            last_logits, axis=-1, keepdims=True
-                        )
-                        sampled = self.sampler(logprobs)
-                        mx.eval(sampled, logprobs)
+                        sampled, logprobs = _sample_first_token(req, last_logits)
 
                         first_tokens.append(sampled.item())
                         all_logprobs.append(logprobs.squeeze(0))
@@ -1279,18 +1323,7 @@ class MLLMBatchGenerator:
 
                         last_logits = logits[:, -1, :]
 
-                        # Apply per-request logits processors BEFORE sampler
-                        # for first-token sampling (prefix cache exact hit).
-                        if getattr(req, "logits_processors", None):
-                            empty_tokens = mx.array([], dtype=mx.int32)
-                            for processor in req.logits_processors:
-                                last_logits = processor(empty_tokens, last_logits)
-
-                        logprobs = last_logits - mx.logsumexp(
-                            last_logits, axis=-1, keepdims=True
-                        )
-                        sampled = self.sampler(logprobs)
-                        mx.eval(sampled, logprobs)
+                        sampled, logprobs = _sample_first_token(req, last_logits)
 
                         first_tokens.append(sampled.item())
                         all_logprobs.append(logprobs.squeeze(0))
@@ -1319,25 +1352,7 @@ class MLLMBatchGenerator:
                         # Extract last token logits
                         last_logits = logits[:, -1, :]
 
-                        # Apply per-request logits processors BEFORE sampler
-                        # (e.g. JSON schema constrained decoding).  Without
-                        # this, the first generated token is unconstrained —
-                        # the model can emit special tokens like <|channel>
-                        # that the schema disallows.  Subsequent tokens are
-                        # masked in ``_step``; this mirrors that behavior for
-                        # the first token sampled from prefill output.
-                        # ``output_tokens`` is empty at prefill time.
-                        if getattr(req, "logits_processors", None):
-                            empty_tokens = mx.array([], dtype=mx.int32)
-                            for processor in req.logits_processors:
-                                last_logits = processor(empty_tokens, last_logits)
-
-                        logprobs = last_logits - mx.logsumexp(
-                            last_logits, axis=-1, keepdims=True
-                        )
-                        sampled = self.sampler(logprobs)
-
-                        mx.eval(sampled, logprobs)
+                        sampled, logprobs = _sample_first_token(req, last_logits)
 
                         first_tokens.append(sampled.item())
                         all_logprobs.append(logprobs.squeeze(0))
@@ -1417,61 +1432,12 @@ class MLLMBatchGenerator:
         # Create initial y (first generated tokens)
         y = mx.array(first_tokens)
 
-        # Build per-request logits processors.  Combines built-in
-        # (repetition_penalty, presence_penalty) with any caller-supplied
-        # processors (e.g. JSON schema constrained decoding via
-        # ``lm-format-enforcer``).
-        from mlx_lm.sample_utils import make_logits_processors, make_sampler
-
-        batch_logits_processors = []
-        has_any_lp = False
-        for req in requests:
-            need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
-            need_pres = req.presence_penalty and req.presence_penalty != 0.0
-            combined: List[Callable] = []
-            if need_rep or need_pres:
-                lp_kwargs = {}
-                if need_rep:
-                    lp_kwargs["repetition_penalty"] = req.repetition_penalty
-                if need_pres:
-                    lp_kwargs["presence_penalty"] = req.presence_penalty
-                combined.extend(make_logits_processors(**lp_kwargs))
-                logger.info(
-                    f"[sampling] request={req.request_id[:12]} "
-                    f"rep_penalty={req.repetition_penalty} "
-                    f"pres_penalty={req.presence_penalty}"
-                )
-            if req.logits_processors:
-                combined.extend(req.logits_processors)
-                logger.info(
-                    f"[sampling] request={req.request_id[:12]} "
-                    f"extra_logits_processors={len(req.logits_processors)}"
-                )
-            if combined:
-                batch_logits_processors.append(combined)
-                has_any_lp = True
-            else:
-                batch_logits_processors.append(None)
-
-        # Build per-request samplers for top_k/min_p
-        batch_samplers = []
-        has_any_sampler = False
-        for req in requests:
-            if req.top_k != 0 or req.min_p != 0.0:
-                s = make_sampler(
-                    temp=req.temperature,
-                    top_p=req.top_p,
-                    top_k=req.top_k,
-                    min_p=req.min_p,
-                )
-                batch_samplers.append(s)
-                has_any_sampler = True
-                logger.info(
-                    f"[sampling] request={req.request_id[:12]} "
-                    f"top_k={req.top_k} min_p={req.min_p}"
-                )
-            else:
-                batch_samplers.append(None)
+        batch_logits_processors = [
+            logits_processors_by_request.get(req.request_id) for req in requests
+        ]
+        has_any_lp = any(batch_logits_processors)
+        batch_samplers = [samplers_by_request.get(req.request_id) for req in requests]
+        has_any_sampler = any(batch_samplers)
 
         self._stats.prompt_time += time.perf_counter() - tic
 
@@ -1664,11 +1630,13 @@ class MLLMBatchGenerator:
             return error_responses
 
         y, logprobs = batch.y, batch.logprobs
-        output_tokens = (
-            [req.output_tokens for req in batch.requests]
-            if batch.logits_processors
-            else None
-        )
+        output_tokens = None
+        if batch.logits_processors:
+            y_list = y.tolist()
+            output_tokens = [
+                list(req.output_tokens) + [token]
+                for req, token in zip(batch.requests, y_list)
+            ]
         batch.y, batch.logprobs = self._step(
             y[:, None],
             batch.cache,


### PR DESCRIPTION
## Summary

- Build MLLM request-local logits processors and samplers before first-token sampling.
- Apply the same request-local sampler to the first token from prefill, not only later decode steps.
- Pass the current generated token into logits-processor prefixes before sampling the next token, so processor state matches the KV cache state.

## Root Cause

The MLLM continuous-batching path sampled the first token with the generator fallback sampler and only built per-request samplers when `top_k` or `min_p` was set. Requests that changed only `temperature` or `top_p` silently used fallback sampling. The decode loop also passed one-token-stale generated prefixes to request-local logits processors.

## Validation

- `/opt/ai-runtime/venv-live/bin/python -m pytest -q tests/test_mllm_continuous_batching.py`
- `/opt/ai-runtime/venv-live/bin/python -m pytest -q tests/test_mllm_continuous_batching.py tests/test_server.py tests/test_reasoning_parser.py tests/test_simple_engine.py`
