### PR TITLE
fix: JSON schema enforcer stuck on arrays of objects

### DIFF
--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -615,5 +615,93 @@ class TestIncrementalCaching:
                 assert arr[i] == -np.inf, f"Position {i} should be -inf"
 
 
+# ---------------------------------------------------------------------------
+# JSON context — array vs object discrimination.
+# ---------------------------------------------------------------------------
+
+
+@pytestmark_lmfe
+class TestJsonContextArrayVsObject:
+    """Verify ``_get_json_context`` distinguishes array from object context.
+
+    Regression test: after ``},`` inside a JSON array, the processor returned
+    ``"key_start"`` and ``_filter_key_start_tokens`` removed ``{``, preventing
+    the next array element from being generated.  The fix uses a container
+    stack to track nesting so ``"key_start"`` is only returned inside objects.
+    """
+
+    def _make_processor(self, schema: dict | None = None):
+        from vllm_mlx.constrained import JSONSchemaLogitsProcessor
+
+        tok = _FakeTokenizer()
+        return JSONSchemaLogitsProcessor(schema, tok), tok
+
+    def test_comma_inside_object_returns_key_start(self):
+        """``{"a": 1,`` → key_start (inside an object)."""
+        import mlx.core as mx
+
+        proc, tok = self._make_processor()
+        text = '{"a": 1,'
+        tokens = tok.encode(text)
+        # Prime prompt_len
+        proc(mx.array([], dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+        # Simulate generation of these tokens
+        for t in tokens:
+            proc(
+                mx.array(tokens[: tokens.index(t) + 1], dtype=mx.int32),
+                mx.zeros((tok.vocab_size,)),
+            )
+        ctx = proc._get_json_context(tokens)
+        assert ctx == "key_start", f"Expected key_start inside object, got {ctx!r}"
+
+    def test_comma_inside_array_returns_other(self):
+        """``[1,`` → other (inside an array, NOT key_start)."""
+        import mlx.core as mx
+
+        proc, tok = self._make_processor()
+        text = "[1,"
+        tokens = tok.encode(text)
+        proc(mx.array([], dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+        for t in tokens:
+            proc(
+                mx.array(tokens[: tokens.index(t) + 1], dtype=mx.int32),
+                mx.zeros((tok.vocab_size,)),
+            )
+        ctx = proc._get_json_context(tokens)
+        assert ctx == "other", f"Expected other inside array, got {ctx!r}"
+
+    def test_brace_after_comma_in_array_is_allowed(self):
+        """After ``[{...},`` the context must be ``"other"`` (not ``"key_start"``).
+
+        This verifies that ``_get_json_context`` does not trigger the key
+        filter at array element boundaries.  We check the context directly
+        rather than the full mask because the FakeTokenizer causes the
+        lm-format-enforcer to get stuck (empty allowed set), which triggers
+        the EOS-force recovery path.
+        """
+        import mlx.core as mx
+
+        proc, tok = self._make_processor()
+
+        # Feed ``[{"n": "a"},``
+        text = '[{"n": "a"},'
+        tokens = tok.encode(text)
+        # Prefill
+        proc(mx.array([], dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+        # Generate each token to update incremental context state
+        for i, t in enumerate(tokens):
+            proc(
+                mx.array(tokens[: i + 1], dtype=mx.int32),
+                mx.zeros((tok.vocab_size,)),
+            )
+
+        # The context after `},` inside an array must NOT be "key_start"
+        ctx = proc._get_json_context(tokens)
+        assert ctx == "other", (
+            f"_get_json_context returned {ctx!r} after comma in array — "
+            f"should be 'other', not 'key_start'"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -337,6 +337,12 @@ class JSONSchemaLogitsProcessor:
         self._brace_depth: int = 0
         self._bracket_depth: int = 0
 
+        # Container nesting stack for distinguishing object vs array context.
+        # Entries are ``"o"`` (object/brace) or ``"a"`` (array/bracket).
+        # Used by ``_get_json_context`` to return ``"key_start"`` only when
+        # inside an object — NOT when inside an array after ``,``.
+        self._container_stack: list[str] = []
+
     # ------------------------------------------------------------------
 
     def _suffix(self, tokens_list: list[int]) -> list[int]:
@@ -406,6 +412,7 @@ class JSONSchemaLogitsProcessor:
             self._json_ctx_last_quote_pos = -1
             self._brace_depth = 0
             self._bracket_depth = 0
+            self._container_stack = []
 
         self._cached_suffix_text = result
         self._cached_suffix_len = suffix_len
@@ -462,6 +469,7 @@ class JSONSchemaLogitsProcessor:
             last_quote_pos = self._json_ctx_last_quote_pos
             brace_depth = self._brace_depth
             bracket_depth = self._bracket_depth
+            container_stack = self._container_stack
             i = self._json_ctx_scanned_len
             while i < text_len:
                 ch = text[i]
@@ -477,12 +485,18 @@ class JSONSchemaLogitsProcessor:
                         last_quote_pos = i
                     elif ch == "{":
                         brace_depth += 1
+                        container_stack.append("o")
                     elif ch == "}":
                         brace_depth -= 1
+                        if container_stack and container_stack[-1] == "o":
+                            container_stack.pop()
                     elif ch == "[":
                         bracket_depth += 1
+                        container_stack.append("a")
                     elif ch == "]":
                         bracket_depth -= 1
+                        if container_stack and container_stack[-1] == "a":
+                            container_stack.pop()
                 i += 1
             self._json_ctx_in_string = in_string
             self._json_ctx_last_quote_pos = last_quote_pos
@@ -495,6 +509,7 @@ class JSONSchemaLogitsProcessor:
             last_quote_pos = -1
             brace_depth = 0
             bracket_depth = 0
+            container_stack: list[str] = []
             i = 0
             while i < text_len:
                 ch = text[i]
@@ -510,22 +525,32 @@ class JSONSchemaLogitsProcessor:
                         last_quote_pos = i
                     elif ch == "{":
                         brace_depth += 1
+                        container_stack.append("o")
                     elif ch == "}":
                         brace_depth -= 1
+                        if container_stack and container_stack[-1] == "o":
+                            container_stack.pop()
                     elif ch == "[":
                         bracket_depth += 1
+                        container_stack.append("a")
                     elif ch == "]":
                         bracket_depth -= 1
+                        if container_stack and container_stack[-1] == "a":
+                            container_stack.pop()
                 i += 1
             self._json_ctx_in_string = in_string
             self._json_ctx_last_quote_pos = last_quote_pos
             self._json_ctx_scanned_len = text_len
             self._brace_depth = brace_depth
             self._bracket_depth = bracket_depth
+            self._container_stack = container_stack
 
         if self._json_ctx_in_string:
             before = text[: self._json_ctx_last_quote_pos].rstrip()
             if not before or before[-1] in ("{", ","):
+                # Only treat as key if we're inside an object, not an array.
+                if self._container_stack and self._container_stack[-1] == "a":
+                    return "other"
                 return "in_key"
             return "other"
 
@@ -533,6 +558,13 @@ class JSONSchemaLogitsProcessor:
         if not stripped:
             return "other"
         if stripped[-1] in ("{", ","):
+            # Only return key_start when inside an object.  After a comma
+            # inside an array (e.g. ``[{...},``), the next element is a
+            # value, not a key — returning "key_start" here would cause
+            # _filter_key_start_tokens to block valid array element tokens
+            # like ``{``.
+            if self._container_stack and self._container_stack[-1] == "a":
+                return "other"
             return "key_start"
         return "other"
 
@@ -677,6 +709,16 @@ class JSONSchemaLogitsProcessor:
     def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
         """Apply the allowed-tokens mask to ``logits``."""
         if self._disabled:
+            # Force EOS immediately — the enforcer got stuck, so continued
+            # generation produces garbage.  Without this cap the model would
+            # generate up to max_tokens (often 262 K) of useless output,
+            # blocking the slot for minutes/hours.
+            if self._eos_set:
+                actual_vocab = logits.shape[-1]
+                mask = self._build_allow_mask(sorted(self._eos_set), actual_vocab)
+                if logits.ndim == 2 and logits.shape[0] == 1:
+                    mask = mask[None, :]
+                return logits + mask
             return logits
 
         try:
@@ -722,11 +764,17 @@ class JSONSchemaLogitsProcessor:
                 if self._suffix_is_complete_json(suffix) and self._eos_set:
                     allowed_list = sorted(self._eos_set)
                 else:
+                    try:
+                        decoded = self._tokenizer.decode(suffix)
+                    except Exception:
+                        decoded = "<decode-error>"
                     logger.warning(
                         "JSONLP: enforcer stuck (empty allowed-set at "
-                        "suffix_len=%d); disabling constrained decoding "
-                        "for this request",
+                        "suffix_len=%d, suffix_tokens=%s, decoded=%r); "
+                        "disabling constrained decoding for this request",
                         len(suffix),
+                        suffix[:10],
+                        decoded[:80],
                     )
                     self._disabled = True
                     return logits


### PR DESCRIPTION
## Summary

Two fixes for constrained JSON decoding (`response_format: json_schema`):

1. **Array context bug**: `_get_json_context()` returned `"key_start"` after commas inside JSON arrays (e.g. `[{...},`), not just inside objects. The schema-aware key filter then removed `{` from allowed tokens (since it doesn't match any property name), causing the enforcer to get stuck with an empty allowed set. The processor disabled itself and the model generated freely, producing degenerate output.

2. **Force EOS on disable**: When the enforcer gets stuck and disables itself, the processor now forces EOS immediately instead of passing logits through unchanged. Previously, with `max_tokens=262144`, the model would continue generating useless output for minutes/hours, blocking the inference slot and never returning a response to the client.

**Fix #1**: Added `_container_stack` to track whether the current nesting context is an object (`"o"`) or array (`"a"`). `_get_json_context` now returns `"key_start"` / `"in_key"` only inside objects.

**Fix #2**: When `_disabled=True`, return an EOS-only mask instead of unmodified logits. Generation stops immediately and the server returns whatever was generated (the JSON extraction layer can often recover valid JSON from partial output).

## Test plan

- [x] 3 new tests in `TestJsonContextArrayVsObject`
- [x] All 28 constrained decoding tests pass
- [x] Live tested on 2 production servers (Qwen3.6-35B-A3B, Qwen3.6-27B) — all schemas produce valid JSON
- [x] Verified stuck requests now return in seconds instead of blocking for hours
- [x] 4 concurrent requests with `max_tokens=262144` all return quickly with valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)