### PR TITLE
fix: remove duplicate repetition_penalty declarations silently ignored by Pydantic

### DIFF
--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -162,7 +162,6 @@ class ChatCompletionRequest(BaseModel):
     top_k: int | None = None
     min_p: float | None = None
     presence_penalty: float | None = None
-    repetition_penalty: float | None = None
     max_tokens: int | None = Field(default=None, gt=0)
     stream: bool = False
     stream_options: StreamOptions | None = (
@@ -263,7 +262,6 @@ class CompletionRequest(BaseModel):
     top_k: int | None = None
     min_p: float | None = None
     presence_penalty: float | None = None
-    repetition_penalty: float | None = None
     max_tokens: int | None = Field(default=None, gt=0)
     stream: bool = False
     stop: list[str] | None = None


### PR DESCRIPTION
> **Note: This PR was created by GitHub Copilot on behalf of the [Clickbrain/vllm-mlx-ui](https://github.com/clickbrain/vllm-mlx-ui) project.**

## Problem

Both `ChatCompletionRequest` and `CompletionRequest` declare `repetition_penalty` twice. Pydantic V2 uses the **last** declaration and silently discards the first. Any validators, descriptions, or default overrides on the first declaration are silently lost.

## Fix

Remove the first (undocumented) duplicate from both models, keeping only the annotated declaration in the sampling penalties block.