### PR TITLE
fix: release stale cache references to prevent Metal memory growth (#442)

### DIFF
--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1000,6 +1000,11 @@ class MLLMBatchGenerator:
             self._prefill_progress[request.request_id] = (total, total)
             output = self.language_model(input_ids, cache=cache)
             request.vision_encoded = True
+            # Release preprocessed inputs after encoding (issue #442)
+            request.pixel_values = None
+            request.attention_mask = None
+            request.image_grid_thw = None
+            request.extra_kwargs.clear()
             if hasattr(output, "logits"):
                 return output.logits
             return output
@@ -1053,6 +1058,11 @@ class MLLMBatchGenerator:
         last_chunk = input_ids[:, processed:]
         output = self.language_model(last_chunk, cache=cache)
         request.vision_encoded = True
+        # Release preprocessed inputs after encoding (issue #442)
+        request.pixel_values = None
+        request.attention_mask = None
+        request.image_grid_thw = None
+        request.extra_kwargs.clear()
         self._prefill_progress[request.request_id] = (total, total)
 
         if chunk_count > 0:
@@ -1102,6 +1112,15 @@ class MLLMBatchGenerator:
 
         output = self.model(input_ids, cache=cache, **kwargs)
         request.vision_encoded = True
+
+        # Release preprocessed vision inputs now that they have been encoded
+        # into the KV cache.  pixel_values can be hundreds of MB for multi-
+        # image requests; holding them pins Metal buffers for the entire
+        # generation duration (issue #442).
+        request.pixel_values = None
+        request.attention_mask = None
+        request.image_grid_thw = None
+        request.extra_kwargs.clear()
 
         # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
@@ -1505,6 +1524,16 @@ class MLLMBatchGenerator:
         has_any_sampler = any(batch_samplers)
 
         self._stats.prompt_time += time.perf_counter() - tic
+
+        # Release preprocessed vision inputs for all requests now that
+        # they have been encoded into the batch KV cache.  pixel_values,
+        # input_ids, etc. can be hundreds of MB per request; holding them
+        # for the entire generation duration pins Metal buffers (issue #442).
+        for req in requests:
+            req.pixel_values = None
+            req.attention_mask = None
+            req.image_grid_thw = None
+            req.extra_kwargs.clear()
 
         return MLLMBatch(
             uids=[req.uid for req in requests],

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1921,6 +1921,9 @@ class Scheduler:
 
         if request is not None:
             request.set_finished(RequestStatus.FINISHED_ABORTED)
+            # Release cache references so Metal buffers can be freed
+            request.prompt_cache = None
+            request._extracted_cache = None
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
 
@@ -2064,6 +2067,12 @@ class Scheduler:
                 self.uid_to_request_id[uid] = request.request_id
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
+                # Release the prompt cache reference now that BatchGenerator
+                # has its own copy.  Holding this reference prevents MLX from
+                # freeing the Metal buffers until the request object is GC'd,
+                # which under sustained traffic can accumulate hundreds of GB
+                # of wired memory (issue #442).
+                request.prompt_cache = None
                 self.running[request.request_id] = request
                 scheduled.append(request)
 
@@ -2327,6 +2336,14 @@ class Scheduler:
                         values_attr = layer.values
                         if not callable(keys_attr) and not callable(values_attr):
                             mx.eval(keys_attr, values_attr)
+
+            # Release all cache references on the request so Metal buffers
+            # can be freed.  The prefix cache (if any) holds its own copy;
+            # keeping a second reference here pins the buffers in wired memory
+            # until the request object is GC'd (issue #442).
+            if request is not None:
+                request.prompt_cache = None
+                request._extracted_cache = None
 
             # Remove from running
             if request_id in self.running:


### PR DESCRIPTION
## Summary

Under sustained traffic, Metal wired memory grows unbounded because request objects retain references to MLX arrays that have already been copied into the BatchGenerator. The Metal buffer cache cannot free these buffers while Python references exist, even after `mx.clear_cache()`.

Three sources of leaked references, all fixed in this PR:

- **`request.prompt_cache`** (LLM scheduler path): Set during prefix cache fetch, never cleared after the cache is passed to `BatchGenerator.insert()`. Every request with a cache hit retains a full KV cache reference for the duration of generation plus until the request object is GC'd. For a 35B model this can be 100MB+ per request.

- **`request._extracted_cache`** (LLM scheduler path): Cleared for memory_aware_cache storage but not for the legacy prefix_cache path, not on storage failure, and not in the abort path.

- **`MLLMBatchRequest.pixel_values` / `attention_mask` / `image_grid_thw` / `extra_kwargs`** (MLLM batch generator): Set during preprocessing, never cleared after vision encoding. For multi-image VLM requests, `pixel_values` can be hundreds of MB and stays pinned in Metal memory for the entire generation duration.

All references are now released at the earliest safe point:
- `prompt_cache` cleared immediately after successful `BatchGenerator.insert()`
- Both `_extracted_cache` and `prompt_cache` cleared in `_cleanup_finished` and `_do_abort_request`
- Vision inputs cleared after each vision encoding / prefill path and at the end of `_process_prompts`

## Test plan

- [ ] Run the server with sustained traffic (6+ concurrent requests) for 2+ hours
- [ ] Monitor `mx.get_active_memory()`, `mx.get_cache_memory()`, and system wired memory via `vm_stat`
- [ ] Verify Metal memory stabilizes and does not grow monotonically
- [ ] Verify prefix cache hits still work correctly (cache is used before release)
- [ ] Verify MLLM (VLM) requests still generate correct output after vision input cleanup
- [ ] Verify abort/timeout paths properly release Metal buffers

Addresses #442