### PR TITLE
add structured issue templates and refresh PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report a bug or unexpected behavior in vllm-mlx
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting, please search existing issues to avoid duplicates.
+
+        Security note: redact API tokens, Hugging Face tokens, private URLs, API keys, and any other credentials from logs and configs you paste below.
+
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        Run the following and paste the output, plus your hardware details.
+
+        ```sh
+        python -c "import sys, mlx.core as mx; print('python', sys.version); print('mlx device', mx.default_device())"
+        pip show vllm-mlx mlx mlx-lm mlx-vlm mlx-audio mlx-embeddings 2>/dev/null | grep -E "^(Name|Version):"
+        sw_vers
+        ```
+      value: |
+        - Chip (M1 / M2 / M3 / M4 / M5, including Pro / Max / Ultra):
+        - RAM:
+        - macOS version:
+        - Python version:
+        - vllm-mlx version:
+        - mlx / mlx-lm / mlx-vlm / mlx-audio versions:
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Model and quantization
+      description: Hugging Face repo and quant scheme used when reproducing.
+      placeholder: mlx-community/Qwen3-0.6B-8bit
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction
+      description: Minimal command or snippet that triggers the bug. Include the full server command and the client request if applicable.
+      placeholder: |
+        vllm-mlx serve mlx-community/Qwen3-0.6B-8bit --port 8000
+        curl -X POST http://localhost:8000/v1/chat/completions \
+          -H 'Content-Type: application/json' \
+          -d '{"model": "...", "messages": [...]}'
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: What you expected to see.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: What you actually got. Include the full traceback or error response.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Server logs, screenshots, links to related issues, or anything else relevant. Reminder to redact secrets.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new feature or capability that does not exist yet in vllm-mlx
+title: "[Feature]: "
+labels: ["feature"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For non-trivial changes, please describe the motivation and the surface impact before jumping into implementation details. If you already plan to send a PR, mention it so reviewers know to expect one.
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who benefits? Link any prior issue or discussion.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: What you want vllm-mlx to do. Be specific about the user-facing surface (CLI flag, endpoint, behavior, default).
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Surface impact
+      multiple: true
+      options:
+        - CLI / serve command
+        - OpenAI API endpoints
+        - Anthropic API endpoints
+        - Scheduler / batching
+        - Sampling
+        - KV cache / prefix cache
+        - Multimodal pipeline
+        - MCP / tool calling
+        - Reasoning models
+        - Metal kernels / v1 engine
+        - Build / packaging
+        - Docs
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why this one is preferred.
+
+  - type: dropdown
+    attributes:
+      label: Are you planning to send a PR for this?
+      options:
+        - "Yes"
+        - "Maybe, depending on feedback"
+        - "No, requesting only"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Reference papers, repos, screenshots, or examples.

--- a/.github/ISSUE_TEMPLATE/new_model_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_model_request.yml
@@ -1,0 +1,56 @@
+name: New model request
+description: Request support for a model that does not currently run in vllm-mlx
+title: "[New Model]: "
+labels: ["new-model"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        vllm-mlx wraps mlx-lm, mlx-vlm, mlx-audio, and mlx-embeddings. If the model already runs in the underlying library, adding support here is usually a small adapter task. If it does not run there yet, please consider opening an issue upstream first.
+
+  - type: input
+    attributes:
+      label: Hugging Face URL
+      placeholder: https://huggingface.co/google/gemma-4-E2B-it
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Modality
+      options:
+        - Text-only
+        - Vision-language (text + image)
+        - Audio (ASR or TTS)
+        - Embeddings
+        - Other (explain below)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Does it already run in mlx-lm, mlx-vlm, mlx-audio, or mlx-embeddings?
+      description: Yes / No / Partially. If yes, link the upstream support. If no, summarize what is missing.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Closest model already supported by vllm-mlx
+      description: Pick the architecturally closest model already runnable in this repo.
+
+  - type: textarea
+    attributes:
+      label: Architecture notes
+      description: New attention variant, new tokenizer, custom operators, or anything unusual that might block support.
+
+  - type: textarea
+    attributes:
+      label: Tool calling, reasoning, or multimodal specifics
+      description: If the model has a tool-call format, thinking tags, or a multimodal prompt template that needs custom handling, describe it here.
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Links to the model card, paper, or reference implementations.

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,68 @@
+name: Performance issue
+description: Report a performance regression or propose a performance improvement
+title: "[Perf]: "
+labels: ["performance"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Performance reports are most actionable when they include hardware, model, quantization, and measured numbers. Apple Silicon performance varies a lot across chip classes. Numbers from one chip do not transfer to another.
+
+  - type: dropdown
+    attributes:
+      label: Kind of report
+      options:
+        - Regression vs a previous version
+        - Improvement proposal
+        - Performance question
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Hardware
+      description: Chip class and RAM matter for triage.
+      value: |
+        - Chip (M1 / M2 / M3 / M4 / M5, including Pro / Max / Ultra):
+        - RAM:
+        - macOS version:
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Model and quantization
+      placeholder: mlx-community/Qwen3-0.6B-8bit
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Measurements
+      description: |
+        Include the metrics you measured. Common ones: time to first token (ms), decode throughput (tok/s) at batch=1, batch=8, batch=32, and peak resident memory. State the benchmark or command you used so we can reproduce.
+      placeholder: |
+        Command: vllm-mlx-bench --model mlx-community/Qwen3-0.6B-8bit
+        Decode tok/s batch=1: 250 (expected ~290)
+        Decode tok/s batch=8: ...
+        TTFT batch=1: ...
+        Peak RSS: ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Comparison baseline
+      description: What are you comparing against? A previous vllm-mlx version, a published claim, another framework, your own prior measurement?
+
+  - type: textarea
+    attributes:
+      label: Reproduction
+      description: Exact command, fixed seed, prompt set if relevant. Mention any non-default flags.
+      render: shell
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Profiler output, Instruments traces, suspected cause, related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,58 @@
 ## Summary
 
-<!-- What changed and why? -->
+<!-- What changed and why? Link the related issue if any. -->
 
-## Validation
+## Type of change
 
-<!-- List local validation and/or CI evidence. If this is docs-only, say so. -->
+<!-- Keep all that apply, remove the rest. -->
 
-## Merge readiness
+- Bug fix
+- New feature
+- Performance
+- Security
+- Documentation
+- Refactor or internal cleanup
 
-- [ ] I am not merging my own substantive PR.
-- [ ] The latest CI run for this exact head commit is green.
-- [ ] If I rebased, resolved conflicts, or pushed after review, I waited for the new CI run to finish green.
-- [ ] Actionable review comments are resolved in this PR or linked to follow-up issues before merge.
-- [ ] Any intentional follow-up debt is linked here and called out in the PR body.
+## Surface touched
+
+<!-- Keep all that apply, remove the rest. -->
+
+- CLI / serve command
+- OpenAI API endpoints
+- Anthropic API endpoints
+- Scheduler / batching
+- Sampling
+- KV cache / prefix cache
+- Multimodal pipeline
+- MCP / tool calling
+- Reasoning models
+- Metal kernels / v1 engine
+- Build / packaging
+- Tests only
+- Docs only
+
+## Test plan
+
+<!-- Exact commands a reviewer can run to verify this PR. Mention the model used. -->
+
+## Test results
+
+<!-- Paste relevant test output. If this PR fixes a failing test, include before and after. -->
+
+## Performance impact
+
+<!-- Skip with "N/A, docs or tests only" if it does not apply. Otherwise: -->
+<!-- - Hardware (chip, RAM): -->
+<!-- - Model and quantization: -->
+<!-- - Benchmark command: -->
+<!-- - Metrics measured (TTFT, decode tok/s at batch=1 and batch=8, peak RSS): -->
+<!-- - Delta vs main: -->
+<!-- A perf-sensitive PR must be equal or faster on every metric it claims to improve. If a metric regresses, justify the trade-off here. -->
+
+## Output parity
+
+<!-- For changes that touch generation (sampling, scheduler, kernels, models, tokenization), confirm that greedy output matches main byte-for-byte on a fixed prompt set, or describe the expected divergence. Skip otherwise. -->
 
 ## Risk notes
 
-<!-- Call out runtime, parser, scheduler, memory, security, or compatibility risk. -->
+<!-- Runtime, parser, scheduler, memory, security, or compatibility risk. Call out anything reviewers should look at closely. -->


### PR DESCRIPTION
This PR adds four issue templates plus a config, and refreshes the existing PR template.

New issue templates in `.github/ISSUE_TEMPLATE/`:

- bug_report.yml: required chip/RAM/macOS/Python and mlx-stack versions, model and quantization, reproduction, expected vs actual. Security note about redacting tokens.
- performance_issue.yml: required hardware, model and quant, measurements (TTFT, decode tok/s at batch=1/8/32), baseline, reproduction. Dropdown separates regression reports from improvement proposals.
- new_model_request.yml: HF URL, modality dropdown, whether the model already runs in mlx-lm/mlx-vlm/mlx-audio/mlx-embeddings, closest existing model, architecture notes.
- feature_request.yml: motivation, proposal, surface impact (multi-select), alternatives, intent to send a PR.
- config.yml: blank issues disabled. No contact_links because Discussions are not enabled on this repo. Easy to add later.

PR template changes vs main:

- Adds Type of change, Surface touched, Test plan, Test results, Performance impact and Output parity sections.
- Removes the 5-checkbox "Merge readiness" block. Those rules (not merging your own PR, waiting for CI after rebase, etc.) are either large-org review hygiene that does not fit a small repo or already enforced by GitHub's UI and branch protection.
- Keeps Summary and Risk notes from the existing template.

All issue YAMLs parse cleanly:

```
OK   .github/ISSUE_TEMPLATE/bug_report.yml
OK   .github/ISSUE_TEMPLATE/performance_issue.yml
OK   .github/ISSUE_TEMPLATE/new_model_request.yml
OK   .github/ISSUE_TEMPLATE/feature_request.yml
OK   .github/ISSUE_TEMPLATE/config.yml
```

Conventions informed by vLLM upstream and Hugging Face transformers, scaled to this repo's surface.