### PR TITLE
fix: don't suppress whitespace-only deltas after partial-markup check

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -5015,10 +5015,7 @@ async def stream_chat_completion(
                         )
                     ):
                         tool_accumulated_text += content
-                        # Suppress whitespace-only content when tools are active;
-                        # avoids emitting stray newlines before tool call XML.
-                        if not content.strip():
-                            continue
+                        # Emit as-is; no tool markup is even possible yet.
                     else:
                         if not tool_markup_possible:
                             tool_markup_possible = True


### PR DESCRIPTION
Fixes #431.

The whitespace suppression block in `chat_completions` streaming runs after `_streaming_tool_markup_possible()` has already determined the buffered text cannot be the start (or partial prefix) of tool-call XML. At that point it isn't guarding against any tool-call use case; it only strips legitimate prose whitespace, collapsing multi-paragraph output into one unbroken blob client-side.

Removing the four-line block. Buffered text is still accumulated for downstream tool-call detection.

## Verification

Reproducer from the linked issue, against `mlx-community/Qwen3.6-35B-A3B-8bit` with `--tool-call-parser qwen`:

```bash
curl -sN -X POST http://127.0.0.1:8002/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/Qwen3.6-35B-A3B-8bit",
    "messages": [{"role": "user", "content": "write three short sentences on three lines"}],
    "max_tokens": 500,
    "stream": true
  }' \
  | sed -n 's/^data: //p' \
  | jq -r '.choices[0].delta.content // empty'
```

Before: every emitted line is non-whitespace content; `"\n\n"` deltas missing.

After: whitespace-only deltas (`"\n\n"`, `"  \n"`, etc.) appear in the stream as expected.

Tool-call streaming verified intact on `--tool-call-parser qwen` and `--tool-call-parser minimax` in production.
