### PR TITLE
Wire MLLM assistant drafters for Gemma 4 MTP

### DIFF
--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -185,6 +185,88 @@ class TestLifecycleCli:
             "mllm_draft_block_size": 4,
         }
 
+    def test_main_rejects_nonpositive_mllm_draft_block_size(self, monkeypatch, capsys):
+        """Drafter block size must be positive at parse time."""
+        import vllm_mlx.cli as cli
+
+        monkeypatch.setattr(
+            cli.sys,
+            "argv",
+            [
+                "vllm-mlx",
+                "serve",
+                "google/gemma-4-E2B-it",
+                "--mllm",
+                "--mllm-draft-model",
+                "assistant",
+                "--mllm-draft-kind",
+                "mtp",
+                "--mllm-draft-block-size",
+                "0",
+            ],
+        )
+
+        with pytest.raises(SystemExit):
+            cli.main()
+
+        assert "--mllm-draft-block-size" in capsys.readouterr().err
+
+    def test_serve_command_rejects_mllm_draft_without_mllm(self, capsys):
+        """Drafter flags should not be silently ignored on text-only models."""
+        import vllm_mlx.cli as cli
+
+        args = SimpleNamespace(
+            model="mlx-community/Qwen3-0.6B-8bit",
+            models_config=None,
+            served_model_name=None,
+            enable_auto_tool_choice=False,
+            tool_call_parser=None,
+            gpu_memory_utilization=0.90,
+            max_tokens=32768,
+            max_request_tokens=32768,
+            mllm_draft_model="assistant",
+            mllm_draft_kind="mtp",
+            mllm_draft_block_size=4,
+            continuous_batching=False,
+            auto_unload_idle_seconds=0.0,
+            lazy_load_model=False,
+            mllm=False,
+        )
+
+        with pytest.raises(SystemExit):
+            cli.serve_command(args)
+
+        assert "--mllm-draft-model requires --mllm" in capsys.readouterr().out
+
+    def test_serve_command_rejects_mllm_draft_with_models_config(self, capsys):
+        """Registry mode must not accept drafter flags that it does not load."""
+        import vllm_mlx.cli as cli
+
+        args = SimpleNamespace(
+            model=None,
+            models_config="/tmp/models.yaml",
+            served_model_name=None,
+            enable_auto_tool_choice=False,
+            tool_call_parser=None,
+            gpu_memory_utilization=0.90,
+            max_tokens=32768,
+            max_request_tokens=32768,
+            mllm_draft_model="assistant",
+            mllm_draft_kind="mtp",
+            mllm_draft_block_size=4,
+            continuous_batching=False,
+            auto_unload_idle_seconds=0.0,
+            lazy_load_model=False,
+            mllm=True,
+        )
+
+        with pytest.raises(SystemExit):
+            cli.serve_command(args)
+
+        assert "--mllm-draft-model cannot be used with --models-config" in (
+            capsys.readouterr().out
+        )
+
     def test_serve_command_wires_auto_unload_idle_seconds_into_load_model(
         self, monkeypatch
     ):

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -148,6 +148,43 @@ class TestLifecycleCli:
 
         assert captured["lazy_load_model"] is False
 
+    def test_main_parses_mllm_draft_flags(self, monkeypatch):
+        """The top-level CLI should accept MLLM assistant drafter knobs."""
+        import vllm_mlx.cli as cli
+
+        captured = {}
+
+        def fake_serve_command(args):
+            captured["mllm_draft_model"] = args.mllm_draft_model
+            captured["mllm_draft_kind"] = args.mllm_draft_kind
+            captured["mllm_draft_block_size"] = args.mllm_draft_block_size
+
+        monkeypatch.setattr(cli, "serve_command", fake_serve_command)
+        monkeypatch.setattr(
+            cli.sys,
+            "argv",
+            [
+                "vllm-mlx",
+                "serve",
+                "google/gemma-4-E2B-it",
+                "--mllm",
+                "--mllm-draft-model",
+                "google/gemma-4-E2B-it-assistant",
+                "--mllm-draft-kind",
+                "mtp",
+                "--mllm-draft-block-size",
+                "4",
+            ],
+        )
+
+        cli.main()
+
+        assert captured == {
+            "mllm_draft_model": "google/gemma-4-E2B-it-assistant",
+            "mllm_draft_kind": "mtp",
+            "mllm_draft_block_size": 4,
+        }
+
     def test_serve_command_wires_auto_unload_idle_seconds_into_load_model(
         self, monkeypatch
     ):
@@ -156,6 +193,7 @@ class TestLifecycleCli:
 
         import vllm_mlx.cli as cli
         import vllm_mlx.server as srv
+        import vllm_mlx.utils.download as download_mod
 
         captured = {}
 
@@ -165,6 +203,11 @@ class TestLifecycleCli:
 
         monkeypatch.setattr(srv, "load_model", fake_load_model)
         monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            download_mod,
+            "ensure_model_downloaded",
+            lambda *args, **kwargs: "/tmp/model",
+        )
 
         args = SimpleNamespace(
             model="mlx-community/Qwen3-0.6B-8bit",

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -320,7 +320,12 @@ class TestCompletionStreamingRelease:
                 raise RuntimeError("generation failed")
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             acquires["count"] += 1
             return FakeEngine()
@@ -393,7 +398,12 @@ class TestCompletionStreamingRelease:
                 )
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -546,7 +556,12 @@ class TestToolParserUsesLocalEngine:
         local_engine = FakeEngine("tok-local")
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return local_engine
 
@@ -619,7 +634,12 @@ class TestLifecycleFailureHandling:
             preserve_native_tool_format = False
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             calls["acquires"] += 1
             return FakeEngine()
@@ -648,7 +668,12 @@ class TestLifecycleFailureHandling:
             preserve_native_tool_format = False
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             calls["acquires"] += 1
             return FakeEngine()
@@ -3497,7 +3522,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -3544,7 +3574,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -3595,7 +3630,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -64,7 +64,85 @@ def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
     assert captured["kwargs"]["draft_block_size"] == 4
 
 
-def test_simple_engine_disables_text_routing_when_mllm_drafter_configured():
+def test_mllm_draft_metrics_use_recorded_draft_counts():
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    draft_model = SimpleNamespace(
+        accept_lens=[1, 0],
+        _vllm_mlx_draft_counts=[2, 1],
+        config=SimpleNamespace(block_size=4),
+    )
+    model = MLXMultimodalLM(
+        "target",
+        draft_model="assistant",
+        draft_kind="mtp",
+        draft_block_size=4,
+    )
+    model._draft_model = draft_model
+
+    assert model._draft_metrics_since(0) == {
+        "mtp_drafts": 3,
+        "mtp_accepted": 1,
+    }
+
+
+def test_mllm_chat_uses_configured_drafter_over_call_kwargs(monkeypatch):
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    captured = {}
+    configured_draft = SimpleNamespace(accept_lens=[], _vllm_mlx_draft_counts=[])
+    caller_draft = SimpleNamespace()
+
+    def fake_generate(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(text="ok", prompt_tokens=3, generation_tokens=1)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm",
+        SimpleNamespace(generate=fake_generate),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.prompt_utils",
+        SimpleNamespace(get_chat_template=lambda *args, **kwargs: "rendered prompt"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.models",
+        SimpleNamespace(cache=SimpleNamespace(make_prompt_cache=lambda *a, **k: None)),
+    )
+
+    tokenizer = SimpleNamespace(encode=lambda text: [1, 2, 3])
+    model = MLXMultimodalLM(
+        "target",
+        draft_model="assistant",
+        draft_kind="mtp",
+        draft_block_size=4,
+    )
+    model._loaded = True
+    model.model = SimpleNamespace(language_model=object())
+    model.processor = SimpleNamespace(tokenizer=tokenizer)
+    model.config = {}
+    model._draft_model = configured_draft
+    model._cache_manager = None
+
+    output = model.chat(
+        [{"role": "user", "content": "hello"}],
+        max_tokens=8,
+        temperature=0.0,
+        draft_model=caller_draft,
+        draft_kind="other",
+        draft_block_size=99,
+    )
+
+    assert output.text == "ok"
+    assert captured["kwargs"]["draft_model"] is configured_draft
+    assert captured["kwargs"]["draft_kind"] == "mtp"
+    assert captured["kwargs"]["draft_block_size"] == 4
+
+
+def test_simple_engine_text_route_stays_default_when_mllm_drafter_configured():
     from vllm_mlx.engine.simple import SimpleEngine
 
     engine = SimpleEngine(
@@ -77,4 +155,29 @@ def test_simple_engine_disables_text_routing_when_mllm_drafter_configured():
     engine._loaded = True
     engine._text_model = object()
 
-    assert engine._should_route_text_through_text_model() is False
+    assert engine._should_route_text_through_text_model() is True
+    assert (
+        engine._should_route_text_through_text_model(mllm_draft_requested=True) is False
+    )
+
+
+def test_chat_request_passes_mllm_draft_opt_in():
+    from vllm_mlx.server import (
+        ChatCompletionRequest,
+        Message,
+        _prepare_chat_completion_invocation,
+    )
+
+    class Engine:
+        is_mllm = True
+        preserve_native_tool_format = False
+
+    request = ChatCompletionRequest(
+        model="gemma4",
+        messages=[Message(role="user", content="hello")],
+        mllm_draft=True,
+    )
+
+    prepared = _prepare_chat_completion_invocation(Engine(), request, 16)
+
+    assert prepared.chat_kwargs["mllm_draft"] is True

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MLLM assistant-drafter speculative wiring."""
+
+import sys
+from types import SimpleNamespace
+
+
+def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    captured = {}
+    draft_model = SimpleNamespace(accept_lens=[99])
+
+    def fake_generate(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        captured["accept_lens_at_call"] = list(draft_model.accept_lens)
+        draft_model.accept_lens = [1, 2]
+        return SimpleNamespace(text="ok", prompt_tokens=3, generation_tokens=2)
+
+    fake_cache = SimpleNamespace(make_prompt_cache=lambda *args, **kwargs: ["cache"])
+    fake_models = SimpleNamespace(cache=fake_cache)
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm",
+        SimpleNamespace(generate=fake_generate),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.prompt_utils",
+        SimpleNamespace(get_chat_template=lambda *args, **kwargs: "rendered prompt"),
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models", fake_models)
+
+    tokenizer = SimpleNamespace(encode=lambda text: [1, 2, 3])
+    processor = SimpleNamespace(tokenizer=tokenizer)
+    target = SimpleNamespace(language_model=object())
+
+    model = MLXMultimodalLM(
+        "target",
+        draft_model="assistant",
+        draft_kind="mtp",
+        draft_block_size=4,
+    )
+    model._loaded = True
+    model.model = target
+    model.processor = processor
+    model.config = {}
+    model._draft_model = draft_model
+    model._cache_manager = None
+
+    output = model.chat(
+        [{"role": "user", "content": "hello"}],
+        max_tokens=8,
+        temperature=0.0,
+    )
+
+    assert output.text == "ok"
+    assert output.mtp_drafts == 6
+    assert output.mtp_accepted == 3
+    assert captured["accept_lens_at_call"] == []
+    assert captured["kwargs"]["draft_model"] is draft_model
+    assert captured["kwargs"]["draft_kind"] == "mtp"
+    assert captured["kwargs"]["draft_block_size"] == 4
+
+
+def test_simple_engine_disables_text_routing_when_mllm_drafter_configured():
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    engine = SimpleEngine(
+        "gemma4",
+        force_mllm=True,
+        mllm_draft_model="assistant",
+        mllm_draft_kind="mtp",
+        mllm_draft_block_size=4,
+    )
+    engine._loaded = True
+    engine._text_model = object()
+
+    assert engine._should_route_text_through_text_model() is False

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -4,6 +4,8 @@
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
     from vllm_mlx.models.mllm import MLXMultimodalLM
@@ -53,6 +55,7 @@ def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
         [{"role": "user", "content": "hello"}],
         max_tokens=8,
         temperature=0.0,
+        mllm_draft=True,
     )
 
     assert output.text == "ok"
@@ -131,6 +134,7 @@ def test_mllm_chat_uses_configured_drafter_over_call_kwargs(monkeypatch):
         [{"role": "user", "content": "hello"}],
         max_tokens=8,
         temperature=0.0,
+        mllm_draft=True,
         draft_model=caller_draft,
         draft_kind="other",
         draft_block_size=99,
@@ -140,6 +144,64 @@ def test_mllm_chat_uses_configured_drafter_over_call_kwargs(monkeypatch):
     assert captured["kwargs"]["draft_model"] is configured_draft
     assert captured["kwargs"]["draft_kind"] == "mtp"
     assert captured["kwargs"]["draft_block_size"] == 4
+
+
+def test_mllm_chat_requires_request_draft_opt_in(monkeypatch):
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    captured = {}
+    configured_draft = SimpleNamespace(accept_lens=[], _vllm_mlx_draft_counts=[])
+
+    def fake_generate(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(text="ok", prompt_tokens=3, generation_tokens=1)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm",
+        SimpleNamespace(generate=fake_generate),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.prompt_utils",
+        SimpleNamespace(get_chat_template=lambda *args, **kwargs: "rendered prompt"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.models",
+        SimpleNamespace(cache=SimpleNamespace(make_prompt_cache=lambda *a, **k: None)),
+    )
+
+    tokenizer = SimpleNamespace(encode=lambda text: [1, 2, 3])
+    model = MLXMultimodalLM(
+        "target",
+        draft_model="assistant",
+        draft_kind="mtp",
+        draft_block_size=4,
+    )
+    model._loaded = True
+    model.model = SimpleNamespace(language_model=object())
+    model.processor = SimpleNamespace(tokenizer=tokenizer)
+    model.config = {}
+    model._draft_model = configured_draft
+    model._cache_manager = None
+
+    output = model.chat(
+        [{"role": "user", "content": "hello"}],
+        max_tokens=8,
+        temperature=0.0,
+        draft_model=object(),
+        draft_kind="other",
+        draft_block_size=99,
+    )
+
+    assert output.text == "ok"
+    assert "mllm_draft" not in captured["kwargs"]
+    assert "draft_model" not in captured["kwargs"]
+    assert "draft_kind" not in captured["kwargs"]
+    assert "draft_block_size" not in captured["kwargs"]
+    assert output.mtp_drafts == 0
+    assert output.mtp_accepted == 0
 
 
 def test_simple_engine_text_route_stays_default_when_mllm_drafter_configured():
@@ -181,3 +243,47 @@ def test_chat_request_passes_mllm_draft_opt_in():
     prepared = _prepare_chat_completion_invocation(Engine(), request, 16)
 
     assert prepared.chat_kwargs["mllm_draft"] is True
+
+
+@pytest.mark.asyncio
+async def test_simple_engine_forwards_mllm_draft_opt_in_to_mllm_path():
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    captured = {}
+
+    class FakeMLLM:
+        def stream_chat(self, *args, **kwargs):
+            captured["kwargs"] = kwargs
+            yield SimpleNamespace(
+                text="ok",
+                finish_reason="stop",
+                prompt_tokens=3,
+                mtp_drafts=2,
+                mtp_accepted=1,
+            )
+
+    engine = SimpleEngine(
+        "gemma4",
+        force_mllm=True,
+        mllm_draft_model="assistant",
+        mllm_draft_kind="mtp",
+        mllm_draft_block_size=4,
+    )
+    engine._loaded = True
+    engine._is_mllm = True
+    engine._text_model = object()
+    engine._model = FakeMLLM()
+
+    outputs = [
+        output
+        async for output in engine.stream_chat(
+            [{"role": "user", "content": "hello"}],
+            max_tokens=8,
+            temperature=0.0,
+            mllm_draft=True,
+        )
+    ]
+
+    assert captured["kwargs"]["mllm_draft"] is True
+    assert outputs[-1].mtp_drafts == 2
+    assert outputs[-1].mtp_accepted == 1

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -245,7 +245,7 @@ def test_chat_request_passes_mllm_draft_opt_in():
     assert prepared.chat_kwargs["mllm_draft"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_simple_engine_forwards_mllm_draft_opt_in_to_mllm_path():
     from vllm_mlx.engine.simple import SimpleEngine
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -188,6 +188,8 @@ class ChatCompletionRequest(BaseModel):
     specprefill_keep_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
+    # MLLM assistant-drafter path: opt in per request when a drafter is configured.
+    mllm_draft: bool | None = None
     # Thinking token budget: cap reasoning tokens by forcing </think> when
     # budget exhausted (None = no budget, unlimited reasoning)
     thinking_token_budget: int | None = Field(default=None, gt=0)

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -188,7 +188,9 @@ class ChatCompletionRequest(BaseModel):
     specprefill_keep_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
-    # MLLM assistant-drafter path: opt in per request when a drafter is configured.
+    # MLLM assistant-drafter path: opt in to using a configured drafter.
+    # Text-only requests also use this flag to leave the default TextModel route
+    # and run through the MLLM path where the drafter can participate.
     mllm_draft: bool | None = None
     # Thinking token budget: cap reasoning tokens by forcing </think> when
     # budget exhausted (None = no budget, unlimited reasoning)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -33,14 +33,16 @@ def serve_command(args):
     from .server import RateLimiter, app, load_model, load_model_registry
 
     logger = logging.getLogger(__name__)
+    model_arg = getattr(args, "model", None)
+    models_config = getattr(args, "models_config", None)
 
-    if args.models_config and args.model:
+    if models_config and model_arg:
         print("Error: use either positional MODEL or --models-config, not both")
         sys.exit(1)
-    if not args.models_config and not args.model:
+    if not models_config and not model_arg:
         print("Error: MODEL is required unless --models-config is provided")
         sys.exit(1)
-    if args.models_config and args.served_model_name:
+    if models_config and args.served_model_name:
         print("Error: --served-model-name cannot be used with --models-config")
         sys.exit(1)
 
@@ -60,12 +62,24 @@ def serve_command(args):
         print("Error: --max-tokens must be at least 1")
         sys.exit(1)
     max_request_tokens = getattr(args, "max_request_tokens", args.max_tokens)
+    max_kv_size = getattr(args, "max_kv_size", None)
     trust_remote_code = getattr(args, "trust_remote_code", False)
     if max_request_tokens < 1:
         print("Error: --max-request-tokens must be at least 1")
         sys.exit(1)
     if args.max_tokens > max_request_tokens:
         print("Error: --max-tokens cannot exceed --max-request-tokens")
+        sys.exit(1)
+    mllm_draft_model = getattr(args, "mllm_draft_model", None)
+    mllm_draft_kind = getattr(args, "mllm_draft_kind", None)
+    mllm_draft_block_size = getattr(args, "mllm_draft_block_size", None)
+    if mllm_draft_model and args.continuous_batching:
+        print(
+            "Error: --mllm-draft-model is supported only without --continuous-batching"
+        )
+        sys.exit(1)
+    if mllm_draft_model and (args.auto_unload_idle_seconds > 0 or args.lazy_load_model):
+        print("Error: --mllm-draft-model is not supported with lifecycle residency yet")
         sys.exit(1)
 
     # Configure server security settings
@@ -99,8 +113,9 @@ def serve_command(args):
     server._max_tts_input_chars = max_tts_input_chars
 
     # Configure thinking token budget
-    if args.default_thinking_token_budget is not None:
-        server._default_thinking_token_budget = args.default_thinking_token_budget
+    default_thinking_token_budget = getattr(args, "default_thinking_token_budget", None)
+    if default_thinking_token_budget is not None:
+        server._default_thinking_token_budget = default_thinking_token_budget
 
     # Configure reasoning parser
     if args.reasoning_parser:
@@ -160,8 +175,8 @@ def serve_command(args):
         print(f"  Reasoning: ENABLED (parser: {args.reasoning_parser})")
     else:
         print("  Reasoning: Use --reasoning-parser to enable")
-    if args.default_thinking_token_budget is not None:
-        print(f"  Thinking budget: {args.default_thinking_token_budget} tokens")
+    if default_thinking_token_budget is not None:
+        print(f"  Thinking budget: {default_thinking_token_budget} tokens")
     print(
         f"  Audio upload limit: {max_audio_upload_mb} MiB, "
         f"TTS input limit: {max_tts_input_chars} chars"
@@ -177,23 +192,23 @@ def serve_command(args):
         max_retries=args.download_retries,
         offline=getattr(args, "offline", False),
     )
-    if args.model:
+    if model_arg:
         ensure_model_downloaded(
-            args.model,
+            model_arg,
             config=download_config,
-            is_mllm=is_mllm_model(args.model),
+            is_mllm=is_mllm_model(model_arg),
         )
         if args.lazy_load_model:
-            print(f"Registering model for lazy load: {args.model}")
+            print(f"Registering model for lazy load: {model_arg}")
             print("Model will load on the first request.")
         else:
-            print(f"Loading model: {args.model}")
+            print(f"Loading model: {model_arg}")
     else:
-        print(f"Loading models config: {args.models_config}")
+        print(f"Loading models config: {models_config}")
     print(f"Default max tokens: {args.max_tokens}")
     print(f"Max request tokens: {max_request_tokens}")
-    if args.max_kv_size is not None:
-        print(f"Max KV size: {args.max_kv_size} (RotatingKVCache)")
+    if max_kv_size is not None:
+        print(f"Max KV size: {max_kv_size} (RotatingKVCache)")
 
     # Store MCP config path for FastAPI startup
     if args.mcp_config:
@@ -254,7 +269,7 @@ def serve_command(args):
             ssd_cache_dir=getattr(args, "ssd_cache_dir", None),
             ssd_cache_max_gb=getattr(args, "ssd_cache_max_gb", 10.0),
             # KV cache size limit
-            max_kv_size=args.max_kv_size or 0,
+            max_kv_size=max_kv_size or 0,
         )
 
         print("Mode: Continuous batching (for multiple concurrent users)")
@@ -293,8 +308,14 @@ def serve_command(args):
                 f"threshold={args.specprefill_threshold}, "
                 f"keep={args.specprefill_keep_pct*100:.0f}%)"
             )
+        if mllm_draft_model:
+            print(
+                "MLLM draft model: enabled "
+                f"(draft={mllm_draft_model}, kind={mllm_draft_kind}, "
+                f"block_size={mllm_draft_block_size})"
+            )
 
-    if args.models_config:
+    if models_config:
         defaults = RegistryServeDefaults(
             continuous_batching=args.continuous_batching,
             force_mllm=getattr(args, "mllm", False),
@@ -310,11 +331,11 @@ def serve_command(args):
             max_tokens=args.max_tokens,
             download_config=download_config,
         )
-        load_model_registry(args.models_config, defaults=defaults)
+        load_model_registry(models_config, defaults=defaults)
     else:
         # Load model with unified server
         load_model(
-            args.model,
+            model_arg,
             use_batching=args.continuous_batching,
             scheduler_config=scheduler_config,
             stream_interval=args.stream_interval if args.continuous_batching else 1,
@@ -330,6 +351,9 @@ def serve_command(args):
             specprefill_threshold=args.specprefill_threshold,
             specprefill_keep_pct=args.specprefill_keep_pct,
             specprefill_draft_model=args.specprefill_draft_model,
+            mllm_draft_model=mllm_draft_model,
+            mllm_draft_kind=mllm_draft_kind,
+            mllm_draft_block_size=mllm_draft_block_size,
             warm_prompts_path=getattr(args, "warm_prompts", None),
             auto_unload_idle_seconds=args.auto_unload_idle_seconds,
             lazy_load_model=args.lazy_load_model,
@@ -1198,6 +1222,27 @@ Examples:
         default=None,
         help="Path to small draft model for SpecPrefill importance scoring. "
         "Must share the same tokenizer as the target model.",
+    )
+    # MLLM speculative draft/assistant model
+    serve_parser.add_argument(
+        "--mllm-draft-model",
+        type=str,
+        default=None,
+        help="Path to an mlx-vlm MLLM draft/assistant model. "
+        "For Gemma 4 assistant drafters, use with --mllm-draft-kind mtp.",
+    )
+    serve_parser.add_argument(
+        "--mllm-draft-kind",
+        type=str,
+        default=None,
+        choices=["mtp"],
+        help="mlx-vlm draft kind for --mllm-draft-model.",
+    )
+    serve_parser.add_argument(
+        "--mllm-draft-block-size",
+        type=int,
+        default=None,
+        help="Draft block size passed to mlx-vlm for --mllm-draft-model.",
     )
     # MCP options
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -16,7 +16,7 @@ import argparse
 import json
 import sys
 
-from .cli_arg_types import make_json_object_arg_parser
+from .cli_arg_types import make_json_object_arg_parser, make_positive_int_arg_parser
 
 
 def serve_command(args):
@@ -73,6 +73,15 @@ def serve_command(args):
     mllm_draft_model = getattr(args, "mllm_draft_model", None)
     mllm_draft_kind = getattr(args, "mllm_draft_kind", None)
     mllm_draft_block_size = getattr(args, "mllm_draft_block_size", None)
+    if mllm_draft_model and models_config:
+        print("Error: --mllm-draft-model cannot be used with --models-config")
+        sys.exit(1)
+    if mllm_draft_model and not getattr(args, "mllm", False):
+        print("Error: --mllm-draft-model requires --mllm")
+        sys.exit(1)
+    if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
+        print("Error: --mllm-draft-block-size must be a positive integer")
+        sys.exit(1)
     if mllm_draft_model and args.continuous_batching:
         print(
             "Error: --mllm-draft-model is supported only without --continuous-batching"
@@ -1240,7 +1249,7 @@ Examples:
     )
     serve_parser.add_argument(
         "--mllm-draft-block-size",
-        type=int,
+        type=make_positive_int_arg_parser("--mllm-draft-block-size"),
         default=None,
         help="Draft block size passed to mlx-vlm for --mllm-draft-model.",
     )

--- a/vllm_mlx/cli_arg_types.py
+++ b/vllm_mlx/cli_arg_types.py
@@ -29,3 +29,34 @@ def make_json_object_arg_parser(option_name: str) -> Callable[[str], dict[str, A
         return parse_json_object_arg(value, option_name)
 
     return _parser
+
+
+def positive_int_arg(value: str) -> int:
+    """Parse an argparse integer that must be greater than zero."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def parse_positive_int_arg(value: str, option_name: str) -> int:
+    """Parse and validate that an option value is a positive integer."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{option_name} must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{option_name} must be a positive integer")
+    return parsed
+
+
+def make_positive_int_arg_parser(option_name: str) -> Callable[[str], int]:
+    """Create an argparse type parser for positive integer options."""
+
+    def _parser(value: str) -> int:
+        return parse_positive_int_arg(value, option_name)
+
+    return _parser

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -27,6 +27,8 @@ class GenerationOutput:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     finish_reason: str | None = "stop"
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
     # For streaming
     new_text: str = ""
     finished: bool = True

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -352,9 +352,11 @@ class SimpleEngine(BaseEngine):
         self._system_kv_token_count = 0
         logger.info("SimpleEngine stopped")
 
-    def _should_route_text_through_text_model(self) -> bool:
+    def _should_route_text_through_text_model(
+        self, *, mllm_draft_requested: bool = False
+    ) -> bool:
         """Return whether text-only MLLM requests may use mlx_lm TextModel."""
-        return self._mllm_draft_model_path is None
+        return not (mllm_draft_requested and self._mllm_draft_model_path is not None)
 
     async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
         """Run a blocking MLX operation under the generation lock.
@@ -639,6 +641,8 @@ class SimpleEngine(BaseEngine):
                 prompt_tokens=final_output.prompt_tokens,
                 completion_tokens=final_output.completion_tokens,
                 finish_reason=final_output.finish_reason,
+                mtp_drafts=final_output.mtp_drafts,
+                mtp_accepted=final_output.mtp_accepted,
             )
 
         # mlx-lm non-streaming chat with tools can stall indefinitely on some
@@ -739,6 +743,7 @@ class SimpleEngine(BaseEngine):
             await self.start()
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        mllm_draft_requested = bool(kwargs.pop("mllm_draft", False))
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -747,7 +752,9 @@ class SimpleEngine(BaseEngine):
         if (
             self._is_mllm
             and self._text_model is not None
-            and self._should_route_text_through_text_model()
+            and self._should_route_text_through_text_model(
+                mllm_draft_requested=mllm_draft_requested
+            )
             and not has_media_content(messages)
         ):
             has_mtp = (

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -125,6 +125,9 @@ class SimpleEngine(BaseEngine):
         specprefill_keep_pct: float = 0.3,
         specprefill_draft_model: str | None = None,
         max_kv_size: int = 0,
+        mllm_draft_model: str | None = None,
+        mllm_draft_kind: str | None = None,
+        mllm_draft_block_size: int | None = None,
     ):
         """
         Initialize the simple engine.
@@ -142,6 +145,9 @@ class SimpleEngine(BaseEngine):
             specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
             specprefill_draft_model: Path to small draft model for importance scoring
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
+            mllm_draft_model: Optional MLLM speculative draft/assistant model path
+            mllm_draft_kind: Optional mlx-vlm draft kind, for example "mtp"
+            mllm_draft_block_size: Optional speculative block size for mlx-vlm
         """
         self._model_name = model_name
         self._created_at = time.time()
@@ -157,6 +163,9 @@ class SimpleEngine(BaseEngine):
         self._specprefill_threshold = specprefill_threshold
         self._specprefill_keep_pct = specprefill_keep_pct
         self._specprefill_draft_model_path = specprefill_draft_model
+        self._mllm_draft_model_path = mllm_draft_model
+        self._mllm_draft_kind = mllm_draft_kind
+        self._mllm_draft_block_size = mllm_draft_block_size
 
         # KV cache size limit
         self._max_kv_size = max_kv_size
@@ -211,6 +220,9 @@ class SimpleEngine(BaseEngine):
                 trust_remote_code=self._trust_remote_code,
                 enable_cache=self._enable_cache,
                 max_kv_size=self._max_kv_size,
+                draft_model=self._mllm_draft_model_path,
+                draft_kind=self._mllm_draft_kind,
+                draft_block_size=self._mllm_draft_block_size,
             )
         else:
             from ..models.llm import MLXLanguageModel
@@ -256,7 +268,7 @@ class SimpleEngine(BaseEngine):
             # Build parallel mlx_lm TextModel for text-only routing.
             # Even when MTP is disabled, text-only requests should not be trapped
             # on the slower mlx_vlm multimodal path.
-            if self._is_mllm:
+            if self._is_mllm and self._should_route_text_through_text_model():
                 try:
                     from ..text_model_from_vlm import build_text_model
 
@@ -339,6 +351,10 @@ class SimpleEngine(BaseEngine):
         self._system_kv_hash = None
         self._system_kv_token_count = 0
         logger.info("SimpleEngine stopped")
+
+    def _should_route_text_through_text_model(self) -> bool:
+        """Return whether text-only MLLM requests may use mlx_lm TextModel."""
+        return self._mllm_draft_model_path is None
 
     async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
         """Run a blocking MLX operation under the generation lock.
@@ -658,6 +674,8 @@ class SimpleEngine(BaseEngine):
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
+                mtp_drafts=getattr(output, "mtp_drafts", 0),
+                mtp_accepted=getattr(output, "mtp_accepted", 0),
             )
         else:
             output = await self._run_blocking_serialized(
@@ -729,6 +747,7 @@ class SimpleEngine(BaseEngine):
         if (
             self._is_mllm
             and self._text_model is not None
+            and self._should_route_text_through_text_model()
             and not has_media_content(messages)
         ):
             has_mtp = (
@@ -788,6 +807,8 @@ class SimpleEngine(BaseEngine):
                             completion_tokens=token_count,
                             finished=finished,
                             finish_reason=chunk.finish_reason if finished else None,
+                            mtp_drafts=getattr(chunk, "mtp_drafts", 0),
+                            mtp_accepted=getattr(chunk, "mtp_accepted", 0),
                         )
 
                         if finished:
@@ -825,6 +846,8 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=token_count,
                     finished=finished,
                     finish_reason=chunk.finish_reason if finished else None,
+                    mtp_drafts=getattr(chunk, "mtp_drafts", 0),
+                    mtp_accepted=getattr(chunk, "mtp_accepted", 0),
                 )
 
                 if finished:

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -774,6 +774,14 @@ class SimpleEngine(BaseEngine):
                 yield chunk
             return
 
+        def mllm_call_kwargs() -> dict:
+            local_kwargs = dict(kwargs)
+            if chat_template_kwargs:
+                local_kwargs["chat_template_kwargs"] = chat_template_kwargs
+            if mllm_draft_requested:
+                local_kwargs["mllm_draft"] = True
+            return local_kwargs
+
         # Build prompt using tokenizer
         if self._is_mllm:
             if self._text_model is not None:
@@ -788,9 +796,7 @@ class SimpleEngine(BaseEngine):
             # current thread. Routing through to_thread can break mlx_vlm stream
             # ownership on some models (Stream(gpu, N) mismatch).
             if self._text_model is None and not has_media_content(messages):
-                local_kwargs = dict(kwargs)
-                if chat_template_kwargs:
-                    local_kwargs["chat_template_kwargs"] = chat_template_kwargs
+                local_kwargs = mllm_call_kwargs()
 
                 async with self._generation_lock:
                     _bind_worker_generation_streams()
@@ -824,9 +830,7 @@ class SimpleEngine(BaseEngine):
 
             # Run stream_chat in thread pool since it's synchronous
             def run_stream():
-                local_kwargs = dict(kwargs)
-                if chat_template_kwargs:
-                    local_kwargs["chat_template_kwargs"] = chat_template_kwargs
+                local_kwargs = mllm_call_kwargs()
                 return list(
                     self._model.stream_chat(
                         messages=messages,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -15,6 +15,7 @@ Features:
 
 import atexit
 import base64
+import json
 import ipaddress
 import logging
 import math
@@ -143,6 +144,42 @@ class MLLMOutput:
     finish_reason: str | None = None
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
+
+
+def load_gemma4_assistant_drafter(model_path: str):
+    """Load a Gemma 4 assistant drafter for mlx-vlm speculative decoding."""
+    try:
+        import mlx.core as mx
+        from mlx_vlm.speculative.drafters import gemma4_assistant as arch
+    except ImportError as exc:
+        raise ImportError(
+            "Gemma 4 assistant drafter support requires an mlx-vlm build that "
+            "provides mlx_vlm.speculative.drafters.gemma4_assistant."
+        ) from exc
+
+    path = Path(model_path)
+    config_path = path / "config.json"
+    weight_paths = sorted(path.glob("*.safetensors"))
+    if not config_path.exists():
+        raise FileNotFoundError(f"Gemma 4 assistant config not found: {config_path}")
+    if not weight_paths:
+        raise FileNotFoundError(f"Gemma 4 assistant weights not found: {path}")
+
+    config = arch.ModelConfig.from_dict(
+        json.loads(config_path.read_text(encoding="utf-8"))
+    )
+    model = arch.Model(config)
+    weights = {}
+    for weight_path in weight_paths:
+        weights.update(mx.load(str(weight_path)))
+    if hasattr(model, "sanitize"):
+        weights = model.sanitize(weights)
+    model.load_weights(list(weights.items()))
+    mx.eval(model.parameters())
+    model.eval()
+    return model
 
 
 def is_base64_image(s: str) -> bool:
@@ -856,6 +893,9 @@ class MLXMultimodalLM:
         enable_cache: bool = True,
         cache_size: int = 50,
         max_kv_size: int = 0,
+        draft_model: str | None = None,
+        draft_kind: str | None = None,
+        draft_block_size: int | None = None,
     ):
         """
         Initialize the MLX multimodal language model.
@@ -866,15 +906,22 @@ class MLXMultimodalLM:
             enable_cache: Enable KV cache for repeated image/video+prompt (default: True)
             cache_size: Maximum cache entries (default: 50)
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
+            draft_model: Optional MLLM speculative draft/assistant model path.
+            draft_kind: Optional mlx-vlm draft kind, for example "mtp".
+            draft_block_size: Optional speculative block size passed to mlx-vlm.
         """
         self.model_name = model_name
         self.trust_remote_code = trust_remote_code
         self.enable_cache = enable_cache
         self.max_kv_size = max_kv_size
+        self.draft_model_path = draft_model
+        self.draft_kind = draft_kind
+        self.draft_block_size = draft_block_size
 
         self.model = None
         self.processor = None
         self.config = None
+        self._draft_model = None
         self._loaded = False
         self._video_native = False
 
@@ -896,6 +943,8 @@ class MLXMultimodalLM:
 
             self.model, self.processor = load(self.model_name)
             self.config = load_config(self.model_name)
+            if self.draft_model_path:
+                self._draft_model = self._load_draft_model()
 
             self._loaded = True
             self._video_native = hasattr(
@@ -913,6 +962,53 @@ class MLXMultimodalLM:
         except Exception as e:
             logger.error(f"Failed to load MLLM: {e}")
             raise
+
+    def _load_draft_model(self):
+        if self.draft_kind == "mtp":
+            return load_gemma4_assistant_drafter(self.draft_model_path)
+
+        from mlx_vlm.utils import load
+
+        draft_model, _ = load(self.draft_model_path)
+        return draft_model
+
+    def _draft_generation_kwargs(self) -> dict:
+        if self._draft_model is None:
+            return {}
+        kwargs = {"draft_model": self._draft_model}
+        if self.draft_kind:
+            kwargs["draft_kind"] = self.draft_kind
+        if self.draft_block_size is not None:
+            kwargs["draft_block_size"] = self.draft_block_size
+        return kwargs
+
+    def _reset_draft_metrics(self) -> int:
+        if self._draft_model is None:
+            return 0
+        if hasattr(self._draft_model, "accept_lens"):
+            self._draft_model.accept_lens = []
+        return 0
+
+    def _draft_metrics_since(self, start_accept_lens: int) -> dict[str, int]:
+        if self._draft_model is None:
+            return {"mtp_drafts": 0, "mtp_accepted": 0}
+        accept_lens = list(getattr(self._draft_model, "accept_lens", []))
+        if start_accept_lens > len(accept_lens):
+            new_accept_lens = accept_lens
+        else:
+            new_accept_lens = accept_lens[start_accept_lens:]
+        block_size = (
+            int(self.draft_block_size)
+            if self.draft_block_size is not None
+            else int(
+                getattr(getattr(self._draft_model, "config", None), "block_size", 0)
+            )
+        )
+        drafted_per_round = max(block_size - 1, 0)
+        return {
+            "mtp_drafts": drafted_per_round * len(new_accept_lens),
+            "mtp_accepted": sum(int(value) for value in new_accept_lens),
+        }
 
     def get_language_model(self):
         """Extract the underlying language model for mlx_lm TextModel construction."""
@@ -1384,6 +1480,7 @@ class MLXMultimodalLM:
                 prompt_cache = None
 
         # Generate with cache
+        draft_accept_start = self._reset_draft_metrics()
         result = generate(
             self.model,
             self.processor,
@@ -1395,8 +1492,10 @@ class MLXMultimodalLM:
             top_p=top_p,
             verbose=False,
             prompt_cache=prompt_cache,
+            **self._draft_generation_kwargs(),
             **kwargs,
         )
+        draft_metrics = self._draft_metrics_since(draft_accept_start)
 
         # Store cache for future reuse (only on miss)
         if use_cache and self._cache_manager and all_sources and not cache_hit:
@@ -1425,6 +1524,7 @@ class MLXMultimodalLM:
             finish_reason="stop",
             prompt_tokens=prompt_tokens,
             completion_tokens=generation_tokens,
+            **draft_metrics,
         )
 
     def stream_generate(
@@ -1513,6 +1613,7 @@ class MLXMultimodalLM:
             audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
+            **self._draft_generation_kwargs(),
             **kwargs,
         ):
             yield chunk
@@ -1826,6 +1927,7 @@ class MLXMultimodalLM:
             except Exception:
                 prompt_cache = None
 
+        draft_accept_start = self._reset_draft_metrics()
         result = generate(
             self.model,
             self.processor,
@@ -1837,8 +1939,10 @@ class MLXMultimodalLM:
             verbose=False,
             prompt_cache=prompt_cache,
             skip_prompt_processing=skip_prompt_processing,
+            **self._draft_generation_kwargs(),
             **kwargs,
         )
+        draft_metrics = self._draft_metrics_since(draft_accept_start)
 
         # Store KV cache for future reuse (on cache miss)
         # IMPORTANT: We need to store only the prompt portion, not generated tokens
@@ -1921,6 +2025,7 @@ class MLXMultimodalLM:
             finish_reason="stop",
             prompt_tokens=prompt_tokens,
             completion_tokens=generation_tokens,
+            **draft_metrics,
         )
 
     def stream_chat(
@@ -2150,6 +2255,7 @@ class MLXMultimodalLM:
         # Stream generate tokens with cache
         accumulated_text = ""
         token_count = 0
+        draft_accept_start = self._reset_draft_metrics()
 
         for chunk in stream_generate(
             self.model,
@@ -2160,6 +2266,7 @@ class MLXMultimodalLM:
             max_tokens=max_tokens,
             temp=temperature,
             prompt_cache=prompt_cache,
+            **self._draft_generation_kwargs(),
             **kwargs,
         ):
             token_count += 1
@@ -2180,6 +2287,7 @@ class MLXMultimodalLM:
             finish_reason="stop",
             prompt_tokens=getattr(chunk, "prompt_tokens", 0) if "chunk" in dir() else 0,
             completion_tokens=token_count,
+            **self._draft_metrics_since(draft_accept_start),
         )
 
     def describe_image(

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -15,6 +15,7 @@ Features:
 
 import atexit
 import base64
+from importlib.metadata import PackageNotFoundError, version
 import json
 import ipaddress
 import logging
@@ -158,6 +159,16 @@ def load_gemma4_assistant_drafter(model_path: str):
             "Gemma 4 assistant drafter support requires an mlx-vlm build that "
             "provides mlx_vlm.speculative.drafters.gemma4_assistant."
         ) from exc
+
+    try:
+        mlx_vlm_version = version("mlx-vlm")
+    except PackageNotFoundError:
+        mlx_vlm_version = "unknown"
+    logger.info(
+        "Loading Gemma 4 assistant drafter from %s using mlx-vlm %s",
+        model_path,
+        mlx_vlm_version,
+    )
 
     path = Path(model_path)
     config_path = path / "config.json"
@@ -1021,11 +1032,20 @@ class MLXMultimodalLM:
         return draft_model
 
     def _draft_generation_kwargs(self, call_kwargs: dict | None = None) -> dict:
+        """Return mlx-vlm drafter kwargs when the request explicitly opts in.
+
+        ``call_kwargs`` is the outbound mlx-vlm kwargs dict. This method removes
+        vllm-mlx drafter control keys before the dict is forwarded so caller
+        passthrough values cannot conflict with the configured server drafter.
+        """
+        draft_requested = False
         if call_kwargs is not None:
+            draft_requested = bool(call_kwargs.pop("mllm_draft", False))
             for key in _DRAFT_KWARG_NAMES:
                 call_kwargs.pop(key, None)
-        if self._draft_model is None:
+        if not draft_requested or self._draft_model is None:
             return {}
+        # Tests may install the draft model after load(); the hook is idempotent.
         _install_draft_metrics_hooks(self._draft_model)
         kwargs = {"draft_model": self._draft_model}
         if self.draft_kind:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -182,6 +182,53 @@ def load_gemma4_assistant_drafter(model_path: str):
     return model
 
 
+_DRAFT_KWARG_NAMES = ("draft_model", "draft_kind", "draft_block_size")
+
+
+def _count_draft_tokens(draft_tokens) -> int:
+    """Best-effort drafted-token count for an mlx-vlm drafter output."""
+    shape = getattr(draft_tokens, "shape", None)
+    if shape:
+        try:
+            return max(int(shape[-1]), 0)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return max(len(draft_tokens), 0)
+    except TypeError:
+        return 0
+
+
+def _install_draft_metrics_hooks(draft_model) -> None:
+    """Record actual drafted token counts from mlx-vlm assistant drafters."""
+    if draft_model is None or getattr(draft_model, "_vllm_mlx_metrics_hooked", False):
+        return
+
+    if not hasattr(draft_model, "_vllm_mlx_draft_counts"):
+        draft_model._vllm_mlx_draft_counts = []
+
+    draft_block = getattr(draft_model, "draft_block", None)
+    if callable(draft_block):
+
+        def draft_block_with_metrics(*args, **kwargs):
+            draft_tokens = draft_block(*args, **kwargs)
+            draft_model._vllm_mlx_draft_counts.append(_count_draft_tokens(draft_tokens))
+            return draft_tokens
+
+        draft_model.draft_block = draft_block_with_metrics
+
+    reset = getattr(draft_model, "reset", None)
+    if callable(reset):
+
+        def reset_with_metrics(*args, **kwargs):
+            draft_model._vllm_mlx_draft_counts = []
+            return reset(*args, **kwargs)
+
+        draft_model.reset = reset_with_metrics
+
+    draft_model._vllm_mlx_metrics_hooked = True
+
+
 def is_base64_image(s: str) -> bool:
     """Check if string is base64-encoded image data."""
     return s.startswith("data:image/") or (
@@ -945,6 +992,7 @@ class MLXMultimodalLM:
             self.config = load_config(self.model_name)
             if self.draft_model_path:
                 self._draft_model = self._load_draft_model()
+                _install_draft_metrics_hooks(self._draft_model)
 
             self._loaded = True
             self._video_native = hasattr(
@@ -972,9 +1020,13 @@ class MLXMultimodalLM:
         draft_model, _ = load(self.draft_model_path)
         return draft_model
 
-    def _draft_generation_kwargs(self) -> dict:
+    def _draft_generation_kwargs(self, call_kwargs: dict | None = None) -> dict:
+        if call_kwargs is not None:
+            for key in _DRAFT_KWARG_NAMES:
+                call_kwargs.pop(key, None)
         if self._draft_model is None:
             return {}
+        _install_draft_metrics_hooks(self._draft_model)
         kwargs = {"draft_model": self._draft_model}
         if self.draft_kind:
             kwargs["draft_kind"] = self.draft_kind
@@ -987,6 +1039,8 @@ class MLXMultimodalLM:
             return 0
         if hasattr(self._draft_model, "accept_lens"):
             self._draft_model.accept_lens = []
+        if hasattr(self._draft_model, "_vllm_mlx_draft_counts"):
+            self._draft_model._vllm_mlx_draft_counts = []
         return 0
 
     def _draft_metrics_since(self, start_accept_lens: int) -> dict[str, int]:
@@ -997,6 +1051,11 @@ class MLXMultimodalLM:
             new_accept_lens = accept_lens
         else:
             new_accept_lens = accept_lens[start_accept_lens:]
+        draft_counts = list(getattr(self._draft_model, "_vllm_mlx_draft_counts", []))
+        if start_accept_lens > len(draft_counts):
+            new_draft_counts = draft_counts
+        else:
+            new_draft_counts = draft_counts[start_accept_lens:]
         block_size = (
             int(self.draft_block_size)
             if self.draft_block_size is not None
@@ -1005,8 +1064,13 @@ class MLXMultimodalLM:
             )
         )
         drafted_per_round = max(block_size - 1, 0)
+        mtp_drafts = (
+            sum(max(int(value), 0) for value in new_draft_counts)
+            if new_draft_counts
+            else drafted_per_round * len(new_accept_lens)
+        )
         return {
-            "mtp_drafts": drafted_per_round * len(new_accept_lens),
+            "mtp_drafts": mtp_drafts,
             "mtp_accepted": sum(int(value) for value in new_accept_lens),
         }
 
@@ -1492,7 +1556,7 @@ class MLXMultimodalLM:
             top_p=top_p,
             verbose=False,
             prompt_cache=prompt_cache,
-            **self._draft_generation_kwargs(),
+            **self._draft_generation_kwargs(kwargs),
             **kwargs,
         )
         draft_metrics = self._draft_metrics_since(draft_accept_start)
@@ -1613,7 +1677,7 @@ class MLXMultimodalLM:
             audio=all_audio if all_audio else None,
             max_tokens=max_tokens,
             temp=temperature,
-            **self._draft_generation_kwargs(),
+            **self._draft_generation_kwargs(kwargs),
             **kwargs,
         ):
             yield chunk
@@ -1939,7 +2003,7 @@ class MLXMultimodalLM:
             verbose=False,
             prompt_cache=prompt_cache,
             skip_prompt_processing=skip_prompt_processing,
-            **self._draft_generation_kwargs(),
+            **self._draft_generation_kwargs(kwargs),
             **kwargs,
         )
         draft_metrics = self._draft_metrics_since(draft_accept_start)
@@ -2266,7 +2330,7 @@ class MLXMultimodalLM:
             max_tokens=max_tokens,
             temp=temperature,
             prompt_cache=prompt_cache,
-            **self._draft_generation_kwargs(),
+            **self._draft_generation_kwargs(kwargs),
             **kwargs,
         ):
             token_count += 1

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -151,7 +151,7 @@ from .audio_limits import (
     save_upload_with_limit,
     validate_tts_input_length,
 )
-from .cli_arg_types import make_json_object_arg_parser
+from .cli_arg_types import make_json_object_arg_parser, make_positive_int_arg_parser
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
 from .endpoint_model_policies import (
     resolve_embedding_model_name,
@@ -597,6 +597,9 @@ def _prepare_chat_completion_invocation(
 
     if request.enable_thinking is not None:
         chat_kwargs["enable_thinking"] = request.enable_thinking
+
+    if request.mllm_draft is not None:
+        chat_kwargs["mllm_draft"] = request.mllm_draft
 
     if request.tools and request.tool_choice != "none":
         template_tools = convert_tools_for_template(request.tools)
@@ -2789,6 +2792,10 @@ def load_model(
         raise ValueError("Max request tokens must be at least 1")
     if max_tokens > max_request_tokens:
         raise ValueError("Default max tokens cannot exceed max request tokens")
+    if mllm_draft_model and not force_mllm:
+        raise ValueError("MLLM draft models require force_mllm/--mllm")
+    if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
+        raise ValueError("MLLM draft block size must be a positive integer")
     if mllm_draft_model and use_batching:
         raise ValueError("MLLM draft models are supported only by SimpleEngine")
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
@@ -6221,7 +6228,7 @@ Examples:
     )
     parser.add_argument(
         "--mllm-draft-block-size",
-        type=int,
+        type=make_positive_int_arg_parser("--mllm-draft-block-size"),
         default=None,
         help="Draft block size passed to mlx-vlm for --mllm-draft-model.",
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2741,6 +2741,9 @@ def load_model(
     specprefill_threshold: int = 8192,
     specprefill_keep_pct: float = 0.3,
     specprefill_draft_model: str = None,
+    mllm_draft_model: str | None = None,
+    mllm_draft_kind: str | None = None,
+    mllm_draft_block_size: int | None = None,
     warm_prompts_path: str | None = None,
     auto_unload_idle_seconds: float = 0.0,
     lazy_load_model: bool = False,
@@ -2763,6 +2766,9 @@ def load_model(
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
+        mllm_draft_model: Optional MLLM speculative draft/assistant model path.
+        mllm_draft_kind: Optional mlx-vlm draft kind, for example "mtp".
+        mllm_draft_block_size: Optional speculative block size passed to mlx-vlm.
         auto_unload_idle_seconds: Idle time before auto-unloading the main model.
             When non-zero, the main model is managed through lifecycle
             residency instead of being loaded immediately in this function.
@@ -2783,6 +2789,12 @@ def load_model(
         raise ValueError("Max request tokens must be at least 1")
     if max_tokens > max_request_tokens:
         raise ValueError("Default max tokens cannot exceed max request tokens")
+    if mllm_draft_model and use_batching:
+        raise ValueError("MLLM draft models are supported only by SimpleEngine")
+    if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
+        raise ValueError(
+            "MLLM draft models are not supported with lifecycle residency yet"
+        )
 
     if _lifespan_active:
         raise RuntimeError(
@@ -2898,6 +2910,9 @@ def load_model(
             specprefill_keep_pct=specprefill_keep_pct,
             specprefill_draft_model=specprefill_draft_model,
             max_kv_size=_max_kv,
+            mllm_draft_model=mllm_draft_model,
+            mllm_draft_kind=mllm_draft_kind,
+            mllm_draft_block_size=mllm_draft_block_size,
         )
         # Start SimpleEngine synchronously (no background loop)
         # Use new_event_loop() for Python 3.10+ compatibility (get_event_loop() is deprecated)
@@ -6123,6 +6138,9 @@ def main():
         max_request_tokens=args.max_request_tokens,
         force_mllm=args.mllm,
         trust_remote_code=args.trust_remote_code,
+        mllm_draft_model=args.mllm_draft_model,
+        mllm_draft_kind=args.mllm_draft_kind,
+        mllm_draft_block_size=args.mllm_draft_block_size,
         auto_unload_idle_seconds=args.auto_unload_idle_seconds,
         lazy_load_model=args.lazy_load_model,
     )
@@ -6187,6 +6205,25 @@ Examples:
         "--continuous-batching",
         action="store_true",
         help="Enable continuous batching for multiple concurrent users",
+    )
+    parser.add_argument(
+        "--mllm-draft-model",
+        type=str,
+        default=None,
+        help="Path to an mlx-vlm MLLM draft/assistant model.",
+    )
+    parser.add_argument(
+        "--mllm-draft-kind",
+        type=str,
+        default=None,
+        choices=["mtp"],
+        help="mlx-vlm draft kind for --mllm-draft-model.",
+    )
+    parser.add_argument(
+        "--mllm-draft-block-size",
+        type=int,
+        default=None,
+        help="Draft block size passed to mlx-vlm for --mllm-draft-model.",
     )
     parser.add_argument(
         "--mcp-config",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -598,8 +598,9 @@ def _prepare_chat_completion_invocation(
     if request.enable_thinking is not None:
         chat_kwargs["enable_thinking"] = request.enable_thinking
 
-    if request.mllm_draft is not None:
-        chat_kwargs["mllm_draft"] = request.mllm_draft
+    mllm_draft = getattr(request, "mllm_draft", None)
+    if mllm_draft is not None:
+        chat_kwargs["mllm_draft"] = mllm_draft
 
     if request.tools and request.tool_choice != "none":
         template_tools = convert_tools_for_template(request.tools)


### PR DESCRIPTION
## Summary
- wire direct SimpleEngine/MLXMultimodalLM support for activation-sharing MLLM assistant drafters
- add CLI/server flags for `--mllm-draft-model`, `--mllm-draft-kind mtp`, and `--mllm-draft-block-size`
- keep text-only MLLM drafter requests on the mlx-vlm MLLM path by disabling TextModel routing when an MLLM drafter is configured
- expose request-local MLLM drafter counters through `MLLMOutput` / `GenerationOutput`
- reject currently unsupported combinations with continuous batching and lifecycle residency

## Runtime motivation
This PR is driven by Runtime Gemma 4 MTP bring-up. The first Runtime target is E2B: `google/gemma-4-E2B-it` plus the `gemma4_assistant` drafter checkpoint. The assistant loader requires an mlx-vlm build that provides `mlx_vlm.speculative.drafters.gemma4_assistant`.

## Runtime qualification evidence
Runtime E2B non-live server proof now passes for the narrow path this PR enables: SimpleEngine, forced MLLM, no-thinking chat-template request, explicit MLLM assistant drafter, `draft_kind=mtp`, `draft_block_size=3`.

Matched non-streaming probe:
- target-only output and target+assistant output matched exactly
- output SHA256: `1e2b24b02560f124666235e1503e1eeffa14d9849891979edc83db9689398bdb`
- target-only metadata: `routing=textmodel`, `mtp_drafts=0`, `mtp_accepted=0`, latency `0.447822334s`, peak Metal `10.31GB`
- target+assistant metadata: `routing=textmodel_mtp`, `mtp_drafts=28`, `mtp_accepted=6`, `mtp_acceptance_rate=0.2143`, latency `0.698765959s`, peak Metal `10.47GB`

Streaming `bench-serve` probe:
- repetitions: `3`
- quality: `passed=true`, `failure_count=0`, `quality_passed=true`
- latency mean: `545.1278886757791ms`
- TTFT mean: `542.30075001639ms`
- all repetitions reported `routing=textmodel_mtp` and `mtp_acceptance_rate=0.2143`

This is narrow non-live Runtime evidence, not a production/live Gemma lane qualification.

## Scope boundary
This is intentionally narrow upstream wiring. It does not add registry/residency support, live routing, continuous batching support, Jobs routing, Open WebUI routing, or broad Runtime model qualification.

## Validation
- `.venv-test/bin/python -m pytest tests/test_mllm_assistant_drafter.py tests/test_lifecycle_cli.py tests/test_mllm_mtp_routing.py tests/test_simple_engine.py tests/test_mllm.py -q` (`81 passed, 6 deselected`)
- `.venv-test/bin/python -m py_compile vllm_mlx/models/mllm.py vllm_mlx/engine/base.py vllm_mlx/engine/simple.py tests/test_mllm_assistant_drafter.py`
- `.venv-test/bin/python -m black --check vllm_mlx/models/mllm.py vllm_mlx/engine/base.py vllm_mlx/engine/simple.py tests/test_mllm_assistant_drafter.py`
- `git diff --check`
