### PR TITLE
fix: dequantize KV cache before disk persistence (#443)

### DIFF
--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1198,9 +1198,18 @@ class MemoryAwarePrefixCache:
         for i, (tokens_key, entry) in enumerate(self._entries.items()):
             entry_path = os.path.join(cache_dir, f"entry_{i}.safetensors")
             try:
+                # Dequantize _QuantizedCacheWrapper layers before saving.
+                # save_prompt_cache requires .state and .meta_state which
+                # the wrapper does not provide; dequantizing restores the
+                # original cache types that do.
+                persist_cache = (
+                    _dequantize_cache(entry.cache)
+                    if any(isinstance(c, _QuantizedCacheWrapper) for c in entry.cache)
+                    else entry.cache
+                )
                 save_prompt_cache(
                     entry_path,
-                    entry.cache,
+                    persist_cache,
                     metadata={"num_tokens": str(len(tokens_key))},
                 )
                 # Save tokens separately (can be 100K+ ints → binary is smaller)


### PR DESCRIPTION
## Summary

- When `--kv-cache-quantization` is enabled, `save_to_disk` fails for every entry after entry 0 because `save_prompt_cache` calls `.state` and `.meta_state` on each cache layer, but `_QuantizedCacheWrapper` does not implement these properties.
- Fix: dequantize quantized layers before calling `save_prompt_cache`, reusing the existing `_dequantize_cache` helper. This restores the original KVCache types that implement the required `.state` / `.meta_state` interface.

## Test plan

- [ ] Start server with `--kv-cache-quantization --ssd-cache-dir /tmp/ssdcache`
- [ ] Drive enough traffic to populate >1 prefix cache entry
- [ ] Stop the server (SIGTERM)
- [ ] Verify shutdown log shows `[cache_persist] SAVED N/N entries` (not `1/N`)
- [ ] Restart and confirm persisted entries reload successfully
- [ ] Verify non-quantized mode is unchanged (regression check)

Fixes #443