### PR TITLE
Use request model in registry responses

### DIFF
--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -3726,3 +3726,64 @@ class TestResponseModelFieldUsesServedName:
         body = json.loads(response.body.decode())
         assert body["model"] == served_name
         assert body["model"] != "user-sent-model-name"
+
+    @pytest.mark.anyio
+    async def test_registry_mode_completion_response_uses_request_model(
+        self, monkeypatch
+    ):
+        import vllm_mlx.server as srv
+        from vllm_mlx.engine.base import GenerationOutput
+
+        class FakeEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+
+            async def generate(self, **kwargs):
+                return GenerationOutput(
+                    text="hello",
+                    completion_tokens=1,
+                    prompt_tokens=1,
+                )
+
+        async def fake_acquire(
+            raw_request,
+            *,
+            total_timeout=None,
+            deadline=None,
+            count_activity=True,
+            model=None,
+        ):
+            return FakeEngine()
+
+        async def fake_release(*, count_activity=True):
+            pass
+
+        monkeypatch.setattr(srv, "_validate_model_name", lambda _m: None)
+        monkeypatch.setattr(srv, "_acquire_default_engine_for_request", fake_acquire)
+        monkeypatch.setattr(srv, "_release_default_engine", fake_release)
+        monkeypatch.setattr(srv, "_model_name", None)
+        monkeypatch.setattr(srv, "_default_max_tokens", 32)
+
+        class FakeRawRequest:
+            async def is_disconnected(self):
+                return False
+
+        request = srv.CompletionRequest(
+            model="registry-model-name",
+            prompt="hi",
+            stream=False,
+        )
+
+        response = await srv.create_completion(request, FakeRawRequest())
+        assert response.model == "registry-model-name"
+
+    def test_registry_mode_response_builders_do_not_use_bare_global_model_name(self):
+        from pathlib import Path
+
+        import vllm_mlx.server as srv
+
+        source = Path(srv.__file__).read_text(encoding="utf-8")
+        endpoint_source = source[source.index("# Completion Endpoints") :]
+
+        assert "model=_model_name," not in endpoint_source
+        assert '"model": _model_name,' not in endpoint_source

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -914,6 +914,11 @@ def _list_available_model_names() -> list[str]:
     return [_model_name] if _model_name else []
 
 
+def _response_model_name(request_model: str) -> str:
+    """Return the response model field for single-model or registry mode."""
+    return _model_name or request_model
+
+
 async def _acquire_request_model(request_model: str) -> RequestModelContext:
     """Acquire the model/engine that should serve this request."""
     _validate_model_name(request_model)
@@ -4501,7 +4506,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             completion_tokens=total_completion_tokens,
         )
         return CompletionResponse(
-            model=_model_name,
+            model=_response_model_name(request.model),
             choices=choices,
             usage=Usage(
                 prompt_tokens=total_prompt_tokens,
@@ -4691,7 +4696,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             completion_tokens=output.completion_tokens,
         )
         return ChatCompletionResponse(
-            model=_model_name,
+            model=_response_model_name(request.model),
             choices=[
                 ChatCompletionChoice(
                     message=AssistantMessage(
@@ -5156,7 +5161,7 @@ async def create_anthropic_message(
         )
 
         anthropic_response = AnthropicResponse(
-            model=_model_name,
+            model=_response_model_name(anthropic_request.model),
             content=content_blocks,
             stop_reason=stop_reason,
             usage=AnthropicUsage(
@@ -5352,7 +5357,7 @@ async def _stream_anthropic_messages(
             "id": msg_id,
             "type": "message",
             "role": "assistant",
-            "model": _model_name,
+            "model": _response_model_name(anthropic_request.model),
             "content": [],
             "stop_reason": None,
             "stop_sequence": None,
@@ -5635,7 +5640,7 @@ async def stream_completion(
                 "id": f"cmpl-{uuid.uuid4().hex[:8]}",
                 "object": "text_completion",
                 "created": int(time.time()),
-                "model": _model_name,
+                "model": _response_model_name(request.model),
                 "choices": [
                     {
                         "index": 0,
@@ -5695,7 +5700,7 @@ async def stream_chat_completion(
     # First chunk with role
     first_chunk = ChatCompletionChunk(
         id=response_id,
-        model=_model_name,
+        model=_response_model_name(request.model),
         choices=[
             ChatCompletionChunkChoice(
                 delta=ChatCompletionChunkDelta(role="assistant"),
@@ -5819,7 +5824,7 @@ async def stream_chat_completion(
                                 # Still emit reasoning while buffering tool call
                                 chunk = ChatCompletionChunk(
                                     id=response_id,
-                                    model=_model_name,
+                                    model=_response_model_name(request.model),
                                     choices=[
                                         ChatCompletionChunkChoice(
                                             delta=ChatCompletionChunkDelta(
@@ -5846,7 +5851,7 @@ async def stream_chat_completion(
                                         )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
-                                model=_model_name,
+                                model=_response_model_name(request.model),
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
@@ -5879,7 +5884,7 @@ async def stream_chat_completion(
 
                 chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=_response_model_name(request.model),
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -5949,7 +5954,7 @@ async def stream_chat_completion(
                                         )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
-                                model=_model_name,
+                                model=_response_model_name(request.model),
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
@@ -5981,7 +5986,7 @@ async def stream_chat_completion(
 
                 chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=_response_model_name(request.model),
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -6010,7 +6015,7 @@ async def stream_chat_completion(
             if final_parse_result.tools_called:
                 tool_chunk = ChatCompletionChunk(
                     id=response_id,
-                    model=_model_name,
+                    model=_response_model_name(request.model),
                     choices=[
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(
@@ -6081,7 +6086,7 @@ async def stream_chat_completion(
         if include_usage:
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
-                model=_model_name,
+                model=_response_model_name(request.model),
                 choices=[],  # Empty choices for usage-only chunk
                 usage=Usage(
                     prompt_tokens=prompt_tokens,


### PR DESCRIPTION
## Summary
- use the request model as the response `model` field when registry mode has no process-wide `_model_name`
- preserve the existing served-name response behavior for single-model mode
- add regression coverage for registry-mode response construction and a source guard for completion/message endpoint response builders

## Why
In `--models-config` registry mode, `load_model_registry()` leaves `_model_name = None` because there is no single served model for the process. Several OpenAI/Anthropic response builders still passed `_model_name` directly into response payloads. Pydantic response models require `model` to be a string, so non-stream responses can fail with HTTP 500; dict/SSE response sites can emit `model: null`.

## Validation
- Red first: `uv run --python 3.12 pytest tests/test_lifecycle_server.py -k 'registry_mode_completion_response_uses_request_model or registry_mode_response_builders_do_not_use_bare_global_model_name' -q` failed with `CompletionResponse(model=None)` and direct `_model_name` endpoint response fields
- `uv run --python 3.12 pytest tests/test_lifecycle_server.py -k 'registry_mode_completion_response_uses_request_model or registry_mode_response_builders_do_not_use_bare_global_model_name' -q` = `2 passed`
- `uv run --python 3.12 pytest tests/test_lifecycle_server.py -k 'ResponseModelFieldUsesServedName' -q` = `5 passed`
- `uv run --python 3.12 pytest tests/test_lifecycle_server.py tests/test_server.py -q` = `185 passed, 3 deselected`
- `uv run --python 3.12 ruff check vllm_mlx/server.py tests/test_lifecycle_server.py` = pass
- `uv run --python 3.12 black --check vllm_mlx/server.py tests/test_lifecycle_server.py` = pass
- `git diff --check` = pass
- `/opt/ai-runtime/bin/upstream-local-repro-preflight --local-root /opt/ai-runtime/worktrees/vllm-mlx/issue-542-registry-model-field --upstream-root /opt/ai-runtime/worktrees/vllm-mlx/upstream-main-clean-542 --code-path vllm_mlx/server.py --code-path tests/test_lifecycle_server.py --no-model-artifact` = pass

## Not claimed
- This does not change model validation or routing.
- This does not change `/v1/status` or admin/cancel metadata semantics.
- This does not change single-model served-name responses.

Refs #542.
Refs #529.
