### PR TITLE
Add model artifact workflow CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ python examples/tts_multilingual.py "Hola mundo" --lang es --play
 vllm-mlx bench-serve --url http://localhost:8000 --concurrency 5 --prompts prompts.txt --output results.csv
 ```
 
+### Model acquisition and conversion
+
+```bash
+# Inspect repo metadata, file sizes, config, and rough fit before downloading weights
+vllm-mlx model inspect mlx-community/Llama-3.2-3B-Instruct-4bit
+
+# Acquire with resumable Hugging Face transfer and write a local artifact manifest
+vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit --target-dir ./models/llama-3b-4bit
+
+# Wrap mlx-lm conversion and record the exact recipe in the converted artifact
+vllm-mlx model convert meta-llama/Llama-3.2-3B-Instruct --output ./models/llama-3b-mlx-q4 --quantize --q-bits 4 --q-group-size 64 --q-mode affine
+```
+
 ### Prometheus metrics
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,6 +81,13 @@ Check your internet connection and HuggingFace access. Some models require authe
 huggingface-cli login
 ```
 
+You can inspect and stage models before serving:
+```bash
+vllm-mlx model inspect mlx-community/Llama-3.2-3B-Instruct-4bit
+vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --target-dir ./models/llama-3b-4bit
+```
+
 ### Out of memory
 
 Use a smaller quantized model:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,6 +5,7 @@
 | Command | Description |
 |---------|-------------|
 | `vllm-mlx serve` | Start OpenAI-compatible server |
+| `vllm-mlx model` | Inspect, acquire, or convert model artifacts |
 | `vllm-mlx-bench` | Run performance benchmarks |
 | `vllm-mlx-chat` | Start Gradio chat interface |
 
@@ -136,6 +137,51 @@ Or with curl:
 ```bash
 curl http://localhost:8000/v1/models \
   -H "Authorization: Bearer your-secret-key"
+```
+
+## `vllm-mlx model`
+
+Inspect, acquire, and convert model artifacts without serving them. These
+commands are intended to make model setup auditable: inspect before download,
+download into a finalized artifact manifest, then convert through `mlx-lm` with
+the exact recipe recorded.
+
+### Usage
+
+```bash
+vllm-mlx model inspect <path-or-hf-model-id>
+vllm-mlx model acquire <hf-model-id> [--target-dir <path>]
+vllm-mlx model convert <path-or-hf-model-id> --output <path> [--quantize]
+```
+
+### Options
+
+| Command | Option | Description |
+|---------|--------|-------------|
+| `inspect` | `--revision` | Hugging Face revision to inspect |
+| `inspect` | `--local-files-only` | Inspect only local Hugging Face cache files |
+| `acquire` | `--target-dir` | Final local directory for a staged download |
+| `acquire` | `--staging-dir` | Temporary directory used before finalizing `--target-dir` |
+| `acquire` | `--mllm` | Download multimodal file patterns |
+| `acquire` | `--no-fast-transfer` | Do not set `HF_HUB_ENABLE_HF_TRANSFER=1` |
+| `convert` | `--output` | Output directory for the converted MLX model |
+| `convert` | `--quantize` | Enable `mlx-lm` quantization |
+| `convert` | `--q-bits`, `--q-group-size`, `--q-mode` | Quantization recipe |
+| `convert` | `--quant-predicate` | `mlx-lm` mixed-bit quantization recipe |
+| `convert` | `--dtype` | Dtype for non-quantized parameters |
+| `convert` | `--dry-run` | Print command and manifest without executing conversion |
+
+### Examples
+
+```bash
+vllm-mlx model inspect mlx-community/Llama-3.2-3B-Instruct-4bit
+
+vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --target-dir ./models/llama-3b-4bit
+
+vllm-mlx model convert meta-llama/Llama-3.2-3B-Instruct \
+  --output ./models/llama-3b-mlx-q4 \
+  --quantize --q-bits 4 --q-group-size 64 --q-mode affine
 ```
 
 ## `vllm-mlx-bench`

--- a/tests/test_model_workflow.py
+++ b/tests/test_model_workflow.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for model artifact inspection, acquisition, and conversion helpers."""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm_mlx.model_workflow import (
+    CONVERSION_MANIFEST_NAME,
+    MODEL_MANIFEST_NAME,
+    AcquisitionOptions,
+    ConversionOptions,
+    acquire_model,
+    convert_model,
+    inspect_model,
+)
+
+
+def test_inspect_local_model_reports_size_and_config(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3",
+                "architectures": ["Qwen3ForCausalLM"],
+                "quantization": {"bits": 4, "group_size": 64},
+                "max_position_embeddings": 32768,
+            }
+        )
+    )
+    (tmp_path / "model.safetensors").write_bytes(b"x" * 1024)
+
+    payload = inspect_model(str(tmp_path))
+
+    assert payload["source"] == "local"
+    assert payload["file_count"] == 2
+    assert payload["model_family"]["model_type"] == "qwen3"
+    assert payload["mlx"]["looks_like_mlx_artifact"] is True
+    assert payload["mlx"]["needs_conversion"] is False
+
+
+def test_inspect_hf_model_uses_metadata_without_weight_download(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "model_type": "qwen3_5_moe",
+                    "mtp_num_hidden_layers": 1,
+                    "max_position_embeddings": 1_000_000,
+                }
+            }
+        )
+    )
+    siblings = [
+        SimpleNamespace(rfilename="config.json", size=100),
+        SimpleNamespace(rfilename="model-00001-of-00002.safetensors", size=1000),
+        SimpleNamespace(rfilename="tokenizer.json", size=200),
+    ]
+    info = SimpleNamespace(sha="abc123", siblings=siblings)
+
+    with (
+        patch("vllm_mlx.model_workflow.HfApi") as mock_api,
+        patch("vllm_mlx.model_workflow.hf_hub_download") as mock_download,
+    ):
+        mock_api.return_value.model_info.return_value = info
+        mock_download.return_value = str(config_path)
+        payload = inspect_model("org/model", revision="main")
+
+    assert payload["revision"] == "abc123"
+    assert payload["total_size_bytes"] == 1300
+    assert payload["model_files_size_gb"] == 0.0
+    assert payload["model_family"]["model_type"] == "qwen3_5_moe"
+    assert payload["mlx"]["needs_conversion"] is True
+    assert payload["warnings"] == [
+        "very large advertised context; choose an explicit serving context before loading"
+    ]
+
+
+def test_acquire_model_finalizes_target_and_writes_manifest(tmp_path):
+    target = tmp_path / "model-final"
+    staging_root = tmp_path / "stage"
+    seen_env = {}
+
+    def fake_snapshot_download(*args, **kwargs):
+        staging = Path(kwargs["local_dir"])
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "config.json").write_text(
+            json.dumps({"model_type": "llama", "quantization": {"bits": 4}})
+        )
+        (staging / "model.safetensors").write_bytes(b"weights")
+        seen_env["fast_transfer"] = os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")
+        return str(staging)
+
+    with (
+        patch("vllm_mlx.model_workflow.find_spec", return_value=object()),
+        patch("vllm_mlx.model_workflow.snapshot_download") as mock_download,
+    ):
+        mock_download.side_effect = fake_snapshot_download
+        manifest = acquire_model(
+            "org/model",
+            options=AcquisitionOptions(
+                revision="rev1",
+                target_dir=str(target),
+                staging_dir=str(staging_root),
+                fast_transfer=True,
+            ),
+        )
+
+    assert seen_env["fast_transfer"] == "1"
+    assert target.exists()
+    assert manifest["model_id"] == "org/model"
+    assert manifest["path"] == str(target)
+    assert manifest["fast_transfer"]["enabled"] is True
+    manifest_path = target / MODEL_MANIFEST_NAME
+    assert manifest_path.exists()
+    saved = json.loads(manifest_path.read_text())
+    assert saved["inspection"]["file_count"] == 2
+
+
+def test_acquire_model_disables_fast_transfer_when_package_missing(tmp_path):
+    target = tmp_path / "model-final"
+
+    def fake_snapshot_download(*args, **kwargs):
+        staging = Path(kwargs["local_dir"])
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        return str(staging)
+
+    with (
+        patch("vllm_mlx.model_workflow.find_spec", return_value=None),
+        patch("vllm_mlx.model_workflow.snapshot_download") as mock_download,
+    ):
+        mock_download.side_effect = fake_snapshot_download
+        manifest = acquire_model(
+            "org/model",
+            options=AcquisitionOptions(target_dir=str(target), fast_transfer=True),
+        )
+
+    assert manifest["fast_transfer"]["requested"] is True
+    assert manifest["fast_transfer"]["enabled"] is False
+    assert "not installed" in manifest["fast_transfer"]["reason"]
+
+
+def test_acquire_model_refuses_existing_target(tmp_path):
+    target = tmp_path / "model-final"
+    target.mkdir()
+
+    with patch("vllm_mlx.model_workflow.snapshot_download") as mock_download:
+        try:
+            acquire_model(
+                "org/model", options=AcquisitionOptions(target_dir=str(target))
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError("expected FileExistsError")
+
+    mock_download.assert_not_called()
+
+
+def test_convert_model_dry_run_records_mlx_lm_command(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    output = tmp_path / "out"
+
+    payload = convert_model(
+        ConversionOptions(
+            source_path=str(source),
+            output_path=str(output),
+            quantize=True,
+            q_bits=3,
+            q_group_size=64,
+            q_mode="affine",
+            dry_run=True,
+        )
+    )
+
+    assert payload["status"] == "dry_run"
+    assert payload["backend"] == "mlx-lm"
+    assert payload["recipe"]["q_bits"] == 3
+    assert "--quantize" in payload["command"]
+    assert "--q-bits" in payload["command"]
+    assert str(output) in payload["command"]
+
+
+def test_convert_model_success_writes_manifest(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    output = tmp_path / "out"
+
+    def fake_run(*args, **kwargs):
+        output.mkdir()
+        (output / "config.json").write_text(
+            json.dumps({"model_type": "llama", "quantization": {"bits": 4}})
+        )
+        (output / "model.safetensors").write_bytes(b"weights")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    with patch("vllm_mlx.model_workflow.subprocess.run", side_effect=fake_run):
+        payload = convert_model(
+            ConversionOptions(source_path=str(source), output_path=str(output))
+        )
+
+    assert payload["status"] == "succeeded"
+    assert (output / CONVERSION_MANIFEST_NAME).exists()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import argparse
+import json
 import sys
 
 from .cli_arg_types import make_json_object_arg_parser
@@ -311,6 +312,58 @@ def download_command(args):
         is_mllm=args.mllm,
     )
     print(f"Model ready at: {path}")
+
+
+def model_command(args):
+    """Run model lifecycle helper commands."""
+    from .model_workflow import (
+        AcquisitionOptions,
+        ConversionOptions,
+        acquire_model,
+        convert_model,
+        inspect_model,
+    )
+
+    if args.model_command == "inspect":
+        payload = inspect_model(
+            args.model,
+            revision=args.revision,
+            local_files_only=args.local_files_only,
+        )
+    elif args.model_command == "acquire":
+        payload = acquire_model(
+            args.model,
+            options=AcquisitionOptions(
+                revision=args.revision,
+                target_dir=args.target_dir,
+                staging_dir=args.staging_dir,
+                is_mllm=args.mllm,
+                fast_transfer=not args.no_fast_transfer,
+                local_files_only=args.local_files_only,
+            ),
+        )
+    elif args.model_command == "convert":
+        payload = convert_model(
+            ConversionOptions(
+                source_path=args.source,
+                output_path=args.output,
+                quantize=args.quantize,
+                q_bits=args.q_bits,
+                q_group_size=args.q_group_size,
+                q_mode=args.q_mode,
+                quant_predicate=args.quant_predicate,
+                dtype=args.dtype,
+                trust_remote_code=args.trust_remote_code,
+                dry_run=args.dry_run,
+            )
+        )
+        if payload.get("status") == "failed":
+            print(json.dumps(payload, indent=2))
+            sys.exit(payload.get("returncode") or 1)
+    else:
+        raise ValueError(f"Unsupported model command: {args.model_command}")
+
+    print(json.dumps(payload, indent=2))
 
 
 def bench_command(args):
@@ -1339,6 +1392,125 @@ Examples:
         help="Download as multimodal model (broader file patterns)",
     )
 
+    # Model lifecycle helpers
+    model_parser = subparsers.add_parser(
+        "model",
+        help="Inspect, acquire, or convert model artifacts",
+    )
+    model_subparsers = model_parser.add_subparsers(
+        dest="model_command", help="Model workflow command", required=True
+    )
+
+    model_inspect_parser = model_subparsers.add_parser(
+        "inspect",
+        help="Inspect a local path or Hugging Face model without loading weights",
+    )
+    model_inspect_parser.add_argument(
+        "model",
+        type=str,
+        help="Local model path or Hugging Face model id",
+    )
+    model_inspect_parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Hugging Face revision to inspect",
+    )
+    model_inspect_parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Use only local Hugging Face cache files",
+    )
+
+    model_acquire_parser = model_subparsers.add_parser(
+        "acquire",
+        help="Download a Hugging Face model and write an artifact manifest",
+    )
+    model_acquire_parser.add_argument("model", type=str, help="Hugging Face model id")
+    model_acquire_parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Hugging Face revision to download",
+    )
+    model_acquire_parser.add_argument(
+        "--target-dir",
+        type=str,
+        default=None,
+        help="Final local directory. Defaults to Hugging Face cache.",
+    )
+    model_acquire_parser.add_argument(
+        "--staging-dir",
+        type=str,
+        default=None,
+        help="Directory for temporary staged downloads before finalizing target-dir",
+    )
+    model_acquire_parser.add_argument(
+        "--mllm",
+        action="store_true",
+        help="Acquire multimodal model files using broader allow patterns",
+    )
+    model_acquire_parser.add_argument(
+        "--no-fast-transfer",
+        action="store_true",
+        help="Do not set HF_HUB_ENABLE_HF_TRANSFER=1 during download",
+    )
+    model_acquire_parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Use only local Hugging Face cache files",
+    )
+
+    model_convert_parser = model_subparsers.add_parser(
+        "convert",
+        help="Run mlx-lm conversion and write a conversion manifest",
+    )
+    model_convert_parser.add_argument(
+        "source",
+        type=str,
+        help="Hugging Face model id or local source path",
+    )
+    model_convert_parser.add_argument(
+        "--output",
+        required=True,
+        type=str,
+        help="Output directory for the converted MLX model",
+    )
+    model_convert_parser.add_argument(
+        "--quantize",
+        action="store_true",
+        help="Generate a quantized MLX model",
+    )
+    model_convert_parser.add_argument("--q-bits", type=int, default=None)
+    model_convert_parser.add_argument("--q-group-size", type=int, default=None)
+    model_convert_parser.add_argument(
+        "--q-mode",
+        choices=["affine", "mxfp4", "nvfp4", "mxfp8"],
+        default=None,
+    )
+    model_convert_parser.add_argument(
+        "--quant-predicate",
+        choices=["mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"],
+        default=None,
+        help="mlx-lm mixed-bit quantization recipe",
+    )
+    model_convert_parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default=None,
+        help="Non-quantized parameter dtype",
+    )
+    model_convert_parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow Hugging Face remote code during mlx-lm conversion",
+    )
+    model_convert_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the conversion command and manifest without executing",
+    )
+
     # Serving benchmark
     bench_serve_parser = subparsers.add_parser(
         "bench-serve", help="Benchmark a running vllm-mlx server via HTTP API"
@@ -1487,6 +1659,8 @@ def main():
         bench_kv_cache_command(args)
     elif args.command == "download":
         download_command(args)
+    elif args.command == "model":
+        model_command(args)
     elif args.command == "bench-serve":
         bench_serve_command(args)
     else:

--- a/vllm_mlx/model_workflow.py
+++ b/vllm_mlx/model_workflow.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model acquisition, inspection, and conversion workflow helpers.
+
+The functions in this module intentionally avoid loading model weights. They
+collect repository/file metadata, download artifacts, and record manifests so a
+model can be qualified before it is served.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from importlib.util import find_spec
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+
+from .utils.download import LLM_ALLOW_PATTERNS, MLLM_ALLOW_PATTERNS
+
+MODEL_MANIFEST_NAME = "vllm_mlx_model_manifest.json"
+CONVERSION_MANIFEST_NAME = "vllm_mlx_conversion_manifest.json"
+
+_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class AcquisitionOptions:
+    """Options for Hugging Face model acquisition."""
+
+    revision: str | None = None
+    target_dir: str | None = None
+    staging_dir: str | None = None
+    is_mllm: bool = False
+    fast_transfer: bool = True
+    local_files_only: bool = False
+
+
+@dataclass(frozen=True)
+class ConversionOptions:
+    """Options for the mlx-lm conversion backend."""
+
+    source_path: str
+    output_path: str
+    quantize: bool = False
+    q_bits: int | None = None
+    q_group_size: int | None = None
+    q_mode: str | None = None
+    quant_predicate: str | None = None
+    dtype: str | None = None
+    trust_remote_code: bool = False
+    dry_run: bool = False
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bytes_to_gb(size: int | float | None) -> float | None:
+    if size is None:
+        return None
+    return round(float(size) / (1024**3), 3)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _local_file_inventory(path: Path) -> tuple[list[dict[str, Any]], int]:
+    files = []
+    total = 0
+    for item in sorted(path.rglob("*")):
+        if not item.is_file():
+            continue
+        try:
+            size = item.stat().st_size
+        except OSError:
+            size = 0
+        total += size
+        files.append({"path": str(item.relative_to(path)), "size": size})
+    return files, total
+
+
+def _hf_file_inventory(
+    model_id: str, *, revision: str | None, local_files_only: bool
+) -> tuple[list[dict[str, Any]], int | None, str | None]:
+    if local_files_only:
+        return [], None, revision
+
+    info = HfApi().model_info(model_id, revision=revision, files_metadata=True)
+    files = []
+    total = 0
+    total_known = True
+    for sibling in getattr(info, "siblings", []) or []:
+        filename = getattr(sibling, "rfilename", None)
+        if not filename:
+            continue
+        size = getattr(sibling, "size", None)
+        if size is None:
+            total_known = False
+        else:
+            total += int(size)
+        files.append({"path": filename, "size": size})
+    return files, total if total_known else None, getattr(info, "sha", revision)
+
+
+def _hf_config(
+    model_id: str, *, revision: str | None, local_files_only: bool
+) -> dict[str, Any]:
+    config_path = hf_hub_download(
+        repo_id=model_id,
+        filename="config.json",
+        revision=revision,
+        local_files_only=local_files_only,
+    )
+    return _read_json(Path(config_path))
+
+
+def _config_value(config: dict[str, Any], key: str) -> Any:
+    if key in config:
+        return config[key]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        return text_config.get(key)
+    return None
+
+
+def _model_family(config: dict[str, Any]) -> dict[str, Any]:
+    architectures = _config_value(config, "architectures") or []
+    if isinstance(architectures, str):
+        architectures = [architectures]
+    max_context = (
+        _config_value(config, "max_position_embeddings")
+        or _config_value(config, "max_sequence_length")
+        or _config_value(config, "seq_length")
+        or _config_value(config, "model_max_length")
+    )
+    return {
+        "model_type": _config_value(config, "model_type"),
+        "architectures": architectures,
+        "torch_dtype": _config_value(config, "torch_dtype"),
+        "max_context": max_context,
+        "quantization": config.get("quantization") or config.get("quantization_config"),
+        "has_text_config": isinstance(config.get("text_config"), dict),
+        "has_vision_config": isinstance(config.get("vision_config"), dict),
+        "mtp_num_hidden_layers": _config_value(config, "mtp_num_hidden_layers"),
+    }
+
+
+def _estimate_fit(
+    *,
+    total_bytes: int | None,
+    model_files_bytes: int | None,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    max_context = _model_family(config).get("max_context")
+    warnings = []
+    if isinstance(max_context, int) and max_context >= 262_144:
+        warnings.append(
+            "very large advertised context; choose an explicit serving context before loading"
+        )
+
+    # Conversion normally needs source weights, output weights, and temporary
+    # shards. Keep this conservative without pretending to know architecture
+    # residency exactly.
+    disk_floor = None
+    if total_bytes is not None:
+        disk_floor = int(total_bytes * 2.2)
+
+    memory_floor = model_files_bytes or total_bytes
+    return {
+        "download_size_gb": _bytes_to_gb(total_bytes),
+        "model_file_size_gb": _bytes_to_gb(model_files_bytes),
+        "estimated_conversion_disk_gb": _bytes_to_gb(disk_floor),
+        "rough_load_memory_gb": _bytes_to_gb(memory_floor),
+        "warnings": warnings,
+    }
+
+
+def _model_file_bytes(files: list[dict[str, Any]]) -> int | None:
+    total = 0
+    known = False
+    for entry in files:
+        path = str(entry.get("path", ""))
+        if not path.endswith((".safetensors", ".bin", ".gguf")):
+            continue
+        size = entry.get("size")
+        if size is None:
+            return None
+        known = True
+        total += int(size)
+    return total if known else None
+
+
+def _looks_like_mlx_name(model: str, *, source: str) -> bool:
+    name = model.lower() if source == "huggingface" else Path(model).name.lower()
+    return (
+        name.startswith("mlx-community/")
+        or "-mlx" in name
+        or "_mlx" in name
+        or name.endswith("mlx")
+    )
+
+
+def _is_model_id(value: str) -> bool:
+    return bool(_MODEL_ID_RE.fullmatch(value))
+
+
+def _fast_transfer_env(requested: bool) -> tuple[dict[str, str], dict[str, Any]]:
+    if not requested:
+        return {}, {"requested": False, "enabled": False, "reason": "disabled"}
+    if find_spec("hf_transfer") is None:
+        return (
+            {},
+            {
+                "requested": True,
+                "enabled": False,
+                "reason": "hf_transfer package is not installed",
+            },
+        )
+    return (
+        {"HF_HUB_ENABLE_HF_TRANSFER": "1"},
+        {"requested": True, "enabled": True, "reason": "enabled"},
+    )
+
+
+def inspect_model(
+    model: str,
+    *,
+    revision: str | None = None,
+    local_files_only: bool = False,
+) -> dict[str, Any]:
+    """Inspect a local model path or Hugging Face model id without loading weights."""
+    model_path = Path(model).expanduser()
+    warnings = []
+
+    if model_path.exists():
+        files, total_bytes = _local_file_inventory(model_path)
+        config = _read_json(model_path / "config.json")
+        resolved_revision = None
+        source = "local"
+        location = str(model_path)
+    else:
+        if not _is_model_id(model):
+            raise ValueError(
+                f"{model!r} is not an existing path or a Hugging Face model id"
+            )
+        source = "huggingface"
+        location = model
+        files, total_bytes, resolved_revision = _hf_file_inventory(
+            model, revision=revision, local_files_only=local_files_only
+        )
+        try:
+            config = _hf_config(
+                model, revision=revision, local_files_only=local_files_only
+            )
+        except Exception as exc:
+            config = {}
+            warnings.append(f"could not read config.json: {exc}")
+
+    model_files_bytes = _model_file_bytes(files)
+    family = _model_family(config)
+    estimate = _estimate_fit(
+        total_bytes=total_bytes,
+        model_files_bytes=model_files_bytes,
+        config=config,
+    )
+    warnings.extend(estimate.pop("warnings"))
+    has_name_signal = _looks_like_mlx_name(model, source=source) and (
+        source == "huggingface" or bool(config)
+    )
+    has_mlx_signals = bool(family.get("quantization")) or has_name_signal
+
+    return {
+        "model": model,
+        "source": source,
+        "location": location,
+        "revision": resolved_revision or revision,
+        "inspected_at": _now_iso(),
+        "file_count": len(files),
+        "total_size_bytes": total_bytes,
+        "total_size_gb": _bytes_to_gb(total_bytes),
+        "model_files_size_gb": _bytes_to_gb(model_files_bytes),
+        "model_family": family,
+        "mlx": {
+            "looks_like_mlx_artifact": has_mlx_signals,
+            "needs_conversion": not has_mlx_signals,
+        },
+        "fit_estimate": estimate,
+        "warnings": warnings,
+    }
+
+
+def acquire_model(
+    model_id: str,
+    *,
+    options: AcquisitionOptions | None = None,
+) -> dict[str, Any]:
+    """Download a model repository and write a finalized artifact manifest."""
+    if options is None:
+        options = AcquisitionOptions()
+    if not _is_model_id(model_id):
+        raise ValueError(f"{model_id!r} is not a Hugging Face model id")
+
+    allow_patterns = MLLM_ALLOW_PATTERNS if options.is_mllm else LLM_ALLOW_PATTERNS
+    env_updates, fast_transfer = _fast_transfer_env(options.fast_transfer)
+
+    old_env = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+    try:
+        if options.target_dir:
+            target = Path(options.target_dir).expanduser()
+            if target.exists():
+                raise FileExistsError(f"target path already exists: {target}")
+            staging_root = (
+                Path(options.staging_dir).expanduser()
+                if options.staging_dir
+                else target.parent
+            )
+            staging_root.mkdir(parents=True, exist_ok=True)
+            staging = Path(
+                tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=staging_root)
+            )
+            try:
+                downloaded = Path(
+                    snapshot_download(
+                        model_id,
+                        revision=options.revision,
+                        allow_patterns=allow_patterns,
+                        local_dir=str(staging),
+                        local_files_only=options.local_files_only,
+                    )
+                )
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(downloaded), str(target))
+            except Exception:
+                shutil.rmtree(staging, ignore_errors=True)
+                raise
+            final_path = target
+        else:
+            final_path = Path(
+                snapshot_download(
+                    model_id,
+                    revision=options.revision,
+                    allow_patterns=allow_patterns,
+                    local_files_only=options.local_files_only,
+                )
+            )
+    finally:
+        for key, value in old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    inspection = inspect_model(str(final_path), revision=options.revision)
+    manifest = {
+        "kind": "vllm-mlx-model-artifact",
+        "model_id": model_id,
+        "revision": options.revision,
+        "path": str(final_path),
+        "created_at": _now_iso(),
+        "allow_patterns": allow_patterns,
+        "fast_transfer": fast_transfer,
+        "local_files_only": options.local_files_only,
+        "inspection": inspection,
+    }
+    manifest_path = final_path / MODEL_MANIFEST_NAME
+    _write_json(manifest_path, manifest)
+    manifest["manifest_path"] = str(manifest_path)
+    return manifest
+
+
+def _conversion_command(options: ConversionOptions) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "mlx_lm",
+        "convert",
+        "--hf-path",
+        options.source_path,
+        "--mlx-path",
+        options.output_path,
+    ]
+    if options.quantize:
+        command.append("--quantize")
+    if options.q_bits is not None:
+        command.extend(["--q-bits", str(options.q_bits)])
+    if options.q_group_size is not None:
+        command.extend(["--q-group-size", str(options.q_group_size)])
+    if options.q_mode:
+        command.extend(["--q-mode", options.q_mode])
+    if options.quant_predicate:
+        command.extend(["--quant-predicate", options.quant_predicate])
+    if options.dtype:
+        command.extend(["--dtype", options.dtype])
+    if options.trust_remote_code:
+        command.append("--trust-remote-code")
+    return command
+
+
+def convert_model(options: ConversionOptions) -> dict[str, Any]:
+    """Run mlx-lm conversion and record the exact recipe."""
+    command = _conversion_command(options)
+    started = _now_iso()
+    source_inspection = inspect_model(options.source_path)
+    result = {
+        "kind": "vllm-mlx-conversion",
+        "backend": "mlx-lm",
+        "command": command,
+        "source_path": options.source_path,
+        "output_path": options.output_path,
+        "started_at": started,
+        "dry_run": options.dry_run,
+        "recipe": {
+            "quantize": options.quantize,
+            "q_bits": options.q_bits,
+            "q_group_size": options.q_group_size,
+            "q_mode": options.q_mode,
+            "quant_predicate": options.quant_predicate,
+            "dtype": options.dtype,
+            "trust_remote_code": options.trust_remote_code,
+        },
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+        },
+        "source_inspection": source_inspection,
+    }
+
+    if options.dry_run:
+        result["status"] = "dry_run"
+        return result
+
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    result["returncode"] = completed.returncode
+    result["stdout"] = completed.stdout
+    result["stderr"] = completed.stderr
+    result["completed_at"] = _now_iso()
+    result["status"] = "succeeded" if completed.returncode == 0 else "failed"
+    if completed.returncode != 0:
+        return result
+
+    output_path = Path(options.output_path).expanduser()
+    output_inspection = inspect_model(str(output_path))
+    result["output_inspection"] = output_inspection
+    manifest_path = output_path / CONVERSION_MANIFEST_NAME
+    _write_json(manifest_path, result)
+    result["manifest_path"] = str(manifest_path)
+    return result


### PR DESCRIPTION
## Summary

This adds a first-class `vllm-mlx model` workflow for model setup before serving:

- `vllm-mlx model inspect <path-or-hf-id>` reads config, HF file inventory, source revision, size estimates, MLX/conversion signals, and large-context warnings without loading weights.
- `vllm-mlx model acquire <hf-id>` downloads through Hugging Face with resumable `snapshot_download`, uses `HF_HUB_ENABLE_HF_TRANSFER=1` when `hf_transfer` is installed, supports staged finalization into `--target-dir`, and writes `vllm_mlx_model_manifest.json`.
- `vllm-mlx model convert <source> --output <path>` wraps `mlx-lm convert`, records the exact quantization recipe and command, supports dry-run, and writes `vllm_mlx_conversion_manifest.json` after successful conversion.

## Why

Model setup is currently an operator workflow: manually inspect a repo, download files, choose conversion flags, remember the source revision, edit local config, then hope the artifact is complete. This PR makes the pre-serve part auditable and scriptable without trying to replace serving policy or qualification.

This intentionally stops before registry/preset mutation. Acquisition and conversion produce manifests. A separate follow-up can wire those manifests into registry insertion and `bench-serve --workload` qualification once that workload contract PR lands.

## Validation

```bash
uv run --extra dev pytest -q tests/test_model_workflow.py tests/test_download.py
uv run --extra dev black --check vllm_mlx/model_workflow.py vllm_mlx/cli.py tests/test_model_workflow.py
uvx ruff check vllm_mlx/model_workflow.py vllm_mlx/cli.py tests/test_model_workflow.py --select E,F,W --ignore E402,E501,E731,F811,F841
git diff --check
uv run --extra dev python -m vllm_mlx.cli model inspect mlx-community/Llama-3.2-1B-Instruct-4bit
uv run --extra dev python -m vllm_mlx.cli model convert /Users/David/code/vllm-mlx-model-workflow --output /tmp/vllm-mlx-dry-run-out --quantize --q-bits 4 --q-group-size 64 --q-mode affine --dry-run
```

Result: `19 passed`; formatting clean; ruff clean; live HF metadata inspect returned revision `08231374eeacb049a0eade7922910865b8fce912` without loading weights.
