### PR TITLE
docs: add PR merge readiness checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Validation
+
+<!-- List local validation and/or CI evidence. If this is docs-only, say so. -->
+
+## Merge readiness
+
+- [ ] I am not merging my own substantive PR.
+- [ ] The latest CI run for this exact head commit is green.
+- [ ] If I rebased, resolved conflicts, or pushed after review, I waited for the new CI run to finish green.
+- [ ] Actionable review comments are resolved in this PR or linked to follow-up issues before merge.
+- [ ] Any intentional follow-up debt is linked here and called out in the PR body.
+
+## Risk notes
+
+<!-- Call out runtime, parser, scheduler, memory, security, or compatibility risk. -->


### PR DESCRIPTION
Addresses #482.

This adds an in-repo PR template checklist for the process failures identified in the self-merge audit:

- authors should not merge their own substantive PRs
- latest CI for the exact head commit should be green before merge
- post-review rebases/conflict fixes need a fresh green CI run
- actionable review comments should be resolved or linked to follow-up issues before merge
- intentional follow-up debt should be visible in the PR body

This does not replace branch protection or repository admin settings. It is a lightweight visible guardrail inside the repository so contributors and maintainers see the expected merge-readiness checks on every PR.

Validation:
- docs/template-only change
- `git diff --check`
