### PR TITLE
Fix generation_tps always 0 in batch stats, expose in /v1/status

### DIFF
--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1046,6 +1046,7 @@ class BatchedEngine(BaseEngine):
                 "memory_aware_cache",
                 "paged_cache",
                 "prefix_cache",
+                "batch_generator",
                 "requests",
             ):
                 if key in mllm_stats:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1715,9 +1715,12 @@ class MLLMBatchGenerator:
         y = y.tolist()
         toc = time.perf_counter()
 
-        if prompt_processing:
+        if prompt_processing and num_active == 0:
+            # Pure prompt processing (new batch, no prior generation)
             self._stats.prompt_time += toc - tic
         else:
+            # Generation step — even if a new request was extended into the
+            # batch, the dominant cost is generating for all existing requests.
             self._stats.generation_time += toc - tic
 
         # Build responses and track finished

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2685,6 +2685,9 @@ async def status():
 
     stats = _engine.get_stats()
 
+    # Extract batch_generator throughput when available (MLLM scheduler).
+    bg = stats.get("batch_generator", {})
+
     return {
         "status": "running" if stats.get("running") else "stopped",
         "model": _model_name,
@@ -2696,6 +2699,8 @@ async def status():
         "total_requests_processed": stats.get("num_requests_processed", 0),
         "total_prompt_tokens": stats.get("total_prompt_tokens", 0),
         "total_completion_tokens": stats.get("total_completion_tokens", 0),
+        "generation_tps": bg.get("generation_tps", 0),
+        "prompt_tps": bg.get("prompt_tps", 0),
         "metal": {
             "active_memory_gb": stats.get("metal_active_memory_gb"),
             "peak_memory_gb": stats.get("metal_peak_memory_gb"),


### PR DESCRIPTION
## Summary

- **Fix `batch_generator` stats not propagated**: `BatchedEngine.get_stats()` promotes selected keys from MLLM scheduler stats to top-level, but `batch_generator` was missing from the promoted keys list. This caused `generation_tps` and `prompt_tps` to always be 0 in `/v1/status`.
- **Fix batch extension time attribution**: Mid-generation batch extension (text-only requests joining an active batch) set `prompt_processing=True`, causing the entire step time to be attributed to `prompt_time` even though the dominant cost is generating tokens for existing requests. This made `generation_tps` permanently 0 while `prompt_tps` was artificially inflated.
- **Expose `generation_tps` and `prompt_tps`** from `MLLMBatchStats` in the `/v1/status` endpoint so monitoring dashboards can consume server-side throughput metrics.

## Test plan

- [x] Verify `generation_tps > 0` in `/v1/status` response during active generation (23.3 tok/s on 27B, 38.0 tok/s on 35B-A3B)
- [x] Verify `prompt_tps` reflects actual prompt processing time
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)