### PR TITLE
fix: streaming parser drops content newlines when tool parser active

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4994,6 +4994,7 @@ async def stream_chat_completion(
     tool_accumulated_text = ""
     tool_calls_detected = False
     tool_markup_possible = False  # Fast path: skip parsing until markers appear
+    _first_content_emitted = False
     tool_parser = _get_streaming_tool_parser(request, engine)
 
     try:
@@ -5052,9 +5053,7 @@ async def stream_chat_completion(
                         )
                     ):
                         tool_accumulated_text += content
-                        # Suppress whitespace-only content when tools are active;
-                        # avoids emitting stray newlines before tool call XML.
-                        if not content.strip():
+                        if not content.strip() and not _first_content_emitted:
                             continue
                     else:
                         if not tool_markup_possible:
@@ -5134,6 +5133,8 @@ async def stream_chat_completion(
                         if flush:
                             content = content + flush
 
+                if content and not _first_content_emitted:
+                    _first_content_emitted = True
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=_model_name,


### PR DESCRIPTION
## Summary

- Streaming whitespace suppression ate ALL whitespace-only chunks when a tool parser was configured, not just the leading whitespace between `</think>` and first content
- Newlines between list items, paragraphs, and other structured content were silently dropped
- Gate on `_first_content_emitted` flag so only pre-content whitespace is suppressed

## Before/After

**Before:** `1. London2. Paris3. Berlin4. Rome5. Madrid`
**After:** `1. London\n2. Paris\n3. Berlin\n4. Rome\n5. Madrid`

Non-streaming and responses without tool parser were unaffected.

## Test plan

- [ ] Stream a numbered list request with `enable_thinking=true` and a tool parser configured
- [ ] Verify newlines appear between list items in the streamed content
- [ ] Verify leading whitespace between `</think>` and first content is still suppressed
- [ ] Verify tool call XML parsing still works (not broken by passing through whitespace)

Closes #462