### PR TITLE
Fix/scheduler logged cross thread stream errors

### DIFF
--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
@@ -24,8 +25,15 @@ from .request import Request, RequestOutput, SamplingParams
 from .scheduler import Scheduler, SchedulerConfig
 from .output_collector import RequestOutputCollector, RequestStreamState
 from .model_registry import get_registry
+from .mlx_streams import bind_generation_streams
 
 logger = logging.getLogger(__name__)
+
+
+def _is_stream_thread_error(error: Exception) -> bool:
+    """True when MLX reports stream ownership mismatch across threads."""
+    message = str(error)
+    return "no Stream(" in message or "no Stream(gpu" in message
 
 
 @dataclass
@@ -138,13 +146,31 @@ class EngineCore:
     async def _engine_loop(self) -> None:
         """Main engine loop.
 
-        mlx-lm's generation_stream is created at module import and is
-        thread-local, so scheduler.step must run on the same thread that
-        imported mlx_lm.generate. PR #399 took this route for the MLLM
-        scheduler; this does the same for the text-only engine.
+        scheduler.step runs on one dedicated worker thread. MLX streams are
+        thread-local, so we rebind generation streams inside that worker.
         """
 
+        loop = asyncio.get_running_loop()
+        worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="engine-core")
+        worker_stream_bound = False
+        model_thread_stream_bound = False
+        use_worker_thread = True
+        stream_thread_fallback_used = False
+
+        def _bind_worker_streams_once() -> None:
+            nonlocal worker_stream_bound
+            if not worker_stream_bound:
+                bind_generation_streams()
+                worker_stream_bound = True
+
+        def _bind_model_streams_once() -> None:
+            nonlocal model_thread_stream_bound
+            if not model_thread_stream_bound:
+                bind_generation_streams()
+                model_thread_stream_bound = True
+
         def _step_on_worker():
+            _bind_worker_streams_once()
             output = self.scheduler.step()
             self._steps_executed += 1
 
@@ -163,10 +189,37 @@ class EngineCore:
 
             return output
 
+        def _step_on_model_thread():
+            _bind_model_streams_once()
+            output = self.scheduler.step()
+            self._steps_executed += 1
+
+            if self._steps_executed % _memory_check_interval == 0:
+                try:
+                    active_mem = mx.get_active_memory()
+                    if active_mem > _memory_pressure_threshold:
+                        mx.clear_cache()
+                        logger.warning(
+                            f"[Memory pressure] {active_mem / 1e9:.1f}GB > "
+                            f"{_memory_pressure_threshold / 1e9:.0f}GB threshold, "
+                            f"forced cache clear"
+                        )
+                except Exception:
+                    pass
+
+            return output
+
+        def _recover_stream_thread_error_on_worker() -> None:
+            _bind_worker_streams_once()
+            self.scheduler._recover_from_cache_error()
+            self.scheduler._reschedule_running_requests()
+
         def _clear_cache_on_worker() -> None:
+            _bind_worker_streams_once()
             mx.clear_cache()
 
         def _close_batch_generator_on_worker() -> None:
+            _bind_worker_streams_once()
             self.scheduler._close_batch_generator()
 
         step_interval = self.config.step_interval
@@ -188,7 +241,30 @@ class EngineCore:
             while self._running:
                 try:
                     if self.scheduler.has_requests():
-                        output = _step_on_worker()
+                        if use_worker_thread:
+                            try:
+                                output = await loop.run_in_executor(
+                                    worker, _step_on_worker
+                                )
+                            except Exception as e:
+                                if (
+                                    _is_stream_thread_error(e)
+                                    and not stream_thread_fallback_used
+                                ):
+                                    await loop.run_in_executor(
+                                        worker, _recover_stream_thread_error_on_worker
+                                    )
+                                    use_worker_thread = False
+                                    stream_thread_fallback_used = True
+                                    _bind_model_streams_once()
+                                    logger.warning(
+                                        "Detected MLX stream/thread mismatch on worker "
+                                        "step; switched this engine to model-thread stepping"
+                                    )
+                                    continue
+                                raise
+                        else:
+                            output = _step_on_model_thread()
                         # Yield to event loop after each step.
                         await asyncio.sleep(0)
 
@@ -225,7 +301,12 @@ class EngineCore:
 
                             # Free Metal buffers after distributing finished outputs
                             if output.finished_request_ids:
-                                _clear_cache_on_worker()
+                                if use_worker_thread:
+                                    await loop.run_in_executor(
+                                        worker, _clear_cache_on_worker
+                                    )
+                                else:
+                                    mx.clear_cache()
 
                             # Always yield to prevent event loop starvation.
                             # Without this, orphaned requests (client disconnected but
@@ -244,9 +325,13 @@ class EngineCore:
                     logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
                     await asyncio.sleep(0.1)
         finally:
-            # Close the batch generator on this (event-loop) thread, which owns
-            # mlx-lm's generation streams.
-            _close_batch_generator_on_worker()
+            try:
+                if use_worker_thread:
+                    await loop.run_in_executor(worker, _close_batch_generator_on_worker)
+                else:
+                    self.scheduler._close_batch_generator()
+            finally:
+                worker.shutdown(wait=True)
 
     async def add_request(
         self,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -816,7 +816,7 @@ class MLLMScheduler:
                 # thread-safe, so this is safe to offload.
                 bg = self.batch_generator
                 if bg is not None:
-                    for req in list(bg.unprocessed_requests):
+                    for req in list(getattr(bg, "unprocessed_requests", ())):
                         if req.input_ids is None and not req.images and not req.videos:
                             try:
                                 tic = time.perf_counter()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2351,6 +2351,11 @@ class Scheduler:
         error_str = str(error)
         return any(pattern in error_str for pattern in CACHE_CORRUPTION_PATTERNS)
 
+    def _is_stream_thread_error(self, error: Exception) -> bool:
+        """Check if an error indicates MLX stream/thread ownership mismatch."""
+        error_str = str(error)
+        return "no Stream(" in error_str or "no Stream(gpu" in error_str
+
     def _recover_from_cache_error(self) -> None:
         """Recover from cache corruption error."""
         # Properly close batch generator (this is the source of the corruption)
@@ -2499,6 +2504,8 @@ class Scheduler:
                 else:
                     raise
             except Exception as e:
+                if self._is_stream_thread_error(e):
+                    raise
                 import traceback
 
                 logger.error(


### PR DESCRIPTION
Fixes errors on main to fix issue #420.

I am running tests with 

```
rm -rf .venv uv.lock
uv venv python --python 3.13
uv sync
uv pip install -e ".[dev,vision]"
uv run pytest
```

Failing tests:
FAILED tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_single_request - AssertionError: assert 0 > 0
FAILED tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_concurrent_requests - assert False
FAILED tests/test_continuous_batching.py::TestContinuousBatchingIntegration::test_batching_improves_throughput - assert 0.0 > 100
FAILED tests/test_engine_core_stream_safety.py::test_engine_core_no_cross_thread_stream_error - AssertionError: scheduler logged cross-thread stream errors: ['Error in batch generation step: There is no Stream(gpu, 5) in current thread.\nTraceback (most recent call last):\n  File "/Users/tperry/code/llm/vllm-mlx/vllm_mlx/scheduler.py", ...
FAILED tests/test_engine_core_thread_streams.py::test_engine_core_runs_all_scheduler_steps_on_one_worker_thread - AttributeError: 'module' object at vllm_mlx.engine_core has no attribute 'bind_generation_streams'
FAILED tests/test_engine_core_thread_streams.py::test_mllm_scheduler_runs_steps_on_model_load_thread - TimeoutError
FAILED tests/test_model_registry.py::TestMultiEngine::test_sequential_engines_with_close - AssertionError: assert 0 > 0
FAILED tests/test_model_registry.py::TestMultiEngine::test_sequential_engines_without_close - AssertionError: assert 0 > 0
FAILED tests/test_model_registry.py::TestCacheRecovery::test_recovery_from_simulated_cache_corruption - AssertionError: assert 0 > 0
FAILED tests/test_model_registry.py::TestBenchmarkScenario::test_benchmark_like_usage - AssertionError: assert 0 > 0
FAILED tests/test_model_registry.py::TestBenchmarkScenario::test_multiple_models_sequentially - AssertionError: assert 0 > 0
FAILED tests/test_rerank.py::TestClassifierForward::test_classifier_forward_returns_logits_shape - RuntimeError: There is no Stream(gpu, 5) in current thread.
FAILED tests/test_rerank.py::TestClassifierForward::test_classifier_forward_different_num_labels - RuntimeError: There is no Stream(gpu, 5) in current thread.
