### PR TITLE
Prevent MLLM preprocessing from blocking event loop

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1228,3 +1228,59 @@ class TestBatchedMLLMConfigWiring:
         asyncio.run(engine._start_mllm())
 
         assert captured["config_kwargs"]["prefill_step_size"] == 256
+
+
+class TestPreprocessIdempotent:
+    """_preprocess_request must be idempotent for text-only requests.
+
+    The scheduler offloads preprocessing to a thread-pool executor so
+    the event loop stays responsive.  _process_prompts then calls
+    _preprocess_request again — the second call must be a no-op.
+    """
+
+    def test_text_only_not_preprocessed_twice(self):
+        """When input_ids is already set (executor did it), skip."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        req = MLLMBatchRequest(
+            uid=0,
+            prompt="Hello",
+            request_id="test-idem",
+        )
+        # Simulate executor having already set input_ids
+        req.input_ids = mx.array([[1, 2, 3]])
+
+        # Build a minimal batch generator with the method
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        gen._preprocess_request = MLLMBatchGenerator._preprocess_request.__get__(
+            gen, MLLMBatchGenerator
+        )
+
+        # Must return immediately without touching prepare_inputs
+        gen._preprocess_request(req)
+        assert req.input_ids.shape == (1, 3)
+
+    def test_vision_request_not_skipped(self):
+        """Vision requests should NOT be skipped even with input_ids set."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        req = MLLMBatchRequest(
+            uid=0,
+            prompt="Describe",
+            request_id="test-vis",
+            images=["fake.png"],
+        )
+        req.input_ids = mx.array([[1, 2, 3]])
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        gen._preprocess_request = MLLMBatchGenerator._preprocess_request.__get__(
+            gen, MLLMBatchGenerator
+        )
+
+        # Should NOT return early — will try to import prepare_inputs
+        with pytest.raises(Exception):
+            gen._preprocess_request(req)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -772,10 +772,17 @@ class MLLMBatchGenerator:
         3. Running vision encoder to get features
 
         Uses vision cache to skip processing for repeated images.
+        Idempotent: if input_ids is already set, returns immediately.
 
         Args:
             request: Request to preprocess
         """
+        # Already preprocessed (e.g. by early executor offloading in
+        # _process_loop).  Only skip for text-only requests; vision
+        # requests need pixel cache lookup even if input_ids was set.
+        if request.input_ids is not None and not request.images and not request.videos:
+            return
+
         from mlx_vlm.utils import prepare_inputs
 
         tic = time.perf_counter()
@@ -997,6 +1004,11 @@ class MLLMBatchGenerator:
                 return output.logits
             return output
 
+        logger.info(
+            f"[chunked_prefill] Starting {request.request_id[:12]}: "
+            f"{total} tokens, step={step}"
+        )
+
         # Process all chunks except the last
         processed = 0
         chunk_count = 0
@@ -1022,6 +1034,14 @@ class MLLMBatchGenerator:
             chunk_count += 1
             self._prefill_progress[request.request_id] = (processed, total)
 
+            # Log progress every 10 chunks so operators can see prefill
+            # is progressing (not hanging) during long prompts.
+            if chunk_count % 10 == 0:
+                logger.info(
+                    f"[chunked_prefill] {request.request_id[:12]}: "
+                    f"chunk {chunk_count}, {processed}/{total} tokens"
+                )
+
             # Release Metal buffer pool periodically.  Full-attention layers
             # produce attention score buffers that grow each chunk (1024 ×
             # growing_context).  Old smaller buffers can't be reused, so the
@@ -1034,6 +1054,12 @@ class MLLMBatchGenerator:
         output = self.language_model(last_chunk, cache=cache)
         request.vision_encoded = True
         self._prefill_progress[request.request_id] = (total, total)
+
+        if chunk_count > 0:
+            logger.info(
+                f"[chunked_prefill] Completed {request.request_id[:12]}: "
+                f"{total} tokens in {chunk_count + 1} chunks"
+            )
 
         if hasattr(output, "logits"):
             return output.logits

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -789,6 +789,11 @@ class MLLMScheduler:
         arrays and cache state must be consumed on that same thread.  Unlike
         the text-only EngineCore path, moving MLLM prefill to a worker crosses
         MLX stream ownership and can fail with "no Stream in current thread".
+
+        Text-only preprocessing (Jinja2 template rendering + tokenization) is
+        run BEFORE ``step()`` with ``await asyncio.sleep(0)`` yields between
+        each request.  This prevents long preprocessing (10-30+ s for 40K+
+        token conversations) from blocking health checks and new connections.
         """
         streams_bound = False
 
@@ -798,12 +803,67 @@ class MLLMScheduler:
                 bind_generation_streams()
                 streams_bound = True
 
+        loop = asyncio.get_running_loop()
+
         while self._running:
             try:
+                # --- Early preprocessing phase ---
+                # Run text-only preprocessing (Jinja2 template rendering +
+                # tokenization) in a thread-pool executor so the event loop
+                # stays responsive for health checks, new connections, and
+                # active streaming requests.  Preprocessing is CPU-bound
+                # (no MLX GPU work) and HuggingFace tokenizers are
+                # thread-safe, so this is safe to offload.
+                bg = self.batch_generator
+                if bg is not None:
+                    for req in list(bg.unprocessed_requests):
+                        if req.input_ids is None and not req.images and not req.videos:
+                            try:
+                                tic = time.perf_counter()
+                                await loop.run_in_executor(
+                                    None, bg._preprocess_request, req
+                                )
+                                elapsed = time.perf_counter() - tic
+                                if elapsed > 1.0:
+                                    n_tok = (
+                                        req.input_ids.size
+                                        if req.input_ids is not None
+                                        else 0
+                                    )
+                                    logger.info(
+                                        f"Preprocessing {req.request_id[:12]}"
+                                        f": {n_tok} tokens in {elapsed:.2f}s"
+                                    )
+                            except Exception as e:
+                                logger.error(
+                                    f"Early preprocessing failed for "
+                                    f"{req.request_id}: {e}"
+                                )
+
+                # --- Step phase ---
                 if self.has_requests():
                     _ensure_streams_bound()
+                    tic = time.perf_counter()
                     self.step()
-                    await asyncio.sleep(0)
+                    elapsed = time.perf_counter() - tic
+                    if elapsed > 2.0:
+                        logger.warning(
+                            f"Slow MLLM step: {elapsed:.2f}s "
+                            f"(waiting={len(self.waiting)}, "
+                            f"running={len(self.running)})"
+                        )
+                    # Yield multiple event-loop cycles so that pending
+                    # HTTP health checks can complete.  A single
+                    # asyncio.sleep() gives only ONE _run_once() cycle,
+                    # but an HTTP request needs ~3 cycles minimum:
+                    #   1. accept TCP connection
+                    #   2. read HTTP request / parse headers
+                    #   3. run handler / write response
+                    # Using repeated asyncio.sleep(0) gives many cycles
+                    # with negligible wall-clock overhead (<1ms total).
+                    n_yields = 10 if elapsed > 1.0 else 5
+                    for _ in range(n_yields):
+                        await asyncio.sleep(0)
                 else:
                     # No work, wait a bit
                     await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary

- Run text-only request preprocessing (Jinja2 template rendering + tokenization) in a thread-pool executor via `run_in_executor()` so the event loop stays responsive during long prompts (40K+ tokens)
- Add chunked prefill progress logging (start, every 10 chunks, completion) for operator visibility
- Add slow-step warnings (>2s) for easier debugging of event loop blocking

## Problem

The MLLM scheduler's `_process_loop()` runs directly on the asyncio event loop. When a long text-only request (40K+ tokens) arrives, `step()` calls `_chunked_next()` which calls `_preprocess_request()` synchronously. For long conversations, Jinja2 template rendering + tokenization can take 10-30+ seconds, completely blocking the event loop during that time. Health checks, new connections, and streaming responses for existing requests all fail.

## Solution

Run `_preprocess_request()` via `await loop.run_in_executor(None, ...)` in a thread-pool worker **before** `step()`. Since preprocessing is CPU-bound (no MLX GPU work) and HuggingFace tokenizers are thread-safe (backed by Rust `tokenizers`), this is safe to offload. The call is idempotent — the subsequent call from `_chunked_next()` or `_process_prompts()` returns immediately when `input_ids` is already set.

## Test plan

- [x] All 1768 existing tests pass (4 pre-existing failures unrelated to this change)
- [x] Verify health checks respond during long prompt preprocessing on a live server (20/20 OK, max 323ms, avg 20ms on Qwen3.6-27B with 202-message conversation)
- [x] Check log output shows chunked prefill progress (start, periodic, completion messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)