### PR TITLE
Add no-final-content watchdog metadata for thinking routes

### DIFF
--- a/tests/test_no_final_content_watchdog.py
+++ b/tests/test_no_final_content_watchdog.py
@@ -7,6 +7,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _load_thinking_processor():
@@ -64,3 +65,47 @@ def test_budget_transition_does_not_mark_watchdog_enforced():
 
     assert proc.state is module.Phase.TRANSITIONING
     assert proc.watchdog_was_enforced is False
+
+
+def test_generation_metadata_uses_processor_limit_not_current_env(monkeypatch):
+    from vllm_mlx import server
+
+    proc = SimpleNamespace(
+        _no_final_content_token_limit=7,
+        watchdog_was_enforced=True,
+    )
+
+    monkeypatch.setenv("VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT", "99")
+
+    metadata = server._generation_metadata(proc)
+
+    assert metadata is not None
+    assert metadata.no_final_content_watchdog_tokens == 7
+    assert metadata.no_final_content_watchdog_enforced is True
+
+
+def test_generation_metadata_omitted_without_thinking_processor(monkeypatch):
+    from vllm_mlx import server
+
+    monkeypatch.setenv("VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT", "7")
+
+    assert server._generation_metadata(None) is None
+
+
+def test_build_thinking_processor_warns_when_watchdog_cannot_fire(monkeypatch, caplog):
+    from vllm_mlx import server
+
+    class Tokenizer:
+        vocab_size = 100
+
+        def encode(self, text, add_special_tokens=False):
+            return {"<think>": [1], "</think>": [2]}[text]
+
+    engine = SimpleNamespace(_tokenizer=Tokenizer())
+    monkeypatch.setenv("VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT", "10")
+
+    proc = server._build_thinking_processor(engine, 5)
+
+    assert proc is not None
+    assert proc._no_final_content_token_limit == 10
+    assert "will not fire" in caplog.text

--- a/tests/test_no_final_content_watchdog.py
+++ b/tests/test_no_final_content_watchdog.py
@@ -1,0 +1,66 @@
+"""No-final-content watchdog regressions for thinking routes."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_thinking_processor():
+    class _FakeArray:
+        pass
+
+    fake_mx = types.SimpleNamespace(array=_FakeArray)
+    sys.modules.setdefault("mlx", types.ModuleType("mlx"))
+    sys.modules["mlx.core"] = fake_mx
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "vllm_mlx/constrained/thinking_processor.py"
+    )
+    loader = importlib.machinery.SourceFileLoader(
+        "thinking_processor_under_test", str(path)
+    )
+    spec = importlib.util.spec_from_loader("thinking_processor_under_test", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_no_final_content_watchdog_forces_transition_before_budget():
+    module = _load_thinking_processor()
+    proc = module.ThinkingAwareLogitsProcessor(
+        start_token_ids=[1],
+        end_token_ids=[2],
+        thinking_token_budget=100,
+        prompt_has_think_tag=True,
+        no_final_content_token_limit=3,
+    )
+
+    for token_id in [10, 11, 12]:
+        proc._advance_with_token(token_id)
+
+    assert proc.state is module.Phase.TRANSITIONING
+    assert proc.watchdog_was_enforced is True
+    assert proc.thinking_tokens == 3
+
+
+def test_budget_transition_does_not_mark_watchdog_enforced():
+    module = _load_thinking_processor()
+    proc = module.ThinkingAwareLogitsProcessor(
+        start_token_ids=[1],
+        end_token_ids=[2],
+        thinking_token_budget=2,
+        prompt_has_think_tag=True,
+        no_final_content_token_limit=10,
+    )
+
+    for token_id in [10, 11]:
+        proc._advance_with_token(token_id)
+
+    assert proc.state is module.Phase.TRANSITIONING
+    assert proc.watchdog_was_enforced is False

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -248,6 +248,7 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: list[ChatCompletionChoice]
     usage: Usage = Field(default_factory=Usage)
+    generation_metadata: dict | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -239,6 +239,13 @@ class Usage(BaseModel):
     total_tokens: int = 0
 
 
+class GenerationMetadata(BaseModel):
+    """Optional generation diagnostics emitted for feature-bearing requests."""
+
+    no_final_content_watchdog_tokens: int | None = None
+    no_final_content_watchdog_enforced: bool = False
+
+
 class ChatCompletionResponse(BaseModel):
     """Response for chat completion."""
 
@@ -248,7 +255,7 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: list[ChatCompletionChoice]
     usage: Usage = Field(default_factory=Usage)
-    generation_metadata: dict | None = None
+    generation_metadata: GenerationMetadata | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/constrained/thinking_processor.py
+++ b/vllm_mlx/constrained/thinking_processor.py
@@ -85,6 +85,8 @@ class ThinkingAwareLogitsProcessor:
         "_processed_len",
         "_processed_token_ids",
         "_snapshots",
+        "watchdog_was_enforced",
+        "_no_final_content_token_limit",
     )
 
     def __init__(
@@ -95,6 +97,7 @@ class ThinkingAwareLogitsProcessor:
         inner: Callable[[mx.array, mx.array], mx.array] | None = None,
         vocab_size: int = 152064,
         prompt_has_think_tag: bool = False,
+        no_final_content_token_limit: int | None = None,
     ) -> None:
         self._start_matcher = BoundedSuffixMatcher(start_token_ids)
         self._end_matcher = BoundedSuffixMatcher(end_token_ids)
@@ -109,6 +112,8 @@ class ThinkingAwareLogitsProcessor:
         self._vocab_size = vocab_size
         self._thinking_tokens = 0
         self._transition_index = 0
+        self.watchdog_was_enforced = False
+        self._no_final_content_token_limit = no_final_content_token_limit
         # When the chat template already injected <think> into the prompt,
         # the first generated token is already inside the thinking span.
         # Start in THINKING (or TRANSITIONING if budget=0) instead of IDLE.
@@ -189,13 +194,14 @@ class ThinkingAwareLogitsProcessor:
 
     def _snapshot_state(
         self,
-    ) -> tuple[Phase, int, int, tuple[int, ...], tuple[int, ...]]:
+    ) -> tuple[Phase, int, int, tuple[int, ...], tuple[int, ...], bool]:
         return (
             self._state,
             self._thinking_tokens,
             self._transition_index,
             self._start_matcher.snapshot(),
             self._end_matcher.snapshot(),
+            self.watchdog_was_enforced,
         )
 
     def _restore_snapshot(self, processed_len: int) -> None:
@@ -210,6 +216,7 @@ class ThinkingAwareLogitsProcessor:
             self._transition_index,
             start_state,
             end_state,
+            self.watchdog_was_enforced,
         ) = self._snapshots[snap_idx]
         self._start_matcher.restore(start_state)
         self._end_matcher.restore(end_state)
@@ -257,6 +264,13 @@ class ThinkingAwareLogitsProcessor:
             if self._thinking_tokens >= self._thinking_token_budget:
                 self._state = Phase.TRANSITIONING
                 self._transition_index = 0
+            elif (
+                self._no_final_content_token_limit is not None
+                and self._thinking_tokens >= self._no_final_content_token_limit
+            ):
+                self._state = Phase.TRANSITIONING
+                self._transition_index = 0
+                self.watchdog_was_enforced = True
             return
 
         if self._state == Phase.TRANSITIONING:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -257,6 +257,7 @@ class PreparedChatInvocation:
     chat_kwargs: dict[str, object]
     response_format: object | None
     json_logits_processor: object | None
+    thinking_processor: object | None = None
 
 
 def _prepare_chat_messages(
@@ -419,6 +420,7 @@ def _build_thinking_processor(
         inner=inner,
         vocab_size=vocab_size,
         prompt_has_think_tag=prompt_has_think_tag,
+        no_final_content_token_limit=_resolve_no_final_content_token_limit(),
     )
     logger.info(
         "Thinking processor enabled: budget=%d, start=%s, end=%s",
@@ -427,6 +429,29 @@ def _build_thinking_processor(
         end_ids,
     )
     return proc
+
+
+def _resolve_no_final_content_token_limit() -> int | None:
+    raw = os.environ.get("VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT")
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT=%r", raw)
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
+def _generation_metadata(thinking_processor: object | None) -> dict:
+    return {
+        "no_final_content_watchdog_tokens": _resolve_no_final_content_token_limit(),
+        "no_final_content_watchdog_enforced": bool(
+            getattr(thinking_processor, "watchdog_was_enforced", False)
+        ),
+    }
 
 
 class _ThinkingAwareLogitsProcessor:
@@ -644,6 +669,7 @@ def _prepare_chat_completion_invocation(
     # default budget should not alter non-thinking requests.
     thinking_budget = request.thinking_token_budget or _default_thinking_token_budget
     enable_thinking = chat_kwargs.get("enable_thinking", True)
+    thinking_proc = None
     if thinking_budget is not None and enable_thinking is not False:
         thinking_proc = _build_thinking_processor(
             engine,
@@ -661,6 +687,7 @@ def _prepare_chat_completion_invocation(
         chat_kwargs=chat_kwargs,
         response_format=response_format,
         json_logits_processor=json_logits_processor,
+        thinking_processor=thinking_proc,
     )
 
 
@@ -4600,6 +4627,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 completion_tokens=output.completion_tokens,
                 total_tokens=output.prompt_tokens + output.completion_tokens,
             ),
+            generation_metadata=_generation_metadata(prepared.thinking_processor),
         )
     finally:
         if release_on_exit:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -87,6 +87,7 @@ from .api.models import (
     EmbeddingResponse,
     EmbeddingUsage,
     FunctionCall,
+    GenerationMetadata,
     ImageUrl,  # noqa: F401
     MCPExecuteRequest,
     MCPExecuteResponse,
@@ -413,6 +414,18 @@ def _build_thinking_processor(
 
     vocab_size = getattr(tokenizer, "vocab_size", 152064)
 
+    no_final_content_token_limit = _resolve_no_final_content_token_limit()
+    if (
+        no_final_content_token_limit is not None
+        and no_final_content_token_limit >= thinking_token_budget
+    ):
+        logger.warning(
+            "VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT=%d will not fire because "
+            "thinking_token_budget=%d is reached first",
+            no_final_content_token_limit,
+            thinking_token_budget,
+        )
+
     proc = ThinkingAwareLogitsProcessor(
         start_token_ids=start_ids,
         end_token_ids=end_ids,
@@ -420,7 +433,7 @@ def _build_thinking_processor(
         inner=inner,
         vocab_size=vocab_size,
         prompt_has_think_tag=prompt_has_think_tag,
-        no_final_content_token_limit=_resolve_no_final_content_token_limit(),
+        no_final_content_token_limit=no_final_content_token_limit,
     )
     logger.info(
         "Thinking processor enabled: budget=%d, start=%s, end=%s",
@@ -445,13 +458,19 @@ def _resolve_no_final_content_token_limit() -> int | None:
     return value
 
 
-def _generation_metadata(thinking_processor: object | None) -> dict:
-    return {
-        "no_final_content_watchdog_tokens": _resolve_no_final_content_token_limit(),
-        "no_final_content_watchdog_enforced": bool(
+def _generation_metadata(
+    thinking_processor: object | None,
+) -> GenerationMetadata | None:
+    if thinking_processor is None:
+        return None
+    return GenerationMetadata(
+        no_final_content_watchdog_tokens=getattr(
+            thinking_processor, "_no_final_content_token_limit", None
+        ),
+        no_final_content_watchdog_enforced=bool(
             getattr(thinking_processor, "watchdog_was_enforced", False)
         ),
-    }
+    )
 
 
 class _ThinkingAwareLogitsProcessor:


### PR DESCRIPTION
# Add no-final-content watchdog metadata for thinking routes

Related issue: #510

## Summary

Adds a conservative, opt-in no-final-content watchdog to thinking-route
generation. When configured, the watchdog forces the thinking close sequence if
generation is still in the reasoning phase after the configured token limit.
The non-streaming chat response metadata reports the configured limit and
whether the watchdog fired for the request.

## Local repro

Local Runtime evidence before this fix:

- `/opt/ai-runtime/run/serving-safety-isolation/20260501-reasoning-logic-precise-codex-1/`
- `/opt/ai-runtime/run/live-feature-parity/20260507T-122b-cb-watchdog-rerun2`
- `/opt/ai-runtime/run/live-feature-parity/20260507T-122b-combined-watchdog-rerun`

Observed behavior:

- generation could remain in the reasoning phase until the length cap
- final content was empty
- `finish_reason=length`
- response metadata did not say whether a no-final-content guard was available
  or enforced

## Exact upstream code path compared

Base commit: `1e24e156f52c26bf96d55d605f266d9debcfa801`

Compared paths/functions:

- `vllm_mlx/constrained/thinking_processor.py::ThinkingAwareLogitsProcessor`
- `vllm_mlx/server.py::_build_thinking_processor`
- `vllm_mlx/api/models.py::ChatCompletionResponse`

## What changed

- Added optional `no_final_content_token_limit` handling to
  `ThinkingAwareLogitsProcessor`.
- Preserved watchdog state in rollback snapshots.
- Added `VLLM_MLX_NO_FINAL_CONTENT_TOKEN_LIMIT` server resolution.
- Added non-streaming `generation_metadata` fields:
  - `no_final_content_watchdog_tokens`
  - `no_final_content_watchdog_enforced`
- Added focused watchdog regression tests.

## Validation

- `git diff --check`
- `python -m py_compile vllm_mlx/constrained/thinking_processor.py vllm_mlx/server.py vllm_mlx/api/models.py tests/test_no_final_content_watchdog.py`
- direct focused execution of:
  - `test_no_final_content_watchdog_forces_transition_before_budget`
  - `test_budget_transition_does_not_mark_watchdog_enforced`

I did not bypass the local Runtime safety gate to run the full pytest command
while a live LaunchAgent was loaded.

## What this does not claim

- This does not change default behavior unless the environment variable is set.
- This is not a model-quality claim.
- This does not change chat template rendering.
- This does not claim every length stop is invalid.
