### PR TITLE
Bound constrained JSON whitespace progress

### DIFF
--- a/tests/test_json_schema_processor_hardening.py
+++ b/tests/test_json_schema_processor_hardening.py
@@ -342,6 +342,70 @@ class TestCallSemantics:
         masked = proc(tokens, logits)
         assert masked.shape == (1, tok.vocab_size)
 
+    def test_long_leading_whitespace_cannot_continue_without_json_progress(self):
+        """Bound legal-but-non-progress whitespace in constrained JSON mode.
+
+        ``lm-format-enforcer`` permits arbitrary whitespace after JSON
+        structural positions such as ``{``.  That is spec-correct, but a model
+        can then spend a long non-streaming request emitting only whitespace
+        while the client sees no useful JSON progress.  Once a suffix has a
+        long trailing whitespace run outside a string, the processor should
+        force a structural/content token instead of allowing more pure
+        whitespace.
+        """
+        import mlx.core as mx
+        import numpy as np
+
+        proc, tok = _make_processor(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+                "additionalProperties": False,
+            }
+        )
+        prompt = tok.encode(" ")
+        proc(mx.array(prompt, dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+
+        full = prompt + tok.encode(" " * 300)
+        masked = proc(mx.array(full, dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+        arr = np.array(masked)
+
+        assert arr[tok._tok_to_id[" "]] == -np.inf
+        assert arr[tok._tok_to_id["\n"]] == -np.inf
+        assert arr[tok._tok_to_id["\t"]] == -np.inf
+        assert arr[tok._tok_to_id["{"]] == 0.0
+
+    def test_long_structural_whitespace_cannot_continue_without_json_progress(self):
+        """The same whitespace-progress bound applies after JSON structure."""
+        import mlx.core as mx
+        import numpy as np
+
+        proc, tok = _make_processor(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+                "additionalProperties": False,
+            }
+        )
+        prompt = tok.encode(" ")
+        proc(mx.array(prompt, dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+
+        full = prompt + tok.encode("{" + (" " * 300))
+        masked = proc(mx.array(full, dtype=mx.int32), mx.zeros((tok.vocab_size,)))
+        arr = np.array(masked)
+
+        assert arr[tok._tok_to_id[" "]] == -np.inf
+        assert arr[tok._tok_to_id["\n"]] == -np.inf
+        assert arr[tok._tok_to_id["\t"]] == -np.inf
+        finite_non_ws = [
+            token_id
+            for token_id, value in enumerate(arr)
+            if np.isfinite(value) and tok.decode([token_id]).strip()
+        ]
+        assert finite_non_ws
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -43,6 +43,8 @@ class LMFormatEnforcerNotAvailableError(RuntimeError):
 # No eviction policy — agent workloads typically reuse a small fixed set of
 # tool schemas, so unbounded growth is not a realistic concern.
 _parser_cache: dict[str, tuple[dict, Any]] = {}
+_MAX_NONPROGRESS_WHITESPACE_CHARS = 256
+_JSON_WHITESPACE = frozenset(" \t\r\n")
 
 
 def _canonical_schema_key(schema: dict | None) -> str:
@@ -724,6 +726,37 @@ class JSONSchemaLogitsProcessor:
         """Return True if *prefix* is a prefix of at least one valid key name."""
         return any(name.startswith(prefix) for name in self._valid_key_names)
 
+    def _filter_nonprogress_whitespace_tokens(
+        self, suffix: list[int], allowed: list[int]
+    ) -> list[int]:
+        """Stop constrained JSON from spending a long run on pure whitespace.
+
+        JSON permits arbitrary whitespace around structural tokens. That is
+        valid, but with non-streaming requests a model can keep selecting
+        whitespace-only tokens for minutes without producing useful JSON
+        content. Once the decoded suffix has a long trailing whitespace run
+        outside a string, remove pure-whitespace tokens from the next-step
+        allowed set so generation must make structural/content progress.
+        """
+        text = self._decode_suffix(suffix)
+        if text is None or not text:
+            return allowed
+
+        trailing = len(text) - len(text.rstrip(" \t\r\n"))
+        if trailing < _MAX_NONPROGRESS_WHITESPACE_CHARS:
+            return allowed
+
+        filtered: list[int] = []
+        for tok_id in allowed:
+            tok_text = self._decode_token_cached(tok_id)
+            if tok_text is None:
+                filtered.append(tok_id)
+                continue
+            if tok_text == "" or all(ch in _JSON_WHITESPACE for ch in tok_text):
+                continue
+            filtered.append(tok_id)
+        return filtered if filtered else allowed
+
     def _build_allow_mask(self, allowed: list[int], vocab_size: int) -> mx.array:
         """
         Build a 1-D mask of length ``vocab_size`` where allowed positions are
@@ -779,6 +812,10 @@ class JSONSchemaLogitsProcessor:
             # incremental JSON context state and bracket depth counters
             # are up-to-date for the _suffix_is_complete_json pre-check).
             context = self._get_json_context(suffix)
+            if not self._json_ctx_in_string:
+                allowed_list = self._filter_nonprogress_whitespace_tokens(
+                    suffix, allowed_list
+                )
             if context in ("key_start", "in_key"):
                 allowed_list = self._filter_at_key_context(
                     context, suffix, allowed_list


### PR DESCRIPTION
## Summary

Bounds non-progress whitespace in `JSONSchemaLogitsProcessor` so constrained JSON decoding cannot keep selecting pure whitespace tokens indefinitely before making JSON structural/content progress.

This is a narrow follow-up for #546. I am not claiming the reported Qwen3-Coder wedge is fully root-caused to whitespace generation, and I am not claiming a sparse-MoE-specific failure. The verified local code path is that the constrained decoder currently permits unlimited pure JSON whitespace at legal positions such as the root and after `{`; in non-streaming calls that can look like no useful output progress while the request holds the serving slot.

## Code path compared

- Local code path: `vllm_mlx/constrained/json_schema_processor.py`, specifically `JSONSchemaLogitsProcessor.__call__`, `_get_json_context`, `_filter_at_key_context`, and the `lm-format-enforcer` allowed-token set.
- Upstream base checked: `waybarrios/vllm-mlx` `upstream/main` at `7e30484`.
- Reported release checked for processor construction/call behavior: `v0.3.0` tag. The issue schema did not hang processor construction or individual processor calls in either `v0.3.0` or current main.

## Observed behavior

Using the schema from #546 with `Qwen/Qwen3-Coder-30B-A3B-Instruct` tokenizer data, the allowed-token set includes many pure whitespace tokens at JSON positions before useful JSON content is produced. On current main before this patch, the processor leaves whitespace tokens finite after long whitespace suffixes.

## Expected behavior

Whitespace remains legal during normal JSON generation, but after a long trailing run of pure whitespace outside a JSON string, the next token should make structural/content progress. This patch removes pure-whitespace tokens only after the trailing whitespace run crosses the bounded threshold, preserving non-whitespace tokens returned by the enforcer.

## Validation

Passed:

- `python -m pytest tests/test_json_schema_processor_hardening.py tests/test_constrained_decoding.py -q` — 46 passed
- `python -m pytest tests/test_json_schema_processor_hardening.py tests/test_constrained_decoding.py tests/test_structured_output.py tests/test_api_models.py -k 'not InjectJsonInstruction' -q` — 167 passed, 2 skipped, 3 deselected
- `uvx ruff check vllm_mlx/constrained/json_schema_processor.py tests/test_json_schema_processor_hardening.py --select E,F,W --ignore E402,E501,E731,F811,F841`
- `python -m black --check vllm_mlx/constrained/json_schema_processor.py tests/test_json_schema_processor_hardening.py`
- `git diff --check`

Full local `pytest -q` did not collect in my Runtime venv because the installed `mlx_lm` package imports an overlay-only `get_generation_stream` symbol from `vllm_mlx.mlx_streams`. That failure appears before test execution in server/scheduler import paths and is not touched by this patch.

## Merge readiness

- [x] I am not merging my own substantive PR.
- [ ] The latest CI run for this exact head commit is green.
- [ ] If I rebased, resolved conflicts, or pushed after review, I waited for the new CI run to finish green.
- [x] Actionable review comments are resolved in this PR or linked to follow-up issues before merge.
- [x] Any intentional follow-up debt is linked here and called out in the PR body.

## Risk notes

This changes constrained JSON token masking only after a long trailing whitespace run outside a JSON string. It does not change schema simplification, parser construction, server request handling, streaming, or unconstrained generation.
