### PR TITLE
fix: bound streaming tool marker precheck

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1906,6 +1906,22 @@ class TestStreamChatCompletion:
         assert delta.get("content") is None
         assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
 
+    def test_streaming_tool_markup_precheck_uses_bounded_boundary(self):
+        """Pre-marker checks should not need the full accumulated stream."""
+        import vllm_mlx.server as server
+
+        long_prefix = "ordinary text " * 1000
+
+        assert not server._streaming_tool_markup_possible_after_delta(
+            long_prefix, "with [ordinary brackets] and no tool call"
+        )
+        assert server._streaming_tool_markup_possible_after_delta(
+            long_prefix, '[read({"file_path": "/tmp/test.py"})]'
+        )
+        assert server._streaming_tool_markup_possible_after_delta(
+            long_prefix + "[read(", '{"file_path": "/tmp/test.py"}'
+        )
+
     @pytest.mark.anyio
     async def test_reasoning_stream_emits_structured_tool_calls(self, monkeypatch):
         """Tool markup after </think> should emit tool_calls chunks."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -597,6 +597,23 @@ class TestAutoToolParser:
 
         assert not result.tools_called
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Read [the docs](https://example.test) before changing this.",
+            "The output array was [1, 2, 3], not a tool call.",
+            'Here is JSON: [{"label": "alpha", "score": 0.7}]',
+            "Use [square brackets] for optional text.",
+            "This prose mentions [read(file_path)] without JSON arguments.",
+        ],
+    )
+    def test_no_false_positive_for_ordinary_bracket_text(self, parser, text):
+        """Ordinary bracket text should remain content, not auto tool calls."""
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+        assert result.content == text
+
 
 class TestEdgeCases:
     """Test edge cases and error handling."""
@@ -693,6 +710,27 @@ class TestBareBracketStreaming:
                 break
 
         assert tool_calls_found
+
+    @pytest.mark.parametrize(
+        "delta",
+        [
+            "See [the docs](https://example.test)",
+            "Values: [1, 2, 3]",
+            'JSON data: [{"label": "alpha"}]',
+            "Literal [square brackets] in text",
+        ],
+    )
+    def test_auto_streaming_ordinary_brackets_emit_content(self, delta):
+        """Auto streaming should not suppress ordinary bracket text."""
+        parser = AutoToolParser()
+
+        result = parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=delta,
+            delta_text=delta,
+        )
+
+        assert result == {"content": delta}
 
 
 class TestStreamingParsing:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -744,6 +744,7 @@ _STREAMING_TOOL_MARKERS = (
 )
 _STREAMING_BARE_BRACKET_MARKER = re.compile(r"\[\w+\(\{")
 _STREAMING_BARE_BRACKET_PARTIAL = re.compile(r"\[\w+\($")
+_STREAMING_TOOL_MARKUP_SCAN_CHARS = 512
 
 
 def _sanitize_log_text(value: object, limit: int | None = None) -> str:
@@ -2281,8 +2282,11 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             # shapes (<tool_call>, <function=, [Calling tool:, [TOOL_CALLS],
             # bare bracket [func({...})], etc.) — the old `"<" not in` check
             # missed bracket formats and let Qwen3.6-style tool calls leak.
-            if not tool_markup_possible and not _streaming_tool_markup_possible(
-                tool_accumulated_text + delta_text
+            if (
+                not tool_markup_possible
+                and not _streaming_tool_markup_possible_after_delta(
+                    tool_accumulated_text, delta_text
+                )
             ):
                 tool_accumulated_text += delta_text
             else:
@@ -2637,6 +2641,24 @@ def _streaming_tool_markup_possible(text: str) -> bool:
         or _STREAMING_BARE_BRACKET_MARKER.search(text) is not None
         or _STREAMING_BARE_BRACKET_PARTIAL.search(text) is not None
     )
+
+
+def _streaming_tool_markup_possible_after_delta(
+    accumulated_text: str, delta_text: str
+) -> bool:
+    """
+    Check only the boundary window needed to detect newly appearing tool markup.
+
+    Streaming paths call this before any marker has been seen. Scanning the full
+    accumulated text on every ordinary chunk is quadratic for long responses, so
+    keep enough trailing context to catch markers split across chunk boundaries.
+    Once markup is possible, callers switch to the parser path with the full
+    accumulated text.
+    """
+    if not delta_text:
+        return False
+    check_text = accumulated_text[-_STREAMING_TOOL_MARKUP_SCAN_CHARS:] + delta_text
+    return _streaming_tool_markup_possible(check_text)
 
 
 def load_embedding_model(
@@ -5238,8 +5260,8 @@ async def _stream_anthropic_messages(
                 if tool_parser and content_to_emit:
                     if (
                         not tool_markup_possible
-                        and not _streaming_tool_markup_possible(
-                            tool_accumulated_text + content_to_emit
+                        and not _streaming_tool_markup_possible_after_delta(
+                            tool_accumulated_text, content_to_emit
                         )
                     ):
                         tool_accumulated_text += content_to_emit
@@ -5288,8 +5310,8 @@ async def _stream_anthropic_messages(
                 if tool_parser and content_to_emit:
                     if (
                         not tool_markup_possible
-                        and not _streaming_tool_markup_possible(
-                            tool_accumulated_text + content_to_emit
+                        and not _streaming_tool_markup_possible_after_delta(
+                            tool_accumulated_text, content_to_emit
                         )
                     ):
                         tool_accumulated_text += content_to_emit
@@ -5599,8 +5621,8 @@ async def stream_chat_completion(
                 if tool_parser and content:
                     if (
                         not tool_markup_possible
-                        and not _streaming_tool_markup_possible(
-                            tool_accumulated_text + content
+                        and not _streaming_tool_markup_possible_after_delta(
+                            tool_accumulated_text, content
                         )
                     ):
                         tool_accumulated_text += content
@@ -5723,8 +5745,8 @@ async def stream_chat_completion(
                     # parser flags are configured.
                     if (
                         not tool_markup_possible
-                        and not _streaming_tool_markup_possible(
-                            tool_accumulated_text + delta_text
+                        and not _streaming_tool_markup_possible_after_delta(
+                            tool_accumulated_text, delta_text
                         )
                     ):
                         tool_accumulated_text += delta_text


### PR DESCRIPTION
## Summary

- Bound pre-marker streaming tool markup checks to a small boundary window instead of rescanning the full accumulated stream on ordinary text chunks.
- Keep full parser behavior once tool markup is possible.
- Add false-positive coverage for ordinary bracket text, markdown links, JSON arrays, and actual bare-bracket tool-call streaming.

Closes #484.

## Validation

- `python -m black --check vllm_mlx/server.py tests/test_tool_parsers.py tests/test_server.py`
- `python -m compileall vllm_mlx/server.py vllm_mlx/tool_parsers/auto_tool_parser.py tests/test_tool_parsers.py tests/test_server.py`
- `AI_RUNTIME_BYPASS_SAFETY_GATE=1 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_tool_parsers.py tests/test_server.py::TestStreamChatCompletion::test_streaming_tool_markup_precheck_uses_bounded_boundary tests/test_server.py::TestStreamChatCompletion::test_auto_parser_streams_bare_bracket_tool_calls -q` — 104 passed