### PR TITLE
Restore runtime fork overlay on current upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ export ANTHROPIC_API_KEY=not-needed
 claude
 ```
 
+## Runtime profiles from a checkout
+
+The PyPI package gives you the `vllm-mlx` command. A source checkout also
+includes profile scripts that keep common local serving setups repeatable.
+
+```bash
+# Daily local text serving
+scripts/serve_profile.sh text-default mlx-community/Qwen3-4B-Instruct-2507-4bit
+
+# Tool-calling profile
+scripts/serve_profile.sh text-tools mlx-community/Qwen3-4B-Instruct-2507-4bit
+
+# Generic OpenAI-compatible client profile
+scripts/serve_client_profile.sh generic-openai mlx-community/Qwen3-4B-Instruct-2507-4bit
+```
+
+The profile launchers default to localhost binding. Set `LISTEN_MODE=public`
+only when the server must be reachable from another host.
+
+See [Client Compatibility](docs/guides/client-compatibility.md) and
+[Model And Serve Profile Matrix](docs/guides/model-profile-matrix.md) for the
+profile map.
+
 ## Features
 
 ### APIs

--- a/docs/guides/client-compatibility.md
+++ b/docs/guides/client-compatibility.md
@@ -1,0 +1,72 @@
+# Client Compatibility
+
+OpenAI-compatible desktop apps and agent tools usually need the same backend
+contract: a `/v1` base URL, a model id that appears in `/v1/models`, and an API
+key value when the client refuses empty credentials.
+
+The checkout script `scripts/serve_client_profile.sh` maps common client names
+onto conservative server profiles. The script does not prove that every feature
+of a client is supported; it starts the backend with settings that are suitable
+for a first connection test.
+
+## Starting A Client Profile
+
+```bash
+scripts/serve_client_profile.sh generic-openai \
+  mlx-community/Qwen3-4B-Instruct-2507-4bit
+```
+
+The script delegates to `scripts/serve_profile.sh`, binds to `127.0.0.1` by
+default, and supplies a local API-key label unless `--api-key` is already
+present. Override the label with `VLLM_MLX_CLIENT_API_KEY`.
+
+## Profile Map
+
+| Client profile | Backend profile | Default API key | Use case |
+|---|---|---|---|
+| `generic-openai` | `text-default` | `local-client` | Desktop or web clients that speak OpenAI chat completions |
+| `generic-mllm` | `mllm-default` | `local-client` | Multimodal OpenAI-compatible clients |
+| `goose-text` | `text-default` | `goose-local` | Goose text and streaming setup |
+| `goose-tools` | `text-tools` | `goose-local` | Goose with tool calling enabled |
+| `open-webui-text` | `text-default` | `openwebui-local` | Open WebUI text setup |
+| `open-webui-mllm` | `mllm-default` | `openwebui-local` | Open WebUI image chat setup |
+| `cherry-studio` | `text-default` | `cherrystudio-local` | Cherry Studio custom OpenAI provider |
+| `chatbox` | `text-default` | `chatbox-local` | Chatbox built-in OpenAI provider |
+| `librechat` | `text-default` | `librechat-local` | LibreChat OpenAI provider |
+| `witsy` | `text-default` | `witsy-local` | Witsy OpenAI engine |
+| `jan` | `text-default` | `jan-local` | Jan remote OpenAI-compatible engine |
+| `anythingllm` | `text-default` | `anythingllm-local` | AnythingLLM generic OpenAI provider |
+| `boltai` | `text-default` | `boltai-local` | BoltAI desktop setup |
+
+## Client Settings
+
+Use `http://127.0.0.1:8000/v1` as the base URL when the client asks for an
+OpenAI API base. Some clients ask for the host without `/v1` and append the
+path themselves; check the client's preview URL before saving.
+
+Set the model to the exact served model id unless you intentionally run without
+strict model-id checks and know the client sends `"default"`.
+
+Use the API key printed or implied by the client profile. The default labels are
+not secrets; they are compatibility values for local clients that require a
+non-empty key field.
+
+## Off-Host Access
+
+Profiles bind to localhost by default. For a client running on another machine
+or inside a container that cannot reach host localhost, make the exposure
+explicit:
+
+```bash
+LISTEN_MODE=public scripts/serve_client_profile.sh generic-openai \
+  mlx-community/Qwen3-4B-Instruct-2507-4bit
+```
+
+When a Dockerized client runs on the same Mac, the reachable base URL is often
+`http://host.docker.internal:8000/v1`.
+
+## Related Guides
+
+- [OpenAI-Compatible Server](server.md)
+- [Tool Calling](tool-calling.md)
+- [Model And Serve Profile Matrix](model-profile-matrix.md)

--- a/docs/guides/model-profile-matrix.md
+++ b/docs/guides/model-profile-matrix.md
@@ -1,0 +1,62 @@
+# Model And Serve Profile Matrix
+
+Serve profiles keep runtime flags stable while you vary the model and request
+payload. Use them from a source checkout when you need a repeatable local
+backend for manual validation, client setup, or latency measurements.
+
+The model id remains an operator choice. Pick an MLX model that fits local
+memory and matches the workload, then choose the narrowest profile that exposes
+the behavior you need.
+
+## Serve Profiles
+
+| Profile | Best use | Main serve flags |
+|---|---|---|
+| `text-default` | Daily local text serving | `--runtime-mode simple --cache-strategy auto` |
+| `text-deterministic` | Reproduction runs and bug triage | `--deterministic` |
+| `text-tools` | OpenAI-compatible tool calling | `--runtime-mode auto --cache-strategy auto --enable-auto-tool-choice --tool-call-parser auto` |
+| `text-json` | JSON extraction and longer structured-output requests | `--runtime-mode simple --cache-strategy auto --timeout 900` |
+| `mllm-default` | Single-user image or mixed media chat | `--runtime-mode simple --cache-strategy auto --mllm` |
+| `mllm-correctness` | Multimodal concurrency with correctness bias | `--runtime-mode auto --cache-strategy auto --mllm --batch-divergence-monitor --batch-divergence-action serialize` |
+
+## Common Starts
+
+```bash
+scripts/serve_profile.sh text-default mlx-community/Qwen3-4B-Instruct-2507-4bit
+scripts/serve_profile.sh text-tools mlx-community/Qwen3-4B-Instruct-2507-4bit
+scripts/serve_profile.sh text-json mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit
+scripts/serve_profile.sh mllm-default mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit
+```
+
+`text-deterministic` is the right first stop for reports where output drift
+would obscure the failure. `text-tools` is the right profile when the request
+includes `tools` or `tool_choice`. `mllm-correctness` trades throughput for a
+safer multimodal concurrency posture.
+
+## Measurement Harnesses
+
+The checkout includes small harnesses for repeatable local checks against a
+running server:
+
+| Script | Measures |
+|---|---|
+| `scripts/serve_profile_benchmark.py` | Chat-completions throughput and usage totals |
+| `scripts/streaming_latency_harness.py` | TTFT, total stream time, token counts, and inter-token latency |
+| `scripts/prefix_reuse_harness.py` | Cold vs warm repeated-prefix request timing |
+| `scripts/batch_invariance_harness.py` | Serial vs concurrent deterministic-output agreement |
+
+Each harness accepts `--base-url`, `--model`, and an optional JSON output path.
+Run `--help` on the script for the full argument list.
+
+## Request Defaults
+
+Profile defaults are intentionally conservative. Set `temperature`, `top_p`,
+`max_tokens`, `enable_thinking`, and `response_format` in the request payload
+when a test depends on those values. Keep the serve profile fixed while
+comparing request-level behavior.
+
+## Related Guides
+
+- [Client Compatibility](client-compatibility.md)
+- [OpenAI-Compatible Server](server.md)
+- [Tool Calling](tool-calling.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ vllm-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 - [MCP & Tool Calling](guides/mcp-tools.md)
 - [Continuous Batching](guides/continuous-batching.md)
 - [Multi-Model Serving](guides/model-registry.md)
+- [Client Compatibility](guides/client-compatibility.md)
+- [Model And Serve Profile Matrix](guides/model-profile-matrix.md)
 
 ### Reference
 - [CLI Commands](reference/cli.md)

--- a/scripts/batch_invariance_harness.py
+++ b/scripts/batch_invariance_harness.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Batch invariance harness for vllm-mlx.
+
+Compares deterministic outputs for the same prompt set under:
+1) isolated requests (one-by-one)
+2) concurrent requests (batch-composition pressure proxy)
+
+Usage:
+  python scripts/batch_invariance_harness.py \
+    --base-url http://localhost:8000 \
+    --model mlx-community/Qwen3-4B-Instruct-4bit
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import math
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+DEFAULT_PROMPTS = [
+    "Write one sentence explaining why caching helps inference throughput.",
+    "List three steps to verify an API endpoint is healthy.",
+    "What is the capital of France? Answer in one word.",
+    "Return exactly: ping",
+    "Name two risks of running without authentication.",
+    "Summarize why deterministic decoding matters in testing.",
+    "What does a 503 status code usually indicate?",
+    "Give a one-line definition of batch invariance.",
+    "Provide two bullet points on memory pressure guardrails.",
+    "Output the word READY and nothing else.",
+]
+
+Z_SCORE_BY_CONFIDENCE = {
+    0.90: 1.645,
+    0.95: 1.960,
+    0.99: 2.576,
+}
+
+
+class HarnessRequestError(RuntimeError):
+    """Raised when probe requests fail after retry."""
+
+
+@dataclass
+class ProbeResult:
+    prompt: str
+    output: str
+    latency_s: float
+    finish_reason: str | None
+
+
+def _load_prompts(path: str | None) -> list[str]:
+    if not path:
+        return list(DEFAULT_PROMPTS)
+    prompt_path = Path(path)
+    lines = [line.strip() for line in prompt_path.read_text(encoding="utf-8").splitlines()]
+    prompts = [line for line in lines if line]
+    if not prompts:
+        raise ValueError(f"No prompts found in {prompt_path}")
+    return prompts
+
+
+def _headers(api_key: str | None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _run_probe(
+    base_url: str,
+    model: str,
+    prompt: str,
+    *,
+    max_tokens: int,
+    timeout_s: float,
+    api_key: str | None,
+    retries: int,
+    retry_backoff_s: float,
+) -> ProbeResult:
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "max_tokens": max_tokens,
+    }
+    url = f"{base_url.rstrip('/')}/v1/chat/completions"
+    attempts = max(1, retries + 1)
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            t0 = time.perf_counter()
+            response = requests.post(
+                url,
+                headers=_headers(api_key),
+                json=payload,
+                timeout=timeout_s,
+            )
+            latency_s = time.perf_counter() - t0
+            response.raise_for_status()
+            body = response.json()
+            choice = body["choices"][0]
+            message = choice.get("message", {})
+            return ProbeResult(
+                prompt=prompt,
+                output=message.get("content") or "",
+                latency_s=latency_s,
+                finish_reason=choice.get("finish_reason"),
+            )
+        except (requests.RequestException, KeyError, IndexError, ValueError) as exc:
+            last_error = exc
+            if attempt >= attempts:
+                break
+            sleep_s = retry_backoff_s * attempt
+            if sleep_s > 0:
+                time.sleep(sleep_s)
+    raise HarnessRequestError(
+        f"Request failed after {attempts} attempt(s) for prompt: {prompt!r}. "
+        f"Last error: {last_error}"
+    )
+
+
+def _tokenize(text: str) -> list[str]:
+    return text.split()
+
+
+def _token_agreement(a: str, b: str) -> float:
+    ta = _tokenize(a)
+    tb = _tokenize(b)
+    max_len = max(len(ta), len(tb), 1)
+    matches = 0
+    for i in range(max_len):
+        tok_a = ta[i] if i < len(ta) else None
+        tok_b = tb[i] if i < len(tb) else None
+        if tok_a == tok_b:
+            matches += 1
+    return matches / max_len
+
+
+def _run_serial(
+    prompts: list[str],
+    *,
+    base_url: str,
+    model: str,
+    max_tokens: int,
+    timeout_s: float,
+    api_key: str | None,
+    retries: int,
+    retry_backoff_s: float,
+) -> list[ProbeResult]:
+    results: list[ProbeResult] = []
+    for prompt in prompts:
+        results.append(
+            _run_probe(
+                base_url,
+                model,
+                prompt,
+                max_tokens=max_tokens,
+                timeout_s=timeout_s,
+                api_key=api_key,
+                retries=retries,
+                retry_backoff_s=retry_backoff_s,
+            )
+        )
+    return results
+
+
+def _run_concurrent(
+    prompts: list[str],
+    *,
+    base_url: str,
+    model: str,
+    max_tokens: int,
+    timeout_s: float,
+    api_key: str | None,
+    concurrency: int,
+    retries: int,
+    retry_backoff_s: float,
+) -> list[ProbeResult]:
+    results: list[ProbeResult] = [None] * len(prompts)  # type: ignore[assignment]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures: dict[concurrent.futures.Future[ProbeResult], int] = {}
+        for idx, prompt in enumerate(prompts):
+            fut = pool.submit(
+                _run_probe,
+                base_url,
+                model,
+                prompt,
+                max_tokens=max_tokens,
+                timeout_s=timeout_s,
+                api_key=api_key,
+                retries=retries,
+                retry_backoff_s=retry_backoff_s,
+            )
+            futures[fut] = idx
+        errors: list[str] = []
+        for fut in concurrent.futures.as_completed(futures):
+            idx = futures[fut]
+            try:
+                results[idx] = fut.result()
+            except Exception as exc:
+                errors.append(f"[prompt_index={idx}] {exc}")
+        if errors:
+            head = "\n".join(errors[:3])
+            tail_note = ""
+            if len(errors) > 3:
+                tail_note = f"\n... and {len(errors) - 3} more error(s)"
+            raise HarnessRequestError(
+                "Concurrent probe run failed. This usually means the server is down, "
+                "restarting, or overloaded under concurrency.\n"
+                f"{head}{tail_note}"
+            )
+    return results
+
+
+def _compute_confidence_interval(
+    values: list[float],
+    *,
+    confidence: float,
+) -> dict[str, float]:
+    if not values:
+        raise ValueError("Cannot compute confidence interval for empty values")
+    mean = statistics.mean(values)
+    if len(values) <= 1:
+        return {
+            "mean": mean,
+            "stdev": 0.0,
+            "ci_lower": mean,
+            "ci_upper": mean,
+        }
+    stdev = statistics.stdev(values)
+    z_score = Z_SCORE_BY_CONFIDENCE[confidence]
+    half_width = z_score * (stdev / math.sqrt(len(values)))
+    return {
+        "mean": mean,
+        "stdev": stdev,
+        "ci_lower": max(0.0, mean - half_width),
+        "ci_upper": min(1.0, mean + half_width),
+    }
+
+
+def _run_single_pass(
+    prompts: list[str],
+    *,
+    base_url: str,
+    model: str,
+    max_tokens: int,
+    timeout_s: float,
+    api_key: str | None,
+    concurrency: int,
+    run_index: int,
+    retries: int,
+    retry_backoff_s: float,
+) -> dict[str, Any]:
+    serial = _run_serial(
+        prompts,
+        base_url=base_url,
+        model=model,
+        max_tokens=max_tokens,
+        timeout_s=timeout_s,
+        api_key=api_key,
+        retries=retries,
+        retry_backoff_s=retry_backoff_s,
+    )
+    concurrent = _run_concurrent(
+        prompts,
+        base_url=base_url,
+        model=model,
+        max_tokens=max_tokens,
+        timeout_s=timeout_s,
+        api_key=api_key,
+        concurrency=concurrency,
+        retries=retries,
+        retry_backoff_s=retry_backoff_s,
+    )
+
+    exact_matches = 0
+    per_prompt_agreement: list[float] = []
+    rows: list[dict[str, Any]] = []
+    for idx, prompt in enumerate(prompts):
+        a = serial[idx]
+        b = concurrent[idx]
+        agreement = _token_agreement(a.output, b.output)
+        exact = a.output == b.output
+        if exact:
+            exact_matches += 1
+        per_prompt_agreement.append(agreement)
+        rows.append(
+            {
+                "index": idx,
+                "prompt": prompt,
+                "serial_output": a.output,
+                "concurrent_output": b.output,
+                "token_agreement": round(agreement, 4),
+                "exact_match": exact,
+                "serial_latency_s": round(a.latency_s, 4),
+                "concurrent_latency_s": round(b.latency_s, 4),
+            }
+        )
+
+    exact_match_rate = exact_matches / len(prompts)
+    token_agreement_rate = statistics.mean(per_prompt_agreement)
+    return {
+        "run_index": run_index,
+        "exact_match_rate": exact_match_rate,
+        "token_agreement_rate": token_agreement_rate,
+        "rows": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Batch invariance harness")
+    parser.add_argument(
+        "--base-url",
+        type=str,
+        default="http://localhost:8000",
+        help="Server base URL",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model identifier to include in request payload",
+    )
+    parser.add_argument(
+        "--prompts-file",
+        type=str,
+        default=None,
+        help="Optional text file (one prompt per line)",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=64,
+        help="Max tokens per probe request",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="Per-request timeout seconds",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=10,
+        help="Concurrent request count for batch-composition run",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="Optional API key (Authorization: Bearer)",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=str,
+        default=None,
+        help="Optional path to write JSON report",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="Number of repeated serial+concurrent passes for confidence intervals",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        choices=sorted(Z_SCORE_BY_CONFIDENCE),
+        default=0.95,
+        help="Confidence level for interval output",
+    )
+    parser.add_argument(
+        "--run-cooldown",
+        type=float,
+        default=0.0,
+        help="Optional seconds to sleep between repeated runs",
+    )
+    parser.add_argument(
+        "--request-retries",
+        type=int,
+        default=2,
+        help="Number of retries per failed probe request",
+    )
+    parser.add_argument(
+        "--retry-backoff",
+        type=float,
+        default=0.5,
+        help="Backoff base seconds between retries",
+    )
+    args = parser.parse_args()
+
+    prompts = _load_prompts(args.prompts_file)
+    concurrency = max(1, min(args.concurrency, len(prompts)))
+    if args.runs < 1:
+        raise ValueError("--runs must be >= 1")
+    if args.run_cooldown < 0:
+        raise ValueError("--run-cooldown must be >= 0")
+    if args.request_retries < 0:
+        raise ValueError("--request-retries must be >= 0")
+    if args.retry_backoff < 0:
+        raise ValueError("--retry-backoff must be >= 0")
+
+    run_reports: list[dict[str, Any]] = []
+    for run_index in range(args.runs):
+        print(f"Run {run_index + 1}/{args.runs}: serial pass on {len(prompts)} prompts...")
+        print(f"Run {run_index + 1}/{args.runs}: concurrent pass (concurrency={concurrency})...")
+        try:
+            run_report = _run_single_pass(
+                prompts,
+                base_url=args.base_url,
+                model=args.model,
+                max_tokens=args.max_tokens,
+                timeout_s=args.timeout,
+                api_key=args.api_key,
+                concurrency=concurrency,
+                run_index=run_index,
+                retries=args.request_retries,
+                retry_backoff_s=args.retry_backoff,
+            )
+        except HarnessRequestError as exc:
+            raise SystemExit(
+                "Harness failed due to request/connection errors.\n"
+                f"{exc}\n\n"
+                "Next checks:\n"
+                "1) Confirm server is still listening on --base-url.\n"
+                "2) Check server logs for OOM/restart/crash during concurrent pass.\n"
+                "3) Retry with lower concurrency (e.g., --concurrency 4).\n"
+                "4) Optionally reduce --max-tokens for stability."
+            ) from exc
+        run_reports.append(run_report)
+        print(
+            f"Run {run_index + 1}/{args.runs}: "
+            f"token={run_report['token_agreement_rate'] * 100:.2f}% "
+            f"exact={run_report['exact_match_rate'] * 100:.2f}%"
+        )
+        if args.run_cooldown > 0 and (run_index + 1) < args.runs:
+            time.sleep(args.run_cooldown)
+
+    token_values = [r["token_agreement_rate"] for r in run_reports]
+    exact_values = [r["exact_match_rate"] for r in run_reports]
+    token_summary = _compute_confidence_interval(token_values, confidence=args.confidence)
+    exact_summary = _compute_confidence_interval(exact_values, confidence=args.confidence)
+    ci_percent = int(args.confidence * 100)
+    latest_rows = run_reports[-1]["rows"]
+
+    print()
+    print("Batch Invariance Report")
+    print("-" * 60)
+    print(f"Model: {args.model}")
+    print(f"Prompts: {len(prompts)}")
+    print(f"Runs: {args.runs}")
+    print(f"Exact output match rate: {exact_summary['mean'] * 100:.2f}%")
+    print(f"Token agreement rate:    {token_summary['mean'] * 100:.2f}%")
+    print(
+        f"{ci_percent}% CI token agreement: "
+        f"[{token_summary['ci_lower'] * 100:.2f}%, {token_summary['ci_upper'] * 100:.2f}%]"
+    )
+    print(
+        f"{ci_percent}% CI exact match:    "
+        f"[{exact_summary['ci_lower'] * 100:.2f}%, {exact_summary['ci_upper'] * 100:.2f}%]"
+    )
+    print("-" * 60)
+    for row in latest_rows:
+        print(
+            f"[{row['index']:02d}] agreement={row['token_agreement']:.2f} "
+            f"exact={row['exact_match']}"
+        )
+
+    if token_summary["ci_lower"] < 0.95:
+        print("Result: potential batch invariance violation (<95% token agreement).")
+    else:
+        print("Result: no significant batch invariance violation detected.")
+
+    report = {
+        "model": args.model,
+        "base_url": args.base_url,
+        "prompt_count": len(prompts),
+        "max_tokens": args.max_tokens,
+        "concurrency": concurrency,
+        "runs": args.runs,
+        "confidence_level": args.confidence,
+        "exact_match_rate": exact_summary["mean"],
+        "token_agreement_rate": token_summary["mean"],
+        "exact_match_summary": exact_summary,
+        "token_agreement_summary": token_summary,
+        "rows": latest_rows,
+        "run_reports": run_reports,
+        "timestamp_epoch": int(time.time()),
+    }
+    if args.json_out:
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"Wrote JSON report: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prefix_reuse_harness.py
+++ b/scripts/prefix_reuse_harness.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Measure repeated-prefix reuse timing against a running server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import httpx
+
+
+def _load_fixture(path: str) -> dict:
+    fixture_path = Path(path)
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    shared_prefix = payload.get("shared_prefix")
+    suffixes = payload.get("suffixes")
+    if not isinstance(shared_prefix, str) or not shared_prefix.strip():
+        raise ValueError(f"Fixture {fixture_path} is missing a non-empty shared_prefix")
+    if not isinstance(suffixes, list) or len(suffixes) < 3:
+        raise ValueError(f"Fixture {fixture_path} must include at least three suffixes")
+
+    normalized_suffixes: list[dict[str, str]] = []
+    for index, item in enumerate(suffixes[:3], start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"Fixture suffix #{index} must be an object")
+        label = item.get("label") or f"suffix-{index}"
+        prompt = item.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError(f"Fixture suffix #{index} is missing a non-empty prompt")
+        normalized_suffixes.append({"label": str(label), "prompt": prompt.strip()})
+
+    return {
+        "fixture_path": str(fixture_path),
+        "shared_prefix": shared_prefix.strip(),
+        "suffixes": normalized_suffixes,
+    }
+
+
+def _load_extra_body(value: str | None) -> dict:
+    if not value:
+        return {}
+    payload = json.loads(value)
+    if not isinstance(payload, dict):
+        raise ValueError("--extra-body-json must decode to a JSON object")
+    return payload
+
+
+def _extract_model_ids(payload: dict) -> list[str]:
+    if payload.get("object") != "list" or not isinstance(payload.get("data"), list):
+        return []
+    model_ids: list[str] = []
+    for item in payload["data"]:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _is_ready_payload(payload: dict) -> bool:
+    if payload.get("status") == "healthy":
+        return True
+    if payload.get("object") == "list" and isinstance(payload.get("data"), list):
+        return True
+    return False
+
+
+async def _wait_for_health(
+    base_url: str,
+    timeout_s: float,
+    required_model_id_substring: str | None = None,
+) -> str:
+    deadline = time.time() + timeout_s
+    probe_urls = [
+        f"{base_url.rstrip('/')}/health",
+        f"{base_url.rstrip('/')}/v1/models",
+    ]
+    last_model_ids: list[str] = []
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        while time.time() < deadline:
+            for probe_url in probe_urls:
+                try:
+                    response = await client.get(probe_url)
+                    if not response.is_success:
+                        continue
+                    payload = response.json()
+                    if not _is_ready_payload(payload):
+                        continue
+                    model_ids = _extract_model_ids(payload)
+                    if model_ids:
+                        last_model_ids = model_ids
+                        if required_model_id_substring:
+                            for model_id in model_ids:
+                                if required_model_id_substring in model_id:
+                                    return model_id
+                        else:
+                            return model_ids[0]
+                except (httpx.HTTPError, ValueError):
+                    pass
+            await asyncio.sleep(0.5)
+    if required_model_id_substring:
+        raise TimeoutError(
+            "Server health/model-id check did not pass within "
+            f"{timeout_s:.1f}s; required substring="
+            f"{required_model_id_substring!r}, last advertised model ids={last_model_ids!r}"
+        )
+    raise TimeoutError(
+        "Server health check did not pass within "
+        f"{timeout_s:.1f}s; last advertised model ids={last_model_ids!r}"
+    )
+
+
+async def _run_stream_request(
+    *,
+    base_url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    request_timeout: float,
+    disable_thinking: bool = False,
+    extra_body: dict | None = None,
+) -> dict:
+    start_time = time.perf_counter()
+    first_content_time = None
+    content_chunks = 0
+    collected_parts: list[str] = []
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "stream": True,
+    }
+    if disable_thinking:
+        payload["enable_thinking"] = False
+    if extra_body:
+        payload.update(extra_body)
+
+    async with httpx.AsyncClient(timeout=request_timeout) as client:
+        async with client.stream(
+            "POST",
+            f"{base_url.rstrip('/')}/v1/chat/completions",
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                content = chunk.get("choices", [{}])[0].get("delta", {}).get("content", "")
+                if not content:
+                    continue
+                if first_content_time is None:
+                    first_content_time = time.perf_counter()
+                content_chunks += 1
+                collected_parts.append(content)
+
+    end_time = time.perf_counter()
+    ttft_ms = (first_content_time - start_time) * 1000 if first_content_time else 0.0
+    total_time_ms = (end_time - start_time) * 1000
+    response_text = "".join(collected_parts)
+    return {
+        "ttft_ms": round(ttft_ms, 4),
+        "total_time_ms": round(total_time_ms, 4),
+        "content_chunk_count": content_chunks,
+        "response_chars": len(response_text),
+        "response_preview": response_text[:200],
+    }
+
+
+def _build_prompt(shared_prefix: str, suffix_prompt: str) -> str:
+    return f"{shared_prefix}\n\nTask:\n{suffix_prompt}\n"
+
+
+def _compute_summary(requests: list[dict]) -> dict:
+    cold = requests[0]
+    warm_requests = requests[1:]
+    warm_ttfts = [request["ttft_ms"] for request in warm_requests]
+    warm_totals = [request["total_time_ms"] for request in warm_requests]
+    mean_warm_ttft = sum(warm_ttfts) / len(warm_ttfts)
+    mean_warm_total = sum(warm_totals) / len(warm_totals)
+    return {
+        "cold_ttft_ms": cold["ttft_ms"],
+        "cold_total_time_ms": cold["total_time_ms"],
+        "warm_ttft_ms_mean": round(mean_warm_ttft, 4),
+        "warm_total_time_ms_mean": round(mean_warm_total, 4),
+        "warm_ttft_delta_from_cold_ms_mean": round(mean_warm_ttft - cold["ttft_ms"], 4),
+        "warm_total_time_delta_from_cold_ms_mean": round(
+            mean_warm_total - cold["total_time_ms"], 4
+        ),
+    }
+
+
+async def _run() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--fixture", required=True)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--request-timeout", type=float, default=120.0)
+    parser.add_argument("--health-timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--require-model-id-substring",
+        help="Fail unless at least one /v1/models id contains this substring",
+    )
+    parser.add_argument(
+        "--disable-thinking",
+        action="store_true",
+        help="Send enable_thinking=false in request body",
+    )
+    parser.add_argument(
+        "--extra-body-json",
+        help="Extra JSON object to merge into each request body",
+    )
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    fixture = _load_fixture(args.fixture)
+    extra_body = _load_extra_body(args.extra_body_json)
+    advertised_model_id = await _wait_for_health(
+        args.base_url,
+        args.health_timeout,
+        required_model_id_substring=args.require_model_id_substring,
+    )
+
+    requests_payload: list[dict] = []
+    for index, suffix in enumerate(fixture["suffixes"], start=1):
+        request_metrics = await _run_stream_request(
+            base_url=args.base_url,
+            model=args.model,
+            prompt=_build_prompt(fixture["shared_prefix"], suffix["prompt"]),
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            request_timeout=args.request_timeout,
+            disable_thinking=args.disable_thinking,
+            extra_body=extra_body,
+        )
+        requests_payload.append(
+            {
+                "request_index": index,
+                "request_type": "cold" if index == 1 else "warm",
+                "suffix_label": suffix["label"],
+                "suffix_prompt": suffix["prompt"],
+                **request_metrics,
+            }
+        )
+
+    summary = {
+        "model": args.model,
+        "base_url": args.base_url,
+        "fixture": fixture["fixture_path"],
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "shared_prefix_chars": len(fixture["shared_prefix"]),
+        "shared_prefix_lines": len(fixture["shared_prefix"].splitlines()),
+        "request_count": len(requests_payload),
+        "advertised_model_id": advertised_model_id,
+        "model_id_guard_substring": args.require_model_id_substring,
+        "extra_body": extra_body or None,
+        **_compute_summary(requests_payload),
+    }
+
+    print("Prefix Reuse Results:")
+    print(f"  Advertised model id: {summary['advertised_model_id']}")
+    print(f"  Cold TTFT: {summary['cold_ttft_ms']:.2f} ms")
+    print(f"  Warm TTFT mean: {summary['warm_ttft_ms_mean']:.2f} ms")
+    print(
+        "  Warm TTFT delta from cold mean: "
+        f"{summary['warm_ttft_delta_from_cold_ms_mean']:.2f} ms"
+    )
+    print(f"  Cold total time: {summary['cold_total_time_ms']:.2f} ms")
+    print(f"  Warm total time mean: {summary['warm_total_time_ms_mean']:.2f} ms")
+
+    if args.json_out:
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"summary": summary, "requests": requests_payload}
+        out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote JSON report: {out_path}")
+
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prefix_reuse_harness.py
+++ b/scripts/prefix_reuse_harness.py
@@ -23,7 +23,7 @@ def _load_fixture(path: str) -> dict:
         raise ValueError(f"Fixture {fixture_path} must include at least three suffixes")
 
     normalized_suffixes: list[dict[str, str]] = []
-    for index, item in enumerate(suffixes[:3], start=1):
+    for index, item in enumerate(suffixes, start=1):
         if not isinstance(item, dict):
             raise ValueError(f"Fixture suffix #{index} must be an object")
         label = item.get("label") or f"suffix-{index}"

--- a/scripts/serve_client_profile.sh
+++ b/scripts/serve_client_profile.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SERVE_PROFILE_SCRIPT="${REPO_ROOT}/scripts/serve_profile.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/serve_client_profile.sh <client-profile> <model> [extra serve args...]
+
+Client profiles:
+  goose-text          Goose CLI basic text validation
+  goose-tools         Goose CLI with tool-calling enabled
+  open-webui-text     Open WebUI text connection
+  open-webui-mllm     Open WebUI multimodal connection
+  cherry-studio       Cherry Studio desktop text baseline
+  chatbox             Chatbox desktop text baseline
+  librechat           LibreChat text baseline
+  witsy               Witsy desktop text baseline
+  jan                 Jan remote OpenAI-compatible engine
+  anythingllm         AnythingLLM generic OpenAI provider
+  boltai              BoltAI desktop text baseline
+  generic-openai      Generic OpenAI-compatible desktop/web client
+  generic-mllm        Generic multimodal OpenAI-compatible client
+
+Environment:
+  VLLM_MLX_CLIENT_API_KEY  Override the default API key for the chosen profile
+  LISTEN_MODE              localhost or public (passed through to serve_profile.sh)
+  PORT                     Port override (passed through to serve_profile.sh)
+
+Examples:
+  scripts/serve_client_profile.sh goose-text mlx-community/Qwen3-4B-Instruct-2507-4bit
+  scripts/serve_client_profile.sh goose-tools mlx-community/Qwen3-4B-Instruct-2507-4bit
+  scripts/serve_client_profile.sh open-webui-mllm mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+CLIENT_PROFILE="$1"
+MODEL="$2"
+shift 2
+
+if [[ ! -x "$SERVE_PROFILE_SCRIPT" ]]; then
+  echo "Missing serve profile launcher: ${SERVE_PROFILE_SCRIPT}" >&2
+  exit 1
+fi
+
+contains_flag() {
+  local needle="$1"
+  shift
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+SERVE_PROFILE=""
+DEFAULT_API_KEY=""
+
+case "$CLIENT_PROFILE" in
+  goose-text)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="goose-local"
+    ;;
+  goose-tools)
+    SERVE_PROFILE="text-tools"
+    DEFAULT_API_KEY="goose-local"
+    ;;
+  open-webui-text)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="openwebui-local"
+    ;;
+  open-webui-mllm)
+    SERVE_PROFILE="mllm-default"
+    DEFAULT_API_KEY="openwebui-local"
+    ;;
+  cherry-studio)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="cherrystudio-local"
+    ;;
+  chatbox)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="chatbox-local"
+    ;;
+  librechat)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="librechat-local"
+    ;;
+  witsy)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="witsy-local"
+    ;;
+  jan)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="jan-local"
+    ;;
+  anythingllm)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="anythingllm-local"
+    ;;
+  boltai)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="boltai-local"
+    ;;
+  generic-openai)
+    SERVE_PROFILE="text-default"
+    DEFAULT_API_KEY="local-client"
+    ;;
+  generic-mllm)
+    SERVE_PROFILE="mllm-default"
+    DEFAULT_API_KEY="local-client"
+    ;;
+  *)
+    echo "Unknown client profile: ${CLIENT_PROFILE}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+API_KEY="${VLLM_MLX_CLIENT_API_KEY:-$DEFAULT_API_KEY}"
+
+EXTRA_ARGS=("$@")
+if ! contains_flag "--api-key" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; then
+  EXTRA_ARGS+=(--api-key "$API_KEY")
+fi
+
+echo "Launching client profile '${CLIENT_PROFILE}'"
+echo "Mapped serve profile: ${SERVE_PROFILE}"
+echo "Default API key label: ${API_KEY}"
+
+exec "${SERVE_PROFILE_SCRIPT}" "${SERVE_PROFILE}" "${MODEL}" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"

--- a/scripts/serve_profile.sh
+++ b/scripts/serve_profile.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PYTHON_BIN="${VLLM_MLX_PYTHON:-${REPO_ROOT}/.venv/bin/python}"
+PORT="${PORT:-8000}"
+LISTEN_MODE="${LISTEN_MODE:-localhost}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/serve_profile.sh <profile> <model> [extra serve args...]
+
+Profiles:
+  text-default         Simple text profile for local usage
+  text-deterministic   Reproducible text diagnostics profile
+  text-tools           Text tool-calling profile
+  text-json            Long-timeout JSON/extraction profile
+  mllm-default         Simple multimodal profile
+  mllm-correctness     Multimodal profile with divergence monitoring + serialize
+
+Environment:
+  VLLM_MLX_PYTHON  Override python entrypoint (default: .venv/bin/python)
+  PORT             Override serve port (default: 8000)
+  LISTEN_MODE      localhost or public (default: localhost)
+
+Examples:
+  scripts/serve_profile.sh text-default mlx-community/Qwen3-4B-Instruct-2507-4bit
+  scripts/serve_profile.sh text-json mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit
+  scripts/serve_profile.sh mllm-default mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+PROFILE="$1"
+MODEL="$2"
+shift 2
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "Python entrypoint not found or not executable: ${PYTHON_BIN}" >&2
+  echo "Create the checkout venv first, or set VLLM_MLX_PYTHON." >&2
+  exit 1
+fi
+
+LISTEN_ARGS=()
+case "${LISTEN_MODE}" in
+  localhost)
+    LISTEN_ARGS+=(--localhost)
+    ;;
+  public)
+    LISTEN_ARGS+=(--host 0.0.0.0)
+    ;;
+  *)
+    echo "Unsupported LISTEN_MODE: ${LISTEN_MODE}" >&2
+    echo "Use LISTEN_MODE=localhost or LISTEN_MODE=public." >&2
+    exit 1
+    ;;
+esac
+
+BASE_ARGS=(
+  serve
+  "${MODEL}"
+  "${LISTEN_ARGS[@]}"
+  --port "${PORT}"
+)
+
+PROFILE_ARGS=()
+case "${PROFILE}" in
+  text-default)
+    PROFILE_ARGS+=(
+      --runtime-mode simple
+      --cache-strategy auto
+      --default-temperature 0.7
+      --default-top-p 0.9
+    )
+    ;;
+  text-deterministic)
+    PROFILE_ARGS+=(
+      --deterministic
+    )
+    ;;
+  text-tools)
+    PROFILE_ARGS+=(
+      --runtime-mode auto
+      --cache-strategy auto
+      --enable-auto-tool-choice
+      --tool-call-parser auto
+    )
+    ;;
+  text-json)
+    PROFILE_ARGS+=(
+      --runtime-mode simple
+      --cache-strategy auto
+      --timeout 900
+      --default-temperature 0.7
+      --default-top-p 0.9
+    )
+    ;;
+  mllm-default)
+    PROFILE_ARGS+=(
+      --runtime-mode simple
+      --cache-strategy auto
+      --mllm
+      --default-temperature 0.0
+      --default-top-p 1.0
+    )
+    ;;
+  mllm-correctness)
+    PROFILE_ARGS+=(
+      --runtime-mode auto
+      --cache-strategy auto
+      --mllm
+      --default-temperature 0.0
+      --default-top-p 1.0
+      --batch-divergence-monitor
+      --batch-divergence-threshold 0.95
+      --batch-divergence-action serialize
+    )
+    ;;
+  *)
+    echo "Unknown profile: ${PROFILE}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+CMD=(
+  "${PYTHON_BIN}"
+  -m
+  vllm_mlx.cli
+  "${BASE_ARGS[@]}"
+  "${PROFILE_ARGS[@]}"
+  "$@"
+)
+
+echo "Launching profile '${PROFILE}' for model '${MODEL}'"
+printf 'Command:'
+printf ' %q' "${CMD[@]}"
+printf '\n'
+
+exec "${CMD[@]}"

--- a/scripts/serve_profile_benchmark.py
+++ b/scripts/serve_profile_benchmark.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Benchmark /v1/chat/completions throughput against a running server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import requests
+
+DEFAULT_PROMPTS = [
+    "Write a short poem about nature.",
+    "Write a short poem about love.",
+    "Write a short poem about technology.",
+    "Write a short poem about space.",
+    "Write a short poem about music.",
+    "Write a short poem about art.",
+    "Write a short poem about science.",
+    "Write a short poem about history.",
+    "Write a short poem about food.",
+    "Write a short poem about travel.",
+]
+
+
+def _load_prompts(path: str | None) -> list[str]:
+    if not path:
+        return list(DEFAULT_PROMPTS)
+    prompt_path = Path(path)
+    lines = [line.strip() for line in prompt_path.read_text(encoding="utf-8").splitlines()]
+    prompts = [line for line in lines if line]
+    if not prompts:
+        raise ValueError(f"No prompts found in {prompt_path}")
+    return prompts
+
+
+def _load_extra_body(value: str | None) -> dict:
+    if not value:
+        return {}
+    payload = json.loads(value)
+    if not isinstance(payload, dict):
+        raise ValueError("--extra-body-json must decode to a JSON object")
+    return payload
+
+
+def _extract_model_ids(payload: dict) -> list[str]:
+    if payload.get("object") != "list" or not isinstance(payload.get("data"), list):
+        return []
+    model_ids: list[str] = []
+    for item in payload["data"]:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _call_chat(
+    *,
+    base_url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    timeout: float,
+    disable_thinking: bool = False,
+    extra_body: dict | None = None,
+) -> dict:
+    started = time.perf_counter()
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if disable_thinking:
+        body["enable_thinking"] = False
+    if extra_body:
+        body.update(extra_body)
+    response = requests.post(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        json=body,
+        timeout=timeout,
+    )
+    latency_s = time.perf_counter() - started
+    response.raise_for_status()
+    payload = response.json()
+    usage = payload.get("usage") or {}
+    return {
+        "prompt": prompt,
+        "latency_s": round(latency_s, 4),
+        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+        "completion_tokens": int(usage.get("completion_tokens") or 0),
+        "total_tokens": int(usage.get("total_tokens") or 0),
+    }
+
+
+def _is_ready_response(response: requests.Response) -> bool:
+    if not response.ok:
+        return False
+    try:
+        payload = response.json()
+    except ValueError:
+        return False
+    if payload.get("status") == "healthy":
+        return True
+    if payload.get("object") == "list" and isinstance(payload.get("data"), list):
+        return True
+    return False
+
+
+def _wait_for_health(
+    base_url: str,
+    timeout_s: float,
+    required_model_id_substring: str | None = None,
+) -> str:
+    deadline = time.time() + timeout_s
+    probe_urls = [
+        f"{base_url.rstrip('/')}/health",
+        f"{base_url.rstrip('/')}/v1/models",
+    ]
+    last_model_ids: list[str] = []
+    while time.time() < deadline:
+        for probe_url in probe_urls:
+            try:
+                response = requests.get(probe_url, timeout=2.0)
+                if not _is_ready_response(response):
+                    continue
+                try:
+                    payload = response.json()
+                except ValueError:
+                    continue
+                model_ids = _extract_model_ids(payload)
+                if model_ids:
+                    last_model_ids = model_ids
+                    if required_model_id_substring:
+                        for model_id in model_ids:
+                            if required_model_id_substring in model_id:
+                                return model_id
+                    else:
+                        return model_ids[0]
+            except requests.RequestException:
+                pass
+        time.sleep(0.5)
+    if required_model_id_substring:
+        raise TimeoutError(
+            "Server health/model-id check did not pass within "
+            f"{timeout_s:.1f}s; required substring="
+            f"{required_model_id_substring!r}, last advertised model ids={last_model_ids!r}"
+        )
+    raise TimeoutError(
+        "Server health check did not pass within "
+        f"{timeout_s:.1f}s; last advertised model ids={last_model_ids!r}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--concurrency", type=int, default=10)
+    parser.add_argument("--prompts-file")
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--warmup-requests", type=int, default=0)
+    parser.add_argument("--request-timeout", type=float, default=180.0)
+    parser.add_argument("--health-timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--require-model-id-substring",
+        help="Fail unless at least one /v1/models id contains this substring",
+    )
+    parser.add_argument("--disable-thinking", action="store_true",
+                        help="Send enable_thinking=false in request body")
+    parser.add_argument(
+        "--extra-body-json",
+        help="Extra JSON object to merge into each request body",
+    )
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    prompts = _load_prompts(args.prompts_file)
+    extra_body = _load_extra_body(args.extra_body_json)
+    advertised_model_id = _wait_for_health(
+        args.base_url,
+        args.health_timeout,
+        required_model_id_substring=args.require_model_id_substring,
+    )
+
+    # Warm the active model and server path before collecting timed results.
+    if prompts and args.warmup_requests > 0:
+        warmup_prompt = prompts[0]
+        for _ in range(args.warmup_requests):
+            _call_chat(
+                base_url=args.base_url,
+                model=args.model,
+                prompt=warmup_prompt,
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                timeout=args.request_timeout,
+                disable_thinking=args.disable_thinking,
+                extra_body=extra_body,
+            )
+
+    started = time.perf_counter()
+    results: list[dict] = []
+
+    with ThreadPoolExecutor(max_workers=max(1, args.concurrency)) as executor:
+        futures = [
+            executor.submit(
+                _call_chat,
+                base_url=args.base_url,
+                model=args.model,
+                prompt=prompt,
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                timeout=args.request_timeout,
+                disable_thinking=args.disable_thinking,
+                extra_body=extra_body,
+            )
+            for prompt in prompts
+        ]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    total_time = time.perf_counter() - started
+    total_prompt_tokens = sum(r["prompt_tokens"] for r in results)
+    total_completion_tokens = sum(r["completion_tokens"] for r in results)
+    total_tokens = sum(r["total_tokens"] for r in results)
+
+    summary = {
+        "total_time_s": round(total_time, 4),
+        "prompts": len(prompts),
+        "prompts_per_second": round(len(prompts) / total_time, 4),
+        "total_prompt_tokens": total_prompt_tokens,
+        "total_completion_tokens": total_completion_tokens,
+        "total_tokens": total_tokens,
+        "tokens_per_second": round(total_completion_tokens / total_time, 4),
+        "throughput_tok_per_s": round(total_tokens / total_time, 4),
+        "max_tokens": args.max_tokens,
+        "concurrency": args.concurrency,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "warmup_requests": args.warmup_requests,
+        "model": args.model,
+        "base_url": args.base_url,
+        "prompts_file": args.prompts_file,
+        "advertised_model_id": advertised_model_id,
+        "model_id_guard_substring": args.require_model_id_substring,
+        "extra_body": extra_body or None,
+    }
+
+    print("Results:")
+    print(f"  Total time: {summary['total_time_s']:.2f}s")
+    print(f"  Prompts: {summary['prompts']}")
+    print(f"  Prompts/second: {summary['prompts_per_second']:.2f}")
+    print(f"  Total prompt tokens: {summary['total_prompt_tokens']}")
+    print(f"  Total completion tokens: {summary['total_completion_tokens']}")
+    print(f"  Total tokens: {summary['total_tokens']}")
+    print(f"  Tokens/second: {summary['tokens_per_second']:.2f}")
+    print(f"  Throughput: {summary['throughput_tok_per_s']:.2f} tok/s")
+
+    if args.json_out:
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        summary["request_results"] = sorted(results, key=lambda item: item["prompt"])
+        out_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote JSON report: {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/serve_profile_benchmark.py
+++ b/scripts/serve_profile_benchmark.py
@@ -82,21 +82,50 @@ def _call_chat(
         body["enable_thinking"] = False
     if extra_body:
         body.update(extra_body)
-    response = requests.post(
-        f"{base_url.rstrip('/')}/v1/chat/completions",
-        json=body,
-        timeout=timeout,
-    )
-    latency_s = time.perf_counter() - started
-    response.raise_for_status()
-    payload = response.json()
-    usage = payload.get("usage") or {}
+    try:
+        response = requests.post(
+            f"{base_url.rstrip('/')}/v1/chat/completions",
+            json=body,
+            timeout=timeout,
+        )
+        latency_s = time.perf_counter() - started
+        response.raise_for_status()
+        payload = response.json()
+        usage = payload.get("usage") or {}
+        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        completion_tokens = int(usage.get("completion_tokens") or 0)
+        total_tokens = int(usage.get("total_tokens") or 0)
+    except (requests.RequestException, ValueError, KeyError, TypeError) as exc:
+        latency_s = time.perf_counter() - started
+        return {
+            "ok": False,
+            "error": str(exc),
+            "prompt": prompt,
+            "latency_s": round(latency_s, 4),
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
     return {
+        "ok": True,
+        "error": None,
         "prompt": prompt,
         "latency_s": round(latency_s, 4),
-        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
-        "completion_tokens": int(usage.get("completion_tokens") or 0),
-        "total_tokens": int(usage.get("total_tokens") or 0),
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _summarize_result_status(results: list[dict]) -> dict:
+    successful_requests = sum(1 for result in results if result.get("ok") is True)
+    failed_requests = len(results) - successful_requests
+    failure_rate = failed_requests / len(results) if results else 0.0
+    return {
+        "successful_requests": successful_requests,
+        "failed_requests": failed_requests,
+        "failure_rate": round(failure_rate, 4),
     }
 
 
@@ -196,7 +225,7 @@ def main() -> int:
     if prompts and args.warmup_requests > 0:
         warmup_prompt = prompts[0]
         for _ in range(args.warmup_requests):
-            _call_chat(
+            warmup_result = _call_chat(
                 base_url=args.base_url,
                 model=args.model,
                 prompt=warmup_prompt,
@@ -207,6 +236,11 @@ def main() -> int:
                 disable_thinking=args.disable_thinking,
                 extra_body=extra_body,
             )
+            if not warmup_result.get("ok"):
+                raise RuntimeError(
+                    "Warmup request failed: "
+                    f"{warmup_result.get('error') or 'unknown error'}"
+                )
 
     started = time.perf_counter()
     results: list[dict] = []
@@ -234,6 +268,7 @@ def main() -> int:
     total_prompt_tokens = sum(r["prompt_tokens"] for r in results)
     total_completion_tokens = sum(r["completion_tokens"] for r in results)
     total_tokens = sum(r["total_tokens"] for r in results)
+    result_status = _summarize_result_status(results)
 
     summary = {
         "total_time_s": round(total_time, 4),
@@ -255,6 +290,7 @@ def main() -> int:
         "advertised_model_id": advertised_model_id,
         "model_id_guard_substring": args.require_model_id_substring,
         "extra_body": extra_body or None,
+        **result_status,
     }
 
     print("Results:")
@@ -266,6 +302,9 @@ def main() -> int:
     print(f"  Total tokens: {summary['total_tokens']}")
     print(f"  Tokens/second: {summary['tokens_per_second']:.2f}")
     print(f"  Throughput: {summary['throughput_tok_per_s']:.2f} tok/s")
+    print(f"  Successful requests: {summary['successful_requests']}")
+    print(f"  Failed requests: {summary['failed_requests']}")
+    print(f"  Failure rate: {summary['failure_rate']:.2%}")
 
     if args.json_out:
         out_path = Path(args.json_out)

--- a/scripts/streaming_latency_harness.py
+++ b/scripts/streaming_latency_harness.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Measure streaming latency metrics against a running server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import time
+from pathlib import Path
+
+import httpx
+
+DEFAULT_PROMPTS = [
+    "What is the capital of France?",
+    "Explain quantum computing in simple terms.",
+    "Write a haiku about programming.",
+]
+
+
+def _load_prompts(path: str | None) -> list[str]:
+    if not path:
+        return list(DEFAULT_PROMPTS)
+    prompt_path = Path(path)
+    lines = [line.strip() for line in prompt_path.read_text(encoding="utf-8").splitlines()]
+    prompts = [line for line in lines if line]
+    if not prompts:
+        raise ValueError(f"No prompts found in {prompt_path}")
+    return prompts
+
+
+def _load_extra_body(value: str | None) -> dict:
+    if not value:
+        return {}
+    payload = json.loads(value)
+    if not isinstance(payload, dict):
+        raise ValueError("--extra-body-json must decode to a JSON object")
+    return payload
+
+
+def _build_request_payload(
+    *,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    disable_thinking: bool,
+    extra_body: dict | None,
+) -> dict:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if disable_thinking:
+        payload["enable_thinking"] = False
+    if not extra_body:
+        return payload
+
+    merged_payload = dict(payload)
+    extra_stream_options = extra_body.get("stream_options")
+    if extra_stream_options is not None and not isinstance(extra_stream_options, dict):
+        raise ValueError("--extra-body-json stream_options must decode to a JSON object")
+
+    for key, value in extra_body.items():
+        if key == "stream_options":
+            continue
+        merged_payload[key] = value
+
+    stream_options = dict(payload["stream_options"])
+    if isinstance(extra_stream_options, dict):
+        stream_options.update(extra_stream_options)
+    stream_options["include_usage"] = True
+    merged_payload["stream_options"] = stream_options
+    return merged_payload
+
+
+def _extract_model_ids(payload: dict) -> list[str]:
+    if payload.get("object") != "list" or not isinstance(payload.get("data"), list):
+        return []
+    model_ids: list[str] = []
+    for item in payload["data"]:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {
+            "mean": 0.0,
+            "median": 0.0,
+            "min": 0.0,
+            "max": 0.0,
+            "stdev": 0.0,
+        }
+    stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+    return {
+        "mean": round(statistics.mean(values), 4),
+        "median": round(statistics.median(values), 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4),
+        "stdev": round(stdev, 4),
+    }
+
+
+def _is_ready_payload(payload: dict) -> bool:
+    if payload.get("status") == "healthy":
+        return True
+    if payload.get("object") == "list" and isinstance(payload.get("data"), list):
+        return True
+    return False
+
+
+async def _wait_for_health(
+    base_url: str,
+    timeout_s: float,
+    required_model_id_substring: str | None = None,
+) -> str:
+    deadline = time.time() + timeout_s
+    probe_urls = [
+        f"{base_url.rstrip('/')}/health",
+        f"{base_url.rstrip('/')}/v1/models",
+    ]
+    last_model_ids: list[str] = []
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        while time.time() < deadline:
+            for probe_url in probe_urls:
+                try:
+                    response = await client.get(probe_url)
+                    if response.is_success:
+                        payload = response.json()
+                        if not _is_ready_payload(payload):
+                            continue
+                        model_ids = _extract_model_ids(payload)
+                        if model_ids:
+                            last_model_ids = model_ids
+                            if required_model_id_substring:
+                                for model_id in model_ids:
+                                    if required_model_id_substring in model_id:
+                                        return model_id
+                            else:
+                                return model_ids[0]
+                except (httpx.HTTPError, ValueError):
+                    pass
+            await asyncio.sleep(0.5)
+    if required_model_id_substring:
+        raise TimeoutError(
+            "Server health/model-id check did not pass within "
+            f"{timeout_s:.1f}s; required substring="
+            f"{required_model_id_substring!r}, last advertised model ids={last_model_ids!r}"
+        )
+    raise TimeoutError(
+        "Server health check did not pass within "
+        f"{timeout_s:.1f}s; last advertised model ids={last_model_ids!r}"
+    )
+
+
+async def _measure_streaming_latency(
+    *,
+    base_url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    request_timeout: float,
+    disable_thinking: bool = False,
+    extra_body: dict | None = None,
+) -> dict:
+    start_time = time.perf_counter()
+    first_token_time = None
+    last_content_time = None
+    content_chunk_count = 0
+    usage = {}
+    payload = _build_request_payload(
+        model=model,
+        prompt=prompt,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        disable_thinking=disable_thinking,
+        extra_body=extra_body,
+    )
+
+    async with httpx.AsyncClient(timeout=request_timeout) as client:
+        async with client.stream(
+            "POST",
+            f"{base_url.rstrip('/')}/v1/chat/completions",
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+
+                current_time = time.perf_counter()
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                chunk_usage = chunk.get("usage")
+                if isinstance(chunk_usage, dict):
+                    usage = chunk_usage
+                choices = chunk.get("choices")
+                delta = {}
+                if isinstance(choices, list) and choices:
+                    first_choice = choices[0]
+                    if isinstance(first_choice, dict):
+                        delta = first_choice.get("delta", {})
+                content = delta.get("content", "") if isinstance(delta, dict) else ""
+                if content:
+                    content_chunk_count += 1
+                    if first_token_time is None:
+                        first_token_time = current_time
+                    last_content_time = current_time
+
+    end_time = time.perf_counter()
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    prompt_tokens = int(usage.get("prompt_tokens") or 0)
+    total_tokens = int(usage.get("total_tokens") or 0)
+
+    if first_token_time is not None and completion_tokens <= 0:
+        raise RuntimeError(
+            "Streaming response did not include usage.completion_tokens. "
+            "Benchmark results would be chunk-count confounded."
+        )
+
+    ttft_ms = (first_token_time - start_time) * 1000 if first_token_time else 0.0
+    total_time_ms = (end_time - start_time) * 1000
+    emission_window_ms = (
+        (last_content_time - first_token_time) * 1000
+        if first_token_time is not None and last_content_time is not None
+        else 0.0
+    )
+    mean_itl_ms = (
+        emission_window_ms / (completion_tokens - 1)
+        if completion_tokens > 1
+        else 0.0
+    )
+
+    return {
+        "prompt": prompt,
+        "ttft_ms": round(ttft_ms, 4),
+        "total_time_ms": round(total_time_ms, 4),
+        "token_count": completion_tokens,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "total_tokens": total_tokens,
+        "content_chunk_count": content_chunk_count,
+        "emission_window_ms": round(emission_window_ms, 4),
+        "mean_itl_ms": round(mean_itl_ms, 4),
+    }
+
+
+async def _run() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--prompts-file")
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--warmup-requests", type=int, default=0)
+    parser.add_argument("--request-timeout", type=float, default=120.0)
+    parser.add_argument("--health-timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--require-model-id-substring",
+        help="Fail unless at least one /v1/models id contains this substring",
+    )
+    parser.add_argument("--disable-thinking", action="store_true",
+                        help="Send enable_thinking=false in request body")
+    parser.add_argument(
+        "--extra-body-json",
+        help="Extra JSON object to merge into each request body",
+    )
+    parser.add_argument("--json-out")
+    args = parser.parse_args()
+
+    prompts = _load_prompts(args.prompts_file)
+    extra_body = _load_extra_body(args.extra_body_json)
+    advertised_model_id = await _wait_for_health(
+        args.base_url,
+        args.health_timeout,
+        required_model_id_substring=args.require_model_id_substring,
+    )
+
+    if prompts and args.warmup_requests > 0:
+        warmup_prompt = prompts[0]
+        for _ in range(args.warmup_requests):
+            await _measure_streaming_latency(
+                base_url=args.base_url,
+                model=args.model,
+                prompt=warmup_prompt,
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                request_timeout=args.request_timeout,
+                disable_thinking=args.disable_thinking,
+                extra_body=extra_body,
+            )
+
+    runs: list[dict] = []
+    for prompt in prompts:
+        for _ in range(args.iterations):
+            runs.append(
+                await _measure_streaming_latency(
+                    base_url=args.base_url,
+                    model=args.model,
+                    prompt=prompt,
+                    max_tokens=args.max_tokens,
+                    temperature=args.temperature,
+                    top_p=args.top_p,
+                    request_timeout=args.request_timeout,
+                    disable_thinking=args.disable_thinking,
+                    extra_body=extra_body,
+                )
+            )
+
+    ttft_values = [run["ttft_ms"] for run in runs]
+    total_values = [run["total_time_ms"] for run in runs]
+    token_values = [run["completion_tokens"] for run in runs]
+    itl_values = [run["mean_itl_ms"] for run in runs if run["completion_tokens"] > 1]
+    chunk_count_values = [run["content_chunk_count"] for run in runs]
+    total_time_s = sum(total_values) / 1000.0
+    total_tokens = sum(token_values)
+    throughput = (total_tokens / total_time_s) if total_time_s > 0 else 0.0
+
+    summary = {
+        "model": args.model,
+        "base_url": args.base_url,
+        "prompts_file": args.prompts_file,
+        "iterations": args.iterations,
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "prompt_count": len(prompts),
+        "run_count": len(runs),
+        "warmup_requests": args.warmup_requests,
+        "metric_method": "stream_usage_completion_tokens",
+        "advertised_model_id": advertised_model_id,
+        "model_id_guard_substring": args.require_model_id_substring,
+        "extra_body": extra_body or None,
+        "ttft_ms": _stats(ttft_values),
+        "itl_ms": _stats(itl_values),
+        "total_time_ms": _stats(total_values),
+        "content_chunk_count": _stats(chunk_count_values),
+        "tokens_per_second": round(throughput, 4),
+        "total_tokens": total_tokens,
+    }
+
+    print("Streaming Latency Results:")
+    print(f"  Runs: {summary['run_count']}")
+    print(f"  Advertised model id: {summary['advertised_model_id']}")
+    print(f"  TTFT mean: {summary['ttft_ms']['mean']:.2f} ms")
+    print(f"  ITL mean: {summary['itl_ms']['mean']:.2f} ms")
+    print(f"  Total time mean: {summary['total_time_ms']['mean']:.2f} ms")
+    print(f"  Tokens/sec: {summary['tokens_per_second']:.2f}")
+
+    if args.json_out:
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"summary": summary, "runs": runs}
+        out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote JSON report: {out_path}")
+
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repetition_detector.py
+++ b/tests/test_repetition_detector.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for scheduler repetition detection."""
+
+import vllm_mlx.scheduler as scheduler
+
+
+def _detect_repetition(tokens: list[int], **kwargs) -> bool:
+    detector = getattr(scheduler, "_detect_repetition", None)
+    assert callable(detector), "scheduler must expose _detect_repetition"
+    return detector(tokens, **kwargs)
+
+
+def _detect_repetition_trigger(tokens: list[int], **kwargs) -> str | None:
+    detector = getattr(scheduler, "_detect_repetition_trigger", None)
+    assert callable(detector), "scheduler must expose _detect_repetition_trigger"
+    return detector(tokens, **kwargs)
+
+
+def _resolve_repetition_detection_config(policy: str | None):
+    resolver = getattr(scheduler, "_resolve_repetition_detection_config", None)
+    assert callable(resolver), (
+        "scheduler must expose _resolve_repetition_detection_config"
+    )
+    return resolver(policy)
+
+
+class TestDetectRepetition:
+    def test_repetition_detector_flags_single_token_tail(self):
+        tokens = [101, 202, 303, 0, 0, 0, 0, 0, 0, 0, 0]
+        assert _detect_repetition(tokens) is True
+
+    def test_repetition_detector_flags_short_pattern_tail(self):
+        tokens = [101, 202, 303] + [7, 8] * 6
+        assert _detect_repetition(tokens) is True
+
+    def test_repetition_detector_ignores_varied_tokens(self):
+        assert _detect_repetition(list(range(32))) is False
+
+    def test_strict_policy_thresholds_trigger_earlier(self):
+        min_repeat, pattern_lengths, pattern_repeats = (
+            _resolve_repetition_detection_config("strict")
+        )
+
+        assert min_repeat == 4
+        assert pattern_lengths == (2, 3, 4, 5, 6)
+        assert pattern_repeats == 4
+        assert (
+            _detect_repetition_trigger(
+                [9, 9, 9, 9],
+                min_repeat=min_repeat,
+                pattern_lengths=pattern_lengths,
+                pattern_repeats=pattern_repeats,
+            )
+            == "single_token_run"
+        )
+
+    def test_safe_policy_avoids_early_trigger(self):
+        min_repeat, pattern_lengths, pattern_repeats = (
+            _resolve_repetition_detection_config("safe")
+        )
+
+        assert min_repeat == 8
+        assert pattern_lengths == (2, 3, 4)
+        assert pattern_repeats == 6
+        assert (
+            _detect_repetition_trigger(
+                [9, 9, 9, 9],
+                min_repeat=min_repeat,
+                pattern_lengths=pattern_lengths,
+                pattern_repeats=pattern_repeats,
+            )
+            is None
+        )

--- a/tests/test_repetition_detector.py
+++ b/tests/test_repetition_detector.py
@@ -24,6 +24,44 @@ def _resolve_repetition_detection_config(policy: str | None):
     return resolver(policy)
 
 
+def _resolve_repetition_detection_runtime(policy: str | None):
+    resolver = getattr(scheduler, "_resolve_repetition_detection_runtime", None)
+    assert callable(resolver), (
+        "scheduler must expose _resolve_repetition_detection_runtime"
+    )
+    return resolver(policy)
+
+
+class FakeGenerationResponse:
+    def __init__(self, uid: int, token: int, finish_reason: str | None = None):
+        self.uid = uid
+        self.token = token
+        self.logprobs = None
+        self.finish_reason = finish_reason
+        self.prompt_cache = None
+        self.all_tokens = None
+
+
+class FakeBatchGenerator:
+    def __init__(self, tokens: list[int]):
+        self.tokens = tokens
+        self.index = 0
+        self.remove_calls: list[tuple[list[int], bool]] = []
+
+    def next(self):
+        if self.index >= len(self.tokens):
+            return [], []
+        token = self.tokens[self.index]
+        self.index += 1
+        return [], [FakeGenerationResponse(uid=7, token=token)]
+
+    def remove(self, uids_to_remove, return_prompt_caches=False):
+        self.remove_calls.append((list(uids_to_remove), return_prompt_caches))
+        if return_prompt_caches:
+            return {7: ("cache-7", [101, *self.tokens[: self.index]])}
+        return None
+
+
 class TestDetectRepetition:
     def test_repetition_detector_flags_single_token_tail(self):
         tokens = [101, 202, 303, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -71,3 +109,40 @@ class TestDetectRepetition:
             )
             is None
         )
+
+    def test_repetition_policy_normalization_is_case_insensitive(self):
+        normalizer = getattr(scheduler, "_normalize_repetition_policy", None)
+        assert callable(normalizer), "scheduler must expose _normalize_repetition_policy"
+
+        assert normalizer("SAFE") == "safe"
+        assert normalizer("Strict") == "strict"
+
+    def test_repetition_runtime_buffer_cap_matches_active_policy(self):
+        runtime_config = _resolve_repetition_detection_runtime("strict")
+
+        required_history = max(
+            runtime_config.min_repeat,
+            max(runtime_config.pattern_lengths) * runtime_config.pattern_repeats,
+        )
+        assert runtime_config.buffer_token_limit == required_history + 8
+
+    def test_default_batch_generator_wrapper_stops_and_cleans_repetition(self):
+        installer = getattr(scheduler, "_install_repetition_detection", None)
+        assert callable(installer), "scheduler must expose _install_repetition_detection"
+
+        batch_gen = FakeBatchGenerator([9, 9, 9, 9, 9])
+        installer(batch_gen, default_repetition_policy="strict")
+
+        for _ in range(3):
+            _, responses = batch_gen.next()
+            assert responses[0].finish_reason is None
+
+        _, responses = batch_gen.next()
+        stopped_response = responses[0]
+        assert stopped_response.finish_reason == "stop"
+        assert stopped_response.prompt_cache == "cache-7"
+        assert stopped_response.all_tokens == [101, 9, 9, 9, 9]
+        assert batch_gen.remove_calls == [([7], True)]
+
+        _, responses = batch_gen.next()
+        assert responses[0].finish_reason is None

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -12,6 +12,77 @@ import pytest
 pytestmark = pytest.mark.anyio
 
 
+class TestSimpleEngineRepetitionPolicy:
+    async def test_llm_chat_does_not_leak_repetition_policy_to_model_call(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        model = MagicMock()
+        model.tokenizer = MagicMock()
+        model.tokenizer.apply_chat_template = MagicMock(return_value=[101, 102])
+
+        def strict_chat(
+            *,
+            messages,
+            max_tokens,
+            temperature,
+            top_p,
+            tools,
+            chat_template_kwargs,
+        ):
+            del messages, max_tokens, temperature, top_p, tools, chat_template_kwargs
+            return MagicMock(text="ok", tokens=[1], finish_reason="stop")
+
+        model.chat = MagicMock(side_effect=strict_chat)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-llm")
+            engine._model = model
+            engine._loaded = True
+
+            result = await engine.chat(
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=8,
+                repetition_policy="strict",
+            )
+
+        _, chat_kwargs = model.chat.call_args
+        assert "repetition_policy" not in chat_kwargs
+        assert result.text == "ok"
+
+    async def test_llm_generate_does_not_leak_repetition_policy_to_stream_call(self):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        model = MagicMock()
+        model.tokenizer = MagicMock()
+        model.tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+
+        def strict_stream_generate(*, prompt, max_tokens, temperature, top_p, stop):
+            del prompt, max_tokens, temperature, top_p, stop
+            chunk = MagicMock()
+            chunk.text = "ok"
+            chunk.finished = True
+            chunk.finish_reason = "stop"
+            chunk.prompt_tokens = 3
+            yield chunk
+
+        model.stream_generate = MagicMock(side_effect=strict_stream_generate)
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-llm")
+            engine._model = model
+            engine._loaded = True
+
+            result = await engine.generate(
+                prompt="ping",
+                max_tokens=8,
+                repetition_policy="safe",
+            )
+
+        _, stream_kwargs = model.stream_generate.call_args
+        assert "repetition_policy" not in stream_kwargs
+        assert result.text == "ok"
+
+
 class TestSimpleEngineConcurrency:
     """Test SimpleEngine lock behavior with concurrent requests."""
 

--- a/tests/test_validation_tooling.py
+++ b/tests/test_validation_tooling.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for public validation helper scripts."""
+
+import json
+
+import requests
+
+from scripts import prefix_reuse_harness, serve_profile_benchmark
+
+
+def test_serve_profile_benchmark_records_request_failure(monkeypatch):
+    def raise_timeout(*args, **kwargs):
+        raise requests.Timeout("deadline exceeded")
+
+    monkeypatch.setattr(serve_profile_benchmark.requests, "post", raise_timeout)
+
+    result = serve_profile_benchmark._call_chat(
+        base_url="http://127.0.0.1:8000",
+        model="local-model",
+        prompt="hello",
+        max_tokens=8,
+        temperature=0.0,
+        top_p=1.0,
+        timeout=0.1,
+    )
+
+    assert result["ok"] is False
+    assert "deadline exceeded" in result["error"]
+    assert result["prompt"] == "hello"
+    assert result["prompt_tokens"] == 0
+    assert result["completion_tokens"] == 0
+    assert result["total_tokens"] == 0
+
+
+def test_serve_profile_benchmark_reports_failure_rate():
+    summarizer = getattr(serve_profile_benchmark, "_summarize_result_status", None)
+    assert callable(summarizer), (
+        "serve_profile_benchmark must expose _summarize_result_status"
+    )
+
+    status = summarizer([{"ok": True}, {"ok": False}, {"error": "missing ok"}])
+
+    assert status == {
+        "successful_requests": 1,
+        "failed_requests": 2,
+        "failure_rate": 0.6667,
+    }
+
+
+def test_prefix_reuse_harness_loads_all_suffixes(tmp_path):
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "shared_prefix": "Shared context",
+                "suffixes": [
+                    {"label": "one", "prompt": "First"},
+                    {"label": "two", "prompt": "Second"},
+                    {"label": "three", "prompt": "Third"},
+                    {"label": "four", "prompt": "Fourth"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fixture = prefix_reuse_harness._load_fixture(str(fixture_path))
+
+    assert [item["label"] for item in fixture["suffixes"]] == [
+        "one",
+        "two",
+        "three",
+        "four",
+    ]

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -775,6 +775,7 @@ class BatchedEngine(BaseEngine):
             min_p=kwargs.pop("min_p", 0.0),
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+            repetition_policy=kwargs.pop("repetition_policy", None),
             stop=stop or [],
             logits_processors=kwargs.pop("logits_processors", None),
         )
@@ -865,6 +866,7 @@ class BatchedEngine(BaseEngine):
             min_p=kwargs.pop("min_p", 0.0),
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
+            repetition_policy=kwargs.pop("repetition_policy", None),
             stop=stop or [],
             logits_processors=kwargs.pop("logits_processors", None),
         )

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -510,6 +510,7 @@ class SimpleEngine(BaseEngine):
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
+        kwargs.pop("repetition_policy", None)
 
         # SpecPrefill for non-MLLM models (MLLM+MTP handles it in _stream_generate_text)
         if not self._is_mllm and self._draft_model is not None:
@@ -647,6 +648,7 @@ class SimpleEngine(BaseEngine):
             await self.start()
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        kwargs.pop("repetition_policy", None)
 
         async def aggregate_stream_chat() -> GenerationOutput:
             final_output = GenerationOutput(text="")

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -59,6 +59,7 @@ class SamplingParams:
     min_p: float = 0.0
     presence_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    repetition_policy: Optional[str] = None
     stop: Optional[List[str]] = None
     stop_token_ids: Optional[List[int]] = None
     # Extra per-request logits processors (e.g. JSON schema constrained

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -42,6 +42,73 @@ CACHE_CORRUPTION_PATTERNS = [
 ]
 
 
+_REPETITION_SAFE_MODE = "safe"
+_REPETITION_STRICT_MODE = "strict"
+_REPETITION_SUPPORTED_MODES = (_REPETITION_SAFE_MODE, _REPETITION_STRICT_MODE)
+
+
+def _normalize_repetition_policy(policy: str | None) -> str:
+    """Normalize repetition detector policy with a conservative default."""
+    if isinstance(policy, str) and policy in _REPETITION_SUPPORTED_MODES:
+        return policy
+    return _REPETITION_SAFE_MODE
+
+
+def _resolve_repetition_detection_config(
+    policy: str | None,
+) -> tuple[int, tuple[int, ...], int]:
+    """Resolve detector thresholds for the selected repetition policy."""
+    mode = _normalize_repetition_policy(policy)
+    if mode == _REPETITION_STRICT_MODE:
+        return 4, (2, 3, 4, 5, 6), 4
+    return 8, (2, 3, 4), 6
+
+
+def _detect_repetition_trigger(
+    recent_tokens: list[int],
+    *,
+    min_repeat: int = 8,
+    pattern_lengths: tuple[int, ...] = (2, 3, 4),
+    pattern_repeats: int = 6,
+) -> str | None:
+    """Return a trigger label when recent tokens are degenerately repetitive."""
+    if len(recent_tokens) < min_repeat:
+        return None
+
+    tail = recent_tokens[-min_repeat:]
+    if len(set(tail)) == 1:
+        return "single_token_run"
+
+    for seq_len in pattern_lengths:
+        check_len = seq_len * pattern_repeats
+        if len(recent_tokens) < check_len:
+            continue
+        tail = recent_tokens[-check_len:]
+        pattern = tail[:seq_len]
+        if all(tail[i] == pattern[i % seq_len] for i in range(check_len)):
+            return f"pattern_loop_len_{seq_len}"
+
+    return None
+
+
+def _detect_repetition(
+    recent_tokens: list[int],
+    min_repeat: int = 8,
+    pattern_lengths: tuple[int, ...] = (2, 3, 4),
+    pattern_repeats: int = 6,
+) -> bool:
+    """Compatibility wrapper returning boolean repetition detection."""
+    return (
+        _detect_repetition_trigger(
+            recent_tokens,
+            min_repeat=min_repeat,
+            pattern_lengths=pattern_lengths,
+            pattern_repeats=pattern_repeats,
+        )
+        is not None
+    )
+
+
 class SchedulingPolicy(Enum):
     """Scheduling policy for request ordering."""
 
@@ -111,10 +178,12 @@ class SchedulerConfig:
     enable_mtp: bool = False
     mtp_num_draft_tokens: int = 1  # Number of draft tokens from MTP head
     mtp_optimistic: bool = False  # Skip acceptance check for max speed
+    repetition_policy: str = _REPETITION_SAFE_MODE
 
     def __post_init__(self) -> None:
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
             raise ValueError("mllm_prefill_step_size must be > 0 when provided")
+        self.repetition_policy = _normalize_repetition_policy(self.repetition_policy)
 
 
 @dataclass
@@ -172,6 +241,7 @@ def _install_chunked_prefill(
     pending_abort_ids: Optional[Set[str]] = None,
     uid_to_request_id: Optional[Dict[int, str]] = None,
     requests: Optional[Dict[str, Any]] = None,
+    default_repetition_policy: str = _REPETITION_SAFE_MODE,
 ) -> None:
     """
     Monkey-patch a BatchGenerator instance so that large prefills are
@@ -257,6 +327,9 @@ def _install_chunked_prefill(
     # Partial prefill state (None when no prefill in progress)
     batch_gen._partial = None
 
+    # Repetition detection: track recent generated tokens per UID.
+    _repetition_buffers: Dict[int, list[int]] = {}
+
     # Monkey-patch _process_prompts to capture prompt-only cache state.
     # At the point where _process_prompts returns, the Batch cache contains
     # the exact prompt-only state: all prompt tokens have been processed
@@ -312,17 +385,61 @@ def _install_chunked_prefill(
             cache_out = None
             num_tok += 1
             batch.num_tokens[e] = num_tok
+
+            buf = _repetition_buffers.get(uid)
+            if buf is None:
+                buf = []
+                _repetition_buffers[uid] = buf
+            buf.append(t)
+            if len(buf) > 32:
+                del buf[: len(buf) - 32]
+
+            effective_repetition_policy = _normalize_repetition_policy(
+                default_repetition_policy
+            )
+            if requests is not None and uid_to_request_id is not None:
+                request_id = uid_to_request_id.get(uid)
+                request = requests.get(request_id) if request_id else None
+                sampling_params = getattr(request, "sampling_params", None)
+                request_policy = getattr(sampling_params, "repetition_policy", None)
+                if request_policy:
+                    effective_repetition_policy = _normalize_repetition_policy(
+                        request_policy
+                    )
+
+            min_repeat, pattern_lengths, pattern_repeats = (
+                _resolve_repetition_detection_config(effective_repetition_policy)
+            )
+            repetition_trigger = _detect_repetition_trigger(
+                buf,
+                min_repeat=min_repeat,
+                pattern_lengths=pattern_lengths,
+                pattern_repeats=pattern_repeats,
+            )
+
             if t in self.stop_tokens:
                 finish_reason = "stop"
                 end_idx.append(e)
             elif num_tok >= max_tok:
                 finish_reason = "length"
                 end_idx.append(e)
+            elif repetition_trigger is not None:
+                finish_reason = "stop"
+                end_idx.append(e)
+                logger.info(
+                    "[repetition_detector] uid=%s stopped after %s tokens "
+                    "(mode=%s trigger=%s)",
+                    uid,
+                    num_tok,
+                    effective_repetition_policy,
+                    repetition_trigger,
+                )
             else:
                 finish_reason = None
                 keep_idx.append(e)
             if finish_reason is not None:
                 cache_out = batch.extract_cache(e)
+                _repetition_buffers.pop(uid, None)
             responses.append(
                 self.Response(uid, t, logprobs[e], finish_reason, cache_out)
             )
@@ -665,6 +782,8 @@ def _install_chunked_prefill(
                 )
                 _self._partial = None
                 mx.clear_cache()  # flush Metal encoders after dropping partial state
+        for uid in uids_to_remove:
+            _repetition_buffers.pop(uid, None)
         _orig_remove(uids_to_remove)
 
     batch_gen._next = _chunked_next
@@ -1365,6 +1484,7 @@ class Scheduler:
                 pending_abort_ids=self._pending_abort_ids,
                 uid_to_request_id=self.uid_to_request_id,
                 requests=self.requests,
+                default_repetition_policy=self.config.repetition_policy,
             )
         elif need_chunked and not chunked_compatible:
             logger.warning(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -45,12 +45,24 @@ CACHE_CORRUPTION_PATTERNS = [
 _REPETITION_SAFE_MODE = "safe"
 _REPETITION_STRICT_MODE = "strict"
 _REPETITION_SUPPORTED_MODES = (_REPETITION_SAFE_MODE, _REPETITION_STRICT_MODE)
+_REPETITION_BUFFER_MARGIN = 8
+
+
+@dataclass(frozen=True)
+class _RepetitionDetectionRuntimeConfig:
+    mode: str
+    min_repeat: int
+    pattern_lengths: tuple[int, ...]
+    pattern_repeats: int
+    buffer_token_limit: int
 
 
 def _normalize_repetition_policy(policy: str | None) -> str:
     """Normalize repetition detector policy with a conservative default."""
-    if isinstance(policy, str) and policy in _REPETITION_SUPPORTED_MODES:
-        return policy
+    if isinstance(policy, str):
+        mode = policy.strip().lower()
+        if mode in _REPETITION_SUPPORTED_MODES:
+            return mode
     return _REPETITION_SAFE_MODE
 
 
@@ -62,6 +74,46 @@ def _resolve_repetition_detection_config(
     if mode == _REPETITION_STRICT_MODE:
         return 4, (2, 3, 4, 5, 6), 4
     return 8, (2, 3, 4), 6
+
+
+def _resolve_repetition_detection_runtime(
+    policy: str | None,
+) -> _RepetitionDetectionRuntimeConfig:
+    """Resolve repetition thresholds plus the required token history limit."""
+    mode = _normalize_repetition_policy(policy)
+    min_repeat, pattern_lengths, pattern_repeats = (
+        _resolve_repetition_detection_config(mode)
+    )
+    required_history = max(
+        min_repeat,
+        max(seq_len * pattern_repeats for seq_len in pattern_lengths),
+    )
+    return _RepetitionDetectionRuntimeConfig(
+        mode=mode,
+        min_repeat=min_repeat,
+        pattern_lengths=pattern_lengths,
+        pattern_repeats=pattern_repeats,
+        buffer_token_limit=required_history + _REPETITION_BUFFER_MARGIN,
+    )
+
+
+def _resolve_repetition_runtime_for_uid(
+    uid: int,
+    *,
+    uid_to_request_id: Optional[Dict[int, str]] = None,
+    requests: Optional[Dict[str, Any]] = None,
+    default_repetition_policy: str = _REPETITION_SAFE_MODE,
+) -> _RepetitionDetectionRuntimeConfig:
+    """Resolve the effective repetition runtime config for one request uid."""
+    effective_repetition_policy = default_repetition_policy
+    if requests is not None and uid_to_request_id is not None:
+        request_id = uid_to_request_id.get(uid)
+        request = requests.get(request_id) if request_id else None
+        sampling_params = getattr(request, "sampling_params", None)
+        request_policy = getattr(sampling_params, "repetition_policy", None)
+        if request_policy:
+            effective_repetition_policy = request_policy
+    return _resolve_repetition_detection_runtime(effective_repetition_policy)
 
 
 def _detect_repetition_trigger(
@@ -107,6 +159,112 @@ def _detect_repetition(
         )
         is not None
     )
+
+
+def _install_repetition_detection(
+    batch_gen: "BatchGenerator",
+    *,
+    uid_to_request_id: Optional[Dict[int, str]] = None,
+    requests: Optional[Dict[str, Any]] = None,
+    default_repetition_policy: str = _REPETITION_SAFE_MODE,
+) -> None:
+    """Monkey-patch public BatchGenerator.next() with repetition safety stops."""
+    if getattr(batch_gen, "_vllm_mlx_repetition_detection_installed", False):
+        return
+
+    _orig_next = batch_gen.next
+    _orig_remove = batch_gen.remove
+    _repetition_buffers: Dict[int, list[int]] = {}
+    _runtime_configs: Dict[int, _RepetitionDetectionRuntimeConfig] = {}
+
+    def _cleanup_uid(uid: int) -> None:
+        _repetition_buffers.pop(uid, None)
+        _runtime_configs.pop(uid, None)
+
+    def _runtime_config_for_uid(uid: int) -> _RepetitionDetectionRuntimeConfig:
+        runtime_config = _runtime_configs.get(uid)
+        if runtime_config is None:
+            runtime_config = _resolve_repetition_runtime_for_uid(
+                uid,
+                uid_to_request_id=uid_to_request_id,
+                requests=requests,
+                default_repetition_policy=default_repetition_policy,
+            )
+            _runtime_configs[uid] = runtime_config
+        return runtime_config
+
+    def _remove_stopped_uids(uids: list[int]):
+        try:
+            return _orig_remove(uids, return_prompt_caches=True) or {}
+        except TypeError:
+            _orig_remove(uids)
+            return {}
+
+    def _patched_remove(uids_to_remove, *args, **kwargs):
+        for uid in uids_to_remove:
+            _cleanup_uid(uid)
+        return _orig_remove(uids_to_remove, *args, **kwargs)
+
+    def _patched_next():
+        result = _orig_next()
+        generation_responses = result[1] if isinstance(result, tuple) else result
+        if not generation_responses:
+            return result
+
+        stopped_responses = {}
+        for response in generation_responses:
+            uid = getattr(response, "uid", None)
+            token = getattr(response, "token", None)
+            if uid is None or token is None:
+                continue
+
+            if getattr(response, "finish_reason", None) is not None:
+                _cleanup_uid(uid)
+                continue
+
+            runtime_config = _runtime_config_for_uid(uid)
+            buf = _repetition_buffers.get(uid)
+            if buf is None:
+                buf = []
+                _repetition_buffers[uid] = buf
+            buf.append(token)
+            if len(buf) > runtime_config.buffer_token_limit:
+                del buf[: len(buf) - runtime_config.buffer_token_limit]
+
+            repetition_trigger = _detect_repetition_trigger(
+                buf,
+                min_repeat=runtime_config.min_repeat,
+                pattern_lengths=runtime_config.pattern_lengths,
+                pattern_repeats=runtime_config.pattern_repeats,
+            )
+            if repetition_trigger is None:
+                continue
+
+            response.finish_reason = "stop"
+            stopped_responses[uid] = response
+            logger.info(
+                "[repetition_detector] uid=%s stopped (mode=%s trigger=%s)",
+                uid,
+                runtime_config.mode,
+                repetition_trigger,
+            )
+
+        if stopped_responses:
+            prompt_caches = _remove_stopped_uids(list(stopped_responses))
+            for uid, response in stopped_responses.items():
+                _cleanup_uid(uid)
+                cache_entry = prompt_caches.get(uid)
+                if isinstance(cache_entry, tuple) and len(cache_entry) == 2:
+                    response.prompt_cache = cache_entry[0]
+                    response.all_tokens = cache_entry[1]
+                elif cache_entry is not None:
+                    response.prompt_cache = cache_entry
+
+        return result
+
+    batch_gen.next = _patched_next
+    batch_gen.remove = _patched_remove
+    batch_gen._vllm_mlx_repetition_detection_installed = True
 
 
 class SchedulingPolicy(Enum):
@@ -329,6 +487,7 @@ def _install_chunked_prefill(
 
     # Repetition detection: track recent generated tokens per UID.
     _repetition_buffers: Dict[int, list[int]] = {}
+    _repetition_runtime_configs: Dict[int, _RepetitionDetectionRuntimeConfig] = {}
 
     # Monkey-patch _process_prompts to capture prompt-only cache state.
     # At the point where _process_prompts returns, the Batch cache contains
@@ -391,30 +550,23 @@ def _install_chunked_prefill(
                 buf = []
                 _repetition_buffers[uid] = buf
             buf.append(t)
-            if len(buf) > 32:
-                del buf[: len(buf) - 32]
+            runtime_config = _repetition_runtime_configs.get(uid)
+            if runtime_config is None:
+                runtime_config = _resolve_repetition_runtime_for_uid(
+                    uid,
+                    uid_to_request_id=uid_to_request_id,
+                    requests=requests,
+                    default_repetition_policy=default_repetition_policy,
+                )
+                _repetition_runtime_configs[uid] = runtime_config
+            if len(buf) > runtime_config.buffer_token_limit:
+                del buf[: len(buf) - runtime_config.buffer_token_limit]
 
-            effective_repetition_policy = _normalize_repetition_policy(
-                default_repetition_policy
-            )
-            if requests is not None and uid_to_request_id is not None:
-                request_id = uid_to_request_id.get(uid)
-                request = requests.get(request_id) if request_id else None
-                sampling_params = getattr(request, "sampling_params", None)
-                request_policy = getattr(sampling_params, "repetition_policy", None)
-                if request_policy:
-                    effective_repetition_policy = _normalize_repetition_policy(
-                        request_policy
-                    )
-
-            min_repeat, pattern_lengths, pattern_repeats = (
-                _resolve_repetition_detection_config(effective_repetition_policy)
-            )
             repetition_trigger = _detect_repetition_trigger(
                 buf,
-                min_repeat=min_repeat,
-                pattern_lengths=pattern_lengths,
-                pattern_repeats=pattern_repeats,
+                min_repeat=runtime_config.min_repeat,
+                pattern_lengths=runtime_config.pattern_lengths,
+                pattern_repeats=runtime_config.pattern_repeats,
             )
 
             if t in self.stop_tokens:
@@ -431,7 +583,7 @@ def _install_chunked_prefill(
                     "(mode=%s trigger=%s)",
                     uid,
                     num_tok,
-                    effective_repetition_policy,
+                    runtime_config.mode,
                     repetition_trigger,
                 )
             else:
@@ -440,6 +592,7 @@ def _install_chunked_prefill(
             if finish_reason is not None:
                 cache_out = batch.extract_cache(e)
                 _repetition_buffers.pop(uid, None)
+                _repetition_runtime_configs.pop(uid, None)
             responses.append(
                 self.Response(uid, t, logprobs[e], finish_reason, cache_out)
             )
@@ -784,7 +937,8 @@ def _install_chunked_prefill(
                 mx.clear_cache()  # flush Metal encoders after dropping partial state
         for uid in uids_to_remove:
             _repetition_buffers.pop(uid, None)
-        _orig_remove(uids_to_remove)
+            _repetition_runtime_configs.pop(uid, None)
+        return _orig_remove(uids_to_remove)
 
     batch_gen._next = _chunked_next
     batch_gen._generation_step = _generation_step
@@ -1515,6 +1669,14 @@ class Scheduler:
                     "[MTP] --enable-mtp is set but model has no MTP head "
                     "(model.mtp is None). MTP will be disabled."
                 )
+
+        if not (need_chunked and chunked_compatible):
+            _install_repetition_detection(
+                bg,
+                uid_to_request_id=self.uid_to_request_id,
+                requests=self.requests,
+                default_repetition_policy=self.config.repetition_policy,
+            )
 
         return bg
 


### PR DESCRIPTION
## Summary
- Rebuilds the fork overlay on current `upstream/main` with four focused commits.
- Restores runtime output-safety guards, including repetition detection for default and chunked batched generation paths.
- Adds public runtime validation tooling and conservative public docs for local serve/client profiles.
- Applies review fixes for repetition guard coverage, detector config sizing, benchmark failure reporting, and prefix harness suffix handling.

## Test Plan
- `./.venv/bin/python -m py_compile vllm_mlx/scheduler.py scripts/serve_profile_benchmark.py scripts/prefix_reuse_harness.py`
- `./.venv/bin/pytest tests/test_repetition_detector.py tests/test_validation_tooling.py -q`
- `./.venv/bin/pytest tests/test_repetition_detector.py tests/test_validation_tooling.py tests/test_batching.py tests/test_server.py -q`
- `./.venv/bin/pytest tests/test_metrics.py -q`
- `./.venv/bin/pytest -q`
- `git diff --check`
