### PR TITLE
fix: use 4-byte encoding in compute_block_hash to prevent false KV cache hits

### DIFF
--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -872,7 +872,7 @@ class PagedCacheManager:
     @staticmethod
     def compute_block_hash(tokens: List[int]) -> str:
         """Compute legacy string hash for a sequence of tokens."""
-        token_bytes = bytes(t & 0xFF for t in tokens)
+        token_bytes = b"".join(t.to_bytes(4, "big") for t in tokens)
         return hashlib.sha256(token_bytes).hexdigest()[:16]
 
     def find_cached_block(self, tokens: List[int]) -> Optional[CacheBlock]:


### PR DESCRIPTION
> **Note: This PR was created by GitHub Copilot on behalf of the [Clickbrain/vllm-mlx-ui](https://github.com/clickbrain/vllm-mlx-ui) project.**

## Problem

`PagedCacheManager.compute_block_hash()` truncates each token to 8 bits:

```python
token_bytes = bytes(t & 0xFF for t in tokens)
```

Any vocabulary with token IDs above 255 — every modern LLM (32k–128k vocab) — produces hash collisions. Token 65 (`"A"`) and token 321 both hash to the same byte value `65`. This causes the prefix cache to return **wrong cached KV blocks**, producing corrupted or nonsensical output silently.

## Fix

Encode each token as 4 bytes big-endian so every token ID maps to a unique byte sequence:

```python
token_bytes = b"".join(t.to_bytes(4, "big") for t in tokens)
```

## Notes

- Only affects the legacy `hash_to_block` dict path in `PagedCacheManager`
- The `BlockHashToBlockMap` chain-hash path is unaffected
- In-memory caches rebuild on process start — no migration needed