### PR TITLE
Hacky fix for the hang in PR 411

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -624,7 +624,7 @@ class BatchedEngine(BaseEngine):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "image_url":
                         new_content.append({"type": "image"})
-                    elif isinstance(part, (dict, str)):
+                    elif isinstance(part, (dict | str)):
                         new_content.append(part)
                     # skip non-dict/non-str parts to avoid passing unexpected types
                 prepared.append({**msg, "content": new_content})

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -23,6 +23,7 @@ from .base import (
     BaseEngine,
     GenerationOutput,
     cleanup_startup_cancellation,
+    run_blocking_startup_work,
 )
 
 logger = logging.getLogger(__name__)
@@ -207,14 +208,16 @@ class BatchedEngine(BaseEngine):
 
         try:
             if self._model is None:
-                # Load inline on the event-loop thread so mlx-lm's
-                # generation_stream (created at module import on this thread)
-                # and the model weights end up on the same thread that drives
-                # scheduler.step. Running this via asyncio.to_thread puts
-                # weights on a worker thread whose stream ID the event loop
-                # does not register, which reproduces issue #407 reliably on
-                # dense Llama 3.x models.
-                self.prepare_for_start()
+                if self._uses_default_prepare_for_start():
+                    # Load inline on the event-loop thread so mlx-lm's
+                    # generation_stream (created at module import on this
+                    # thread) and model weights are owned by the same thread
+                    # that drives scheduler.step (issue #407).
+                    self.prepare_for_start()
+                else:
+                    # Test doubles and custom overrides may block; run them via
+                    # the shared cancellation-safe thread helper.
+                    await run_blocking_startup_work(self.prepare_for_start)
 
             if self._is_mllm:
                 await self._start_mllm()
@@ -228,6 +231,11 @@ class BatchedEngine(BaseEngine):
         except asyncio.CancelledError:
             await cleanup_startup_cancellation(self.stop)
             raise
+
+    def _uses_default_prepare_for_start(self) -> bool:
+        """Return True when prepare_for_start is the class implementation."""
+        method = getattr(self.prepare_for_start, "__func__", None)
+        return method is BatchedEngine.prepare_for_start
 
     def _prepare_mllm_model(self) -> None:
         """Load the MLLM model before scheduler startup."""


### PR DESCRIPTION
This fixes the hang in tests/test_lifecycle_server.py::TestLifecycleFailureHandling::test_eager_engine_start_cancellation_cleans_prepared_state[batched-llm]

The following tests still fail

========================================= short test summary info ========================================== FAILED tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_single_request - AssertionError: assert 0 > 0 FAILED tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_concurrent_requests - assert False FAILED 

tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_batching_improves_throughput - assert 0.0 > 100 FAILED tests/test_engine_core_stream_safety.py::test_engine_core_no_cross_thread_stream_error - AssertionError: scheduler logged cross-thread stream errors: ['Error in batch generation step: There is... FAILED 

tests/test_engine_core_thread_streams.py::test_engine_core_runs_all_scheduler_steps_on_one_worker_thread - AttributeError: 'module' object at vllm_mlx.engine_core has no attribute 'bind_generation_streams' FAILED 

tests/test_model_registry.py::TestMultiEngine::test_sequential_engines_with_close - AssertionError: assert 0 > 0 FAILED tests/test_model_registry.py::TestMultiEngine::test_sequential_engines_without_close - AssertionError: assert 0 > 0 FAILED 

tests/test_model_registry.py::TestCacheRecovery::test_recovery_from_simulated_cache_corruption - AssertionError: assert 0 > 0 FAILED 

tests/test_model_registry.py::TestBenchmarkScenario::test_benchmark_like_usage - AssertionError: assert 0 > 0 FAILED tests/test_model_registry.py::TestBenchmarkScenario::test_multiple_models_sequentially - AssertionError: assert 0 > 0 FAILED tests/test_rerank.py::TestClassifierForward::test_classifier_forward_returns_logits_shape - RuntimeError: There is no Stream(gpu, 5) in current thread. FAILED 

tests/test_rerank.py::TestClassifierForward::test_classifier_forward_different_num_labels - RuntimeError: There is no Stream(gpu, 5) in current thread. 

======================= 12 failed, 1728 passed, 11 skipped, 23 deselected in 25.21s
