### PR TITLE
fix(reasoning): respect enable_thinking=false from chat_template_kwargs

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -309,3 +309,76 @@ async def test_simple_engine_stream_generate_text_applies_chat_template_kwargs()
             ]
             is False
         )
+
+
+# Regression tests for the reasoning-parser bypass when enable_thinking=False.
+# Server started with --default-chat-template-kwargs '{"enable_thinking": false}'
+# plus a Qwen3 reasoning parser used to route every token into a `thinking`
+# block and leave `text` empty, so Claude Code saw `result: ""`.
+
+
+@pytest.mark.parametrize(
+    "enable_thinking, ctk, expected",
+    [
+        (None, None, False),  # nothing set
+        (False, None, True),  # request-level flag
+        (None, {"enable_thinking": False}, True),  # server default surface
+        (True, {"enable_thinking": True}, False),  # explicit True
+        (None, {}, False),  # empty kwargs
+    ],
+)
+def test_thinking_disabled_helper(enable_thinking, ctk, expected):
+    request = SimpleNamespace(enable_thinking=enable_thinking)
+    chat_kwargs = {"chat_template_kwargs": ctk} if ctk is not None else {}
+    assert srv._thinking_disabled(request, chat_kwargs) is expected
+
+
+@pytest.mark.anyio
+async def test_stream_anthropic_skips_reasoning_parser_when_thinking_disabled():
+    from vllm_mlx.reasoning import DeltaMessage
+
+    class _EatsEverythingAsReasoning:
+        # Mimics BaseThinkingReasoningParser's implicit-mode default.
+        def reset_state(self):
+            pass
+
+        def extract_reasoning_streaming(self, prev, cur, delta):
+            return DeltaMessage(reasoning=delta)
+
+    async def fake_stream_chat(messages, **kwargs):
+        for piece in ("HEL", "LO"):
+            yield SimpleNamespace(new_text=piece, prompt_tokens=4, completion_tokens=1)
+
+    engine = MagicMock(stream_chat=fake_stream_chat)
+    msgs = [{"role": "user", "content": "Say HELLO"}]
+    openai_request = srv.ChatCompletionRequest(
+        model="test-model", messages=[srv.Message(**msgs[0])], max_tokens=8
+    )
+    anthropic_request = srv.AnthropicRequest(
+        model="test-model", max_tokens=8, messages=msgs
+    )
+    prepared = srv.PreparedChatInvocation(
+        messages=msgs,
+        chat_kwargs={"chat_template_kwargs": {"enable_thinking": False}},
+        response_format=None,
+        json_logits_processor=None,
+    )
+
+    saved = (srv._reasoning_parser, srv._model_name)
+    srv._reasoning_parser, srv._model_name = _EatsEverythingAsReasoning(), "test-model"
+    try:
+        body = "".join(
+            [
+                c
+                async for c in srv._stream_anthropic_messages(
+                    engine, openai_request, anthropic_request, prepared
+                )
+            ]
+        )
+    finally:
+        srv._reasoning_parser, srv._model_name = saved
+
+    assert "thinking_delta" not in body  # would fire on broken path
+    assert '"type": "thinking"' not in body
+    assert "HEL" in body and "LO" in body
+    assert '"type": "text_delta"' in body

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -819,6 +819,7 @@ def _thinking_disabled(request, chat_kwargs: dict | None = None) -> bool:
             return True
     return False
 
+
 # Tool calling configuration
 _enable_auto_tool_choice: bool = False
 _tool_call_parser: str | None = None  # Parser name: auto, mistral, qwen, llama, hermes

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -800,6 +800,25 @@ _auth_warning_logged: bool = False
 _reasoning_parser = None  # ReasoningParser instance when enabled
 _reasoning_parser_name: str | None = None
 
+
+def _thinking_disabled(request, chat_kwargs: dict | None = None) -> bool:
+    """Return True iff thinking is explicitly disabled for this request.
+
+    Checks both the request-level ``enable_thinking`` field and the resolved
+    ``chat_template_kwargs`` (which may carry the server-wide default set via
+    ``--default-chat-template-kwargs``). When thinking is disabled the prompt
+    contains no injected ``<think>`` block, so the streaming reasoning parser
+    must not default to implicit-thinking mode and swallow plain content into
+    a ``thinking`` block.
+    """
+    if getattr(request, "enable_thinking", None) is False:
+        return True
+    if chat_kwargs:
+        ctk = chat_kwargs.get("chat_template_kwargs") or {}
+        if ctk.get("enable_thinking") is False:
+            return True
+    return False
+
 # Tool calling configuration
 _enable_auto_tool_choice: bool = False
 _tool_call_parser: str | None = None  # Parser name: auto, mistral, qwen, llama, hermes
@@ -2344,7 +2363,7 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if _reasoning_parser:
+        if _reasoning_parser and not _thinking_disabled(request, chat_kwargs):
             delta_msg = _reasoning_parser.extract_reasoning_streaming(
                 previous_text, raw_accumulated_text, delta_text
             )
@@ -4640,7 +4659,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         reasoning_text, cleaned_text, tool_calls = _extract_reasoning_and_tool_calls(
             output.text,
             request,
-            allow_reasoning=(getattr(request, "enable_thinking", None) is not False),
+            allow_reasoning=not _thinking_disabled(request, prepared.chat_kwargs),
             engine=engine,
         )
 
@@ -5061,10 +5080,13 @@ async def create_anthropic_message(
             output.text,
             openai_request,
             allow_reasoning=(
-                prepared.json_logits_processor is None
-                or isinstance(
-                    prepared.json_logits_processor,
-                    _ThinkingAwareLogitsProcessor,
+                not _thinking_disabled(openai_request, prepared.chat_kwargs)
+                and (
+                    prepared.json_logits_processor is None
+                    or isinstance(
+                        prepared.json_logits_processor,
+                        _ThinkingAwareLogitsProcessor,
+                    )
                 )
             ),
             engine=engine,
@@ -5341,8 +5363,10 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
-    use_reasoning = _reasoning_parser is not None and not chat_kwargs.get(
-        "logits_processors"
+    use_reasoning = (
+        _reasoning_parser is not None
+        and not chat_kwargs.get("logits_processors")
+        and not _thinking_disabled(openai_request, chat_kwargs)
     )
 
     if use_reasoning:
@@ -5734,11 +5758,13 @@ async def stream_chat_completion(
             if hasattr(output, "completion_tokens") and output.completion_tokens:
                 completion_tokens = output.completion_tokens
 
-            # Use reasoning parser if enabled (skip when enable_thinking=False)
+            # Use reasoning parser if enabled (skip when enable_thinking=False
+            # is set either on the request or via the resolved chat template
+            # kwargs / server default).
             if (
                 _reasoning_parser
                 and delta_text
-                and request.enable_thinking is not False
+                and not _thinking_disabled(request, kwargs)
             ):
                 previous_text = accumulated_text
                 accumulated_text += delta_text


### PR DESCRIPTION
_First contribution here — I'm running vllm-mlx on a Mac Studio M3 Ultra (96 GB) as a local Claude Code backend with Qwen 3.6 and Gemma 4. More fixes likely as I keep wiring this up._

## Summary

With `--reasoning-parser qwen3 --default-chat-template-kwargs '{"enable_thinking": false}'`, streamed `/v1/messages` responses route every model token into a `thinking` content block and leave `text` empty. Claude Code sees `result: ""` despite tokens being generated.

Cause: the reasoning-parser gate only consulted `request.enable_thinking`. The server-default surface (`--default-chat-template-kwargs`) lives in `chat_kwargs["chat_template_kwargs"]` and was never checked. With thinking disabled the template injects no `<think>`, so `BaseThinkingReasoningParser.extract_reasoning_streaming` falls into its implicit-mode default and classifies all deltas as reasoning.

Fix: new `_thinking_disabled(request, chat_kwargs)` helper consulted at the four reasoning-parser entry points (`/v1/messages` streaming + non-streaming, `/v1/chat/completions` streaming, `/v1/responses` streaming). Parser behavior when thinking is enabled is unchanged.

Reproducer:
```
# qwen-27b plist config -- reasoning parser + enable_thinking=false default
claude -p --model sonnet "Reply with HELLO."
# before: {"result": "", "output_tokens": 3, ...}
# after:  {"result": "HELLO", "output_tokens": 3, ...}
```

## Validation

- New tests in `tests/test_chat_template_kwargs.py` (+114 lines): 5 unit cases for `_thinking_disabled` and one `_stream_anthropic_messages` integration test asserting that with the parser eating everything as reasoning, the SSE body contains only `text_delta` events. The integration test **fails on the parent commit** with the exact buggy stream body and passes on this branch.
- `pytest tests/test_chat_template_kwargs.py tests/test_reasoning_parser.py tests/test_thinking_aware_processor.py tests/test_thinking_processor.py` — 169/169 pass.
- `ruff` and `black --check` clean on changed files.
- mypy not run locally (CI is 3.11, my local is 3.12); change adds one typed helper.
- End-to-end on the live Qwen 3.6-27B server: empty `result` → `"HELLO"`, stream goes from `thinking_delta` to `text_delta`.

## Merge readiness

- [x] I am not merging my own substantive PR.
- [ ] The latest CI run for this exact head commit is green. _(will confirm after push)_
- [x] If I rebased, resolved conflicts, or pushed after review, I waited for the new CI run to finish green. _(N/A on initial push)_
- [x] Actionable review comments are resolved in this PR or linked to follow-up issues before merge.
- [x] Any intentional follow-up debt is linked here and called out in the PR body. _(none)_

## Risk notes

Gate-only change at four entry points; when thinking is enabled, behavior is byte-identical to before. The implicit-mode default in `BaseThinkingReasoningParser` (`think_parser.py:185-189`) is intentionally left alone since other callers may legitimately rely on it for chat-template-injected `<think>`. No scheduler/memory/security surface touched.
