### PR TITLE
Add Gemma 4 audio support to chat completions

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -201,17 +201,18 @@ class TestExtractMultimodalContent:
             Message(role="system", content="You are helpful."),
             Message(role="user", content="Hello"),
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(processed) == 2
         assert processed[0] == {"role": "system", "content": "You are helpful."}
         assert processed[1] == {"role": "user", "content": "Hello"}
         assert images == []
         assert videos == []
+        assert audios == []
 
     def test_none_content(self):
         messages = [Message(role="assistant", content=None)]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert processed[0] == {"role": "assistant", "content": ""}
 
     def test_multimodal_with_image_url(self):
@@ -227,12 +228,13 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(processed) == 1
         assert processed[0]["content"] == "What is this?"
         assert images == ["https://example.com/img.png"]
         assert videos == []
+        assert audios == []
 
     def test_multimodal_with_dict_image_url(self):
         messages = [
@@ -247,7 +249,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert images == ["data:image/png;base64,abc"]
 
     def test_multimodal_with_string_image_url(self):
@@ -260,7 +262,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert images == ["https://example.com/img.png"]
 
     def test_multimodal_with_video(self):
@@ -273,7 +275,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert videos == ["/path/to/video.mp4"]
 
     def test_multimodal_with_video_url(self):
@@ -289,7 +291,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert videos == ["https://example.com/v.mp4"]
 
     def test_multimodal_with_string_video_url(self):
@@ -302,8 +304,49 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert videos == ["https://example.com/v.mp4"]
+
+    def test_multimodal_with_audio_url(self):
+        messages = [
+            Message(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Transcribe this"},
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": "data:audio/wav;base64,abc"},
+                    },
+                ],
+            )
+        ]
+        processed, images, videos, audios = extract_multimodal_content(messages)
+        assert processed[0]["content"] == "Transcribe this"
+        assert images == []
+        assert videos == []
+        assert audios == ["data:audio/wav;base64,abc"]
+
+    def test_multimodal_with_audio_type(self):
+        raw_messages = [
+            type(
+                "Msg",
+                (),
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Listen"},
+                        {"type": "audio", "audio": "/tmp/example.wav"},
+                    ],
+                    "tool_calls": None,
+                    "tool_call_id": None,
+                },
+            )()
+        ]
+        processed, images, videos, audios = extract_multimodal_content(raw_messages)
+        assert processed[0]["content"] == "Listen"
+        assert images == []
+        assert videos == []
+        assert audios == ["/tmp/example.wav"]
 
     def test_multiple_images(self):
         messages = [
@@ -316,14 +359,14 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert len(images) == 2
 
     def test_tool_response_message(self):
         messages = [
             Message(role="tool", content="72F and sunny", tool_call_id="call_1")
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert processed[0]["role"] == "user"
         assert "Tool Result" in processed[0]["content"]
         assert "call_1" in processed[0]["content"]
@@ -332,7 +375,7 @@ class TestExtractMultimodalContent:
         messages = [
             Message(role="tool", content="72F and sunny", tool_call_id="call_1")
         ]
-        processed, images, videos = extract_multimodal_content(
+        processed, images, videos, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["role"] == "tool"
@@ -356,7 +399,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert processed[0]["role"] == "assistant"
         assert "get_weather" in processed[0]["content"]
 
@@ -377,7 +420,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(
+        processed, images, videos, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["role"] == "assistant"
@@ -390,7 +433,7 @@ class TestExtractMultimodalContent:
             Message(role="user", content="Hello"),
         ]
         # Also test with raw dicts (the function handles both)
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert processed[0]["content"] == "Hello"
 
     def test_image_type_content_with_raw_dicts(self):
@@ -411,18 +454,19 @@ class TestExtractMultimodalContent:
                 },
             )()
         ]
-        processed, images, videos = extract_multimodal_content(raw_messages)
+        processed, images, videos, _ = extract_multimodal_content(raw_messages)
         assert images == ["https://example.com/img.png"]
 
     def test_empty_messages(self):
-        processed, images, videos = extract_multimodal_content([])
+        processed, images, videos, audios = extract_multimodal_content([])
         assert processed == []
         assert images == []
         assert videos == []
+        assert audios == []
 
     def test_tool_response_none_content(self):
         messages = [Message(role="tool", content=None, tool_call_id="call_1")]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert processed[0]["role"] == "user"
         assert "call_1" in processed[0]["content"]
 
@@ -436,7 +480,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, _ = extract_multimodal_content(messages)
         assert "First part." in processed[0]["content"]
         assert "Second part." in processed[0]["content"]
 
@@ -458,7 +502,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        result, images, videos = extract_multimodal_content(messages)
+        result, images, videos, _ = extract_multimodal_content(messages)
         assert isinstance(result[0]["content"], str)
         assert "Let me check." in result[0]["content"]
         assert "get_weather" in result[0]["content"]
@@ -481,7 +525,7 @@ class TestExtractMultimodalContent:
                 ],
             )
         ]
-        result, images, videos = extract_multimodal_content(
+        result, images, videos, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert isinstance(result[0]["content"], str)

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -657,7 +657,7 @@ class TestLifecycleFailureHandling:
             calls["releases"] += 1
 
         def fake_extract(messages, preserve_native_format):
-            return ([{"role": "user", "content": "hi"}], [], [])
+            return ([{"role": "user", "content": "hi"}], [], [], [])
 
         def fake_convert_tools(_tools):
             raise RuntimeError("boom")
@@ -2492,7 +2492,7 @@ class TestLifecycleFailureHandling:
                 return False
 
         def fake_extract(messages, preserve_native_format):
-            return ([{"role": "user", "content": "hi"}], [], [])
+            return ([{"role": "user", "content": "hi"}], [], [], [])
 
         async def fake_engine_factory(spec):
             return FakeEngine()

--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -89,6 +89,20 @@ def test_video_path(tmp_path):
         return str(path)
 
 
+@pytest.fixture
+def test_audio_path(tmp_path):
+    """Create a small local WAV file for audio input tests."""
+    import wave
+
+    path = tmp_path / "test_audio.wav"
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        wav_file.writeframes(b"\x00\x00" * 1600)
+    return str(path)
+
+
 # =============================================================================
 # Unit Tests - No Model Loading Required
 # =============================================================================
@@ -114,6 +128,15 @@ class TestMLLMHelperFunctions:
         assert is_base64_video("data:video/webm;base64,AAAA")
         assert not is_base64_video("https://example.com/video.mp4")
         assert not is_base64_video("/path/to/video.mp4")
+
+    def test_is_base64_audio(self):
+        """Test base64 audio detection."""
+        from vllm_mlx.models.mllm import is_base64_audio
+
+        assert is_base64_audio("data:audio/wav;base64,AAAA")
+        assert is_base64_audio("data:audio/mp3;base64,AAAA")
+        assert not is_base64_audio("https://example.com/audio.wav")
+        assert not is_base64_audio("/path/to/audio.wav")
 
     def test_is_url(self):
         """Test URL detection."""
@@ -313,6 +336,58 @@ class TestVideoProcessing:
 
         with pytest.raises(mllm.UnsafeRemoteURLError):
             mllm.download_video("http://127.0.0.1/internal.mp4")
+
+
+class TestAudioProcessing:
+    """Test audio processing functions."""
+
+    def test_process_audio_input_local_file(self, test_audio_path):
+        """Test processing local audio file."""
+        from vllm_mlx.models.mllm import process_audio_input
+
+        result = process_audio_input(test_audio_path)
+        assert result == test_audio_path
+
+    def test_process_audio_input_dict_format(self, test_audio_path):
+        """Test processing audio in dict format."""
+        from pathlib import Path
+
+        from vllm_mlx.models.mllm import process_audio_input
+
+        result = process_audio_input({"url": test_audio_path})
+        assert Path(result).exists()
+
+    def test_collect_audio_inputs(self):
+        """Audio items should be extracted and keyed by message index."""
+        from vllm_mlx.models.mllm import MLXMultimodalLM
+
+        model = MLXMultimodalLM.__new__(MLXMultimodalLM)
+        model._loaded = False
+        model._video_native = False
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": "https://example.com/a.wav"},
+                    },
+                    {"type": "text", "text": "Transcribe this"},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "audio": "/tmp/b.wav"},
+                    {"type": "text", "text": "And this"},
+                ],
+            },
+        ]
+
+        result = model._collect_audio_inputs(messages)
+        assert result[0] == ["https://example.com/a.wav"]
+        assert result[1] == ["/tmp/b.wav"]
 
 
 # =============================================================================

--- a/tests/test_mllm_mtp_routing.py
+++ b/tests/test_mllm_mtp_routing.py
@@ -132,6 +132,27 @@ def test_has_media_content_text_list():
     assert _has_media_content(messages) is False
 
 
+def test_batched_prepare_mllm_messages_converts_audio_url():
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "audio_url",
+                    "audio_url": {"url": "data:audio/wav;base64,..."},
+                },
+                {"type": "text", "text": "Transcribe this"},
+            ],
+        }
+    ]
+
+    prepared = BatchedEngine._prepare_mllm_messages(messages)
+    assert prepared[0]["content"][0] == {"type": "audio"}
+    assert prepared[0]["content"][1]["type"] == "text"
+
+
 def test_has_media_content_with_message_models():
     """Pydantic message models should follow the attribute-based content path."""
     from vllm_mlx.api.models import ContentPart, Message, VideoUrl

--- a/tests/test_native_tool_format.py
+++ b/tests/test_native_tool_format.py
@@ -125,7 +125,9 @@ class TestExtractMultimodalContentNativeFormat:
 
     def test_default_converts_to_text(self, messages_with_tool_calls):
         """Default behavior converts tool messages to text format."""
-        processed, images, videos = extract_multimodal_content(messages_with_tool_calls)
+        processed, images, videos, audios = extract_multimodal_content(
+            messages_with_tool_calls
+        )
 
         assert len(processed) == 4
 
@@ -146,10 +148,13 @@ class TestExtractMultimodalContentNativeFormat:
         # Final user message unchanged
         assert processed[3]["role"] == "user"
         assert processed[3]["content"] == "Thanks!"
+        assert images == []
+        assert videos == []
+        assert audios == []
 
     def test_preserve_native_format_true(self, messages_with_tool_calls):
         """preserve_native_format=True keeps native tool format."""
-        processed, images, videos = extract_multimodal_content(
+        processed, images, videos, audios = extract_multimodal_content(
             messages_with_tool_calls, preserve_native_format=True
         )
 
@@ -174,6 +179,9 @@ class TestExtractMultimodalContentNativeFormat:
         # Final user message unchanged
         assert processed[3]["role"] == "user"
         assert processed[3]["content"] == "Thanks!"
+        assert images == []
+        assert videos == []
+        assert audios == []
 
     def test_empty_tool_call_id(self):
         """Handle empty or missing tool_call_id gracefully."""
@@ -182,12 +190,12 @@ class TestExtractMultimodalContentNativeFormat:
         ]
 
         # Default mode
-        processed, _, _ = extract_multimodal_content(messages)
+        processed, _, _, _ = extract_multimodal_content(messages)
         assert processed[0]["role"] == "user"
         assert "[Tool Result ()]" in processed[0]["content"]
 
         # Native mode
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["role"] == "tool"
@@ -219,7 +227,7 @@ class TestExtractMultimodalContentNativeFormat:
         ]
 
         # Native mode
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
 
@@ -239,10 +247,10 @@ class TestExtractMultimodalContentNativeFormat:
         ]
 
         # Default mode
-        processed_default, _, _ = extract_multimodal_content(messages)
+        processed_default, _, _, _ = extract_multimodal_content(messages)
 
         # Native mode
-        processed_native, _, _ = extract_multimodal_content(
+        processed_native, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
 
@@ -270,12 +278,12 @@ class TestExtractMultimodalContentNativeFormat:
         ]
 
         # Default mode - content and tool calls merged
-        processed, _, _ = extract_multimodal_content(messages)
+        processed, _, _, _ = extract_multimodal_content(messages)
         assert "Let me check that for you." in processed[0]["content"]
         assert "[Calling tool: search" in processed[0]["content"]
 
         # Native mode - content and tool_calls separate
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["content"] == "Let me check that for you."
@@ -292,7 +300,7 @@ class TestEdgeCases:
             {"role": "tool", "tool_call_id": "call_1", "content": None},
         ]
 
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["content"] == ""
@@ -316,7 +324,7 @@ class TestEdgeCases:
             }
         ]
 
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["tool_calls"][0]["id"] == "call_v2"
@@ -341,7 +349,7 @@ class TestEdgeCases:
             }
         ]
 
-        processed, _, _ = extract_multimodal_content(
+        processed, _, _, _ = extract_multimodal_content(
             messages, preserve_native_format=True
         )
         assert processed[0]["tool_calls"][0]["id"] == "call_v1"
@@ -363,10 +371,12 @@ class TestEdgeCases:
             {"role": "tool", "tool_call_id": "call_1", "content": "Analysis result"},
         ]
 
-        processed, images, videos = extract_multimodal_content(
+        processed, images, videos, audios = extract_multimodal_content(
             messages, preserve_native_format=True
         )
 
         assert len(images) == 1
         assert images[0] == "http://example.com/img.jpg"
+        assert videos == []
+        assert audios == []
         assert processed[1]["role"] == "tool"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -737,12 +737,13 @@ class TestHelperFunctions:
             Message(role="assistant", content="Hi there!"),
         ]
 
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(processed) == 2
         assert processed[0]["content"] == "Hello"
         assert len(images) == 0
         assert len(videos) == 0
+        assert len(audios) == 0
 
     def test_extract_multimodal_content_with_image(self):
         """Test extracting content with images."""
@@ -761,12 +762,13 @@ class TestHelperFunctions:
             )
         ]
 
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(processed) == 1
         assert processed[0]["content"] == "What's this?"
         assert len(images) == 1
         assert "https://example.com/img.jpg" in images[0]
+        assert len(audios) == 0
 
     def test_extract_multimodal_content_with_video(self):
         """Test extracting content with videos."""
@@ -782,12 +784,13 @@ class TestHelperFunctions:
             )
         ]
 
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(processed) == 1
         assert processed[0]["content"] == "Describe this video"
         assert len(videos) == 1
         assert videos[0] == "/path/to/video.mp4"
+        assert len(audios) == 0
 
     def test_extract_multimodal_content_with_video_url(self):
         """Test extracting content with video_url format."""
@@ -806,9 +809,35 @@ class TestHelperFunctions:
             )
         ]
 
-        processed, images, videos = extract_multimodal_content(messages)
+        processed, images, videos, audios = extract_multimodal_content(messages)
 
         assert len(videos) == 1
+        assert len(audios) == 0
+
+    def test_extract_multimodal_content_with_audio_url(self):
+        """Test extracting content with audio_url format."""
+        from vllm_mlx.server import extract_multimodal_content, Message
+
+        messages = [
+            Message(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Transcribe this"},
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": "data:audio/wav;base64,abc"},
+                    },
+                ],
+            )
+        ]
+
+        processed, images, videos, audios = extract_multimodal_content(messages)
+
+        assert len(processed) == 1
+        assert processed[0]["content"] == "Transcribe this"
+        assert len(images) == 0
+        assert len(videos) == 0
+        assert audios == ["data:audio/wav;base64,abc"]
 
 
 # =============================================================================
@@ -2418,7 +2447,7 @@ class TestReasoningAndToolCallsNonStreaming:
 
         def fake_extract(messages, preserve_native_format=False):
             extract_calls["count"] += 1
-            return ([{"role": "user", "content": "hi"}], [], [])
+            return ([{"role": "user", "content": "hi"}], [], [], [])
 
         monkeypatch.setattr(server, "_engine", FakeEngine())
         monkeypatch.setattr(server, "_model_name", "test-model")
@@ -2469,7 +2498,7 @@ class TestReasoningAndToolCallsNonStreaming:
 
         def fake_extract(messages, preserve_native_format=False):
             extract_calls["count"] += 1
-            return ([{"role": "user", "content": "hi"}], [], [])
+            return ([{"role": "user", "content": "hi"}], [], [], [])
 
         monkeypatch.setattr(server, "_engine", FakeEngine())
         monkeypatch.setattr(server, "_model_name", "test-model")

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -450,13 +450,13 @@ def _content_to_text(content) -> str:
 def extract_multimodal_content(
     messages: list[Message],
     preserve_native_format: bool = False,
-) -> tuple[list[dict], list[str], list[str]]:
+) -> tuple[list[dict], list[str], list[str], list[str]]:
     """
-    Extract text content, images, and videos from OpenAI-format messages.
+    Extract text content, images, videos, and audio from OpenAI-format messages.
 
     Handles:
     - Simple text messages
-    - Multimodal messages with images/videos
+    - Multimodal messages with images/videos/audio
     - Tool call messages (assistant with tool_calls)
     - Tool response messages (role="tool")
 
@@ -468,14 +468,16 @@ def extract_multimodal_content(
             (e.g., Mistral, Llama 3+, DeepSeek V3).
 
     Returns:
-        Tuple of (processed_messages, images, videos)
+        Tuple of (processed_messages, images, videos, audios)
         - processed_messages: List of {"role": str, "content": str}
         - images: List of image URLs/paths/base64
         - videos: List of video URLs/paths/base64
+        - audios: List of audio URLs/paths/base64
     """
     processed_messages = []
     images = []
     videos = []
+    audios = []
 
     for msg in messages:
         # Handle both dict and Pydantic model messages
@@ -612,6 +614,16 @@ def extract_multimodal_content(
                     elif isinstance(vid_url, dict):
                         videos.append(vid_url.get("url", ""))
 
+                elif item_type == "audio":
+                    audios.append(item.get("audio", item.get("url", "")))
+
+                elif item_type == "audio_url":
+                    audio_url = item.get("audio_url", {})
+                    if isinstance(audio_url, str):
+                        audios.append(audio_url)
+                    elif isinstance(audio_url, dict):
+                        audios.append(audio_url.get("url", ""))
+
             # Combine text parts
             combined_text = "\n".join(text_parts) if text_parts else ""
             processed_messages.append({"role": role, "content": combined_text})
@@ -619,4 +631,4 @@ def extract_multimodal_content(
             # Unknown format, try to convert
             processed_messages.append({"role": role, "content": str(content)})
 
-    return processed_messages, images, videos
+    return processed_messages, images, videos, audios

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -32,13 +32,14 @@ logger = logging.getLogger(__name__)
 
 def _extract_media_from_messages(messages: list[dict[str, Any]]) -> tuple:
     """
-    Extract images and videos from OpenAI-format messages.
+    Extract images, videos, and audio from OpenAI-format messages.
 
     Returns:
-        Tuple of (has_media, images_list, videos_list)
+        Tuple of (has_media, images_list, videos_list, audios_list)
     """
     images = []
     videos = []
+    audios = []
 
     for msg in messages:
         content = msg.get("content")
@@ -85,8 +86,22 @@ def _extract_media_from_messages(messages: list[dict[str, Any]]) -> tuple:
                 if vid:
                     videos.append(vid)
 
-    has_media = bool(images or videos)
-    return has_media, images, videos
+            elif item_type == "audio_url":
+                audio_url = item.get("audio_url", {})
+                if isinstance(audio_url, str):
+                    audios.append(audio_url)
+                elif isinstance(audio_url, dict):
+                    url = audio_url.get("url", "")
+                    if url:
+                        audios.append(url)
+
+            elif item_type == "audio":
+                audio = item.get("audio") or item.get("url", "")
+                if audio:
+                    audios.append(audio)
+
+    has_media = bool(images or videos or audios)
+    return has_media, images, videos, audios
 
 
 class MLLMModelWrapper:
@@ -525,6 +540,7 @@ class BatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         num_images: int = 0,
+        num_audios: int = 0,
         chat_template_kwargs: dict[str, Any] | None = None,
         enable_thinking: bool | None = None,
     ) -> str:
@@ -552,7 +568,7 @@ class BatchedEngine(BaseEngine):
         if template_applicator is not None:
             # Convert OpenAI image_url content parts to HuggingFace format
             # so the processor can insert the correct vision placeholder tokens.
-            if self._is_mllm and num_images > 0:
+            if self._is_mllm and (num_images > 0 or num_audios > 0):
                 messages = self._prepare_mllm_messages(messages)
 
             # Per-request enable_thinking override; default: True unless coder model.
@@ -611,18 +627,20 @@ class BatchedEngine(BaseEngine):
     def _prepare_mllm_messages(
         messages: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
-        """Convert OpenAI-style image_url content to HuggingFace format.
+        """Convert OpenAI-style multimodal content to HuggingFace format.
 
         The OpenAI API uses ``{"type": "image_url", "image_url": {"url": ...}}``
-        while HuggingFace processors expect ``{"type": "image"}``.
+        and ``{"type": "audio_url", "audio_url": {"url": ...}}`` while
+        HuggingFace processors expect ``{"type": "image"}`` / ``{"type": "audio"}``.
 
         Args:
             messages: List of chat messages in OpenAI format. Each message is a
                 dict with at least ``role`` and ``content`` keys.
 
         Returns:
-            A new list of messages with ``image_url`` parts replaced by
-            ``{"type": "image"}`` entries for the HuggingFace processor.
+            A new list of messages with ``image_url`` / ``audio_url`` parts
+            replaced by ``{"type": "image"}`` / ``{"type": "audio"}`` entries
+            for the HuggingFace processor.
         """
         prepared = []
         for msg in messages:
@@ -634,6 +652,8 @@ class BatchedEngine(BaseEngine):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "image_url":
                         new_content.append({"type": "image"})
+                    elif isinstance(part, dict) and part.get("type") == "audio_url":
+                        new_content.append({"type": "audio"})
                     elif isinstance(part, (dict | str)):
                         new_content.append(part)
                     # skip non-dict/non-str parts to avoid passing unexpected types
@@ -651,6 +671,7 @@ class BatchedEngine(BaseEngine):
         stop: list[str] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        audio: list[str] | None = None,
         **kwargs,
     ) -> GenerationOutput:
         """
@@ -664,6 +685,7 @@ class BatchedEngine(BaseEngine):
             stop: Stop sequences
             images: Optional image URLs/paths (for MLLM)
             videos: Optional video URLs/paths (for MLLM)
+            audio: Optional audio URLs/paths (for MLLM)
             **kwargs: Additional model-specific parameters
 
         Returns:
@@ -680,6 +702,7 @@ class BatchedEngine(BaseEngine):
                 prompt=prompt,
                 images=images,
                 videos=videos,
+                audio=audio,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
@@ -737,6 +760,7 @@ class BatchedEngine(BaseEngine):
         stop: list[str] | None = None,
         images: list[str] | None = None,
         videos: list[str] | None = None,
+        audio: list[str] | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -750,6 +774,7 @@ class BatchedEngine(BaseEngine):
             stop: Stop sequences
             images: Optional image URLs/paths (for MLLM)
             videos: Optional video URLs/paths (for MLLM)
+            audio: Optional audio URLs/paths (for MLLM)
             **kwargs: Additional model-specific parameters
 
         Yields:
@@ -764,6 +789,7 @@ class BatchedEngine(BaseEngine):
                 prompt=prompt,
                 images=images,
                 videos=videos,
+                audio=audio,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
@@ -853,11 +879,14 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        # Extract images/videos from messages (OpenAI multimodal format)
+        # Extract images/videos/audio from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+        _, extracted_images, extracted_videos, extracted_audios = (
+            extract_multimodal_content(messages)
+        )
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
+        all_audios = extracted_audios
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -871,6 +900,7 @@ class BatchedEngine(BaseEngine):
             messages,
             template_tools,
             num_images=len(all_images),
+            num_audios=len(all_audios),
             chat_template_kwargs=chat_template_kwargs,
             enable_thinking=enable_thinking,
         )
@@ -882,6 +912,7 @@ class BatchedEngine(BaseEngine):
             top_p=top_p,
             images=all_images if all_images else None,
             videos=all_videos if all_videos else None,
+            audio=all_audios if all_audios else None,
             **kwargs,
         )
 
@@ -981,11 +1012,14 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        # Extract images/videos from messages (OpenAI multimodal format)
+        # Extract images/videos/audio from messages (OpenAI multimodal format)
         # Note: We only use extracted media here, messages are already processed by server
-        _, extracted_images, extracted_videos = extract_multimodal_content(messages)
+        _, extracted_images, extracted_videos, extracted_audios = (
+            extract_multimodal_content(messages)
+        )
         all_images = (images or []) + extracted_images
         all_videos = (videos or []) + extracted_videos
+        all_audios = extracted_audios
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -999,6 +1033,7 @@ class BatchedEngine(BaseEngine):
             messages,
             template_tools,
             num_images=len(all_images),
+            num_audios=len(all_audios),
             chat_template_kwargs=chat_template_kwargs,
             enable_thinking=enable_thinking,
         )
@@ -1019,6 +1054,7 @@ class BatchedEngine(BaseEngine):
             top_p=top_p,
             images=all_images if all_images else None,
             videos=all_videos if all_videos else None,
+            audio=all_audios if all_audios else None,
             **kwargs,
         ):
             yield output

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -113,6 +113,7 @@ class MLLMBatchRequest:
     prompt: str  # Text prompt
     images: Optional[List[str]] = None  # Image paths/URLs/base64
     videos: Optional[List[str]] = None  # Video inputs
+    audio: Optional[List[str]] = None  # Audio inputs
     max_tokens: int = 256
     temperature: float = 0.7
     top_p: float = 0.9
@@ -733,8 +734,8 @@ class MLLMBatchGenerator:
         self.unprocessed_requests = sorted(
             self.unprocessed_requests,
             key=lambda x: (
-                0 if not x.images and not x.videos else 1,
-                len(x.images or []) + len(x.videos or []),
+                0 if not x.images and not x.videos and not x.audio else 1,
+                len(x.images or []) + len(x.videos or []) + len(x.audio or []),
             ),
         )
 
@@ -782,17 +783,23 @@ class MLLMBatchGenerator:
         """
         # Already preprocessed (e.g. by early executor offloading in
         # _process_loop or chunked prefill interleaving).  Only skip for
-        # text-only requests; vision requests need pixel cache lookup even
-        # if input_ids was set.
-        if request.input_ids is not None and not request.images and not request.videos:
+        # text-only requests; media requests need pixel/audio cache lookup
+        # even if input_ids was set.
+        if (
+            request.input_ids is not None
+            and not request.images
+            and not request.videos
+            and not request.audio
+        ):
             return
 
         from mlx_vlm.utils import prepare_inputs
 
         tic = time.perf_counter()
 
-        # Collect all images (including video frames)
+        # Collect all images (including video frames) and audio inputs
         all_images = []
+        all_audio = []
 
         if request.images:
             from .models.mllm import process_image_input
@@ -826,8 +833,22 @@ class MLLMBatchGenerator:
                 except Exception as e:
                     logger.warning(f"Failed to process video: {e}")
 
+        if request.audio:
+            from .models.mllm import process_audio_input
+
+            for audio in request.audio:
+                try:
+                    path = process_audio_input(audio)
+                    all_audio.append(path)
+                except Exception as e:
+                    logger.warning(f"Failed to process audio: {e}")
+
         # Check pixel cache first
-        cached_pixels = self.vision_cache.get_pixel_cache(all_images, request.prompt)
+        cached_pixels = None
+        if not all_audio:
+            cached_pixels = self.vision_cache.get_pixel_cache(
+                all_images, request.prompt
+            )
         if cached_pixels is not None:
             # Cache hit - use cached pixel values
             request.input_ids = cached_pixels.input_ids
@@ -853,6 +874,7 @@ class MLLMBatchGenerator:
         inputs = prepare_inputs(
             self.processor,
             images=all_images if all_images else None,
+            audio=all_audio if all_audio else None,
             prompts=request.prompt,
             image_token_index=image_token_index,
         )
@@ -872,7 +894,7 @@ class MLLMBatchGenerator:
         processing_time = time.perf_counter() - tic
 
         # Store in pixel cache for future reuse
-        if all_images and request.pixel_values is not None:
+        if all_images and not all_audio and request.pixel_values is not None:
             self.vision_cache.set_pixel_cache(
                 images=all_images,
                 prompt=request.prompt,
@@ -888,11 +910,12 @@ class MLLMBatchGenerator:
         self._stats.vision_encoding_time += processing_time
 
         # Mark text-only requests (eligible for prefix cache)
-        request.is_text_only = not bool(all_images)
+        request.is_text_only = not bool(all_images or all_audio)
 
         logger.debug(
             f"Preprocessed request {request.request_id}: "
-            f"{len(all_images)} images, {request.input_ids.size if request.input_ids is not None else 0} tokens "
+            f"{len(all_images)} images, {len(all_audio)} audio clips, "
+            f"{request.input_ids.size if request.input_ids is not None else 0} tokens "
             f"({processing_time:.2f}s)"
         )
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -96,6 +96,7 @@ class MLLMRequest:
     prompt: str
     images: Optional[List[str]] = None
     videos: Optional[List[str]] = None
+    audio: Optional[List[str]] = None
     sampling_params: SamplingParams = field(default_factory=SamplingParams)
     arrival_time: float = field(default_factory=time.time)
 
@@ -344,6 +345,7 @@ class MLLMScheduler:
         prompt: str,
         images: Optional[List[str]] = None,
         videos: Optional[List[str]] = None,
+        audio: Optional[List[str]] = None,
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -357,6 +359,7 @@ class MLLMScheduler:
             prompt: Text prompt (should be formatted with chat template)
             images: List of image inputs (paths, URLs, base64)
             videos: List of video inputs
+            audio: List of audio inputs
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
@@ -387,6 +390,7 @@ class MLLMScheduler:
             prompt=prompt,
             images=images,
             videos=videos,
+            audio=audio,
             sampling_params=sampling_params,
         )
 
@@ -526,6 +530,7 @@ class MLLMScheduler:
                 prompt=request.prompt,
                 images=request.images,
                 videos=request.videos,
+                audio=request.audio,
                 max_tokens=request.sampling_params.max_tokens,
                 temperature=request.sampling_params.temperature,
                 top_p=request.sampling_params.top_p,
@@ -838,7 +843,12 @@ class MLLMScheduler:
                 bg = self.batch_generator
                 if bg is not None:
                     for req in list(getattr(bg, "unprocessed_requests", ())):
-                        if req.input_ids is None and not req.images and not req.videos:
+                        if (
+                            req.input_ids is None
+                            and not req.images
+                            and not req.videos
+                            and not req.audio
+                        ):
                             try:
                                 tic = time.perf_counter()
                                 await loop.run_in_executor(
@@ -900,6 +910,7 @@ class MLLMScheduler:
         prompt: str,
         images: Optional[List[str]] = None,
         videos: Optional[List[str]] = None,
+        audio: Optional[List[str]] = None,
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -912,6 +923,7 @@ class MLLMScheduler:
             prompt: Text prompt
             images: List of image inputs
             videos: List of video inputs
+            audio: List of audio inputs
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
@@ -924,6 +936,7 @@ class MLLMScheduler:
             prompt=prompt,
             images=images,
             videos=videos,
+            audio=audio,
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
@@ -977,6 +990,7 @@ class MLLMScheduler:
         prompt: str,
         images: Optional[List[str]] = None,
         videos: Optional[List[str]] = None,
+        audio: Optional[List[str]] = None,
         **kwargs,
     ) -> RequestOutput:
         """
@@ -986,6 +1000,7 @@ class MLLMScheduler:
             prompt: Text prompt
             images: Image inputs
             videos: Video inputs
+            audio: Audio inputs
             **kwargs: Generation parameters
 
         Returns:
@@ -995,6 +1010,7 @@ class MLLMScheduler:
             prompt=prompt,
             images=images,
             videos=videos,
+            audio=audio,
             **kwargs,
         )
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -107,8 +107,10 @@ IMAGE_FACTOR = 28  # For smart resize
 # Security: File size limits (in bytes)
 MAX_IMAGE_SIZE = 20 * 1024 * 1024  # 20 MB max for images
 MAX_VIDEO_SIZE = 500 * 1024 * 1024  # 500 MB max for videos
+MAX_AUDIO_SIZE = 100 * 1024 * 1024  # 100 MB max for audio
 MAX_BASE64_IMAGE_LENGTH = 30 * 1024 * 1024  # 30 MB base64 string (~22 MB decoded)
 MAX_BASE64_VIDEO_LENGTH = 700 * 1024 * 1024  # 700 MB base64 string (~500 MB decoded)
+MAX_BASE64_AUDIO_LENGTH = 140 * 1024 * 1024  # 140 MB base64 string (~100 MB decoded)
 
 
 class FileSizeExceededError(Exception):
@@ -158,6 +160,11 @@ def is_url(s: str) -> bool:
 def is_base64_video(s: str) -> bool:
     """Check if string is base64-encoded video data."""
     return s.startswith("data:video/")
+
+
+def is_base64_audio(s: str) -> bool:
+    """Check if string is base64-encoded audio data."""
+    return s.startswith("data:audio/")
 
 
 def decode_base64_image(
@@ -355,28 +362,43 @@ def download_image(url: str, timeout: int = 30, max_size: int = MAX_IMAGE_SIZE) 
     return _temp_manager.register(temp_file.name)
 
 
-def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE) -> str:
-    """
-    Download video from URL and return local path.
+_VIDEO_EXT_MAP: dict[str, str] = {
+    "mp4": ".mp4",
+    "webm": ".webm",
+    "avi": ".avi",
+    "mov": ".mov",
+    "quicktime": ".mov",
+    "mkv": ".mkv",
+}
 
-    Args:
-        url: Video URL (http/https)
-        timeout: Download timeout in seconds (default 120s for larger videos)
-        max_size: Maximum allowed file size in bytes
+_AUDIO_EXT_MAP: dict[str, str] = {
+    "wav": ".wav",
+    "mpeg": ".mp3",
+    "mp3": ".mp3",
+    "flac": ".flac",
+    "ogg": ".ogg",
+    "webm": ".webm",
+    "mp4": ".m4a",
+    "m4a": ".m4a",
+    "aac": ".m4a",
+}
 
-    Returns:
-        Local file path to downloaded video
 
-    Raises:
-        FileSizeExceededError: If video exceeds max_size
-    """
+def _download_media(
+    url: str,
+    media_type: str,
+    ext_map: dict[str, str],
+    default_ext: str,
+    timeout: int,
+    max_size: int,
+) -> str:
+    """Download media from URL, enforce size limits, and return a local temp path."""
     headers = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
     }
 
-    logger.info(f"Downloading video from: {url}")
+    logger.info(f"Downloading {media_type} from: {url}")
 
-    # First, make a HEAD request to check Content-Length
     try:
         head_response = _request_with_safe_redirects(
             "HEAD", url, timeout=timeout, headers=headers
@@ -384,11 +406,10 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
         content_length = head_response.headers.get("content-length")
         if content_length and int(content_length) > max_size:
             raise FileSizeExceededError(
-                f"Video at {url} exceeds maximum size: {int(content_length) / 1024 / 1024:.1f} MB > "
-                f"{max_size / 1024 / 1024:.1f} MB limit"
+                f"{media_type.capitalize()} at {url} exceeds maximum size: "
+                f"{int(content_length) / 1024 / 1024:.1f} MB > {max_size / 1024 / 1024:.1f} MB limit"
             )
     except requests.RequestException:
-        # HEAD request failed, proceed with GET and check during download
         pass
 
     response = _request_with_safe_redirects(
@@ -396,32 +417,24 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
     )
     response.raise_for_status()
 
-    # Check Content-Length header from GET response
     content_length = response.headers.get("content-length")
     if content_length and int(content_length) > max_size:
         raise FileSizeExceededError(
-            f"Video at {url} exceeds maximum size: {int(content_length) / 1024 / 1024:.1f} MB > "
-            f"{max_size / 1024 / 1024:.1f} MB limit"
+            f"{media_type.capitalize()} at {url} exceeds maximum size: "
+            f"{int(content_length) / 1024 / 1024:.1f} MB > {max_size / 1024 / 1024:.1f} MB limit"
         )
 
-    # Determine extension from content type or URL
-    content_type = response.headers.get("content-type", "")
-    if "mp4" in content_type:
-        ext = ".mp4"
-    elif "webm" in content_type:
-        ext = ".webm"
-    elif "avi" in content_type:
-        ext = ".avi"
-    elif "mov" in content_type or "quicktime" in content_type:
-        ext = ".mov"
-    elif "mkv" in content_type:
-        ext = ".mkv"
+    content_type = response.headers.get("content-type", "").lower()
+    ext = default_ext
+    for key, mapped_ext in ext_map.items():
+        if key in content_type:
+            ext = mapped_ext
+            break
     else:
-        # Try to get from URL
-        path = urlparse(response.url).path
-        ext = Path(path).suffix or ".mp4"
+        path_ext = Path(urlparse(response.url).path).suffix
+        if path_ext:
+            ext = path_ext
 
-    # Save to temp file (stream for larger files) with size checking
     temp_file = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
     downloaded_size = 0
     try:
@@ -431,7 +444,7 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
                 temp_file.close()
                 os.unlink(temp_file.name)
                 raise FileSizeExceededError(
-                    f"Video at {url} exceeds maximum size during download: "
+                    f"{media_type.capitalize()} at {url} exceeds maximum size during download: "
                     f"{downloaded_size / 1024 / 1024:.1f} MB > {max_size / 1024 / 1024:.1f} MB limit"
                 )
             temp_file.write(chunk)
@@ -446,10 +459,20 @@ def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE)
 
     file_size = Path(temp_file.name).stat().st_size
     logger.info(
-        f"Video downloaded: {temp_file.name} ({file_size / 1024 / 1024:.1f} MB)"
+        f"{media_type.capitalize()} downloaded: {temp_file.name} ({file_size / 1024 / 1024:.1f} MB)"
     )
 
     return _temp_manager.register(temp_file.name)
+
+
+def download_video(url: str, timeout: int = 120, max_size: int = MAX_VIDEO_SIZE) -> str:
+    """Download video from URL and return local path."""
+    return _download_media(url, "video", _VIDEO_EXT_MAP, ".mp4", timeout, max_size)
+
+
+def download_audio(url: str, timeout: int = 120, max_size: int = MAX_AUDIO_SIZE) -> str:
+    """Download audio from URL and return local path."""
+    return _download_media(url, "audio", _AUDIO_EXT_MAP, ".wav", timeout, max_size)
 
 
 def decode_base64_video(
@@ -501,6 +524,35 @@ def decode_base64_video(
     return _temp_manager.register(temp_file.name)
 
 
+def decode_base64_audio(
+    base64_string: str, max_length: int = MAX_BASE64_AUDIO_LENGTH
+) -> str:
+    """
+    Decode base64 audio to temp file and return path.
+
+    Supports format: data:audio/wav;base64,AAAA...
+    """
+    if len(base64_string) > max_length:
+        raise FileSizeExceededError(
+            f"Base64 audio data exceeds maximum size: {len(base64_string) / 1024 / 1024:.1f} MB > "
+            f"{max_length / 1024 / 1024:.1f} MB limit"
+        )
+
+    if base64_string.startswith("data:audio/"):
+        header, data = base64_string.split(",", 1)
+        format_part = header.split(";")[0]
+        ext = "." + format_part.split("/")[-1]
+    else:
+        data = base64_string
+        ext = ".wav"
+
+    audio_bytes = base64.b64decode(data)
+    temp_file = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
+    temp_file.write(audio_bytes)
+    temp_file.close()
+    return _temp_manager.register(temp_file.name)
+
+
 def process_video_input(video: str | dict) -> str:
     """
     Process video input in various formats and return local path.
@@ -537,6 +589,37 @@ def process_video_input(video: str | dict) -> str:
     raise ValueError(
         "Unsupported video input. Only http(s) URLs and data:video base64 payloads are allowed."
     )
+
+
+def process_audio_input(audio: str | dict) -> str:
+    """
+    Process audio input in various formats and return local path.
+
+    Supports:
+    - Local file path
+    - URL (http/https)
+    - Base64 encoded string (data:audio/wav;base64,...)
+    - OpenAI format dict: {"url": "..."} or {"audio_url": {"url": "..."}}
+    """
+    if isinstance(audio, dict):
+        url = audio.get("url", audio.get("audio_url", ""))
+        if isinstance(url, dict):
+            url = url.get("url", "")
+        audio = url
+
+    if not audio:
+        raise ValueError("Empty audio input")
+
+    if is_base64_audio(audio):
+        return decode_base64_audio(audio)
+
+    if is_url(audio):
+        return download_audio(audio)
+
+    if len(audio) < 4096 and Path(audio).exists():
+        return audio
+
+    raise ValueError(f"Cannot process audio: {audio[:50]}...")
 
 
 # Cache for base64 images to avoid re-saving the same image
@@ -850,6 +933,17 @@ class MLXMultimodalLM:
                 logger.warning(f"Failed to process image: {e}")
         return processed
 
+    def _prepare_audio(self, audio_inputs: list) -> list[str]:
+        """Process audio inputs and return local file paths."""
+        processed = []
+        for audio_input in audio_inputs:
+            try:
+                path = process_audio_input(audio_input)
+                processed.append(path)
+            except Exception as e:
+                logger.warning(f"Failed to process audio: {e}")
+        return processed
+
     def _prepare_video(
         self,
         video_input: str | dict,
@@ -916,6 +1010,37 @@ class MLXMultimodalLM:
                         if url:
                             video_inputs.setdefault(msg_idx, []).append(url)
         return video_inputs
+
+    def _collect_audio_inputs(self, messages: list[dict]) -> dict[int, list]:
+        """Collect audio inputs from messages, keyed by message index."""
+        audio_inputs: dict[int, list] = {}
+        for msg_idx, msg in enumerate(messages):
+            content = msg.get("content", "")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if hasattr(item, "model_dump"):
+                    item = item.model_dump(exclude_none=True)
+                elif hasattr(item, "dict"):
+                    item = {k: v for k, v in item.dict().items() if v is not None}
+
+                if not isinstance(item, dict):
+                    continue
+
+                item_type = item.get("type", "")
+                if item_type == "audio":
+                    audio_value = item.get("audio", item.get("url", ""))
+                    if audio_value:
+                        audio_inputs.setdefault(msg_idx, []).append(audio_value)
+                elif item_type == "audio_url":
+                    audio_url = item.get("audio_url", {})
+                    if isinstance(audio_url, str):
+                        audio_inputs.setdefault(msg_idx, []).append(audio_url)
+                    elif isinstance(audio_url, dict):
+                        url = audio_url.get("url", "")
+                        if url:
+                            audio_inputs.setdefault(msg_idx, []).append(url)
+        return audio_inputs
 
     def _prepare_native_video_inputs(
         self,
@@ -1190,8 +1315,9 @@ class MLXMultimodalLM:
         videos = videos or []
         audio = audio or []
 
-        # Process all images (including frames from videos)
+        # Process all images (including frames from videos) and audio inputs
         all_images = []
+        all_audio = []
         all_sources = []  # Track original sources for cache key
 
         # Process image inputs
@@ -1214,14 +1340,18 @@ class MLXMultimodalLM:
             )
             logger.info(f"Added {len(frames)} frames from video: {video_path}")
 
+        if audio:
+            all_audio.extend(self._prepare_audio(audio))
+
         # Apply chat template if needed
-        if all_images and hasattr(self.processor, "apply_chat_template"):
+        if (all_images or all_audio) and hasattr(self.processor, "apply_chat_template"):
             try:
                 formatted_prompt = apply_chat_template(
                     self.processor,
                     self.config,
                     prompt,
                     num_images=len(all_images),
+                    num_audios=len(all_audio),
                 )
             except Exception:
                 formatted_prompt = prompt
@@ -1231,6 +1361,10 @@ class MLXMultimodalLM:
         # Check cache for existing KV state
         prompt_cache = None
         cache_hit = False
+
+        if use_cache and all_audio:
+            logger.info("MLLM cache disabled for audio inputs")
+            use_cache = False
 
         if use_cache and self._cache_manager is not None and all_sources:
             prompt_cache, cache_hit = self._cache_manager.fetch_cache(
@@ -1255,6 +1389,7 @@ class MLXMultimodalLM:
             self.processor,
             formatted_prompt,
             all_images if all_images else None,
+            audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
             top_p=top_p,
@@ -1297,6 +1432,7 @@ class MLXMultimodalLM:
         prompt: str,
         images: list | None = None,
         videos: list[str] | None = None,
+        audio: list[str] | None = None,
         max_tokens: int = 256,
         temperature: float = 0.7,
         video_fps: float = DEFAULT_FPS,
@@ -1309,6 +1445,7 @@ class MLXMultimodalLM:
             prompt: Text prompt
             images: List of image inputs
             videos: List of video paths
+            audio: List of audio inputs
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             video_fps: FPS for video frame extraction
@@ -1329,6 +1466,7 @@ class MLXMultimodalLM:
                 prompt=prompt,
                 images=images,
                 videos=videos,
+                audio=audio,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 video_fps=video_fps,
@@ -1339,23 +1477,28 @@ class MLXMultimodalLM:
 
         images = images or []
         videos = videos or []
+        audio = audio or []
 
         # Process images
         all_images = []
+        all_audio = []
         if images:
             all_images.extend(self._prepare_images(images))
         for video_path in videos:
             frames = self._prepare_video(video_path, fps=video_fps)
             all_images.extend(frames)
+        if audio:
+            all_audio.extend(self._prepare_audio(audio))
 
         # Apply chat template
-        if all_images:
+        if all_images or all_audio:
             try:
                 formatted_prompt = apply_chat_template(
                     self.processor,
                     self.config,
                     prompt,
                     num_images=len(all_images),
+                    num_audios=len(all_audio),
                 )
             except Exception:
                 formatted_prompt = prompt
@@ -1367,6 +1510,7 @@ class MLXMultimodalLM:
             self.processor,
             formatted_prompt,
             all_images if all_images else None,
+            audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
             **kwargs,
@@ -1406,7 +1550,6 @@ class MLXMultimodalLM:
         # Extract text, images and audio from messages
         # Build chat_messages for multi-turn support WITH proper image/audio tokens per message
         all_image_urls = []  # Raw URLs/paths to process later
-        all_audio_urls = []  # Raw audio URLs/paths to process later
         chat_messages = []  # List of properly formatted messages for chat template
 
         logger.info(f"MLLM.chat() called with {len(messages)} messages")
@@ -1418,8 +1561,9 @@ class MLXMultimodalLM:
         use_cache = kwargs.pop("use_cache", True)
         enable_thinking = kwargs.pop("enable_thinking", True)
 
-        # Collect video inputs from messages
+        # Collect video and audio inputs from messages
         _msg_video_inputs = self._collect_video_inputs(messages)
+        _msg_audio_inputs = self._collect_audio_inputs(messages)
 
         # Use native video pipeline for supported models
         if self._video_native and _msg_video_inputs:
@@ -1436,6 +1580,7 @@ class MLXMultimodalLM:
         # Fallback: extract frames and treat as individual images
         _msg_video_frame_counts: dict[int, int] = {}
         all_video_frames: list[str] = []
+        all_audio_inputs: list[str] = []
         for msg_idx, vid_inputs in _msg_video_inputs.items():
             total_frames = 0
             for vid_input in vid_inputs:
@@ -1447,12 +1592,16 @@ class MLXMultimodalLM:
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
 
+        for aud_inputs in _msg_audio_inputs.values():
+            all_audio_inputs.extend(aud_inputs)
+
         # Second pass: build chat messages with image counts that include video frames
         for msg_idx, msg in enumerate(messages):
             role = msg.get("role", "user")
             content = msg.get("content", "")
             msg_text = ""  # Text content for this message
             msg_image_count = 0  # Number of images in THIS message
+            msg_audio_count = 0  # Number of audio clips in THIS message
 
             if isinstance(content, str):
                 msg_text = content
@@ -1490,16 +1639,9 @@ class MLXMultimodalLM:
                             )
                             msg_image_count += 1
 
-                        elif item_type == "audio_url":
-                            aud_url = item.get("audio_url", {})
-                            if isinstance(aud_url, str):
-                                all_audio_urls.append(aud_url)
-                            else:
-                                all_audio_urls.append(aud_url.get("url", ""))
-
             # Add video frame count to image count for this message
             msg_image_count += _msg_video_frame_counts.get(msg_idx, 0)
-            msg_audio_count = len(all_audio_urls)
+            msg_audio_count += len(_msg_audio_inputs.get(msg_idx, []))
 
             # Build properly structured message
             # Format: {"role": "...", "content": [{"type": "image"}, ..., {"type": "audio"}, ..., {"type": "text", "text": "..."}]}
@@ -1535,10 +1677,11 @@ class MLXMultimodalLM:
             all_images.extend(self._prepare_images(all_image_urls))
         # Append pre-processed video frames
         all_images.extend(all_video_frames)
+        all_audio = self._prepare_audio(all_audio_inputs) if all_audio_inputs else []
 
         # Apply chat template directly - messages are already properly structured
         logger.info(
-            f"Applying chat template with {len(chat_messages)} messages, {len(all_images)} images, {len(all_audio_urls)} audios"
+            f"Applying chat template with {len(chat_messages)} messages, {len(all_images)} images, {len(all_audio)} audios"
         )
         for i, cm in enumerate(chat_messages):
             content_preview = str(cm.get("content", ""))[:80]
@@ -1598,6 +1741,10 @@ class MLXMultimodalLM:
         token_ids = tokenizer.encode(formatted_prompt)
 
         # Check prefix cache
+        if use_cache and all_audio:
+            logger.info("Prefix cache disabled for audio inputs")
+            use_cache = False
+
         if use_cache and self._cache_manager is not None and all_images:
             try:
                 cache_entry, prefix_match_len = self._cache_manager.fetch(
@@ -1684,7 +1831,7 @@ class MLXMultimodalLM:
             self.processor,
             formatted_prompt,
             all_images if all_images else None,
-            audio=all_audio_urls if all_audio_urls else None,
+            audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
             verbose=False,
@@ -1829,8 +1976,9 @@ class MLXMultimodalLM:
         use_cache = kwargs.pop("use_cache", True)
         enable_thinking = kwargs.pop("enable_thinking", True)
 
-        # Collect video inputs from messages
+        # Collect video and audio inputs from messages
         _msg_video_inputs = self._collect_video_inputs(messages)
+        _msg_audio_inputs = self._collect_audio_inputs(messages)
 
         # Use native video pipeline for supported models.
         # NOTE: Native video yields a single chunk (not incremental streaming)
@@ -1854,6 +2002,7 @@ class MLXMultimodalLM:
         # Fallback: frames as images
         _msg_video_frame_counts: dict[int, int] = {}
         all_video_frames: list[str] = []
+        all_audio_inputs: list[str] = []
         for msg_idx, vid_inputs in _msg_video_inputs.items():
             total_frames = 0
             for vid_input in vid_inputs:
@@ -1865,11 +2014,15 @@ class MLXMultimodalLM:
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
 
+        for aud_inputs in _msg_audio_inputs.values():
+            all_audio_inputs.extend(aud_inputs)
+
         for msg_idx, msg in enumerate(messages):
             role = msg.get("role", "user")
             content = msg.get("content", "")
             msg_text = ""
             msg_image_count = 0
+            msg_audio_count = 0
 
             if isinstance(content, str):
                 msg_text = content
@@ -1905,12 +2058,14 @@ class MLXMultimodalLM:
                             msg_image_count += 1
 
             msg_image_count += _msg_video_frame_counts.get(msg_idx, 0)
-
-            if msg_text or msg_image_count > 0:
-                if role == "user" and msg_image_count > 0:
+            msg_audio_count += len(_msg_audio_inputs.get(msg_idx, []))
+            if msg_text or msg_image_count > 0 or msg_audio_count > 0:
+                if role == "user" and (msg_image_count > 0 or msg_audio_count > 0):
                     content_list = []
                     for _ in range(msg_image_count):
                         content_list.append({"type": "image"})
+                    for _ in range(msg_audio_count):
+                        content_list.append({"type": "audio"})
                     content_list.append(
                         {"type": "text", "text": msg_text, "content": msg_text}
                     )
@@ -1931,6 +2086,7 @@ class MLXMultimodalLM:
         if all_image_urls:
             all_images.extend(self._prepare_images(all_image_urls))
         all_images.extend(all_video_frames)
+        all_audio = self._prepare_audio(all_audio_inputs) if all_audio_inputs else []
 
         # Build template kwargs for tool definitions (tools already popped above)
         template_extra_kwargs = {}
@@ -1970,6 +2126,10 @@ class MLXMultimodalLM:
         prompt_cache = None
         cache_hit = False
 
+        if use_cache and all_audio:
+            logger.info("Stream chat cache disabled for audio inputs")
+            use_cache = False
+
         if use_cache and self._cache_manager is not None and all_images:
             prompt_cache, cache_hit = self._cache_manager.fetch_cache(
                 all_images, formatted_prompt
@@ -1996,6 +2156,7 @@ class MLXMultimodalLM:
             self.processor,
             formatted_prompt,
             all_images if all_images else None,
+            audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
             prompt_cache=prompt_cache,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -616,7 +616,7 @@ def _prepare_anthropic_invocation(
     effective_max_tokens: int,
 ) -> PreparedChatInvocation:
     """Precompute messages, kwargs, and decoding constraints for Anthropic API."""
-    messages, _, _, _ = _prepare_chat_messages(engine, openai_request.messages)
+    messages, _, _, _, _ = _prepare_chat_messages(engine, openai_request.messages)
     response_format = openai_request.response_format
     messages, json_logits_processor = _prepare_json_logits_processor(
         engine,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -262,7 +262,7 @@ class PreparedChatInvocation:
 def _prepare_chat_messages(
     engine: BaseEngine,
     request_messages: list[Message | dict],
-) -> tuple[list[dict], list, list, bool]:
+) -> tuple[list[dict], list, list, list, bool]:
     """Normalize messages and collect media once for both stream/non-stream paths."""
     is_mllm = bool(getattr(engine, "is_mllm", False))
     preserve_native = bool(getattr(engine, "preserve_native_tool_format", False))
@@ -278,7 +278,7 @@ def _prepare_chat_messages(
                 raw = dict(msg)
                 msg_dict = {k: v for k, v in raw.items() if v is not None}
             messages.append(msg_dict)
-        images, videos = [], []  # MLLM extracts these from messages
+        images, videos, audios = [], [], []  # MLLM extracts these from messages
         logger.debug(f"MLLM: Processing {len(messages)} messages")
         # Convert tool_call arguments from JSON string to dict so that
         # chat templates can iterate them (e.g. GLM-4.6V calls .items()).
@@ -296,14 +296,14 @@ def _prepare_chat_messages(
                             pass
         messages = _normalize_messages(messages)
     else:
-        # For LLM, extract text, images, and videos separately
-        messages, images, videos = extract_multimodal_content(
+        # For LLM, extract text and media separately
+        messages, images, videos, audios = extract_multimodal_content(
             request_messages,
             preserve_native_format=preserve_native,
         )
         messages = _normalize_messages(messages)
 
-    has_media = bool(images or videos)
+    has_media = bool(images or videos or audios)
     if is_mllm and not has_media:
         # MLLM extracts media from messages directly, so images/videos are
         # always empty. Check message content for video/image types instead.
@@ -316,13 +316,20 @@ def _prepare_chat_messages(
                         if hasattr(item, "type")
                         else (item.get("type", "") if isinstance(item, dict) else "")
                     )
-                    if item_type in ("image_url", "image", "video", "video_url"):
+                    if item_type in (
+                        "image_url",
+                        "image",
+                        "video",
+                        "video_url",
+                        "audio",
+                        "audio_url",
+                    ):
                         has_media = True
                         break
             if has_media:
                 break
 
-    return messages, images, videos, has_media
+    return messages, images, videos, audios, has_media
 
 
 def _prepare_json_logits_processor(
@@ -504,7 +511,7 @@ def _prepare_chat_completion_invocation(
     effective_max_tokens: int,
 ) -> PreparedChatInvocation:
     """Precompute messages, kwargs, and decoding constraints for chat completions."""
-    messages, images, videos, has_media = _prepare_chat_messages(
+    messages, images, videos, audios, has_media = _prepare_chat_messages(
         engine, request.messages
     )
     response_format = request.response_format
@@ -1953,7 +1960,7 @@ def _prepare_responses_request(
             f"tools={len(request.tools)}"
         )
 
-    messages, images, videos = extract_multimodal_content(
+    messages, images, videos, audios = extract_multimodal_content(
         chat_request.messages,
         preserve_native_format=engine.preserve_native_tool_format,
     )


### PR DESCRIPTION
## Summary

Re-implementation of #430 against current main. Threads audio inputs through the full chat completion pipeline so Gemma 4 (and future audio-capable models) can process audio content alongside text and images.

- **api/utils.py**: `extract_multimodal_content` now returns a 4-tuple `(messages, images, videos, audios)`, handling both `audio` and `audio_url` content types
- **engine/batched.py**: Audio parameter plumbed through `generate`, `stream_generate`, `chat`, `stream_chat`; `_prepare_mllm_messages` converts `audio_url` to HuggingFace `audio` format; `_extract_media_from_messages` extracts audio alongside images/videos
- **mllm_scheduler.py / mllm_batch_generator.py**: `audio` field on `MLLMRequest` and `MLLMBatchRequest` dataclasses; audio passed through scheduling and preprocessing
- **models/mllm.py**: New helpers `is_base64_audio`, `decode_base64_audio`, `download_audio`, `process_audio_input`, `_prepare_audio`, `_collect_audio_inputs`; refactored `download_video` into shared `_download_media` with extension mapping; audio support in `generate`, `stream_generate`, `chat`, `stream_chat`; cache disabled for audio inputs
- **server.py**: All `extract_multimodal_content` call sites updated for 4-tuple; `audio`/`audio_url` added to MLLM media type detection

## Test plan

- [x] `test_api_utils.py`: 22 tests pass -- all `extract_multimodal_content` callers updated to 4-tuple, new `test_multimodal_with_audio_url` and `test_multimodal_with_audio_type`
- [x] `test_mllm.py`: New `TestAudioProcessing` class with `test_process_audio_input_local_file`, `test_process_audio_input_dict_format`, `test_collect_audio_inputs`; new `test_is_base64_audio`
- [x] `test_mllm_mtp_routing.py`: New `test_batched_prepare_mllm_messages_converts_audio_url`
- [x] `test_native_tool_format.py`: All 3-tuple unpacking updated to 4-tuple with `audios` assertions
- [x] `test_server.py`: New `test_extract_multimodal_content_with_audio_url`; existing tests updated for 4-tuple; `fake_extract` stubs return 4-tuple
- [x] `test_lifecycle_server.py`: `fake_extract` stubs return 4-tuple
- [x] `black --check` passes on all changed files
- [ ] Integration test with Gemma 4 audio model (requires model weights)