### PR TITLE
fix(engine): pin MLX load + inference to one worker thread (fixes gpt-oss-120b crash)

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1152,11 +1152,16 @@ class TestSimpleEngineConcurrency:
     async def test_mllm_nonstream_text_only_without_text_model_keeps_stream_thread_owner(
         self,
     ):
-        """MLLM text-only non-stream path must keep stream_chat on model thread.
+        """MLLM text-only non-stream path must keep stream_chat on the same
+        thread as model construction (the SimpleEngine MLX worker).
 
-        Regression: aggregate_stream_chat -> stream_chat used _run_blocking_serialized,
-        which moved mlx_vlm stream generation to a worker thread and could raise
-        "There is no Stream(gpu, N) in current thread".
+        Regression: aggregate_stream_chat -> stream_chat used
+        _run_blocking_serialized, which moved mlx_vlm stream generation to
+        a different worker thread per call and could raise "There is no
+        Stream(gpu, N) in current thread". Now both load and inference are
+        pinned to ``self._mlx_executor`` (a single-thread executor), so the
+        model's "owner thread" is the executor thread and stream_chat must
+        run on that same thread.
         """
         from types import SimpleNamespace
 
@@ -1164,7 +1169,12 @@ class TestSimpleEngineConcurrency:
 
         class FakeMllmModel:
             def __init__(self):
+                # Captured on whichever thread SimpleEngine constructs us,
+                # which under the executor-pinning fix is the MLX worker.
                 self._owner_thread = threading.get_ident()
+
+            def load(self):
+                pass  # SimpleEngine.prepare_for_start calls this; no-op here
 
             def stream_chat(self, **kwargs):
                 if threading.get_ident() != self._owner_thread:
@@ -1175,15 +1185,23 @@ class TestSimpleEngineConcurrency:
                     prompt_tokens=3,
                 )
 
-        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
-        engine._loaded = True
-        engine._text_model = None
-        engine._model = FakeMllmModel()
+        # Patch the MLLM model class so SimpleEngine constructs FakeMllmModel
+        # via prepare_for_start on the MLX worker thread (matching prod load
+        # behavior), then the same executor runs stream_chat — single-thread
+        # invariant holds.
+        with patch(
+            "vllm_mlx.models.mllm.MLXMultimodalLM",
+            lambda *a, **k: FakeMllmModel(),
+        ):
+            engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
+            engine.prepare_for_start()  # constructs FakeMllmModel on MLX worker
+            engine._loaded = True
+            engine._text_model = None
 
-        output = await engine.chat(
-            messages=[{"role": "user", "content": "Count: one, two, three"}],
-            max_tokens=16,
-        )
+            output = await engine.chat(
+                messages=[{"role": "user", "content": "Count: one, two, three"}],
+                max_tokens=16,
+            )
 
         assert output.text == "one, two, three"
         assert output.finish_reason == "stop"

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -460,15 +460,23 @@ class SimpleEngine(BaseEngine):
         Mirrors the threading constraint enforced by ``prepare_for_start``:
         the model was loaded on the MLX worker, so iteration must happen on
         the same worker for MLX thread-local stream ownership to hold.
+
+        Cancellation: the consumer sets ``cancel_event`` in its ``finally``
+        block. The producer checks the event between chunks and breaks out
+        early so a disconnected client doesn't keep the single-threaded
+        ``_mlx_executor`` busy generating tokens nothing will consume.
         """
         import queue as _queue
 
         q: _queue.Queue = _queue.Queue()  # unbounded; max_tokens caps memory
+        cancel_event = threading.Event()
 
         def producer():
             try:
                 _bind_worker_generation_streams()
                 for chunk in factory():
+                    if cancel_event.is_set():
+                        break
                     q.put(("c", chunk))
             except BaseException as exc:
                 q.put(("e", exc))
@@ -486,8 +494,13 @@ class SimpleEngine(BaseEngine):
                     raise payload
                 yield payload
         finally:
-            # If the consumer broke early, the producer keeps pushing to an
-            # unbounded queue; it will exit on its own when the model
+            # Signal the producer to stop ASAP if the consumer is bailing
+            # (client disconnect, exception, or early break). Without this
+            # the producer continues generating tokens to completion on the
+            # single MLX worker thread and blocks all subsequent requests.
+            cancel_event.set()
+            # Producer will still emit the trailing ("d", None) sentinel after
+            # observing the cancel between chunks; no need to wait for fut.
             # iterator finishes or raises. No further action required here.
             if not fut.done():
                 pass
@@ -509,9 +522,10 @@ class SimpleEngine(BaseEngine):
             # asyncio.to_thread uses the default thread pool, landing on a
             # different worker per call and breaking model-parameter stream
             # affinity for models that touch the GPU during __init__.
+            # loop.run_in_executor already returns an asyncio.Future, so
+            # asyncio.shield/ensure_future work on it directly.
             loop = asyncio.get_running_loop()
-            future = loop.run_in_executor(self._mlx_executor, run_bound)
-            task = asyncio.ensure_future(asyncio.wrap_future(future))
+            task = loop.run_in_executor(self._mlx_executor, run_bound)
             try:
                 return await asyncio.shield(task)
             except asyncio.CancelledError:

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -498,12 +498,10 @@ class SimpleEngine(BaseEngine):
             # (client disconnect, exception, or early break). Without this
             # the producer continues generating tokens to completion on the
             # single MLX worker thread and blocks all subsequent requests.
+            # The producer still emits the trailing ("d", None) sentinel
+            # after observing the cancel between chunks; no need to wait
+            # on the future explicitly.
             cancel_event.set()
-            # Producer will still emit the trailing ("d", None) sentinel after
-            # observing the cancel between chunks; no need to wait for fut.
-            # iterator finishes or raises. No further action required here.
-            if not fut.done():
-                pass
 
     async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
         """Run a blocking MLX operation under the generation lock.

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -932,20 +932,25 @@ class SimpleEngine(BaseEngine):
             accumulated_text = ""
             token_count = 0
 
-            # Text-only fallback when no TextModel exists: keep execution on the
-            # current thread. Routing through to_thread can break mlx_vlm stream
-            # ownership on some models (Stream(gpu, N) mismatch).
+            # Text-only fallback when no TextModel exists: drive the sync
+            # iterator on the engine's dedicated MLX worker (same thread as
+            # load()), bridging chunks back via _stream_in_mlx_executor.
+            # mlx_vlm.stream_generate has the same Stream(gpu, N) thread-affinity
+            # bug as mlx_lm.stream_generate when run on a different thread than
+            # load() — see vllm-mlx PR #556 for the equivalent text-LLM fix.
             if self._text_model is None and not has_media_content(messages):
                 local_kwargs = mllm_call_kwargs()
 
                 async with self._generation_lock:
-                    _bind_worker_generation_streams()
-                    for chunk in self._model.stream_chat(
+                    stream_chat_kwargs = dict(
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
                         tools=template_tools,
                         **local_kwargs,
+                    )
+                    async for chunk in self._stream_in_mlx_executor(
+                        lambda: self._model.stream_chat(**stream_chat_kwargs)
                     ):
                         token_count += 1
                         new_text = chunk.text if hasattr(chunk, "text") else str(chunk)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -13,6 +13,7 @@ import os
 import threading
 import time
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import mlx.core as mx
@@ -196,6 +197,19 @@ class SimpleEngine(BaseEngine):
         # restore would silently desynchronize. Probed once in ``start()``.
         self._supports_system_kv_cache: bool = False
 
+        # MLX streams are thread-local. Some models (gpt-oss-120b's
+        # QuantizedSwitchLinear) touch the GPU during nn.Module __init__,
+        # which binds the model parameter arrays to the loading thread's
+        # stream. Routing inference through asyncio's default executor or
+        # asyncio.to_thread (a different thread per call) breaks those
+        # arrays. Owning ONE worker thread for the lifetime of the engine,
+        # and pinning load + every inference call to it, keeps the model's
+        # stream namespace consistent.
+        self._mlx_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mlx-worker"
+        )
+        self._mlx_thread_id: int | None = None
+
     @property
     def model_name(self) -> str:
         """Get the model name."""
@@ -216,10 +230,35 @@ class SimpleEngine(BaseEngine):
         return self._model.tokenizer
 
     def prepare_for_start(self) -> None:
-        """Load the backing model off the serving event loop."""
+        """Load the backing model on the engine's dedicated MLX worker thread.
+
+        Routes through self._mlx_executor regardless of which thread the
+        caller is on. Necessary because models that touch the GPU during
+        nn.Module __init__ (e.g. gpt-oss-120b's QuantizedSwitchLinear) bind
+        their parameter mx.array objects to the loading thread's stream.
+        Subsequent inference must run on the SAME thread to share that
+        stream namespace.
+
+        Callable from any thread; blocks the caller until load completes.
+        """
         if self._model is not None:
             return
+        if threading.get_ident() == self._mlx_thread_id:
+            # Already on the MLX worker (re-entry from inference path).
+            self._do_prepare_for_start()
+        else:
+            fut = self._mlx_executor.submit(self._mlx_marked_prepare)
+            fut.result()
 
+    def _mlx_marked_prepare(self) -> None:
+        """Record the MLX worker thread id, then run the real load."""
+        self._mlx_thread_id = threading.get_ident()
+        self._do_prepare_for_start()
+
+    def _do_prepare_for_start(self) -> None:
+        """Actual model construction + weight load. Runs on the MLX worker."""
+        if self._model is not None:
+            return
         if self._is_mllm:
             from ..models.mllm import MLXMultimodalLM
 
@@ -397,6 +436,15 @@ class SimpleEngine(BaseEngine):
         self._system_kv_hash = None
         self._system_kv_token_count = 0
         self._supports_system_kv_cache = False
+        try:
+            self._mlx_executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            logger.debug("mlx executor shutdown failed", exc_info=True)
+        # Rebuild so a subsequent start() (e.g. in tests) gets a fresh worker.
+        self._mlx_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="mlx-worker"
+        )
+        self._mlx_thread_id = None
         logger.info("SimpleEngine stopped")
 
     def _should_route_text_through_text_model(
@@ -404,6 +452,45 @@ class SimpleEngine(BaseEngine):
     ) -> bool:
         """Return whether text-only MLLM requests may use mlx_lm TextModel."""
         return not (mllm_draft_requested and self._mllm_draft_model_path is not None)
+
+    async def _stream_in_mlx_executor(self, factory):
+        """Run a synchronous chunk iterator on the dedicated MLX worker thread,
+        bridging chunks back to the event loop via a thread-safe queue.
+
+        Mirrors the threading constraint enforced by ``prepare_for_start``:
+        the model was loaded on the MLX worker, so iteration must happen on
+        the same worker for MLX thread-local stream ownership to hold.
+        """
+        import queue as _queue
+
+        q: _queue.Queue = _queue.Queue()  # unbounded; max_tokens caps memory
+
+        def producer():
+            try:
+                _bind_worker_generation_streams()
+                for chunk in factory():
+                    q.put(("c", chunk))
+            except BaseException as exc:
+                q.put(("e", exc))
+            finally:
+                q.put(("d", None))
+
+        fut = self._mlx_executor.submit(producer)
+        loop = asyncio.get_running_loop()
+        try:
+            while True:
+                tag, payload = await loop.run_in_executor(None, q.get)
+                if tag == "d":
+                    return
+                if tag == "e":
+                    raise payload
+                yield payload
+        finally:
+            # If the consumer broke early, the producer keeps pushing to an
+            # unbounded queue; it will exit on its own when the model
+            # iterator finishes or raises. No further action required here.
+            if not fut.done():
+                pass
 
     async def _run_blocking_serialized(self, func, /, *args, on_cancel=None, **kwargs):
         """Run a blocking MLX operation under the generation lock.
@@ -418,7 +505,13 @@ class SimpleEngine(BaseEngine):
                 _bind_worker_generation_streams()
                 return func(*args, **kwargs)
 
-            task = asyncio.create_task(asyncio.to_thread(run_bound))
+            # Pin to the engine's dedicated MLX thread — see __init__.
+            # asyncio.to_thread uses the default thread pool, landing on a
+            # different worker per call and breaking model-parameter stream
+            # affinity for models that touch the GPU during __init__.
+            loop = asyncio.get_running_loop()
+            future = loop.run_in_executor(self._mlx_executor, run_bound)
+            task = asyncio.ensure_future(asyncio.wrap_future(future))
             try:
                 return await asyncio.shield(task)
             except asyncio.CancelledError:
@@ -577,23 +670,23 @@ class SimpleEngine(BaseEngine):
                     return
 
         async with self._generation_lock:
-            # Non-stream chat runs in a worker thread and rebinds generation
-            # streams there. Rebind again on the current thread before
-            # stream_generate so nonstream->stream mode switches remain valid.
-            _bind_worker_generation_streams()
-
             accumulated_text = ""
             prompt_tokens = 0
             completion_tokens = 0
             finished = False
 
-            for chunk in self._model.stream_generate(
+            # Drive the sync iterator on the engine's MLX worker thread (same
+            # thread as load()), bridging chunks back via _stream_in_mlx_executor.
+            stream_kwargs = dict(
                 prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
                 stop=stop,
                 **kwargs,
+            )
+            async for chunk in self._stream_in_mlx_executor(
+                lambda: self._model.stream_generate(**stream_kwargs)
             ):
                 prompt_tokens = (
                     chunk.prompt_tokens


### PR DESCRIPTION
## Summary

`vllm-mlx serve mlx-community/gpt-oss-120b-MXFP4-Q8` cannot generate a single token — every `POST /v1/chat/completions` returns 500 with `RuntimeError: There is no Stream(gpu, N) in current thread.` This PR gives `SimpleEngine` a dedicated single-thread MLX worker (`ThreadPoolExecutor(max_workers=1)`) and pins load, blocking inference, and streaming (both LLM and MLLM paths) to it. Load thread == inference thread == one MLX stream namespace, so models whose `nn.Module.__init__` touches the GPU (e.g. gpt-oss-120b's `QuantizedSwitchLinear`) no longer leave the model parameter arrays bound to a stream the inference worker can't reach.

Issue: #555 (root-cause walkthrough + reproducer).
Companion docs PR: #557 (M5 docs update, split out per review).

## Root cause (one paragraph)

`mlx_lm/models/switch_layers.py:QuantizedSwitchLinear.__init__` calls `mx.quantize(mx.random.uniform(shape=(num_experts, output_dims, input_dims)), mode="mxfp4")` before saved-weight load. That GPU op runs on whichever thread `MLXLanguageModel(...)` is constructed on — historically the event-loop thread — and promotes that thread's default stream so the model parameter `mx.array`s carry pending ops queued against it. `_run_blocking_serialized` then routes `model.chat` through `asyncio.to_thread`, landing on the default `ThreadPoolExecutor` (a different worker each call). `_bind_worker_generation_streams()` patches `mlx_lm.generate.generation_stream` for the worker, but can't re-thread the parameter arrays' stream affinity. `mx.eval([c.state for c in prompt_cache])` at `mlx_lm/generate.py:442` then can't find the loader's stream → `RuntimeError`. The comment at the old `vllm_mlx/engine/simple.py:239-242` explicitly predicted this class of issue ("Keep model load on the event-loop thread so default LLM stream_generate() runs on the same thread that owns model-associated streams") — but the streaming path doesn't actually run on the event-loop thread for all routes. This PR makes the invariant true unconditionally by owning one worker.

## Commits

1. **`180e3e7` engine: pin MLX load + inference to one worker thread**
   - `SimpleEngine.__init__` allocates `self._mlx_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-worker")` and `self._mlx_thread_id: int | None = None`.
   - **`prepare_for_start`** self-routes: if the caller is on the MLX worker (re-entry from an inference path), runs inline; otherwise `self._mlx_executor.submit(self._mlx_marked_prepare).result()`. `_mlx_marked_prepare` records the worker thread id on first run. Callers on any thread — including `ResidencyManager._prepare_engine_start` in `lifecycle.py`, which calls `engine.prepare_for_start()` directly on the event-loop thread — end up with load running on the same single worker with **no `lifecycle.py` changes needed**.
   - **`_run_blocking_serialized`** routes through the engine's executor.
   - **`stream_generate`** body drives the sync iterator on the same executor via `_stream_in_mlx_executor`, piping chunks back to the event loop through `queue.Queue` + `await loop.run_in_executor(None, q.get)`. Event loop is no longer blocked synchronously during streaming.
   - **`stop`** shuts the executor down (`wait=False, cancel_futures=True`) and rebuilds it so re-`start` works in tests.

2. **`ad6364d` engine: extend MLLM `stream_chat` path through MLX worker too**
   - Same Stream(gpu, N) bug as the LLM path, different file. Hit live during a production migration when `gemma-4-E4B` (multimodal — loads through `mllm.py`) reproduced the error at `mllm.py:2161` via `mlx_vlm.generate.stream_generate`.
   - Routes the `_text_model is None and not has_media_content(messages)` branch in `stream_chat` through `_stream_in_mlx_executor` with the same pattern as the LLM path.

3. **`93effbf` engine: propagate cancel + drop redundant `wrap_future`** (review feedback)
   - **Cancel propagation in `_stream_in_mlx_executor`.** A consumer-side `threading.Event` is set in the async generator's `finally`; the producer checks it between chunks and exits early. Without this, a client disconnect leaves the producer generating tokens to completion on the single MLX worker, blocking all subsequent requests for the lifetime of the orphaned generation. **Verified live**: client disconnect after 2 chunks of an 800-token request → follow-up `'pong'` returns in **0.7 s** instead of waiting for the orphan to drain.
   - **Drop redundant `asyncio.wrap_future`.** `loop.run_in_executor` already returns an `asyncio.Future`; `asyncio.shield(task)` and `await task` work on it directly. Simplified to `task = loop.run_in_executor(self._mlx_executor, run_bound)`.

4. **`1e98201` test(simple_engine): update MLLM-stream-thread test for executor-pinning fix**
   - The existing regression `test_mllm_nonstream_text_only_without_text_model_keeps_stream_thread_owner` bypassed `prepare_for_start` and constructed `FakeMllmModel` on the test thread, asserting `stream_chat` ran on that thread. Under the new pinning behavior the model's owner is the MLX worker thread. Updated the test to construct `FakeMllmModel` via `prepare_for_start` under a patched `MLXMultimodalLM`, mirroring real load behavior. Same invariant — model owner thread == `stream_chat` thread — with the right owner.

`BatchedEngine` was not inspected; if it has the same architecture it would need the same shape — happy to send as a follow-up.

## Verification

Host: Apple **M5 Pro Max**, 128 GB unified memory, macOS Tahoe (Darwin 25.5.0).

- **Live smoke** against the actual misbehaving model:
  - `mlx-community/gpt-oss-120b-MXFP4-Q8` — chat: 200 OK with real text + `finish_reason`. Streaming: full SSE stream with `data: [DONE]` terminal. Three sequential warm-cache requests in <1 s each. No `Stream(gpu, N)` errors anywhere in server log.
  - `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-4bit` — `"pong"` with `finish_reason="stop"`. No regression.
  - `lmstudio-community/gemma-4-E4B-it-MLX-4bit` (MLLM-loaded) — `"pong"` with `finish_reason="stop"` via the MLLM text-only fallback path.
- **Cancel propagation** (commit 3): client disconnect mid-stream → follow-up request returns in 0.7 s; without the fix, follow-up would queue behind the orphaned generation.
- **Project test suite** on this branch:
  - Full fast suite (`pytest --ignore=test_lifecycle_cli.py`): **2070 passed, 0 failed**.
  - Targeted: `test_simple_engine` (38) + `test_simple_engine_cancel_serialization` (3) + `test_engine_core_stream_safety` (1) + `test_engine_core_thread_streams` (2) + `test_server::test_streaming_chat_no_stream_thread_error_after_residency_preload` (1) → **45/45 pass**.
  - `test_lifecycle_cli.py` has 3 pre-existing failures on `main` unrelated to this change (`'SimpleNamespace' object has no attribute 'models_config'` in `vllm_mlx/cli.py:37`); flagging FYI for a separate fix.

## Notes

- **Cancellation semantics in `_run_blocking_serialized`** preserved (`asyncio.shield(task) + on_cancel`), now operating directly on the `asyncio.Future` from `loop.run_in_executor`.
- **Streaming back-pressure**: the queue is unbounded; bounded only by `max_tokens` total memory (each chunk is a small `SimpleNamespace`). If you'd prefer bounded with backpressure, easy follow-up.
- **Alternative considered**: fix upstream in `mlx-lm` by lazy-init'ing `QuantizedSwitchLinear` so `__init__` doesn't touch the GPU. That would fix this for every consumer of mlx-lm, not just vllm-mlx, but it's a much wider surface. Happy to defer to your call.

## Test plan

- [ ] CI: full fast suite green
- [ ] Manual: `vllm-mlx serve` a gpt-oss-120b checkpoint, hit `/v1/chat/completions` with both `stream=false` and `stream=true`
- [ ] Manual: same against a non-MoE model (Qwen3-Coder-30B) and a multimodal model loaded as text-only (gemma-4-E4B-IT) to confirm both fixed paths and non-regression
- [ ] Manual: client-disconnect mid-stream → next request not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
