### PR TITLE
fix: harden SSD cache review follow-ups

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for memory-aware prefix cache."""
 
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -395,6 +397,43 @@ class TestMemoryAwarePrefixCache:
     def test_try_reserve_memory_denies_over_limit(self, small_cache):
         assert small_cache.try_reserve_memory(2 * 1024 * 1024) is False
         assert small_cache.get_stats()["current_memory_mb"] == 0
+
+    def test_memory_mutations_wait_for_memory_lock(self, small_cache, mock_kv_cache):
+        def assert_waits_for_lock(operation):
+            result = {}
+            errors = []
+            small_cache._memory_lock.acquire()
+
+            def run_operation():
+                try:
+                    result["value"] = operation()
+                except Exception as exc:  # pragma: no cover - surfaced below
+                    errors.append(exc)
+
+            thread = threading.Thread(target=run_operation)
+            thread.start()
+            try:
+                time.sleep(0.05)
+                assert thread.is_alive()
+            finally:
+                small_cache._memory_lock.release()
+            thread.join(timeout=1)
+
+            assert not thread.is_alive()
+            assert errors == []
+            return result.get("value")
+
+        assert assert_waits_for_lock(
+            lambda: small_cache.store([10], mock_kv_cache(1000))
+        )
+
+        small_cache.store([20], mock_kv_cache(1000))
+        assert assert_waits_for_lock(lambda: small_cache.remove([20]))
+
+        small_cache.store([30], mock_kv_cache(1000))
+        assert_waits_for_lock(small_cache.clear)
+        assert len(small_cache) == 0
+        assert small_cache.memory_usage_mb == 0
 
     def test_reset_stats(self, small_cache, mock_kv_cache):
         small_cache.store([1, 2, 3], mock_kv_cache(1000))

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -385,6 +385,17 @@ class TestMemoryAwarePrefixCache:
         assert stats["misses"] == 1
         assert stats["entry_count"] == 1
 
+    def test_try_reserve_and_release_memory(self, small_cache):
+        assert small_cache.try_reserve_memory(512 * 1024) is True
+        assert small_cache.get_stats()["current_memory_mb"] == 0.5
+
+        small_cache.release_reserved_memory(128 * 1024)
+        assert small_cache.get_stats()["current_memory_mb"] == 0.38
+
+    def test_try_reserve_memory_denies_over_limit(self, small_cache):
+        assert small_cache.try_reserve_memory(2 * 1024 * 1024) is False
+        assert small_cache.get_stats()["current_memory_mb"] == 0
+
     def test_reset_stats(self, small_cache, mock_kv_cache):
         small_cache.store([1, 2, 3], mock_kv_cache(1000))
         small_cache.fetch([1, 2, 3])

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -88,6 +88,7 @@ class TestSSDCacheStats:
 
 import os
 
+from vllm_mlx import ssd_cache as ssd_cache_module
 from vllm_mlx.ssd_cache import SSDIndex
 
 
@@ -141,6 +142,71 @@ class TestSSDIndex:
         assert "b.safetensors" in file_paths
         assert "c.safetensors" in file_paths
         assert "d.safetensors" not in file_paths
+
+    def test_lookup_prefix_uses_bounded_prefix_hash_candidates(self, index):
+        index.insert_entry((1, 2, 3, 4), "match.safetensors", 1000, 4)
+        for i in range(100):
+            index.insert_entry((9000 + i, 2, 3, 4), f"miss-{i}.safetensors", 1000, 4)
+
+        results = index.lookup_prefix((1, 2, 3, 4, 5))
+
+        assert [r["file_path"] for r in results] == ["match.safetensors"]
+        with index._db_lock:
+            cur = index._conn.execute(
+                "SELECT COUNT(*) FROM entries WHERE prefix_hash = ?",
+                (ssd_cache_module._prefix_hash((1, 2, 3, 4)),),
+            )
+            assert cur.fetchone()[0] == 1
+
+    def test_legacy_index_backfills_prefix_hashes(self, db_dir):
+        import sqlite3
+        import time
+
+        os.makedirs(db_dir, exist_ok=True)
+        conn = sqlite3.connect(os.path.join(db_dir, "index.db"))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (1);
+            CREATE TABLE entries (
+                token_hash   TEXT PRIMARY KEY,
+                tokens_blob  BLOB NOT NULL,
+                num_tokens   INTEGER NOT NULL,
+                file_path    TEXT NOT NULL,
+                memory_bytes INTEGER NOT NULL,
+                created_at   REAL NOT NULL,
+                accessed_at  REAL NOT NULL
+            );
+            """)
+        tokens = (1, 2, 3)
+        now = time.time()
+        conn.execute(
+            "INSERT INTO entries VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                ssd_cache_module._tokens_hash(tokens),
+                ssd_cache_module._tokens_to_blob(tokens),
+                len(tokens),
+                "legacy.safetensors",
+                1000,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        idx = SSDIndex(db_dir)
+        try:
+            assert (
+                idx.lookup_prefix((1, 2, 3, 4))[0]["file_path"] == "legacy.safetensors"
+            )
+            with idx._db_lock:
+                cur = idx._conn.execute(
+                    "SELECT prefix_hash FROM entries WHERE file_path = ?",
+                    ("legacy.safetensors",),
+                )
+                assert cur.fetchone()[0] == ssd_cache_module._prefix_hash(tokens)
+        finally:
+            idx.close()
 
     def test_delete_entry(self, index):
         tokens = (10, 20, 30)
@@ -363,6 +429,29 @@ class TestSSDCacheTierCore:
         tier = SSDCacheTier(config)
         tier.close()
         tier.close()  # Should not raise
+
+    def test_init_closes_index_when_later_setup_fails(self, tmp_path, monkeypatch):
+        fake_index = type(
+            "FakeIndex",
+            (),
+            {
+                "closed": False,
+                "close": lambda self: setattr(self, "closed", True),
+            },
+        )()
+
+        monkeypatch.setattr(ssd_cache_module, "SSDIndex", lambda cache_dir: fake_index)
+
+        def fail_queue(*args, **kwargs):
+            raise RuntimeError("queue setup failed")
+
+        monkeypatch.setattr(ssd_cache_module.queue, "Queue", fail_queue)
+
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "init_fail"))
+        with pytest.raises(RuntimeError, match="queue setup failed"):
+            SSDCacheTier(config)
+
+        assert fake_index.closed
 
 
 import time
@@ -897,6 +986,21 @@ class TestIntegrationSpillAndFetch:
         )
 
         tier.close()
+
+    def test_scheduler_reconstructs_real_arrays_cache(self):
+        cache_mod = pytest.importorskip("mlx_lm.models.cache")
+        mx = pytest.importorskip("mlx.core")
+        from vllm_mlx.scheduler import Scheduler
+
+        scheduler = object.__new__(Scheduler)
+        reconstructed = Scheduler._reconstruct_ssd_layers(
+            scheduler,
+            [{"state": [np.array([1, 2], dtype=np.float32)]}],
+        )
+
+        assert reconstructed is not None
+        assert isinstance(reconstructed[0], cache_mod.ArraysCache)
+        assert reconstructed[0].state[0].tolist() == mx.array([1, 2]).tolist()
 
     def test_capacity_eviction_end_to_end(self, tmp_path):
         """Entries beyond max_entries are evicted from SSD."""

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -453,6 +453,24 @@ class TestSSDCacheTierCore:
 
         assert fake_index.closed
 
+    def test_init_preserves_setup_failure_when_index_close_fails(
+        self, tmp_path, monkeypatch
+    ):
+        class FakeIndex:
+            def close(self):
+                raise RuntimeError("index close failed")
+
+        monkeypatch.setattr(ssd_cache_module, "SSDIndex", lambda cache_dir: FakeIndex())
+
+        def fail_queue(*args, **kwargs):
+            raise RuntimeError("queue setup failed")
+
+        monkeypatch.setattr(ssd_cache_module.queue, "Queue", fail_queue)
+
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "init_close_fail"))
+        with pytest.raises(RuntimeError, match="queue setup failed"):
+            SSDCacheTier(config)
+
 
 import time
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import bisect
 import logging
 import math
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -671,6 +672,7 @@ class MemoryAwarePrefixCache:
         # Memory tracking
         self._max_memory = self._config.compute_memory_limit()
         self._current_memory = 0
+        self._memory_lock = threading.Lock()
 
         # Statistics
         self._stats = CacheStats(max_memory_bytes=self._max_memory)
@@ -1096,6 +1098,21 @@ class MemoryAwarePrefixCache:
     def memory_limit_mb(self) -> float:
         """Memory limit in MB."""
         return self._max_memory / _BYTES_PER_MB
+
+    def try_reserve_memory(self, nbytes: int) -> bool:
+        """Tentatively reserve cache memory for an upcoming promotion."""
+        with self._memory_lock:
+            if self._current_memory + nbytes > self._max_memory:
+                return False
+            self._current_memory += nbytes
+            self._stats.current_memory_bytes = self._current_memory
+            return True
+
+    def release_reserved_memory(self, nbytes: int) -> None:
+        """Release memory previously reserved by try_reserve_memory()."""
+        with self._memory_lock:
+            self._current_memory = max(0, self._current_memory - nbytes)
+            self._stats.current_memory_bytes = self._current_memory
 
     def __len__(self) -> int:
         """Return number of cached entries."""

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -672,7 +672,7 @@ class MemoryAwarePrefixCache:
         # Memory tracking
         self._max_memory = self._config.compute_memory_limit()
         self._current_memory = 0
-        self._memory_lock = threading.Lock()
+        self._memory_lock = threading.RLock()
 
         # Statistics
         self._stats = CacheStats(max_memory_bytes=self._max_memory)
@@ -934,79 +934,80 @@ class MemoryAwarePrefixCache:
         if not tokens or not cache:
             return False
 
-        tokens_key = tuple(tokens)
+        with self._memory_lock:
+            tokens_key = tuple(tokens)
 
-        # If already cached, just update LRU order (skip expensive trim/quantize)
-        if tokens_key in self._entries:
-            self._entries.move_to_end(tokens_key)
-            return True
+            # If already cached, just update LRU order (skip expensive trim/quantize)
+            if tokens_key in self._entries:
+                self._entries.move_to_end(tokens_key)
+                return True
 
-        # Trim oversized KV arrays to actual used size
-        cache = _trim_to_offset(cache)
+            # Trim oversized KV arrays to actual used size
+            cache = _trim_to_offset(cache)
 
-        # Quantize if enabled and sequence is long enough
-        if (
-            self._config.kv_quantize
-            and len(tokens) >= self._config.kv_min_quantize_tokens
-        ):
-            cache = _quantize_cache(
-                cache, self._config.kv_bits, self._config.kv_group_size
-            )
-
-        # Create entry and estimate memory
-        entry = _CacheEntry.create(tokens, cache)
-
-        # Check if single entry exceeds limit
-        if entry.memory_bytes > self._max_memory:
-            logger.warning(
-                f"Cache entry too large: {entry.memory_bytes / _BYTES_PER_MB:.1f}MB "
-                f"exceeds limit {self._max_memory / _BYTES_PER_MB:.1f}MB"
-            )
-            return False
-
-        # Prefix-subset eviction: remove entries whose token sequence
-        # is a strict prefix of the new entry.  Uses sorted index for
-        # O(log N + K) lookup instead of O(N) scan.
-        if evict_prefixes and self._sorted_keys:
-            to_remove = []
-            idx = bisect.bisect_left(self._sorted_keys, tokens_key)
-            # Scan backwards — prefixes of tokens_key are immediately before idx
-            for i in range(idx - 1, -1, -1):
-                key = self._sorted_keys[i]
-                klen = len(key)
-                if klen >= len(tokens_key):
-                    continue
-                if tokens_key[:klen] == key:
-                    to_remove.append(key)
-                elif key[0] != tokens_key[0]:
-                    break
-            for key in to_remove:
-                old = self._entries.pop(key)
-                self._current_memory -= old.memory_bytes
-                self._stats.evictions += 1
-                self._remove_from_sorted(key)
-                logger.debug(
-                    f"[prefix_evict] removed {len(key)} tokens, "
-                    f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
-                    f"new_entry={len(tokens_key)} tokens"
+            # Quantize if enabled and sequence is long enough
+            if (
+                self._config.kv_quantize
+                and len(tokens) >= self._config.kv_min_quantize_tokens
+            ):
+                cache = _quantize_cache(
+                    cache, self._config.kv_bits, self._config.kv_group_size
                 )
-            if to_remove:
-                self._stats.entry_count = len(self._entries)
-                self._stats.current_memory_bytes = self._current_memory
 
-        # Evict until we have room
-        while (
-            self._current_memory + entry.memory_bytes > self._max_memory
-            or len(self._entries) >= self._config.max_entries
-        ) and self._entries:
-            self._evict_lru()
+            # Create entry and estimate memory
+            entry = _CacheEntry.create(tokens, cache)
 
-        # Store entry
-        self._entries[tokens_key] = entry
-        self._current_memory += entry.memory_bytes
-        bisect.insort(self._sorted_keys, tokens_key)
-        self._stats.entry_count = len(self._entries)
-        self._stats.current_memory_bytes = self._current_memory
+            # Check if single entry exceeds limit
+            if entry.memory_bytes > self._max_memory:
+                logger.warning(
+                    f"Cache entry too large: {entry.memory_bytes / _BYTES_PER_MB:.1f}MB "
+                    f"exceeds limit {self._max_memory / _BYTES_PER_MB:.1f}MB"
+                )
+                return False
+
+            # Prefix-subset eviction: remove entries whose token sequence
+            # is a strict prefix of the new entry.  Uses sorted index for
+            # O(log N + K) lookup instead of O(N) scan.
+            if evict_prefixes and self._sorted_keys:
+                to_remove = []
+                idx = bisect.bisect_left(self._sorted_keys, tokens_key)
+                # Scan backwards — prefixes of tokens_key are immediately before idx
+                for i in range(idx - 1, -1, -1):
+                    key = self._sorted_keys[i]
+                    klen = len(key)
+                    if klen >= len(tokens_key):
+                        continue
+                    if tokens_key[:klen] == key:
+                        to_remove.append(key)
+                    elif key[0] != tokens_key[0]:
+                        break
+                for key in to_remove:
+                    old = self._entries.pop(key)
+                    self._current_memory -= old.memory_bytes
+                    self._stats.evictions += 1
+                    self._remove_from_sorted(key)
+                    logger.debug(
+                        f"[prefix_evict] removed {len(key)} tokens, "
+                        f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
+                        f"new_entry={len(tokens_key)} tokens"
+                    )
+                if to_remove:
+                    self._stats.entry_count = len(self._entries)
+                    self._stats.current_memory_bytes = self._current_memory
+
+            # Evict until we have room
+            while (
+                self._current_memory + entry.memory_bytes > self._max_memory
+                or len(self._entries) >= self._config.max_entries
+            ) and self._entries:
+                self._evict_lru()
+
+            # Store entry
+            self._entries[tokens_key] = entry
+            self._current_memory += entry.memory_bytes
+            bisect.insort(self._sorted_keys, tokens_key)
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
 
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "
@@ -1028,16 +1029,17 @@ class MemoryAwarePrefixCache:
         If an SSD tier is attached, the entry is spilled to disk instead
         of being discarded.
         """
-        if not self._entries:
-            return
+        with self._memory_lock:
+            if not self._entries:
+                return
 
-        # popitem(last=False) removes oldest entry (FIFO order = LRU)
-        tokens_key, entry = self._entries.popitem(last=False)
-        self._current_memory -= entry.memory_bytes
-        self._remove_from_sorted(tokens_key)
-        self._stats.evictions += 1
-        self._stats.entry_count = len(self._entries)
-        self._stats.current_memory_bytes = self._current_memory
+            # popitem(last=False) removes oldest entry (FIFO order = LRU)
+            tokens_key, entry = self._entries.popitem(last=False)
+            self._current_memory -= entry.memory_bytes
+            self._remove_from_sorted(tokens_key)
+            self._stats.evictions += 1
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
 
         # Spill to SSD tier if available
         if self._ssd_tier is not None:
@@ -1059,22 +1061,24 @@ class MemoryAwarePrefixCache:
         Returns:
             True if entry was found and removed.
         """
-        tokens_key = tuple(tokens)
-        entry = self._entries.pop(tokens_key, None)
-        if entry is not None:
-            self._current_memory -= entry.memory_bytes
-            self._remove_from_sorted(tokens_key)
-            self._stats.entry_count = len(self._entries)
-            self._stats.current_memory_bytes = self._current_memory
-            return True
-        return False
+        with self._memory_lock:
+            tokens_key = tuple(tokens)
+            entry = self._entries.pop(tokens_key, None)
+            if entry is not None:
+                self._current_memory -= entry.memory_bytes
+                self._remove_from_sorted(tokens_key)
+                self._stats.entry_count = len(self._entries)
+                self._stats.current_memory_bytes = self._current_memory
+                return True
+            return False
 
     def clear(self) -> None:
         """Clear all cached entries."""
-        self._entries.clear()
-        self._sorted_keys.clear()
-        self._current_memory = 0
-        self._stats = CacheStats(max_memory_bytes=self._max_memory)
+        with self._memory_lock:
+            self._entries.clear()
+            self._sorted_keys.clear()
+            self._current_memory = 0
+            self._stats = CacheStats(max_memory_bytes=self._max_memory)
         logger.debug("Cache cleared")
 
     def get_stats(self) -> dict[str, Any]:
@@ -1083,11 +1087,12 @@ class MemoryAwarePrefixCache:
 
     def reset_stats(self) -> None:
         """Reset statistics while preserving cache contents."""
-        self._stats = CacheStats(
-            max_memory_bytes=self._max_memory,
-            current_memory_bytes=self._current_memory,
-            entry_count=len(self._entries),
-        )
+        with self._memory_lock:
+            self._stats = CacheStats(
+                max_memory_bytes=self._max_memory,
+                current_memory_bytes=self._current_memory,
+                entry_count=len(self._entries),
+            )
 
     @property
     def memory_usage_mb(self) -> float:
@@ -1333,25 +1338,26 @@ class MemoryAwarePrefixCache:
                 # Estimate memory
                 memory = estimate_kv_cache_memory(cache)
 
-                # Check if it fits
-                if self._current_memory + memory > self._max_memory:
-                    logger.info(
-                        f"[cache_persist] entry {i} would exceed memory limit "
-                        f"({(self._current_memory + memory) / _BYTES_PER_MB:.0f}MB > "
-                        f"{self._max_memory / _BYTES_PER_MB:.0f}MB), stopping load"
-                    )
-                    break
+                with self._memory_lock:
+                    # Check if it fits
+                    if self._current_memory + memory > self._max_memory:
+                        logger.info(
+                            f"[cache_persist] entry {i} would exceed memory limit "
+                            f"({(self._current_memory + memory) / _BYTES_PER_MB:.0f}MB > "
+                            f"{self._max_memory / _BYTES_PER_MB:.0f}MB), stopping load"
+                        )
+                        break
 
-                tokens_key = tuple(tokens)
-                entry = _CacheEntry(
-                    tokens=tokens_key,
-                    cache=cache,
-                    memory_bytes=memory,
-                )
-                self._entries[tokens_key] = entry
-                self._current_memory += memory
-                bisect.insort(self._sorted_keys, tokens_key)
-                loaded += 1
+                    tokens_key = tuple(tokens)
+                    entry = _CacheEntry(
+                        tokens=tokens_key,
+                        cache=cache,
+                        memory_bytes=memory,
+                    )
+                    self._entries[tokens_key] = entry
+                    self._current_memory += memory
+                    bisect.insort(self._sorted_keys, tokens_key)
+                    loaded += 1
 
                 logger.info(
                     f"[cache_persist] loaded entry {i}: "
@@ -1362,8 +1368,9 @@ class MemoryAwarePrefixCache:
             except Exception as e:
                 logger.warning(f"[cache_persist] failed to load entry {i}: {e}")
 
-        self._stats.entry_count = len(self._entries)
-        self._stats.current_memory_bytes = self._current_memory
+        with self._memory_lock:
+            self._stats.entry_count = len(self._entries)
+            self._stats.current_memory_bytes = self._current_memory
 
         dt = _time.monotonic() - t0
         logger.info(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1164,6 +1164,7 @@ class Scheduler:
         self.memory_aware_cache: Optional[MemoryAwarePrefixCache] = None
         self.paged_cache_manager: Optional[PagedCacheManager] = None
         self.block_aware_cache: Optional[BlockAwarePrefixCache] = None
+        self._ssd_tier: Optional[SSDCacheTier] = None
 
         if self.config.enable_prefix_cache:
             if self.config.use_paged_cache:
@@ -1199,8 +1200,6 @@ class Scheduler:
                     f"limit={self.memory_aware_cache.memory_limit_mb:.1f}MB"
                 )
 
-                # Attach SSD tier if configured
-                self._ssd_tier: Optional[SSDCacheTier] = None
                 if self.config.ssd_cache_dir is not None:
                     ssd_config = SSDCacheConfig(
                         cache_dir=self.config.ssd_cache_dir,
@@ -1822,7 +1821,7 @@ class Scheduler:
                     f"time={_fetch_dt:.3f}s entries={len(self.memory_aware_cache._entries)}"
                 )
                 # Check SSD tier for cold-tier hit
-                if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+                if self._ssd_tier is not None:
                     ssd_candidate = self.memory_aware_cache.check_ssd(
                         request.prompt_token_ids
                     )
@@ -1969,7 +1968,7 @@ class Scheduler:
         # Attempt synchronous SSD promotion for any ssd_pending requests
         # before scheduling. This keeps SSD I/O out of fetch() while
         # avoiding engine modifications.
-        if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+        if self._ssd_tier is not None:
             self._try_promote_ssd_pending()
 
         scheduled = []
@@ -2821,7 +2820,7 @@ class Scheduler:
 
     def close_ssd_tier(self) -> None:
         """Shut down the SSD cache tier if present."""
-        if hasattr(self, "_ssd_tier") and self._ssd_tier is not None:
+        if self._ssd_tier is not None:
             self._ssd_tier.close()
             self._ssd_tier = None
             logger.info("SSD cache tier closed")
@@ -2847,10 +2846,7 @@ class Scheduler:
                 request.cache_hit_type = "miss"
                 continue
 
-            if (
-                self.memory_aware_cache._current_memory + memory_bytes
-                > self.memory_aware_cache._max_memory
-            ):
+            if not self.memory_aware_cache.try_reserve_memory(memory_bytes):
                 self._ssd_tier._stats.promotion_failures += 1
                 request.cache_hit_type = "miss"
                 logger.info(
@@ -2858,9 +2854,6 @@ class Scheduler:
                     f"budget denied ({memory_bytes} bytes)"
                 )
                 continue
-
-            # Tentatively reserve budget
-            self.memory_aware_cache._current_memory += memory_bytes
 
             # Use the SSD entry's actual token count for read and store,
             # NOT the full prompt tokens. For prefix hits these differ.
@@ -2872,7 +2865,7 @@ class Scheduler:
                     matched_tokens, candidate["file_path"]
                 )
             except Exception:
-                self.memory_aware_cache._current_memory -= memory_bytes
+                self.memory_aware_cache.release_reserved_memory(memory_bytes)
                 self._ssd_tier._stats.promotion_failures += 1
                 request.cache_hit_type = "miss"
                 logger.exception(
@@ -2882,13 +2875,13 @@ class Scheduler:
                 continue
 
             if cache_layers is None:
-                self.memory_aware_cache._current_memory -= memory_bytes
+                self.memory_aware_cache.release_reserved_memory(memory_bytes)
                 self._ssd_tier._stats.promotion_failures += 1
                 request.cache_hit_type = "miss"
                 continue
 
             # Release tentative budget (store() will account properly)
-            self.memory_aware_cache._current_memory -= memory_bytes
+            self.memory_aware_cache.release_reserved_memory(memory_bytes)
 
             # Reconstruct and store under the matched prefix tokens
             reconstructed = self._reconstruct_ssd_layers(cache_layers)
@@ -2922,7 +2915,7 @@ class Scheduler:
 
         Returns True if promotion succeeded and request was updated.
         """
-        if not hasattr(self, "_ssd_tier") or self._ssd_tier is None:
+        if self._ssd_tier is None:
             return False
 
         candidate = getattr(request, "_ssd_candidate", None)
@@ -2933,18 +2926,12 @@ class Scheduler:
             """Tentatively reserve RAM budget for promotion."""
             if self.memory_aware_cache is None:
                 return False
-            if (
-                self.memory_aware_cache._current_memory + nbytes
-                > self.memory_aware_cache._max_memory
-            ):
-                return False
-            self.memory_aware_cache._current_memory += nbytes
-            return True
+            return self.memory_aware_cache.try_reserve_memory(nbytes)
 
         def release_budget(nbytes: int) -> None:
             """Release tentatively reserved budget on failure."""
             if self.memory_aware_cache is not None:
-                self.memory_aware_cache._current_memory -= nbytes
+                self.memory_aware_cache.release_reserved_memory(nbytes)
 
         # Use matched token count, not full prompt, for prefix hits
         matched_count = candidate.get("matched_tokens", len(request.prompt_token_ids))
@@ -2991,7 +2978,7 @@ class Scheduler:
         Converts numpy arrays back to MLX arrays and creates KVCache objects.
         """
         try:
-            from mlx_lm.models.cache import KVCache
+            from mlx_lm.models.cache import ArraysCache, KVCache
 
             result = []
             for ld in layer_dicts:
@@ -3005,10 +2992,9 @@ class Scheduler:
                             setattr(kv, attr, ld[attr])
                     result.append(kv)
                 elif "state" in ld:
-                    # ArraysCache — need to wrap in a compatible object
                     state_arrays = [mx.array(a) for a in ld["state"]]
-                    # Create a simple namespace-like object
-                    layer_obj = type("ArraysCacheLayer", (), {"state": state_arrays})()
+                    layer_obj = ArraysCache(len(state_arrays))
+                    layer_obj.state = state_arrays
                     result.append(layer_obj)
                 else:
                     logger.warning(

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 _BYTES_PER_MB = 1024 * 1024
 _BYTES_PER_GB = 1024 * 1024 * 1024
+_PREFIX_FILTER_TOKENS = 16
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,11 @@ def _tokens_hash(tokens: tuple[int, ...]) -> str:
     return hashlib.sha256(_tokens_to_blob(tokens)).hexdigest()
 
 
+def _prefix_hash(tokens: tuple[int, ...]) -> str:
+    """Hash the bounded token prefix used to prefilter prefix lookups."""
+    return _tokens_hash(tokens[:_PREFIX_FILTER_TOKENS])
+
+
 class SSDIndex:
     """SQLite-backed index for SSD cache entries.
 
@@ -173,6 +179,7 @@ class SSDIndex:
             CREATE TABLE IF NOT EXISTS entries (
                 token_hash   TEXT PRIMARY KEY,
                 tokens_blob  BLOB NOT NULL,
+                prefix_hash  TEXT,
                 num_tokens   INTEGER NOT NULL,
                 file_path    TEXT NOT NULL,
                 memory_bytes INTEGER NOT NULL,
@@ -180,13 +187,19 @@ class SSDIndex:
                 accessed_at  REAL NOT NULL
             );
 
+            """
+        self._conn.executescript(schema_sql)
+        self._ensure_column("entries", "prefix_hash", "TEXT")
+        self._conn.executescript("""
             CREATE INDEX IF NOT EXISTS idx_entries_accessed
                 ON entries(accessed_at);
 
             CREATE INDEX IF NOT EXISTS idx_entries_num_tokens
                 ON entries(num_tokens);
-            """
-        self._conn.executescript(schema_sql)
+
+            CREATE INDEX IF NOT EXISTS idx_entries_prefix_hash_num_tokens
+                ON entries(prefix_hash, num_tokens);
+            """)
         # Insert schema version if not present
         cur = self._conn.execute("SELECT COUNT(*) FROM schema_version")
         if cur.fetchone()[0] == 0:
@@ -194,7 +207,25 @@ class SSDIndex:
                 "INSERT INTO schema_version (version) VALUES (?)",
                 (self._SCHEMA_VERSION,),
             )
+        self._backfill_prefix_hashes()
         self._conn.commit()
+
+    def _ensure_column(self, table: str, column: str, definition: str) -> None:
+        cur = self._conn.execute(f"PRAGMA table_info({table})")
+        if column not in {row["name"] for row in cur.fetchall()}:
+            self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+
+    def _backfill_prefix_hashes(self) -> None:
+        cur = self._conn.execute(
+            "SELECT token_hash, tokens_blob FROM entries WHERE prefix_hash IS NULL"
+        )
+        rows = cur.fetchall()
+        for row in rows:
+            tokens = _blob_to_tokens(row["tokens_blob"])
+            self._conn.execute(
+                "UPDATE entries SET prefix_hash = ? WHERE token_hash = ?",
+                (_prefix_hash(tokens), row["token_hash"]),
+            )
 
     def insert_entry(
         self,
@@ -206,18 +237,20 @@ class SSDIndex:
         """Insert or replace a cache entry in the index."""
         now = time.time()
         token_hash = _tokens_hash(tokens_key)
+        prefix_hash = _prefix_hash(tokens_key)
         tokens_blob = _tokens_to_blob(tokens_key)
         with self._db_lock:
             self._conn.execute(
                 """
                 INSERT OR REPLACE INTO entries
-                    (token_hash, tokens_blob, num_tokens, file_path,
+                    (token_hash, tokens_blob, prefix_hash, num_tokens, file_path,
                      memory_bytes, created_at, accessed_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     token_hash,
                     tokens_blob,
+                    prefix_hash,
                     num_tokens,
                     file_path,
                     memory_bytes,
@@ -247,19 +280,28 @@ class SSDIndex:
     def lookup_prefix(self, query_tokens: tuple[int, ...]) -> list[dict]:
         """Find entries whose token sequence is a prefix of query_tokens.
 
-        Scans entries with num_tokens <= len(query_tokens) and compares the
-        full stored token blob against the corresponding prefix of query_tokens.
+        Uses a bounded token-prefix hash to avoid scanning all entries, then
+        compares the full stored token blob against the corresponding prefix of
+        query_tokens.
 
         Returns list of dicts sorted by num_tokens descending (longest prefix first).
         """
         query_len = len(query_tokens)
         query_blob = _tokens_to_blob(query_tokens)
+        prefix_hashes = {
+            _tokens_hash(query_tokens[:n])
+            for n in range(1, min(query_len, _PREFIX_FILTER_TOKENS) + 1)
+        }
+        if not prefix_hashes:
+            return []
 
         with self._db_lock:
+            placeholders = ",".join("?" for _ in prefix_hashes)
             cur = self._conn.execute(
                 "SELECT token_hash, tokens_blob, num_tokens, file_path, memory_bytes "
-                "FROM entries WHERE num_tokens <= ? ORDER BY num_tokens DESC",
-                (query_len,),
+                f"FROM entries WHERE num_tokens <= ? AND prefix_hash IN ({placeholders}) "
+                "ORDER BY num_tokens DESC",
+                (query_len, *prefix_hashes),
             )
             rows = cur.fetchall()
 
@@ -534,6 +576,8 @@ class SSDCacheTier:
 
     def __init__(self, config: SSDCacheConfig) -> None:
         self._config = config
+        self._closed = True
+        self._writer_thread: threading.Thread | None = None
 
         if config.cache_dir is None:
             raise ValueError("SSDCacheConfig.cache_dir must be set")
@@ -545,18 +589,25 @@ class SSDCacheTier:
         os.makedirs(self._cache_dir, mode=config.dir_permissions, exist_ok=True)
         os.makedirs(self._data_dir, mode=config.dir_permissions, exist_ok=True)
 
-        # Open SQLite index
-        self._index = SSDIndex(self._cache_dir)
+        try:
+            # Open SQLite index
+            self._index = SSDIndex(self._cache_dir)
 
-        # Stats
-        self._stats = SSDCacheStats()
-        self._lock = threading.Lock()
-        self._closed = False
+            # Stats
+            self._stats = SSDCacheStats()
+            self._lock = threading.Lock()
 
-        # Spill queue and writer thread
-        self._spill_queue: queue.Queue = queue.Queue(maxsize=config.spill_queue_size)
-        self._writer_thread: threading.Thread | None = None
-        self._writer_stop = threading.Event()
+            # Spill queue and writer thread
+            self._spill_queue: queue.Queue = queue.Queue(
+                maxsize=config.spill_queue_size
+            )
+            self._writer_stop = threading.Event()
+            self._closed = False
+        except Exception:
+            index = getattr(self, "_index", None)
+            if index is not None:
+                index.close()
+            raise
 
     @staticmethod
     def _entry_hash(tokens: tuple[int, ...]) -> str:

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -606,7 +606,12 @@ class SSDCacheTier:
         except Exception:
             index = getattr(self, "_index", None)
             if index is not None:
-                index.close()
+                try:
+                    index.close()
+                except Exception:
+                    logger.exception(
+                        "ssd_cache: failed to close index during init cleanup"
+                    )
             raise
 
     @staticmethod


### PR DESCRIPTION
## Summary

This follows up issue #480 / PR #309 review debt with a narrow source patch. It keeps the SSD tier opt-in as before, but hardens the implementation details called out in review.

Changes:
- add a bounded prefix-hash filter to SSD prefix lookup, including legacy index backfill
- initialize the scheduler SSD tier invariant directly instead of relying on hasattr checks
- move SSD promotion RAM reservation behind MemoryAwarePrefixCache APIs
- reconstruct real ArraysCache instances instead of ad-hoc dynamic cache objects
- close the SQLite index if SSDCacheTier initialization fails after opening it
- add regression coverage for the above paths

## Why

PR #309 merged before the review concerns were converted into explicit follow-up work. This PR addresses the source-level concerns without changing the public opt-in surface for SSD tiering.

## Validation

- `PYTHONPATH=/opt/ai-runtime/worktrees/vllm-mlx/issue-480-ssd-cache-review-debt AI_RUNTIME_BYPASS_SAFETY_GATE=1 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_ssd_cache.py tests/test_memory_cache.py`
- `python -m black --check --target-version py312 vllm_mlx/ssd_cache.py vllm_mlx/memory_cache.py vllm_mlx/scheduler.py tests/test_ssd_cache.py tests/test_memory_cache.py`
- `git diff --check`

Closes #480