### PR TITLE
fix: update constrained decoding for lm-format-enforcer >= 0.10 API

### DIFF
--- a/vllm_mlx/constrained/cache.py
+++ b/vllm_mlx/constrained/cache.py
@@ -168,8 +168,6 @@ def get_tokenizer_data(tokenizer: Any) -> Any | None:
             regular_tokens,
             decode_fn,
             eos_token_id,
-            False,  # use_bitmask
-            vocab_size,
         )
     except Exception as exc:
         logger.warning("Failed to build TokenEnforcerTokenizerData: %s", exc)

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -24,7 +24,7 @@ from typing import Any
 import mlx.core as mx
 import numpy as np
 
-from .cache import get_tokenizer_data
+from .cache import _get_vocab_size, get_tokenizer_data
 
 logger = logging.getLogger(__name__)
 
@@ -300,7 +300,7 @@ class JSONSchemaLogitsProcessor:
                 self._disabled = True
 
         self._prompt_len: int | None = None
-        self._vocab_size: int = self._tok_data.vocab_size
+        self._vocab_size: int = _get_vocab_size(tokenizer)
 
         # EOS/stop tokens cache.
         eos_id = getattr(self._tok_data, "eos_token_id", None)


### PR DESCRIPTION
> **Note: This PR was created by GitHub Copilot on behalf of the [Clickbrain/vllm-mlx-ui](https://github.com/clickbrain/vllm-mlx-ui) project.**

## Problem

`lm-format-enforcer` removed `use_bitmask` and `vocab_size` from `TokenEnforcerTokenizerData.__init__()` in v0.10+. The current code passes 5 arguments, raising:

```
TypeError: TokenEnforcerTokenizerData.__init__() takes 4 positional arguments but 6 were given
```

This crashes **all** constrained/JSON-schema decoding on startup.

Additionally, `TokenEnforcerTokenizerData.vocab_size` no longer exists as an attribute, causing a second `AttributeError` in `JSONSchemaLogitsProcessor.__init__`.

## Fix

**`constrained/cache.py`** — drop the removed args:
```python
# Before:
data = TokenEnforcerTokenizerData(regular_tokens, decode_fn, eos_token_id, False, vocab_size)

# After:
data = TokenEnforcerTokenizerData(regular_tokens, decode_fn, eos_token_id)
```

**`constrained/json_schema_processor.py`** — get vocab_size from the tokenizer directly:
```python
# Before:
self._vocab_size: int = self._tok_data.vocab_size

# After:
self._vocab_size: int = _get_vocab_size(tokenizer)
```

`_get_vocab_size()` already exists in `constrained/cache.py` and handles all tokenizer variants.

## Testing

Restores all constrained decoding functionality with current `lm-format-enforcer` releases.