### PR TITLE
Fix MLLM prefix cache disable wiring

### DIFF
--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -1,0 +1,79 @@
+"""BatchedEngine MLLM scheduler configuration wiring tests.
+
+These tests avoid model loading and MLX imports. They validate that CLI-level
+SchedulerConfig fields survive the BatchedEngine -> MLLMSchedulerConfig bridge.
+"""
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+
+def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch):
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    captured = {}
+
+    class FakeMLXMultimodalLM:
+        def __init__(self, model_name, trust_remote_code=True, **kwargs):
+            self.model_name = model_name
+            self.model = object()
+            self.processor = object()
+
+        def load(self):
+            return None
+
+    class FakeMLLMSchedulerConfig:
+        def __init__(self, **kwargs):
+            captured["config_kwargs"] = kwargs
+            self.__dict__.update(kwargs)
+
+    class FakeMLLMScheduler:
+        def __init__(self, model, processor, config):
+            captured["scheduler_config"] = config
+
+        async def start(self):
+            return None
+
+    import vllm_mlx.engine.batched as batched_mod
+
+    fake_mllm_scheduler = types.ModuleType("vllm_mlx.mllm_scheduler")
+    fake_mllm_scheduler.MLLMScheduler = FakeMLLMScheduler
+    fake_mllm_scheduler.MLLMSchedulerConfig = FakeMLLMSchedulerConfig
+    fake_mllm_model = types.ModuleType("vllm_mlx.models.mllm")
+    fake_mllm_model.MLXMultimodalLM = FakeMLXMultimodalLM
+    monkeypatch.setitem(sys.modules, "vllm_mlx.mllm_scheduler", fake_mllm_scheduler)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.models.mllm", fake_mllm_model)
+    monkeypatch.setattr(
+        batched_mod.BatchedEngine, "_inject_mtp_mllm", lambda self: None
+    )
+
+    engine = BatchedEngine(
+        model_name="fake-qwen",
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=16,
+            prefill_batch_size=4,
+            completion_batch_size=8,
+            prefill_step_size=256,
+            mllm_prefill_step_size=None,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            cache_memory_mb=123,
+            enable_mtp=False,
+            mtp_num_draft_tokens=1,
+            kv_cache_quantization=False,
+            kv_cache_quantization_bits=8,
+            kv_cache_quantization_group_size=64,
+            chunked_prefill_tokens=0,
+            max_kv_size=0,
+        ),
+        force_mllm=True,
+    )
+
+    asyncio.run(engine._start_mllm())
+
+    assert captured["config_kwargs"]["enable_prefix_cache"] is False
+    assert captured["config_kwargs"]["use_memory_aware_cache"] is False
+    assert captured["config_kwargs"]["cache_memory_mb"] == 123
+    assert captured["config_kwargs"]["prefix_cache_memory_mb"] == 123

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1280,6 +1280,9 @@ class TestBatchedMLLMConfigWiring:
             prefill_batch_size=4,
             completion_batch_size=8,
             prefill_step_size=256,
+            enable_prefix_cache=False,
+            use_memory_aware_cache=False,
+            cache_memory_mb=123,
             enable_mtp=False,
         )
         engine = BatchedEngine(
@@ -1291,6 +1294,10 @@ class TestBatchedMLLMConfigWiring:
         asyncio.run(engine._start_mllm())
 
         assert captured["config_kwargs"]["prefill_step_size"] == 256
+        assert captured["config_kwargs"]["enable_prefix_cache"] is False
+        assert captured["config_kwargs"]["use_memory_aware_cache"] is False
+        assert captured["config_kwargs"]["cache_memory_mb"] == 123
+        assert captured["config_kwargs"]["prefix_cache_memory_mb"] == 123
 
 
 class TestPreprocessIdempotent:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -316,6 +316,15 @@ class BatchedEngine(BaseEngine):
 
         cache_memory_mb = getattr(self._scheduler_config, "cache_memory_mb", None)
         max_kv_size = getattr(self._scheduler_config, "max_kv_size", 0)
+        enable_prefix_cache = getattr(
+            self._scheduler_config, "enable_prefix_cache", True
+        )
+        use_memory_aware_cache = getattr(
+            self._scheduler_config, "use_memory_aware_cache", True
+        )
+        prefix_cache_memory_mb = getattr(
+            self._scheduler_config, "cache_memory_mb", None
+        )
         enable_mtp = (
             self._scheduler_config.enable_mtp if self._scheduler_config else False
         )
@@ -347,6 +356,9 @@ class BatchedEngine(BaseEngine):
             enable_vision_cache=True,
             vision_cache_size=100,
             cache_memory_mb=cache_memory_mb,
+            enable_prefix_cache=enable_prefix_cache,
+            use_memory_aware_cache=use_memory_aware_cache,
+            prefix_cache_memory_mb=prefix_cache_memory_mb,
             enable_mtp=enable_mtp,
             mtp_num_draft_tokens=mtp_num_draft,
             kv_cache_quantization=kv_quant,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -72,6 +72,9 @@ class MLLMSchedulerConfig:
     mtp_num_draft_tokens: int = 1
     # Enable KV prefix cache for text-only requests
     enable_prefix_cache: bool = True
+    # MLLM supports the memory-aware prefix cache only; if disabled, prefix
+    # caching is disabled rather than silently falling back to another cache.
+    use_memory_aware_cache: bool = True
     # Memory limit for prefix cache (None = auto-detect)
     prefix_cache_memory_mb: Optional[int] = None
     # KV cache quantization for prefix cache store/fetch
@@ -294,7 +297,7 @@ class MLLMScheduler:
             # Quantization happens on store(), dequantization on fetch() —
             # the model always receives normal KVCache with plain arrays.
             prefix_cache_config = None
-            if self.config.enable_prefix_cache:
+            if self.config.enable_prefix_cache and self.config.use_memory_aware_cache:
                 prefix_cache_config = MemoryCacheConfig(
                     max_memory_mb=self.config.prefix_cache_memory_mb,
                     kv_quantize=self.config.kv_cache_quantization,


### PR DESCRIPTION
## Summary

Fixes the MLLM continuous-batching path so cache disable flags actually reach `MLLMSchedulerConfig`.

Before this change, the serve CLI computed `enable_prefix_cache = args.enable_prefix_cache and not args.disable_prefix_cache`, but `BatchedEngine._start_mllm()` did not forward that value into the MLLM scheduler. As a result, `--disable-prefix-cache` could still create `MemoryAwarePrefixCache` on MLLM continuous batching.

This also forwards `use_memory_aware_cache`. MLLM currently only has a memory-aware prefix cache implementation, so `--no-memory-aware-cache` disables MLLM prefix caching instead of silently creating the memory-aware cache anyway.

## Why

This addresses the latest #442 telemetry where current main plus `--max-kv-size 65536` still showed `memory_aware_cache` entries growing even when the server was started with `--disable-prefix-cache`.

## Tests

- `python -m pytest tests/test_batched_engine_mllm_config.py -q`
- `python -m pytest tests/test_mllm_continuous_batching.py::TestBatchedMLLMConfigWiring::test_batched_engine_forwards_prefill_step_size_to_mllm_scheduler -q -rs` (skips locally without MLX, should run in CI)

## Notes

This does not claim to close all Metal memory growth in #442. It fixes the first concrete control-plane bug exposed by the new data: cache-off flags were not actually honored by the MLLM continuous-batching path. After this lands, the clean next reproduction is current main with `--max-kv-size 65536 --disable-prefix-cache` and sustained traffic to see whether `memory_aware_cache.entry_count` remains zero and whether Metal active memory plateaus.