### PR TITLE
Fix streamed tool-call qualification

### DIFF
--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from vllm_mlx.engine.batched import _normalize_tool_call_arguments_for_template
+
 
 class TestBatchedEngineGenerate:
     """Test BatchedEngine.generate() output fields."""
@@ -182,3 +184,54 @@ class TestBatchedEngineAbortRequest:
         engine._engine = None
 
         assert await engine.abort_request("req-1") is False
+
+
+class TestToolCallReplayNormalization:
+    """Tests for OpenAI tool-call replay normalization before chat templating."""
+
+    def test_parses_function_arguments_string_to_mapping(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Tokyo"}',
+                        },
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "city": "Tokyo"
+        }
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
+            '{"city": "Tokyo"}'
+        )
+
+    def test_wraps_non_mapping_arguments_for_template_items(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "echo",
+                            "arguments": '["not", "object"]',
+                        }
+                    }
+                ],
+            }
+        ]
+
+        normalized = _normalize_tool_call_arguments_for_template(messages)
+
+        assert normalized[0]["tool_calls"][0]["function"]["arguments"] == {
+            "value": ["not", "object"]
+        }

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -19,10 +19,12 @@ from vllm_mlx.bench_serve import (
     Workload,
     WorkloadCase,
     _validate_sql_identifier,
+    accumulate_tool_calls,
     compute_request_metrics,
     compute_summary_stats,
     detect_hardware_fingerprint,
     expand_sweep,
+    finalize_tool_calls,
     format_csv,
     format_json,
     format_sql,
@@ -674,6 +676,81 @@ class TestSSEParsing:
         assert result is not None
         assert result["finish_reason"] == "stop"
 
+    def test_parse_tool_call_delta(self):
+        chunk = {
+            "id": "chatcmpl-test",
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city"',
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        result = parse_sse_line(f"data: {json.dumps(chunk)}")
+
+        assert result is not None
+        assert result["tool_calls_delta"][0]["function"]["name"] == "get_weather"
+
+
+class TestToolCallAccumulation:
+    """Unit tests for streamed tool-call delta accumulation."""
+
+    def test_accumulates_split_arguments(self):
+        acc: dict[int, dict] = {}
+
+        accumulate_tool_calls(
+            acc,
+            [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city"'},
+                }
+            ],
+        )
+        accumulate_tool_calls(
+            acc,
+            [{"index": 0, "function": {"arguments": ': "Tokyo"}'}}],
+        )
+
+        assert finalize_tool_calls(acc) == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Tokyo"}',
+                },
+            }
+        ]
+
+    def test_preserves_index_order(self):
+        acc: dict[int, dict] = {}
+
+        accumulate_tool_calls(
+            acc,
+            [
+                {"index": 1, "function": {"name": "b", "arguments": "{}"}},
+                {"index": 0, "function": {"name": "a", "arguments": "{}"}},
+            ],
+        )
+
+        assert [tc["function"]["name"] for tc in finalize_tool_calls(acc)] == ["a", "b"]
+
 
 # ---------------------------------------------------------------------------
 # TestRequestMetrics  (Task 4)
@@ -799,6 +876,22 @@ class TestValidation:
         assert is_valid is False
         assert "empty" in msg.lower()
 
+    def test_empty_content_with_tool_call_is_valid(self):
+        is_valid, msg = validate_response(
+            finish_reason="tool_calls",
+            content="",
+            status_code=200,
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{}"},
+                }
+            ],
+        )
+        assert is_valid is True
+        assert msg == ""
+
     def test_length_truncation(self):
         is_valid, msg = validate_response(
             finish_reason="length", content="partial text", status_code=200
@@ -878,6 +971,44 @@ class TestQualityChecks:
         )
         assert ok is False
         assert any("invalid forbidden_regex" in i for i in issues)
+
+    def test_tool_call_checks(self):
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Tokyo"}',
+                },
+            }
+        ]
+
+        ok, issues = validate_quality_checks(
+            "tool_calls",
+            "",
+            {
+                "finish_reason": "tool_calls",
+                "tool_call_count": 1,
+                "tool_call_names": ["get_weather"],
+                "tool_call_args_required_keys": {"get_weather": ["city"]},
+            },
+            tool_calls=tool_calls,
+        )
+
+        assert ok is True
+        assert issues == []
+
+    def test_required_tool_call_name_must_exist(self):
+        ok, issues = validate_quality_checks(
+            "tool_calls",
+            "",
+            {"tool_call_args_required_keys": {"get_weather": ["city"]}},
+            tool_calls=[],
+        )
+
+        assert ok is False
+        assert any("no tool call named 'get_weather'" in issue for issue in issues)
 
 
 class TestWorkloadChecksMerge:

--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -657,7 +657,8 @@ def parse_sse_line(line: str) -> Optional[dict]:
         parsed and a dict is returned::
 
             {"id": Optional[str], "content": str,
-             "finish_reason": Optional[str], "usage": Optional[dict]}
+             "finish_reason": Optional[str], "usage": Optional[dict],
+             "tool_calls_delta": Optional[list]}
 
         Missing keys (``choices``, ``delta``, ``content``) are handled
         gracefully and default to empty string / ``None``.
@@ -683,12 +684,14 @@ def parse_sse_line(line: str) -> Optional[dict]:
     content = delta.get("content", "") or ""
     finish_reason = choices[0].get("finish_reason") if choices else None
     usage = chunk.get("usage")
+    tool_calls_delta = delta.get("tool_calls")
 
     return {
         "id": chunk.get("id"),
         "content": content,
         "finish_reason": finish_reason,
         "usage": usage,
+        "tool_calls_delta": tool_calls_delta,
     }
 
 
@@ -706,6 +709,33 @@ async def _cancel_server_request(
         # Older servers may not expose request cancellation. Closing the stream
         # still gives the server disconnect signal; this endpoint is best effort.
         pass
+
+
+def accumulate_tool_calls(acc: dict[int, dict], delta_list: list[dict]) -> None:
+    """Merge streamed OpenAI tool-call deltas into *acc* by index."""
+    for tc_delta in delta_list:
+        idx = int(tc_delta.get("index", 0))
+        if idx not in acc:
+            acc[idx] = {
+                "id": tc_delta.get("id", ""),
+                "type": tc_delta.get("type", "function"),
+                "function": {"name": "", "arguments": ""},
+            }
+        entry = acc[idx]
+        if tc_delta.get("id"):
+            entry["id"] = tc_delta["id"]
+        if tc_delta.get("type"):
+            entry["type"] = tc_delta["type"]
+        function_delta = tc_delta.get("function") or {}
+        if function_delta.get("name"):
+            entry["function"]["name"] += function_delta["name"]
+        if function_delta.get("arguments"):
+            entry["function"]["arguments"] += function_delta["arguments"]
+
+
+def finalize_tool_calls(acc: dict[int, dict]) -> list[dict]:
+    """Return accumulated tool calls in stream index order."""
+    return [acc[idx] for idx in sorted(acc)]
 
 
 def compute_request_metrics(
@@ -852,6 +882,7 @@ async def stream_chat_completion(
     finish_reason: Optional[str] = None
     usage: Optional[dict] = None
     request_id: Optional[str] = None
+    tool_calls_acc: dict[int, dict] = {}
 
     async def _consume_stream() -> None:
         nonlocal finish_reason, request_id, t_first_token, usage
@@ -869,6 +900,13 @@ async def stream_chat_completion(
                     usage = parsed["usage"]
                 if parsed.get("finish_reason"):
                     finish_reason = parsed["finish_reason"]
+                tc_delta = parsed.get("tool_calls_delta")
+                if tc_delta:
+                    now = time.perf_counter()
+                    if t_first_token is None:
+                        t_first_token = now
+                    token_times.append(now)
+                    accumulate_tool_calls(tool_calls_acc, tc_delta)
                 chunk_content = parsed.get("content", "")
                 if chunk_content:
                     now = time.perf_counter()
@@ -911,6 +949,7 @@ async def stream_chat_completion(
         "prompt_tokens": prompt_tokens,
         "finish_reason": finish_reason,
         "content": "".join(content_parts),
+        "tool_calls": finalize_tool_calls(tool_calls_acc),
     }
 
 
@@ -923,6 +962,8 @@ def validate_response(
     finish_reason: Optional[str],
     content: str,
     status_code: int,
+    *,
+    tool_calls: Optional[list[dict]] = None,
 ) -> tuple[bool, str]:
     """Validate a single streaming response result.
 
@@ -944,7 +985,7 @@ def validate_response(
         return (False, "Missing finish_reason")
     if finish_reason == "length":
         return (False, "Truncated (finish_reason=length)")
-    if not content:
+    if not content and not tool_calls:
         return (False, "Empty response content")
     return (True, "")
 
@@ -955,6 +996,7 @@ def validate_quality_checks(
     checks: Optional[dict],
     *,
     status_code: int = 200,
+    tool_calls: Optional[list[dict]] = None,
 ) -> tuple[bool, list[str]]:
     """Validate content against generic workload quality checks.
 
@@ -964,10 +1006,17 @@ def validate_quality_checks(
     - ``forbidden_regex``: list of regex patterns that must not match
     - ``min_chars`` / ``max_chars``: length bounds
     - ``json``: when true, content must parse as JSON
+    - ``tool_call_count``: exact number of streamed tool calls
+    - ``tool_call_names``: expected function names, order-independent
+    - ``tool_call_args_required_keys``: required JSON argument keys by function
+    - ``no_tool_calls``: assert that no tool calls were emitted
     """
-    basic_ok, basic_issue = validate_response(finish_reason, content, status_code)
+    basic_ok, basic_issue = validate_response(
+        finish_reason, content, status_code, tool_calls=tool_calls
+    )
     issues: list[str] = [] if basic_ok else [basic_issue]
     checks = checks or {}
+    tool_calls = tool_calls or []
 
     allowed_finish = checks.get("finish_reason")
     if allowed_finish is not None:
@@ -1008,6 +1057,59 @@ def validate_quality_checks(
             json.loads(content)
         except json.JSONDecodeError as exc:
             issues.append(f"content is not valid JSON: {exc}")
+
+    if checks.get("no_tool_calls") and tool_calls:
+        issues.append(f"no_tool_calls: expected 0 tool calls, got {len(tool_calls)}")
+
+    expected_count = checks.get("tool_call_count")
+    if expected_count is not None and len(tool_calls) != int(expected_count):
+        issues.append(
+            f"tool_call_count: expected {expected_count}, got {len(tool_calls)}"
+        )
+
+    expected_names = checks.get("tool_call_names")
+    if expected_names is not None:
+        actual_names = sorted(
+            tc.get("function", {}).get("name", "") for tc in tool_calls
+        )
+        expected_sorted = sorted(str(name) for name in expected_names)
+        if actual_names != expected_sorted:
+            issues.append(
+                f"tool_call_names: expected {expected_sorted!r}, got {actual_names!r}"
+            )
+
+    required_args = checks.get("tool_call_args_required_keys") or {}
+    if required_args:
+        by_name: dict[str, list[dict]] = {}
+        for tc in tool_calls:
+            name = tc.get("function", {}).get("name", "")
+            by_name.setdefault(name, []).append(tc)
+        for name, required_keys in required_args.items():
+            matches = by_name.get(str(name), [])
+            if not matches:
+                issues.append(
+                    f"tool_call_args_required_keys: no tool call named {name!r}"
+                )
+                continue
+            for tc in matches:
+                raw_args = tc.get("function", {}).get("arguments", "")
+                try:
+                    parsed_args = json.loads(raw_args or "{}")
+                except json.JSONDecodeError as exc:
+                    issues.append(
+                        f"tool_call_args_required_keys: {name} arguments invalid JSON: {exc}"
+                    )
+                    continue
+                if not isinstance(parsed_args, dict):
+                    issues.append(
+                        f"tool_call_args_required_keys: {name} arguments not an object"
+                    )
+                    continue
+                missing = [key for key in required_keys if key not in parsed_args]
+                if missing:
+                    issues.append(
+                        f"tool_call_args_required_keys: {name} missing keys {missing!r}"
+                    )
 
     return (not issues, issues)
 
@@ -1174,6 +1276,7 @@ async def run_workload_case(
             "completion_tokens": 0,
             "finish_reason": None,
             "content": "",
+            "tool_calls": [],
         }
         error = str(exc)
 
@@ -1202,6 +1305,7 @@ async def run_workload_case(
         content,
         case.checks,
         status_code=500 if error else 200,
+        tool_calls=result.get("tool_calls") or [],
     )
     if error:
         quality_issues.append(f"request error: {error}")
@@ -1258,6 +1362,18 @@ async def run_workload_case(
             "content_chars": len(content),
             "content_preview": content[:240],
         },
+        "tool_calls": (
+            {
+                "count": len(result.get("tool_calls") or []),
+                "names": sorted(
+                    tc.get("function", {}).get("name", "")
+                    for tc in (result.get("tool_calls") or [])
+                ),
+                "raw": result.get("tool_calls") or [],
+            }
+            if result.get("tool_calls")
+            else None
+        ),
         "ok": quality_ok,
     }
     if include_content:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -13,6 +13,7 @@ LLM engine), so text-only requests must also be routed through it.
 
 import asyncio
 import inspect
+import json
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -28,6 +29,34 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_tool_call_arguments_for_template(messages: list[dict]) -> list[dict]:
+    """Normalize OpenAI tool-call replay for templates expecting mappings."""
+    normalized = json.loads(json.dumps(messages, default=str))
+    for message in normalized:
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if not isinstance(arguments, str):
+                continue
+            try:
+                parsed = json.loads(arguments)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                parsed = {"value": arguments}
+            if not isinstance(parsed, dict):
+                parsed = {"value": parsed}
+            function["arguments"] = parsed
+    return normalized
 
 
 def _extract_media_from_messages(messages: list[dict[str, Any]]) -> tuple:
@@ -564,6 +593,8 @@ class BatchedEngine(BaseEngine):
         user message text via mlx_vlm.prompt_utils.apply_chat_template,
         which dropped system prompts and all prior turns.
         """
+        messages = _normalize_tool_call_arguments_for_template(messages)
+
         # Choose the best template applicator.
         # For MLLM models, the processor handles special vision tokens.
         # For text-only models, the tokenizer is sufficient.


### PR DESCRIPTION
## Summary

I fixed two gaps in the tool-call qualification path:

- `bench-serve` now preserves streamed `delta.tool_calls`, accumulates fragmented function names and arguments by index, and exposes completed tool calls in workload results.
- Workload quality checks can now assert tool-call count, function names, required JSON argument keys, and no-tool-call behavior.
- OpenAI assistant tool-call replay is normalized before chat-template rendering so templates that iterate `function.arguments|items` receive a mapping rather than a JSON string.

This is intentionally narrow: it does not add non-streaming workload execution or dynamic tool execution. It makes the existing streaming workload path able to prove the tool protocol it was already trying to measure.

## Why

The runtime tool protocol gate found two issues that were easy to miss without structural tool-call assertions:

- Multi-turn OpenAI tool-result replay can break Qwen-style templates when assistant `tool_calls[].function.arguments` is a JSON string.
- A workload could previously pass/fail on finish reason or content leakage without proving which tool was called or what arguments were emitted.

## Validation

- `AI_RUNTIME_BYPASS_SAFETY_GATE=1 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_bench_serve.py tests/test_batched_engine.py tests/test_tool_choice_forced.py -q`
- `python -m compileall -q vllm_mlx/bench_serve.py vllm_mlx/engine/batched.py tests/test_bench_serve.py tests/test_batched_engine.py`
- `git diff --check`

Focused tests: `136 passed, 2 skipped`.
