### PR TITLE
Fix sampling defaults and short prefix-cache reuse

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 def _serve_args(**overrides):
     args = {
         "api_key": None,
+        "auto_unload_idle_seconds": 0.0,
         "cache_memory_mb": None,
         "cache_memory_percent": 0.2,
         "chunked_prefill_tokens": 0,
@@ -19,6 +20,7 @@ def _serve_args(**overrides):
         "download_timeout": 1,
         "embedding_model": None,
         "enable_auto_tool_choice": False,
+        "enable_metrics": False,
         "enable_mtp": False,
         "enable_prefix_cache": True,
         "gpu_memory_utilization": 0.9,
@@ -31,6 +33,7 @@ def _serve_args(**overrides):
         "max_num_seqs": 32,
         "max_tokens": 16,
         "mcp_config": None,
+        "mllm_prefill_step_size": None,
         "mllm": False,
         "model": "local-test-model",
         "mtp_num_draft_tokens": 1,
@@ -53,6 +56,7 @@ def _serve_args(**overrides):
         "stream_interval": 1,
         "tool_call_parser": None,
         "timeout": 300,
+        "lazy_load_model": False,
         "use_paged_cache": False,
     }
     args.update(overrides)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+
+def _serve_args(**overrides):
+    args = {
+        "api_key": None,
+        "cache_memory_mb": None,
+        "cache_memory_percent": 0.2,
+        "chunked_prefill_tokens": 0,
+        "continuous_batching": False,
+        "default_min_p": None,
+        "default_presence_penalty": None,
+        "default_repetition_penalty": None,
+        "default_temperature": None,
+        "default_top_k": None,
+        "default_top_p": None,
+        "disable_prefix_cache": False,
+        "download_retries": 0,
+        "download_timeout": 1,
+        "embedding_model": None,
+        "enable_auto_tool_choice": False,
+        "enable_mtp": False,
+        "enable_prefix_cache": True,
+        "gpu_memory_utilization": 0.9,
+        "host": "127.0.0.1",
+        "kv_cache_min_quantize_tokens": 256,
+        "kv_cache_quantization": False,
+        "kv_cache_quantization_bits": 8,
+        "kv_cache_quantization_group_size": 64,
+        "max_cache_blocks": 1000,
+        "max_num_seqs": 32,
+        "max_tokens": 16,
+        "mcp_config": None,
+        "mllm": False,
+        "model": "local-test-model",
+        "mtp_num_draft_tokens": 1,
+        "mtp_optimistic": False,
+        "no_memory_aware_cache": False,
+        "offline": True,
+        "paged_cache_block_size": 64,
+        "port": 8000,
+        "prefill_batch_size": 8,
+        "prefill_step_size": 512,
+        "prefix_cache_size": 100,
+        "rate_limit": 0,
+        "reasoning_parser": None,
+        "served_model_name": None,
+        "specprefill": False,
+        "specprefill_backbone_pct": 0.0,
+        "specprefill_draft_model": None,
+        "specprefill_keep_pct": 0.3,
+        "specprefill_threshold": 8192,
+        "stream_interval": 1,
+        "tool_call_parser": None,
+        "timeout": 300,
+        "use_paged_cache": False,
+    }
+    args.update(overrides)
+    return SimpleNamespace(**args)
+
+
+def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
+    from vllm_mlx import cli, server
+    from vllm_mlx.utils import download
+
+    monkeypatch.setattr(
+        download, "ensure_model_downloaded", lambda *args, **kwargs: "local-test-model"
+    )
+    monkeypatch.setattr(server, "load_model", lambda *args, **kwargs: None)
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    for attr in (
+        "_default_temperature",
+        "_default_top_p",
+        "_default_top_k",
+        "_default_min_p",
+        "_default_presence_penalty",
+        "_default_repetition_penalty",
+    ):
+        monkeypatch.setattr(server, attr, None)
+
+    cli.serve_command(
+        _serve_args(
+            default_temperature=0.6,
+            default_top_p=0.95,
+            default_top_k=20,
+            default_min_p=0.0,
+            default_presence_penalty=0.0,
+            default_repetition_penalty=1.0,
+        )
+    )
+
+    assert server._default_temperature == 0.6
+    assert server._default_top_p == 0.95
+    assert server._default_top_k == 20
+    assert server._default_min_p == 0.0
+    assert server._default_presence_penalty == 0.0
+    assert server._default_repetition_penalty == 1.0

--- a/tests/test_kv_cache_quantization.py
+++ b/tests/test_kv_cache_quantization.py
@@ -166,7 +166,11 @@ class TestPrefixCacheIntegration:
 
     def test_store_fetch_without_quantization(self):
         model = self._make_cache_and_model()
-        config = MemoryCacheConfig(kv_quantize=False, max_memory_mb=500)
+        config = MemoryCacheConfig(
+            kv_quantize=False,
+            max_memory_mb=500,
+            min_prefix_tokens=1,
+        )
         pc = MemoryAwarePrefixCache(model, config)
 
         cache = _make_kv_cache(n_layers=2, seq_len=50)
@@ -187,6 +191,7 @@ class TestPrefixCacheIntegration:
             kv_bits=8,
             kv_min_quantize_tokens=0,
             max_memory_mb=500,
+            min_prefix_tokens=1,
         )
         pc = MemoryAwarePrefixCache(model, config)
 
@@ -282,6 +287,7 @@ class TestMinQuantizeTokensThreshold:
             kv_bits=8,
             kv_min_quantize_tokens=256,
             max_memory_mb=500,
+            min_prefix_tokens=1,
         )
         pc = MemoryAwarePrefixCache(model, config)
 
@@ -319,7 +325,11 @@ class TestMinQuantizeTokensThreshold:
     def test_trim_applied_without_quantization(self):
         """Oversized arrays should be trimmed even without quantization."""
         model = self._make_model()
-        config = MemoryCacheConfig(kv_quantize=False, max_memory_mb=500)
+        config = MemoryCacheConfig(
+            kv_quantize=False,
+            max_memory_mb=500,
+            min_prefix_tokens=1,
+        )
         pc = MemoryAwarePrefixCache(model, config)
 
         # Create oversized cache: arrays have 4096 but offset is 100

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -25,6 +25,7 @@ class TestMemoryCacheConfig:
         assert config.max_memory_percent == 0.20
         assert config.max_entries == 1000
         assert config.enable_memory_tracking is True
+        assert config.min_prefix_tokens == 128
 
     def test_custom_config(self):
         config = MemoryCacheConfig(
@@ -51,6 +52,10 @@ class TestMemoryCacheConfig:
     def test_invalid_max_entries(self):
         with pytest.raises(ValueError, match="max_entries"):
             MemoryCacheConfig(max_entries=0)
+
+    def test_invalid_min_prefix_tokens(self):
+        with pytest.raises(ValueError, match="min_prefix_tokens"):
+            MemoryCacheConfig(min_prefix_tokens=0)
 
     def test_compute_memory_limit_explicit(self):
         config = MemoryCacheConfig(max_memory_mb=1024)
@@ -239,7 +244,11 @@ class TestMemoryAwarePrefixCache:
     @pytest.fixture
     def small_cache(self, model):
         """Cache with 1MB limit."""
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=10)
+        config = MemoryCacheConfig(
+            max_memory_mb=1,
+            max_entries=10,
+            min_prefix_tokens=1,
+        )
         return MemoryAwarePrefixCache(model, config)
 
     @pytest.fixture
@@ -270,6 +279,26 @@ class TestMemoryAwarePrefixCache:
         assert result is kv  # Same reference, no copy
         assert remaining == []
 
+    def test_short_prefix_reuse_is_rejected(self, model, mock_kv_cache):
+        cache = MemoryAwarePrefixCache(
+            model,
+            MemoryCacheConfig(
+                max_memory_mb=10,
+                max_entries=10,
+                min_prefix_tokens=8,
+            ),
+        )
+        short_tokens = [1, 2, 3, 4, 5]
+        kv = mock_kv_cache(1000)
+
+        assert cache.store(short_tokens, kv) is False
+        assert len(cache) == 0
+
+        result, remaining = cache.fetch(short_tokens)
+        assert result is None
+        assert remaining == short_tokens
+        assert cache.get_stats()["misses"] == 1
+
     def test_fetch_prefix_match(self, small_cache, mock_kv_cache):
         # Store shorter sequence
         short_tokens = [1, 2, 3]
@@ -295,7 +324,11 @@ class TestMemoryAwarePrefixCache:
 
     def test_lru_eviction_on_memory_pressure(self, model, mock_kv_cache):
         # Create cache with 500KB limit
-        config = MemoryCacheConfig(max_memory_mb=0.5, max_entries=100)
+        config = MemoryCacheConfig(
+            max_memory_mb=0.5,
+            max_entries=100,
+            min_prefix_tokens=1,
+        )
         cache = MemoryAwarePrefixCache(model, config)
 
         # Store entries that together exceed limit

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -251,7 +251,8 @@ class TestTrimCacheOffset:
 
         model = MagicMock()
         cache = MemoryAwarePrefixCache(
-            model, MemoryCacheConfig(max_memory_mb=64, max_entries=10)
+            model,
+            MemoryCacheConfig(max_memory_mb=64, max_entries=10, min_prefix_tokens=1),
         )
 
         # Stored: tokens [1..120] with 120 positions of KV data, the first 60
@@ -424,6 +425,7 @@ class TestDequantizeCacheSlice:
                 kv_bits=8,
                 kv_group_size=64,
                 kv_min_quantize_tokens=0,
+                min_prefix_tokens=1,
             ),
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,6 +192,64 @@ class TestCompletionRequest:
             )
 
 
+class TestSamplingDefaults:
+    """Test server-wide sampling default resolution."""
+
+    def test_extended_sampling_defaults_resolve_from_server_globals(self):
+        from vllm_mlx import server
+
+        old_values = (
+            server._default_top_k,
+            server._default_min_p,
+            server._default_presence_penalty,
+            server._default_repetition_penalty,
+        )
+        try:
+            server._default_top_k = 20
+            server._default_min_p = 0.05
+            server._default_presence_penalty = 1.5
+            server._default_repetition_penalty = 1.1
+
+            assert server._resolve_top_k(None) == 20
+            assert server._resolve_min_p(None) == 0.05
+            assert server._resolve_presence_penalty(None) == 1.5
+            assert server._resolve_repetition_penalty(None) == 1.1
+        finally:
+            (
+                server._default_top_k,
+                server._default_min_p,
+                server._default_presence_penalty,
+                server._default_repetition_penalty,
+            ) = old_values
+
+    def test_request_values_override_extended_sampling_defaults(self):
+        from vllm_mlx import server
+
+        old_values = (
+            server._default_top_k,
+            server._default_min_p,
+            server._default_presence_penalty,
+            server._default_repetition_penalty,
+        )
+        try:
+            server._default_top_k = 20
+            server._default_min_p = 0.05
+            server._default_presence_penalty = 1.5
+            server._default_repetition_penalty = 1.1
+
+            assert server._resolve_top_k(0) == 0
+            assert server._resolve_min_p(0.0) == 0.0
+            assert server._resolve_presence_penalty(0.0) == 0.0
+            assert server._resolve_repetition_penalty(1.0) == 1.0
+        finally:
+            (
+                server._default_top_k,
+                server._default_min_p,
+                server._default_presence_penalty,
+                server._default_repetition_penalty,
+            ) = old_values
+
+
 class TestAnthropicRequest:
     """Test Anthropic request model."""
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -81,6 +81,14 @@ def serve_command(args):
     if args.default_top_p is not None:
         server._default_top_p = args.default_top_p
     server._default_chat_template_kwargs = args.default_chat_template_kwargs
+    if args.default_top_k is not None:
+        server._default_top_k = args.default_top_k
+    if args.default_min_p is not None:
+        server._default_min_p = args.default_min_p
+    if args.default_presence_penalty is not None:
+        server._default_presence_penalty = args.default_presence_penalty
+    if args.default_repetition_penalty is not None:
+        server._default_repetition_penalty = args.default_repetition_penalty
     max_audio_upload_mb = getattr(args, "max_audio_upload_mb", 25)
     max_tts_input_chars = getattr(args, "max_tts_input_chars", 4096)
     server._max_audio_upload_bytes = max_audio_upload_mb * 1024 * 1024

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -80,7 +80,9 @@ def serve_command(args):
         server._default_temperature = args.default_temperature
     if args.default_top_p is not None:
         server._default_top_p = args.default_top_p
-    server._default_chat_template_kwargs = args.default_chat_template_kwargs
+    server._default_chat_template_kwargs = getattr(
+        args, "default_chat_template_kwargs", None
+    )
     if args.default_top_k is not None:
         server._default_top_k = args.default_top_k
     if args.default_min_p is not None:
@@ -1155,6 +1157,36 @@ Examples:
             "Default chat template kwargs to apply to all requests when request "
             "chat_template_kwargs is omitted or empty; empty request kwargs use "
             'existing server defaults (JSON object, e.g. {"enable_thinking": true})'
+        ),
+    )
+    serve_parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Override default top_k for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Override default min_p for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help=(
+            "Override default presence_penalty for all requests "
+            "(default: use model default)"
+        ),
+    )
+    serve_parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help=(
+            "Override default repetition_penalty for all requests "
+            "(default: use model default)"
         ),
     )
     # Embedding model option

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -158,6 +158,7 @@ class MemoryCacheConfig:
         kv_bits: Number of bits for KV cache quantization.
         kv_group_size: Group size for KV cache quantization.
         kv_min_quantize_tokens: Minimum sequence length for quantization to apply.
+        min_prefix_tokens: Minimum cached prefix length eligible for reuse.
     """
 
     max_memory_mb: int | None = None
@@ -168,6 +169,7 @@ class MemoryCacheConfig:
     kv_bits: int = 8
     kv_group_size: int = 64
     kv_min_quantize_tokens: int = 256
+    min_prefix_tokens: int = 128
 
     def __post_init__(self) -> None:
         if not 0.0 < self.max_memory_percent <= 1.0:
@@ -179,6 +181,10 @@ class MemoryCacheConfig:
         if self.kv_min_quantize_tokens < 0:
             raise ValueError(
                 f"kv_min_quantize_tokens must be >= 0, got {self.kv_min_quantize_tokens}"
+            )
+        if self.min_prefix_tokens < 1:
+            raise ValueError(
+                f"min_prefix_tokens must be >= 1, got {self.min_prefix_tokens}"
             )
 
     def compute_memory_limit(self) -> int:
@@ -710,6 +716,10 @@ class MemoryAwarePrefixCache:
             self._stats.misses += 1
             self._last_match_type = "miss"
             return None, tokens
+        if len(tokens) < self._config.min_prefix_tokens:
+            self._stats.misses += 1
+            self._last_match_type = "miss_short_prefix"
+            return None, tokens
 
         tokens_key = tuple(tokens)
 
@@ -862,6 +872,15 @@ class MemoryAwarePrefixCache:
                     )
 
         if best_lcp_entry is not None and best_lcp_length > 0:
+            if best_lcp_length < self._config.min_prefix_tokens:
+                logger.debug(
+                    "[cache_fetch] LCP skipped: shared=%s below min_prefix_tokens=%s",
+                    best_lcp_length,
+                    self._config.min_prefix_tokens,
+                )
+                self._stats.misses += 1
+                self._last_match_type = "miss_short_lcp"
+                return None, tokens
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
             has_non_trimmable = any(
@@ -930,6 +949,13 @@ class MemoryAwarePrefixCache:
             True if stored successfully, False if rejected.
         """
         if not tokens or not cache:
+            return False
+        if len(tokens) < self._config.min_prefix_tokens:
+            logger.debug(
+                "[cache_store] skipped short prefix: tokens=%s min_prefix_tokens=%s",
+                len(tokens),
+                self._config.min_prefix_tokens,
+            )
             return False
 
         tokens_key = tuple(tokens)
@@ -1300,6 +1326,15 @@ class MemoryAwarePrefixCache:
                 with open(tokens_path, "rb") as f:
                     arr.fromfile(f, entry_meta["num_tokens"])
                 tokens = list(arr)
+                if len(tokens) < self._config.min_prefix_tokens:
+                    logger.info(
+                        "[cache_persist] skipping short entry %s: %s tokens < "
+                        "min_prefix_tokens=%s",
+                        i,
+                        len(tokens),
+                        self._config.min_prefix_tokens,
+                    )
+                    continue
 
                 # Load KV cache
                 cache = load_prompt_cache(entry_path)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -181,6 +181,10 @@ _default_timeout: float = 300.0  # Default request timeout in seconds (5 minutes
 _default_temperature: float | None = None  # Set via --default-temperature
 _default_top_p: float | None = None  # Set via --default-top-p
 _default_chat_template_kwargs: dict[str, object] | None = None
+_default_top_k: int | None = None  # Set via --default-top-k
+_default_min_p: float | None = None  # Set via --default-min-p
+_default_presence_penalty: float | None = None  # Set via --default-presence-penalty
+_default_repetition_penalty: float | None = None  # Set via --default-repetition-penalty
 _metrics_enabled = False
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
@@ -193,6 +197,10 @@ _lifespan_active: bool = False
 
 _FALLBACK_TEMPERATURE = 0.7
 _FALLBACK_TOP_P = 0.9
+_FALLBACK_TOP_K = 0
+_FALLBACK_MIN_P = 0.0
+_FALLBACK_PRESENCE_PENALTY = 0.0
+_FALLBACK_REPETITION_PENALTY = 1.0
 
 
 def _resolve_temperature(request_value: float | None) -> float:
@@ -211,6 +219,42 @@ def _resolve_top_p(request_value: float | None) -> float:
     if _default_top_p is not None:
         return _default_top_p
     return _FALLBACK_TOP_P
+
+
+def _resolve_top_k(request_value: int | None) -> int:
+    """Resolve top_k: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_top_k is not None:
+        return _default_top_k
+    return _FALLBACK_TOP_K
+
+
+def _resolve_min_p(request_value: float | None) -> float:
+    """Resolve min_p: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_min_p is not None:
+        return _default_min_p
+    return _FALLBACK_MIN_P
+
+
+def _resolve_presence_penalty(request_value: float | None) -> float:
+    """Resolve presence_penalty: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_presence_penalty is not None:
+        return _default_presence_penalty
+    return _FALLBACK_PRESENCE_PENALTY
+
+
+def _resolve_repetition_penalty(request_value: float | None) -> float:
+    """Resolve repetition_penalty: request > CLI default > fallback."""
+    if request_value is not None:
+        return request_value
+    if _default_repetition_penalty is not None:
+        return _default_repetition_penalty
+    return _FALLBACK_REPETITION_PENALTY
 
 
 def _resolve_request_max_tokens(requested_value: int | None) -> int:
@@ -381,18 +425,15 @@ def _prepare_chat_completion_invocation(
         tool_choice=request.tool_choice,
     )
 
-    rep_penalty = request.repetition_penalty
     chat_kwargs = {
         "max_tokens": effective_max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
-        "repetition_penalty": request.repetition_penalty or 1.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(request.repetition_penalty),
     }
-    if rep_penalty is not None:
-        chat_kwargs["repetition_penalty"] = rep_penalty
 
     if has_media:
         chat_kwargs["images"] = images if images else None
@@ -461,12 +502,14 @@ def _prepare_anthropic_invocation(
 
     chat_kwargs = {
         "max_tokens": effective_max_tokens,
-        "temperature": openai_request.temperature,
-        "top_p": openai_request.top_p,
-        "top_k": openai_request.top_k or 0,
-        "min_p": openai_request.min_p or 0.0,
-        "presence_penalty": openai_request.presence_penalty or 0.0,
-        "repetition_penalty": openai_request.repetition_penalty or 1.0,
+        "temperature": _resolve_temperature(openai_request.temperature),
+        "top_p": _resolve_top_p(openai_request.top_p),
+        "top_k": _resolve_top_k(openai_request.top_k),
+        "min_p": _resolve_min_p(openai_request.min_p),
+        "presence_penalty": _resolve_presence_penalty(openai_request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(
+            openai_request.repetition_penalty
+        ),
     }
     resolved_chat_template_kwargs = _resolve_chat_template_kwargs(
         openai_request.chat_template_kwargs
@@ -3700,13 +3743,14 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 "max_tokens": effective_max_tokens,
                 "temperature": _resolve_temperature(request.temperature),
                 "top_p": _resolve_top_p(request.top_p),
-                "top_k": request.top_k or 0,
-                "min_p": request.min_p or 0.0,
-                "presence_penalty": request.presence_penalty or 0.0,
+                "top_k": _resolve_top_k(request.top_k),
+                "min_p": _resolve_min_p(request.min_p),
+                "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
                 "stop": request.stop,
             }
-            if comp_rep_penalty is not None:
-                generate_kwargs["repetition_penalty"] = comp_rep_penalty
+            generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(
+                comp_rep_penalty
+            )
             if request.specprefill is not None:
                 generate_kwargs["specprefill"] = request.specprefill
             if request.specprefill_keep_pct is not None:
@@ -4746,13 +4790,14 @@ async def stream_completion(
         "max_tokens": max_tokens,
         "temperature": _resolve_temperature(request.temperature),
         "top_p": _resolve_top_p(request.top_p),
-        "top_k": request.top_k or 0,
-        "min_p": request.min_p or 0.0,
-        "presence_penalty": request.presence_penalty or 0.0,
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
         "stop": request.stop,
     }
-    if repetition_penalty is not None:
-        generate_kwargs["repetition_penalty"] = repetition_penalty
+    generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(
+        repetition_penalty
+    )
     if request.specprefill is not None:
         generate_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
@@ -5305,6 +5350,8 @@ def main():
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
     global _default_temperature, _default_top_p, _default_chat_template_kwargs
+    global _default_top_k, _default_min_p
+    global _default_presence_penalty, _default_repetition_penalty
     global _max_audio_upload_bytes, _max_tts_input_chars
     _api_key = args.api_key
     _default_timeout = args.timeout
@@ -5315,6 +5362,14 @@ def main():
     if args.default_top_p is not None:
         _default_top_p = args.default_top_p
     _default_chat_template_kwargs = args.default_chat_template_kwargs
+    if args.default_top_k is not None:
+        _default_top_k = args.default_top_k
+    if args.default_min_p is not None:
+        _default_min_p = args.default_min_p
+    if args.default_presence_penalty is not None:
+        _default_presence_penalty = args.default_presence_penalty
+    if args.default_repetition_penalty is not None:
+        _default_repetition_penalty = args.default_repetition_penalty
     _max_audio_upload_bytes = args.max_audio_upload_mb * 1024 * 1024
     _max_tts_input_chars = args.max_tts_input_chars
 
@@ -5532,6 +5587,32 @@ Examples:
             "Default chat template kwargs to apply to all requests when request "
             "chat_template_kwargs is omitted or empty; empty request kwargs use "
             'existing server defaults (JSON object, e.g. {"enable_thinking": false})'
+        ),
+    )
+    parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Default top_k for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Default min_p for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Default presence_penalty for generation when not specified in request",
+    )
+    parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help=(
+            "Default repetition_penalty for generation when not specified in request"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Supersedes #405 because the fork branch cannot be refreshed through the current OAuth token after upstream CI workflow changes landed. This branch is rebased on current `main` and carries the same scope:

- propagate CLI/server defaults for `top_k`, `min_p`, `presence_penalty`, and `repetition_penalty`
- preserve server default chat-template kwargs from current `main`
- avoid reusing short prefix-cache entries that are too small to be useful and can contaminate benchmark runs
- update focused tests for the current upstream helper/refactor shape

Local validation:

```bash
uv run --extra dev pytest -q tests/test_cli.py tests/test_server.py tests/test_server_cache_controls.py tests/test_memory_cache.py tests/test_memory_cache_mlx.py tests/test_prefix_cache.py
# 186 passed, 3 deselected

uv run --extra dev black --check vllm_mlx/cli.py vllm_mlx/server.py tests/test_cli.py tests/test_server.py
uvx ruff check vllm_mlx/cli.py vllm_mlx/server.py tests/test_cli.py tests/test_server.py --select E,F,W --ignore E402,E501,E731,F811,F841
git diff --check
# clean
```