### PR TITLE
fix: enforce workload timeouts in bench serve

### DIFF
--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -38,6 +38,7 @@ from vllm_mlx.bench_serve import (
     parse_status_response,
     run_bench_serve_workload,
     run_workload_case,
+    stream_chat_completion,
     summarize_workload_results,
     validate_quality_checks,
     validate_response,
@@ -622,6 +623,7 @@ class TestSSEParsing:
     def _make_line(self, delta_content=None, finish_reason=None, usage=None):
         """Build a synthetic SSE data line."""
         chunk: dict = {
+            "id": "chatcmpl-test",
             "choices": [
                 {
                     "delta": (
@@ -629,7 +631,7 @@ class TestSSEParsing:
                     ),
                     "finish_reason": finish_reason,
                 }
-            ]
+            ],
         }
         if usage is not None:
             chunk["usage"] = usage
@@ -639,6 +641,7 @@ class TestSSEParsing:
         line = self._make_line(delta_content="Hello")
         result = parse_sse_line(line)
         assert result is not None
+        assert result["id"] == "chatcmpl-test"
         assert result["content"] == "Hello"
         assert result["finish_reason"] is None
         assert result["usage"] is None
@@ -725,6 +728,53 @@ class TestRequestMetrics:
         )
         # Single token → no inter-token interval → TPOT = 0.0
         assert metrics["tpot_ms"] == pytest.approx(0.0)
+
+    def test_stream_chat_completion_timeout_cancels_request(self):
+        class SlowResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_lines(self):
+                yield 'data: {"id":"chatcmpl-timeout","choices":[{"delta":{"content":"A"},"finish_reason":null}]}'
+                await asyncio.sleep(10)
+
+        class FakeClient:
+            def __init__(self):
+                self.cancel_urls = []
+
+            def stream(self, *args, **kwargs):
+                return SlowResponse()
+
+            async def post(self, url, **kwargs):
+                self.cancel_urls.append(url)
+
+                class Response:
+                    status_code = 200
+
+                return Response()
+
+        client = FakeClient()
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            asyncio.run(
+                stream_chat_completion(
+                    client=client,
+                    base_url="http://server",
+                    messages=[{"role": "user", "content": "slow"}],
+                    model="test-model",
+                    timeout_s=0.01,
+                )
+            )
+
+        assert client.cancel_urls == [
+            "http://server/v1/requests/chatcmpl-timeout/cancel"
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -1021,6 +1071,7 @@ class TestWorkloadRunner:
             assert kwargs["max_tokens"] == 64
             assert kwargs["enable_thinking"] is True
             assert kwargs["extra_body"] == {"temperature": 0.6}
+            assert kwargs["timeout_s"] == 1.8
             return {
                 "ttft_ms": 25.0,
                 "tpot_ms": 3.0,

--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -656,7 +656,8 @@ def parse_sse_line(line: str) -> Optional[dict]:
         ``data: [DONE]`` sentinel.  For all other ``data:`` lines the JSON is
         parsed and a dict is returned::
 
-            {"content": str, "finish_reason": Optional[str], "usage": Optional[dict]}
+            {"id": Optional[str], "content": str,
+             "finish_reason": Optional[str], "usage": Optional[dict]}
 
         Missing keys (``choices``, ``delta``, ``content``) are handled
         gracefully and default to empty string / ``None``.
@@ -684,10 +685,27 @@ def parse_sse_line(line: str) -> Optional[dict]:
     usage = chunk.get("usage")
 
     return {
+        "id": chunk.get("id"),
         "content": content,
         "finish_reason": finish_reason,
         "usage": usage,
     }
+
+
+async def _cancel_server_request(
+    client: httpx.AsyncClient,
+    base_url: str,
+    request_id: Optional[str],
+) -> None:
+    """Best-effort server-side cancellation for timed-out workload streams."""
+    if not request_id:
+        return
+    try:
+        await client.post(f"{base_url}/v1/requests/{request_id}/cancel", timeout=5.0)
+    except Exception:
+        # Older servers may not expose request cancellation. Closing the stream
+        # still gives the server disconnect signal; this endpoint is best effort.
+        pass
 
 
 def compute_request_metrics(
@@ -790,6 +808,7 @@ async def stream_chat_completion(
     max_tokens: int = 256,
     enable_thinking: Optional[bool] = None,
     extra_body: Optional[dict] = None,
+    timeout_s: Optional[float] = None,
 ) -> dict:
     """Send a streaming chat completion and collect per-token timing data.
 
@@ -805,6 +824,9 @@ async def stream_chat_completion(
         enable_thinking: If not ``None``, passed as ``enable_thinking`` in the
             request body.
         extra_body: Optional extra keys merged into the request body.
+        timeout_s: Optional case-level timeout. When set, the stream is closed
+            and best-effort server cancellation is attempted before raising
+            :class:`TimeoutError`.
 
     Returns:
         Dict with all :func:`compute_request_metrics` fields plus
@@ -829,26 +851,43 @@ async def stream_chat_completion(
     content_parts: list[str] = []
     finish_reason: Optional[str] = None
     usage: Optional[dict] = None
+    request_id: Optional[str] = None
 
-    async with client.stream(
-        "POST", f"{base_url}/v1/chat/completions", json=body
-    ) as response:
-        response.raise_for_status()
-        async for raw_line in response.aiter_lines():
-            parsed = parse_sse_line(raw_line)
-            if parsed is None:
-                continue
-            if parsed.get("usage"):
-                usage = parsed["usage"]
-            if parsed.get("finish_reason"):
-                finish_reason = parsed["finish_reason"]
-            chunk_content = parsed.get("content", "")
-            if chunk_content:
-                now = time.perf_counter()
-                if t_first_token is None:
-                    t_first_token = now
-                token_times.append(now)
-                content_parts.append(chunk_content)
+    async def _consume_stream() -> None:
+        nonlocal finish_reason, request_id, t_first_token, usage
+        async with client.stream(
+            "POST", f"{base_url}/v1/chat/completions", json=body
+        ) as response:
+            response.raise_for_status()
+            async for raw_line in response.aiter_lines():
+                parsed = parse_sse_line(raw_line)
+                if parsed is None:
+                    continue
+                if parsed.get("id"):
+                    request_id = parsed["id"]
+                if parsed.get("usage"):
+                    usage = parsed["usage"]
+                if parsed.get("finish_reason"):
+                    finish_reason = parsed["finish_reason"]
+                chunk_content = parsed.get("content", "")
+                if chunk_content:
+                    now = time.perf_counter()
+                    if t_first_token is None:
+                        t_first_token = now
+                    token_times.append(now)
+                    content_parts.append(chunk_content)
+
+    try:
+        if timeout_s and timeout_s > 0:
+            async with asyncio.timeout(timeout_s):
+                await _consume_stream()
+        else:
+            await _consume_stream()
+    except TimeoutError:
+        await _cancel_server_request(client, base_url, request_id)
+        raise TimeoutError(
+            f"stream_chat_completion timed out after {timeout_s:.3f}s"
+        ) from None
 
     t_end = time.perf_counter()
     if t_first_token is None:
@@ -1117,6 +1156,11 @@ async def run_workload_case(
             max_tokens=int(case.max_tokens or workload.defaults.get("max_tokens", 256)),
             enable_thinking=case.enable_thinking,
             extra_body=case.extra_body,
+            timeout_s=(
+                case.policy_timeout_ms / 1000
+                if case.policy_timeout_ms is not None
+                else None
+            ),
         )
         error = ""
     except Exception as exc:


### PR DESCRIPTION
## Summary

I changed bench-serve workload execution so a case-level policy_timeout_ms now acts as an execution boundary for that case, not just post-hoc metadata. When a streaming request exceeds the timeout, bench-serve closes the stream, attempts best-effort server-side cancellation using the OpenAI stream id, and records the case as a request error instead of allowing the qualification run to hang indefinitely.

This also preserves the stream id from SSE chunks so the cancellation endpoint can be addressed when the server supports /v1/requests/{id}/cancel. Servers without that endpoint continue to work because cancellation is best-effort.

## Why

Long-thinking qualification cases can otherwise pin a workload run well past the intended case budget. That makes feature-matrix results hard to trust because one pathological case can block stage progress and leave operators guessing whether the harness or the runtime is stuck.

## Tests

- python -m pytest -q tests/test_bench_serve.py
- uvx ruff check vllm_mlx/bench_serve.py tests/test_bench_serve.py --select E,F,W --ignore E402,E501,E731,F811,F841
- black --check --target-version py312 vllm_mlx/bench_serve.py tests/test_bench_serve.py