### PR TITLE
Add request cancellation and streaming timeout enforcement

### DIFF
--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -124,3 +124,43 @@ class TestBatchedEngineCacheRestore:
         assert loaded == 2
         scheduler._ensure_batch_generator.assert_called_once_with()
         prefix_cache.load_from_disk.assert_called_once_with("/tmp/cache")
+
+
+class TestBatchedEngineAbortRequest:
+    @pytest.mark.asyncio
+    async def test_abort_request_routes_to_mllm_scheduler(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=True):
+            engine = BatchedEngine("test-mllm")
+
+        engine._mllm_scheduler = MagicMock()
+        engine._mllm_scheduler.abort_request.return_value = True
+
+        assert await engine.abort_request("req-1") is True
+        engine._mllm_scheduler.abort_request.assert_called_once_with("req-1")
+
+    @pytest.mark.asyncio
+    async def test_abort_request_routes_to_text_engine(self):
+        engine = TestBatchedEngineGenerate()._make_engine()
+        engine._engine = MagicMock()
+        engine._engine.abort_request.return_value = True
+
+        assert await engine.abort_request("req-1") is True
+        engine._engine.abort_request.assert_called_once_with("req-1")
+
+    @pytest.mark.asyncio
+    async def test_abort_request_routes_to_async_text_engine(self):
+        engine = TestBatchedEngineGenerate()._make_engine()
+        engine._engine = MagicMock()
+        engine._engine.abort_request = AsyncMock(return_value=True)
+
+        assert await engine.abort_request("req-1") is True
+        engine._engine.abort_request.assert_awaited_once_with("req-1")
+
+    @pytest.mark.asyncio
+    async def test_abort_request_returns_false_without_supported_engine(self):
+        engine = TestBatchedEngineGenerate()._make_engine()
+        engine._engine = None
+
+        assert await engine.abort_request("req-1") is False

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -127,7 +127,7 @@ class TestBatchedEngineCacheRestore:
 
 
 class TestBatchedEngineAbortRequest:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request_routes_to_mllm_scheduler(self):
         from vllm_mlx.engine.batched import BatchedEngine
 
@@ -140,7 +140,7 @@ class TestBatchedEngineAbortRequest:
         assert await engine.abort_request("req-1") is True
         engine._mllm_scheduler.abort_request.assert_called_once_with("req-1")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request_routes_to_text_engine(self):
         engine = TestBatchedEngineGenerate()._make_engine()
         engine._engine = MagicMock()
@@ -149,7 +149,7 @@ class TestBatchedEngineAbortRequest:
         assert await engine.abort_request("req-1") is True
         engine._engine.abort_request.assert_called_once_with("req-1")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request_routes_to_async_text_engine(self):
         engine = TestBatchedEngineGenerate()._make_engine()
         engine._engine = MagicMock()
@@ -158,7 +158,7 @@ class TestBatchedEngineAbortRequest:
         assert await engine.abort_request("req-1") is True
         engine._engine.abort_request.assert_awaited_once_with("req-1")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_abort_request_returns_false_without_supported_engine(self):
         engine = TestBatchedEngineGenerate()._make_engine()
         engine._engine = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the OpenAI-compatible API server."""
 
+import asyncio
 import json
 import platform
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -899,6 +900,38 @@ class TestRequestTimeoutField:
             model="test-model", prompt="Once upon a time", timeout=120.0
         )
         assert request_with_timeout.timeout == 120.0
+
+    @pytest.mark.anyio
+    async def test_disconnect_guard_enforces_stream_timeout(self):
+        """Streaming timeout cancels generators that keep heartbeating forever."""
+        from vllm_mlx.server import _disconnect_guard
+
+        closed = asyncio.Event()
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        async def slow_generator():
+            try:
+                while True:
+                    await asyncio.sleep(10)
+                    yield "data: never\n\n"
+            finally:
+                closed.set()
+
+        chunks = []
+        async for chunk in _disconnect_guard(
+            slow_generator(),
+            FakeRequest(),
+            poll_interval=0.01,
+            heartbeat_interval=1.0,
+            timeout=0.05,
+        ):
+            chunks.append(chunk)
+
+        assert chunks == []
+        assert closed.is_set()
 
 
 class TestMaxTokensLimit:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -193,7 +193,7 @@ class TestCompletionRequest:
 
 
 class TestRequestCancellationEndpoint:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_request_routes_to_loaded_engine(self):
         import vllm_mlx.server as server
 
@@ -221,7 +221,7 @@ class TestRequestCancellationEndpoint:
             server._engine = old_engine
             server._model_name = old_model_name
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_request_404_for_unknown_request(self):
         import vllm_mlx.server as server
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,6 +192,57 @@ class TestCompletionRequest:
             )
 
 
+class TestRequestCancellationEndpoint:
+    @pytest.mark.asyncio
+    async def test_cancel_request_routes_to_loaded_engine(self):
+        import vllm_mlx.server as server
+
+        class DummyEngine:
+            is_mllm = False
+
+            async def abort_request(self, request_id):
+                self.request_id = request_id
+                return True
+
+        engine = DummyEngine()
+        old_engine = server._engine
+        old_model_name = server._model_name
+        try:
+            server._engine = engine
+            server._model_name = "test-model"
+
+            result = await server.cancel_request("req-123")
+
+            assert result["cancelled"] is True
+            assert result["id"] == "req-123"
+            assert result["model"] == "test-model"
+            assert engine.request_id == "req-123"
+        finally:
+            server._engine = old_engine
+            server._model_name = old_model_name
+
+    @pytest.mark.asyncio
+    async def test_cancel_request_404_for_unknown_request(self):
+        import vllm_mlx.server as server
+
+        class DummyEngine:
+            is_mllm = False
+
+            async def abort_request(self, request_id):
+                return False
+
+        old_engine = server._engine
+        try:
+            server._engine = DummyEngine()
+
+            with pytest.raises(server.HTTPException) as exc:
+                await server.cancel_request("missing")
+
+            assert exc.value.status_code == 404
+        finally:
+            server._engine = old_engine
+
+
 class TestAnthropicRequest:
     """Test Anthropic request model."""
 

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -269,3 +269,7 @@ class BaseEngine(ABC):
     def clear_runtime_caches(self) -> dict[str, Any] | None:
         """Clear engine-managed runtime caches. Override in subclasses."""
         return None
+
+    async def abort_request(self, request_id: str) -> bool:
+        """Abort an active or queued request when the engine supports it."""
+        return False

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -12,6 +12,7 @@ LLM engine), so text-only requests must also be routed through it.
 """
 
 import asyncio
+import inspect
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -1057,6 +1058,17 @@ class BatchedEngine(BaseEngine):
         if self._engine is not None:
             return self._engine.clear_runtime_caches()
         return None
+
+    async def abort_request(self, request_id: str) -> bool:
+        """Abort an active or queued batched request by request ID."""
+        if self._mllm_scheduler is not None:
+            return self._mllm_scheduler.abort_request(request_id)
+        if self._engine is not None and hasattr(self._engine, "abort_request"):
+            result = self._engine.abort_request(request_id)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        return False
 
     def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk for persistence across restarts."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3124,15 +3124,16 @@ async def _disconnect_guard(
     poll_interval: float = 0.5,
     heartbeat_interval: float = 5.0,
     cleanup=None,
+    timeout: float | None = None,
 ) -> AsyncIterator[str]:
     """Wrap streaming generator to abort on client disconnect.
 
-    Uses asyncio racing: each __anext__() on the inner generator is
-    raced against a disconnect poller.  When neither completes within
-    ``heartbeat_interval`` seconds, an SSE comment is yielded as a
-    heartbeat.  This forces an ASGI write which triggers broken-pipe
-    detection — without heartbeats, ``is_disconnected()`` stays False
-    during long prefill because no data is written to the socket.
+    Uses asyncio racing: each __anext__() on the inner generator is raced
+    against a disconnect poller and an optional wall-clock timeout.  When
+    neither completes within ``heartbeat_interval`` seconds, an SSE comment
+    is yielded as a heartbeat.  This forces an ASGI write which triggers
+    broken-pipe detection — without heartbeats, ``is_disconnected()`` stays
+    False during long prefill because no data is written to the socket.
 
     On disconnect, the cancellation propagates to stream_outputs()
     finally-block → abort_request() → abort_prefill().
@@ -3174,11 +3175,43 @@ async def _disconnect_guard(
             if anext_task is None:
                 anext_task = asyncio.ensure_future(aiter.__anext__())
 
+            wait_timeout = heartbeat_interval
+            if timeout is not None:
+                elapsed_s = _time.monotonic() - _t0
+                remaining_s = timeout - elapsed_s
+                if remaining_s <= 0:
+                    logger.warning(
+                        f"[disconnect_guard] STREAM TIMEOUT after "
+                        f"{elapsed_s:.1f}s, chunks={chunk_count}, "
+                        f"heartbeats={heartbeat_count}"
+                    )
+                    anext_task.cancel()
+                    try:
+                        await anext_task
+                    except (asyncio.CancelledError, StopAsyncIteration):
+                        pass
+                    break
+                wait_timeout = min(heartbeat_interval, remaining_s)
+
             done, _ = await asyncio.wait(
                 [anext_task, disconnect_task],
                 return_when=asyncio.FIRST_COMPLETED,
-                timeout=heartbeat_interval,
+                timeout=wait_timeout,
             )
+
+            if not done and timeout is not None and _time.monotonic() - _t0 >= timeout:
+                elapsed_s = _time.monotonic() - _t0
+                logger.warning(
+                    f"[disconnect_guard] STREAM TIMEOUT after "
+                    f"{elapsed_s:.1f}s, chunks={chunk_count}, "
+                    f"heartbeats={heartbeat_count}"
+                )
+                anext_task.cancel()
+                try:
+                    await anext_task
+                except (asyncio.CancelledError, StopAsyncIteration):
+                    pass
+                break
 
             if disconnect_task in done:
                 logger.info(
@@ -3448,6 +3481,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     ),
                     raw_request,
                     cleanup=_release_default_engine,
+                    timeout=_remaining_request_timeout(total_timeout, deadline),
                 ),
                 media_type="text/event-stream",
             )
@@ -3785,6 +3819,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                     ),
                     raw_request,
                     cleanup=_release_default_engine,
+                    timeout=_remaining_request_timeout(total_timeout, deadline),
                 ),
                 media_type="text/event-stream",
             )
@@ -3955,7 +3990,11 @@ async def create_response(request: ResponsesRequest, raw_request: Request):
     """Create a Responses API response."""
     if request.stream:
         return StreamingResponse(
-            _disconnect_guard(_stream_responses_request(request), raw_request),
+            _disconnect_guard(
+                _stream_responses_request(request),
+                raw_request,
+                timeout=_default_timeout,
+            ),
             media_type="text/event-stream",
         )
 
@@ -4103,6 +4142,7 @@ async def create_anthropic_message(
                     ),
                     request,
                     cleanup=_release_default_engine,
+                    timeout=_remaining_request_timeout(total_timeout, deadline),
                 ),
                 media_type="text/event-stream",
                 headers={

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2424,6 +2424,46 @@ async def status():
     }
 
 
+@app.post(
+    "/v1/requests/{request_id}/cancel",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
+async def cancel_request(request_id: str):
+    """Cancel an active or queued request without restarting the model server."""
+    engine = get_engine()
+    try:
+        aborted = await engine.abort_request(request_id)
+    except Exception as exc:
+        logger.exception("Failed to cancel request %s", request_id)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to cancel request {request_id}: {exc}",
+        ) from exc
+
+    if not aborted:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Request not found or cancellation is unsupported: {request_id}",
+        )
+
+    logger.info("[cancel_request] accepted request_id=%s", request_id)
+    return {
+        "object": "request.cancel",
+        "id": request_id,
+        "cancelled": True,
+        "model": _model_name,
+    }
+
+
+@app.delete(
+    "/v1/requests/{request_id}",
+    dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+)
+async def delete_request(request_id: str):
+    """OpenAI-style alias for cancelling an active or queued request."""
+    return await cancel_request(request_id)
+
+
 @app.get("/v1/cache/stats", dependencies=[Depends(verify_api_key)])
 async def cache_stats():
     """Get cache statistics for debugging and monitoring."""


### PR DESCRIPTION
## Summary

I added an explicit request cancellation surface so an operator can abort an active or queued request without restarting the server.

The patch adds:
- `BaseEngine.abort_request(...)` as the default async engine contract
- async-aware `BatchedEngine.abort_request(...)` routing for both MLLM scheduler cancellation and text `AsyncEngineCore.abort_request(...)`
- `POST /v1/requests/{request_id}/cancel`
- `DELETE /v1/requests/{request_id}` as an alias

## Why

The existing streaming disconnect path is useful but not sufficient as the only safety surface. A client can disappear or be killed while the server still has a long generation active. In that state, the safe operator action should be cancelling the request id exposed by `/v1/status`, not restarting the resident process.

## Validation

```bash
/opt/ai-runtime/venv-live/bin/python -m pytest -q tests/test_batched_engine.py tests/test_server.py
# 82 passed, 3 deselected

/opt/ai-runtime/venv-live/bin/black --fast --check \
  vllm_mlx/engine/base.py \
  vllm_mlx/engine/batched.py \
  vllm_mlx/server.py \
  tests/test_batched_engine.py \
  tests/test_server.py

git diff --check
```

I also promoted the same change locally and validated it against a live resident MLLM lane by cancelling an in-flight streaming request from `/v1/status`; the server returned to `num_running=0`, `num_waiting=0` without a restart.
