### PR TITLE
Canonicalize volatile system prompt headers in OpenAI paths

### DIFF
--- a/tests/test_prompt_canonicalize.py
+++ b/tests/test_prompt_canonicalize.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for system-prompt canonicalization."""
+
+from vllm_mlx.api.prompt_canonicalize import canonicalize_system_prompt
+
+
+def test_canonicalize_system_prompt_strips_anthropic_billing_header_line():
+    text = (
+        "You are a coding assistant.\n"
+        "x-anthropic-billing-header: account=abc; cch=rotating-hash\n"
+        "Follow the repository instructions."
+    )
+
+    expected = "\n".join(
+        ["You are a coding assistant.", "Follow the repository instructions."]
+    )
+    assert canonicalize_system_prompt(text) == expected
+
+
+def test_canonicalize_system_prompt_is_idempotent_for_clean_input():
+    text = "You are a coding assistant.\nCurrent time: 2026-05-12T01:00:00Z"
+
+    assert canonicalize_system_prompt(text) == text
+
+
+def test_canonicalize_system_prompt_does_not_strip_user_visible_timestamp():
+    text = "Current time: 2026-05-12T01:00:00Z\nUse it when answering."
+
+    assert canonicalize_system_prompt(text) == text
+
+
+def test_canonicalize_system_prompt_handles_empty_and_none():
+    assert canonicalize_system_prompt("") == ""
+    assert canonicalize_system_prompt(None) is None

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -416,6 +416,30 @@ class TestResponsesEndpoint:
         assert messages[1]["role"] == "user"
         assert messages[1]["content"] == "Hi"
 
+    def test_system_prompt_canonicalization_strips_billing_header(self, client):
+        import vllm_mlx.server as srv
+
+        engine = _mock_engine(_output("Ready"))
+        srv._engine = engine
+
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "instructions": (
+                    "Be terse.\n"
+                    "x-anthropic-billing-header: account=abc; cch=rotating-hash\n"
+                    "Answer directly."
+                ),
+                "input": "Say hello",
+            },
+        )
+
+        assert resp.status_code == 200
+        messages = engine.chat.call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "Be terse.\nAnswer directly."
+
     def test_instructions_and_developer_message_are_merged(self, client):
         import vllm_mlx.server as srv
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -170,6 +170,46 @@ class TestChatCompletionRequest:
             )
 
 
+class TestPromptCanonicalization:
+    """Test OpenAI-path system prompt canonicalization."""
+
+    def test_prepare_chat_completion_canonicalizes_system_prompt(self):
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            _prepare_chat_completion_invocation,
+        )
+
+        engine = SimpleNamespace(is_mllm=False, preserve_native_tool_format=False)
+        system_text = (
+            "You are a coding assistant.\n"
+            "x-anthropic-billing-header: account=abc; cch=rotating-hash\n"
+            "Follow the repository instructions."
+        )
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                Message(role="system", content=system_text),
+                Message(
+                    role="user",
+                    content="x-anthropic-billing-header: keep user content",
+                ),
+            ],
+        )
+
+        prepared = _prepare_chat_completion_invocation(engine, request, 128)
+
+        expected_system_text = "\n".join(
+            ["You are a coding assistant.", "Follow the repository instructions."]
+        )
+        assert prepared.messages[0]["content"] == expected_system_text
+        assert (
+            prepared.messages[1]["content"]
+            == "x-anthropic-billing-header: keep user content"
+        )
+        assert request.messages[0].content == system_text
+
+
 class TestCompletionRequest:
     """Test CompletionRequest model."""
 

--- a/vllm_mlx/api/prompt_canonicalize.py
+++ b/vllm_mlx/api/prompt_canonicalize.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""System-prompt canonicalization helpers."""
+
+from __future__ import annotations
+
+import re
+
+_STRIPPERS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "anthropic_billing_header",
+        re.compile(r"(?im)^x-anthropic-billing-header:[^\n]*(?:\n|$)"),
+        "",
+    ),
+)
+
+
+def canonicalize_system_prompt(text: str | None) -> str | None:
+    """Remove known non-semantic volatile lines from system prompt text."""
+    if text is None:
+        return None
+
+    for _name, pattern, replacement in _STRIPPERS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def canonicalize_system_messages(messages: list[dict]) -> list[dict]:
+    """Canonicalize string content on system-role messages without mutation."""
+    canonicalized: list[dict] = []
+    changed = False
+    for message in messages:
+        if message.get("role") != "system":
+            canonicalized.append(message)
+            continue
+
+        content = message.get("content")
+        if not isinstance(content, str):
+            canonicalized.append(message)
+            continue
+
+        next_content = canonicalize_system_prompt(content)
+        if next_content == content:
+            canonicalized.append(message)
+            continue
+
+        changed = True
+        next_message = message.copy()
+        next_message["content"] = next_content
+        canonicalized.append(next_message)
+
+    return canonicalized if changed else messages

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -105,6 +105,7 @@ from .api.models import (
     Usage,  # noqa: F401
     VideoUrl,  # noqa: F401
 )
+from .api.prompt_canonicalize import canonicalize_system_messages
 from .api.responses_models import (
     ResponseCompletedEvent,
     ResponseContentPartAddedEvent,
@@ -305,6 +306,8 @@ def _prepare_chat_messages(
             preserve_native_format=preserve_native,
         )
         messages = _normalize_messages(messages)
+
+    messages = canonicalize_system_messages(messages)
 
     has_media = bool(images or videos or audios)
     if is_mllm and not has_media:
@@ -2082,6 +2085,7 @@ def _prepare_responses_request(
         chat_request.messages,
         preserve_native_format=engine.preserve_native_tool_format,
     )
+    messages = canonicalize_system_messages(messages)
 
     chat_kwargs = {
         "max_tokens": chat_request.max_tokens or _default_max_tokens,


### PR DESCRIPTION
Refs #524.

## Summary

- Add a small static system-prompt canonicalization helper with the currently validated `x-anthropic-billing-header` stripper.
- Apply it to prepared system-role messages in Chat Completions and Responses paths before engine execution.
- Cover the helper, Chat Completions preparation, Responses preparation, and existing Anthropic adapter behavior.

## Local repro / observed behavior

On current `waybarrios/vllm-mlx` main (`f068991` when this branch was cut), the Anthropic Messages adapter removes `x-anthropic-billing-header:` from `request.system` in `vllm_mlx/api/anthropic_adapter.py::anthropic_to_openai`, but the OpenAI server paths did not apply the same canonicalization:

- `vllm_mlx/server.py::_prepare_chat_messages`
- `vllm_mlx/server.py::_prepare_responses_request`

A Chat Completions system message or Responses `instructions` value containing:

```text
x-anthropic-billing-header: account=abc; cch=rotating-hash
```

was still present in the prepared system message sent to the engine.

## Expected behavior

The validated billing-header line is non-semantic request metadata and should be removed from system-role text before engine execution. User-role content with the same text is preserved, and user-visible timestamp text is not stripped.

## Minimal patch shape

- New `vllm_mlx/api/prompt_canonicalize.py` module with a static stripper list and `canonicalize_system_prompt()`.
- New `canonicalize_system_messages()` helper that copies only changed system messages.
- Call the helper after existing message normalization in Chat Completions and after Responses input conversion.
- Do not add runtime registration APIs or speculative strippers.

## Explicitly not claimed

- This does not add timestamp, MCP UUID, or session-ID strippers.
- This does not change SimpleEngine system-prefix KV-cache logic from #523.
- This does not include new TTFT or cache-hit-rate benchmark results.
- This does not change media extraction, tool parsing, sampling, or decode controls.

## Verification

```sh
AI_RUNTIME_BYPASS_SAFETY_GATE=1 PYTHONPATH=/opt/ai-runtime/worktrees/vllm-mlx/issue-524-prompt-canonicalization /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_prompt_canonicalize.py tests/test_responses_api.py tests/test_anthropic_adapter.py tests/test_server.py::TestPromptCanonicalization -q
# 74 passed

uvx ruff check vllm_mlx/api/prompt_canonicalize.py vllm_mlx/server.py tests/test_prompt_canonicalize.py tests/test_server.py tests/test_responses_api.py
# All checks passed

/opt/ai-runtime/venv-live/bin/python -m black --check --target-version py312 vllm_mlx/api/prompt_canonicalize.py vllm_mlx/server.py tests/test_prompt_canonicalize.py tests/test_server.py tests/test_responses_api.py
# 5 files would be left unchanged

git diff --check
# clean
```
