### PR TITLE
fix: unexpected keyword argument 'mtp' when enable-mtp is set

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -74,7 +74,7 @@ def test_model_stream_generate_passes_num_draft_tokens():
         chunks = list(model.stream_generate("Hello", max_tokens=8))
 
     assert chunks[-1].text == "Hello"
-    assert captured_kwargs["mtp"] is True
+    assert "mtp" not in captured_kwargs
     assert captured_kwargs["num_draft_tokens"] == 4
 
 

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -965,8 +965,9 @@ class TestSimpleEngineConcurrency:
         assert len(calls) == 2
         assert "mtp" not in calls[0]
         assert calls[0]["logits_processors"][0] is processor
-        assert calls[1]["mtp"] is True
+        assert "mtp" not in calls[1]
         assert calls[1]["num_draft_tokens"] == 4
+        assert "prompt_cache" in calls[1]
         assert "logits_processors" not in calls[1]
 
     @pytest.mark.anyio
@@ -1053,8 +1054,9 @@ class TestSimpleEngineConcurrency:
 
         assert outputs[-1].text == "Hello world"
         assert len(calls) == 1
-        assert calls[0]["mtp"] is True
+        assert "mtp" not in calls[0]
         assert calls[0]["num_draft_tokens"] == 4
+        assert "prompt_cache" in calls[0]
         assert "logits_processors" not in calls[0]
 
     @pytest.mark.anyio

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -892,7 +892,7 @@ class TestSimpleEngineConcurrency:
             ]
 
         assert outputs[-1].text == "Hello"
-        assert captured_kwargs["mtp"] is True
+        assert "mtp" not in captured_kwargs
         assert captured_kwargs["num_draft_tokens"] == 4
 
     @pytest.mark.anyio

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -310,6 +310,14 @@ class SimpleEngine(BaseEngine):
                     logger.error("SpecPrefill: draft model load failed: %s", e)
                     self._draft_model = None
 
+            # Warn if MTP is enabled without continuous-batching and text routing not available
+            if self._mtp and (not self._is_mllm or self._text_model is None):
+                logger.warning(
+                    "[MTP] --enable-mtp without --continuous-batching: "
+                    "speculative decoding via draft tokens will not be active. "
+                    "For full MTP support, use: --enable-mtp --continuous-batching"
+                )
+
             mtp_info = ""
             if self._mtp:
                 mtp_info = (
@@ -1356,7 +1364,6 @@ class SimpleEngine(BaseEngine):
                 # a fresh MTP cache so stale speculative state cannot survive the
                 # processor-to-content handoff.
                 resume_kwargs["prompt_cache"] = prompt_cache + model.make_mtp_cache()
-                resume_kwargs["mtp"] = True
                 resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
             for resp in mlx_stream_generate(
                 model,
@@ -1457,7 +1464,6 @@ class SimpleEngine(BaseEngine):
             if all_processors:
                 gen_kwargs["logits_processors"] = all_processors
             if use_mtp:
-                gen_kwargs["mtp"] = True
                 gen_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
             if prompt_cache is not None:
                 gen_kwargs["prompt_cache"] = prompt_cache

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -276,7 +276,6 @@ class MLXLanguageModel:
 
         mtp_kwargs = {}
         if self._mtp:
-            mtp_kwargs["mtp"] = True
             mtp_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache


### PR DESCRIPTION
### Problem
When enabling MTP with the `enable-mtp` flag on the `Qwen3.6-35B-A3B` model, the server reports following error:
```
ERROR:vllm_mlx.server:Streaming error, ensuring terminal frame: generate_step() got an unexpected keyword argument 'mtp'
```

### Root Cause
The `mtp_kwargs` dictionary, which is constructed when MTP is enabled, contains a field named `"mtp"`. This dictionary is passed as keyword arguments to the `generate_step()` method. However, `generate_step()` does not accept an `mtp` parameter, causing a `TypeError` when the argument is passed.

### Solution
- Identified the location where `mtp_kwargs` is built and passed to `generate_step()`.
- Remove `"mtp"` field from the kwargs.
- Added a startup warning when [--enable-mtp] is used without --continuous-batching (only when MTP is not effectively available).
- Verified that MTP functionality remains intact and the error no longer occurs.

### Testing
- Ran the server with `enable-mtp` on `Qwen3.6-35B-A3B`.
- Confirmed that generation proceeds without the unexpected keyword argument error.
- Checked that MTP behavior (as expected by the model) is preserved.