### PR TITLE
Support XLM-RoBERTa reranker heads

### DIFF
--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -425,6 +425,59 @@ class TestClassifierForward:
                 config,
             )
 
+    def test_classifier_forward_supports_xlm_roberta_two_layer_head(self):
+        """XLM-RoBERTa rerankers use dense -> tanh -> out_proj classifier heads."""
+        import mlx.core as mx
+
+        from vllm_mlx.rerank_forward import classifier_forward
+
+        config = {
+            "model_type": "xlm-roberta",
+            "hidden_size": 8,
+            "num_attention_heads": 2,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_labels": 1,
+            "vocab_size": 20,
+            "max_position_embeddings": 32,
+            "type_vocab_size": 2,
+            "layer_norm_eps": 1e-12,
+            "hidden_act": "gelu",
+            "pad_token_id": 1,
+        }
+        weights = _rename_bert_prefix(_make_bert_weights(config), "xlm-roberta")
+        del weights["classifier.weight"]
+        del weights["classifier.bias"]
+        weights["classifier.dense.weight"] = mx.random.normal((8, 8)) * 0.02
+        weights["classifier.dense.bias"] = mx.zeros((8,))
+        weights["classifier.out_proj.weight"] = mx.random.normal((1, 8)) * 0.02
+        weights["classifier.out_proj.bias"] = mx.zeros((1,))
+
+        logits = classifier_forward(
+            mx.array([[1, 2, 3]]),
+            mx.array([[1, 1, 1]]),
+            weights,
+            config,
+        )
+        mx.eval(logits)
+
+        assert logits.shape == (1, 1)
+
+    def test_roberta_position_ids_use_padding_offset(self):
+        """RoBERTa-family rerankers reserve pad position and offset real tokens."""
+        import mlx.core as mx
+
+        from vllm_mlx.rerank_forward import _position_ids_for_config
+
+        config = {"model_type": "xlm-roberta", "pad_token_id": 1}
+        input_ids = mx.array([[7, 8, 1, 1], [9, 10, 11, 1]])
+        attention_mask = mx.array([[1, 1, 0, 0], [1, 1, 1, 0]])
+
+        position_ids = _position_ids_for_config(config, input_ids, attention_mask)
+        mx.eval(position_ids)
+
+        assert position_ids.tolist() == [[2, 3, 1, 1], [2, 3, 4, 1]]
+
 
 def _make_bert_weights(config: dict) -> dict:
     """Build minimal random BERT-style weights for testing."""
@@ -479,6 +532,13 @@ def _make_bert_weights(config: dict) -> dict:
     w["classifier.bias"] = mx.zeros((num_labels,))
 
     return w
+
+
+def _rename_bert_prefix(weights: dict, new_prefix: str) -> dict:
+    renamed = {}
+    for key, value in weights.items():
+        renamed[key.replace("bert.", f"{new_prefix}.", 1)] = value
+    return renamed
 
 
 # =============================================================================

--- a/vllm_mlx/rerank_forward.py
+++ b/vllm_mlx/rerank_forward.py
@@ -50,7 +50,7 @@ def classifier_forward(
     ln_b = weights[f"{prefix}.embeddings.LayerNorm.bias"]
 
     batch_size, seq_len = input_ids.shape
-    position_ids = mx.arange(seq_len)[None, :]  # (1, seq_len)
+    position_ids = _position_ids_for_config(config, input_ids, attention_mask)
     token_type_ids = mx.zeros_like(input_ids)
 
     hidden = word_emb[input_ids] + pos_emb[position_ids] + tok_type_emb[token_type_ids]
@@ -80,11 +80,46 @@ def classifier_forward(
         pooled = cls_hidden
 
     # --- Classifier head ---
-    clf_w = weights["classifier.weight"]
-    clf_b = weights["classifier.bias"]
-    logits = pooled @ clf_w.T + clf_b  # (batch, num_labels)
+    logits = _classification_head_forward(pooled, weights)
 
     return logits
+
+
+def _position_ids_for_config(
+    config: dict,
+    input_ids: mx.array,
+    attention_mask: mx.array | None,
+) -> mx.array:
+    """Build BERT or RoBERTa-family absolute position IDs."""
+    _, seq_len = input_ids.shape
+    model_type = str(config.get("model_type", "")).lower()
+    if model_type not in {"roberta", "xlm-roberta", "xlm_roberta"}:
+        return mx.arange(seq_len)[None, :]
+
+    padding_idx = int(config.get("pad_token_id", 1))
+    if attention_mask is None:
+        return mx.arange(padding_idx + 1, seq_len + padding_idx + 1)[None, :]
+
+    mask = attention_mask.astype(mx.int32)
+    positions = mx.cumsum(mask, axis=1) * mask + padding_idx
+    return positions.astype(mx.int32)
+
+
+def _classification_head_forward(
+    pooled: mx.array,
+    weights: dict[str, mx.array],
+) -> mx.array:
+    """Run BERT flat or XLM-RoBERTa two-layer sequence-classification head."""
+    if "classifier.dense.weight" in weights:
+        hidden = pooled @ weights["classifier.dense.weight"].T
+        hidden = hidden + weights["classifier.dense.bias"]
+        hidden = mx.tanh(hidden)
+        return (
+            hidden @ weights["classifier.out_proj.weight"].T
+            + weights["classifier.out_proj.bias"]
+        )
+
+    return pooled @ weights["classifier.weight"].T + weights["classifier.bias"]
 
 
 def _detect_prefix(weights: dict) -> str:


### PR DESCRIPTION
## Summary
- support XLM-RoBERTa/RoBERTa two-layer sequence-classification heads in the rerank forward path
- use RoBERTa-family position IDs with the padding offset instead of BERT-style `arange(seq_len)`
- keep existing flat BERT classifier heads working

## Why
XLM-RoBERTa rerankers such as BGE/Jina v2 expose `classifier.dense.*` plus `classifier.out_proj.*`, not flat `classifier.weight` / `classifier.bias`. The old forward path raised `KeyError: 'classifier.weight'` on those models. RoBERTa-family models also reserve the pad position and offset real token positions, so plain `arange(seq_len)` gives the wrong position embeddings.

## Validation
- Red first: `uv run --python 3.12 pytest tests/test_rerank.py -k 'xlm_roberta_two_layer_head or roberta_position_ids_use_padding_offset' -q` failed with `KeyError: 'classifier.weight'` and missing `_position_ids_for_config`
- `uv run --python 3.12 pytest tests/test_rerank.py -k 'xlm_roberta_two_layer_head or roberta_position_ids_use_padding_offset' -q` = `2 passed`
- `uv run --python 3.12 pytest tests/test_rerank.py -q` = `41 passed`
- `uv run --python 3.12 ruff check vllm_mlx/rerank_forward.py tests/test_rerank.py` = pass
- `uv run --python 3.12 black --check vllm_mlx/rerank_forward.py tests/test_rerank.py` = pass
- `git diff --check` = pass
- `/opt/ai-runtime/bin/upstream-local-repro-preflight --local-root /opt/ai-runtime/worktrees/vllm-mlx/issue-545-xlm-roberta-rerank --upstream-root /opt/ai-runtime/worktrees/vllm-mlx/upstream-main-clean-545 --code-path vllm_mlx/rerank_forward.py --code-path tests/test_rerank.py --no-model-artifact` = pass

## Not claimed
- This does not add a new reranker API surface.
- This does not claim a full live BGE/Jina/Qwen3-Reranker quality benchmark was run.
- This does not change non-RoBERTa BERT position IDs or flat classifier heads.

Refs #545.
