### PR TITLE
fix(ssd-cache): snapshot KV on producer thread + handle bf16↔numpy

### DIFF
--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -579,10 +579,8 @@ class TestSpillPath:
 
     def test_evict_lru_calls_ssd_spill(self, tmp_path):
         model = MagicMock()
-        # min_prefix_tokens=1: this test uses 10-token sequences; the prod
-        # default (128) would silently reject every store() call and leave
-        # the cache empty, so the eviction-triggers-spill assertion below
-        # would never fire. Same override applied to the other spill tests.
+        # min_prefix_tokens=1: test uses 10-token sequences (prod default 128
+        # would silently reject every store()).
         config = MemoryCacheConfig(max_memory_mb=1, max_entries=3, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
@@ -615,8 +613,6 @@ class TestSpillPath:
     def test_evict_without_ssd_tier_still_works(self):
         """Eviction without SSD tier should work as before (discard)."""
         model = MagicMock()
-        # min_prefix_tokens=1 so the 10-token sequences below actually store
-        # (prod default 128 would reject them silently).
         config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
@@ -628,43 +624,22 @@ class TestSpillPath:
         assert len(cache) <= 2
 
     def test_snapshot_runs_on_caller_thread(self, tmp_path):
-        """Producer-thread snapshot invariant: enqueue_spill MUST materialize
-        layer tensors on the *calling* thread, not the writer thread.
-
-        This is the regression test for the SSD spill Stream(gpu, N) crash.
-        We give the SSD tier a fake layer whose ``keys``/``values`` attributes
-        raise on access from any thread other than the one that created the
-        layer — simulating the MLX behavior of a per-thread Stream that's
-        only registered on the request handler.
-
-        Pre-fix: ``serialize_layer`` did ``np.array(layer.keys)`` on the
-        writer thread → access from the wrong thread → would crash.
-        Post-fix: ``enqueue_spill`` calls ``snapshot_layer`` on the calling
-        thread, so the materialization happens before the queue handoff.
-        """
+        """Regression: enqueue_spill must materialize layers on the caller
+        thread (real mx.array hard-aborts the process if accessed off the
+        Stream(gpu, N) it was created on)."""
         import threading as _threading
 
         creator_thread_id = _threading.get_ident()
 
         class ThreadBoundArray:
-            """Mimics an mx.array that errors when read off-thread.
-
-            Real mx.array doesn't error this way at the Python level — it
-            crashes at the C++ level with the Stream(gpu, N) abort. We use a
-            controlled Python exception so the test can observe a failure
-            without taking down the test process.
-            """
-
+            # Python-level proxy for the MLX cross-thread Stream abort.
             def __init__(self, data, owner_tid):
                 self._data = data
                 self._owner_tid = owner_tid
 
             def __array__(self):
                 if _threading.get_ident() != self._owner_tid:
-                    raise RuntimeError(
-                        "ThreadBoundArray accessed from wrong thread "
-                        "(simulates MLX Stream(gpu, N) cross-thread abort)"
-                    )
+                    raise RuntimeError("accessed from wrong thread")
                 return self._data
 
         class ThreadBoundKV:
@@ -682,9 +657,7 @@ class TestSpillPath:
         ssd_tier.start_writer()
 
         try:
-            # enqueue_spill runs on THIS thread, the creator thread, so
-            # snapshot_layer's np.array(layer.keys) is allowed.
-            tokens = tuple(range(0, 200))  # arbitrary
+            tokens = tuple(range(0, 200))
             enqueued = ssd_tier.enqueue_spill(
                 tokens,
                 [ThreadBoundKV(creator_thread_id)],
@@ -692,10 +665,6 @@ class TestSpillPath:
             )
             assert enqueued is True
 
-            # Writer thread now picks up the snapshot (numpy-only). It must
-            # NEVER touch the ThreadBoundArray instances. If it did, we'd
-            # see spill_count==0 and a warning in the log; with the fix in
-            # place spill_count goes to 1.
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
                 if ssd_tier._stats.spill_count >= 1:
@@ -971,8 +940,6 @@ class TestMemoryCacheSSDCheck:
     def test_check_ssd_returns_none_on_ram_hit(self, tmp_path):
         """When RAM has a hit, check_ssd should return None (not needed)."""
         model = MagicMock()
-        # 3-token sequence; need min_prefix_tokens=1 so the store() below
-        # actually populates the cache and a RAM hit is observable.
         config = MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
@@ -995,9 +962,6 @@ class TestIntegrationSpillAndFetch:
     def cache_with_ssd(self, tmp_path):
         """RAM cache + SSD tier, small limits to force eviction."""
         model = MagicMock()
-        # 10-token test sequences need min_prefix_tokens lowered from the
-        # 128 production default; without this every store() returns False
-        # and the spill-and-promote round-trip can never be observed.
         config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         ram_cache = MemoryAwarePrefixCache(model, config)
 

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -322,7 +322,12 @@ class TestLayerSerializer:
 
         serializer = KVCacheSerializer()
         file_path = str(tmp_path / "layer_0.safetensors")
-        metadata = serializer.serialize_layer(layer, 0, file_path)
+        # serialize_layer now expects a snapshot (CPU-only dict) produced by
+        # snapshot_layer, not the raw MLX-backed layer. This mirrors the
+        # producer/writer thread split: snapshot runs on the request thread,
+        # serialize runs on the SSD writer thread with only the snapshot.
+        snapshot = serializer.snapshot_layer(layer)
+        metadata = serializer.serialize_layer(snapshot, 0, file_path)
 
         assert os.path.exists(file_path)
         assert metadata["layer_type"] == "KVCache"
@@ -346,7 +351,10 @@ class TestLayerSerializer:
 
         serializer = ArraysCacheSerializer()
         file_path = str(tmp_path / "layer_0.safetensors")
-        metadata = serializer.serialize_layer(layer, 0, file_path)
+        # See KVCacheSerializer round-trip test: snapshot is the producer-
+        # side step, serialize is the writer-side step.
+        snapshot = serializer.snapshot_layer(layer)
+        metadata = serializer.serialize_layer(snapshot, 0, file_path)
 
         assert os.path.exists(file_path)
         assert metadata["layer_type"] == "ArraysCache"
@@ -571,7 +579,11 @@ class TestSpillPath:
 
     def test_evict_lru_calls_ssd_spill(self, tmp_path):
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=3)
+        # min_prefix_tokens=1: this test uses 10-token sequences; the prod
+        # default (128) would silently reject every store() call and leave
+        # the cache empty, so the eviction-triggers-spill assertion below
+        # would never fire. Same override applied to the other spill tests.
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=3, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "spill_test"))
@@ -603,7 +615,9 @@ class TestSpillPath:
     def test_evict_without_ssd_tier_still_works(self):
         """Eviction without SSD tier should work as before (discard)."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        # min_prefix_tokens=1 so the 10-token sequences below actually store
+        # (prod default 128 would reject them silently).
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         for i in range(5):
@@ -612,6 +626,84 @@ class TestSpillPath:
 
         # Should not raise, just discard
         assert len(cache) <= 2
+
+    def test_snapshot_runs_on_caller_thread(self, tmp_path):
+        """Producer-thread snapshot invariant: enqueue_spill MUST materialize
+        layer tensors on the *calling* thread, not the writer thread.
+
+        This is the regression test for the SSD spill Stream(gpu, N) crash.
+        We give the SSD tier a fake layer whose ``keys``/``values`` attributes
+        raise on access from any thread other than the one that created the
+        layer — simulating the MLX behavior of a per-thread Stream that's
+        only registered on the request handler.
+
+        Pre-fix: ``serialize_layer`` did ``np.array(layer.keys)`` on the
+        writer thread → access from the wrong thread → would crash.
+        Post-fix: ``enqueue_spill`` calls ``snapshot_layer`` on the calling
+        thread, so the materialization happens before the queue handoff.
+        """
+        import threading as _threading
+
+        creator_thread_id = _threading.get_ident()
+
+        class ThreadBoundArray:
+            """Mimics an mx.array that errors when read off-thread.
+
+            Real mx.array doesn't error this way at the Python level — it
+            crashes at the C++ level with the Stream(gpu, N) abort. We use a
+            controlled Python exception so the test can observe a failure
+            without taking down the test process.
+            """
+
+            def __init__(self, data, owner_tid):
+                self._data = data
+                self._owner_tid = owner_tid
+
+            def __array__(self):
+                if _threading.get_ident() != self._owner_tid:
+                    raise RuntimeError(
+                        "ThreadBoundArray accessed from wrong thread "
+                        "(simulates MLX Stream(gpu, N) cross-thread abort)"
+                    )
+                return self._data
+
+        class ThreadBoundKV:
+            def __init__(self, tid):
+                self.keys = ThreadBoundArray(
+                    np.zeros((1, 1, 1, 1), dtype=np.float16), tid
+                )
+                self.values = ThreadBoundArray(
+                    np.zeros((1, 1, 1, 1), dtype=np.float16), tid
+                )
+                self.offset = 1
+
+        ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "snapshot_test"))
+        ssd_tier = SSDCacheTier(ssd_config)
+        ssd_tier.start_writer()
+
+        try:
+            # enqueue_spill runs on THIS thread, the creator thread, so
+            # snapshot_layer's np.array(layer.keys) is allowed.
+            tokens = tuple(range(0, 200))  # arbitrary
+            enqueued = ssd_tier.enqueue_spill(
+                tokens,
+                [ThreadBoundKV(creator_thread_id)],
+                memory_bytes=64,
+            )
+            assert enqueued is True
+
+            # Writer thread now picks up the snapshot (numpy-only). It must
+            # NEVER touch the ThreadBoundArray instances. If it did, we'd
+            # see spill_count==0 and a warning in the log; with the fix in
+            # place spill_count goes to 1.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if ssd_tier._stats.spill_count >= 1:
+                    break
+                time.sleep(0.05)
+            assert ssd_tier._stats.spill_count == 1
+        finally:
+            ssd_tier.close()
 
 
 import asyncio
@@ -879,7 +971,9 @@ class TestMemoryCacheSSDCheck:
     def test_check_ssd_returns_none_on_ram_hit(self, tmp_path):
         """When RAM has a hit, check_ssd should return None (not needed)."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1)
+        # 3-token sequence; need min_prefix_tokens=1 so the store() below
+        # actually populates the cache and a RAM hit is observable.
+        config = MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         kv = [MockKVCacheForSpill(1000)]
@@ -901,7 +995,10 @@ class TestIntegrationSpillAndFetch:
     def cache_with_ssd(self, tmp_path):
         """RAM cache + SSD tier, small limits to force eviction."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        # 10-token test sequences need min_prefix_tokens lowered from the
+        # 128 production default; without this every store() returns False
+        # and the spill-and-promote round-trip can never be observed.
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         ram_cache = MemoryAwarePrefixCache(model, config)
 
         ssd_config = SSDCacheConfig(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2980,13 +2980,10 @@ class Scheduler:
         try:
             from mlx_lm.models.cache import ArraysCache, KVCache
 
-            # Resolve mlx dtype objects by string name. Used to cast back
-            # arrays that were upcast (e.g. bf16 → fp32) on the spill path so
-            # numpy could persist them — see ssd_cache._mx_to_numpy_safe.
+            # Cast restored arrays back to their original dtype if the spill
+            # path upcast for numpy (bf16 → fp32). None = mlx lacks the named
+            # dtype on this version; accept default from mx.array(np_fp32).
             def _mx_dtype_from_name(name: str):
-                # Defensive: mlx might not have every dtype on every version;
-                # falling through with None means "skip the cast and accept
-                # the default dtype from mx.array(numpy_fp32)".
                 return getattr(mx, name, None)
 
             result = []
@@ -2995,11 +2992,6 @@ class Scheduler:
                     kv = KVCache()
                     kv.keys = mx.array(ld["keys"])
                     kv.values = mx.array(ld["values"])
-                    # Restore original dtype (e.g. bfloat16) if the snapshot
-                    # had to upcast for safetensors/numpy compatibility. The
-                    # model expects its native KV dtype; without this, the
-                    # next attention call would either pay an implicit cast
-                    # or refuse the input.
                     keys_orig = ld.get("keys_original_dtype")
                     if keys_orig is not None:
                         dt = _mx_dtype_from_name(keys_orig)
@@ -3017,7 +3009,6 @@ class Scheduler:
                     result.append(kv)
                 elif "state" in ld:
                     state_arrays = [mx.array(a) for a in ld["state"]]
-                    # Same dtype-restore for ArraysCache state entries.
                     state_dtypes = ld.get("state_original_dtypes")
                     if state_dtypes is not None:
                         for i, dtype_name in enumerate(state_dtypes):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2980,12 +2980,36 @@ class Scheduler:
         try:
             from mlx_lm.models.cache import ArraysCache, KVCache
 
+            # Resolve mlx dtype objects by string name. Used to cast back
+            # arrays that were upcast (e.g. bf16 → fp32) on the spill path so
+            # numpy could persist them — see ssd_cache._mx_to_numpy_safe.
+            def _mx_dtype_from_name(name: str):
+                # Defensive: mlx might not have every dtype on every version;
+                # falling through with None means "skip the cast and accept
+                # the default dtype from mx.array(numpy_fp32)".
+                return getattr(mx, name, None)
+
             result = []
             for ld in layer_dicts:
                 if "keys" in ld and "values" in ld:
                     kv = KVCache()
                     kv.keys = mx.array(ld["keys"])
                     kv.values = mx.array(ld["values"])
+                    # Restore original dtype (e.g. bfloat16) if the snapshot
+                    # had to upcast for safetensors/numpy compatibility. The
+                    # model expects its native KV dtype; without this, the
+                    # next attention call would either pay an implicit cast
+                    # or refuse the input.
+                    keys_orig = ld.get("keys_original_dtype")
+                    if keys_orig is not None:
+                        dt = _mx_dtype_from_name(keys_orig)
+                        if dt is not None:
+                            kv.keys = kv.keys.astype(dt)
+                    values_orig = ld.get("values_original_dtype")
+                    if values_orig is not None:
+                        dt = _mx_dtype_from_name(values_orig)
+                        if dt is not None:
+                            kv.values = kv.values.astype(dt)
                     kv.offset = ld["offset"]
                     for attr in ("max_size", "keep", "step", "_idx"):
                         if attr in ld:
@@ -2993,6 +3017,15 @@ class Scheduler:
                     result.append(kv)
                 elif "state" in ld:
                     state_arrays = [mx.array(a) for a in ld["state"]]
+                    # Same dtype-restore for ArraysCache state entries.
+                    state_dtypes = ld.get("state_original_dtypes")
+                    if state_dtypes is not None:
+                        for i, dtype_name in enumerate(state_dtypes):
+                            if dtype_name is None:
+                                continue
+                            dt = _mx_dtype_from_name(dtype_name)
+                            if dt is not None:
+                                state_arrays[i] = state_arrays[i].astype(dt)
                     layer_obj = ArraysCache(len(state_arrays))
                     layer_obj.state = state_arrays
                     result.append(layer_obj)

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -416,106 +416,51 @@ SERIALIZER_SUPPORT_MATRIX = {
 class LayerSerializer(ABC):
     """Interface for per-layer cache serialization.
 
-    Each implementation handles a specific cache type's serialization
-    to/from safetensors files with metadata.
-
-    Threading note for ``snapshot_layer`` vs ``serialize_layer``
-    -----------------------------------------------------------
-    Spill happens in two stages, on two different threads:
-
-    1. ``snapshot_layer`` runs on the **producer thread** — the request handler
-       that just finished generation. That thread owns the per-request MLX
-       ``Stream(gpu, N)`` (where N is the per-request uid) the KV tensors
-       were computed on. Materializing those tensors to CPU/numpy MUST happen
-       here, while the stream is still registered on this thread.
-    2. ``serialize_layer`` runs on the **SSD writer thread** — a long-lived
-       background thread with no MLX streams registered. It only touches the
-       already-materialized numpy snapshot, so it can run anywhere.
-
-    If you skip stage 1 and let the writer thread call ``np.array(mx_array)``
-    directly, MLX tries to use ``Stream(gpu, N)`` on the writer thread, can't
-    find it, and the whole process aborts with
-    ``std::runtime_error: There is no Stream(gpu, N) in current thread.``
+    Spill is split across two threads: ``snapshot_layer`` runs on the
+    producer (request handler) thread so the mx→numpy materialization
+    happens where the per-request Stream(gpu, N) is registered;
+    ``serialize_layer`` then runs on the SSD writer thread with numpy only.
     """
 
     @abstractmethod
     def snapshot_layer(self, layer: Any) -> dict[str, Any]:
-        """Take a CPU-only snapshot of an MLX-backed cache layer.
-
-        Called on the **producer thread** (the one that owns the layer's MLX
-        stream) so that any ``mx.array → np.ndarray`` materialization happens
-        where streams are valid. The returned dict is a self-contained,
-        thread-safe payload that ``serialize_layer`` can persist later.
-
-        Args:
-            layer: The live MLX-backed cache layer object.
-
-        Returns:
-            Dict with numpy-only fields needed by ``serialize_layer``.
-        """
+        """Producer-thread CPU snapshot of an MLX-backed cache layer."""
         ...
 
     @abstractmethod
     def serialize_layer(
         self, snapshot: dict[str, Any], layer_idx: int, file_path: str
     ) -> dict[str, Any]:
-        """Persist a snapshot to disk on the SSD writer thread.
+        """Writer-thread: persist a snapshot to safetensors at file_path.
 
-        Args:
-            snapshot: The CPU-only snapshot produced by ``snapshot_layer``.
-            layer_idx: Index of this layer in the cache list.
-            file_path: Path to write the safetensors file.
-
-        Returns:
-            Metadata dict with at least 'layer_type' key.
+        Returns metadata dict with at least 'layer_type'.
         """
         ...
 
     @abstractmethod
     def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
-        """Deserialize a single cache layer from a file.
-
-        Args:
-            file_path: Path to the safetensors file.
-            metadata: Metadata dict from serialize_layer.
-
-        Returns:
-            Dict with layer state (keys/values/offset or state list).
-        """
+        """Read a layer back from disk. Returns layer-state dict."""
         ...
 
 
 def _mx_to_numpy_safe(arr: Any) -> tuple[np.ndarray, str | None]:
-    """Convert an mx.array → np.ndarray, upcasting numpy-unsupported dtypes.
+    """mx.array → np.ndarray, upcasting numpy-unsupported dtypes (bf16) to fp32.
 
-    numpy >= 1.x has no native bfloat16; mlx's PEP 3118 buffer export of a
-    bf16 array confuses numpy ("Item size 2 for ... buffer format string B
-    does not match the dtype B item size 1"). For any dtype we can't hand to
-    numpy directly, we upcast to fp32 on the producer thread (lossless for
-    bf16/fp16; transient 2× memory) and remember the original dtype as a
-    string in metadata so the SSD-promote path can cast back.
-
-    Returns ``(numpy_array, original_dtype_str_or_None)``. ``original`` is
-    only set when an upcast happened.
+    Returns (numpy_array, original_dtype_name_or_None). The name is only set
+    when an upcast happened, so the SSD-promote path can cast back.
     """
     try:
         return np.array(arr), None
     except RuntimeError as exc:
-        # Specific to the numpy ↔ bf16 buffer-protocol mismatch on mlx 0.31+.
-        # Don't swallow unrelated runtime errors — re-raise if message doesn't
-        # match the expected pattern.
+        # numpy ↔ mlx bf16 buffer-protocol mismatch on mlx ≥ 0.31. Re-raise
+        # anything else — don't swallow unrelated errors.
         if "buffer format string" not in str(exc):
             raise
-        try:
-            import mlx.core as mx
-        except ImportError:  # pragma: no cover — mlx must be importable here
-            raise
-        # Record dtype name (e.g. "bfloat16") for caller-side downcast.
+        import mlx.core as mx
+
         original_dtype = str(arr.dtype).rsplit(".", 1)[-1]
         upcast = arr.astype(mx.float32)
-        # Force materialization on this thread before handing to numpy, since
-        # astype itself is lazy.
-        mx.eval(upcast)
+        mx.eval(upcast)  # astype is lazy; force materialization here
         return np.array(upcast), original_dtype
 
 
@@ -531,19 +476,6 @@ class KVCacheSerializer(LayerSerializer):
     _ROTATING_ATTRS = ("max_size", "keep", "step", "_idx")
 
     def snapshot_layer(self, layer: Any) -> dict[str, Any]:
-        """Producer-thread snapshot: pull keys/values to numpy *here* so the
-        writer thread never touches MLX. See ``LayerSerializer`` docstring for
-        the threading rationale (Stream(gpu,N) is thread-local; the writer
-        thread doesn't have it; an mx→np conversion there aborts the process).
-
-        We also detect the bf16-vs-numpy buffer-protocol mismatch and upcast
-        to fp32 so safetensors can persist the data. The original dtype is
-        carried in the snapshot so the SSD-promote path can downcast back
-        before handing the array back to the model.
-        """
-        # np.array(mx.array) triggers __array__ → MLX materialization. Must
-        # happen on the thread that owns the request's GPU stream. The helper
-        # handles bf16 (and any other dtype numpy refuses) by upcasting.
         keys_np, keys_orig_dtype = _mx_to_numpy_safe(layer.keys)
         values_np, values_orig_dtype = _mx_to_numpy_safe(layer.values)
 
@@ -552,16 +484,12 @@ class KVCacheSerializer(LayerSerializer):
             "values_np": values_np,
             "offset": layer.offset,
         }
-        # Persist original dtype only if we had to upcast; saves bytes in the
-        # manifest for the common (fp16/fp32) case where numpy roundtrips
-        # without conversion.
         if keys_orig_dtype is not None:
             snapshot["keys_original_dtype"] = keys_orig_dtype
         if values_orig_dtype is not None:
             snapshot["values_original_dtype"] = values_orig_dtype
 
-        # RotatingKVCache carries scalar bookkeeping (no MLX involved) — copy
-        # by reference; these are plain Python ints/values.
+        # RotatingKVCache extras (plain Python scalars, no MLX).
         for attr in self._ROTATING_ATTRS:
             if hasattr(layer, attr):
                 snapshot[attr] = getattr(layer, attr)
@@ -570,7 +498,6 @@ class KVCacheSerializer(LayerSerializer):
     def serialize_layer(
         self, snapshot: dict[str, Any], layer_idx: int, file_path: str
     ) -> dict[str, Any]:
-        # Runs on the SSD writer thread. Only touches numpy + disk; no MLX.
         from safetensors.numpy import save_file
 
         tensors = {
@@ -584,8 +511,6 @@ class KVCacheSerializer(LayerSerializer):
             "layer_idx": layer_idx,
             "offset": snapshot["offset"],
         }
-        # Propagate original-dtype hints so the deserialize side can ask the
-        # caller to cast back to bf16 (or whatever the model expects).
         for k in ("keys_original_dtype", "values_original_dtype"):
             if k in snapshot:
                 metadata[k] = snapshot[k]
@@ -606,10 +531,7 @@ class KVCacheSerializer(LayerSerializer):
             "values": tensors[f"layer_{layer_idx}_values"],
             "offset": metadata["offset"],
         }
-        # Surface dtype hints so ``_reconstruct_ssd_layers`` (in
-        # scheduler.py) can re-cast to the original mlx dtype before the
-        # cache returns to the model — preserves memory layout and avoids
-        # implicit-cast surprises in attention kernels.
+        # Dtype hints surfaced so _reconstruct_ssd_layers can cast back.
         for k in ("keys_original_dtype", "values_original_dtype"):
             if k in metadata:
                 result[k] = metadata[k]
@@ -626,12 +548,6 @@ class ArraysCacheSerializer(LayerSerializer):
     """
 
     def snapshot_layer(self, layer: Any) -> dict[str, Any]:
-        """Producer-thread snapshot for ArraysCache. Same threading rule as
-        KVCacheSerializer.snapshot_layer — materialize MLX arrays to numpy
-        *here* so the writer thread never has to touch MLX.
-
-        Also handles the bf16-vs-numpy buffer mismatch via _mx_to_numpy_safe.
-        """
         state_np: list[np.ndarray] = []
         original_dtypes: list[str | None] = []
         for arr in layer.state:
@@ -640,8 +556,7 @@ class ArraysCacheSerializer(LayerSerializer):
             original_dtypes.append(orig)
 
         snapshot: dict[str, Any] = {"state_np": state_np}
-        # Only attach dtype hints if any entry was upcast — keeps the manifest
-        # quiet for fp16/fp32 ArraysCache layers (the common path).
+        # Skip the dtype list in the common (fp16/fp32) case.
         if any(d is not None for d in original_dtypes):
             snapshot["state_original_dtypes"] = original_dtypes
         return snapshot
@@ -781,15 +696,7 @@ class SSDCacheTier:
         logger.info("[ssd_cache] writer thread started")
 
     def _writer_loop(self) -> None:
-        """Background loop: drain spill queue and write to disk.
-
-        Items in the queue are
-        ``(tokens_key, layer_snapshots, memory_bytes)`` — where
-        ``layer_snapshots`` is a list of ``(serializer, snapshot_dict)``
-        already materialized to numpy by ``enqueue_spill``. This thread
-        intentionally never touches MLX, because it has no
-        ``Stream(gpu, N)`` registered (streams are thread-local).
-        """
+        """Drain spill queue and persist entries. Numpy-only — no MLX here."""
         while not self._writer_stop.is_set():
             try:
                 item = self._spill_queue.get(timeout=0.5)
@@ -815,26 +722,12 @@ class SSDCacheTier:
     ) -> bool:
         """Enqueue a cache entry for async spill to SSD.
 
-        Critical: this method runs on the **producer thread** (the request
-        handler that just evicted the entry). It snapshots every layer's MLX
-        arrays to CPU/numpy here, while the request's ``Stream(gpu, N)`` is
-        still registered. The background writer thread receives only the
-        numpy snapshots, so it never has to materialize MLX arrays itself
-        (which would crash with ``There is no Stream(gpu, N) in current
-        thread`` because streams are thread-local in MLX >= 0.31.2).
-
-        See ``LayerSerializer.snapshot_layer`` for the per-type producer-side
-        materialization. See issue waybarrios/vllm-mlx#496 (closed) and PR
-        #479 for the broader stream-ownership context — this fixes the
-        last known cross-thread MLX site in the SSD spill path.
+        Must be called on the producer thread (the request handler that
+        owns the layer's Stream(gpu, N)) — the snapshot below materializes
+        MLX → numpy here so the writer thread never has to.
 
         Returns True if enqueued, False if queue is full (entry dropped).
         """
-        # Snapshot on the producer thread. Each layer becomes a CPU-only
-        # dict ({"keys_np": ndarray, "values_np": ndarray, "offset": int,
-        # ...} for KVCache; {"state_np": [ndarray, ...]} for ArraysCache).
-        # Pre-resolved serializers so we don't repeat duck-type dispatch
-        # work on the writer.
         try:
             layer_snapshots: list[tuple[LayerSerializer, dict[str, Any]]] = []
             for layer in cache:
@@ -842,10 +735,6 @@ class SSDCacheTier:
                 snapshot = serializer.snapshot_layer(layer)
                 layer_snapshots.append((serializer, snapshot))
         except Exception:
-            # Snapshot itself failed (unusual layer type, OOM during
-            # materialization, etc.). Log + drop the entry rather than
-            # crashing the request loop — the request that triggered the
-            # eviction has already returned to the user.
             logger.exception(
                 "[ssd_cache] failed to snapshot layers for spill "
                 f"({len(tokens)} tokens) — entry dropped"
@@ -868,15 +757,7 @@ class SSDCacheTier:
         layer_snapshots: list[tuple[LayerSerializer, dict[str, Any]]],
         memory_bytes: int,
     ) -> None:
-        """Write a single cache entry to disk atomically.
-
-        Runs on the **writer thread**. The ``layer_snapshots`` list was
-        already materialized to numpy on the producer thread by
-        ``enqueue_spill`` — see that method's docstring for the threading
-        rationale. We just persist bytes here; no MLX, no GPU.
-
-        Uses temp-file + rename for crash consistency.
-        """
+        """Atomically persist one entry (writer thread; numpy-only input)."""
         import shutil
 
         entry_hash = self._entry_hash(tokens_key)

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -418,16 +418,51 @@ class LayerSerializer(ABC):
 
     Each implementation handles a specific cache type's serialization
     to/from safetensors files with metadata.
+
+    Threading note for ``snapshot_layer`` vs ``serialize_layer``
+    -----------------------------------------------------------
+    Spill happens in two stages, on two different threads:
+
+    1. ``snapshot_layer`` runs on the **producer thread** — the request handler
+       that just finished generation. That thread owns the per-request MLX
+       ``Stream(gpu, N)`` (where N is the per-request uid) the KV tensors
+       were computed on. Materializing those tensors to CPU/numpy MUST happen
+       here, while the stream is still registered on this thread.
+    2. ``serialize_layer`` runs on the **SSD writer thread** — a long-lived
+       background thread with no MLX streams registered. It only touches the
+       already-materialized numpy snapshot, so it can run anywhere.
+
+    If you skip stage 1 and let the writer thread call ``np.array(mx_array)``
+    directly, MLX tries to use ``Stream(gpu, N)`` on the writer thread, can't
+    find it, and the whole process aborts with
+    ``std::runtime_error: There is no Stream(gpu, N) in current thread.``
     """
 
     @abstractmethod
-    def serialize_layer(
-        self, layer: Any, layer_idx: int, file_path: str
-    ) -> dict[str, Any]:
-        """Serialize a single cache layer to a file.
+    def snapshot_layer(self, layer: Any) -> dict[str, Any]:
+        """Take a CPU-only snapshot of an MLX-backed cache layer.
+
+        Called on the **producer thread** (the one that owns the layer's MLX
+        stream) so that any ``mx.array → np.ndarray`` materialization happens
+        where streams are valid. The returned dict is a self-contained,
+        thread-safe payload that ``serialize_layer`` can persist later.
 
         Args:
-            layer: The cache layer object.
+            layer: The live MLX-backed cache layer object.
+
+        Returns:
+            Dict with numpy-only fields needed by ``serialize_layer``.
+        """
+        ...
+
+    @abstractmethod
+    def serialize_layer(
+        self, snapshot: dict[str, Any], layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        """Persist a snapshot to disk on the SSD writer thread.
+
+        Args:
+            snapshot: The CPU-only snapshot produced by ``snapshot_layer``.
             layer_idx: Index of this layer in the cache list.
             file_path: Path to write the safetensors file.
 
@@ -450,6 +485,40 @@ class LayerSerializer(ABC):
         ...
 
 
+def _mx_to_numpy_safe(arr: Any) -> tuple[np.ndarray, str | None]:
+    """Convert an mx.array → np.ndarray, upcasting numpy-unsupported dtypes.
+
+    numpy >= 1.x has no native bfloat16; mlx's PEP 3118 buffer export of a
+    bf16 array confuses numpy ("Item size 2 for ... buffer format string B
+    does not match the dtype B item size 1"). For any dtype we can't hand to
+    numpy directly, we upcast to fp32 on the producer thread (lossless for
+    bf16/fp16; transient 2× memory) and remember the original dtype as a
+    string in metadata so the SSD-promote path can cast back.
+
+    Returns ``(numpy_array, original_dtype_str_or_None)``. ``original`` is
+    only set when an upcast happened.
+    """
+    try:
+        return np.array(arr), None
+    except RuntimeError as exc:
+        # Specific to the numpy ↔ bf16 buffer-protocol mismatch on mlx 0.31+.
+        # Don't swallow unrelated runtime errors — re-raise if message doesn't
+        # match the expected pattern.
+        if "buffer format string" not in str(exc):
+            raise
+        try:
+            import mlx.core as mx
+        except ImportError:  # pragma: no cover — mlx must be importable here
+            raise
+        # Record dtype name (e.g. "bfloat16") for caller-side downcast.
+        original_dtype = str(arr.dtype).rsplit(".", 1)[-1]
+        upcast = arr.astype(mx.float32)
+        # Force materialization on this thread before handing to numpy, since
+        # astype itself is lazy.
+        mx.eval(upcast)
+        return np.array(upcast), original_dtype
+
+
 class KVCacheSerializer(LayerSerializer):
     """Serializer for KVCache and RotatingKVCache layers.
 
@@ -457,29 +526,72 @@ class KVCacheSerializer(LayerSerializer):
     RotatingKVCache also has .max_size, .keep, .step, ._idx.
     """
 
+    # Extra attributes carried by RotatingKVCache (but not vanilla KVCache).
+    # Stored in metadata so deserialize can faithfully reconstruct either type.
+    _ROTATING_ATTRS = ("max_size", "keep", "step", "_idx")
+
+    def snapshot_layer(self, layer: Any) -> dict[str, Any]:
+        """Producer-thread snapshot: pull keys/values to numpy *here* so the
+        writer thread never touches MLX. See ``LayerSerializer`` docstring for
+        the threading rationale (Stream(gpu,N) is thread-local; the writer
+        thread doesn't have it; an mx→np conversion there aborts the process).
+
+        We also detect the bf16-vs-numpy buffer-protocol mismatch and upcast
+        to fp32 so safetensors can persist the data. The original dtype is
+        carried in the snapshot so the SSD-promote path can downcast back
+        before handing the array back to the model.
+        """
+        # np.array(mx.array) triggers __array__ → MLX materialization. Must
+        # happen on the thread that owns the request's GPU stream. The helper
+        # handles bf16 (and any other dtype numpy refuses) by upcasting.
+        keys_np, keys_orig_dtype = _mx_to_numpy_safe(layer.keys)
+        values_np, values_orig_dtype = _mx_to_numpy_safe(layer.values)
+
+        snapshot: dict[str, Any] = {
+            "keys_np": keys_np,
+            "values_np": values_np,
+            "offset": layer.offset,
+        }
+        # Persist original dtype only if we had to upcast; saves bytes in the
+        # manifest for the common (fp16/fp32) case where numpy roundtrips
+        # without conversion.
+        if keys_orig_dtype is not None:
+            snapshot["keys_original_dtype"] = keys_orig_dtype
+        if values_orig_dtype is not None:
+            snapshot["values_original_dtype"] = values_orig_dtype
+
+        # RotatingKVCache carries scalar bookkeeping (no MLX involved) — copy
+        # by reference; these are plain Python ints/values.
+        for attr in self._ROTATING_ATTRS:
+            if hasattr(layer, attr):
+                snapshot[attr] = getattr(layer, attr)
+        return snapshot
+
     def serialize_layer(
-        self, layer: Any, layer_idx: int, file_path: str
+        self, snapshot: dict[str, Any], layer_idx: int, file_path: str
     ) -> dict[str, Any]:
+        # Runs on the SSD writer thread. Only touches numpy + disk; no MLX.
         from safetensors.numpy import save_file
 
-        keys_np = np.array(layer.keys)
-        values_np = np.array(layer.values)
-
         tensors = {
-            f"layer_{layer_idx}_keys": keys_np,
-            f"layer_{layer_idx}_values": values_np,
+            f"layer_{layer_idx}_keys": snapshot["keys_np"],
+            f"layer_{layer_idx}_values": snapshot["values_np"],
         }
         save_file(tensors, file_path)
 
         metadata = {
             "layer_type": "KVCache",
             "layer_idx": layer_idx,
-            "offset": layer.offset,
+            "offset": snapshot["offset"],
         }
-        # Preserve RotatingKVCache extra attributes
-        for attr in ("max_size", "keep", "step", "_idx"):
-            if hasattr(layer, attr):
-                metadata[attr] = getattr(layer, attr)
+        # Propagate original-dtype hints so the deserialize side can ask the
+        # caller to cast back to bf16 (or whatever the model expects).
+        for k in ("keys_original_dtype", "values_original_dtype"):
+            if k in snapshot:
+                metadata[k] = snapshot[k]
+        for attr in self._ROTATING_ATTRS:
+            if attr in snapshot:
+                metadata[attr] = snapshot[attr]
 
         return metadata
 
@@ -494,7 +606,14 @@ class KVCacheSerializer(LayerSerializer):
             "values": tensors[f"layer_{layer_idx}_values"],
             "offset": metadata["offset"],
         }
-        for attr in ("max_size", "keep", "step", "_idx"):
+        # Surface dtype hints so ``_reconstruct_ssd_layers`` (in
+        # scheduler.py) can re-cast to the original mlx dtype before the
+        # cache returns to the model — preserves memory layout and avoids
+        # implicit-cast surprises in attention kernels.
+        for k in ("keys_original_dtype", "values_original_dtype"):
+            if k in metadata:
+                result[k] = metadata[k]
+        for attr in self._ROTATING_ATTRS:
             if attr in metadata:
                 result[attr] = metadata[attr]
         return result
@@ -506,23 +625,47 @@ class ArraysCacheSerializer(LayerSerializer):
     Handles layers with .state attribute containing a list of arrays.
     """
 
+    def snapshot_layer(self, layer: Any) -> dict[str, Any]:
+        """Producer-thread snapshot for ArraysCache. Same threading rule as
+        KVCacheSerializer.snapshot_layer — materialize MLX arrays to numpy
+        *here* so the writer thread never has to touch MLX.
+
+        Also handles the bf16-vs-numpy buffer mismatch via _mx_to_numpy_safe.
+        """
+        state_np: list[np.ndarray] = []
+        original_dtypes: list[str | None] = []
+        for arr in layer.state:
+            np_arr, orig = _mx_to_numpy_safe(arr)
+            state_np.append(np_arr)
+            original_dtypes.append(orig)
+
+        snapshot: dict[str, Any] = {"state_np": state_np}
+        # Only attach dtype hints if any entry was upcast — keeps the manifest
+        # quiet for fp16/fp32 ArraysCache layers (the common path).
+        if any(d is not None for d in original_dtypes):
+            snapshot["state_original_dtypes"] = original_dtypes
+        return snapshot
+
     def serialize_layer(
-        self, layer: Any, layer_idx: int, file_path: str
+        self, snapshot: dict[str, Any], layer_idx: int, file_path: str
     ) -> dict[str, Any]:
+        # Writer-thread side: pure numpy + disk.
         from safetensors.numpy import save_file
 
-        state = layer.state
-        tensors = {}
-        for i, arr in enumerate(state):
-            tensors[f"layer_{layer_idx}_state_{i}"] = np.array(arr)
-
+        state_np = snapshot["state_np"]
+        tensors = {
+            f"layer_{layer_idx}_state_{i}": arr for i, arr in enumerate(state_np)
+        }
         save_file(tensors, file_path)
 
-        return {
+        metadata = {
             "layer_type": "ArraysCache",
             "layer_idx": layer_idx,
-            "num_arrays": len(state),
+            "num_arrays": len(state_np),
         }
+        if "state_original_dtypes" in snapshot:
+            metadata["state_original_dtypes"] = snapshot["state_original_dtypes"]
+        return metadata
 
     def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
         from safetensors.numpy import load_file
@@ -534,7 +677,10 @@ class ArraysCacheSerializer(LayerSerializer):
         state = []
         for i in range(num_arrays):
             state.append(tensors[f"layer_{layer_idx}_state_{i}"])
-        return {"state": state}
+        result = {"state": state}
+        if "state_original_dtypes" in metadata:
+            result["state_original_dtypes"] = metadata["state_original_dtypes"]
+        return result
 
 
 def get_serializer_for_layer(layer: Any) -> LayerSerializer:
@@ -635,7 +781,15 @@ class SSDCacheTier:
         logger.info("[ssd_cache] writer thread started")
 
     def _writer_loop(self) -> None:
-        """Background loop: drain spill queue and write to disk."""
+        """Background loop: drain spill queue and write to disk.
+
+        Items in the queue are
+        ``(tokens_key, layer_snapshots, memory_bytes)`` — where
+        ``layer_snapshots`` is a list of ``(serializer, snapshot_dict)``
+        already materialized to numpy by ``enqueue_spill``. This thread
+        intentionally never touches MLX, because it has no
+        ``Stream(gpu, N)`` registered (streams are thread-local).
+        """
         while not self._writer_stop.is_set():
             try:
                 item = self._spill_queue.get(timeout=0.5)
@@ -645,9 +799,9 @@ class SSDCacheTier:
             if item is None:  # Poison pill for shutdown
                 break
 
-            tokens_key, cache_layers, memory_bytes = item
+            tokens_key, layer_snapshots, memory_bytes = item
             try:
-                self._write_entry(tokens_key, cache_layers, memory_bytes)
+                self._write_entry(tokens_key, layer_snapshots, memory_bytes)
             except Exception:
                 logger.exception(
                     f"[ssd_cache] failed to write entry " f"({len(tokens_key)} tokens)"
@@ -661,10 +815,45 @@ class SSDCacheTier:
     ) -> bool:
         """Enqueue a cache entry for async spill to SSD.
 
+        Critical: this method runs on the **producer thread** (the request
+        handler that just evicted the entry). It snapshots every layer's MLX
+        arrays to CPU/numpy here, while the request's ``Stream(gpu, N)`` is
+        still registered. The background writer thread receives only the
+        numpy snapshots, so it never has to materialize MLX arrays itself
+        (which would crash with ``There is no Stream(gpu, N) in current
+        thread`` because streams are thread-local in MLX >= 0.31.2).
+
+        See ``LayerSerializer.snapshot_layer`` for the per-type producer-side
+        materialization. See issue waybarrios/vllm-mlx#496 (closed) and PR
+        #479 for the broader stream-ownership context — this fixes the
+        last known cross-thread MLX site in the SSD spill path.
+
         Returns True if enqueued, False if queue is full (entry dropped).
         """
+        # Snapshot on the producer thread. Each layer becomes a CPU-only
+        # dict ({"keys_np": ndarray, "values_np": ndarray, "offset": int,
+        # ...} for KVCache; {"state_np": [ndarray, ...]} for ArraysCache).
+        # Pre-resolved serializers so we don't repeat duck-type dispatch
+        # work on the writer.
         try:
-            self._spill_queue.put_nowait((tokens, cache, memory_bytes))
+            layer_snapshots: list[tuple[LayerSerializer, dict[str, Any]]] = []
+            for layer in cache:
+                serializer = get_serializer_for_layer(layer)
+                snapshot = serializer.snapshot_layer(layer)
+                layer_snapshots.append((serializer, snapshot))
+        except Exception:
+            # Snapshot itself failed (unusual layer type, OOM during
+            # materialization, etc.). Log + drop the entry rather than
+            # crashing the request loop — the request that triggered the
+            # eviction has already returned to the user.
+            logger.exception(
+                "[ssd_cache] failed to snapshot layers for spill "
+                f"({len(tokens)} tokens) — entry dropped"
+            )
+            return False
+
+        try:
+            self._spill_queue.put_nowait((tokens, layer_snapshots, memory_bytes))
             return True
         except queue.Full:
             logger.warning(
@@ -676,10 +865,15 @@ class SSDCacheTier:
     def _write_entry(
         self,
         tokens_key: tuple[int, ...],
-        cache_layers: list[Any],
+        layer_snapshots: list[tuple[LayerSerializer, dict[str, Any]]],
         memory_bytes: int,
     ) -> None:
         """Write a single cache entry to disk atomically.
+
+        Runs on the **writer thread**. The ``layer_snapshots`` list was
+        already materialized to numpy on the producer thread by
+        ``enqueue_spill`` — see that method's docstring for the threading
+        rationale. We just persist bytes here; no MLX, no GPU.
 
         Uses temp-file + rename for crash consistency.
         """
@@ -698,10 +892,9 @@ class SSDCacheTier:
         layer_manifests = []
         total_file_bytes = 0
 
-        for i, layer in enumerate(cache_layers):
-            serializer = get_serializer_for_layer(layer)
+        for i, (serializer, snapshot) in enumerate(layer_snapshots):
             layer_path = os.path.join(tmp_dir, f"layer_{i}.safetensors")
-            metadata = serializer.serialize_layer(layer, i, layer_path)
+            metadata = serializer.serialize_layer(snapshot, i, layer_path)
             layer_manifests.append(metadata)
 
             # Set file permissions
@@ -710,7 +903,7 @@ class SSDCacheTier:
 
         # Write manifest
         manifest = {
-            "num_layers": len(cache_layers),
+            "num_layers": len(layer_snapshots),
             "layers": layer_manifests,
             "memory_bytes": memory_bytes,
             "num_tokens": len(tokens_key),


### PR DESCRIPTION
## Summary

Fixes two distinct bugs that together made `--ssd-cache-dir` crash the server on any text-only model under `--continuous-batching --enable-prefix-cache` whenever the prefix cache filled and triggered eviction. Affects every top model I could test (qwen3-coder-30b, gpt-oss-20b, gpt-oss-120b).

## Bug 1 — `std::runtime_error: There is no Stream(gpu, N) in current thread.`

When an eviction triggered `ssd_tier.enqueue_spill()`, the live `mx.array` references for `layer.keys / layer.values` were placed on a queue and consumed by a background writer thread. The writer then called `np.array(mx_array)` inside `serialize_layer`, forcing an MLX materialization. MLX ≥ 0.31.2 ties each request's compute to a thread-local `Stream(gpu, N)` (N == request uid); the writer thread had no such stream registered, so the conversion aborted the entire process.

Same architectural class as issue #496 / PR #479, but at a new site — the SSD spill writer is its own background daemon thread, not the BatchedEngine MLLM inference thread #479 fixes.

### Fix

- Add `LayerSerializer.snapshot_layer(layer) -> dict`, called on the **producer (request handler) thread** inside `enqueue_spill` **before** the queue handoff. The snapshot materializes each `mx.array` to numpy while the request's stream is still valid.
- `serialize_layer` now takes the snapshot dict instead of the live layer — the writer thread can't accidentally touch MLX because the API doesn't give it any MLX objects.
- Both KV/RotatingKVCache and ArraysCache (Mamba) serializers implement the new method.

## Bug 2 — `RuntimeError: Item size 2 for PEP 3118 buffer format string B does not match the dtype B item size 1.`

`np.array(mx.array<bfloat16>)` raises because numpy has no native bfloat16 and the mlx ≥ 0.31 buffer-protocol export confuses it. qwen3-coder-30b and many modern MLX models use bf16 KV cache, so this was masked behind Bug 1 on every model that actually evicted.

### Fix

- New helper `ssd_cache._mx_to_numpy_safe(arr)` try/excepts the bf16 case and falls back to `arr.astype(mx.float32) + mx.eval + np.array`.
- The original dtype is recorded in the snapshot/manifest as a string (e.g. `"bfloat16"`).
- `scheduler._reconstruct_ssd_layers` casts the restored array back to the original dtype via `mx.array(numpy_fp32).astype(dt)` so the model sees its native KV layout (preserves memory + avoids implicit-cast surprises in attention kernels).
- fp32 on disk is 2× bf16, accepted as a transient trade-off for the spill path.

## Plus: 4 stale unit tests fixed

`test_evict_lru_calls_ssd_spill`, `test_check_ssd_returns_none_on_ram_hit`, `test_full_round_trip`, `test_metrics_accuracy` were all failing on clean v0.4.0rc1 base. The `MemoryCacheConfig.min_prefix_tokens` default is 128; the tests used 10-token sequences, so every `store()` was silently rejected as "short prefix" and the cache stayed empty. Pass `min_prefix_tokens=1` explicitly. (Bug 1 was masking these too — even if `store()` worked, the writer would crash before any test could assert on `spill_count`.)

## Plus: new regression test

`test_snapshot_runs_on_caller_thread` uses a `ThreadBoundArray` fake that raises if `__array__()` is accessed off the creator thread, proving `enqueue_spill` materializes layers on the calling thread (not the writer). This is the architectural invariant Bug 1 violated.

## Verification

**Host:** Apple M5 Pro Max, 128 GB unified memory, macOS Tahoe.

### Unit tests

```
tests/test_ssd_cache.py — 59 passed (was 54 passed + 4 failed; +1 new test)
tests/test_memory_cache.py — 47 passed (non-regression)
```

Lint clean: `ruff check vllm_mlx/ssd_cache.py vllm_mlx/scheduler.py tests/test_ssd_cache.py --select E,F,W --ignore E402,E501,E731,F811,F841` passes. `black --check` passes.

### Runtime verification

Same harness for all three: start vllm-mlx with `--continuous-batching --enable-prefix-cache --cache-memory-mb 50 --ssd-cache-dir /tmp/test --ssd-cache-max-gb 5`, send 9 distinct ≥200-token prompts to force eviction.

| Model | Pre-fix | Post-fix |
|---|---|---|
| `Qwen3-Coder-30B-A3B-Instruct-MLX-4bit` (bf16 KV) | crashes `Stream(gpu, 2)` after request 6 | ✅ 400 spill files / 462 MB, 8 evictions, no crash |
| `mlx-community/gpt-oss-20b-MXFP4-Q8` | crashes `Stream(gpu, 3)` after request 4 | ✅ 130 spill files / 115 MB, 5 evictions, 8/8 hits on replay |
| `mlx-community/gpt-oss-120b-MXFP4-Q8` | crashes `Stream(gpu, 3)` after request 3 | ✅ 266 spill files / 242 MB, 7 evictions, 8/8 hits on replay |

## Related

- Issue #496 (closed) — the original Stream(gpu, N) thread-local invariant write-up.
- Issue #468 (open) — "Define stronger MLX generation stream ownership invariant" — this PR is one site of the broader work.
- PR #479 (open) — `MLXWorkerThread` for BatchedEngine MLLM. Orthogonal; this PR doesn't depend on it and doesn't conflict (different thread, different site).
- PR #481 (merged) — addressed SQLite/locking concerns from issue #480 but did not touch the writer-thread stream crash.

## Test plan

- [ ] CI: `tests/test_ssd_cache.py` + `tests/test_memory_cache.py` green on all matrix Pythons.
- [ ] Manual: `vllm-mlx serve <bf16-KV model> --continuous-batching --enable-prefix-cache --cache-memory-mb 50 --ssd-cache-dir /tmp/test`, send N>cache-capacity prompts, confirm `/v1/cache/stats` shows `evictions > 0`, files appear under `/tmp/test/data/`, no process abort.
- [ ] Manual: replay the first prompt after eviction, confirm SSD reload path runs without dtype errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)