### PR TITLE
fix: eval all cache types in MLLM chunked prefill to prevent OOM

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -37,6 +37,76 @@ pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 TEST_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 
+class TestMLLMPromptCacheEval:
+    def test_collects_kv_and_arrays_cache_tensors(self):
+        from vllm_mlx.mllm_batch_generator import _cache_eval_tensors
+
+        kv_keys = object()
+        kv_values = object()
+        state_a = object()
+        state_b = object()
+
+        class KVLikeCache:
+            keys = kv_keys
+            values = kv_values
+
+            @property
+            def state(self):
+                raise AssertionError("KV cache state should not be read")
+
+        class ArraysLikeCache:
+            state = [state_a, None, state_b]
+
+        class EmptyKVLikeCache:
+            keys = None
+            values = None
+
+            @property
+            def state(self):
+                raise AttributeError("empty KV cache has no state")
+
+        assert _cache_eval_tensors(
+            [KVLikeCache(), ArraysLikeCache(), EmptyKVLikeCache()]
+        ) == [kv_keys, kv_values, state_a, state_b]
+
+    def test_eval_prompt_cache_skips_empty_cache(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import _eval_prompt_cache
+
+        eval_mock = MagicMock()
+        monkeypatch.setattr(mx, "eval", eval_mock)
+
+        class EmptyCache:
+            keys = None
+            values = None
+            state = [None]
+
+        _eval_prompt_cache([EmptyCache()])
+
+        eval_mock.assert_not_called()
+
+    def test_eval_prompt_cache_flattens_cache_tensors(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import _eval_prompt_cache
+
+        kv_keys = object()
+        kv_values = object()
+        state = object()
+        eval_mock = MagicMock()
+        monkeypatch.setattr(mx, "eval", eval_mock)
+
+        class KVLikeCache:
+            keys = kv_keys
+            values = kv_values
+
+        class ArraysLikeCache:
+            pass
+
+        ArraysLikeCache.state = [state]
+
+        _eval_prompt_cache([KVLikeCache(), ArraysLikeCache()])
+
+        eval_mock.assert_called_once_with(kv_keys, kv_values, state)
+
+
 def create_test_image(path: str, size: tuple = (32, 32)) -> str:
     """Create a test image file."""
     try:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -979,7 +979,18 @@ class MLLMBatchGenerator:
 
             chunk = input_ids[:, processed : processed + step]
             self.language_model(chunk, cache=cache)
-            mx.eval([c.state for c in cache])
+            # Eval ALL cache types to break the lazy graph between chunks.
+            # ArraysCache (e.g. GatedDeltaNet) has .state; KVCache (full
+            # attention) has .keys/.values. Hybrid models like Qwen3.5 use
+            # both. Skipping either type lets the computation graph grow
+            # across chunks → OOM on long prompts.
+            cache_tensors = []
+            for c in cache:
+                if hasattr(c, "keys") and c.keys is not None:
+                    cache_tensors.extend([c.keys, c.values])
+                elif hasattr(c, "state"):
+                    cache_tensors.extend([s for s in c.state if s is not None])
+            mx.eval(cache_tensors)
             processed += step
             chunk_count += 1
             self._prefill_progress[request.request_id] = (processed, total)
@@ -1266,7 +1277,16 @@ class MLLMBatchGenerator:
 
                                 chunk = remaining[:, processed : processed + step]
                                 self.language_model(chunk, cache=request_cache)
-                                mx.eval([c.state for c in request_cache])
+                                # Eval ALL cache types (see _run_chunked_text_prefill)
+                                cache_tensors = []
+                                for c in request_cache:
+                                    if hasattr(c, "keys") and c.keys is not None:
+                                        cache_tensors.extend([c.keys, c.values])
+                                    elif hasattr(c, "state"):
+                                        cache_tensors.extend(
+                                            [s for s in c.state if s is not None]
+                                        )
+                                mx.eval(cache_tensors)
                                 processed += step
                                 chunk_count += 1
                                 self._prefill_progress[req.request_id] = (

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -66,6 +66,39 @@ class PrefillAbortedError(Exception):
         super().__init__(f"Prefill aborted for request {request_id}")
 
 
+def _cache_eval_tensors(cache: List[Any]) -> List[Any]:
+    """Return realized tensors that break lazy cache graphs between chunks."""
+    tensors: List[Any] = []
+    for c in cache:
+        keys = getattr(c, "keys", None)
+        values = getattr(c, "values", None)
+        if keys is not None or values is not None:
+            if keys is not None:
+                tensors.append(keys)
+            if values is not None:
+                tensors.append(values)
+            continue
+
+        try:
+            state = getattr(c, "state", None)
+        except AttributeError:
+            state = None
+        if state is None:
+            continue
+        if isinstance(state, (list, tuple)):
+            tensors.extend(s for s in state if s is not None)
+        else:
+            tensors.append(state)
+    return tensors
+
+
+def _eval_prompt_cache(cache: List[Any]) -> None:
+    """Evaluate all cache tensors used by hybrid chunked prefill."""
+    tensors = _cache_eval_tensors(cache)
+    if tensors:
+        mx.eval(*tensors)
+
+
 @dataclass
 class MLLMBatchRequest:
     """
@@ -984,13 +1017,7 @@ class MLLMBatchGenerator:
             # attention) has .keys/.values. Hybrid models like Qwen3.5 use
             # both. Skipping either type lets the computation graph grow
             # across chunks → OOM on long prompts.
-            cache_tensors = []
-            for c in cache:
-                if hasattr(c, "keys") and c.keys is not None:
-                    cache_tensors.extend([c.keys, c.values])
-                elif hasattr(c, "state"):
-                    cache_tensors.extend([s for s in c.state if s is not None])
-            mx.eval(cache_tensors)
+            _eval_prompt_cache(cache)
             processed += step
             chunk_count += 1
             self._prefill_progress[request.request_id] = (processed, total)
@@ -1278,15 +1305,7 @@ class MLLMBatchGenerator:
                                 chunk = remaining[:, processed : processed + step]
                                 self.language_model(chunk, cache=request_cache)
                                 # Eval ALL cache types (see _run_chunked_text_prefill)
-                                cache_tensors = []
-                                for c in request_cache:
-                                    if hasattr(c, "keys") and c.keys is not None:
-                                        cache_tensors.extend([c.keys, c.values])
-                                    elif hasattr(c, "state"):
-                                        cache_tensors.extend(
-                                            [s for s in c.state if s is not None]
-                                        )
-                                mx.eval(cache_tensors)
+                                _eval_prompt_cache(request_cache)
                                 processed += step
                                 chunk_count += 1
                                 self._prefill_progress[req.request_id] = (


### PR DESCRIPTION
Hybrid models like Qwen3.5 use both ArraysCache (GatedDeltaNet linear attention with .state) and KVCache (full MLA attention with .keys/.values).

The existing `mx.eval([c.state for c in cache])` only evaluates ArraysCache layers. KVCache layers silently pass through because they have no .state attribute, letting the lazy computation graph accumulate across chunks. On long prompts (96K+ tokens), this causes OOM as the graph grows unbounded.

Fix: check for both cache types between chunks:
- KVCache: eval .keys and .values
- ArraysCache: eval .state entries

Affects both _run_chunked_text_prefill (text-only long prompts) and the prefix-cache partial-hit path (cached prefix + remaining tokens).