### PR TITLE
Update .pre-commit-config.yaml and pyproject.toml to match ci.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     hooks:
       - id: ruff
         args: [--select, E,F,W, --ignore, E402,E501,E731,F811,F841]
-      - id: ruff-format
 
   - repo: https://github.com/psf/black
     rev: 24.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,15 @@ repos:
     rev: v0.1.9
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--select, E,F,W, --ignore, E402,E501,E731,F811,F841]
       - id: ruff-format
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        args: [--check]
+        files: ^(vllm_mlx|tests)/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "pytz>=2024.1",
     # Note: mlx-audio moved to optional [audio] deps due to mlx-lm version conflict
     # See: https://github.com/waybarrios/vllm-mlx/issues/19
-    "mlx-embeddings>=0.0.5"
+    "mlx-embeddings>=0.0.5",
 ]
 
 [project.optional-dependencies]
@@ -72,6 +72,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "pre-commit>=4.6.0",
 ]
 vllm = [
     "vllm>=0.4.0",
@@ -130,8 +131,8 @@ target-version = ["py310", "py311", "py312", "py313"]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
-ignore = ["E501", "B905"]
+select = ["E", "F", "W"]
+ignore = ["B905", "E402", "E501", "E731", "F811", "F841"]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Update .pre-commit-config.yaml and pyproject.toml to use ruff and black like ci.yml

Fixes #239