### PR TITLE
feat: multi-slot LRU for system-KV cache + hit-ratio counters (follow-up to #523)

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -790,22 +790,229 @@ class TestSimpleEngineConcurrency:
         assert chunks and chunks[0].text == "ok"
 
     @pytest.mark.anyio
+    async def test_stream_generate_text_skips_cache_path_when_text_model_unsafe(self):
+        """Same snapshot-safety contract as the LLM path, but for MLLM text
+        routing: ``_stream_generate_text`` must not enter the system-KV cache
+        branch when ``start()``'s probe of the derived ``_text_model`` returned
+        non-KVCache entries (e.g. a sliding-window text head). The gate must
+        fall back to the uncached path — no encode of the system prefix, no
+        snapshot store, no LRU mutation."""
+        from collections import OrderedDict
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = (
+            "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+            "<|im_start|>user\nhello<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        tokenizer.bos_token = None
+        tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+        tokenizer.decode = MagicMock(return_value="")
+        tokenizer.eos_token_id = 99
+
+        text_model = MagicMock()
+        text_model.mtp = None
+
+        engine = SimpleEngine("test-model", force_mllm=True)
+        engine._loaded = True
+        engine._text_model = text_model
+        engine._text_tokenizer = tokenizer
+        # Probe at start() decided this text model is NOT snapshot-safe.
+        engine._supports_system_kv_cache = False
+        engine._system_kv_cache = OrderedDict()
+        # Seed counters to verify they don't move on the uncached path.
+        engine._system_kv_cache_stats = {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
+
+        def fake_stream_generate(*args, **kw):
+            # _run_all iterates this synchronously (`for resp in ...`), so the
+            # mock must be a sync generator, not an async one.
+            yield SimpleNamespace(
+                text="ok",
+                new_text="ok",
+                prompt_tokens=3,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+                token=99,
+            )
+
+        with (
+            patch("vllm_mlx.engine.simple._bind_worker_generation_streams"),
+            patch(
+                "mlx_lm.models.cache.make_prompt_cache",
+                return_value=["backbone-cache"],
+            ),
+            patch("mlx_lm.sample_utils.make_sampler", return_value=MagicMock()),
+            patch(
+                "mlx_lm.sample_utils.make_logits_processors",
+                return_value=[],
+            ),
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+        ):
+            chunks = [
+                c
+                async for c in engine._stream_generate_text(
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "hello"},
+                    ],
+                    max_tokens=4,
+                    temperature=0.7,
+                    top_p=0.95,
+                )
+            ]
+
+        assert chunks, "expected uncached fallback to emit at least one chunk"
+        # System-prefix tokenization must NOT have been invoked: the only
+        # encode() call is the full-prompt one for the uncached path. The
+        # cache branch would have issued a second encode() for the system
+        # prefix before storing.
+        assert tokenizer.encode.call_count <= 1, (
+            "snapshot path ran despite _supports_system_kv_cache=False: "
+            f"encode called {tokenizer.encode.call_count} times"
+        )
+        # And nothing should have landed in the LRU or moved counters.
+        assert len(engine._system_kv_cache) == 0
+        assert engine._system_kv_cache_stats == {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
+
+    @pytest.mark.anyio
+    async def test_stream_generate_text_skips_cache_path_under_bounded_kv(self):
+        """Bounded-KV snapshot-safety contract for the MLLM text route.
+
+        When ``_max_kv_size > 0`` the runtime cache branch builds the prompt
+        cache via ``make_prompt_cache(model, max_kv_size=N)``. For models
+        without a custom ``make_cache``, ``mlx_lm.models.cache.make_prompt_cache``
+        returns ``RotatingKVCache`` whose ``.state`` aliases buffers that
+        ``update_and_fetch`` mutates in place — snapshot capture would corrupt
+        the cached prefix on the next decode.
+
+        The startup probe is now wired with the same ``max_kv_size`` arg as
+        the runtime constructor, so under bounded KV the probe sees
+        ``RotatingKVCache`` and sets ``_supports_system_kv_cache=False``.
+        This test locks in the runtime side of that chain: with the flag set
+        False (the correct post-probe state for ``_max_kv_size > 0``),
+        ``_stream_generate_text`` must fall back to the uncached path — no
+        encode of the system prefix, no LRU store, no counter movement.
+
+        Regression for PR #541 review (Thump604, 2026-05-17 16:04 UTC).
+        """
+        from collections import OrderedDict
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = (
+            "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+            "<|im_start|>user\nhello<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        tokenizer.bos_token = None
+        tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+        tokenizer.decode = MagicMock(return_value="")
+        tokenizer.eos_token_id = 99
+
+        text_model = MagicMock()
+        text_model.mtp = None
+
+        engine = SimpleEngine("test-model", force_mllm=True)
+        engine._loaded = True
+        engine._text_model = text_model
+        engine._text_tokenizer = tokenizer
+        # Bounded-KV serving: the startup probe (called with the same
+        # max_kv_size as runtime) would have built RotatingKVCache and
+        # flipped this flag to False.
+        engine._max_kv_size = 2048
+        engine._supports_system_kv_cache = False
+        engine._system_kv_cache = OrderedDict()
+        engine._system_kv_cache_stats = {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
+
+        def fake_stream_generate(*args, **kw):
+            yield SimpleNamespace(
+                text="ok",
+                new_text="ok",
+                prompt_tokens=3,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+                token=99,
+            )
+
+        with (
+            patch("vllm_mlx.engine.simple._bind_worker_generation_streams"),
+            patch(
+                "mlx_lm.models.cache.make_prompt_cache",
+                return_value=["backbone-cache"],
+            ),
+            patch("mlx_lm.sample_utils.make_sampler", return_value=MagicMock()),
+            patch(
+                "mlx_lm.sample_utils.make_logits_processors",
+                return_value=[],
+            ),
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+        ):
+            chunks = [
+                c
+                async for c in engine._stream_generate_text(
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "hello"},
+                    ],
+                    max_tokens=4,
+                    temperature=0.7,
+                    top_p=0.95,
+                )
+            ]
+
+        assert chunks, "expected uncached fallback to emit at least one chunk"
+        # The cache branch would have issued a second encode() for the system
+        # prefix before storing; under bounded KV the gate must skip that.
+        assert tokenizer.encode.call_count <= 1, (
+            "snapshot path ran under _max_kv_size>0: "
+            f"encode called {tokenizer.encode.call_count} times"
+        )
+        assert len(engine._system_kv_cache) == 0
+        assert engine._system_kv_cache_stats == {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
+
+    @pytest.mark.anyio
     async def test_stream_chat_uses_gate_time_snapshot_under_concurrent_mutation(
         self,
     ):
-        """A concurrent MISS that reassigns ``self._system_kv_snapshot`` between
+        """A concurrent MISS that mutates ``self._system_kv_cache`` between
         the cache-hit gate (which runs outside ``_run_blocking_serialized``) and
         the snapshot restore (which runs inside the serialized worker) must not
         corrupt the HIT. The restore must use the snapshot reference captured at
-        gate time, not re-read ``self._system_kv_snapshot`` later — otherwise a
+        gate time, not re-read ``self._system_kv_cache`` later — otherwise a
         different system prefix's KV would be loaded under the hash that decided
         HIT.
 
-        Simulates the race by reassigning ``engine._system_kv_snapshot`` inside
+        Simulates the race by replacing the cache entry for the same hash inside
         the ``_run_blocking_serialized`` hook (executed after the gate but
         before the worker enters the cache branch), then asserts the restore
         loop wrote the gate-time entries, not the post-gate intruder."""
         import hashlib
+        from collections import OrderedDict
 
         from vllm_mlx.engine.simple import SimpleEngine
 
@@ -871,14 +1078,16 @@ class TestSimpleEngineConcurrency:
             engine._loaded = True
             engine._supports_system_kv_cache = True
             # Pre-seed HIT state matching the divergence-detected prefix.
-            engine._system_kv_hash = expected_hash
-            engine._system_kv_token_count = 20
-            engine._system_kv_snapshot = original_snapshot
+            engine._system_kv_cache = OrderedDict(
+                [(expected_hash, (original_snapshot, 20))]
+            )
 
             async def serialized_with_race(func, *args, on_cancel=None, **kw):
-                # Simulate a concurrent MISS overwriting the instance attribute
-                # AFTER the gate's HIT decision but BEFORE the worker restores.
-                engine._system_kv_snapshot = intruder_snapshot
+                # Simulate a concurrent MISS replacing the cache entry for the
+                # same hash AFTER the gate's HIT decision but BEFORE the worker
+                # restores. The gate captured a reference to the original
+                # tuple; replacement here must not affect that capture.
+                engine._system_kv_cache[expected_hash] = (intruder_snapshot, 20)
                 await asyncio.to_thread(func)
                 return None
 
@@ -905,7 +1114,7 @@ class TestSimpleEngineConcurrency:
                 ]
 
         # Restore wrote the gate-time snapshot exactly once.
-        # If the worker had re-read ``self._system_kv_snapshot`` we would see
+        # If the worker had re-read ``self._system_kv_cache`` we would see
         # ``("INTRUDER_K", "INTRUDER_V")`` instead — that's the TOCTOU bug.
         assert captured_states == [("ORIGINAL_K", "ORIGINAL_V")], (
             "Snapshot restore did not use the gate-time reference; "
@@ -2086,3 +2295,63 @@ class TestSimpleEngineConcurrency:
                 with pytest.raises(asyncio.CancelledError):
                     await task
         assert await asyncio.to_thread(prefill_cancelled.wait, 1.0)
+
+
+class TestSimpleEngineClearRuntimeCaches:
+    """Operational reset (DELETE /v1/cache) must actually release the
+    multi-slot system-prompt KV cache state introduced in the LRU patch —
+    otherwise multi-GB Metal-heap snapshots can survive a reset while
+    /v1/cache/stats still reports them.
+    """
+
+    def test_clear_runtime_caches_drops_lru_and_resets_counters(self):
+        from collections import OrderedDict
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine("test-model")
+        # Seed a populated LRU + non-zero counters as if the engine had been
+        # serving traffic with two distinct system prefixes.
+        engine._system_kv_cache = OrderedDict(
+            [
+                ("hash_a", ([b"snap_a_layer_0", b"snap_a_layer_1"], 28000)),
+                ("hash_b", ([b"snap_b_layer_0", b"snap_b_layer_1"], 6500)),
+            ]
+        )
+        engine._system_kv_cache_stats = {
+            "hits": 5,
+            "misses": 2,
+            "stores": 2,
+            "evictions": 0,
+        }
+
+        result = engine.clear_runtime_caches()
+
+        assert len(engine._system_kv_cache) == 0, "LRU must be empty after clear"
+        assert engine._system_kv_cache_stats == {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }, "counters must reset so /v1/cache/stats reflects cleared state"
+        assert result is not None
+        assert result["system_kv_cache"] == {"dropped_entries": 2}
+
+    def test_clear_runtime_caches_no_op_when_lru_empty_and_counters_zero(self):
+        from collections import OrderedDict
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine("test-model")
+        engine._system_kv_cache = OrderedDict()
+        engine._system_kv_cache_stats = {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
+
+        result = engine.clear_runtime_caches()
+
+        # Non-MLLM, empty LRU, zeroed counters → nothing to report.
+        assert result is None

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -12,6 +12,7 @@ import logging
 import os
 import threading
 import time
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -175,10 +176,25 @@ class SimpleEngine(BaseEngine):
         # Lock to serialize MLX operations (prevents Metal command buffer conflicts)
         self._generation_lock = asyncio.Lock()
 
-        # System prompt KV cache (reduces repeated prefill across requests)
-        self._system_kv_snapshot = None  # List of (keys, values) per backbone layer
-        self._system_kv_hash = None  # Hash of system prefix text
-        self._system_kv_token_count = 0  # Tokens in cached prefix
+        # System prompt KV cache (reduces repeated prefill across requests).
+        # OrderedDict acts as an LRU keyed by system-prefix hash so that the
+        # main agent and any sub-agents with different toolsets can coexist
+        # without thrashing a single snapshot slot.
+        # Value is (snapshot_list, system_token_count).
+        self._system_kv_capacity = max(
+            1, int(os.environ.get("VLLM_MLX_SYSTEM_KV_SLOTS", "4"))
+        )
+        self._system_kv_cache: "OrderedDict[str, tuple[list, int]]" = OrderedDict()
+        # Cache-effectiveness counters. Incremented only from inside the
+        # serialized worker (single writer) so plain ``+=`` is safe; reads
+        # from ``get_stats`` may be slightly stale, which is fine for
+        # metrics.
+        self._system_kv_cache_stats = {
+            "hits": 0,
+            "misses": 0,
+            "stores": 0,
+            "evictions": 0,
+        }
         # True only when the model's prompt cache is composed entirely of
         # plain ``KVCache`` entries. Sliding-window models (gemma3_text,
         # olmo3, recurrent_gemma) return ``RotatingKVCache`` whose ``.state``
@@ -311,6 +327,46 @@ class SimpleEngine(BaseEngine):
                                 self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
                             )
 
+                        # Probe the derived TextModel's prompt cache for snapshot-safety
+                        # (same gate stream_chat uses for the pure-LLM path).
+                        # _stream_generate_text only enters the system-KV cache branch
+                        # when this flag is True, so sliding-window text models won't
+                        # desynchronize on restore.
+                        #
+                        # Probe args must match the runtime constructor in
+                        # _stream_generate_text (max_kv_size=self._max_kv_size or None).
+                        # Under bounded-KV serving (max_kv_size > 0) make_prompt_cache
+                        # returns RotatingKVCache for models without a custom
+                        # make_cache; probing with default args would mis-classify that
+                        # path as snapshot-safe.
+                        try:
+                            from mlx_lm.models.cache import KVCache, make_prompt_cache
+
+                            probe_cache = make_prompt_cache(
+                                self._text_model, max_kv_size=self._max_kv_size or None
+                            )
+                            self._supports_system_kv_cache = bool(probe_cache) and all(
+                                isinstance(c, KVCache) for c in probe_cache
+                            )
+                            if not self._supports_system_kv_cache:
+                                cache_types = sorted(
+                                    {type(c).__name__ for c in probe_cache}
+                                )
+                                logger.info(
+                                    "System KV cache snapshot disabled for MLLM "
+                                    "text routing: TextModel returned non-KVCache "
+                                    "entries (%s); _stream_generate_text will use "
+                                    "the uncached path",
+                                    cache_types,
+                                )
+                        except Exception as e:
+                            logger.debug(
+                                "MLLM TextModel KV cache support probe failed "
+                                "(%s); disabling snapshot path",
+                                e,
+                            )
+                            self._supports_system_kv_cache = False
+
                         has_mtp = (
                             hasattr(self._text_model, "mtp")
                             and self._text_model.mtp is not None
@@ -380,9 +436,9 @@ class SimpleEngine(BaseEngine):
         self._text_tokenizer = None
         self._draft_model = None
         self._loaded = False
-        self._system_kv_snapshot = None
-        self._system_kv_hash = None
-        self._system_kv_token_count = 0
+        self._system_kv_cache.clear()
+        for k in self._system_kv_cache_stats:
+            self._system_kv_cache_stats[k] = 0
         self._supports_system_kv_cache = False
         logger.info("SimpleEngine stopped")
 
@@ -922,9 +978,9 @@ class SimpleEngine(BaseEngine):
         system_hash = None
         kv_cache_eligible = False
         # Snapshot reference captured at gate time so a concurrent MISS that
-        # reassigns ``self._system_kv_snapshot`` between the gate and the
-        # restore (which runs later inside ``_run_blocking_serialized``)
-        # can't desynchronize the restored KV from the hash that decided HIT.
+        # mutates ``self._system_kv_cache`` between the gate and the restore
+        # (which runs later inside ``_run_blocking_serialized``) can't
+        # desynchronize the restored KV from the hash that decided HIT.
         hit_snapshot: Any = None
 
         # Decode-control gate.
@@ -1082,19 +1138,16 @@ class SimpleEngine(BaseEngine):
                         suffix_tokens = full_tokens_list[system_token_count:]
                         kv_cache_eligible = True
                         # Read the snapshot reference once. If we promote to
-                        # HIT, ``hit_snapshot`` is the exact list the hash
-                        # check just validated against. A later concurrent
-                        # MISS that reassigns ``self._system_kv_snapshot``
-                        # before our serialized worker restores it cannot
-                        # alias what we captured here.
-                        candidate_snapshot = self._system_kv_snapshot
-                        if (
-                            system_hash == self._system_kv_hash
-                            and candidate_snapshot is not None
-                            and system_token_count == self._system_kv_token_count
-                        ):
+                        # HIT, ``hit_snapshot`` is the exact list the dict
+                        # lookup just returned. A later concurrent MISS that
+                        # mutates ``self._system_kv_cache`` before our
+                        # serialized worker restores it cannot alias what we
+                        # captured here — dict.get is atomic under the GIL
+                        # and returns a reference to an immutable tuple.
+                        candidate = self._system_kv_cache.get(system_hash)
+                        if candidate is not None and system_token_count == candidate[1]:
                             cache_hit = True
-                            hit_snapshot = candidate_snapshot
+                            hit_snapshot = candidate[0]
                             logger.info(
                                 "System KV cache HIT (stream_chat): reusing %d "
                                 "tokens, prefilling %d new (hash=%s)",
@@ -1142,12 +1195,16 @@ class SimpleEngine(BaseEngine):
                 if cache_hit:
                     bc = make_prompt_cache(model)
                     # Restore from the closure-local reference captured at the
-                    # gate, never from ``self._system_kv_snapshot`` directly:
-                    # a concurrent MISS could have replaced the instance
-                    # attribute with a snapshot for a different system prefix
-                    # between the gate check and this point.
+                    # gate, never from ``self._system_kv_cache`` directly:
+                    # a concurrent MISS could have evicted the entry between
+                    # the gate check and this point.
                     for i, saved_state in enumerate(hit_snapshot):
                         bc[i].state = saved_state
+                    # Bump LRU position. Safe to mutate here because the
+                    # worker is serialized under ``_generation_lock``.
+                    if system_hash in self._system_kv_cache:
+                        self._system_kv_cache.move_to_end(system_hash)
+                    self._system_kv_cache_stats["hits"] += 1
                 else:
                     bc = make_prompt_cache(model)
                     sys_arr = mx.array(system_tokens)
@@ -1170,9 +1227,26 @@ class SimpleEngine(BaseEngine):
 
                     snapshot = [c.state for c in bc]
                     mx.eval([s for pair in snapshot for s in pair])
-                    self._system_kv_snapshot = snapshot
-                    self._system_kv_hash = system_hash
-                    self._system_kv_token_count = system_token_count
+                    self._system_kv_cache[system_hash] = (snapshot, system_token_count)
+                    self._system_kv_cache.move_to_end(system_hash)
+                    evicted_count = 0
+                    while len(self._system_kv_cache) > self._system_kv_capacity:
+                        evicted_hash, _ = self._system_kv_cache.popitem(last=False)
+                        self._system_kv_cache_stats["evictions"] += 1
+                        evicted_count += 1
+                        logger.info(
+                            "System KV cache EVICTED (stream_chat): hash=%s "
+                            "(capacity=%d)",
+                            evicted_hash,
+                            self._system_kv_capacity,
+                        )
+                    if evicted_count:
+                        # Eviction dropped MLX array refs; reclaim Metal heap.
+                        # Skip on the common non-eviction path to avoid
+                        # flushing the Metal allocator's reuse pool.
+                        mx.clear_cache()
+                    self._system_kv_cache_stats["misses"] += 1
+                    self._system_kv_cache_stats["stores"] += 1
                     try:
                         cache_mb = sum(c.nbytes for c in bc) / 1e6
                     except Exception:
@@ -1574,7 +1648,14 @@ class SimpleEngine(BaseEngine):
         # Extract system messages for caching
         has_system = any(m.get("role") == "system" for m in messages)
 
-        if has_system and self._text_model is not None:
+        # Snapshot-safety: only enter the system-KV cache branch when start()'s
+        # probe verified the derived TextModel returns KVCache entries (and not
+        # RotatingKVCache, which aliases buffers mutated in place).
+        if (
+            has_system
+            and self._text_model is not None
+            and self._supports_system_kv_cache
+        ):
             # Find system prefix boundary in full prompt text.
             # ChatML format: system section ends where first non-system message begins.
             # Works with tools (rendered inside system section by Qwen templates).
@@ -1616,10 +1697,10 @@ class SimpleEngine(BaseEngine):
                     system_tokens = system_tokens_list
                     suffix_tokens = full_tokens_list[system_token_count:]
 
+                    hit_candidate = self._system_kv_cache.get(system_hash)
                     if (
-                        system_hash == self._system_kv_hash
-                        and self._system_kv_snapshot is not None
-                        and system_token_count == self._system_kv_token_count
+                        hit_candidate is not None
+                        and system_token_count == hit_candidate[1]
                     ):
                         # Cache HIT — restore KV state into fresh backbone cache
                         def make_cache_with_snapshot(
@@ -1643,9 +1724,13 @@ class SimpleEngine(BaseEngine):
                             await self._run_blocking_serialized(
                                 make_cache_with_snapshot,
                                 self._text_model,
-                                self._system_kv_snapshot,
+                                hit_candidate[0],
                             )
                         )
+                        # Bump LRU position now that we know we'll use it.
+                        if system_hash in self._system_kv_cache:
+                            self._system_kv_cache.move_to_end(system_hash)
+                        self._system_kv_cache_stats["hits"] += 1
                         cache_hit = True
 
                         logger.info(
@@ -1821,9 +1906,25 @@ class SimpleEngine(BaseEngine):
                 snapshot = [c.state for c in mc]
                 mx.eval([s for pair in snapshot for s in pair])
 
-                self._system_kv_snapshot = snapshot
-                self._system_kv_hash = system_hash
-                self._system_kv_token_count = system_token_count
+                self._system_kv_cache[system_hash] = (snapshot, system_token_count)
+                self._system_kv_cache.move_to_end(system_hash)
+                evicted_count = 0
+                while len(self._system_kv_cache) > self._system_kv_capacity:
+                    evicted_hash, _ = self._system_kv_cache.popitem(last=False)
+                    self._system_kv_cache_stats["evictions"] += 1
+                    evicted_count += 1
+                    logger.info(
+                        "System KV cache EVICTED: hash=%s (capacity=%d)",
+                        evicted_hash,
+                        self._system_kv_capacity,
+                    )
+                if evicted_count:
+                    # Eviction dropped MLX array refs; reclaim Metal heap.
+                    # Skip on the common non-eviction path to avoid flushing
+                    # the Metal allocator's reuse pool.
+                    mx.clear_cache()
+                self._system_kv_cache_stats["misses"] += 1
+                self._system_kv_cache_stats["stores"] += 1
 
                 backbone_cache = mc
                 prompt_to_send = mx.array(suffix_tokens)
@@ -2185,18 +2286,36 @@ class SimpleEngine(BaseEngine):
                 "keep_pct": self._specprefill_keep_pct,
             }
 
-        # System KV cache stats
-        if self._system_kv_snapshot is not None:
-            cache_bytes = 0
-            for entry in self._system_kv_snapshot:
-                if isinstance(entry, tuple) and len(entry) == 2:
-                    cache_bytes += entry[0].nbytes + entry[1].nbytes
-                elif isinstance(entry, list):
-                    cache_bytes += sum(a.nbytes for a in entry if a is not None)
+        # System KV cache stats (LRU over multiple system prefixes)
+        if self._system_kv_cache:
+            slots = []
+            total_bytes = 0
+            for slot_hash, (snapshot, tokens) in self._system_kv_cache.items():
+                slot_bytes = 0
+                for entry in snapshot:
+                    if isinstance(entry, tuple) and len(entry) == 2:
+                        slot_bytes += entry[0].nbytes + entry[1].nbytes
+                    elif isinstance(entry, list):
+                        slot_bytes += sum(a.nbytes for a in entry if a is not None)
+                total_bytes += slot_bytes
+                slots.append(
+                    {
+                        "hash": slot_hash,
+                        "tokens": tokens,
+                        "memory_mb": round(slot_bytes / 1e6, 1),
+                    }
+                )
+            counters = dict(self._system_kv_cache_stats)
+            denom = counters["hits"] + counters["misses"]
+            counters["hit_ratio"] = (
+                round(counters["hits"] / denom, 3) if denom > 0 else None
+            )
             stats["system_kv_cache"] = {
-                "tokens": self._system_kv_token_count,
-                "hash": self._system_kv_hash,
-                "memory_mb": round(cache_bytes / 1e6, 1),
+                "capacity": self._system_kv_capacity,
+                "in_use": len(self._system_kv_cache),
+                "total_memory_mb": round(total_bytes / 1e6, 1),
+                "slots": slots,
+                "counters": counters,
             }
 
         # Include Metal memory stats
@@ -2213,14 +2332,55 @@ class SimpleEngine(BaseEngine):
         return stats
 
     def get_cache_stats(self) -> dict[str, Any] | None:
-        """Get cache statistics (for MLLM models)."""
+        """Get cache statistics for the system-prompt KV LRU plus, when the
+        model is multimodal, the MLLM's own cache stats.
+        """
+        result: dict[str, Any] = {}
+        if self._supports_system_kv_cache:
+            counters = dict(self._system_kv_cache_stats)
+            denom = counters["hits"] + counters["misses"]
+            counters["hit_ratio"] = (
+                round(counters["hits"] / denom, 3) if denom > 0 else None
+            )
+            result["system_kv_cache"] = {
+                "capacity": self._system_kv_capacity,
+                "in_use": len(self._system_kv_cache),
+                "counters": counters,
+            }
         if self._is_mllm and self._model is not None:
-            return self._model.get_cache_stats()
-        return None
+            result["mllm_cache"] = self._model.get_cache_stats()
+        return result or None
 
     def clear_runtime_caches(self) -> dict[str, Any] | None:
-        """Clear engine-managed runtime caches."""
+        """Clear engine-managed runtime caches.
+
+        Includes the multi-slot system-prompt KV LRU — each retained snapshot
+        is multi-GB on the Metal heap, so DELETE /v1/cache must drop them or
+        the operator's reset is silently incomplete. Counters reset alongside
+        so /v1/cache/stats reflects the cleared state immediately.
+
+        OrderedDict ops are atomic under the GIL: a concurrent worker that has
+        already captured a tuple reference from .get() finishes safely against
+        its own copy; any new request after this call hits MISS and repopulates
+        from scratch. No need to acquire _generation_lock for the clear itself.
+        """
+        result: dict[str, Any] = {}
+
+        dropped = len(self._system_kv_cache)
+        if dropped or any(self._system_kv_cache_stats.values()):
+            self._system_kv_cache.clear()
+            for k in self._system_kv_cache_stats:
+                self._system_kv_cache_stats[k] = 0
+            try:
+                import mlx.core as mx
+
+                mx.clear_cache()
+            except Exception:
+                pass
+            result["system_kv_cache"] = {"dropped_entries": dropped}
+
         if self._is_mllm and self._model is not None:
             self._model.clear_cache()
-            return {"model_cache": True}
-        return None
+            result["model_cache"] = True
+
+        return result or None


### PR DESCRIPTION
Follow-up to #523. cc @Thump604 — touches the `SimpleEngine` stream/cache paths you own; would value your read.

## Problem

#523 introduced a single-slot system-prompt KV snapshot. Works on the validation pattern it shipped with (2 turns, same system prefix: 100s → 7s). Regresses to zero benefit the moment a client uses more than one system prefix in a session.

The case we hit: Claude Code's main-agent + sub-agent dispatch pattern interleaves two distinct system prefixes within one session:

- Main agent: ~28K tokens (system prompt + full toolset)
- Sub-agents (Explore / Plan / general-purpose): ~6–7K tokens

Every sub-agent dispatch evicts the main snapshot; every return to main re-prefills 28K cold. On Qwen3-Coder-30B-A3B that's ~140s TTFT per turn, which trips the server's 300s request timeout before the end-of-stream STORE runs, so the snapshot never lands. Cache stays empty across the entire session.

## Fix

### 1. Multi-slot LRU snapshot

Replace the 3 single-slot instance vars (`_system_kv_snapshot`, `_system_kv_hash`, `_system_kv_token_count`) with an `OrderedDict[str, tuple[list, int]]` LRU keyed by system-prefix hash.

- Capacity via `VLLM_MLX_SYSTEM_KV_SLOTS` env var, default **4** (covers main + 2–3 sub-agent variants with headroom). `=1` restores #523 behavior exactly.
- LRU `move_to_end()` / `popitem(last=False)` happen inside the serialized worker (`_run_blocking_serialized`), so the existing `_generation_lock` already prevents concurrent mutation.
- Gate read uses `dict.get()` returning an immutable `(snapshot, count)` tuple under the GIL — a concurrent store can't desync the snapshot from the hash that decided HIT.
- `EVICTED` log line on overflow; `mx.clear_cache()` after eviction to reclaim Metal heap.
- Applied to both `stream_chat` (the path Claude Code uses) and the older non-stream text path.

### 2. Counters + `/v1/cache/stats` exposure

Add `hits` / `misses` / `stores` / `evictions` counters to `SimpleEngine`, incremented only from inside the serialized worker (single writer, no locks). Exposed via a new `get_cache_stats()` method; the existing `/v1/cache/stats` route already picks it up via `hasattr(_engine, "get_cache_stats")`.

```json
{
  "engine_cache": {
    "system_kv_cache": {
      "capacity": 4,
      "in_use": 2,
      "counters": {
        "hits": 3, "misses": 2, "stores": 2, "evictions": 0,
        "hit_ratio": 0.6
      }
    }
  }
}
```

Rationale for bundling: #523's gap wasn't only the snapshot shape — it was that the cache could be 0% effective in production with no signal beyond log greps. Counters add ~10 LOC and let the next regression surface by metric, not by user complaint.

## Validation

Smoke runs `A, A, B, A, B` with two distinct ~70K-token system prompts on Qwen3-Coder-30B-A3B-Instruct-8bit:

| Step    | System | TTFT      | Cache event |
| ------- | ------ | --------- | ----------- |
| A1 cold | A      | 144.27s   | MISS → STORED 70008 tokens (6.9 GB) |
| A2 warm | A      | **0.85s** | HIT 70008 |
| B1 cold | B      | 133.33s   | MISS → STORED 67008 tokens (6.6 GB) |
| A3 warm | A      | **0.86s** | HIT 70008 ← only possible with multi-slot |
| B2 warm | B      | **0.81s** | HIT 67008 |

**~170× TTFT speedup on warm prefixes.** Under single-slot, B1 would evict A and A3 would be another 144s cold MISS. With the LRU at capacity 4, both prefixes coexist; round-trip alternation costs the same as repeated same-prefix traffic.

Post-run `/v1/cache/stats`:

```json
{"capacity": 4, "in_use": 2,
 "counters": {"hits": 3, "misses": 2, "stores": 2, "evictions": 0, "hit_ratio": 0.6}}
```

Memory: 2 snapshots × ~6.7 GB ≈ 13.5 GB on Metal heap. Collocated embeddings engine on the same Mac continued serving without issue.

## What this does **not** change

- System-prefix detection logic from #523 — untouched.
- Startup probe that disables snapshotting for sliding-window models (RotatingKVCache aliasing) — untouched.
- Decode-path codepath — identical.
- Single-slot behavior is recoverable: `VLLM_MLX_SYSTEM_KV_SLOTS=1`.

## Files touched

`vllm_mlx/engine/simple.py` only. ~170 lines of diff including counters; the cache-shape change itself is ~50 lines.

## Open questions

- Default capacity of **4** — defensible for Claude Code's main + 3 sub-agent variants. Env var keeps it tunable. Push higher?
- Should `clear_runtime_caches` (DELETE `/v1/cache`) also clear the system-KV LRU? Leaning yes for consistent "reset everything" semantics — happy to add if you want it in this PR.
- `hit_ratio` recomputed on every `/v1/cache/stats` read. Cheap today; could cache + invalidate on counter mutation if anyone scrapes high-frequency. Not worth complexity yet.
