### PR TITLE
detect MLLM via config.json with substring matcher as fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,18 @@ jobs:
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
             tests/test_harmony_parsers.py \
+            tests/test_endpoint_model_policies.py \
+            tests/test_gemma4_openai_format.py \
+            tests/test_gemma4_streaming_edge.py \
+            tests/test_gemma4_tool_parser.py \
+            tests/test_minimax_tool_calling.py \
+            tests/test_qwen3_xml_parser.py \
+            tests/test_qwen3_xml_registration.py \
+            tests/test_qwen3_xml_streaming_chunks.py \
+            tests/test_streaming_fence_stripper.py \
+            tests/test_streaming_think_router.py \
+            tests/test_streaming_tool_filter.py \
+            tests/test_tool_call_promotion.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \
@@ -135,6 +147,11 @@ jobs:
             tests/test_batching.py \
             tests/test_continuous_batching.py \
             tests/test_memory_cache_mlx.py \
+            tests/test_normalize_messages.py \
+            tests/test_responses_api.py \
+            tests/test_thinking_aware_processor.py \
+            tests/test_tool_choice_forced.py \
+            tests/test_tool_choice_none.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -288,16 +288,12 @@ class TestIsMllmModelConfigPriority:
 
     def test_config_indicates_vlm_recognises_llava(self):
         assert (
-            _config_indicates_vlm(
-                {"architectures": ["LlavaForConditionalGeneration"]}
-            )
+            _config_indicates_vlm({"architectures": ["LlavaForConditionalGeneration"]})
             is True
         )
 
     def test_config_indicates_vlm_rejects_text_only_qwen3(self):
-        assert (
-            _config_indicates_vlm({"architectures": ["Qwen3ForCausalLM"]}) is False
-        )
+        assert _config_indicates_vlm({"architectures": ["Qwen3ForCausalLM"]}) is False
 
     def test_config_indicates_vlm_handles_missing_architectures(self):
         assert _config_indicates_vlm({"model_type": "qwen3"}) is False

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -6,11 +6,16 @@ Tests clean_output_text, is_mllm_model, and extract_multimodal_content
 from vllm_mlx/api/utils.py. No MLX dependency.
 """
 
+import json
+
 from vllm_mlx.api.models import ContentPart, ImageUrl, Message
 from vllm_mlx.api.utils import (
     MLLM_PATTERNS,
     SPECIAL_TOKENS_PATTERN,
+    _check_legacy_string_patterns,
+    _config_indicates_vlm,
     _content_to_text,
+    _try_read_config_json,
     clean_output_text,
     extract_multimodal_content,
     is_mllm_model,
@@ -191,6 +196,114 @@ class TestIsMllmModel:
 
     def test_all_patterns_defined(self):
         assert len(MLLM_PATTERNS) > 20
+
+
+class TestIsMllmModelConfigPriority:
+    """Tests that config.json takes priority over the legacy substring matcher.
+
+    Regression coverage for issue #516: a local path with a triggering
+    substring (e.g. "vl-") used to be misrouted to the MLLM loader even when
+    the model itself was text-only. With config.json inspection in front,
+    the model's own metadata wins.
+    """
+
+    @staticmethod
+    def _write_config(tmp_path, name, payload):
+        model_dir = tmp_path / name
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps(payload))
+        return model_dir
+
+    def test_text_only_config_overrides_triggering_path(self, tmp_path):
+        # Path basename contains "vl-" which would match the legacy pattern,
+        # but the model declares itself as text-only via config.json.
+        model_dir = self._write_config(
+            tmp_path,
+            "qwen3-vl-derived",
+            {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]},
+        )
+        assert _check_legacy_string_patterns(str(model_dir)) is True
+        assert is_mllm_model(str(model_dir)) is False
+
+    def test_vlm_config_under_neutral_path(self, tmp_path):
+        model_dir = self._write_config(
+            tmp_path,
+            "my-model",
+            {
+                "model_type": "qwen2_vl",
+                "architectures": ["Qwen2VLForConditionalGeneration"],
+            },
+        )
+        assert _check_legacy_string_patterns(str(model_dir)) is False
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_vision_config_key_indicates_vlm(self, tmp_path):
+        model_dir = self._write_config(
+            tmp_path,
+            "exotic-vlm",
+            {"model_type": "custom", "vision_config": {"hidden_size": 768}},
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_audio_config_key_indicates_vlm(self, tmp_path):
+        model_dir = self._write_config(
+            tmp_path,
+            "audio-model",
+            {"model_type": "custom_audio", "audio_config": {"sample_rate": 16000}},
+        )
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_missing_config_falls_back_to_string_matcher(self, tmp_path):
+        # No config.json present, so detection falls back to the legacy
+        # matcher against the input string.
+        model_dir = tmp_path / "Qwen3-VL-7B"
+        model_dir.mkdir()
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_malformed_config_falls_back_gracefully(self, tmp_path):
+        model_dir = tmp_path / "broken-vl-model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text("{not valid json")
+        # Falls back to legacy matcher; basename has "vl-" → True.
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_oversized_config_falls_back_gracefully(self, tmp_path):
+        model_dir = tmp_path / "huge-config-vl-model"
+        model_dir.mkdir()
+        # 2 MB of payload exceeds the 1 MB cap.
+        (model_dir / "config.json").write_text("x" * (2 * 1024 * 1024))
+        assert is_mllm_model(str(model_dir)) is True
+
+    def test_hf_repo_id_uses_legacy_matcher(self):
+        # HF repo IDs are not local dirs, so config inspection short-circuits
+        # and the legacy matcher decides. This preserves prior behaviour.
+        assert is_mllm_model("Qwen/Qwen3-32B") is False
+        assert is_mllm_model("mlx-community/Qwen3-VL-4B-Instruct-3bit") is True
+
+    def test_try_read_config_json_returns_none_for_repo_id(self):
+        assert _try_read_config_json("Qwen/Qwen3-32B") is None
+
+    def test_try_read_config_json_returns_none_for_missing_dir(self, tmp_path):
+        assert _try_read_config_json(str(tmp_path / "does-not-exist")) is None
+
+    def test_config_indicates_vlm_recognises_llava(self):
+        assert (
+            _config_indicates_vlm(
+                {"architectures": ["LlavaForConditionalGeneration"]}
+            )
+            is True
+        )
+
+    def test_config_indicates_vlm_rejects_text_only_qwen3(self):
+        assert (
+            _config_indicates_vlm({"architectures": ["Qwen3ForCausalLM"]}) is False
+        )
+
+    def test_config_indicates_vlm_handles_missing_architectures(self):
+        assert _config_indicates_vlm({"model_type": "qwen3"}) is False
+
+    def test_config_indicates_vlm_handles_non_list_architectures(self):
+        assert _config_indicates_vlm({"architectures": "Qwen3ForCausalLM"}) is False
 
 
 class TestExtractMultimodalContent:

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -3,8 +3,10 @@
 Utility functions for text processing and model detection.
 """
 
+import json
 import logging
 import re
+from pathlib import Path
 
 from .models import Message
 
@@ -363,21 +365,132 @@ MLLM_PATTERNS = [
 ]
 
 
-def is_mllm_model(model_name: str) -> bool:
+# Config.json keys that, when present, indicate a multimodal model.
+_VLM_CONFIG_KEYS = (
+    "vision_config",
+    "audio_config",
+    "vision_tower",
+    "mm_vision_tower",
+    "image_token_id",
+    "image_token_index",
+    "audio_token_id",
+    "audio_token_index",
+)
+
+# Substrings (case-insensitive) inside `architectures` entries that identify VLMs.
+# Covers both ForConditionalGeneration VLMs (Qwen2VL, LLaVA, PaliGemma, Mllama, etc.)
+# and the few VLMs that use ForCausalLM (Phi3V, Molmo, CogVLM, InternVL).
+_VLM_ARCHITECTURE_KEYWORDS = (
+    "VLForCondition",
+    "VLForCausal",
+    "VisionForCondition",
+    "VisionForCausal",
+    "MultiModalityCausalLM",
+    "Llava",
+    "Idefics",
+    "PaliGemma",
+    "Pixtral",
+    "Molmo",
+    "Phi3V",
+    "Phi4V",
+    "CogVLM",
+    "InternVL",
+    "DeepseekVL",
+    "Mllama",
+    "Gemma3ForConditional",
+    "Gemma4ForConditional",
+)
+
+# Defensive cap on config.json size to bound parsing cost.
+_MAX_CONFIG_JSON_BYTES = 1 * 1024 * 1024
+
+
+def _try_read_config_json(name_or_path: str) -> dict | None:
+    """Read config.json from a local model directory.
+
+    Returns None when the input is not a local directory, the directory has
+    no config.json, the file is too large, or it cannot be parsed.
     """
-    Check if model name indicates a multimodal language model.
+    try:
+        candidate = Path(name_or_path)
+    except (TypeError, ValueError):
+        return None
 
-    Args:
-        model_name: HuggingFace model name or local path
+    if not candidate.is_dir():
+        return None
 
-    Returns:
-        True if model is detected as MLLM/VLM
+    config_path = candidate / "config.json"
+    if not config_path.is_file():
+        return None
+
+    try:
+        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
+            return None
+        with config_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
+def _config_indicates_vlm(config: dict) -> bool:
+    """Inspect a parsed config.json dict for multimodal markers."""
+    archs = config.get("architectures") or []
+    if isinstance(archs, list):
+        for arch in archs:
+            if not isinstance(arch, str):
+                continue
+            arch_lower = arch.lower()
+            for keyword in _VLM_ARCHITECTURE_KEYWORDS:
+                if keyword.lower() in arch_lower:
+                    return True
+
+    for key in _VLM_CONFIG_KEYS:
+        if key in config:
+            return True
+
+    return False
+
+
+def _check_legacy_string_patterns(model_name: str) -> bool:
+    """Validation 1: substring match of MLLM_PATTERNS against the input string.
+
+    Kept for HF repo IDs (where no local config.json is reachable) and as
+    a fallback when config.json cannot be read.
     """
     model_lower = model_name.lower()
     for pattern in MLLM_PATTERNS:
         if pattern.lower() in model_lower:
             return True
     return False
+
+
+def is_mllm_model(model_name: str) -> bool:
+    """Check if a model name or path indicates a multimodal language model.
+
+    Two complementary validations are run:
+
+    1. config.json inspection: when ``model_name`` resolves to a local
+       directory containing a readable config.json, inspect the model's
+       own metadata (``architectures`` field, ``vision_config``,
+       ``audio_config``, etc.). Authoritative when available because it
+       reflects what the model actually is, not how it is named on disk.
+
+    2. Legacy substring match against ``MLLM_PATTERNS``: applied when no
+       config.json is reachable (e.g., a HuggingFace repo ID before the
+       weights are downloaded). Preserves the historical behaviour.
+
+    Args:
+        model_name: HuggingFace repo ID or local filesystem path.
+
+    Returns:
+        True if the model is detected as multimodal (MLLM/VLM).
+    """
+    config = _try_read_config_json(model_name)
+    if config is not None:
+        return _config_indicates_vlm(config)
+    return _check_legacy_string_patterns(model_name)
 
 
 # Backwards compatibility alias


### PR DESCRIPTION
## Summary

Fixes #516. `is_mllm_model` previously routed any path whose lowercased form contained one of the `MLLM_PATTERNS` substrings (e.g. `vl-`, `qwen3.5-`, `gemma-3`) through the multimodal loader, regardless of what the model actually was. A user with a text-only Qwen3 stored under a path like `~/dl-vl-experiments/qwen3-32b/` would hit `mlx_vlm.load()` and crash with `ValueError: Model type qwen3 not supported`.

This PR keeps two validations and gives priority to the model's own metadata when it is available on disk:

1. **`config.json` inspection** (new, primary): when the input resolves to a local directory with a readable `config.json`, the model's `architectures` field and modality config keys (`vision_config`, `audio_config`, `vision_tower`, `image_token_id`, etc.) decide.
2. **Legacy `MLLM_PATTERNS` substring match** (kept as fallback): used when the input is a HuggingFace repo ID, when no config is reachable, or when the file fails to parse.

`config.json` wins when present because the model declares what it actually is. Filesystem layout never overrides that.

Both helpers are exposed as `_check_legacy_string_patterns(model_name)` and `_try_read_config_json(name_or_path)` / `_config_indicates_vlm(config)`, which keeps each validation independently testable.

## Changes

- `vllm_mlx/api/utils.py`:
  - `_VLM_CONFIG_KEYS`: keys that indicate multimodality (vision/audio).
  - `_VLM_ARCHITECTURE_KEYWORDS`: substrings inside `architectures` entries that identify VLMs (covers both `*ForConditionalGeneration` and the few VLMs that use `*ForCausalLM` like `Phi3V`, `Molmo`, `CogVLM`, `InternVL`, `MultiModalityCausalLM`, etc.).
  - `_try_read_config_json`: bounded read (1 MiB cap, swallows OS / parse errors, returns `None` for non-directories or repo IDs).
  - `_config_indicates_vlm`: defensive type checks, no false positives on `T5ForConditionalGeneration` and similar text seq2seq models.
  - `_check_legacy_string_patterns`: extracted from previous `is_mllm_model` body.
  - `is_mllm_model`: orchestrates the two with config-priority.
- `tests/test_api_utils.py`: 13 new regression tests in `TestIsMllmModelConfigPriority`.

## Test plan

- [x] **Unit / regression**: `pytest tests/test_api_utils.py` → 93 passed (80 prior + 13 new). New tests cover config-priority, vision_config / audio_config detection, malformed config fallback, oversized config fallback, HF repo ID fallback, and per-helper smoke tests.
- [x] **Engine integration**: `pytest tests/test_simple_engine.py` → all passed.
- [x] **Pre-existing failure baseline**: full `pytest tests/ -k "not slow"` run, then `git stash` and re-run. Branch failures = main failures = 15 (test_lifecycle_server.py + test_lifecycle_cli.py), all unrelated to `is_mllm_model` (they fail on `_acquire_default_engine_for_request` kwarg mismatch). **Zero new regressions.**
- [x] **Sweep on 82 local HuggingFace cache models** comparing legacy matcher vs `is_mllm_model` final verdict on every snapshot present locally:
  - Every previously-detected VLM still detected: Qwen-VL family, Qwen2-VL, Qwen2.5-VL, Qwen3-VL (multiple sizes), gemma-3, gemma-4 (with audio), llava, etc.
  - Every text-only model still text-only: Qwen3 dense / MoE, Llama 2 / 3.2, Mistral, Falcon, GLM-4.x, Granite, Nemotron, gpt-oss, Kimi-Linear, t5-base (still False; `T5ForConditionalGeneration` correctly does not match the VLM keyword list), etc.
  - One *improvement*: `mlx-community/Qwen3.6-35B-A3B-4bit` (architecture `Qwen3_5MoeForConditionalGeneration` + `vision_config`) is now correctly detected; the legacy matcher missed it because no pattern listed `qwen3.6`.
- [x] **Adversarial symlink tests**: 7 cases combining triggering / non-triggering names with text / VLM models. Same model files, different symlink names → routing now reflects the model, not the path string.
  - 4 text-only models under triggering names (`qwen3-vl-eval-finetune`, `dl-vl-experiments`, `qwen3.5-derived-text`, `qwen3_5-text-only`): legacy=True (false positive), final=False ✓
  - 3 VLMs under clean names (`cleanly-named-model`, `just-a-folder-32b`, `instruct-finetune`): legacy=False (false negative), final=True ✓
- [x] **End-to-end `SimpleEngine` load** of two adversarial cases (text-only Qwen3 under VL-triggering symlink, VLM gemma-3 under clean symlink). Both load to the correct class (`MLXLanguageModel` / `MLXMultimodalLM`) and serve.
- [x] **Original issue #516 reproduction** (`/tmp/qwen3-vl-test` symlink to `Qwen/Qwen3-32B`): on `main` crashes with `Model type qwen3 not supported. Error: No module named 'mlx_vlm.speculative.drafters.qwen3'`. On this branch routes to LLM and loads successfully.

## Out of scope

- The mlx-vlm 0.5.0 `get_model_and_args` fallback loop that produces the misleading `mlx_vlm.speculative.drafters.qwen3` message in the traceback. That is upstream behaviour and would never have surfaced if routing did not reach `mlx_vlm.load()` in the first place. Left untouched.
- Pre-existing test failures in `test_lifecycle_server.py` and `test_lifecycle_cli.py` (kwarg mismatch in `_acquire_default_engine_for_request`). Not introduced here.

## Release plan

After merge: cut `0.3.1rc1` so the issue reporter can validate against their actual path before promoting to `0.3.1` final.
