### PR TITLE
Add thinking-aware logits processor with token budget

### DIFF
--- a/tests/test_thinking_processor.py
+++ b/tests/test_thinking_processor.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ThinkingAwareLogitsProcessor.
+
+Covers:
+* Phase state machine transitions (IDLE -> THINKING -> CONTENT)
+* Budget enforcement (THINKING -> TRANSITIONING -> CONTENT)
+* Budget-zero edge case (immediate TRANSITIONING)
+* Inner processor delegation in CONTENT phase
+* Content-phase control token masking
+* BoundedSuffixMatcher correctness
+* Snapshot/restore for speculative decoding rollback
+* prompt_has_think_tag fast-start paths
+
+These tests are pure-logic: they use synthetic token IDs and small
+vocab sizes. No model loading required.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.constrained.thinking_processor import (
+    BoundedSuffixMatcher,
+    Phase,
+    ThinkingAwareLogitsProcessor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VOCAB_SIZE = 32
+# Synthetic token IDs for <think> and </think>
+THINK_START = [10]
+THINK_END = [11]
+# Multi-token end sequence for testing
+THINK_END_MULTI = [11, 12]
+
+
+def _make_logits(vocab_size: int = VOCAB_SIZE) -> mx.array:
+    """Return uniform logits (all zeros)."""
+    return mx.zeros((vocab_size,))
+
+
+def _tokens(*ids: int) -> mx.array:
+    """Build a 1-D token array from integer IDs."""
+    return mx.array(list(ids), dtype=mx.int32)
+
+
+def _argmax(logits: mx.array) -> int:
+    """Return the argmax of a logits vector."""
+    return int(logits.argmax().item())
+
+
+# ---------------------------------------------------------------------------
+# BoundedSuffixMatcher
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedSuffixMatcher:
+    def test_single_token_match(self):
+        m = BoundedSuffixMatcher([5])
+        assert not m.feed(4)
+        assert m.feed(5)
+
+    def test_multi_token_match(self):
+        m = BoundedSuffixMatcher([1, 2, 3])
+        assert not m.feed(1)
+        assert not m.feed(2)
+        assert m.feed(3)
+
+    def test_no_false_positive(self):
+        m = BoundedSuffixMatcher([1, 2])
+        m.feed(1)
+        m.feed(9)  # breaks the sequence
+        assert not m.feed(2)  # 9,2 != 1,2
+
+    def test_overlapping_prefix(self):
+        """The rolling buffer catches overlapping prefixes."""
+        m = BoundedSuffixMatcher([1, 1])
+        m.feed(1)
+        # Buffer is [1]; next 1 gives [1,1]
+        assert m.feed(1)
+
+    def test_snapshot_restore(self):
+        m = BoundedSuffixMatcher([1, 2, 3])
+        m.feed(1)
+        m.feed(2)
+        snap = m.snapshot()
+        assert not m.feed(9)  # break it
+        m.restore(snap)
+        assert m.feed(3)  # restored to [1,2], feed 3 -> match
+
+    def test_reset(self):
+        m = BoundedSuffixMatcher([5])
+        m.feed(5)
+        m.reset()
+        assert not m.feed(4)
+        assert m.feed(5)
+
+    def test_empty_target_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            BoundedSuffixMatcher([])
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — basic lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessorLifecycle:
+    def test_idle_to_thinking_to_content(self):
+        """Full natural lifecycle: IDLE -> THINKING -> CONTENT via end tokens."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert proc.state == Phase.IDLE
+
+        # Feed start token
+        logits = proc(_tokens(*THINK_START), _make_logits())
+        assert proc.state == Phase.THINKING
+
+        # Feed some thinking tokens
+        logits = proc(_tokens(*THINK_START, 5, 6), _make_logits())
+        assert proc.state == Phase.THINKING
+        assert proc.thinking_tokens == 2
+
+        # Feed end token
+        logits = proc(_tokens(*THINK_START, 5, 6, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+
+    def test_budget_enforcement(self):
+        """Budget exhaustion triggers TRANSITIONING then CONTENT."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=3,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Enter thinking
+        proc(_tokens(*THINK_START), _make_logits())
+        assert proc.state == Phase.THINKING
+
+        # Consume budget: 3 thinking tokens
+        proc(_tokens(*THINK_START, 1, 2, 3), _make_logits())
+        assert proc.state == Phase.TRANSITIONING
+
+        # During TRANSITIONING, logits force the end token
+        logits = proc(_tokens(*THINK_START, 1, 2, 3), _make_logits())
+        assert _argmax(logits) == THINK_END[0]
+
+        # After forced end token is consumed, enter CONTENT
+        proc(_tokens(*THINK_START, 1, 2, 3, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+        assert proc.thinking_tokens == 3
+
+    def test_budget_zero(self):
+        """Budget=0 with prompt_has_think_tag starts in TRANSITIONING."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=0,
+            vocab_size=VOCAB_SIZE,
+            prompt_has_think_tag=True,
+        )
+        assert proc.state == Phase.TRANSITIONING
+
+        # Force transition on empty tokens
+        logits = proc(_tokens(), _make_logits())
+        assert _argmax(logits) == THINK_END[0]
+
+    def test_prompt_has_think_tag_starts_thinking(self):
+        """prompt_has_think_tag=True with budget>0 starts in THINKING."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+            prompt_has_think_tag=True,
+        )
+        assert proc.state == Phase.THINKING
+
+    def test_is_retired_no_inner(self):
+        """is_retired is True in CONTENT with no inner processor."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert not proc.is_retired
+        # Drive to CONTENT
+        proc(_tokens(*THINK_START, 5, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+        assert proc.is_retired
+
+    def test_is_retired_with_inner(self):
+        """is_retired is False in CONTENT when inner processor is present."""
+        inner_called = []
+
+        def fake_inner(tokens, logits):
+            inner_called.append(True)
+            return logits
+
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            inner=fake_inner,
+            vocab_size=VOCAB_SIZE,
+        )
+        proc(_tokens(*THINK_START, 5, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+        assert not proc.is_retired
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — multi-token end sequence
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessorMultiTokenEnd:
+    def test_multi_token_transition(self):
+        """Budget exhaustion with multi-token end forces each token in sequence."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END_MULTI,
+            thinking_token_budget=2,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Enter thinking and exhaust budget
+        proc(_tokens(*THINK_START, 1, 2), _make_logits())
+        assert proc.state == Phase.TRANSITIONING
+
+        # First forced token
+        logits = proc(_tokens(*THINK_START, 1, 2), _make_logits())
+        assert _argmax(logits) == THINK_END_MULTI[0]
+
+        # Feed first end token, still transitioning
+        proc(_tokens(*THINK_START, 1, 2, THINK_END_MULTI[0]), _make_logits())
+        assert proc.state == Phase.TRANSITIONING
+
+        # Second forced token
+        logits = proc(_tokens(*THINK_START, 1, 2, THINK_END_MULTI[0]), _make_logits())
+        assert _argmax(logits) == THINK_END_MULTI[1]
+
+        # Feed second end token, now CONTENT
+        proc(_tokens(*THINK_START, 1, 2, *THINK_END_MULTI), _make_logits())
+        assert proc.state == Phase.CONTENT
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — inner processor delegation
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessorInnerDelegation:
+    def test_inner_called_in_content_phase(self):
+        """Inner processor is called during CONTENT phase."""
+        calls = []
+
+        def tracking_inner(tokens, logits):
+            calls.append(len(tokens) if hasattr(tokens, "__len__") else tokens.size)
+            return logits
+
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            inner=tracking_inner,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Drive to CONTENT -- inner is called on this step too since the
+        # processor reaches CONTENT and then __call__ delegates.
+        proc(_tokens(*THINK_START, 5, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+        assert len(calls) == 1
+
+        # Another call in CONTENT phase
+        proc(_tokens(*THINK_START, 5, *THINK_END, 20), _make_logits())
+        assert len(calls) == 2
+
+    def test_inner_not_called_during_thinking(self):
+        """Inner processor is NOT called during THINKING phase."""
+        calls = []
+
+        def tracking_inner(tokens, logits):
+            calls.append(True)
+            return logits
+
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            inner=tracking_inner,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        proc(_tokens(*THINK_START, 5, 6), _make_logits())
+        assert proc.state == Phase.THINKING
+        assert len(calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — content-phase masking
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessorContentMasking:
+    def test_control_tokens_masked_in_content(self):
+        """Start/end tag tokens are masked to -inf during CONTENT."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Drive to CONTENT
+        proc(_tokens(*THINK_START, 5, *THINK_END), _make_logits())
+        logits = proc(_tokens(*THINK_START, 5, *THINK_END, 20), _make_logits())
+
+        # Start and end tokens should be masked
+        assert logits[THINK_START[0]].item() == float("-inf")
+        assert logits[THINK_END[0]].item() == float("-inf")
+
+    def test_control_tokens_not_masked_during_thinking(self):
+        """During THINKING phase, control tokens are NOT masked (pass-through)."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # In THINKING
+        proc(_tokens(*THINK_START), _make_logits())
+        logits = proc(_tokens(*THINK_START, 5), _make_logits())
+        # Should be pass-through (all zeros)
+        assert logits[THINK_START[0]].item() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — snapshot/restore (speculative rollback)
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessorRollback:
+    def test_rollback_on_prefix_change(self):
+        """Sync correctly handles token prefix divergence (speculative rollback)."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Feed: start + two thinking tokens
+        proc(_tokens(*THINK_START, 5, 6), _make_logits())
+        assert proc.state == Phase.THINKING
+        assert proc.thinking_tokens == 2
+
+        # Now the sequence diverges: start + one thinking token (rollback)
+        proc(_tokens(*THINK_START, 5), _make_logits())
+        assert proc.state == Phase.THINKING
+        assert proc.thinking_tokens == 1
+
+    def test_rollback_across_phases(self):
+        """Rollback from CONTENT to THINKING when prefix diverges."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=100,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Drive to CONTENT
+        proc(_tokens(*THINK_START, 5, *THINK_END), _make_logits())
+        assert proc.state == Phase.CONTENT
+
+        # Diverge at a shorter prefix still in THINKING range
+        proc(_tokens(*THINK_START, 5, 7), _make_logits())
+        assert proc.state == Phase.THINKING
+        assert proc.thinking_tokens == 2
+
+
+# ---------------------------------------------------------------------------
+# ThinkingAwareLogitsProcessor — 2-D logits
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingProcessor2DLogits:
+    def test_2d_logits_transition(self):
+        """Force transition works with 2-D (1, vocab) logits shape."""
+        proc = ThinkingAwareLogitsProcessor(
+            start_token_ids=THINK_START,
+            end_token_ids=THINK_END,
+            thinking_token_budget=1,
+            vocab_size=VOCAB_SIZE,
+        )
+
+        # Enter thinking, exhaust budget
+        proc(_tokens(*THINK_START, 1), _make_logits())
+        assert proc.state == Phase.TRANSITIONING
+
+        logits_2d = mx.zeros((1, VOCAB_SIZE))
+        result = proc(_tokens(*THINK_START, 1), logits_2d)
+        assert result.shape == (1, VOCAB_SIZE)
+        assert result[0, THINK_END[0]].item() == 0.0
+        # All others should be -inf
+        assert result[0, 0].item() == float("-inf")

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -238,7 +238,6 @@ class Usage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
-    reasoning_tokens: int | None = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -189,6 +189,9 @@ class ChatCompletionRequest(BaseModel):
     specprefill_keep_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
+    # Thinking token budget: cap reasoning tokens by forcing </think> when
+    # budget exhausted (None = no budget, unlimited reasoning)
+    thinking_token_budget: int | None = Field(default=None, gt=0)
 
 
 class AssistantMessage(BaseModel):
@@ -235,6 +238,7 @@ class Usage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    reasoning_tokens: int | None = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -86,6 +86,10 @@ def serve_command(args):
     server._max_audio_upload_bytes = max_audio_upload_mb * 1024 * 1024
     server._max_tts_input_chars = max_tts_input_chars
 
+    # Configure thinking token budget
+    if args.default_thinking_token_budget is not None:
+        server._default_thinking_token_budget = args.default_thinking_token_budget
+
     # Configure reasoning parser
     if args.reasoning_parser:
         try:
@@ -142,6 +146,8 @@ def serve_command(args):
         print(f"  Reasoning: ENABLED (parser: {args.reasoning_parser})")
     else:
         print("  Reasoning: Use --reasoning-parser to enable")
+    if args.default_thinking_token_budget is not None:
+        print(f"  Thinking budget: {args.default_thinking_token_budget} tokens")
     print(
         f"  Audio upload limit: {max_audio_upload_mb} MiB, "
         f"TTS input limit: {max_tts_input_chars} chars"
@@ -1138,6 +1144,16 @@ Examples:
         type=float,
         default=None,
         help="Override default top_p for all requests (default: use model default)",
+    )
+    serve_parser.add_argument(
+        "--default-thinking-token-budget",
+        type=int,
+        default=None,
+        help=(
+            "Default thinking token budget for reasoning models. Caps reasoning "
+            "tokens by forcing the end-think sequence when the budget is exhausted. "
+            "Per-request thinking_token_budget overrides this. (default: None = unlimited)"
+        ),
     )
     serve_parser.add_argument(
         "--default-chat-template-kwargs",

--- a/vllm_mlx/constrained/__init__.py
+++ b/vllm_mlx/constrained/__init__.py
@@ -13,9 +13,11 @@ from .json_schema_processor import (
     LMFormatEnforcerNotAvailableError,
     is_available,
 )
+from .thinking_processor import ThinkingAwareLogitsProcessor
 
 __all__ = [
     "JSONSchemaLogitsProcessor",
     "LMFormatEnforcerNotAvailableError",
+    "ThinkingAwareLogitsProcessor",
     "is_available",
 ]

--- a/vllm_mlx/constrained/thinking_processor.py
+++ b/vllm_mlx/constrained/thinking_processor.py
@@ -1,0 +1,259 @@
+"""Thinking-aware logits processor for reasoning models.
+
+Manages the full thinking lifecycle: budget enforcement, phase transitions,
+and content-phase constrained decoding delegation.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections import deque
+from typing import Callable
+
+import mlx.core as mx
+
+
+class BoundedSuffixMatcher:
+    """Detect a target token sequence in a stream using a rolling suffix buffer.
+
+    Unlike a naive sequential matcher that resets to position 0 on mismatch,
+    this uses a bounded buffer that catches overlapping prefixes.
+    """
+
+    __slots__ = ("target", "_buf", "_max_len")
+
+    def __init__(self, target_ids: list[int]) -> None:
+        if not target_ids:
+            raise ValueError("target_ids must be non-empty")
+        self.target = tuple(target_ids)
+        self._max_len = len(target_ids)
+        self._buf: deque[int] = deque(maxlen=self._max_len)
+
+    def feed(self, token_id: int) -> bool:
+        """Feed one token. Returns True when the buffer suffix equals the target."""
+        self._buf.append(token_id)
+        return len(self._buf) == self._max_len and tuple(self._buf) == self.target
+
+    def reset(self) -> None:
+        """Clear the buffer."""
+        self._buf.clear()
+
+    def snapshot(self) -> tuple[int, ...]:
+        """Return a serializable copy of the current suffix buffer."""
+        return tuple(self._buf)
+
+    def restore(self, state: tuple[int, ...]) -> None:
+        """Restore the suffix buffer from a previous snapshot."""
+        self._buf.clear()
+        self._buf.extend(state)
+
+
+class Phase(enum.Enum):
+    """Thinking lifecycle phases."""
+
+    IDLE = "idle"
+    THINKING = "thinking"
+    TRANSITIONING = "transitioning"
+    CONTENT = "content"
+
+
+class ThinkingAwareLogitsProcessor:
+    """Unified logits processor for thinking-model lifecycle management.
+
+    Manages a four-phase state machine:
+      IDLE -> THINKING -> TRANSITIONING -> CONTENT
+
+    - IDLE: before reasoning start tokens. Pass through.
+    - THINKING: inside reasoning span. Count tokens, pass through.
+    - TRANSITIONING: forcing reasoning end sequence via logits masking.
+    - CONTENT: after reasoning closed. Delegate to inner processor.
+
+    No re-entry into THINKING after CONTENT is reached.
+    """
+
+    __slots__ = (
+        "_start_matcher",
+        "_end_matcher",
+        "_end_token_ids",
+        "_content_phase_mask_ids",
+        "_thinking_token_budget",
+        "_inner",
+        "_vocab_size",
+        "_state",
+        "_thinking_tokens",
+        "_transition_index",
+        "_processed_len",
+        "_processed_token_ids",
+        "_snapshots",
+    )
+
+    def __init__(
+        self,
+        start_token_ids: list[int],
+        end_token_ids: list[int],
+        thinking_token_budget: int,
+        inner: Callable[[mx.array, mx.array], mx.array] | None = None,
+        vocab_size: int = 152064,
+        prompt_has_think_tag: bool = False,
+    ) -> None:
+        self._start_matcher = BoundedSuffixMatcher(start_token_ids)
+        self._end_matcher = BoundedSuffixMatcher(end_token_ids)
+        self._end_token_ids = list(end_token_ids)
+        self._content_phase_mask_ids = tuple(
+            dict.fromkeys([start_token_ids[0], end_token_ids[0]])
+        )
+        self._thinking_token_budget = thinking_token_budget
+        self._inner = inner
+        self._vocab_size = vocab_size
+        self._thinking_tokens = 0
+        self._transition_index = 0
+        # When the chat template already injected <think> into the prompt,
+        # the first generated token is already inside the thinking span.
+        # Start in THINKING (or TRANSITIONING if budget=0) instead of IDLE.
+        if prompt_has_think_tag:
+            if thinking_token_budget == 0:
+                self._state = Phase.TRANSITIONING
+            else:
+                self._state = Phase.THINKING
+        else:
+            self._state = Phase.IDLE
+        self._processed_len = 0
+        self._processed_token_ids: list[int] = []
+        self._snapshots = [self._snapshot_state()]
+
+    @property
+    def state(self) -> Phase:
+        return self._state
+
+    @property
+    def thinking_tokens(self) -> int:
+        return self._thinking_tokens
+
+    @property
+    def is_retired(self) -> bool:
+        """True when the processor is in CONTENT with no inner constraint.
+
+        The engine can use this signal to drop the processor and re-enable
+        MTP for the remaining content generation (Phase 2 optimization).
+        """
+        return self._state == Phase.CONTENT and self._inner is None
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        # The MLLM scheduler applies processors before the first completion
+        # token is emitted, so ``tokens`` can be empty on step 0.
+        if tokens.size == 0:
+            if self._state == Phase.TRANSITIONING:
+                return self._force_transition(logits)
+            if self._state == Phase.CONTENT:
+                return self._call_inner(tokens, logits)
+            return logits
+
+        self._sync_to_tokens(tokens)
+
+        if self._state == Phase.TRANSITIONING:
+            return self._force_transition(logits)
+
+        # Phase.CONTENT
+        if self._state == Phase.CONTENT:
+            return self._call_inner(tokens, logits)
+        return logits
+
+    def _force_transition(self, logits: mx.array) -> mx.array:
+        """Force the next token in the reasoning end sequence."""
+        target_id = self._end_token_ids[self._transition_index]
+        # Mask all logits to -inf, then set the target token to 0.
+        # Handle both 1-D (vocab,) and 2-D (1, vocab) logits shapes.
+        masked = mx.full(logits.shape, float("-inf"))
+        if masked.ndim == 1:
+            masked[target_id] = 0.0
+        else:
+            masked[..., target_id] = 0.0
+        return masked
+
+    def _call_inner(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        """Delegate to inner processor if present."""
+        if self._inner is not None:
+            logits = self._inner(tokens, logits)
+        return self._mask_content_phase_control_tokens(logits)
+
+    def _mask_content_phase_control_tokens(self, logits: mx.array) -> mx.array:
+        """Prevent reserved think-tag starts from leaking into final content."""
+        for token_id in self._content_phase_mask_ids:
+            if logits.ndim == 1:
+                logits[token_id] = float("-inf")
+            else:
+                logits[..., token_id] = float("-inf")
+        return logits
+
+    def _snapshot_state(
+        self,
+    ) -> tuple[Phase, int, int, tuple[int, ...], tuple[int, ...]]:
+        return (
+            self._state,
+            self._thinking_tokens,
+            self._transition_index,
+            self._start_matcher.snapshot(),
+            self._end_matcher.snapshot(),
+        )
+
+    def _restore_snapshot(self, processed_len: int) -> None:
+        (
+            self._state,
+            self._thinking_tokens,
+            self._transition_index,
+            start_state,
+            end_state,
+        ) = self._snapshots[processed_len]
+        self._start_matcher.restore(start_state)
+        self._end_matcher.restore(end_state)
+        self._processed_len = processed_len
+        self._processed_token_ids = self._processed_token_ids[:processed_len]
+        self._snapshots = self._snapshots[: processed_len + 1]
+
+    def _sync_to_tokens(self, tokens: mx.array) -> None:
+        target_len = int(tokens.size)
+        token_ids = [int(tokens[idx].item()) for idx in range(target_len)]
+        common_len = 0
+        max_common = min(target_len, self._processed_len)
+        while (
+            common_len < max_common
+            and self._processed_token_ids[common_len] == token_ids[common_len]
+        ):
+            common_len += 1
+        if common_len < self._processed_len:
+            self._restore_snapshot(common_len)
+        if target_len == self._processed_len:
+            return
+        for token_id in token_ids[self._processed_len :]:
+            self._advance_with_token(token_id)
+            self._processed_token_ids.append(token_id)
+            self._processed_len += 1
+            self._snapshots.append(self._snapshot_state())
+
+    def _advance_with_token(self, token_id: int) -> None:
+        if self._state == Phase.IDLE:
+            if self._start_matcher.feed(token_id):
+                self._state = Phase.THINKING
+                if self._thinking_token_budget == 0:
+                    self._state = Phase.TRANSITIONING
+                    self._transition_index = 0
+            return
+
+        if self._state == Phase.THINKING:
+            if self._end_matcher.feed(token_id):
+                self._state = Phase.CONTENT
+                return
+            self._thinking_tokens += 1
+            if self._thinking_tokens >= self._thinking_token_budget:
+                self._state = Phase.TRANSITIONING
+                self._transition_index = 0
+            return
+
+        if self._state == Phase.TRANSITIONING:
+            expected = self._end_token_ids[self._transition_index]
+            if token_id == expected:
+                self._transition_index += 1
+                if self._transition_index >= len(self._end_token_ids):
+                    self._state = Phase.CONTENT
+                    self._end_matcher.reset()
+            return

--- a/vllm_mlx/constrained/thinking_processor.py
+++ b/vllm_mlx/constrained/thinking_processor.py
@@ -199,18 +199,23 @@ class ThinkingAwareLogitsProcessor:
         )
 
     def _restore_snapshot(self, processed_len: int) -> None:
+        # In CONTENT phase, snapshots stop growing (see _sync_to_tokens).
+        # If rollback targets a CONTENT position beyond the snapshot list,
+        # use the last available snapshot -- the state is identical since
+        # _advance_with_token is a no-op in CONTENT.
+        snap_idx = min(processed_len, len(self._snapshots) - 1)
         (
             self._state,
             self._thinking_tokens,
             self._transition_index,
             start_state,
             end_state,
-        ) = self._snapshots[processed_len]
+        ) = self._snapshots[snap_idx]
         self._start_matcher.restore(start_state)
         self._end_matcher.restore(end_state)
         self._processed_len = processed_len
         self._processed_token_ids = self._processed_token_ids[:processed_len]
-        self._snapshots = self._snapshots[: processed_len + 1]
+        self._snapshots = self._snapshots[: snap_idx + 1]
 
     def _sync_to_tokens(self, tokens: mx.array) -> None:
         target_len = int(tokens.size)
@@ -230,7 +235,10 @@ class ThinkingAwareLogitsProcessor:
             self._advance_with_token(token_id)
             self._processed_token_ids.append(token_id)
             self._processed_len += 1
-            self._snapshots.append(self._snapshot_state())
+            # Skip snapshots in CONTENT -- _advance_with_token is a no-op
+            # there, so snapshots would just waste memory on long generations.
+            if self._state != Phase.CONTENT:
+                self._snapshots.append(self._snapshot_state())
 
     def _advance_with_token(self, token_id: int) -> None:
         if self._state == Phase.IDLE:

--- a/vllm_mlx/constrained/thinking_processor.py
+++ b/vllm_mlx/constrained/thinking_processor.py
@@ -99,6 +99,8 @@ class ThinkingAwareLogitsProcessor:
         self._start_matcher = BoundedSuffixMatcher(start_token_ids)
         self._end_matcher = BoundedSuffixMatcher(end_token_ids)
         self._end_token_ids = list(end_token_ids)
+        # Mask only the first token of each sequence: sufficient because most
+        # tokenizers encode <think>/<|think|> as a single special token.
         self._content_phase_mask_ids = tuple(
             dict.fromkeys([start_token_ids[0], end_token_ids[0]])
         )
@@ -212,7 +214,7 @@ class ThinkingAwareLogitsProcessor:
 
     def _sync_to_tokens(self, tokens: mx.array) -> None:
         target_len = int(tokens.size)
-        token_ids = [int(tokens[idx].item()) for idx in range(target_len)]
+        token_ids = tokens.tolist()
         common_len = 0
         max_common = min(target_len, self._processed_len)
         while (

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -186,6 +186,9 @@ _metrics_enabled = False
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
 _force_mllm_model: bool = False
+_default_thinking_token_budget: int | None = (
+    None  # Set via --default-thinking-token-budget
+)
 _auto_unload_idle_seconds: float = 0.0
 _lazy_load_model: bool = False
 _residency_manager: ResidencyManager | None = None
@@ -364,6 +367,49 @@ def _prepare_json_logits_processor(
     return messages, json_logits_processor
 
 
+def _build_thinking_processor(
+    engine: BaseEngine,
+    thinking_token_budget: int,
+    *,
+    inner: object | None = None,
+) -> object | None:
+    """Build a ThinkingAwareLogitsProcessor if the tokenizer has think tokens."""
+    from .constrained.thinking_processor import ThinkingAwareLogitsProcessor
+
+    tokenizer = _get_engine_tokenizer(engine)
+    if tokenizer is None:
+        return None
+
+    # Resolve <think> and </think> token IDs from the tokenizer.
+    try:
+        start_ids = tokenizer.encode("<think>", add_special_tokens=False)
+        end_ids = tokenizer.encode("</think>", add_special_tokens=False)
+    except Exception:
+        logger.debug("Tokenizer cannot encode think tags; skipping thinking processor")
+        return None
+
+    if not start_ids or not end_ids:
+        return None
+
+    vocab_size = getattr(tokenizer, "vocab_size", 152064)
+
+    proc = ThinkingAwareLogitsProcessor(
+        start_token_ids=start_ids,
+        end_token_ids=end_ids,
+        thinking_token_budget=thinking_token_budget,
+        inner=inner,
+        vocab_size=vocab_size,
+        prompt_has_think_tag=True,
+    )
+    logger.info(
+        "Thinking processor enabled: budget=%d, start=%s, end=%s",
+        thinking_token_budget,
+        start_ids,
+        end_ids,
+    )
+    return proc
+
+
 def _prepare_chat_completion_invocation(
     engine: BaseEngine,
     request: ChatCompletionRequest,
@@ -438,6 +484,17 @@ def _prepare_chat_completion_invocation(
         if request.enable_thinking is None:
             request.enable_thinking = False
             chat_kwargs["enable_thinking"] = False
+
+    # Thinking-aware logits processor: cap reasoning tokens when a budget is set.
+    thinking_budget = request.thinking_token_budget or _default_thinking_token_budget
+    if thinking_budget is not None:
+        thinking_proc = _build_thinking_processor(
+            engine, thinking_budget, inner=json_logits_processor
+        )
+        if thinking_proc is not None:
+            # Replace the logits_processors list: the thinking processor wraps
+            # the JSON processor as its inner delegate, so we don't double-add.
+            chat_kwargs["logits_processors"] = [thinking_proc]
 
     return PreparedChatInvocation(
         messages=messages,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -372,6 +372,7 @@ def _build_thinking_processor(
     thinking_token_budget: int,
     *,
     inner: object | None = None,
+    prompt_has_think_tag: bool = True,
 ) -> object | None:
     """Build a ThinkingAwareLogitsProcessor if the tokenizer has think tokens."""
     from .constrained.thinking_processor import ThinkingAwareLogitsProcessor
@@ -399,7 +400,7 @@ def _build_thinking_processor(
         thinking_token_budget=thinking_token_budget,
         inner=inner,
         vocab_size=vocab_size,
-        prompt_has_think_tag=True,
+        prompt_has_think_tag=prompt_has_think_tag,
     )
     logger.info(
         "Thinking processor enabled: budget=%d, start=%s, end=%s",
@@ -492,7 +493,10 @@ def _prepare_chat_completion_invocation(
     enable_thinking = chat_kwargs.get("enable_thinking", True)
     if thinking_budget is not None and enable_thinking is not False:
         thinking_proc = _build_thinking_processor(
-            engine, thinking_budget, inner=json_logits_processor
+            engine,
+            thinking_budget,
+            inner=json_logits_processor,
+            prompt_has_think_tag=bool(enable_thinking),
         )
         if thinking_proc is not None:
             # Replace the logits_processors list: the thinking processor wraps

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -486,8 +486,11 @@ def _prepare_chat_completion_invocation(
             chat_kwargs["enable_thinking"] = False
 
     # Thinking-aware logits processor: cap reasoning tokens when a budget is set.
+    # Only build when thinking is actually enabled for this request -- a CLI
+    # default budget should not alter non-thinking requests.
     thinking_budget = request.thinking_token_budget or _default_thinking_token_budget
-    if thinking_budget is not None:
+    enable_thinking = chat_kwargs.get("enable_thinking", True)
+    if thinking_budget is not None and enable_thinking is not False:
         thinking_proc = _build_thinking_processor(
             engine, thinking_budget, inner=json_logits_processor
         )


### PR DESCRIPTION
## Summary

- `ThinkingAwareLogitsProcessor` with a four-phase state machine (IDLE/THINKING/TRANSITIONING/CONTENT) that manages the thinking lifecycle for reasoning models
- `thinking_token_budget` request parameter caps reasoning tokens as a sub-limit of `max_tokens` via logits-level enforcement
- Thinking-aware constrained decoding: JSON/schema enforcer only activates during CONTENT phase
- `usage.reasoning_tokens` in responses for token accounting
- `--default-thinking-token-budget` server CLI argument

## Motivation

Thinking models can spend their entire `max_tokens` budget on reasoning without ever producing content (vllm-project/vllm#38894). The current workaround forces thinking off when constrained decoding is active, which loses reasoning quality. This feature makes thinking and constrained decoding coexist correctly.

## Design

When `thinking_token_budget` is set, the processor tracks tokens inside `<think>...</think>`. When the budget is exhausted, it forces the reasoning end sequence by masking logits, then transitions to content phase. During content phase, it delegates to an inner JSON/schema enforcer if present.

Re-implementation of #379 against current main. Narrowed to core processor, OpenAI API, and server wiring. Anthropic adapter can follow separately.

## Test plan

- [x] 21 unit tests covering: suffix matcher, lifecycle transitions, budget enforcement, budget-zero edge case, multi-token end sequences, inner delegation, content-phase control token masking, speculative rollback, 2-D logits shapes
- [x] Existing tests pass (test_simple_engine + test_reasoning_parser: 146 passed)