### PR TITLE
fix: bind MLX streams in generate_batch_sync and test conftest (#420)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,26 @@ def server_url(request):
 def anyio_backend():
     """Run anyio-marked tests on asyncio only."""
     return "asyncio"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _bind_mlx_default_stream():
+    """Ensure the main-thread default MLX stream is set once at session start.
+
+    Tests that create worker threads with ``bind_generation_streams`` allocate
+    new MLX streams and call ``mx.set_default_stream``.  Because MLX streams
+    are thread-local, this is harmless to the main thread.  However, if a test
+    *on the main thread* calls ``bind_generation_streams`` (e.g. via
+    ``generate_batch_sync`` or a monkeypatch), the default stream changes and
+    later tests that assume the original default stream will fail with
+    ``RuntimeError: There is no Stream(gpu, N) in current thread``.
+
+    Binding once at session start gives all main-thread tests a known-good
+    default stream.
+    """
+    try:
+        import mlx.core as mx
+
+        mx.set_default_stream(mx.new_stream(mx.default_device()))
+    except ImportError:
+        pass

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -588,6 +588,11 @@ class EngineCore:
             self.scheduler.add_request(request)
             request_ids.append(request_id)
 
+        # Bind MLX generation streams to the calling thread so that
+        # scheduler.step() can evaluate KV cache state without hitting
+        # "There is no Stream(gpu, N) in current thread" errors.
+        bind_generation_streams()
+
         # Process until all done - direct scheduler access, no async overhead
         results: Dict[str, RequestOutput] = {}
         while self.scheduler.has_requests():


### PR DESCRIPTION
## Summary

- `generate_batch_sync` calls `scheduler.step()` directly without binding MLX generation streams to the calling thread. When the model was loaded on a different thread, this causes `RuntimeError: There is no Stream(gpu, N) in current thread`, which surfaces as 0 completion tokens in tests.
- Tests that create worker threads with `bind_generation_streams` (e.g. `test_engine_core_thread_streams`) can leave MLX stream state polluted for later tests running on the main thread.

Two changes:

1. Call `bind_generation_streams()` at the top of `generate_batch_sync` so the calling thread owns the required MLX streams before stepping.
2. Add a session-scoped autouse conftest fixture that creates a fresh default MLX stream on the main thread at test session start, preventing cross-test stream pollution.

Together these address the majority of test failures reported in #420:
- `test_model_registry` (`assert 0 > 0` in sequential engine tests, cache recovery, benchmark scenarios)
- `test_continuous_batching` integration tests (`assert 0 > 0` in single/concurrent request tests)
- `test_rerank` classifier_forward tests (`Stream(gpu, 5)` error)
- `test_engine_core_stream_safety` (cross-thread stream errors with Llama model)

## Remaining test failures from #420 that need separate investigation

- `test_engine_core_thread_streams::test_engine_core_runs_all_scheduler_steps_on_one_worker_thread`: monkeypatch `AttributeError` for `bind_generation_streams`. This may be Python 3.13-specific or related to import ordering. The attribute is set at module import time via `from .mlx_streams import bind_generation_streams`.
- `test_engine_core_thread_streams::test_mllm_scheduler_runs_steps_on_model_load_thread`: TimeoutError. Likely needs the `MLLMScheduler._process_loop` to be stubbed differently.

## Test plan

- [ ] Run `pytest tests/test_model_registry.py tests/test_continuous_batching.py tests/test_rerank.py tests/test_engine_core_stream_safety.py` on Apple Silicon with a small model available
- [ ] Verify `test_sequential_engines_with_close`, `test_sequential_engines_without_close`, `test_benchmark_like_usage` pass
- [ ] Verify `test_classifier_forward_returns_logits_shape` and `test_classifier_forward_different_num_labels` pass
- [ ] Verify no regressions in existing passing tests

Addresses #420