### PR TITLE
Add raw_output to preserve unstripped text for parsers

### DIFF
--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -154,6 +154,7 @@ class BaseEngine(ABC):
         temperature: float = 0.7,
         top_p: float = 0.9,
         stop: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -180,6 +181,7 @@ class BaseEngine(ABC):
         temperature: float = 0.7,
         top_p: float = 0.9,
         stop: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -208,6 +210,7 @@ class BaseEngine(ABC):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -238,6 +241,7 @@ class BaseEngine(ABC):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -641,6 +641,7 @@ class BatchedEngine(BaseEngine):
         stop: list[str] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -681,7 +682,11 @@ class BatchedEngine(BaseEngine):
             )
 
             return GenerationOutput(
-                text=clean_output_text(output.output_text),
+                text=(
+                    output.output_text
+                    if raw_output
+                    else clean_output_text(output.output_text)
+                ),
                 tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
@@ -708,7 +713,9 @@ class BatchedEngine(BaseEngine):
             sampling_params=sampling_params,
         )
 
-        text = clean_output_text(output.output_text)
+        text = (
+            output.output_text if raw_output else clean_output_text(output.output_text)
+        )
 
         return GenerationOutput(
             text=text,
@@ -727,6 +734,7 @@ class BatchedEngine(BaseEngine):
         stop: list[str] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -766,7 +774,11 @@ class BatchedEngine(BaseEngine):
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
                 yield GenerationOutput(
-                    text=clean_output_text(output.output_text),
+                    text=(
+                        output.output_text
+                        if raw_output
+                        else clean_output_text(output.output_text)
+                    ),
                     new_text=output.new_text,
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
@@ -798,7 +810,11 @@ class BatchedEngine(BaseEngine):
         )
 
         async for output in self._engine.stream_outputs(request_id):
-            text = clean_output_text(output.output_text)
+            text = (
+                output.output_text
+                if raw_output
+                else clean_output_text(output.output_text)
+            )
 
             yield GenerationOutput(
                 text=text,
@@ -818,6 +834,7 @@ class BatchedEngine(BaseEngine):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -872,6 +889,7 @@ class BatchedEngine(BaseEngine):
             top_p=top_p,
             images=all_images if all_images else None,
             videos=all_videos if all_videos else None,
+            raw_output=raw_output,
             **kwargs,
         )
 
@@ -946,6 +964,7 @@ class BatchedEngine(BaseEngine):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -1009,6 +1028,7 @@ class BatchedEngine(BaseEngine):
             top_p=top_p,
             images=all_images if all_images else None,
             videos=all_videos if all_videos else None,
+            raw_output=raw_output,
             **kwargs,
         ):
             yield output

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -359,6 +359,7 @@ class SimpleEngine(BaseEngine):
         temperature: float = 0.7,
         top_p: float = 0.9,
         stop: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -399,6 +400,7 @@ class SimpleEngine(BaseEngine):
             temperature=temperature,
             top_p=top_p,
             stop=stop,
+            raw_output=raw_output,
             **kwargs,
         ):
             last_output = output
@@ -406,7 +408,7 @@ class SimpleEngine(BaseEngine):
         if last_output is None:
             return GenerationOutput(text="", finish_reason="stop")
 
-        text = clean_output_text(last_output.text)
+        text = last_output.text if raw_output else clean_output_text(last_output.text)
         return GenerationOutput(
             text=text,
             tokens=list(last_output.tokens),
@@ -423,6 +425,7 @@ class SimpleEngine(BaseEngine):
         temperature: float = 0.7,
         top_p: float = 0.9,
         stop: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -555,6 +558,7 @@ class SimpleEngine(BaseEngine):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -588,11 +592,16 @@ class SimpleEngine(BaseEngine):
                 tools=tools,
                 images=images,
                 videos=videos,
+                raw_output=raw_output,
                 chat_template_kwargs=chat_template_kwargs,
                 **kwargs,
             ):
                 final_output = output
-            text = clean_output_text(final_output.text)
+            text = (
+                final_output.text
+                if raw_output
+                else clean_output_text(final_output.text)
+            )
             return GenerationOutput(
                 text=text,
                 tokens=list(final_output.tokens),
@@ -633,7 +642,7 @@ class SimpleEngine(BaseEngine):
                 tools=template_tools,
                 **kwargs,
             )
-            text = clean_output_text(output.text)
+            text = output.text if raw_output else clean_output_text(output.text)
             return GenerationOutput(
                 text=text,
                 prompt_tokens=output.prompt_tokens,
@@ -651,7 +660,7 @@ class SimpleEngine(BaseEngine):
                 chat_template_kwargs=chat_template_kwargs,
                 **kwargs,
             )
-            text = clean_output_text(output.text)
+            text = output.text if raw_output else clean_output_text(output.text)
             # Preserve upstream prompt accounting while routing the blocking
             # chat call through the cancellation-safe serialized runner.
             tokenizer = self._model.tokenizer
@@ -680,6 +689,7 @@ class SimpleEngine(BaseEngine):
         tools: list[dict] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        raw_output: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -811,6 +821,7 @@ class SimpleEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            raw_output=raw_output,
             **kwargs,
         ):
             yield output

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1715,7 +1715,7 @@ async def _run_responses_request(
 
     timeout = _default_timeout
     output = await _wait_with_disconnect(
-        engine.chat(messages=messages, **chat_kwargs),
+        engine.chat(messages=messages, raw_output=True, **chat_kwargs),
         raw_request,
         timeout=timeout,
     )
@@ -3897,7 +3897,11 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
 
         try:
             output = await _wait_with_disconnect(
-                engine.chat(messages=prepared.messages, **prepared.chat_kwargs),
+                engine.chat(
+                    messages=prepared.messages,
+                    raw_output=True,
+                    **prepared.chat_kwargs,
+                ),
                 raw_request,
                 timeout=_remaining_request_timeout(total_timeout, deadline),
                 timeout_detail_seconds=total_timeout,
@@ -4295,7 +4299,11 @@ async def create_anthropic_message(
         start_time = time.perf_counter()
         try:
             output = await _wait_with_disconnect(
-                engine.chat(messages=prepared.messages, **prepared.chat_kwargs),
+                engine.chat(
+                    messages=prepared.messages,
+                    raw_output=True,
+                    **prepared.chat_kwargs,
+                ),
                 request,
                 timeout=_remaining_request_timeout(total_timeout, deadline),
                 timeout_detail_seconds=total_timeout,


### PR DESCRIPTION
## Summary

- Add `raw_output: bool = False` to `generate()`, `chat()`, `stream_generate()`, `stream_chat()` on both `SimpleEngine` and `BatchedEngine`
- When `raw_output=True`, `clean_output_text()` is skipped so reasoning/tool parsers receive the model's original special tokens
- Server non-streaming chat paths (OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`, Responses API) now pass `raw_output=True`

Fixes a double-clean bug where special tokens were stripped before the reasoning parser could see them in non-streaming responses.

Re-implementation of #428 against current main.

## Test plan

- [x] 146 existing tests pass (test_simple_engine + test_reasoning_parser)
- [ ] Manual: non-streaming chat with reasoning model returns correct `reasoning_content`
- [ ] Manual: streaming path behavior unchanged