### PR TITLE
Correct _suffix off-by-one and strip backslashes before non-ASCII in JSON output

### DIFF
--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -348,7 +348,11 @@ class JSONSchemaLogitsProcessor:
     def _suffix(self, tokens_list: list[int]) -> list[int]:
         """Return the slice of ``tokens`` that corresponds to generated output."""
         if self._prompt_len is None:
-            self._prompt_len = max(0, len(tokens_list) - 1)
+            # Use len(tokens_list) so the prompt is excluded entirely.
+            # The previous ``- 1`` caused the last prompt token (e.g. Gemma-4's
+            # <channel|> thinking-end special token) to be prepended to every
+            # suffix fed to the enforcer, corrupting the JSON grammar state.
+            self._prompt_len = len(tokens_list)
         return tokens_list[self._prompt_len :]
 
     def _decode_token_cached(self, tok_id: int) -> str | None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -825,6 +825,23 @@ _STREAMING_BARE_BRACKET_PARTIAL = re.compile(r"\[\w+\($")
 _STREAMING_TOOL_MARKUP_SCAN_CHARS = 512
 
 
+def _strip_backslash_before_unicode(obj: object) -> object:
+    """Remove spurious backslashes before non-ASCII chars in JSON string values.
+
+    lm-format-enforcer's grammar allows ``\\`` (valid JSON escape) followed by
+    non-ASCII characters such as Korean syllables.  The model therefore generates
+    ``\\빠\\르\\게`` — valid JSON whose decoded value contains literal backslashes.
+    This helper strips those spurious backslashes so clients receive clean text.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_backslash_before_unicode(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_backslash_before_unicode(v) for v in obj]
+    if isinstance(obj, str):
+        return re.sub(r"\\([^\x00-\x7F])", r"\1", obj)
+    return obj
+
+
 def _sanitize_log_text(value: object, limit: int | None = None) -> str:
     """Escape control characters before logging untrusted text."""
     text = str(value)
@@ -4631,7 +4648,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             )
             if parsed_json is not None:
                 # Return JSON as string
-                cleaned_text = json.dumps(parsed_json)
+                parsed_json = _strip_backslash_before_unicode(parsed_json)
+                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
             if not is_valid:
                 if prepared.json_logits_processor is not None:
                     logger.error(
@@ -5054,7 +5072,8 @@ async def create_anthropic_message(
                 json_input, prepared.response_format
             )
             if parsed_json is not None:
-                cleaned_text = json.dumps(parsed_json)
+                parsed_json = _strip_backslash_before_unicode(parsed_json)
+                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
             if not is_valid:
                 if prepared.json_logits_processor is not None:
                     logger.error(


### PR DESCRIPTION
This change is to fix running VLLM-MLX with Gemma 4 with:

  - json_schema_processor: `_suffix()` was initialising `_prompt_len` as `len(tokens_list) - 1`, which prepended the last prompt token to every suffix fed to the enforcer.  For Gemma 4 that token is `<channel|>` (the end-of-thinking marker), causing the JSON grammar to fail immediately and produce empty output. 
    - Fix: use `len(tokens_list)` so the prompt is fully excluded.

  - server: add `_strip_backslash_before_unicode()` and apply it at both JSON post-processing call sites (OpenAI and Anthropic endpoints). `lm-format-enforcer` allows `\\` followed by non-ASCII characters as a valid JSON escape sequence, so the model generates `\\빠\\르\\게` for Korean text.  The helper strips the spurious backslashes after `json.loads` decodes them to literal `\; json.dumps` with `ensure_ascii=False` then emits clean Unicode rather than `\\uXXXX` escapes.