### PR TITLE
Fail invalid response_format output before returning success

### DIFF
--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -246,6 +246,22 @@ class TestProcessorMask:
         result = processor(tokens, logits)
         assert result.shape == logits.shape
 
+    def test_complete_json_forces_eos(self):
+        """Once the suffix is complete JSON, only EOS should remain allowed."""
+        import mlx.core as mx
+        import numpy as np
+
+        processor, tok = self._make_processor()
+        processor._prompt_len = 0
+        tokens = mx.array(tok.encode('{"a":1}'), dtype=mx.int32)
+        logits = mx.zeros((tok.vocab_size,))
+
+        masked = processor(tokens, logits)
+        arr = np.array(masked)
+        finite = {i for i, value in enumerate(arr) if np.isfinite(value)}
+
+        assert finite == {tok.eos_token_id}
+
 
 # ---------------------------------------------------------------------------
 # Anthropic adapter — response_format propagation.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2140,6 +2140,83 @@ class TestStreamChatCompletion:
         assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 
     @pytest.mark.anyio
+    async def test_response_format_stream_promotes_reasoning_json_to_content(
+        self, monkeypatch
+    ):
+        """response_format JSON belongs on the streaming content channel."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning import DeltaMessage
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="",
+                    new_text='{"ok": true}',
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=4,
+                    completion_tokens=3,
+                )
+
+        class ReasoningOnlyParser:
+            def reset_state(self):
+                pass
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                return DeltaMessage(reasoning=delta_text)
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", ReasoningOnlyParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="return json")],
+            stream=True,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ok",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"ok": {"type": "boolean"}},
+                        "required": ["ok"],
+                    },
+                },
+            },
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        delta = payloads[1]["choices"][0]["delta"]
+        assert json.loads(delta["content"]) == {"ok": True}
+        assert "reasoning_content" not in delta
+        assert payloads[1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.anyio
     async def test_streaming_chat_no_stream_thread_error_after_residency_preload(
         self, monkeypatch, caplog
     ):

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -6,14 +6,17 @@ Tests the JSON parsing, validation, and response_format handling.
 """
 
 import json
+
 import pytest
+from vllm_mlx.api.models import ResponseFormat, ResponseFormatJsonSchema
 from vllm_mlx.api.tool_calling import (
-    validate_json_schema,
+    InvalidResponseFormatOutput,
+    apply_response_format_or_error,
+    build_json_system_prompt,
     extract_json_from_text,
     parse_json_output,
-    build_json_system_prompt,
+    validate_json_schema,
 )
-from vllm_mlx.api.models import ResponseFormat, ResponseFormatJsonSchema
 
 
 class TestValidateJsonSchema:
@@ -399,6 +402,27 @@ class TestParseJsonOutput:
         assert is_valid is True
 
 
+class TestServerResponseFormatBoundary:
+    """Tests for the server boundary after response_format parsing."""
+
+    def test_invalid_response_format_output_fails_before_success_response(self):
+        with pytest.raises(InvalidResponseFormatOutput) as excinfo:
+            apply_response_format_or_error(
+                "I will reason first and then maybe return JSON.",
+                {"type": "json_object"},
+            )
+
+        assert "Failed to extract valid JSON" in excinfo.value.message
+
+    def test_valid_response_format_output_returns_canonical_json(self):
+        content = apply_response_format_or_error(
+            'prefix {"ok": true, "count": 2} suffix',
+            {"type": "json_object"},
+        )
+
+        assert json.loads(content) == {"ok": True, "count": 2}
+
+
 class TestBuildJsonSystemPrompt:
     """Tests for build_json_system_prompt function."""
 
@@ -510,7 +534,7 @@ class TestInjectJsonInstruction:
 
         original = [{"role": "user", "content": "Hello"}]
         original_content = original[0]["content"]
-        result = _inject_json_instruction(original, "Return JSON only")
+        _inject_json_instruction(original, "Return JSON only")
 
         # Original should be unchanged
         assert len(original) == 1

--- a/tests/test_thinking_aware_processor.py
+++ b/tests/test_thinking_aware_processor.py
@@ -45,7 +45,10 @@ class _FakeInnerProcessor:
 # Import the class under test
 # ---------------------------------------------------------------------------
 
-from vllm_mlx.server import _ThinkingAwareLogitsProcessor
+from vllm_mlx.server import (
+    _attach_response_format_logits_processor,
+    _ThinkingAwareLogitsProcessor,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -117,6 +120,29 @@ class TestPreambleSkipped:
         assert results[2] == "CONSTRAINED"
         assert proc._active is True
         assert inner._prompt_len == len(prompt) + 0  # { is at gen position 0
+
+    def test_response_format_attachment_suppresses_thinking(self):
+        """response_format constraints must own generation from token one."""
+        tok = _FakeTokenizer({10: "{"})
+        inner = _FakeInnerProcessor(tok)
+        chat_kwargs = {
+            "enable_thinking": True,
+            "chat_template_kwargs": {"enable_thinking": True, "foo": "bar"},
+            "logits_processors": ["existing"],
+        }
+
+        result = _attach_response_format_logits_processor(chat_kwargs, inner)
+
+        assert result is inner
+        assert chat_kwargs["enable_thinking"] is False
+        assert chat_kwargs["chat_template_kwargs"] == {
+            "enable_thinking": False,
+            "foo": "bar",
+        }
+        assert chat_kwargs["logits_processors"] == ["existing", inner]
+        assert not isinstance(
+            chat_kwargs["logits_processors"][-1], _ThinkingAwareLogitsProcessor
+        )
 
 
 class TestThinkThenPreamble:

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -21,6 +21,14 @@ from jsonschema import validate, ValidationError
 from .models import FunctionCall, ResponseFormat, ToolCall
 
 
+class InvalidResponseFormatOutput(ValueError):
+    """Raised when generated content does not satisfy response_format."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
 def _looks_like_tool_call(obj: Any) -> bool:
     """
     Heuristic: decide whether a parsed JSON object really represents a tool
@@ -845,6 +853,24 @@ def parse_json_output(
 
     # Unknown format type - treat as text
     return text, None, True, None
+
+
+def apply_response_format_or_error(
+    text: str,
+    response_format: object,
+    *,
+    ensure_ascii: bool = False,
+) -> str:
+    """Return canonical JSON content or raise for invalid response_format output."""
+    _, parsed_json, is_valid, error = parse_json_output(text, response_format)
+    if is_valid and parsed_json is not None:
+        return json.dumps(parsed_json, ensure_ascii=ensure_ascii)
+    if is_valid:
+        return text
+
+    raise InvalidResponseFormatOutput(
+        error or "model output did not satisfy response_format"
+    )
 
 
 def build_json_system_prompt(

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -262,6 +262,41 @@ def _walk_properties(node: Any, names: set[str]) -> None:
                 _walk_properties(item, names)
 
 
+def _complete_json_eos_logits(
+    eos_set: set[int],
+    suffix: list[int],
+    logits: mx.array,
+    is_complete_json,
+    build_allow_mask,
+) -> mx.array | None:
+    if not eos_set or not is_complete_json(suffix):
+        return None
+    return _eos_logits(eos_set, logits, build_allow_mask)
+
+
+def _eos_logits(
+    eos_set: set[int],
+    logits: mx.array,
+    build_allow_mask,
+) -> mx.array | None:
+    if not eos_set:
+        return None
+    actual_vocab = logits.shape[-1]
+    mask = build_allow_mask(sorted(eos_set), actual_vocab)
+    if logits.ndim == 2 and logits.shape[0] == 1:
+        mask = mask[None, :]
+    return logits + mask
+
+
+def _eos_logits_or_original(
+    eos_set: set[int],
+    logits: mx.array,
+    build_allow_mask,
+) -> mx.array:
+    masked = _eos_logits(eos_set, logits, build_allow_mask)
+    return logits if masked is None else masked
+
+
 class JSONSchemaLogitsProcessor:
     """
     Logits processor that constrains generation to valid JSON.
@@ -750,13 +785,11 @@ class JSONSchemaLogitsProcessor:
             # generation produces garbage.  Without this cap the model would
             # generate up to max_tokens (often 262 K) of useless output,
             # blocking the slot for minutes/hours.
-            if self._eos_set:
-                actual_vocab = logits.shape[-1]
-                mask = self._build_allow_mask(sorted(self._eos_set), actual_vocab)
-                if logits.ndim == 2 and logits.shape[0] == 1:
-                    mask = mask[None, :]
-                return logits + mask
-            return logits
+            return _eos_logits_or_original(
+                self._eos_set,
+                logits,
+                self._build_allow_mask,
+            )
 
         try:
             tokens_list = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
@@ -766,6 +799,16 @@ class JSONSchemaLogitsProcessor:
                 tokens_list = tokens_list[0]
 
             suffix = self._suffix(tokens_list)
+            eos_logits = _complete_json_eos_logits(
+                self._eos_set,
+                suffix,
+                logits,
+                self._suffix_is_complete_json,
+                self._build_allow_mask,
+            )
+            if eos_logits is not None:
+                return eos_logits
+
             # Use prompt_len directly instead of O(n) list comparison.
             pass_to_enforcer = suffix if self._prompt_len else tokens_list
             allowed_result = self._enforcer.get_allowed_tokens(pass_to_enforcer)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1694,6 +1694,35 @@ def _apply_response_format_or_raise(
     return _strip_backslash_before_unicode(text)
 
 
+def _response_format_type(response_format: object | None) -> str | None:
+    if response_format is None:
+        return None
+    if isinstance(response_format, dict):
+        return response_format.get("type")
+    return getattr(response_format, "type", None)
+
+
+def _promote_streaming_response_format_delta(
+    content: str | None,
+    reasoning: str | None,
+    request: ChatCompletionRequest,
+) -> tuple[str | None, str | None]:
+    """Keep response_format JSON on the streaming content channel.
+
+    Some thinking parsers classify direct JSON output as reasoning when the
+    model emits JSON without an explicit reasoning end marker.  For
+    response_format requests, that JSON is the final assistant content.
+    """
+    if content or not reasoning:
+        return content, reasoning
+    if _response_format_type(getattr(request, "response_format", None)) in (
+        "json_object",
+        "json_schema",
+    ):
+        return reasoning, None
+    return content, reasoning
+
+
 def _new_response_item_id(prefix: str) -> str:
     """Generate stable OpenAI-style item ids."""
     return f"{prefix}_{uuid.uuid4().hex}"
@@ -5759,6 +5788,9 @@ async def stream_chat_completion(
 
                 content = delta_msg.content
                 reasoning = delta_msg.reasoning
+                content, reasoning = _promote_streaming_response_format_delta(
+                    content, reasoning, request
+                )
 
                 # Some models (e.g. MiniMax) wrap tool calls in <think>
                 # blocks, so reasoning parser captures tool call XML as

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -131,7 +131,9 @@ from .api.responses_models import (
     ResponsesUsage,
 )
 from .api.tool_calling import (
+    InvalidResponseFormatOutput,
     StreamingJsonFenceStripper,
+    apply_response_format_or_error,
     build_json_logits_processor,
     build_json_system_prompt,
     convert_tools_for_template,
@@ -1686,6 +1688,28 @@ def _parse_tool_calls_with_parser(
     except Exception as e:
         logger.warning("Tool parser error: %s", _sanitize_log_text(e, limit=500))
         return parse_tool_calls(output_text, request_dict)
+
+
+def _apply_response_format_or_raise(
+    text: str,
+    response_format: object,
+    *,
+    ensure_ascii: bool = False,
+) -> str:
+    """Return validated JSON content or fail before returning a success response."""
+    try:
+        text = apply_response_format_or_error(
+            text, response_format, ensure_ascii=ensure_ascii
+        )
+    except InvalidResponseFormatOutput as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "invalid_response_format_output",
+                "message": exc.message,
+            },
+        ) from exc
+    return _strip_backslash_before_unicode(text)
 
 
 def _new_response_item_id(prefix: str) -> str:
@@ -4647,20 +4671,20 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         # Process response_format if specified (after reasoning parser cleaned the text)
         if prepared.response_format and not tool_calls:
             json_input = cleaned_text or output.text
-            _, parsed_json, is_valid, error = parse_json_output(
-                json_input, prepared.response_format
-            )
-            if parsed_json is not None:
-                # Return JSON as string
-                parsed_json = _strip_backslash_before_unicode(parsed_json)
-                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
-            if not is_valid:
+            try:
+                cleaned_text = _apply_response_format_or_raise(
+                    json_input,
+                    prepared.response_format,
+                    ensure_ascii=False,
+                )
+            except HTTPException as exc:
                 if prepared.json_logits_processor is not None:
                     logger.error(
-                        "Constrained decoding produced invalid JSON: %s", error
+                        "Constrained decoding produced invalid JSON: %s", exc.detail
                     )
                 else:
-                    logger.warning(f"JSON validation failed: {error}")
+                    logger.warning("JSON validation failed: %s", exc.detail)
+                raise
 
         # Determine finish reason
         finish_reason = "tool_calls" if tool_calls else output.finish_reason
@@ -5072,22 +5096,23 @@ async def create_anthropic_message(
 
         if prepared.response_format and not tool_calls:
             json_input = cleaned_text or output.text
-            _, parsed_json, is_valid, error = parse_json_output(
-                json_input, prepared.response_format
-            )
-            if parsed_json is not None:
-                parsed_json = _strip_backslash_before_unicode(parsed_json)
-                cleaned_text = json.dumps(parsed_json, ensure_ascii=False)
-            if not is_valid:
+            try:
+                cleaned_text = _apply_response_format_or_raise(
+                    json_input,
+                    prepared.response_format,
+                    ensure_ascii=False,
+                )
+            except HTTPException as exc:
                 if prepared.json_logits_processor is not None:
                     logger.error(
                         "Constrained decoding produced invalid JSON on Anthropic endpoint: %s",
-                        error,
+                        exc.detail,
                     )
                 else:
                     logger.warning(
-                        "JSON validation failed on Anthropic endpoint: %s", error
+                        "JSON validation failed on Anthropic endpoint: %s", exc.detail
                     )
+                raise
 
         # Clean output text
         final_content = None

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -594,6 +594,26 @@ class _ThinkingAwareLogitsProcessor:
         return self._inner._disabled
 
 
+def _attach_response_format_logits_processor(
+    chat_kwargs: dict, json_logits_processor: object
+) -> object:
+    """Attach response_format constraints and keep thinking disabled.
+
+    response_format content must be constrained from the first generated token.
+    If the processor is hidden behind thinking-state handling, direct JSON
+    emissions can bypass the constraint and run until max_tokens.
+    """
+
+    chat_kwargs["enable_thinking"] = False
+    if "chat_template_kwargs" in chat_kwargs:
+        chat_kwargs["chat_template_kwargs"] = dict(chat_kwargs["chat_template_kwargs"])
+        chat_kwargs["chat_template_kwargs"]["enable_thinking"] = False
+
+    existing = chat_kwargs.get("logits_processors") or []
+    chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
+    return json_logits_processor
+
+
 def _prepare_chat_completion_invocation(
     engine: BaseEngine,
     request: ChatCompletionRequest,
@@ -662,33 +682,9 @@ def _prepare_chat_completion_invocation(
         chat_kwargs["stop"] = merged_stop
 
     if json_logits_processor is not None:
-        # Determine the *effective* thinking state: the request field, the
-        # resolved chat_template_kwargs, or the server default can all inject
-        # ``<think>`` into the rendered prompt independently.
-        ctk = chat_kwargs.get("chat_template_kwargs") or {}
-        effective_thinking = (
-            request.enable_thinking is True or ctk.get("enable_thinking") is True
+        json_logits_processor = _attach_response_format_logits_processor(
+            chat_kwargs, json_logits_processor
         )
-
-        if _reasoning_parser and effective_thinking:
-            # User explicitly requested thinking with constrained decoding
-            # (via top-level enable_thinking or chat_template_kwargs).
-            # Wrap the processor so the enforcer only activates after </think>.
-            json_logits_processor = _ThinkingAwareLogitsProcessor(
-                json_logits_processor, prompt_has_think_tag=True
-            )
-        else:
-            # Suppress thinking so the model goes straight to JSON.
-            # The template injects an empty <think></think> block and the
-            # enforcer constrains output from the first token onward.
-            # Force both top-level and chat_template_kwargs to prevent the
-            # Jinja template from rendering an open <think> block.
-            request.enable_thinking = False
-            chat_kwargs["enable_thinking"] = False
-            if "chat_template_kwargs" in chat_kwargs:
-                chat_kwargs["chat_template_kwargs"]["enable_thinking"] = False
-        existing = chat_kwargs.get("logits_processors") or []
-        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
 
     # Thinking-aware logits processor: cap reasoning tokens when a budget is set.
     # Only build when thinking is actually enabled for this request -- a CLI
@@ -756,23 +752,9 @@ def _prepare_anthropic_invocation(
         chat_kwargs["tools"] = template_tools
 
     if json_logits_processor is not None:
-        # Same logic as the OpenAI path: check both top-level and
-        # chat_template_kwargs for an explicit thinking request.
-        ctk = chat_kwargs.get("chat_template_kwargs") or {}
-        effective_thinking = (
-            openai_request.enable_thinking is True or ctk.get("enable_thinking") is True
+        json_logits_processor = _attach_response_format_logits_processor(
+            chat_kwargs, json_logits_processor
         )
-
-        if _reasoning_parser and effective_thinking:
-            json_logits_processor = _ThinkingAwareLogitsProcessor(
-                json_logits_processor, prompt_has_think_tag=True
-            )
-        else:
-            chat_kwargs["enable_thinking"] = False
-            if "chat_template_kwargs" in chat_kwargs:
-                chat_kwargs["chat_template_kwargs"]["enable_thinking"] = False
-        existing = chat_kwargs.get("logits_processors") or []
-        chat_kwargs["logits_processors"] = list(existing) + [json_logits_processor]
 
     return PreparedChatInvocation(
         messages=messages,


### PR DESCRIPTION
## Summary
- add a shared response-format boundary helper that returns canonical JSON only after `parse_json_output` validates it
- have the non-streaming server boundary raise HTTP 422 instead of returning HTTP 200 with non-JSON `message.content` when `response_format` output is invalid
- force EOS once the JSON logits processor has already produced a complete JSON value
- keep `response_format` constraints in direct control of generation instead of hiding them behind thinking-state handling
- keep streaming `response_format` JSON/JSON-schema deltas on the assistant `content` channel when a thinking parser classifies direct JSON as reasoning
- add structured-output, constrained-decoding, and streaming content-channel tests for the hard-fail, EOS, thinking, and streaming interactions

Fixes #538.

## Local repro
The existing upstream path in `vllm_mlx/server.py` calls `parse_json_output(json_input, response_format)`. When `is_valid=False`, it logs `JSON validation failed` and then continues to return a normal `ChatCompletionResponse`.

The first focused unit repro covers the shared helper: `apply_response_format_or_error("I will reason first...", {"type": "json_object"})` raises `InvalidResponseFormatOutput`, and the server translates that into HTTP 422 at the API boundary.

A second local Runtime repro showed constrained JSON output could parse correctly but still continue until the output cap because `JSONSchemaLogitsProcessor` did not force EOS once the suffix was already complete JSON.

A third local Runtime repro showed thinking-enabled `response_format` could allow direct JSON emissions to bypass the JSON processor when the processor was wrapped behind thinking-state handling. The upstream branch had the same `_ThinkingAwareLogitsProcessor` path in both OpenAI and Anthropic preparation.

A fourth local Runtime repro showed a long streaming `response_format={"type":"json_schema"}` request on a Qwen thinking mode emitted valid JSON through the streaming reasoning channel instead of assistant content. The local certification artifact is `/opt/ai-runtime/run/qwen-response-format-streaming-certification/20260517T052855Z/summary.json`: HTTP 200, `finish_reason=stop`, JSON/schema valid, `content_length=2243`, `reasoning_length=0` after the content-channel fix.

## Upstream code path compared
- repo: `waybarrios/vllm-mlx`
- base: `main` first checked at `6d55631`; PR branch rebased onto `c2d3aec`; streaming follow-up compared against `upstream/main` at `c2d3aec4be51f3b7bc31b7b5d489ced41b1f8fbf`
- paths:
  - `vllm_mlx/server.py` non-streaming `create_chat_completion` response-format post-processing
  - `vllm_mlx/server.py` OpenAI and Anthropic response-format logits-processor attachment
  - `vllm_mlx/server.py::stream_chat_completion` reasoning-parser delta handling and streaming response-format fence stripping
  - `vllm_mlx/api/tool_calling.py` structured-output helpers
  - `vllm_mlx/constrained/json_schema_processor.py` EOS and mask handling

## Observed behavior
Invalid structured output could be returned as a successful response after only logging a warning.

A complete JSON value could remain open for more generation instead of stopping cleanly.

When thinking was explicitly enabled with `response_format`, JSON constraints could wait behind thinking-state handling and fail to own generation from the first token.

In streaming, a thinking parser could classify valid direct JSON as `reasoning_content`, leaving `delta.content` empty even though the request contract asked for `response_format` final assistant content.

## Expected behavior
If `response_format` is requested and final non-streaming output does not parse or validate, the API should fail the request instead of returning invalid content as success.

Once constrained decoding has produced a complete JSON value, EOS should be the only allowed continuation.

For `response_format`, the JSON processor should constrain generated content directly. This patch disables thinking template flags for that request path rather than wrapping the JSON processor behind thinking detection.

For streaming `response_format`, JSON/JSON-schema deltas that a reasoning parser emits as reasoning should be promoted back to assistant content unless ordinary content is already present.

## Tests
- `UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --extra dev python -m pytest -q tests/test_constrained_decoding.py tests/test_thinking_aware_processor.py tests/test_structured_output.py`
- `UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --extra dev python -m pytest tests/test_mcp_security.py tests/test_structured_output.py tests/test_reasoning_parser.py tests/test_tool_parsers.py tests/test_streaming_json_encoder.py tests/test_native_tool_format.py tests/test_memory_cache.py tests/test_prefix_cache.py tests/test_mllm_cache.py tests/test_api_models.py tests/test_api_utils.py tests/test_request.py tests/test_anthropic_models.py tests/test_anthropic_adapter.py tests/test_harmony_parsers.py tests/test_endpoint_model_policies.py tests/test_gemma4_openai_format.py tests/test_gemma4_streaming_edge.py tests/test_gemma4_tool_parser.py tests/test_minimax_tool_calling.py tests/test_qwen3_xml_parser.py tests/test_qwen3_xml_registration.py tests/test_qwen3_xml_streaming_chunks.py tests/test_streaming_fence_stripper.py tests/test_streaming_think_router.py tests/test_streaming_tool_filter.py tests/test_tool_call_promotion.py -q -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache"`
- `python -m py_compile vllm_mlx/server.py vllm_mlx/api/tool_calling.py vllm_mlx/constrained/json_schema_processor.py tests/test_structured_output.py tests/test_constrained_decoding.py tests/test_thinking_aware_processor.py`
- `UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --extra dev ruff check vllm_mlx/server.py vllm_mlx/api/tool_calling.py vllm_mlx/constrained/json_schema_processor.py tests/test_structured_output.py tests/test_constrained_decoding.py tests/test_thinking_aware_processor.py`
- `UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --extra dev black --check vllm_mlx/server.py vllm_mlx/api/tool_calling.py vllm_mlx/constrained/json_schema_processor.py tests/test_structured_output.py tests/test_constrained_decoding.py tests/test_thinking_aware_processor.py`
- `.venv/bin/python -m pytest tests/test_server.py::TestStreamChatCompletion -q`
- `.venv/bin/ruff check vllm_mlx/server.py tests/test_server.py`
- `git diff --check`

Outbound local gates for the streaming follow-up:
- agent-slop-lint touched-file before/after comparison on `vllm_mlx/server.py` and `tests/test_server.py`: 75 violations before, 75 after; no regression
- Desloppify touched-file before/after comparison on `vllm_mlx/server.py` and `tests/test_server.py`: 56 open issues before, 56 after; objective 77.6 before and after; no regression
- `bin/lint-upstream-claims --root /tmp/outbound-vllm-mlx-539.VScyyJ vllm_mlx/server.py tests/test_server.py`

## Not claimed
- does not change model sampling defaults
- does not claim `tools` plus `response_format` semantics
- does not claim model-quality results
- does not claim every model/parser emits direct JSON through the same streaming path
