### PR TITLE
feat(engine): add raw_output to preserve unstripped text for parsers

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -576,6 +576,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all requests when model is multimodal.
             # MLLM models only initialise the _mllm_scheduler (not _engine),
@@ -594,8 +596,13 @@ class BatchedEngine(BaseEngine):
                 logits_processors=kwargs.pop("logits_processors", None),
             )
 
+            text = (
+                output.output_text
+                if raw_output
+                else clean_output_text(output.output_text)
+            )
             return GenerationOutput(
-                text=clean_output_text(output.output_text),
+                text=text,
                 tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
@@ -622,7 +629,9 @@ class BatchedEngine(BaseEngine):
             sampling_params=sampling_params,
         )
 
-        text = clean_output_text(output.output_text)
+        text = (
+            output.output_text if raw_output else clean_output_text(output.output_text)
+        )
 
         return GenerationOutput(
             text=text,
@@ -662,6 +671,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
             request_id = await self._mllm_scheduler.add_request_async(
@@ -679,8 +690,13 @@ class BatchedEngine(BaseEngine):
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
+                text = (
+                    output.output_text
+                    if raw_output
+                    else clean_output_text(output.output_text)
+                )
                 yield GenerationOutput(
-                    text=clean_output_text(output.output_text),
+                    text=text,
                     new_text=output.new_text,
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
@@ -712,7 +728,11 @@ class BatchedEngine(BaseEngine):
         )
 
         async for output in self._engine.stream_outputs(request_id):
-            text = clean_output_text(output.output_text)
+            text = (
+                output.output_text
+                if raw_output
+                else clean_output_text(output.output_text)
+            )
 
             yield GenerationOutput(
                 text=text,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -298,6 +298,8 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        raw_output = bool(kwargs.pop("raw_output", False))
+
         last_output: GenerationOutput | None = None
         async for output in self.stream_generate(
             prompt=prompt,
@@ -312,7 +314,7 @@ class SimpleEngine(BaseEngine):
         if last_output is None:
             return GenerationOutput(text="", finish_reason="stop")
 
-        text = clean_output_text(last_output.text)
+        text = last_output.text if raw_output else clean_output_text(last_output.text)
         return GenerationOutput(
             text=text,
             tokens=list(last_output.tokens),
@@ -483,6 +485,7 @@ class SimpleEngine(BaseEngine):
             await self.start()
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        raw_output = bool(kwargs.pop("raw_output", False))
 
         # mlx-lm non-streaming chat with tools can stall indefinitely on some
         # local models, while the streaming path completes normally. Reuse the
@@ -502,7 +505,11 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ):
                 final_output = output
-            text = clean_output_text(final_output.text)
+            text = (
+                final_output.text
+                if raw_output
+                else clean_output_text(final_output.text)
+            )
             return GenerationOutput(
                 text=text,
                 tokens=list(final_output.tokens),
@@ -525,7 +532,7 @@ class SimpleEngine(BaseEngine):
                 tools=template_tools,
                 **kwargs,
             )
-            text = clean_output_text(output.text)
+            text = output.text if raw_output else clean_output_text(output.text)
             return GenerationOutput(
                 text=text,
                 prompt_tokens=output.prompt_tokens,
@@ -543,7 +550,7 @@ class SimpleEngine(BaseEngine):
                 chat_template_kwargs=chat_template_kwargs,
                 **kwargs,
             )
-            text = clean_output_text(output.text)
+            text = output.text if raw_output else clean_output_text(output.text)
             # Preserve upstream prompt accounting while routing the blocking
             # chat call through the cancellation-safe serialized runner.
             tokenizer = self._model.tokenizer
@@ -594,6 +601,10 @@ class SimpleEngine(BaseEngine):
             await self.start()
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        # Accept raw_output so it doesn't leak into sub-calls via **kwargs.
+        # stream_chat already yields raw text; the flag is consumed here for
+        # API consistency with chat() / generate().
+        kwargs.pop("raw_output", None)
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2778,6 +2778,10 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     start_time = time.perf_counter()
     timeout = request.timeout or _default_timeout
 
+    # Request raw output so reasoning/tool parsers see unstripped text.
+    # The server applies clean_output_text() itself after parsing.
+    chat_kwargs["raw_output"] = True
+
     try:
         output = await _wait_with_disconnect(
             engine.chat(messages=messages, **chat_kwargs),
@@ -3141,6 +3145,9 @@ async def create_anthropic_message(
         chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
         # Suppress thinking: constrained decoding prevents <think> tags.
         chat_kwargs["enable_thinking"] = False
+
+    # Request raw output so reasoning/tool parsers see unstripped text.
+    chat_kwargs["raw_output"] = True
 
     start_time = time.perf_counter()
     timeout = _default_timeout


### PR DESCRIPTION
## Summary

- Adds `raw_output` parameter to `generate()`, `chat()`, `stream_generate()`, and `stream_chat()` on both `SimpleEngine` and `BatchedEngine`
- When `raw_output=True`, `clean_output_text()` is skipped so reasoning/tool parsers receive unstripped model output
- Server non-streaming chat paths (OpenAI `/v1/chat/completions` and Anthropic `/v1/messages`) now pass `raw_output=True` to `engine.chat()`, fixing a double-clean bug where special tokens were stripped before the reasoning parser could see them

## Motivation

The reasoning parser (`extract_reasoning()`) and tool call parser need to see raw model output including special tokens like `<think>`, `</think>`, `<|channel|>`, etc. Previously, `engine.chat()` applied `clean_output_text()` which stripped these tokens, and then the server applied it again on the result. This caused:
1. Reasoning tokens stripped before the parser could extract them (non-streaming path)
2. Redundant double-cleaning

The streaming path (`stream_chat`) was already effectively raw — this change adds the parameter for API consistency and ensures it doesn't leak into sub-calls.

Supersedes #255 with a narrower, single-commit change rebased on current main.

## Test plan

- [x] `tests/test_simple_engine.py` — 8/8 pass
- [ ] Manual: non-streaming chat with reasoning model returns correct `reasoning_content`
- [ ] Manual: non-streaming chat with tool calls returns correct `tool_calls`
- [ ] Verify streaming path behavior unchanged