### PR TITLE
fix: use 'is not None' check for execution_time_ms in MCP audit log

### DIFF
--- a/vllm_mlx/mcp/security.py
+++ b/vllm_mlx/mcp/security.py
@@ -754,7 +754,7 @@ class ToolSandbox:
             logger.info(
                 f"AUDIT: Tool executed - {server_name}__{tool_name} "
                 f"(took {execution_time_ms:.1f}ms)"
-                if execution_time_ms
+                if execution_time_ms is not None
                 else f"AUDIT: Tool executed - {server_name}__{tool_name}"
             )
         else:


### PR DESCRIPTION
> **Note: This PR was created by GitHub Copilot on behalf of the [Clickbrain/vllm-mlx-ui](https://github.com/clickbrain/vllm-mlx-ui) project.**

## Problem

```python
if execution_time_ms:  # falsy — 0.0 is falsy in Python
    ...
```

Tool calls completing in under ~0.5ms (rounds to 0.0) are silently logged without timing data, making the audit log incomplete for fast tools.

## Fix

```python
if execution_time_ms is not None:
    ...
```