### PR TITLE
Re-enable lifecycle tests and wire them into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \
             tests/test_tool_call_promotion.py \
-            tests/test_lifecycle_cli.py \
-            tests/test_lifecycle_server.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \
@@ -149,6 +147,8 @@ jobs:
             tests/test_batching.py \
             tests/test_continuous_batching.py \
             tests/test_memory_cache_mlx.py \
+            tests/test_lifecycle_cli.py \
+            tests/test_lifecycle_server.py \
             tests/test_normalize_messages.py \
             tests/test_responses_api.py \
             tests/test_thinking_aware_processor.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
             tests/test_harmony_parsers.py \
+            tests/test_lifecycle_cli.py \
+            tests/test_lifecycle_server.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -218,6 +218,9 @@ class TestLifecycleCli:
             mllm_prefill_step_size=None,
             lazy_load_model=True,
             auto_unload_idle_seconds=300,
+            models_config=None,
+            default_thinking_token_budget=None,
+            max_kv_size=0,
         )
 
         cli.serve_command(args)
@@ -305,6 +308,9 @@ class TestLifecycleCli:
             mllm_prefill_step_size=0,
             lazy_load_model=True,
             auto_unload_idle_seconds=300,
+            models_config=None,
+            default_thinking_token_budget=None,
+            max_kv_size=0,
         )
 
         cli.serve_command(args)
@@ -415,6 +421,9 @@ class TestLifecycleCli:
             mllm_prefill_step_size=None,
             lazy_load_model=True,
             auto_unload_idle_seconds=0.0,
+            models_config=None,
+            default_thinking_token_budget=None,
+            max_kv_size=0,
         )
 
         cli.serve_command(args)

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -320,7 +320,12 @@ class TestCompletionStreamingRelease:
                 raise RuntimeError("generation failed")
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             acquires["count"] += 1
             return FakeEngine()
@@ -393,7 +398,12 @@ class TestCompletionStreamingRelease:
                 )
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -546,7 +556,12 @@ class TestToolParserUsesLocalEngine:
         local_engine = FakeEngine("tok-local")
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return local_engine
 
@@ -619,7 +634,12 @@ class TestLifecycleFailureHandling:
             preserve_native_tool_format = False
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             calls["acquires"] += 1
             return FakeEngine()
@@ -648,7 +668,12 @@ class TestLifecycleFailureHandling:
             preserve_native_tool_format = False
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             calls["acquires"] += 1
             return FakeEngine()
@@ -711,8 +736,7 @@ class TestLifecycleFailureHandling:
             preserve_native_tool_format = False
 
         class FakeRequest:
-            async def is_disconnected(self):
-                return True
+            _is_disconnected = True
 
         async def fake_acquire(model_key):
             try:
@@ -2594,7 +2618,8 @@ class TestLifecycleFailureHandling:
                 )
 
         class FakeRequest:
-            async def is_disconnected(self):
+            @property
+            def _is_disconnected(self):
                 disconnect_polled.set()
                 return True
 
@@ -2715,7 +2740,8 @@ class TestLifecycleFailureHandling:
                     "messages": [{"role": "user", "content": "hi"}],
                 }
 
-            async def is_disconnected(self):
+            @property
+            def _is_disconnected(self):
                 disconnect_polled.set()
                 return True
 
@@ -2980,11 +3006,11 @@ class TestLifecycleFailureHandling:
         task_ref = {"task": None}
 
         class FakeRequest:
-            async def is_disconnected(self):
+            @property
+            def _is_disconnected(self):
                 task = task_ref["task"]
                 assert task is not None
                 task.cancel()
-                await asyncio.sleep(0)
                 return True
 
         async def cancellable_work():
@@ -3497,7 +3523,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -3544,7 +3575,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 
@@ -3595,7 +3631,12 @@ class TestResponseModelFieldUsesServedName:
         served_name = "my-custom-served-name"
 
         async def fake_acquire(
-            raw_request, *, total_timeout=None, deadline=None, count_activity=True
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
         ):
             return FakeEngine()
 

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -53,6 +53,32 @@ def restore_server_globals():
     )
     snapshot = {name: getattr(srv, name, sentinel) for name in global_names}
 
+    # Reset state-holding globals before each test so prior-file pollution
+    # (an engine left alive by test_simple_engine.py, a model name registered
+    # by test_server.py) doesn't leak in.  Config defaults like _default_timeout
+    # stay untouched because they're numbers used in arithmetic.
+    state_reset = {
+        "_engine": None,
+        "_model_name": None,
+        "_model_path": None,
+        "_default_model_key": None,
+        "_force_mllm_model": None,
+        "_residency_manager": None,
+        "_lifecycle_task": None,
+        "_lifespan_active": False,
+        "_mcp_manager": None,
+        "_mcp_executor": None,
+        "_embedding_engine": None,
+        "_embedding_model_locked": False,
+        "_reasoning_parser": None,
+        "_enable_auto_tool_choice": False,
+        "_tool_call_parser": None,
+        "_tool_parser_instance": None,
+        "_idle_unload_enabled": None,
+    }
+    for name, value in state_reset.items():
+        setattr(srv, name, value)
+
     yield
 
     leaked_task = getattr(srv, "_lifecycle_task", None)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4295,19 +4295,22 @@ async def _acquire_default_engine_for_request(
     )
 
 
-async def _release_engine_for_request(raw_request: Request | None) -> None:
+async def _release_engine_for_request(
+    raw_request: Request | None, *, count_activity: bool = True
+) -> None:
     """Release the engine acquired for this request.
 
     In registry mode, releases the model lease stashed by
     ``_acquire_default_engine_for_request``.  In single-model mode, falls
-    through to the default release path.
+    through to the default release path.  ``count_activity`` must match the
+    flag used on the matching acquire so idle-unload accounting stays correct.
     """
     if raw_request is not None:
         ctx = _active_request_contexts.pop(id(raw_request), None)
         if ctx is not None:
             await ctx.release()
             return
-    await _release_default_engine()
+    await _release_default_engine(count_activity=count_activity)
 
 
 def _make_release_cleanup(raw_request: Request | None):
@@ -5217,7 +5220,7 @@ async def count_anthropic_tokens(request: Request):
 
         return {"input_tokens": total_tokens}
     finally:
-        await _release_engine_for_request(request)
+        await _release_engine_for_request(request, count_activity=False)
 
 
 def _emit_content_pieces(


### PR DESCRIPTION
## Summary

The `tests/test_lifecycle_cli.py` and `tests/test_lifecycle_server.py` suites had drifted out of sync with `vllm_mlx/server.py` and `vllm_mlx/cli.py` and were silently failing locally — 15 failures on `main`. Neither file was wired into `ci.yml`, so the drift went unnoticed. This PR realigns the mocks with the current production signatures, fixes one real server bug that the suite uncovered, and adds both files to the no-MLX matrix job so the same drift doesn't reappear.

## Changes

### `vllm_mlx/server.py`

`_release_engine_for_request` did not propagate `count_activity` to `_release_default_engine`. Any caller that acquired with `count_activity=False` (specifically `count_anthropic_tokens`) was then releasing with `count_activity=True`, which bumped `last_used_at` and prevented idle unload. Threaded the flag through and updated the `count_anthropic_tokens` finally block to pass `count_activity=False` so token-budgeting traffic no longer keeps the resident hot.

### `tests/test_lifecycle_server.py`

Three independent mock-vs-production mismatches:

- `_acquire_default_engine_for_request` gained a `model` kwarg some time ago; eight `fake_acquire` stubs still used the old signature and raised `TypeError`. Added `model=None` to each.
- `_is_client_disconnected` now bypasses Starlette's `is_disconnected()` and reads uvicorn's internal `disconnected` flag (or a cached `_is_disconnected` attribute) directly. Four `FakeRequest` classes still relied on the old async method, which is no longer called. Replaced them with `_is_disconnected` attribute / property so the disconnect path actually fires.

### `tests/test_lifecycle_cli.py`

Three `SimpleNamespace` fixtures for `serve_command(args)` were missing CLI flags added later: `models_config`, `default_thinking_token_budget`, `max_kv_size`. Added them so the tests stop tripping `AttributeError` on the first attribute access.

### `.github/workflows/ci.yml`

Added `tests/test_lifecycle_cli.py` and `tests/test_lifecycle_server.py` to the `test-matrix` (Ubuntu, no-MLX) job. Both suites are pure mock-based behavior tests, so they fit there with no extra setup.

## Test plan

- [x] `pytest tests/test_lifecycle_cli.py -v` — 7/7 passed
- [x] `pytest tests/test_lifecycle_server.py -v` — 79/79 passed
- [x] `pytest tests/ -k "not slow" -q` — 2045 passed, 0 failed, 11 skipped, 23 deselected
- [x] Confirm GitHub Actions `test-matrix` job picks up the two new files