### PR TITLE
Clarify MLLM MTP bypass counter semantics

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1010,6 +1010,10 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert stats["requested_draft_tokens"] == 4
         assert stats["effective_draft_tokens"] == 1
         assert stats["attempted"] == 0
+        assert (
+            stats["bypass_counts_semantics"]
+            == "per_condition_overlapping_not_total_steps"
+        )
         assert stats["bypass_counts"] == {
             "prefill": 0,
             "no_active_batch": 0,

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2005,6 +2005,7 @@ def install_mtp_mllm(
             "errors": errors,
             "acceptance_rate": acceptance_rate,
             "bypass_counts": bypass_counts,
+            "bypass_counts_semantics": "per_condition_overlapping_not_total_steps",
         }
 
     batch_gen.get_mtp_stats = _get_mtp_stats


### PR DESCRIPTION
Refs #473.

## Summary

Adds an explicit `/v1/status.mtp` schema marker for `bypass_counts`:

```json
"bypass_counts_semantics": "per_condition_overlapping_not_total_steps"
```

This preserves the current counter behavior while making it clear to clients that the `bypass_counts` values are per-condition counters. Conditions can overlap, so summing the values is not a total bypassed-step count.

## Validation

- `AI_RUNTIME_BYPASS_SAFETY_GATE=1 PYTHONPATH=/opt/ai-runtime/worktrees/vllm-mlx/issue-473-bypass-counts-schema-note /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mllm_continuous_batching.py::TestMLLMBatchGeneratorMTPGuards -q` -> 11 passed
- `AI_RUNTIME_BYPASS_SAFETY_GATE=1 PYTHONPATH=/opt/ai-runtime/worktrees/vllm-mlx/issue-473-bypass-counts-schema-note /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_mllm_continuous_batching.py -q` -> 47 passed, 4 deselected
- `python3 -m py_compile vllm_mlx/mllm_batch_generator.py tests/test_mllm_continuous_batching.py`
- `uvx ruff check vllm_mlx/mllm_batch_generator.py tests/test_mllm_continuous_batching.py --select E,F,W --ignore E402,E501,E731,F811,F841`
- `black --check --target-version py312 vllm_mlx/mllm_batch_generator.py tests/test_mllm_continuous_batching.py`
- `git diff --check`

## Out of scope

- No MTP counter behavior changes.
- No changes to acceptance-rate math.
- No performance or routing changes.
