### PR TITLE
Split summarize_workload_results into per-case helper

### DIFF
--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -1593,11 +1593,63 @@ async def run_workload_case(
     )
 
 
+def _group_results_by_case_id(results: list[dict]) -> dict[str, list[dict]]:
+    """Bucket workload case records by their ``case_id`` field, defaulting
+    a missing ``case_id`` to the empty string so the grouping is stable."""
+    cases: dict[str, list[dict]] = {}
+    for result in results:
+        cases.setdefault(str(result.get("case_id", "")), []).append(result)
+    return cases
+
+
+def _summarize_case(case_results: list[dict]) -> dict:
+    """Build the per-case summary block.
+
+    Mirrors the shape used at the run-level (sample counts, pass/fail
+    rates, policy-timeout outcome, latency / ttft / gen_tps summaries)
+    and adds two case-only fields: ``sample_count`` and ``repetitions``
+    (the sorted set of repetition indices the case was run under), plus
+    ``content_chars`` since content length is more useful per-case than
+    per-run.
+    """
+    quality_failures = [r for r in case_results if not r["quality"].get("ok")]
+    policy_trials = [
+        r for r in case_results if r["policy"].get("within_timeout") is not None
+    ]
+    policy_failures = [
+        r for r in policy_trials if r["policy"].get("within_timeout") is False
+    ]
+    return {
+        "sample_count": len(case_results),
+        "repetitions": sorted(
+            {
+                int(r.get("repetition", 0))
+                for r in case_results
+                if r.get("repetition") is not None
+            }
+        ),
+        "passed": not quality_failures,
+        "failure_count": len(quality_failures),
+        "failure_rate": (
+            round(len(quality_failures) / len(case_results), 4) if case_results else 0.0
+        ),
+        "policy_timeout_passed": (not policy_failures if policy_trials else None),
+        "policy_timeout_failure_count": (
+            len(policy_failures) if policy_trials else None
+        ),
+        "latency_ms": _summary_or_empty(
+            [r["metrics"]["e2e_latency_ms"] for r in case_results]
+        ),
+        "ttft_ms": _summary_or_empty([r["metrics"]["ttft_ms"] for r in case_results]),
+        "gen_tps": _summary_or_empty([r["metrics"]["gen_tps"] for r in case_results]),
+        "content_chars": _summary_or_empty(
+            [r["quality"].get("content_chars", 0) for r in case_results]
+        ),
+    }
+
+
 def summarize_workload_results(results: list[dict]) -> dict:
     """Aggregate workload case records into stable qualification summary stats."""
-    latencies = [r["metrics"]["e2e_latency_ms"] for r in results]
-    ttft = [r["metrics"]["ttft_ms"] for r in results]
-    gen_tps = [r["metrics"]["gen_tps"] for r in results]
     failures = [r for r in results if not r["quality"]["ok"]]
     policy_trials = [
         r for r in results if r["policy"].get("within_timeout") is not None
@@ -1605,54 +1657,12 @@ def summarize_workload_results(results: list[dict]) -> dict:
     policy_failures = [
         r for r in policy_trials if r["policy"].get("within_timeout") is False
     ]
-    cases: dict[str, list[dict]] = {}
-    for result in results:
-        cases.setdefault(str(result.get("case_id", "")), []).append(result)
 
-    case_summaries = {}
-    for case_id, case_results in sorted(cases.items()):
-        case_quality_failures = [r for r in case_results if not r["quality"].get("ok")]
-        case_policy_trials = [
-            r for r in case_results if r["policy"].get("within_timeout") is not None
-        ]
-        case_policy_failures = [
-            r for r in case_policy_trials if r["policy"].get("within_timeout") is False
-        ]
-        case_summaries[case_id] = {
-            "sample_count": len(case_results),
-            "repetitions": sorted(
-                {
-                    int(r.get("repetition", 0))
-                    for r in case_results
-                    if r.get("repetition") is not None
-                }
-            ),
-            "passed": not case_quality_failures,
-            "failure_count": len(case_quality_failures),
-            "failure_rate": (
-                round(len(case_quality_failures) / len(case_results), 4)
-                if case_results
-                else 0.0
-            ),
-            "policy_timeout_passed": (
-                not case_policy_failures if case_policy_trials else None
-            ),
-            "policy_timeout_failure_count": (
-                len(case_policy_failures) if case_policy_trials else None
-            ),
-            "latency_ms": _summary_or_empty(
-                [r["metrics"]["e2e_latency_ms"] for r in case_results]
-            ),
-            "ttft_ms": _summary_or_empty(
-                [r["metrics"]["ttft_ms"] for r in case_results]
-            ),
-            "gen_tps": _summary_or_empty(
-                [r["metrics"]["gen_tps"] for r in case_results]
-            ),
-            "content_chars": _summary_or_empty(
-                [r["quality"].get("content_chars", 0) for r in case_results]
-            ),
-        }
+    cases = _group_results_by_case_id(results)
+    case_summaries = {
+        case_id: _summarize_case(case_results)
+        for case_id, case_results in sorted(cases.items())
+    }
 
     return {
         "case_count": len(results),
@@ -1670,9 +1680,11 @@ def summarize_workload_results(results: list[dict]) -> dict:
         "policy_timeout_failure_count": (
             len(policy_failures) if policy_trials else None
         ),
-        "latency_ms": _summary_or_empty(latencies),
-        "ttft_ms": _summary_or_empty(ttft),
-        "gen_tps": _summary_or_empty(gen_tps),
+        "latency_ms": _summary_or_empty(
+            [r["metrics"]["e2e_latency_ms"] for r in results]
+        ),
+        "ttft_ms": _summary_or_empty([r["metrics"]["ttft_ms"] for r in results]),
+        "gen_tps": _summary_or_empty([r["metrics"]["gen_tps"] for r in results]),
         "case_summaries": case_summaries,
     }
 


### PR DESCRIPTION
Refs #499. Follow-up to #515, #517, #518.

## Summary

Splits the 80-line `summarize_workload_results` into a thinner
top-level aggregator plus two helpers along the same boundaries the
earlier splits in #515, #517, and #518 followed. This is the last
follow-up issue #499 calls out for `vllm_mlx/bench_serve.py`.

Behavior-preserving on every input. The existing
`test_summarize_workload_results_tracks_quality_and_policy` in
`tests/test_bench_serve.py:1145` passes without modification.

## Refactor: split summarize_workload_results

Extracted from `vllm_mlx/bench_serve.py` `summarize_workload_results`:

- **`_group_results_by_case_id(results) -> dict[str, list[dict]]`**.
  Buckets workload case records by their `case_id` field, defaulting
  a missing `case_id` to the empty string so the grouping is stable.
- **`_summarize_case(case_results) -> dict`**. Builds the per-case
  summary block. Mirrors the shape used at the run level (sample
  counts, pass/fail rates, policy-timeout outcome, latency / ttft /
  gen_tps summaries) and adds the case-only fields `sample_count`,
  `repetitions`, `content_chars`.

`summarize_workload_results` itself becomes a clean top-level
aggregator: compute global failures and policy trials, group by case,
build per-case summaries via the helper, return the assembled dict.

The workload formatters (`format_workload_table`,
`format_workload_csv`, `format_workload_sql`,
`format_workload_json`, `format_workload_payload`,
`write_workload_sqlite`) were considered as part of this split too,
but `_workload_record_to_row` (the only repeated logic) is already
factored out, and each formatter is small and single-purpose. No
extraction needed there.

## Verification

```text
======================== 98 passed in 0.40s ========================
```

Full bench-serve suite is green:
`pytest tests/test_bench_serve.py` → 98 passed + 2 skipped (live-run
integration).

`black --check vllm_mlx/bench_serve.py` is clean.

## Note on scope

This is the final refactor split for #499. With #515, #517, #518,
and this PR, the four splits the advisory complexity scan asked for
are all in flight, each independent of the others (all based on
`main`, no merge conflicts). The last of the four to land closes the
issue.

No new tests required: the existing
`test_summarize_workload_results_tracks_quality_and_policy` exercises
the per-case summary path through the public function.