### PR TITLE
Route constrained non-stream chat through stream path

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1189,6 +1189,62 @@ class TestSimpleEngineConcurrency:
         assert output.finish_reason == "stop"
 
     @pytest.mark.anyio
+    async def test_llm_nonstream_with_logits_processors_uses_stream_path(self):
+        """Constrained non-stream chat must not call the blocking chat API.
+
+        ``response_format`` is implemented by request-local logits processors.
+        If a non-stream request goes through the blocking model.chat() path,
+        the server cannot observe token progress or cancel at token boundaries
+        when a client/proxy disconnects.  Aggregating stream_chat keeps the
+        constrained and unconstrained chat paths on the same cancellable stream
+        implementation.
+        """
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        captured_stream_kwargs = {}
+
+        class FakeTokenizer:
+            bos_token = None
+
+            def apply_chat_template(self, messages, **kwargs):
+                return "<|im_start|>user\nhello"
+
+            def encode(self, text, **kwargs):
+                return [1, 2, 3]
+
+        class FakeModel:
+            tokenizer = FakeTokenizer()
+
+            def chat(self, **kwargs):
+                raise AssertionError("blocking chat path should not be used")
+
+            def stream_generate(self, **kwargs):
+                captured_stream_kwargs.update(kwargs)
+                yield SimpleNamespace(
+                    text="{}",
+                    finish_reason="stop",
+                    finished=True,
+                    prompt_tokens=3,
+                )
+
+        engine = SimpleEngine("test-model", force_mllm=False, mtp=False)
+        engine._loaded = True
+        engine._model = FakeModel()
+        sentinel_processor = object()
+
+        output = await engine.chat(
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=16,
+            logits_processors=[sentinel_processor],
+        )
+
+        assert output.text == "{}"
+        assert output.finish_reason == "stop"
+        assert captured_stream_kwargs["logits_processors"] == [sentinel_processor]
+
+    @pytest.mark.anyio
     async def test_requests_complete_in_order(self, mock_model):
         """Test that concurrent requests complete (may be in any order due to lock)."""
         from vllm_mlx.engine.simple import SimpleEngine

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -678,6 +678,14 @@ class SimpleEngine(BaseEngine):
         if tools and not self._is_mllm:
             return await aggregate_stream_chat()
 
+        # Request-local logits processors (response_format / constrained JSON)
+        # need token-boundary progress and cancellation.  The blocking
+        # model.chat() call below only returns after the whole completion, so a
+        # slow constrained decode can look like a no-progress non-stream wedge
+        # and hold the serialized generation lock until max_tokens/timeout.
+        if kwargs.get("logits_processors") and not self._is_mllm:
+            return await aggregate_stream_chat()
+
         # Text-only requests on MLLM models should always aggregate the
         # streaming path for non-streaming chat. This keeps one execution seam
         # and avoids mlx_vlm non-stream thread/stream ownership mismatches.


### PR DESCRIPTION
## Summary
- route non-stream LLM chat with request-local logits processors through the existing stream aggregation path
- keep ordinary non-stream LLM chat on the existing blocking `model.chat()` path
- add a regression test that ensures constrained-decoding kwargs reach `stream_generate` instead of `model.chat`

## Why
`response_format` uses request-local logits processors. In simple LLM mode without tools, non-stream chat previously called blocking `model.chat()`, so strict-schema decode could hold the serialized generation lock without token-boundary progress or cooperative cancellation. That matches the non-stream constrained JSON wedge shape reported in #546.

## Validation
- Red first: `uv run --python 3.12 pytest tests/test_simple_engine.py -k 'llm_nonstream_with_logits_processors_uses_stream_path' -q` failed with `AssertionError: blocking chat path should not be used`
- `uv run --python 3.12 pytest tests/test_simple_engine.py -k 'llm_nonstream_with_logits_processors_uses_stream_path' -q` = `1 passed, 38 deselected`
- `uv run --python 3.12 pytest tests/test_simple_engine.py tests/test_constrained_decoding.py tests/test_structured_output.py -q` = `112 passed, 2 skipped`
- `uv run --python 3.12 ruff check vllm_mlx/engine/simple.py tests/test_simple_engine.py` = pass
- `uv run --python 3.12 black --check vllm_mlx/engine/simple.py tests/test_simple_engine.py` = pass
- `git diff --check` = pass
- `/opt/ai-runtime/bin/upstream-local-repro-preflight --local-root /opt/ai-runtime/worktrees/vllm-mlx/issue-546-disconnect-root-cause --upstream-root /opt/ai-runtime/worktrees/vllm-mlx/upstream-main-clean --code-path vllm_mlx/engine/simple.py --code-path tests/test_simple_engine.py --no-model-artifact` = pass

## Not claimed
- This does not claim sparse-MoE behavior is the cause.
- This does not change ordinary non-stream chat without request-local logits processors.
- This does not replace #547's whitespace-progress hardening.
- This does not prove the reporter's exact MLX model no longer wedges because the exact MLX weights were not available locally.

Refs #546.
