### PR TITLE
fix: credit in-flight tokens on request abort

### DIFF
--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -466,6 +466,12 @@ class MLLMScheduler:
         if request_id in self.running:
             del self.running[request_id]
 
+        # Credit in-flight tokens so dashboard metrics stay accurate
+        # (without this, aborted requests' tokens vanish from /v1/status).
+        if request.num_output_tokens > 0:
+            self.total_completion_tokens += request.num_output_tokens
+            self.total_prompt_tokens += request.num_prompt_tokens
+
         # Mark as aborted
         request.status = RequestStatus.FINISHED_ABORTED
         self.finished_req_ids.add(request_id)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1919,6 +1919,12 @@ class Scheduler:
         if request_id in self.running:
             del self.running[request_id]
 
+        # Credit in-flight tokens so dashboard metrics stay accurate
+        # (without this, aborted requests' tokens vanish from /v1/status).
+        if request is not None and request.num_output_tokens > 0:
+            self.total_completion_tokens += request.num_output_tokens
+            self.total_prompt_tokens += request.num_prompt_tokens
+
         if request is not None:
             request.set_finished(RequestStatus.FINISHED_ABORTED)
         self.finished_req_ids.add(request_id)


### PR DESCRIPTION
## Summary

- When a request is aborted (timeout, client disconnect, orphan cleanup), its in-flight `completion_tokens` and `prompt_tokens` were silently discarded
- `/v1/status` `total_completion_tokens` only reflected normally completed requests
- Monitoring dashboards that compute throughput as `delta(total_completion_tokens) / delta(time)` showed **0.0 tok/s** whenever a batch of requests timed out simultaneously, because the in-flight tokens vanished from both the per-request array and the running total

## Fix

Add token accounting to `abort_request()` in both schedulers (`mllm_scheduler.py` and `scheduler.py`): credit `num_output_tokens` and `num_prompt_tokens` to the running totals **before** removing the request.

## Files changed

- `vllm_mlx/mllm_scheduler.py` — `abort_request()`: credit tokens before marking as aborted
- `vllm_mlx/scheduler.py` — `_do_abort_request()`: credit tokens before marking as aborted

## Test plan

- [x] Verified `/v1/status` `total_completion_tokens` increments on abort (production server)
- [x] Dashboard no longer drops to 0.0 tok/s on timeout-induced batch abort
- [x] Normal request completion path unaffected (tokens still credited in `_process_outputs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)