### PR TITLE
Add model artifact workflow with registration and qualification

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -156,6 +156,8 @@ manifest recording, and `hf_transfer` support but does not include retry logic.
 vllm-mlx model inspect <path-or-hf-model-id>
 vllm-mlx model acquire <hf-model-id> [--target-dir <path>]
 vllm-mlx model convert <path-or-hf-model-id> --output <path> [--quantize]
+vllm-mlx model register <artifact-dir> [--model-id <id>] [--mllm]
+vllm-mlx model qualify <model-id> [--workload <path>] [--dry-run]
 ```
 
 ### Options
@@ -173,6 +175,18 @@ vllm-mlx model convert <path-or-hf-model-id> --output <path> [--quantize]
 | `convert` | `--quant-predicate` | `mlx-lm` mixed-bit quantization recipe |
 | `convert` | `--dtype` | Dtype for non-quantized parameters |
 | `convert` | `--dry-run` | Print command and manifest without executing conversion |
+| `register` | `--model-id` | Model identifier (defaults to directory name) |
+| `register` | `--served-model-name` | Name for the /v1/models endpoint |
+| `register` | `--mllm` / `--no-mllm` | Mark as multimodal or text-only |
+| `register` | `--default-temperature`, `--default-top-p`, ... | Serving defaults |
+| `register` | `--tool-call-parser`, `--reasoning-parser` | Parser policy |
+| `register` | `--feature-flag` | Feature flag (repeatable) |
+| `qualify` | `--url` | Server URL (default: `http://127.0.0.1:8080`) |
+| `qualify` | `--workload` | bench-serve workload contract path |
+| `qualify` | `--repetitions` | bench-serve repetitions |
+| `qualify` | `--timeout` | Max seconds before aborting |
+| `qualify` | `--dry-run` | Print command without executing |
+| `qualify` | `--extra-arg` | Extra arg passed to bench-serve (repeatable) |
 
 ### Examples
 
@@ -185,6 +199,13 @@ vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit \
 vllm-mlx model convert meta-llama/Llama-3.2-3B-Instruct \
   --output ./models/llama-3b-mlx-q4 \
   --quantize --q-bits 4 --q-group-size 64 --q-mode affine
+
+vllm-mlx model register ./models/llama-3b-mlx-q4 \
+  --model-id llama-3b-q4 --mllm \
+  --default-temperature 0.6 --default-top-p 0.95
+
+vllm-mlx model qualify llama-3b-q4 \
+  --workload ./config/workload.json --repetitions 5 --dry-run
 ```
 
 ## `vllm-mlx-bench`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,6 +5,7 @@
 | Command | Description |
 |---------|-------------|
 | `vllm-mlx serve` | Start OpenAI-compatible server |
+| `vllm-mlx model` | Inspect, acquire, or convert model artifacts |
 | `vllm-mlx-bench` | Run performance benchmarks |
 | `vllm-mlx-chat` | Start Gradio chat interface |
 
@@ -136,6 +137,54 @@ Or with curl:
 ```bash
 curl http://localhost:8000/v1/models \
   -H "Authorization: Bearer your-secret-key"
+```
+
+## `vllm-mlx model`
+
+Inspect, acquire, and convert model artifacts without serving them. These
+commands make model setup auditable: inspect before download, download into a
+finalized artifact manifest, then convert through `mlx-lm` with the exact
+recipe recorded.
+
+For quick cache-based downloads with retry logic, see `vllm-mlx download`.
+`model acquire` uses `snapshot_download` directly with staged finalization,
+manifest recording, and `hf_transfer` support but does not include retry logic.
+
+### Usage
+
+```bash
+vllm-mlx model inspect <path-or-hf-model-id>
+vllm-mlx model acquire <hf-model-id> [--target-dir <path>]
+vllm-mlx model convert <path-or-hf-model-id> --output <path> [--quantize]
+```
+
+### Options
+
+| Command | Option | Description |
+|---------|--------|-------------|
+| `inspect` | `--revision` | Hugging Face revision to inspect |
+| `acquire` | `--target-dir` | Final local directory for a staged download |
+| `acquire` | `--staging-dir` | Temporary directory used before finalizing `--target-dir` |
+| `acquire` | `--mllm` | Download multimodal file patterns |
+| `acquire` | `--no-fast-transfer` | Do not set `HF_HUB_ENABLE_HF_TRANSFER=1` |
+| `convert` | `--output` | Output directory for the converted MLX model |
+| `convert` | `--quantize` | Enable `mlx-lm` quantization |
+| `convert` | `--q-bits`, `--q-group-size`, `--q-mode` | Quantization recipe |
+| `convert` | `--quant-predicate` | `mlx-lm` mixed-bit quantization recipe |
+| `convert` | `--dtype` | Dtype for non-quantized parameters |
+| `convert` | `--dry-run` | Print command and manifest without executing conversion |
+
+### Examples
+
+```bash
+vllm-mlx model inspect mlx-community/Llama-3.2-3B-Instruct-4bit
+
+vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --target-dir ./models/llama-3b-4bit
+
+vllm-mlx model convert meta-llama/Llama-3.2-3B-Instruct \
+  --output ./models/llama-3b-mlx-q4 \
+  --quantize --q-bits 4 --q-group-size 64 --q-mode affine
 ```
 
 ## `vllm-mlx-bench`

--- a/tests/test_model_workflow.py
+++ b/tests/test_model_workflow.py
@@ -10,11 +10,18 @@ from unittest.mock import patch
 from vllm_mlx.model_workflow import (
     CONVERSION_MANIFEST_NAME,
     MODEL_MANIFEST_NAME,
+    QUALIFICATION_REQUEST_NAME,
+    REGISTRATION_MANIFEST_NAME,
     AcquisitionOptions,
     ConversionOptions,
+    QualificationOptions,
+    RegistrationOptions,
+    _drop_none,
     acquire_model,
     convert_model,
     inspect_model,
+    qualify_model,
+    register_model,
 )
 
 
@@ -284,3 +291,189 @@ def test_read_json_handles_malformed_json(tmp_path):
     bad = tmp_path / "bad.json"
     bad.write_text("{not valid json")
     assert _read_json(bad) == {}
+
+
+# --- Registration tests ---
+
+
+def test_register_model_writes_manifest_from_artifact(tmp_path):
+    artifact = tmp_path / "artifact-model"
+    artifact.mkdir()
+    (artifact / "config.json").write_text(
+        json.dumps({"model_type": "qwen3", "quantization": {"bits": 4}})
+    )
+    (artifact / MODEL_MANIFEST_NAME).write_text(
+        json.dumps({"kind": "vllm-mlx-model-artifact", "model_id": "org/model"})
+    )
+
+    payload = register_model(
+        RegistrationOptions(
+            artifact_path=str(artifact),
+            model_id="qwen-test",
+            served_model_name="qwen-test-served",
+            preset_alias="fast-qwen",
+            mllm=True,
+            tool_call_parser="qwen3_coder",
+            reasoning_parser="qwen3",
+            default_temperature=0.6,
+            default_top_p=0.95,
+            default_top_k=20,
+            default_min_p=0.0,
+            default_presence_penalty=0.0,
+            default_repetition_penalty=1.0,
+            chat_template_kwargs={"enable_thinking": True},
+            feature_flags=["prefix_cache"],
+        )
+    )
+
+    assert payload["kind"] == "vllm-mlx-model-registration"
+    assert payload["model_id"] == "qwen-test"
+    assert payload["served_model_name"] == "qwen-test-served"
+    assert payload["preset_alias"] == "fast-qwen"
+    assert payload["mllm"] is True
+    assert payload["production_ready"] is False
+    assert payload["qualification_required"] is True
+    assert payload["serving_defaults"]["top_k"] == 20
+    assert payload["serving_defaults"]["chat_template_kwargs"] == {
+        "enable_thinking": True
+    }
+    assert payload["parser_policy"]["reasoning_parser"] == "qwen3"
+    assert payload["source_manifests"]["acquisition"]["payload"]["model_id"] == (
+        "org/model"
+    )
+    assert (artifact / REGISTRATION_MANIFEST_NAME).exists()
+
+
+def test_register_model_with_minimal_defaults(tmp_path):
+    """register_model with only artifact_path must produce a valid manifest."""
+    artifact = tmp_path / "minimal-model"
+    artifact.mkdir()
+    (artifact / "config.json").write_text(json.dumps({"model_type": "llama"}))
+
+    payload = register_model(RegistrationOptions(artifact_path=str(artifact)))
+
+    assert payload["kind"] == "vllm-mlx-model-registration"
+    assert payload["model_id"] == "minimal-model"
+    assert payload["served_model_name"] == "minimal-model"
+    assert payload["mllm"] is None
+    assert payload["preset_alias"] is None
+    assert payload["serving_defaults"] == {}
+    assert payload["parser_policy"] == {}
+    assert payload["feature_flags"] == []
+    assert payload["production_ready"] is False
+    assert (artifact / REGISTRATION_MANIFEST_NAME).exists()
+
+
+def test_register_model_requires_local_directory(tmp_path):
+    missing = tmp_path / "missing"
+
+    try:
+        register_model(RegistrationOptions(artifact_path=str(missing)))
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_register_model_rejects_file_path(tmp_path):
+    """artifact_path must be a directory, not a file."""
+    a_file = tmp_path / "not-a-dir.txt"
+    a_file.write_text("hello")
+
+    try:
+        register_model(RegistrationOptions(artifact_path=str(a_file)))
+    except NotADirectoryError:
+        pass
+    else:
+        raise AssertionError("expected NotADirectoryError")
+
+
+# --- Qualification tests ---
+
+
+def test_qualify_model_dry_run_records_bench_command(tmp_path):
+    output = tmp_path / QUALIFICATION_REQUEST_NAME
+
+    payload = qualify_model(
+        QualificationOptions(
+            model_id="qwen-test",
+            server_url="http://127.0.0.1:8090",
+            workload_path="/tmp/workload.json",
+            output_path=str(output),
+            result_path="/tmp/results.json",
+            repetitions=3,
+            dry_run=True,
+            extra_args=["--tag", "nightly"],
+        )
+    )
+
+    assert payload["status"] == "dry_run"
+    assert payload["production_ready"] is False
+    assert "--workload" in payload["command"]
+    assert "/tmp/workload.json" in payload["command"]
+    assert "--tag" in payload["command"]
+    assert "environment" in payload
+    assert "python" in payload["environment"]
+    assert output.exists()
+
+
+def test_qualify_model_runs_command_and_records_failure(tmp_path):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=7, stdout="", stderr="bad workload")
+
+    with patch("vllm_mlx.model_workflow.subprocess.run", side_effect=fake_run):
+        payload = qualify_model(
+            QualificationOptions(
+                model_id="qwen-test",
+                workload_path="/tmp/workload.json",
+            )
+        )
+
+    assert payload["status"] == "failed"
+    assert payload["returncode"] == 7
+    assert payload["stderr"] == "bad workload"
+
+
+def test_qualify_model_success_path(tmp_path):
+    """qualification with returncode=0 should report succeeded."""
+    output = tmp_path / "qual-result.json"
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    with patch("vllm_mlx.model_workflow.subprocess.run", side_effect=fake_run):
+        payload = qualify_model(
+            QualificationOptions(
+                model_id="qwen-test",
+                output_path=str(output),
+            )
+        )
+
+    assert payload["status"] == "succeeded"
+    assert payload["returncode"] == 0
+    assert payload["production_ready"] is False
+    assert output.exists()
+
+
+# --- _drop_none tests ---
+
+
+def test_drop_none_preserves_zero_values():
+    """Zero-valued defaults (0, 0.0, False, empty string) must survive _drop_none."""
+    result = _drop_none(
+        {
+            "temperature": 0.0,
+            "top_k": 0,
+            "presence_penalty": 0.0,
+            "flag": False,
+            "name": "",
+            "removed": None,
+        }
+    )
+    assert result == {
+        "temperature": 0.0,
+        "top_k": 0,
+        "presence_penalty": 0.0,
+        "flag": False,
+        "name": "",
+    }

--- a/tests/test_model_workflow.py
+++ b/tests/test_model_workflow.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for model artifact inspection, acquisition, and conversion helpers."""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vllm_mlx.model_workflow import (
+    CONVERSION_MANIFEST_NAME,
+    MODEL_MANIFEST_NAME,
+    AcquisitionOptions,
+    ConversionOptions,
+    acquire_model,
+    convert_model,
+    inspect_model,
+)
+
+
+def test_inspect_local_model_reports_size_and_config(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3",
+                "architectures": ["Qwen3ForCausalLM"],
+                "quantization": {"bits": 4, "group_size": 64},
+                "max_position_embeddings": 32768,
+            }
+        )
+    )
+    (tmp_path / "model.safetensors").write_bytes(b"x" * 1024)
+
+    payload = inspect_model(str(tmp_path))
+
+    assert payload["source"] == "local"
+    assert payload["file_count"] == 2
+    assert payload["model_family"]["model_type"] == "qwen3"
+    assert payload["mlx"]["looks_like_mlx_artifact"] is True
+    assert payload["mlx"]["needs_conversion"] is False
+
+
+def test_inspect_hf_model_uses_metadata_without_weight_download(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "model_type": "qwen3_5_moe",
+                    "mtp_num_hidden_layers": 1,
+                    "max_position_embeddings": 1_000_000,
+                }
+            }
+        )
+    )
+    siblings = [
+        SimpleNamespace(rfilename="config.json", size=100),
+        SimpleNamespace(rfilename="model-00001-of-00002.safetensors", size=1000),
+        SimpleNamespace(rfilename="tokenizer.json", size=200),
+    ]
+    info = SimpleNamespace(sha="abc123", siblings=siblings)
+
+    with (
+        patch("vllm_mlx.model_workflow.HfApi") as mock_api,
+        patch("vllm_mlx.model_workflow.hf_hub_download") as mock_download,
+    ):
+        mock_api.return_value.model_info.return_value = info
+        mock_download.return_value = str(config_path)
+        payload = inspect_model("org/model", revision="main")
+
+    assert payload["revision"] == "abc123"
+    assert payload["total_size_bytes"] == 1300
+    assert payload["model_files_size_gb"] == 0.0
+    assert payload["model_family"]["model_type"] == "qwen3_5_moe"
+    assert payload["mlx"]["needs_conversion"] is True
+    assert payload["warnings"] == [
+        "very large advertised context; choose an explicit serving context before loading"
+    ]
+
+
+def test_inspect_gptq_model_not_detected_as_mlx(tmp_path):
+    """GPTQ/AWQ models with quantization_config must not be treated as MLX artifacts."""
+    model_dir = tmp_path / "gptq-source"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "quantization_config": {
+                    "quant_method": "gptq",
+                    "bits": 4,
+                    "group_size": 128,
+                },
+            }
+        )
+    )
+    (model_dir / "model.safetensors").write_bytes(b"x" * 1024)
+
+    payload = inspect_model(str(model_dir))
+
+    assert payload["mlx"]["looks_like_mlx_artifact"] is False
+    assert payload["mlx"]["needs_conversion"] is True
+
+
+def test_inspect_awq_model_not_detected_as_mlx(tmp_path):
+    """AWQ models with quantization_config must not be treated as MLX artifacts."""
+    model_dir = tmp_path / "awq-source"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "llama",
+                "quantization_config": {
+                    "quant_method": "awq",
+                    "bits": 4,
+                    "group_size": 128,
+                },
+            }
+        )
+    )
+
+    payload = inspect_model(str(model_dir))
+
+    assert payload["mlx"]["looks_like_mlx_artifact"] is False
+    assert payload["mlx"]["needs_conversion"] is True
+
+
+def test_acquire_model_finalizes_target_and_writes_manifest(tmp_path):
+    target = tmp_path / "model-final"
+    staging_root = tmp_path / "stage"
+    seen_env = {}
+
+    def fake_snapshot_download(*args, **kwargs):
+        staging = Path(kwargs["local_dir"])
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "config.json").write_text(
+            json.dumps({"model_type": "llama", "quantization": {"bits": 4}})
+        )
+        (staging / "model.safetensors").write_bytes(b"weights")
+        seen_env["fast_transfer"] = os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")
+        return str(staging)
+
+    with (
+        patch("vllm_mlx.model_workflow.find_spec", return_value=object()),
+        patch("vllm_mlx.model_workflow.snapshot_download") as mock_download,
+    ):
+        mock_download.side_effect = fake_snapshot_download
+        manifest = acquire_model(
+            "org/model",
+            options=AcquisitionOptions(
+                revision="rev1",
+                target_dir=str(target),
+                staging_dir=str(staging_root),
+                fast_transfer=True,
+            ),
+        )
+
+    assert seen_env["fast_transfer"] == "1"
+    assert target.exists()
+    assert manifest["model_id"] == "org/model"
+    assert manifest["path"] == str(target)
+    assert manifest["fast_transfer"]["enabled"] is True
+    manifest_path = target / MODEL_MANIFEST_NAME
+    assert manifest_path.exists()
+    saved = json.loads(manifest_path.read_text())
+    assert saved["inspection"]["file_count"] == 2
+
+
+def test_acquire_model_disables_fast_transfer_when_package_missing(tmp_path):
+    target = tmp_path / "model-final"
+
+    def fake_snapshot_download(*args, **kwargs):
+        staging = Path(kwargs["local_dir"])
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        return str(staging)
+
+    with (
+        patch("vllm_mlx.model_workflow.find_spec", return_value=None),
+        patch("vllm_mlx.model_workflow.snapshot_download") as mock_download,
+    ):
+        mock_download.side_effect = fake_snapshot_download
+        manifest = acquire_model(
+            "org/model",
+            options=AcquisitionOptions(target_dir=str(target), fast_transfer=True),
+        )
+
+    assert manifest["fast_transfer"]["requested"] is True
+    assert manifest["fast_transfer"]["enabled"] is False
+    assert "not installed" in manifest["fast_transfer"]["reason"]
+
+
+def test_acquire_model_refuses_existing_target(tmp_path):
+    target = tmp_path / "model-final"
+    target.mkdir()
+
+    with patch("vllm_mlx.model_workflow.snapshot_download") as mock_download:
+        try:
+            acquire_model(
+                "org/model", options=AcquisitionOptions(target_dir=str(target))
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError("expected FileExistsError")
+
+    mock_download.assert_not_called()
+
+
+def test_convert_model_dry_run_records_mlx_lm_command(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    output = tmp_path / "out"
+
+    payload = convert_model(
+        ConversionOptions(
+            model=str(source),
+            output_path=str(output),
+            quantize=True,
+            q_bits=3,
+            q_group_size=64,
+            q_mode="affine",
+            dry_run=True,
+        )
+    )
+
+    assert payload["status"] == "dry_run"
+    assert payload["backend"] == "mlx-lm"
+    assert payload["recipe"]["q_bits"] == 3
+    assert "--quantize" in payload["command"]
+    assert "--q-bits" in payload["command"]
+    assert str(output) in payload["command"]
+
+
+def test_convert_model_success_writes_manifest(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    output = tmp_path / "out"
+
+    def fake_run(*args, **kwargs):
+        output.mkdir()
+        (output / "config.json").write_text(
+            json.dumps({"model_type": "llama", "quantization": {"bits": 4}})
+        )
+        (output / "model.safetensors").write_bytes(b"weights")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    with patch("vllm_mlx.model_workflow.subprocess.run", side_effect=fake_run):
+        payload = convert_model(
+            ConversionOptions(model=str(source), output_path=str(output))
+        )
+
+    assert payload["status"] == "succeeded"
+    assert (output / CONVERSION_MANIFEST_NAME).exists()
+
+
+def test_convert_model_failure_returns_status_and_stderr(tmp_path):
+    """Conversion failure must return status=failed with stderr captured."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    output = tmp_path / "out"
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="conversion error")
+
+    with patch("vllm_mlx.model_workflow.subprocess.run", side_effect=fake_run):
+        payload = convert_model(
+            ConversionOptions(model=str(source), output_path=str(output))
+        )
+
+    assert payload["status"] == "failed"
+    assert payload["returncode"] == 1
+    assert payload["stderr"] == "conversion error"
+    assert not (output / CONVERSION_MANIFEST_NAME).exists()
+
+
+def test_read_json_handles_malformed_json(tmp_path):
+    """_read_json must not raise on malformed JSON."""
+    from vllm_mlx.model_workflow import _read_json
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    assert _read_json(bad) == {}

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -319,9 +319,13 @@ def model_command(args):
     from .model_workflow import (
         AcquisitionOptions,
         ConversionOptions,
+        QualificationOptions,
+        RegistrationOptions,
         acquire_model,
         convert_model,
         inspect_model,
+        qualify_model,
+        register_model,
     )
 
     if args.model_command == "inspect":
@@ -353,6 +357,44 @@ def model_command(args):
                 dtype=args.dtype,
                 trust_remote_code=args.trust_remote_code,
                 dry_run=args.dry_run,
+            )
+        )
+        if payload.get("status") == "failed":
+            print(json.dumps(payload, indent=2), file=sys.stderr)
+            sys.exit(payload.get("returncode") or 1)
+    elif args.model_command == "register":
+        payload = register_model(
+            RegistrationOptions(
+                artifact_path=args.artifact,
+                model_id=args.model_id,
+                served_model_name=args.served_model_name,
+                preset_alias=args.preset_alias,
+                output_path=args.output,
+                mllm=args.mllm,
+                tool_call_parser=args.tool_call_parser,
+                reasoning_parser=args.reasoning_parser,
+                default_temperature=args.default_temperature,
+                default_top_p=args.default_top_p,
+                default_top_k=args.default_top_k,
+                default_min_p=args.default_min_p,
+                default_presence_penalty=args.default_presence_penalty,
+                default_repetition_penalty=args.default_repetition_penalty,
+                chat_template_kwargs=args.default_chat_template_kwargs,
+                feature_flags=args.feature_flag,
+            )
+        )
+    elif args.model_command == "qualify":
+        payload = qualify_model(
+            QualificationOptions(
+                model_id=args.model_id,
+                server_url=args.url,
+                workload_path=args.workload,
+                output_path=args.output,
+                result_path=args.result_output,
+                repetitions=args.repetitions,
+                timeout=args.timeout,
+                dry_run=args.dry_run,
+                extra_args=args.extra_arg,
             )
         )
         if payload.get("status") == "failed":
@@ -1513,6 +1555,173 @@ Examples:
         "--dry-run",
         action="store_true",
         help="Print the conversion command and manifest without executing",
+    )
+
+    model_register_parser = model_subparsers.add_parser(
+        "register",
+        help="Write a portable registration manifest for a finalized artifact",
+    )
+    model_register_parser.add_argument(
+        "artifact",
+        type=str,
+        help="Finalized local model artifact directory",
+    )
+    model_register_parser.add_argument(
+        "--model-id",
+        type=str,
+        default=None,
+        help="Model identifier. Defaults to the artifact directory name.",
+    )
+    model_register_parser.add_argument(
+        "--served-model-name",
+        type=str,
+        default=None,
+        help="Name exposed via the OpenAI /v1/models endpoint. Defaults to model-id.",
+    )
+    model_register_parser.add_argument(
+        "--preset-alias",
+        type=str,
+        default=None,
+        help="Short alias for configuration presets",
+    )
+    model_register_parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Manifest path. Defaults to artifact/vllm_mlx_registration_manifest.json",
+    )
+    mllm_group = model_register_parser.add_mutually_exclusive_group()
+    mllm_group.add_argument(
+        "--mllm",
+        action="store_true",
+        default=None,
+        help="Mark the artifact as an MLLM serving candidate",
+    )
+    mllm_group.add_argument(
+        "--no-mllm",
+        dest="mllm",
+        action="store_false",
+        help="Mark the artifact as a text-only (non-MLLM) model",
+    )
+    model_register_parser.add_argument(
+        "--tool-call-parser",
+        type=str,
+        default=None,
+        help="Tool call parser name for the model",
+    )
+    model_register_parser.add_argument(
+        "--reasoning-parser",
+        type=str,
+        default=None,
+        help="Reasoning parser name for the model",
+    )
+    model_register_parser.add_argument(
+        "--default-temperature",
+        type=float,
+        default=None,
+        help="Default serving temperature",
+    )
+    model_register_parser.add_argument(
+        "--default-top-p",
+        type=float,
+        default=None,
+        help="Default top-p sampling value",
+    )
+    model_register_parser.add_argument(
+        "--default-top-k",
+        type=int,
+        default=None,
+        help="Default top-k sampling value",
+    )
+    model_register_parser.add_argument(
+        "--default-min-p",
+        type=float,
+        default=None,
+        help="Default min-p sampling value",
+    )
+    model_register_parser.add_argument(
+        "--default-presence-penalty",
+        type=float,
+        default=None,
+        help="Default presence penalty",
+    )
+    model_register_parser.add_argument(
+        "--default-repetition-penalty",
+        type=float,
+        default=None,
+        help="Default repetition penalty",
+    )
+    model_register_parser.add_argument(
+        "--default-chat-template-kwargs",
+        type=make_json_object_arg_parser("--default-chat-template-kwargs"),
+        default=None,
+        help='Default chat template kwargs as JSON, e.g. {"enable_thinking": true}',
+    )
+    model_register_parser.add_argument(
+        "--feature-flag",
+        action="append",
+        default=[],
+        help="Feature flag to record in the registration manifest. Repeatable.",
+    )
+
+    model_qualify_parser = model_subparsers.add_parser(
+        "qualify",
+        help="Create or run a bench-serve qualification handoff",
+    )
+    model_qualify_parser.add_argument(
+        "model_id",
+        type=str,
+        help="Model identifier to qualify against a running server",
+    )
+    model_qualify_parser.add_argument(
+        "--url",
+        type=str,
+        default="http://127.0.0.1:8080",
+        help="Running server URL for bench-serve",
+    )
+    model_qualify_parser.add_argument(
+        "--workload",
+        type=str,
+        default=None,
+        help="bench-serve workload contract path",
+    )
+    model_qualify_parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Qualification request manifest path",
+    )
+    model_qualify_parser.add_argument(
+        "--result-output",
+        type=str,
+        default=None,
+        help="Result output path passed to bench-serve --output",
+    )
+    model_qualify_parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=None,
+        help="Number of bench-serve repetitions",
+    )
+    model_qualify_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Maximum seconds to wait for bench-serve before aborting",
+    )
+    model_qualify_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write or print the qualification command without running it",
+    )
+    model_qualify_parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help=(
+            "Extra argument passed through to bench-serve. Repeatable. "
+            "Warning: can override earlier flags such as --format."
+        ),
     )
 
     # Serving benchmark

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import argparse
+import json
 import sys
 
 from .cli_arg_types import make_json_object_arg_parser
@@ -311,6 +312,56 @@ def download_command(args):
         is_mllm=args.mllm,
     )
     print(f"Model ready at: {path}")
+
+
+def model_command(args):
+    """Run model lifecycle helper commands."""
+    from .model_workflow import (
+        AcquisitionOptions,
+        ConversionOptions,
+        acquire_model,
+        convert_model,
+        inspect_model,
+    )
+
+    if args.model_command == "inspect":
+        payload = inspect_model(
+            args.model,
+            revision=args.revision,
+        )
+    elif args.model_command == "acquire":
+        payload = acquire_model(
+            args.model,
+            options=AcquisitionOptions(
+                revision=args.revision,
+                target_dir=args.target_dir,
+                staging_dir=args.staging_dir,
+                is_mllm=args.mllm,
+                fast_transfer=not args.no_fast_transfer,
+            ),
+        )
+    elif args.model_command == "convert":
+        payload = convert_model(
+            ConversionOptions(
+                model=args.model,
+                output_path=args.output,
+                quantize=args.quantize,
+                q_bits=args.q_bits,
+                q_group_size=args.q_group_size,
+                q_mode=args.q_mode,
+                quant_predicate=args.quant_predicate,
+                dtype=args.dtype,
+                trust_remote_code=args.trust_remote_code,
+                dry_run=args.dry_run,
+            )
+        )
+        if payload.get("status") == "failed":
+            print(json.dumps(payload, indent=2), file=sys.stderr)
+            sys.exit(payload.get("returncode") or 1)
+    else:
+        raise ValueError(f"Unsupported model command: {args.model_command}")
+
+    print(json.dumps(payload, indent=2))
 
 
 def bench_command(args):
@@ -1339,6 +1390,131 @@ Examples:
         help="Download as multimodal model (broader file patterns)",
     )
 
+    # Model lifecycle helpers (see also ``vllm-mlx download`` for the simpler
+    # retry-capable cache download path)
+    model_parser = subparsers.add_parser(
+        "model",
+        help="Inspect, acquire, or convert model artifacts",
+    )
+    model_subparsers = model_parser.add_subparsers(
+        dest="model_command", help="Model workflow command", required=True
+    )
+
+    model_inspect_parser = model_subparsers.add_parser(
+        "inspect",
+        help="Inspect a local path or Hugging Face model without loading weights",
+    )
+    model_inspect_parser.add_argument(
+        "model",
+        type=str,
+        help="Local model path or Hugging Face model id",
+    )
+    model_inspect_parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Hugging Face revision to inspect",
+    )
+
+    model_acquire_parser = model_subparsers.add_parser(
+        "acquire",
+        help="Download a Hugging Face model and write an artifact manifest",
+    )
+    model_acquire_parser.add_argument(
+        "model",
+        type=str,
+        help="Hugging Face model id to download",
+    )
+    model_acquire_parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Hugging Face revision to download",
+    )
+    model_acquire_parser.add_argument(
+        "--target-dir",
+        type=str,
+        default=None,
+        help="Final local directory. Defaults to Hugging Face cache.",
+    )
+    model_acquire_parser.add_argument(
+        "--staging-dir",
+        type=str,
+        default=None,
+        help="Directory for temporary staged downloads before finalizing target-dir",
+    )
+    model_acquire_parser.add_argument(
+        "--mllm",
+        action="store_true",
+        help="Acquire multimodal model files using broader allow patterns",
+    )
+    model_acquire_parser.add_argument(
+        "--no-fast-transfer",
+        action="store_true",
+        help="Do not set HF_HUB_ENABLE_HF_TRANSFER=1 during download",
+    )
+
+    model_convert_parser = model_subparsers.add_parser(
+        "convert",
+        help="Run mlx-lm conversion and write a conversion manifest",
+    )
+    model_convert_parser.add_argument(
+        "model",
+        type=str,
+        help="Hugging Face model id or local source path to convert",
+    )
+    model_convert_parser.add_argument(
+        "--output",
+        required=True,
+        type=str,
+        help="Output directory for the converted MLX model",
+    )
+    model_convert_parser.add_argument(
+        "--quantize",
+        action="store_true",
+        help="Generate a quantized MLX model",
+    )
+    model_convert_parser.add_argument(
+        "--q-bits",
+        type=int,
+        default=None,
+        help="Quantization bit width",
+    )
+    model_convert_parser.add_argument(
+        "--q-group-size",
+        type=int,
+        default=None,
+        help="Quantization group size",
+    )
+    model_convert_parser.add_argument(
+        "--q-mode",
+        choices=["affine", "mxfp4", "nvfp4", "mxfp8"],
+        default=None,
+        help="Quantization mode",
+    )
+    model_convert_parser.add_argument(
+        "--quant-predicate",
+        choices=["mixed_2_6", "mixed_3_4", "mixed_3_6", "mixed_4_6"],
+        default=None,
+        help="mlx-lm mixed-bit quantization recipe",
+    )
+    model_convert_parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default=None,
+        help="Non-quantized parameter dtype",
+    )
+    model_convert_parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow Hugging Face remote code during mlx-lm conversion",
+    )
+    model_convert_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the conversion command and manifest without executing",
+    )
+
     # Serving benchmark
     bench_serve_parser = subparsers.add_parser(
         "bench-serve", help="Benchmark a running vllm-mlx server via HTTP API"
@@ -1487,6 +1663,8 @@ def main():
         bench_kv_cache_command(args)
     elif args.command == "download":
         download_command(args)
+    elif args.command == "model":
+        model_command(args)
     elif args.command == "bench-serve":
         bench_serve_command(args)
     else:

--- a/vllm_mlx/model_workflow.py
+++ b/vllm_mlx/model_workflow.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model acquisition, inspection, and conversion workflow helpers.
+
+The functions in this module intentionally avoid loading model weights. They
+collect repository/file metadata, download artifacts, and record manifests so a
+model can be qualified before it is served.
+
+Relationship to ``vllm-mlx download``:
+    The existing ``download`` command is a thin wrapper around
+    ``ensure_model_downloaded`` with retry logic and is intended for quick,
+    cache-based downloads.  ``model acquire`` uses ``snapshot_download``
+    directly with staged finalization, manifest recording, and
+    ``hf_transfer`` support.  It does *not* include retry logic -- callers
+    should re-run the command on transient failures until retry support is
+    added.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from importlib.util import find_spec
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+
+from .utils.download import LLM_ALLOW_PATTERNS, MLLM_ALLOW_PATTERNS
+
+MODEL_MANIFEST_NAME = "vllm_mlx_model_manifest.json"
+CONVERSION_MANIFEST_NAME = "vllm_mlx_conversion_manifest.json"
+
+_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+# MLX-specific quantization keys that distinguish MLX artifacts from
+# PyTorch GPTQ/AWQ models.  A config that has ``quantization_config`` with
+# ``quant_method: gptq`` (or ``awq``) is a *source* model that still needs
+# conversion, not an MLX artifact.
+_MLX_QUANT_KEYS = frozenset({"bits", "group_size"})
+
+
+@dataclass(frozen=True)
+class AcquisitionOptions:
+    """Options for Hugging Face model acquisition."""
+
+    revision: str | None = None
+    target_dir: str | None = None
+    staging_dir: str | None = None
+    is_mllm: bool = False
+    fast_transfer: bool = True
+
+
+@dataclass(frozen=True)
+class ConversionOptions:
+    """Options for the mlx-lm conversion backend."""
+
+    model: str
+    output_path: str
+    quantize: bool = False
+    q_bits: int | None = None
+    q_group_size: int | None = None
+    q_mode: str | None = None
+    quant_predicate: str | None = None
+    dtype: str | None = None
+    trust_remote_code: bool = False
+    dry_run: bool = False
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bytes_to_gb(size: int | float | None) -> float | None:
+    if size is None:
+        return None
+    return round(float(size) / (1024**3), 3)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _local_file_inventory(path: Path) -> tuple[list[dict[str, Any]], int]:
+    files = []
+    total = 0
+    for item in sorted(path.rglob("*")):
+        if not item.is_file():
+            continue
+        try:
+            size = item.stat().st_size
+        except OSError:
+            size = 0
+        total += size
+        files.append({"path": str(item.relative_to(path)), "size": size})
+    return files, total
+
+
+def _hf_file_inventory(
+    model_id: str, *, revision: str | None
+) -> tuple[list[dict[str, Any]], int | None, str | None]:
+    info = HfApi().model_info(model_id, revision=revision, files_metadata=True)
+    files = []
+    total = 0
+    total_known = True
+    for sibling in getattr(info, "siblings", []) or []:
+        filename = getattr(sibling, "rfilename", None)
+        if not filename:
+            continue
+        size = getattr(sibling, "size", None)
+        if size is None:
+            total_known = False
+        else:
+            total += int(size)
+        files.append({"path": filename, "size": size})
+    return files, total if total_known else None, getattr(info, "sha", revision)
+
+
+def _hf_config(model_id: str, *, revision: str | None) -> dict[str, Any]:
+    config_path = hf_hub_download(
+        repo_id=model_id,
+        filename="config.json",
+        revision=revision,
+    )
+    return _read_json(Path(config_path))
+
+
+def _config_value(config: dict[str, Any], key: str) -> Any:
+    if key in config:
+        return config[key]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        return text_config.get(key)
+    return None
+
+
+def _model_family(config: dict[str, Any]) -> dict[str, Any]:
+    architectures = _config_value(config, "architectures") or []
+    if isinstance(architectures, str):
+        architectures = [architectures]
+    max_context = (
+        _config_value(config, "max_position_embeddings")
+        or _config_value(config, "max_sequence_length")
+        or _config_value(config, "seq_length")
+        or _config_value(config, "model_max_length")
+    )
+    return {
+        "model_type": _config_value(config, "model_type"),
+        "architectures": architectures,
+        "torch_dtype": _config_value(config, "torch_dtype"),
+        "max_context": max_context,
+        "quantization": config.get("quantization") or config.get("quantization_config"),
+        "has_text_config": isinstance(config.get("text_config"), dict),
+        "has_vision_config": isinstance(config.get("vision_config"), dict),
+        "mtp_num_hidden_layers": _config_value(config, "mtp_num_hidden_layers"),
+    }
+
+
+def _estimate_fit(
+    *,
+    total_bytes: int | None,
+    model_files_bytes: int | None,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    max_context = _model_family(config).get("max_context")
+    warnings = []
+    if isinstance(max_context, int) and max_context >= 262_144:
+        warnings.append(
+            "very large advertised context; choose an explicit serving context before loading"
+        )
+
+    # Conversion normally needs source weights, output weights, and temporary
+    # shards. Keep this conservative without pretending to know architecture
+    # residency exactly.
+    disk_floor = None
+    if total_bytes is not None:
+        disk_floor = int(total_bytes * 2.2)
+
+    memory_floor = model_files_bytes or total_bytes
+    return {
+        "download_size_gb": _bytes_to_gb(total_bytes),
+        "model_file_size_gb": _bytes_to_gb(model_files_bytes),
+        "estimated_conversion_disk_gb": _bytes_to_gb(disk_floor),
+        "rough_load_memory_gb": _bytes_to_gb(memory_floor),
+        "warnings": warnings,
+    }
+
+
+def _model_file_bytes(files: list[dict[str, Any]]) -> int | None:
+    total = 0
+    known = False
+    for entry in files:
+        path = str(entry.get("path", ""))
+        if not path.endswith((".safetensors", ".bin", ".gguf")):
+            continue
+        size = entry.get("size")
+        if size is None:
+            return None
+        known = True
+        total += int(size)
+    return total if known else None
+
+
+def _looks_like_mlx_name(model: str, *, source: str) -> bool:
+    name = model.lower() if source == "huggingface" else Path(model).name.lower()
+    return (
+        name.startswith("mlx-community/")
+        or "-mlx" in name
+        or "_mlx" in name
+        or name.endswith("mlx")
+    )
+
+
+def _is_mlx_quantization(quant: Any) -> bool:
+    """Return True only if *quant* looks like an MLX quantization config.
+
+    PyTorch GPTQ/AWQ models carry ``quantization_config`` with a
+    ``quant_method`` field (e.g. ``gptq``, ``awq``).  MLX artifacts use a
+    flat dict with ``bits`` and ``group_size`` but no ``quant_method``.
+    """
+    if not isinstance(quant, dict):
+        return False
+    if "quant_method" in quant:
+        return False
+    return bool(_MLX_QUANT_KEYS & quant.keys())
+
+
+def _is_model_id(value: str) -> bool:
+    return bool(_MODEL_ID_RE.fullmatch(value))
+
+
+def _fast_transfer_env(requested: bool) -> tuple[dict[str, str], dict[str, Any]]:
+    if not requested:
+        return {}, {"requested": False, "enabled": False, "reason": "disabled"}
+    if find_spec("hf_transfer") is None:
+        return (
+            {},
+            {
+                "requested": True,
+                "enabled": False,
+                "reason": "hf_transfer package is not installed",
+            },
+        )
+    return (
+        {"HF_HUB_ENABLE_HF_TRANSFER": "1"},
+        {"requested": True, "enabled": True, "reason": "enabled"},
+    )
+
+
+def inspect_model(
+    model: str,
+    *,
+    revision: str | None = None,
+) -> dict[str, Any]:
+    """Inspect a local model path or Hugging Face model id without loading weights."""
+    model_path = Path(model).expanduser()
+    warnings: list[str] = []
+
+    if model_path.exists():
+        files, total_bytes = _local_file_inventory(model_path)
+        config = _read_json(model_path / "config.json")
+        resolved_revision = None
+        source = "local"
+        location = str(model_path)
+    else:
+        if not _is_model_id(model):
+            raise ValueError(
+                f"{model!r} is not an existing path or a Hugging Face model id"
+            )
+        source = "huggingface"
+        location = model
+        files, total_bytes, resolved_revision = _hf_file_inventory(
+            model, revision=revision
+        )
+        try:
+            config = _hf_config(model, revision=revision)
+        except Exception as exc:
+            config = {}
+            warnings.append(f"could not read config.json: {exc}")
+
+    model_files_bytes = _model_file_bytes(files)
+    family = _model_family(config)
+    estimate = _estimate_fit(
+        total_bytes=total_bytes,
+        model_files_bytes=model_files_bytes,
+        config=config,
+    )
+    warnings.extend(estimate.pop("warnings"))
+    has_name_signal = _looks_like_mlx_name(model, source=source) and (
+        source == "huggingface" or bool(config)
+    )
+    has_mlx_signals = (
+        _is_mlx_quantization(family.get("quantization")) or has_name_signal
+    )
+
+    return {
+        "model": model,
+        "source": source,
+        "location": location,
+        "revision": resolved_revision or revision,
+        "inspected_at": _now_iso(),
+        "file_count": len(files),
+        "total_size_bytes": total_bytes,
+        "total_size_gb": _bytes_to_gb(total_bytes),
+        "model_files_size_gb": _bytes_to_gb(model_files_bytes),
+        "model_family": family,
+        "mlx": {
+            "looks_like_mlx_artifact": has_mlx_signals,
+            "needs_conversion": not has_mlx_signals,
+        },
+        "fit_estimate": estimate,
+        "warnings": warnings,
+    }
+
+
+def acquire_model(
+    model_id: str,
+    *,
+    options: AcquisitionOptions | None = None,
+) -> dict[str, Any]:
+    """Download a model repository and write a finalized artifact manifest.
+
+    This does not include retry logic.  Re-run the command on transient
+    network failures until retry support is added.
+    """
+    if options is None:
+        options = AcquisitionOptions()
+    if not _is_model_id(model_id):
+        raise ValueError(f"{model_id!r} is not a Hugging Face model id")
+
+    allow_patterns = MLLM_ALLOW_PATTERNS if options.is_mllm else LLM_ALLOW_PATTERNS
+    env_updates, fast_transfer = _fast_transfer_env(options.fast_transfer)
+
+    old_env = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+    try:
+        if options.target_dir:
+            target = Path(options.target_dir).expanduser()
+            if target.exists():
+                raise FileExistsError(f"target path already exists: {target}")
+            staging_root = (
+                Path(options.staging_dir).expanduser()
+                if options.staging_dir
+                else target.parent
+            )
+            staging_root.mkdir(parents=True, exist_ok=True)
+            staging = Path(
+                tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=staging_root)
+            )
+            try:
+                downloaded = Path(
+                    snapshot_download(
+                        model_id,
+                        revision=options.revision,
+                        allow_patterns=allow_patterns,
+                        local_dir=str(staging),
+                    )
+                )
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(downloaded), str(target))
+            except Exception:
+                shutil.rmtree(staging, ignore_errors=True)
+                raise
+            final_path = target
+        else:
+            final_path = Path(
+                snapshot_download(
+                    model_id,
+                    revision=options.revision,
+                    allow_patterns=allow_patterns,
+                )
+            )
+    finally:
+        for key, value in old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    inspection = inspect_model(str(final_path), revision=options.revision)
+    manifest = {
+        "kind": "vllm-mlx-model-artifact",
+        "model_id": model_id,
+        "revision": options.revision,
+        "path": str(final_path),
+        "created_at": _now_iso(),
+        "allow_patterns": allow_patterns,
+        "fast_transfer": fast_transfer,
+        "inspection": inspection,
+    }
+    manifest_path = final_path / MODEL_MANIFEST_NAME
+    _write_json(manifest_path, manifest)
+    manifest["manifest_path"] = str(manifest_path)
+    return manifest
+
+
+def _conversion_command(options: ConversionOptions) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "mlx_lm",
+        "convert",
+        "--hf-path",
+        options.model,
+        "--mlx-path",
+        options.output_path,
+    ]
+    if options.quantize:
+        command.append("--quantize")
+    if options.q_bits is not None:
+        command.extend(["--q-bits", str(options.q_bits)])
+    if options.q_group_size is not None:
+        command.extend(["--q-group-size", str(options.q_group_size)])
+    if options.q_mode:
+        command.extend(["--q-mode", options.q_mode])
+    if options.quant_predicate:
+        command.extend(["--quant-predicate", options.quant_predicate])
+    if options.dtype:
+        command.extend(["--dtype", options.dtype])
+    if options.trust_remote_code:
+        command.append("--trust-remote-code")
+    return command
+
+
+def convert_model(options: ConversionOptions) -> dict[str, Any]:
+    """Run mlx-lm conversion and record the exact recipe."""
+    command = _conversion_command(options)
+    started = _now_iso()
+    source_inspection = inspect_model(options.model)
+    result = {
+        "kind": "vllm-mlx-conversion",
+        "backend": "mlx-lm",
+        "command": command,
+        "source_path": options.model,
+        "output_path": options.output_path,
+        "started_at": started,
+        "dry_run": options.dry_run,
+        "recipe": {
+            "quantize": options.quantize,
+            "q_bits": options.q_bits,
+            "q_group_size": options.q_group_size,
+            "q_mode": options.q_mode,
+            "quant_predicate": options.quant_predicate,
+            "dtype": options.dtype,
+            "trust_remote_code": options.trust_remote_code,
+        },
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+        },
+        "source_inspection": source_inspection,
+    }
+
+    if options.dry_run:
+        result["status"] = "dry_run"
+        return result
+
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    result["returncode"] = completed.returncode
+    result["stdout"] = completed.stdout
+    result["stderr"] = completed.stderr
+    result["completed_at"] = _now_iso()
+    result["status"] = "succeeded" if completed.returncode == 0 else "failed"
+    if completed.returncode != 0:
+        return result
+
+    output_path = Path(options.output_path).expanduser()
+    output_inspection = inspect_model(str(output_path))
+    result["output_inspection"] = output_inspection
+    manifest_path = output_path / CONVERSION_MANIFEST_NAME
+    _write_json(manifest_path, result)
+    result["manifest_path"] = str(manifest_path)
+    return result

--- a/vllm_mlx/model_workflow.py
+++ b/vllm_mlx/model_workflow.py
@@ -37,6 +37,8 @@ from .utils.download import LLM_ALLOW_PATTERNS, MLLM_ALLOW_PATTERNS
 
 MODEL_MANIFEST_NAME = "vllm_mlx_model_manifest.json"
 CONVERSION_MANIFEST_NAME = "vllm_mlx_conversion_manifest.json"
+REGISTRATION_MANIFEST_NAME = "vllm_mlx_registration_manifest.json"
+QUALIFICATION_REQUEST_NAME = "vllm_mlx_qualification_request.json"
 
 _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -72,6 +74,48 @@ class ConversionOptions:
     dtype: str | None = None
     trust_remote_code: bool = False
     dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class RegistrationOptions:
+    """Options for generating a portable model registration manifest.
+
+    ``artifact_path`` is stored as an absolute path.  The manifest is
+    intended as a local handoff artifact; move or copy the artifact
+    directory and re-register if portability across machines is needed.
+    """
+
+    artifact_path: str
+    model_id: str | None = None
+    served_model_name: str | None = None
+    preset_alias: str | None = None
+    output_path: str | None = None
+    mllm: bool | None = None
+    tool_call_parser: str | None = None
+    reasoning_parser: str | None = None
+    default_temperature: float | None = None
+    default_top_p: float | None = None
+    default_top_k: int | None = None
+    default_min_p: float | None = None
+    default_presence_penalty: float | None = None
+    default_repetition_penalty: float | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
+    feature_flags: list[str] | None = None
+
+
+@dataclass(frozen=True)
+class QualificationOptions:
+    """Options for creating or running a bench-serve qualification handoff."""
+
+    model_id: str
+    server_url: str = "http://127.0.0.1:8080"
+    workload_path: str | None = None
+    output_path: str | None = None
+    result_path: str | None = None
+    repetitions: int | None = None
+    timeout: int | None = None
+    dry_run: bool = False
+    extra_args: list[str] | None = None
 
 
 def _now_iso() -> str:
@@ -486,3 +530,176 @@ def convert_model(options: ConversionOptions) -> dict[str, Any]:
     _write_json(manifest_path, result)
     result["manifest_path"] = str(manifest_path)
     return result
+
+
+def _existing_manifests(path: Path) -> dict[str, Any]:
+    manifests: dict[str, Any] = {}
+    for name, key in (
+        (MODEL_MANIFEST_NAME, "acquisition"),
+        (CONVERSION_MANIFEST_NAME, "conversion"),
+    ):
+        manifest_path = path / name
+        if manifest_path.exists():
+            manifests[key] = {
+                "path": str(manifest_path),
+                "payload": _read_json(manifest_path),
+            }
+    return manifests
+
+
+def _drop_none(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _environment_metadata() -> dict[str, Any]:
+    """Collect Python, vllm-mlx, and MLX version metadata."""
+    env: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+    }
+    try:
+        import importlib.metadata as _meta
+
+        env["vllm_mlx"] = _meta.version("vllm-mlx")
+    except Exception:
+        pass
+    try:
+        import importlib.metadata as _meta
+
+        env["mlx"] = _meta.version("mlx")
+    except Exception:
+        pass
+    return env
+
+
+def register_model(options: RegistrationOptions) -> dict[str, Any]:
+    """Write a portable registration manifest for a finalized local artifact.
+
+    This deliberately does not mutate a production registry. The manifest is a
+    handoff artifact that Ops or a deployment tool can apply after qualification.
+    """
+    artifact = Path(options.artifact_path).expanduser()
+    if not artifact.exists():
+        raise FileNotFoundError(f"artifact path does not exist: {artifact}")
+    if not artifact.is_dir():
+        raise NotADirectoryError(f"artifact path must be a directory: {artifact}")
+
+    inspection = inspect_model(str(artifact))
+    model_id = options.model_id or artifact.name
+    serving_defaults = _drop_none(
+        {
+            "temperature": options.default_temperature,
+            "top_p": options.default_top_p,
+            "top_k": options.default_top_k,
+            "min_p": options.default_min_p,
+            "presence_penalty": options.default_presence_penalty,
+            "repetition_penalty": options.default_repetition_penalty,
+            "chat_template_kwargs": options.chat_template_kwargs,
+        }
+    )
+    parser_policy = _drop_none(
+        {
+            "tool_call_parser": options.tool_call_parser,
+            "reasoning_parser": options.reasoning_parser,
+        }
+    )
+    payload = {
+        "kind": "vllm-mlx-model-registration",
+        "schema_version": 1,
+        "created_at": _now_iso(),
+        "model_id": model_id,
+        "served_model_name": options.served_model_name or model_id,
+        "preset_alias": options.preset_alias,
+        "artifact_path": str(artifact),
+        "mllm": options.mllm,
+        "feature_flags": options.feature_flags or [],
+        "serving_defaults": serving_defaults,
+        "parser_policy": parser_policy,
+        "inspection": inspection,
+        "source_manifests": _existing_manifests(artifact),
+        "qualification_required": True,
+        "production_ready": False,
+    }
+
+    output = (
+        Path(options.output_path).expanduser()
+        if options.output_path
+        else artifact / REGISTRATION_MANIFEST_NAME
+    )
+    _write_json(output, payload)
+    payload["manifest_path"] = str(output)
+    return payload
+
+
+def _qualification_command(options: QualificationOptions) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "bench-serve",
+        "--url",
+        options.server_url,
+        "--model",
+        options.model_id,
+        "--format",
+        "json",
+    ]
+    if options.workload_path:
+        command.extend(["--workload", options.workload_path])
+    if options.repetitions is not None:
+        command.extend(["--repetitions", str(options.repetitions)])
+    if options.result_path:
+        command.extend(["--output", options.result_path])
+    if options.extra_args:
+        command.extend(options.extra_args)
+    return command
+
+
+def qualify_model(options: QualificationOptions) -> dict[str, Any]:
+    """Create or run a bench-serve qualification handoff."""
+    command = _qualification_command(options)
+    payload: dict[str, Any] = {
+        "kind": "vllm-mlx-model-qualification",
+        "schema_version": 1,
+        "created_at": _now_iso(),
+        "model_id": options.model_id,
+        "server_url": options.server_url,
+        "workload_path": options.workload_path,
+        "result_path": options.result_path,
+        "repetitions": options.repetitions,
+        "dry_run": options.dry_run,
+        "command": command,
+        "environment": _environment_metadata(),
+        "production_ready": False,
+    }
+
+    if not options.dry_run:
+        timeout = options.timeout
+        try:
+            completed = subprocess.run(
+                command,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            payload["status"] = "timeout"
+            payload["completed_at"] = _now_iso()
+            if options.output_path:
+                _write_json(Path(options.output_path).expanduser(), payload)
+                payload["manifest_path"] = str(Path(options.output_path).expanduser())
+            return payload
+        payload["returncode"] = completed.returncode
+        payload["stdout"] = completed.stdout
+        payload["stderr"] = completed.stderr
+        payload["completed_at"] = _now_iso()
+        payload["status"] = "succeeded" if completed.returncode == 0 else "failed"
+    else:
+        payload["status"] = "dry_run"
+
+    if options.output_path:
+        output = Path(options.output_path).expanduser()
+        _write_json(output, payload)
+        payload["manifest_path"] = str(output)
+    return payload


### PR DESCRIPTION
## Summary

Fresh re-implementation combining the content from #423 (model artifact workflow CLI) and #425 (registration + qualification handoff), with all review feedback from both PRs addressed.

- `vllm-mlx model inspect` reads config, HF metadata, size estimates, and MLX/conversion signals without loading weights
- `vllm-mlx model acquire` downloads via snapshot_download with staged finalization, hf_transfer, and artifact manifest
- `vllm-mlx model convert` wraps mlx-lm with recorded recipe, dry-run support, and conversion manifest
- `vllm-mlx model register` writes a portable registration manifest with serving defaults, parser policy, feature flags, and source manifest chain
- `vllm-mlx model qualify` creates or runs a bench-serve qualification handoff with environment metadata and timeout support

## Review fixes applied

From #423:
- Fix double print on conversion failure (single stderr print, then sys.exit)
- Fix GPTQ/AWQ false positive in has_mlx_signals (check for MLX-specific quant keys, reject quant_method: gptq/awq)
- Add test for conversion failure path
- Remove --local-files-only from acquire (contradicts download purpose)
- Catch json.JSONDecodeError in _read_json
- Document relationship with existing download command (retry gap noted)
- Rename convert positional arg from source to model for consistency
- Add help= text to bare --q-bits and --q-group-size arguments

From #425:
- Base branch fixed (fresh branch from upstream/main)
- Add --no-mllm flag (store_false counterpart via mutually exclusive group)
- Test: register_model with minimal/default options
- Test: qualification success path (returncode=0)
- Test: NotADirectoryError path
- Add help= text to all bare arguments
- Assert zero-valued defaults survive _drop_none
- Document artifact_path portability limitation in docstring
- Add --timeout to qualify (subprocess timeout)
- Document extra_args override risk in --extra-arg help text
- Add environment metadata to qualification manifest (Python/vllm-mlx/MLX version)

## Validation

```
pytest -q tests/test_model_workflow.py   # 19 passed
black --check                            # clean
ruff check                               # clean
```

## Test plan

- [ ] Verify `model inspect` against a local MLX artifact and a HF model id
- [ ] Verify `model acquire` with --target-dir produces a staged download with manifest
- [ ] Verify `model convert --dry-run` records the command without executing
- [ ] Verify `model register` with minimal options writes a valid manifest
- [ ] Verify `model qualify --dry-run` records the bench-serve command
- [ ] Verify GPTQ model is correctly detected as needing conversion (not an MLX artifact)