### PR TITLE
Fail fast on occupied SimpleEngine serialized route

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -104,6 +104,7 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_model
             engine._loaded = True
+            engine._generation_lock_admission = "wait"
 
             # Launch multiple concurrent generate calls
             tasks = [
@@ -128,6 +129,7 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_llm_model
             engine._loaded = True
+            engine._generation_lock_admission = "wait"
 
             # Launch multiple concurrent chat calls
             tasks = [
@@ -144,6 +146,76 @@ class TestSimpleEngineConcurrency:
                 f"Expected max concurrent to be 1, but got {mock_llm_model._max_concurrent}. "
                 "The lock is not working correctly."
             )
+
+    @pytest.mark.anyio
+    async def test_default_admission_rejects_second_serialized_request(self):
+        """Default SimpleEngine admission fails fast instead of queueing."""
+        from vllm_mlx.engine.base import EngineBusy
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+
+            started = threading.Event()
+            release = threading.Event()
+
+            def slow_call():
+                started.set()
+                release.wait(timeout=1.0)
+                return "ok"
+
+            first = asyncio.create_task(
+                engine._run_blocking_serialized(
+                    slow_call,
+                    request_id="first-serialized-request",
+                )
+            )
+            await asyncio.to_thread(started.wait, 1.0)
+
+            with pytest.raises(EngineBusy) as excinfo:
+                await engine._run_blocking_serialized(
+                    lambda: "late",
+                    request_id="second-serialized-request",
+                )
+
+            assert "text_generation_busy" == excinfo.value.code
+            assert "active=first-serialized-request" in str(excinfo.value)
+            assert engine._generation_busy_rejections == 1
+
+            release.set()
+            await first
+
+    @pytest.mark.anyio
+    async def test_blocking_serialized_tracks_active_request(self):
+        """Busy errors include the current blocking serialized holder."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._loaded = True
+
+            def slow_call():
+                import time
+
+                time.sleep(0.05)
+                return "ok"
+
+            first = asyncio.create_task(
+                engine._run_blocking_serialized(
+                    slow_call,
+                    request_id="probe-active-holder",
+                )
+            )
+            for _ in range(100):
+                if engine._generation_lock.locked():
+                    break
+                await asyncio.sleep(0.001)
+
+            assert "probe-active-holder" in engine._generation_lock_holder_summary()
+
+            await first
+            assert engine._generation_lock_holder_summary() == "none"
 
     async def test_chat_with_tools_aggregates_streaming_path(self, mock_llm_model):
         """Tool-enabled non-stream chat should use the streaming path."""
@@ -1142,6 +1214,7 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_model
             engine._loaded = True
+            engine._generation_lock_admission = "wait"
 
             # Test that stream_generate acquires the lock
             # by checking if it blocks when lock is already held
@@ -2027,6 +2100,7 @@ class TestSimpleEngineConcurrency:
             engine = SimpleEngine("test-model")
             engine._model = mock_llm_model
             engine._loaded = True
+            engine._generation_lock_admission = "wait"
 
             task1 = asyncio.create_task(
                 engine.chat(

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -37,6 +37,12 @@ class GenerationOutput:
     mtp_accepted: int = 0
 
 
+class EngineBusy(RuntimeError):
+    """Raised when a serialized engine route is already serving a request."""
+
+    code = "text_generation_busy"
+
+
 @contextmanager
 def suspend_cancellation():
     """Temporarily clear task cancellation so cleanup can finish deterministically."""

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -16,6 +16,7 @@ import time
 import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 # Re-entrancy guard for SimpleEngine._track_request_stream so that
@@ -33,6 +34,7 @@ from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, has_media_content, is_mllm_model
 from .base import (
     BaseEngine,
+    EngineBusy,
     GenerationOutput,
     cleanup_startup_cancellation,
     run_blocking_startup_work,
@@ -209,6 +211,19 @@ class SimpleEngine(BaseEngine):
 
         # Lock to serialize MLX operations (prevents Metal command buffer conflicts)
         self._generation_lock = asyncio.Lock()
+        self._generation_lock_admission = (
+            os.environ.get("VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION", "fail_fast")
+            .strip()
+            .lower()
+        )
+        if self._generation_lock_admission not in {"fail_fast", "wait"}:
+            logger.warning(
+                "Invalid VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=%r; using fail_fast",
+                self._generation_lock_admission,
+            )
+        self._generation_lock_admission = "fail_fast"
+        self._generation_waiters = 0
+        self._generation_busy_rejections = 0
 
         # System prompt KV cache (reduces repeated prefill across requests).
         # OrderedDict acts as an LRU keyed by system-prefix hash so that the
@@ -254,6 +269,54 @@ class SimpleEngine(BaseEngine):
         if self._is_mllm:
             return getattr(self._model, "processor", None)
         return self._model.tokenizer
+
+    def _generation_lock_holder_summary(self) -> str:
+        if not self._active_requests:
+            return "none"
+
+        holders = []
+        now = time.time()
+        for request_id, info in self._active_requests.items():
+            elapsed_s = info.get("elapsed_s")
+            started_at = info.get("started_at")
+            if started_at is not None:
+                elapsed_s = round(now - started_at, 1)
+            kind = info.get("kind", "unknown")
+            status = info.get("status", "unknown")
+            holders.append(
+                f"{request_id}:{status}:{kind}:"
+                f"prompt={info.get('prompt_tokens', 0)}:"
+                f"completion={info.get('completion_tokens', 0)}:"
+                f"elapsed_s={elapsed_s if elapsed_s is not None else 'unknown'}"
+            )
+        return ",".join(holders)
+
+    @asynccontextmanager
+    async def _acquire_generation_slot(self, request_id: str):
+        """Admission control for SimpleEngine's serialized MLX route."""
+        if (
+            self._generation_lock_admission == "fail_fast"
+            and self._generation_lock.locked()
+        ):
+            self._generation_busy_rejections += 1
+            raise EngineBusy(
+                "SimpleEngine serialized route is busy; "
+                f"request_id={request_id}; "
+                f"active={self._generation_lock_holder_summary()}; "
+                f"waiters={self._generation_waiters}; "
+                "retry later"
+            )
+
+        self._generation_waiters += 1
+        acquired = False
+        try:
+            async with self._generation_lock:
+                acquired = True
+                self._generation_waiters -= 1
+                yield
+        finally:
+            if not acquired and self._generation_waiters > 0:
+                self._generation_waiters -= 1
 
     def prepare_for_start(self) -> None:
         """Load the backing model off the serving event loop."""
@@ -485,14 +548,33 @@ class SimpleEngine(BaseEngine):
         """Return whether text-only MLLM requests may use mlx_lm TextModel."""
         return not (mllm_draft_requested and self._mllm_draft_model_path is not None)
 
-    async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
+    async def _run_blocking_serialized(
+        self,
+        func,
+        /,
+        *args,
+        request_id: str | None = None,
+        on_cancel=None,
+        **kwargs,
+    ):
         """Run a blocking MLX operation under the generation lock.
 
         Cancellation must not release the async lock before the worker thread
         finishes, or a follow-up request can enter MLX/Metal concurrently and
         corrupt the command-buffer state.
         """
-        async with self._generation_lock:
+        request_id = request_id or f"simple-{id(func):x}"
+        async with self._acquire_generation_slot(request_id):
+            started_at = time.time()
+            self._active_requests[request_id] = {
+                "request_id": request_id,
+                "status": "running",
+                "kind": "blocking_serialized",
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "elapsed_s": 0.0,
+                "started_at": started_at,
+            }
 
             def run_bound():
                 _bind_worker_generation_streams()
@@ -515,6 +597,8 @@ class SimpleEngine(BaseEngine):
                 except BaseException:
                     pass
                 raise
+            finally:
+                self._active_requests.pop(request_id, None)
 
     async def generate(
         self,
@@ -719,6 +803,7 @@ class SimpleEngine(BaseEngine):
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
+        request_id = str(kwargs.pop("request_id", "") or f"simple-{id(prompt):x}")
 
         # SpecPrefill for non-MLLM models (MLLM+MTP handles it in _stream_generate_text)
         if not self._is_mllm and self._draft_model is not None:
@@ -766,64 +851,94 @@ class SimpleEngine(BaseEngine):
                         yield output
                     return
 
-        async with self._generation_lock:
+        async with self._acquire_generation_slot(request_id):
+            started_at = time.time()
+            self._active_requests[request_id] = {
+                "request_id": request_id,
+                "status": "running",
+                "kind": "stream_generate",
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "elapsed_s": 0.0,
+                "started_at": started_at,
+            }
             # Non-stream chat runs in a worker thread and rebinds generation
             # streams there. Rebind again on the current thread before
             # stream_generate so nonstream->stream mode switches remain valid.
             _bind_worker_generation_streams()
 
-            accumulated_text = ""
-            prompt_tokens = 0
-            completion_tokens = 0
-            finished = False
+            try:
+                accumulated_text = ""
+                prompt_tokens = 0
+                completion_tokens = 0
+                finished = False
 
-            for chunk in self._model.stream_generate(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                stop=stop,
-                **kwargs,
-            ):
-                prompt_tokens = (
-                    chunk.prompt_tokens
-                    if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
-                    else prompt_tokens
-                )
-                completion_tokens += 1
-                new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                accumulated_text += new_text
+                for chunk in self._model.stream_generate(
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    stop=stop,
+                    **kwargs,
+                ):
+                    prompt_tokens = (
+                        chunk.prompt_tokens
+                        if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
+                        else prompt_tokens
+                    )
+                    completion_tokens += 1
+                    if request_id in self._active_requests:
+                        self._active_requests[request_id].update(
+                            {
+                                "prompt_tokens": prompt_tokens,
+                                "completion_tokens": completion_tokens,
+                                "elapsed_s": round(time.time() - started_at, 1),
+                            }
+                        )
+                    new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
+                    accumulated_text += new_text
 
-                finished = (
-                    getattr(chunk, "finished", False) or completion_tokens >= max_tokens
-                )
-                finish_reason = None
-                if finished:
-                    finish_reason = getattr(chunk, "finish_reason", "stop")
+                    finished = (
+                        getattr(chunk, "finished", False)
+                        or completion_tokens >= max_tokens
+                    )
+                    finish_reason = None
+                    if finished:
+                        finish_reason = getattr(chunk, "finish_reason", "stop")
 
-                yield GenerationOutput(
-                    text=accumulated_text,
-                    new_text=new_text,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    finished=finished,
-                    finish_reason=finish_reason,
-                )
+                    yield GenerationOutput(
+                        text=accumulated_text,
+                        new_text=new_text,
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        finished=finished,
+                        finish_reason=finish_reason,
+                    )
 
-                if finished:
-                    break
+                    if finished:
+                        break
 
-            if not finished:
-                if prompt_tokens == 0:
-                    prompt_tokens = len(self._model.tokenizer.encode(prompt))
-                yield GenerationOutput(
-                    text=accumulated_text,
-                    new_text="",
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    finished=True,
-                    finish_reason=None,
-                )
+                if not finished:
+                    if prompt_tokens == 0:
+                        prompt_tokens = len(self._model.tokenizer.encode(prompt))
+                    if request_id in self._active_requests:
+                        self._active_requests[request_id].update(
+                            {
+                                "prompt_tokens": prompt_tokens,
+                                "completion_tokens": completion_tokens,
+                                "elapsed_s": round(time.time() - started_at, 1),
+                            }
+                        )
+                    yield GenerationOutput(
+                        text=accumulated_text,
+                        new_text="",
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        finished=True,
+                        finish_reason=None,
+                    )
+            finally:
+                self._active_requests.pop(request_id, None)
 
     async def chat(
         self,
@@ -2494,7 +2609,7 @@ class SimpleEngine(BaseEngine):
             "loaded": self._loaded,
             "running": self._loaded,
             "num_running": self._num_running,
-            "num_waiting": 0,
+            "num_waiting": self._generation_waiters,
             "num_requests_processed": self._total_requests_processed,
             "total_prompt_tokens": self._total_prompt_tokens,
             "total_completion_tokens": self._total_completion_tokens,
@@ -2503,6 +2618,11 @@ class SimpleEngine(BaseEngine):
                 "prompt_tps": 0.0,
             },
             "requests": requests_snapshot,
+            "generation_lock": {
+                "locked": self._generation_lock.locked(),
+                "admission": self._generation_lock_admission,
+                "busy_rejections": self._generation_busy_rejections,
+            },
         }
 
         # MLLM prefix cache stats, remapped to the shape BatchedEngine emits

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -162,7 +162,7 @@ from .endpoint_model_policies import (
     resolve_stt_model_name,
     resolve_tts_model_name,
 )
-from .engine.base import suspend_cancellation
+from .engine.base import EngineBusy, suspend_cancellation
 from .lifecycle import ModelSpec, ResidencyManager
 from .model_registry import (
     ModelLease,
@@ -971,6 +971,17 @@ def _log_and_raise_internal_error(log_prefix: str, exc: Exception, detail: str) 
     """Log a sanitized exception string and raise a generic 500 response."""
     logger.error("%s: %s", log_prefix, _sanitize_log_text(exc, limit=500))
     raise HTTPException(status_code=500, detail=detail)
+
+
+def _raise_engine_busy(exc: EngineBusy) -> None:
+    """Translate serialized-engine admission failures into retryable HTTP 503."""
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "error": exc.code,
+            "message": str(exc),
+        },
+    ) from exc
 
 
 @dataclass
@@ -4637,6 +4648,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             except HTTPException as exc:
                 tracker.finish(result=_metrics_result_from_status(exc.status_code))
                 raise
+            except EngineBusy as exc:
+                tracker.finish(result="busy")
+                _raise_engine_busy(exc)
             if output is None:
                 tracker.finish(
                     result="client_closed",
@@ -4815,6 +4829,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         except HTTPException as exc:
             tracker.finish(result=_metrics_result_from_status(exc.status_code))
             raise
+        except EngineBusy as exc:
+            tracker.finish(result="busy")
+            _raise_engine_busy(exc)
         if output is None:
             tracker.finish(result="client_closed")
             return Response(status_code=499)  # Client closed request


### PR DESCRIPTION
## Summary
- add a small `EngineBusy` exception for serialized engine admission failures
- make `SimpleEngine` fail fast by default when its serialized MLX lock is already occupied, with `VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait` as an explicit compatibility mode
- track active serialized request metadata and expose lock/admission stats in `get_stats()`
- translate non-streaming completion/chat `EngineBusy` failures into retryable HTTP 503 responses with `error=text_generation_busy`

Fixes #495.

## Local repro
`SimpleEngine` serializes MLX work through `_generation_lock`. Before this patch, a second request entering the serialized route waited behind that lock, which can create request pileup under concurrent traffic. The focused regression starts one serialized request, then verifies a second serialized request fails immediately with `EngineBusy` and includes the active holder in the error text.

## Upstream code path compared
- repo: `waybarrios/vllm-mlx`
- base: current `main` at `c2d3aec`
- paths: `vllm_mlx/engine/simple.py` `_run_blocking_serialized` / `stream_generate`, `vllm_mlx/server.py` non-streaming completion/chat calls, and `vllm_mlx/engine/base.py`

## Observed behavior
The serialized SimpleEngine path had a lock, but no default fail-fast admission result and no active holder metadata for diagnosing the request currently occupying the route.

## Expected behavior
When the route is already occupied, a second request should get a retryable busy result instead of silently queueing behind the serialized MLX lock. Operators should be able to see the active holder, waiters, and busy rejection count.

## Tests
- `UV_PYTHON=/opt/homebrew/bin/python3.12 uv run --extra dev python -m pytest -q tests/test_simple_engine.py`
- `python -m py_compile vllm_mlx/engine/base.py vllm_mlx/engine/simple.py vllm_mlx/server.py tests/test_simple_engine.py`
- `uv run --with ruff ruff check vllm_mlx/engine/base.py vllm_mlx/engine/simple.py vllm_mlx/server.py tests/test_simple_engine.py --select E,F,W --ignore E402,E501,E731,F811,F841`
- `black --check vllm_mlx/engine/base.py vllm_mlx/engine/simple.py vllm_mlx/server.py tests/test_simple_engine.py`
- `git diff --check`

## Not claimed
- does not claim this is continuous batching
- does not change model sampling
- does not remove the serialized lock; it changes default admission behavior when that lock is occupied
- does not address streaming HTTP response semantics beyond the engine-side busy invariant
