### PR TITLE
feat: TurboQuant — R1 Hadamard rotation for outlier-free MoE weight quantization

### DIFF
--- a/scripts/TURBOQUANT.md
+++ b/scripts/TURBOQUANT.md
@@ -1,0 +1,73 @@
+# TurboQuant — Hadamard-rotated weight quantization
+
+QuaRot-style R1 (residual-stream Hadamard) rotation fused offline into model
+weights, enabling 4-bit quantization on hybrid-attention MoE models like
+Qwen3.5/3.6 and MiniMax-M2 without quality degradation.
+
+## What's included
+
+- `turboquant_rotations.py` — math primitives (Hadamard helpers, RMSNorm fold,
+  R1/R2/R4 fusion).
+- `turboquant_quantize.py` — main conversion script for Qwen3.5/3.6 family
+  (BF16 source). Supports both dense (Qwen3.6-27B) and MoE (Qwen3.6-35B-A3B).
+- `minimax_m2_convert.py` — conversion script for MiniMax-M2 family
+  (FP8 block-128 source). Handles `mx.from_fp8` dequantization + per-block
+  scaling + per-expert stacking (256 separate `block_sparse_moe.experts.<n>.w1/w2/w3`
+  → batched `switch_mlp.{gate,down,up}_proj` per layer).
+- `vllm_mlx/utils/tokenizer.py` — loader hook detecting `quantization.type ==
+  "turboquant_v1"` and installing (optional) R4 runtime patch.
+- `vllm_mlx/patches/turboquant_r4.py` — opt-in monkey-patch for online R4
+  Hadamard (only useful with activation quantization).
+
+## Recipe (default)
+
+- `R1` (residual stream Hadamard): fused offline into embed, lm_head, and ALL
+  in/out projections (q/k/v/o_proj, gate/up/down_proj per expert, etc).
+- `R2` (head-space rotation): SKIPPED for Qwen3.5/3.6 because of their gated
+  attention quirk (`output = o_proj(attn_out * sigmoid(query_gate))`) —
+  element-wise gate breaks R2's offline cancellation. Applicable to MiniMax-M2
+  and standard-attention models.
+- `R4` (online Hadamard before down_proj): **NOT applied by default**. Per the
+  QuaRot paper, R4 is only needed for activation quantization. For weight-only
+  4-bit/8-bit affine schemes, R4 is redundant. The implementation is included
+  as opt-in (`--enable-r4` + `VLLM_MLX_TURBOQUANT_R4=all`) for users who pair
+  this with NVFP4/MXFP8 activation quantization downstream.
+- RMSNorm fold: `(1 + raw_norm_weight)` (Qwen3.5/3.6 offset semantics) folded
+  into downstream projections. Norm weights stored as 1.0 so runtime
+  `weight * normalized = normalized` is identity.
+- Quantization: 4-bit affine on routed `switch_mlp.*` experts; 8-bit affine
+  on attention, linear_attn projections, `shared_expert`, embed_tokens,
+  lm_head. Router gate (`mlp.gate`) and gating heads kept in fp16.
+
+## Usage
+
+### Qwen3.5/3.6 family (BF16 source)
+
+```bash
+# Verify BF16 source shards via SHA256 first (see mandatory rule).
+python scripts/turboquant_quantize.py \
+    --src /path/to/Qwen3.6-Model-BF16 \
+    --dst /path/to/Qwen3.6-Model-mlx-turboquant
+```
+
+### MiniMax-M2 family (FP8 source)
+
+```bash
+python scripts/minimax_m2_convert.py \
+    --src /path/to/MiniMax-M2-Model-FP8 \
+    --dst /path/to/MiniMax-M2-Model-mlx-turboquant
+```
+
+Both produce mlx-loadable safetensors with `quantization.type == "turboquant_v1"`.
+
+## Validated on
+
+- Qwen3.6-35B-A3B (256 routed experts, MoE, 40 layers, BF16 source): 22 GB, 12/12.
+- Qwen3.6-27B Heretic (dense, 64 layers, BF16 source): 19 GB, 12/12.
+- MiniMax-M2.7 (256 routed experts, MoE, 62 layers, FP8 block-128 source):
+  ~145 GB output (in progress).
+
+## References
+
+- [QuaRot: Outlier-Free 4-Bit Inference in Rotated LLMs (Ashkboos et al., 2024)](https://arxiv.org/abs/2404.00456)
+- [AMD Quark — Rotation-based quantization with QuaRot](https://quark.docs.amd.com/release-0.9/pytorch/tutorial_quarot.html)

--- a/scripts/minimax_m2_convert.py
+++ b/scripts/minimax_m2_convert.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""TurboQuant conversion for MiniMax-M2 family (model_type = minimax_m2).
+
+Differences from Qwen3.5/3.6 pipeline (turboquant_quantize.py):
+  - Source is FP8 block-128 (uint8 weight + fp32 scale_inv per 128x128 block).
+    Requires dequant via mx.from_fp8 + per-block scaling before any rotation/quant.
+  - Experts stored per-expert (block_sparse_moe.experts.<n>.w1/w2/w3.weight),
+    must be stacked into batched (E, out, in) form matching SwitchLinear layout
+    (semantic: w1 -> gate_proj, w2 -> down_proj, w3 -> up_proj).
+  - Top-level prefix is `model.*` (NOT `language_model.model.*`).
+  - No shared_expert / shared_expert_gate.
+  - No GatedDeltaNet (full attention only — but interleaved SWA per model docs).
+  - Per-head QK RMSNorm (q_norm, k_norm) with same +1.0 sanitize offset as Qwen.
+
+Memory strategy: process layer-by-layer with shard-on-demand loading.
+Per-layer peak: ~7-10 GB (256 experts × 3 projections × ~10 MB each in bf16).
+
+Reuses turboquant_rotations primitives for R1 Hadamard fusion.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import re
+import shutil
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+import mlx.core as mx
+
+sys.path.insert(0, str(Path(__file__).parent))
+from turboquant_rotations import (
+    apply_r1_to_in_projection,
+    apply_r1_to_out_projection,
+)
+
+# ----------------------------------------------------------------------------
+# FP8 dequantization (DeepSeek-V3 / MiniMax block-128 format).
+# ----------------------------------------------------------------------------
+
+
+def dequant_fp8_block128(weight_u8: mx.array, scale_inv: mx.array) -> mx.array:
+    """Dequantize FP8 weight via per-block-128 scale, matching mlx_lm/models/minimax.py.
+
+    weight_u8: uint8 array of shape (M, N) — FP8 E4M3 storage.
+    scale_inv: float32 array of shape (M/128, N/128) — per-block multipliers
+               (despite the "inv" suffix, mlx_lm multiplies by these).
+    Returns: bf16 array of shape (M, N).
+    """
+    weight = mx.from_fp8(weight_u8, dtype=mx.bfloat16)
+    bs = 128
+    m, n = weight.shape
+    pad_bottom = (-m) % bs
+    pad_side = (-n) % bs
+    if pad_bottom or pad_side:
+        weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+    weight = weight.reshape(((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs))
+    weight = (weight * scale_inv[:, None, :, None]).reshape(
+        m + pad_bottom, n + pad_side
+    )
+    return weight[:m, :n].astype(mx.bfloat16)
+
+
+def _maybe_dequant(weight: mx.array, scale_inv: mx.array | None) -> mx.array:
+    """Dequant if scale present (FP8 source), otherwise return as-is (bf16)."""
+    if scale_inv is None:
+        return weight
+    return dequant_fp8_block128(weight, scale_inv)
+
+
+# ----------------------------------------------------------------------------
+# Shard indexing — map each layer to the source shards it needs.
+# ----------------------------------------------------------------------------
+
+
+def build_layer_shard_index(model_path: Path) -> Tuple[Dict[int, Set[str]], Set[str]]:
+    """Returns ({layer_idx: {shard_names}}, {global_shards}).
+
+    `global_shards` covers embed_tokens, lm_head, model.norm.
+    """
+    idx = json.loads((model_path / "model.safetensors.index.json").read_text())
+    layer_shards: Dict[int, Set[str]] = defaultdict(set)
+    global_shards: Set[str] = set()
+    layer_re = re.compile(r"^model\.layers\.(\d+)\.")
+    for key, shard in idx["weight_map"].items():
+        m = layer_re.match(key)
+        if m:
+            layer_shards[int(m.group(1))].add(shard)
+        elif key in (
+            "model.embed_tokens.weight",
+            "lm_head.weight",
+            "model.norm.weight",
+        ):
+            global_shards.add(shard)
+    return layer_shards, global_shards
+
+
+# ----------------------------------------------------------------------------
+# Collect + dequant + stack one layer's weights.
+# ----------------------------------------------------------------------------
+
+
+def collect_minimax_layer(
+    model_path: Path,
+    layer_idx: int,
+    shards: Set[str],
+    num_experts: int,
+    shard_cache: Dict[str, dict],
+) -> Dict[str, mx.array]:
+    """Load needed shards (with LRU cache), dequant FP8 + stack experts.
+
+    Returns dict of bf16 weights with sanitized minimax-native keys:
+      model.layers.{L}.block_sparse_moe.switch_mlp.{gate,down,up}_proj.weight
+      model.layers.{L}.self_attn.{q,k,v,o}_proj.weight
+      model.layers.{L}.{input_layernorm,post_attention_layernorm}.weight
+      model.layers.{L}.block_sparse_moe.gate.weight
+      ... + qk norms, biases, etc.
+    """
+    # Load shards on demand (simple LRU).
+    for s in shards:
+        if s not in shard_cache:
+            shard_cache[s] = mx.load(str(model_path / s))
+
+    # Aggregate all keys for this layer.
+    prefix = f"model.layers.{layer_idx}"
+    layer_keys: Dict[str, mx.array] = {}
+    for s in shards:
+        for k, v in shard_cache[s].items():
+            if k.startswith(prefix + "."):
+                layer_keys[k] = v
+
+    out: Dict[str, mx.array] = {}
+
+    # ---- Stack + dequant routed experts ----
+    expert_mapping = [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]
+    for orig_name, new_name in expert_mapping:
+        first_key = f"{prefix}.block_sparse_moe.experts.0.{orig_name}.weight"
+        if first_key not in layer_keys:
+            continue
+        weights = []
+        for e in range(num_experts):
+            wk = f"{prefix}.block_sparse_moe.experts.{e}.{orig_name}.weight"
+            sk = f"{prefix}.block_sparse_moe.experts.{e}.{orig_name}.weight_scale_inv"
+            if wk not in layer_keys:
+                raise KeyError(f"missing expert weight: {wk}")
+            w_u8 = layer_keys[wk]
+            scale = layer_keys.get(sk)
+            w_bf16 = _maybe_dequant(w_u8, scale)
+            weights.append(w_bf16)
+        stacked = mx.stack(weights, axis=0)
+        out_key = f"{prefix}.block_sparse_moe.switch_mlp.{new_name}.weight"
+        out[out_key] = stacked.astype(mx.bfloat16)
+        mx.eval(out[out_key])
+
+    # ---- Attention (q/k/v/o_proj) — dequant FP8 ----
+    for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+        wk = f"{prefix}.self_attn.{proj}.weight"
+        sk = f"{prefix}.self_attn.{proj}.weight_scale_inv"
+        if wk not in layer_keys:
+            continue
+        out[wk] = _maybe_dequant(layer_keys[wk], layer_keys.get(sk))
+        mx.eval(out[wk])
+
+    # ---- Router gate (block_sparse_moe.gate) — usually fp32 bf16, no scale ----
+    for tail in (
+        "block_sparse_moe.gate.weight",
+        "block_sparse_moe.e_score_correction_bias",
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+    ):
+        wk = f"{prefix}.{tail}"
+        if wk in layer_keys:
+            out[wk] = layer_keys[wk]
+
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Per-tensor classification + TurboQuant pipeline.
+# ----------------------------------------------------------------------------
+
+
+# Sensitive-layer heuristic (matches Qwen3.6 mixed_4_8).
+def _is_sensitive_layer(layer: int, num_layers: int) -> bool:
+    if layer < 0 or num_layers <= 0:
+        return False
+    first_eighth = num_layers // 8
+    return (
+        layer < first_eighth
+        or layer >= 7 * first_eighth
+        or (layer - first_eighth) % 3 == 2
+    )
+
+
+# Classify minimax key -> (role, layer_idx)
+MINIMAX_PATTERNS = [
+    # Stacked experts (post-sanitize names)
+    (
+        r"model\.layers\.(\d+)\.block_sparse_moe\.switch_mlp\.gate_proj\.weight$",
+        "expert_gate",
+    ),
+    (
+        r"model\.layers\.(\d+)\.block_sparse_moe\.switch_mlp\.up_proj\.weight$",
+        "expert_up",
+    ),
+    (
+        r"model\.layers\.(\d+)\.block_sparse_moe\.switch_mlp\.down_proj\.weight$",
+        "expert_down",
+    ),
+    # Attention
+    (r"model\.layers\.(\d+)\.self_attn\.q_proj\.weight$", "self_q"),
+    (r"model\.layers\.(\d+)\.self_attn\.k_proj\.weight$", "self_k"),
+    (r"model\.layers\.(\d+)\.self_attn\.v_proj\.weight$", "self_v"),
+    (r"model\.layers\.(\d+)\.self_attn\.o_proj\.weight$", "self_o"),
+    (r"model\.layers\.(\d+)\.self_attn\.[qk]_norm\.weight$", "self_qk_norm"),
+    # Norms
+    (r"model\.layers\.(\d+)\.input_layernorm\.weight$", "input_norm"),
+    (r"model\.layers\.(\d+)\.post_attention_layernorm\.weight$", "post_norm"),
+    # Router gate (small fp32, no quant)
+    (r"model\.layers\.(\d+)\.block_sparse_moe\.gate\.weight$", "router_gate"),
+    (
+        r"model\.layers\.(\d+)\.block_sparse_moe\.e_score_correction_bias$",
+        "router_bias",
+    ),
+    # Global
+    (r"model\.embed_tokens\.weight$", "embed"),
+    (r"lm_head\.weight$", "lm_head"),
+    (r"model\.norm\.weight$", "final_norm"),
+]
+
+
+def classify(key: str) -> Tuple[str, int]:
+    for pat, role in MINIMAX_PATTERNS:
+        m = re.match(pat, key)
+        if m:
+            idx = int(m.group(1)) if m.groups() else -1
+            return role, idx
+    return "unknown", -1
+
+
+INPUT_NORM_FOLD_ROLES = {"self_q", "self_k", "self_v"}
+POST_NORM_FOLD_ROLES = {"router_gate", "expert_gate", "expert_up"}
+
+
+def apply_turboquant_per_tensor(
+    key: str,
+    tensor: mx.array,
+    role: str,
+    layer: int,
+    norms: Dict[str, mx.array],
+    hidden_size: int,
+    num_layers: int,
+    enable_r1: bool = True,
+) -> Tuple[mx.array, str]:
+    """Apply RMSNorm fold + R1 rotation + quant-mode decision for a minimax tensor.
+
+    Returns (transformed_tensor, qmode in {"q4","q8","fp16","skip"}).
+    """
+    w = tensor
+    orig_dtype = w.dtype
+
+    # ---- RMSNorm fold (Qwen3.5/3.6-style +1.0 offset semantics) ----
+    if role in INPUT_NORM_FOLD_ROLES:
+        nw = norms[f"model.layers.{layer}.input_layernorm.weight"]
+        scale = 1.0 + nw.astype(mx.float32)
+        w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+    elif role in POST_NORM_FOLD_ROLES:
+        nw = norms[f"model.layers.{layer}.post_attention_layernorm.weight"]
+        scale = 1.0 + nw.astype(mx.float32)
+        if role in ("expert_gate", "expert_up"):
+            w = (w.astype(mx.float32) * scale[None, None, :]).astype(orig_dtype)
+        else:
+            w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+    elif role == "lm_head":
+        nw = norms["model.norm.weight"]
+        scale = 1.0 + nw.astype(mx.float32)
+        w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+
+    # ---- R1 rotation (residual stream Hadamard) ----
+    in_axis_roles = INPUT_NORM_FOLD_ROLES | POST_NORM_FOLD_ROLES | {"embed", "lm_head"}
+    out_axis_roles = {"self_o", "expert_down"}
+    if enable_r1:
+        if role in in_axis_roles:
+            if role in ("expert_gate", "expert_up"):
+                w = mx.hadamard_transform(w.astype(mx.float32))
+            else:
+                w = apply_r1_to_in_projection(w, hidden_size)
+        elif role in out_axis_roles:
+            if role == "expert_down":
+                wT = mx.swapaxes(w.astype(mx.float32), 1, 2)
+                wT_rot = mx.hadamard_transform(wT)
+                w = mx.swapaxes(wT_rot, 1, 2)
+            else:
+                w = apply_r1_to_out_projection(w, hidden_size)
+
+    # ---- Norm weight post-process (sanitize +1 baked in for format=mlx output) ----
+    if role in ("input_norm", "post_norm", "final_norm"):
+        w = mx.ones_like(w)  # folded into projections; runtime weight * x = x
+    elif role == "self_qk_norm":
+        w = (w.astype(mx.float32) + 1.0).astype(orig_dtype)
+
+    # ---- Quantization decision (mixed_4_8 with sensitive layer 8-bit) ----
+    if role == "expert_down":
+        return w, ("q8" if _is_sensitive_layer(layer, num_layers) else "q4")
+    if role in ("expert_gate", "expert_up"):
+        return w, "q4"
+    if role == "self_v":
+        return w, ("q8" if _is_sensitive_layer(layer, num_layers) else "q4")
+    if role in ("self_q", "self_k", "self_o"):
+        return w, "q4"
+    if role in ("embed", "lm_head"):
+        return w, "q8"
+    if role in (
+        "router_gate",
+        "router_bias",
+        "self_qk_norm",
+        "input_norm",
+        "post_norm",
+        "final_norm",
+    ):
+        return w, "fp16"
+    return w, "fp16"
+
+
+def quantize(w: mx.array, mode: str, group_size: int = 64) -> Dict[str, mx.array]:
+    """Run mx.quantize. Returns {".weight": qw, ".scales": sc, ".biases": bi} or {"": w}."""
+    if mode == "fp16":
+        return {"": w.astype(mx.bfloat16)}
+    if mode == "skip":
+        return {"": w}
+    bits = 4 if mode == "q4" else 8
+    # Always cast to bf16 BEFORE quantize so scales+biases come out as bf16
+    # (mx.quantize matches output scale dtype to input). FP32 scales would
+    # add ~25 GB of unnecessary overhead on MiniMax (256 experts × 62 layers).
+    w_in = w.astype(mx.bfloat16)
+    if w.ndim == 2:
+        if w.shape[-1] % group_size != 0:
+            return {"": w_in}
+        qw, sc, bi = mx.quantize(w_in, group_size=group_size, bits=bits)
+        return {".weight": qw, ".scales": sc, ".biases": bi}
+    if w.ndim == 3:
+        E = w.shape[0]
+        qws, scs, bss = [], [], []
+        for e in range(E):
+            qw, sc, bi = mx.quantize(w_in[e], group_size=group_size, bits=bits)
+            qws.append(qw)
+            scs.append(sc)
+            bss.append(bi)
+        return {
+            ".weight": mx.stack(qws, axis=0),
+            ".scales": mx.stack(scs, axis=0),
+            ".biases": mx.stack(bss, axis=0),
+        }
+    return {"": w_in}
+
+
+# ----------------------------------------------------------------------------
+# Main conversion driver — streaming layer-by-layer.
+# ----------------------------------------------------------------------------
+
+
+def convert(
+    src: Path,
+    dst: Path,
+    max_shard_gb: float = 5.0,
+    layer_limit: int | None = None,
+    enable_r1: bool = True,
+) -> None:
+    src = src.expanduser().resolve()
+    dst = dst.expanduser().resolve()
+    dst.mkdir(parents=True, exist_ok=True)
+    print(f"[main] src = {src}")
+    print(f"[main] dst = {dst}")
+
+    cfg = json.loads((src / "config.json").read_text())
+    hidden = cfg["hidden_size"]
+    num_layers = cfg["num_hidden_layers"]
+    num_experts = cfg.get("num_local_experts", cfg.get("num_experts", 256))
+    print(f"[main] hidden={hidden}, layers={num_layers}, experts={num_experts}")
+    if layer_limit:
+        print(f"[main] LAYER LIMIT (sanity test): {layer_limit}")
+
+    print("[main] indexing shards...")
+    layer_shards, global_shards = build_layer_shard_index(src)
+    print(
+        f"  {len(layer_shards)} layers, {sum(len(s) for s in layer_shards.values())} shard-references, {len(global_shards)} global shards"
+    )
+
+    # Phase 1: collect norms (needed for fold computations later)
+    print("[main] pre-loading norms (input/post layernorm per layer + model.norm)...")
+    norms: Dict[str, mx.array] = {}
+    for L in range(num_layers):
+        for s in layer_shards.get(L, set()):
+            d = mx.load(str(src / s))
+            for nk in (
+                f"model.layers.{L}.input_layernorm.weight",
+                f"model.layers.{L}.post_attention_layernorm.weight",
+            ):
+                if nk in d:
+                    norms[nk] = d[nk]
+    for s in global_shards:
+        d = mx.load(str(src / s))
+        if "model.norm.weight" in d:
+            norms["model.norm.weight"] = d["model.norm.weight"]
+    print(f"  collected {len(norms)} norms")
+
+    # Output state
+    out_shards: List[Dict[str, mx.array]] = [{}]
+    cur_size = 0
+    max_size = int(max_shard_gb * 1e9)
+    out_weight_map: Dict[str, str] = {}
+    quant_per_path: Dict[str, dict] = {}
+
+    quant_cfg = {
+        "type": "turboquant_v1",
+        "r1": "hadamard" if enable_r1 else "none",
+        "r4": "none",
+        "expert_bits": 4,
+        "attn_bits": 8,
+        "group_size": 64,
+        "fold_offset_norms": True,
+        "skip_r2": "mixed_attention_safety",
+    }
+    GROUP = 64
+
+    def emit_quantized(out_key: str, w: mx.array, mode: str):
+        nonlocal cur_size
+        parts = quantize(w, mode, group_size=GROUP)
+        bits = 4 if mode == "q4" else 8
+        base = out_key[: -len(".weight")] if out_key.endswith(".weight") else out_key
+        for suf, t in parts.items():
+            ok = base + suf if suf else out_key
+            mx.eval(t)
+            sz = t.nbytes
+            if cur_size + sz > max_size:
+                out_shards.append({})
+                cur_size = 0
+            out_shards[-1][ok] = t
+            cur_size += sz
+        quant_per_path[base] = {"group_size": GROUP, "bits": bits, "mode": "affine"}
+
+    def emit_raw(out_key: str, t: mx.array):
+        nonlocal cur_size
+        mx.eval(t)
+        sz = t.nbytes
+        if cur_size + sz > max_size:
+            out_shards.append({})
+            cur_size = 0
+        out_shards[-1][out_key] = t
+        cur_size += sz
+
+    # Phase 2: per-layer streaming
+    shard_cache: Dict[str, dict] = {}
+    t0 = time.time()
+    for L in range(num_layers):
+        if layer_limit is not None and L >= layer_limit:
+            break
+        shards = layer_shards.get(L, set())
+        if not shards:
+            print(f"  [L{L}] no shards — skip")
+            continue
+        t_layer = time.time()
+        layer_tensors = collect_minimax_layer(src, L, shards, num_experts, shard_cache)
+        t_collect = time.time() - t_layer
+
+        # Apply turboquant per tensor
+        for k, t in layer_tensors.items():
+            role, lyr = classify(k)
+            new_w, mode = apply_turboquant_per_tensor(
+                k, t, role, lyr, norms, hidden, num_layers, enable_r1=enable_r1
+            )
+            if mode in ("q4", "q8"):
+                emit_quantized(k, new_w, mode)
+            else:
+                emit_raw(k, new_w)
+
+        # Evict shards that no future layer needs
+        future_shards = set()
+        for fut_L in range(L + 1, num_layers):
+            future_shards |= layer_shards.get(fut_L, set())
+        future_shards |= global_shards
+        for s in list(shard_cache.keys()):
+            if s not in future_shards:
+                del shard_cache[s]
+
+        elapsed_layer = time.time() - t_layer
+        print(
+            f"  [L{L:2d}] collect={t_collect:5.1f}s  total={elapsed_layer:5.1f}s  "
+            f"shards_cached={len(shard_cache)}  out_shards={len(out_shards)}"
+        )
+
+    # Phase 3: global tensors (embed, lm_head, model.norm)
+    print("\n[main] processing global tensors (embed, lm_head, model.norm)...")
+    for s in global_shards:
+        d = shard_cache.get(s) or mx.load(str(src / s))
+        for k, t in d.items():
+            if k not in (
+                "model.embed_tokens.weight",
+                "lm_head.weight",
+                "model.norm.weight",
+            ):
+                continue
+            role, lyr = classify(k)
+            new_w, mode = apply_turboquant_per_tensor(
+                k, t, role, lyr, norms, hidden, num_layers, enable_r1=enable_r1
+            )
+            if mode in ("q4", "q8"):
+                emit_quantized(k, new_w, mode)
+            else:
+                emit_raw(k, new_w)
+
+    print(f"\n[main] total time: {time.time() - t0:.1f}s")
+
+    # Phase 4: write output
+    print(f"[main] writing {len(out_shards)} output shards...")
+    for i, shard in enumerate(out_shards):
+        name = f"model-{i+1:05d}-of-{len(out_shards):05d}.safetensors"
+        mx.save_safetensors(str(dst / name), shard, metadata={"format": "mlx"})
+        for k in shard:
+            out_weight_map[k] = name
+        sz = sum(v.nbytes for v in shard.values())
+        print(f"  wrote {name} ({len(shard)} tensors, {sz/1e9:.2f} GB)")
+
+    total_size = sum(v.nbytes for s in out_shards for v in s.values())
+    (dst / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": int(total_size)},
+                "weight_map": out_weight_map,
+            },
+            indent=2,
+        )
+    )
+
+    # Phase 5: copy aux + write quant config
+    out_cfg = dict(cfg)
+    out_cfg["quantization"] = {
+        **quant_cfg,
+        "group_size": GROUP,
+        "bits": 4,
+        "mode": "affine",
+    }
+    for k, v in quant_per_path.items():
+        out_cfg["quantization"][k] = v
+    out_cfg["quantization_config"] = out_cfg["quantization"]
+    (dst / "config.json").write_text(json.dumps(out_cfg, indent=2))
+
+    for f in src.glob("*"):
+        if f.is_file() and f.suffix in (".json", ".jinja", ".py", ".md", ".txt"):
+            if f.name not in ("config.json", "model.safetensors.index.json"):
+                shutil.copy(f, dst / f.name)
+
+    import subprocess
+
+    r = subprocess.run(["du", "-sh", str(dst)], capture_output=True, text=True)
+    print(f"\n[main] DONE: {dst}")
+    print(f"  total size: {r.stdout.strip()}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True, type=Path)
+    ap.add_argument("--dst", required=True, type=Path)
+    ap.add_argument("--max-shard-gb", default=5.0, type=float)
+    ap.add_argument(
+        "--layer-limit",
+        type=int,
+        default=None,
+        help="Process only first N layers (sanity test).",
+    )
+    ap.add_argument(
+        "--no-r1",
+        action="store_true",
+        help="DIAGNOSTIC: skip R1 rotation (matches mixed_4_8 baseline).",
+    )
+    args = ap.parse_args()
+    convert(
+        args.src,
+        args.dst,
+        args.max_shard_gb,
+        args.layer_limit,
+        enable_r1=not args.no_r1,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/turboquant_quantize.py
+++ b/scripts/turboquant_quantize.py
@@ -1,0 +1,883 @@
+#!/usr/bin/env python3
+"""TurboQuant conversion: BF16 → R1+R4 rotated + 4-bit/8-bit affine quantized.
+
+Operates DIRECTLY on safetensors shards without loading the full model into
+memory. Per-tensor pipeline: read → fold norm → rotate → quantize → write.
+
+Targets Qwen3.6-35B-A3B (qwen3_5_moe, hybrid attention) for Phase 0 PoC,
+extendable to MiniMax-M2.7 (minimax_m2) in Phase 1.
+
+Recipe:
+  - R1 (residual stream Hadamard): fused offline into all in/out projections,
+    embed_tokens, lm_head.
+  - R4 (intermediate Hadamard before down_proj): pre-rotation fused offline;
+    runtime patch applies mx.hadamard_transform online.
+  - R2 (head-space rotation): SKIPPED for qwen3.5/3.6 (gated attention quirk).
+  - RMSNorm fold: (1 + norm_weight) folded into downstream projections; norm
+    weights set to 0 so runtime `(1 + 0) = 1` identity.
+  - Quantization: 4-bit affine on switch_mlp experts, 8-bit affine on
+    attention, shared_expert, embed_tokens, lm_head. Router gate fp16.
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import mlx.core as mx
+import numpy as np
+
+# Import rotation helpers from sibling module.
+# Add this directory to path so sibling import works regardless of cwd.
+import sys as _sys
+from pathlib import Path as _Path
+
+_sys.path.insert(0, str(_Path(__file__).parent))
+
+from turboquant_rotations import (
+    apply_r1_to_in_projection,
+    apply_r1_to_out_projection,
+    apply_r4_to_down_proj,
+)
+
+# ---------------------------------------------------------------------------
+# Architecture-specific module classification.
+# ---------------------------------------------------------------------------
+
+# Special key marker meaning "BF16 source has fused gate+up, split during processing".
+GATE_UP_FUSED_SUFFIX = "switch_mlp.gate_up_proj.weight"
+
+
+# Patterns that match weight tensor paths. (Qwen3.6-35B-A3B style.)
+# Each entry: (regex, role)
+QWEN36_PATTERNS = [
+    # Embeddings / head
+    (r"language_model\.model\.embed_tokens\.weight$", "embed"),
+    (r"language_model\.lm_head\.weight$", "lm_head"),
+    (r"language_model\.model\.norm\.weight$", "final_norm"),
+    # Per-layer norms
+    (r"language_model\.model\.layers\.(\d+)\.input_layernorm\.weight$", "input_norm"),
+    (
+        r"language_model\.model\.layers\.(\d+)\.post_attention_layernorm\.weight$",
+        "post_norm",
+    ),
+    # Full attention (layers where is_linear=False, every 4th)
+    (r"language_model\.model\.layers\.(\d+)\.self_attn\.q_proj\.weight$", "self_q"),
+    (r"language_model\.model\.layers\.(\d+)\.self_attn\.k_proj\.weight$", "self_k"),
+    (r"language_model\.model\.layers\.(\d+)\.self_attn\.v_proj\.weight$", "self_v"),
+    (r"language_model\.model\.layers\.(\d+)\.self_attn\.o_proj\.weight$", "self_o"),
+    (
+        r"language_model\.model\.layers\.(\d+)\.self_attn\.[qk]_norm\.weight$",
+        "self_qk_norm",
+    ),
+    # GatedDeltaNet (linear_attn)
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.in_proj_qkv\.weight$",
+        "linear_in_qkv",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.in_proj_z\.weight$",
+        "linear_in_z",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.in_proj_a\.weight$",
+        "linear_in_a",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.in_proj_b\.weight$",
+        "linear_in_b",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.out_proj\.weight$",
+        "linear_out",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.conv1d\.weight$",
+        "linear_conv",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.linear_attn\.norm\.weight$",
+        "linear_inner_norm",
+    ),
+    (r"language_model\.model\.layers\.(\d+)\.linear_attn\.dt_bias$", "linear_dt_bias"),
+    (r"language_model\.model\.layers\.(\d+)\.linear_attn\.A_log$", "linear_A_log"),
+    # MoE
+    (r"language_model\.model\.layers\.(\d+)\.mlp\.gate\.weight$", "router_gate"),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.shared_expert_gate\.weight$",
+        "shared_expert_gate",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.shared_expert\.gate_proj\.weight$",
+        "shared_gate",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.shared_expert\.up_proj\.weight$",
+        "shared_up",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.shared_expert\.down_proj\.weight$",
+        "shared_down",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.switch_mlp\.gate_proj\.weight$",
+        "expert_gate",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.switch_mlp\.up_proj\.weight$",
+        "expert_up",
+    ),
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.switch_mlp\.down_proj\.weight$",
+        "expert_down",
+    ),
+    # Fused gate+up marker (will be split at processing time).
+    (
+        r"language_model\.model\.layers\.(\d+)\.mlp\.switch_mlp\.gate_up_proj\.weight$",
+        "expert_gate_up_fused",
+    ),
+    # Dense MLP (Qwen3.6-27B, model_type qwen3_5_text without MoE)
+    # WARNING: order matters — match these AFTER the switch_mlp/shared_expert patterns above.
+    (r"language_model\.model\.layers\.(\d+)\.mlp\.gate_proj\.weight$", "dense_gate"),
+    (r"language_model\.model\.layers\.(\d+)\.mlp\.up_proj\.weight$", "dense_up"),
+    (r"language_model\.model\.layers\.(\d+)\.mlp\.down_proj\.weight$", "dense_down"),
+    # Vision tower (pass through unchanged)
+    (r"^visual\.", "vision_passthrough"),
+    (r"vision_tower\.", "vision_passthrough"),
+    (r"mtp\.", "mtp_passthrough"),
+]
+
+
+def classify(key: str) -> Tuple[str, int]:
+    """Return (role_name, layer_idx or -1)."""
+    for pat, role in QWEN36_PATTERNS:
+        m = re.search(pat, key)
+        if m:
+            idx = int(m.group(1)) if m.groups() else -1
+            return role, idx
+    return "unknown", -1
+
+
+# ---------------------------------------------------------------------------
+# Two-pass conversion: pass 1 collects norm weights per layer; pass 2 rewrites.
+# ---------------------------------------------------------------------------
+
+
+def sanitize_key(key: str) -> str | None:
+    """Apply mlx_vlm/mlx_lm-style key rename. Returns None to drop the key.
+
+    Matches sanitize() in mlx_vlm/models/qwen3_5/qwen3_5.py +
+    qwen3_5_moe specifics (NOT including expert split — that's handled
+    at processing time by EXPERT_SPLIT_SUFFIXES below).
+    """
+    if key.startswith("mtp."):
+        return None
+    # Rename top-level prefixes.
+    if key.startswith("model.language_model"):
+        key = key.replace("model.language_model", "language_model.model")
+    elif key.startswith("model.visual"):
+        key = key.replace("model.visual", "vision_tower")
+    elif key.startswith("lm_head"):
+        key = "language_model." + key
+    # Rename fused experts.gate_up_proj → marker, will be split at processing.
+    if key.endswith(".mlp.experts.gate_up_proj"):
+        return key.replace(
+            ".mlp.experts.gate_up_proj", ".mlp.switch_mlp.gate_up_proj.weight"
+        )
+    if key.endswith(".mlp.experts.down_proj"):
+        return key.replace(".mlp.experts.down_proj", ".mlp.switch_mlp.down_proj.weight")
+    return key
+
+
+def load_all_keys(model_dir: Path) -> Dict[str, str]:
+    """Return {sanitized_weight_key: (shard_filename, original_key)}."""
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        idx = json.loads(idx_path.read_text())
+        raw = idx["weight_map"]
+    else:
+        files = list(model_dir.glob("*.safetensors"))
+        assert len(files) == 1, f"expected single shard, got {files}"
+        data = mx.load(str(files[0]))
+        raw = {k: files[0].name for k in data}
+    # Apply sanitize, drop None.
+    sanitized: Dict[str, Tuple[str, str]] = {}
+    for orig, shard in raw.items():
+        new_k = sanitize_key(orig)
+        if new_k is None:
+            continue
+        sanitized[new_k] = (shard, orig)
+    return sanitized
+
+
+def collect_norm_weights(
+    model_dir: Path, keys: Dict[str, Tuple[str, str]]
+) -> Dict[str, mx.array]:
+    """Pre-load all norm weights (small) for fold computation. Keys is dict of
+    {sanitized_key: (shard_name, original_key)}. Returns dict by SANITIZED key."""
+    norms: Dict[str, mx.array] = {}
+    norm_keys = [
+        k
+        for k in keys
+        if k.endswith("input_layernorm.weight")
+        or k.endswith("post_attention_layernorm.weight")
+        or k.endswith("model.norm.weight")
+    ]
+    by_shard: Dict[str, List[Tuple[str, str]]] = {}
+    for k in norm_keys:
+        shard, orig = keys[k]
+        by_shard.setdefault(shard, []).append((k, orig))
+    for shard, ks in by_shard.items():
+        data = mx.load(str(model_dir / shard))
+        for sanitized_k, orig_k in ks:
+            norms[sanitized_k] = data[orig_k]
+        del data
+    return norms
+
+
+def get_norm_for_layer(norms: Dict[str, mx.array], layer: int, role: str) -> mx.array:
+    """Return the (1 + w) scale for fold given role."""
+    if role == "input_norm":
+        k = f"language_model.model.layers.{layer}.input_layernorm.weight"
+    elif role == "post_norm":
+        k = f"language_model.model.layers.{layer}.post_attention_layernorm.weight"
+    elif role == "final_norm":
+        k = "language_model.model.norm.weight"
+    else:
+        raise KeyError(role)
+    return norms[k]
+
+
+# Roles needing input-norm fold (uses input_layernorm of same layer).
+INPUT_NORM_FOLD_ROLES = {
+    "self_q",
+    "self_k",
+    "self_v",
+    "linear_in_qkv",
+    "linear_in_z",
+    "linear_in_a",
+    "linear_in_b",
+}
+# Roles needing post-norm fold (uses post_attention_layernorm of same layer).
+POST_NORM_FOLD_ROLES = {
+    "router_gate",
+    "shared_expert_gate",
+    "shared_gate",
+    "shared_up",
+    "expert_gate",
+    "expert_up",
+    "dense_gate",
+    "dense_up",
+}
+
+
+def _is_sensitive_layer(layer: int, num_layers: int) -> bool:
+    """mixed_4_8 sensitive layer heuristic: first 1/8, last 1/8, every 3rd middle.
+
+    Sensitive layers get 8-bit (instead of 4-bit base) for the most precision-
+    critical projections (down_proj, v_proj). Matches the predicate used by
+    Qwen3.6-27B PROD mixed_4_8.
+    """
+    if layer < 0 or num_layers <= 0:
+        return False  # global tensors (embed, lm_head) handled separately
+    first_eighth = num_layers // 8
+    return (
+        layer < first_eighth
+        or layer >= 7 * first_eighth
+        or (layer - first_eighth) % 3 == 2
+    )
+
+
+def apply_fold_and_rotate(
+    key: str,
+    tensor: mx.array,
+    role: str,
+    layer: int,
+    norms: Dict[str, mx.array],
+    hidden_size: int,
+    intermediate_size: int,
+    skip_rotations: bool = False,
+    fold_norms: bool = True,
+    r1_roles: set | None = None,
+    enable_r4: bool = True,
+    expert_bits: int = 4,
+    num_layers: int = 0,
+) -> Tuple[mx.array, str]:
+    """Apply RMSNorm fold + R1 + (R4 if applicable). Returns (new_tensor, suggested_quant).
+
+    suggested_quant in {"q4", "q8", "fp16", "skip"}.
+    skip_rotations: diagnostic — fold norms but DON'T rotate. Should produce
+    a model equivalent to standard 4-bit/8-bit mix quantization.
+    fold_norms: if False, keep (1+raw) in norm (matching PROD mixed_4_8 behavior).
+    Required True for R1 rotation to make sense.
+    """
+    w = tensor  # already mx.array bf16
+    orig_dtype = w.dtype
+
+    # --- Norm folds ---
+    if fold_norms:
+        if role in INPUT_NORM_FOLD_ROLES:
+            nw = get_norm_for_layer(norms, layer, "input_norm")
+            scale = 1.0 + nw.astype(mx.float32)
+            w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+        elif role in POST_NORM_FOLD_ROLES:
+            nw = get_norm_for_layer(norms, layer, "post_norm")
+            scale = 1.0 + nw.astype(mx.float32)
+            if role in ("expert_gate", "expert_up"):
+                # 3D weight (E, out, in)
+                w = (w.astype(mx.float32) * scale[None, None, :]).astype(orig_dtype)
+            else:
+                w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+        elif role == "lm_head":
+            nw = get_norm_for_layer(norms, 0, "final_norm")  # final norm is global
+            scale = 1.0 + nw.astype(mx.float32)
+            w = (w.astype(mx.float32) * scale[None, :]).astype(orig_dtype)
+
+    # --- R1 rotation (skipped in diagnostic mode) ---
+    # IMPORTANT: rotated weights stay in fp32 throughout the pipeline to avoid
+    # bf16 down-cast precision loss after Hadamard transform. mx.quantize
+    # accepts fp32 input and handles precision internally.
+    in_axis_roles = INPUT_NORM_FOLD_ROLES | POST_NORM_FOLD_ROLES | {"lm_head", "embed"}
+    out_axis_roles = {
+        "self_o",
+        "linear_out",
+        "shared_down",
+        "expert_down",
+        "dense_down",
+    }
+    if skip_rotations:
+        # Skip R1 + R4 — just fold norms + quantize. Diagnostic only.
+        # Output format is "mlx" → sanitize() is skipped at load.
+        # If fold_norms=True: norm absorbed into projections, store norm=1.0.
+        # If fold_norms=False: store norm=(1+raw) matching PROD behavior.
+        if role in ("input_norm", "post_norm", "final_norm"):
+            if fold_norms:
+                w = mx.ones_like(w)
+            else:
+                w = (w.astype(mx.float32) + 1.0).astype(orig_dtype)
+        elif role == "self_qk_norm":
+            w = (w.astype(mx.float32) + 1.0).astype(orig_dtype)
+        # Determine quant mode and return early.
+        if role in (
+            "expert_gate",
+            "expert_up",
+            "expert_down",
+            "dense_gate",
+            "dense_up",
+            "dense_down",
+        ):
+            return w, ("q4" if expert_bits == 4 else "q8")
+        elif role in (
+            "self_q",
+            "self_k",
+            "self_v",
+            "self_o",
+            "linear_in_qkv",
+            "linear_in_z",
+            "linear_in_a",
+            "linear_in_b",
+            "linear_out",
+            "shared_gate",
+            "shared_up",
+            "shared_down",
+            "embed",
+            "lm_head",
+        ):
+            return w, "q8"
+        elif role in (
+            "router_gate",
+            "shared_expert_gate",
+            "self_qk_norm",
+            "linear_inner_norm",
+            "input_norm",
+            "post_norm",
+            "final_norm",
+            "linear_dt_bias",
+            "linear_A_log",
+            "linear_conv",
+        ):
+            return w, "fp16"
+        elif role in ("vision_passthrough", "mtp_passthrough"):
+            return w, "skip"
+        return w, "fp16"
+    # R1 only if role is in selected set (bisect-friendly).
+    apply_r1 = r1_roles is None or role in r1_roles
+    if apply_r1:
+        if role in in_axis_roles:
+            if role in ("expert_gate", "expert_up"):
+                # 3D — Hadamard on last axis (input). Stay fp32 after rotation.
+                w = mx.hadamard_transform(w.astype(mx.float32))
+            else:
+                w = apply_r1_to_in_projection(w, hidden_size)
+        elif role in out_axis_roles:
+            if role == "expert_down":
+                # 3D (E, hidden, intermediate) — rotate hidden axis (axis=1)
+                wT = mx.swapaxes(w.astype(mx.float32), 1, 2)
+                wT_rot = mx.hadamard_transform(wT)
+                w = mx.swapaxes(wT_rot, 1, 2)
+            else:
+                w = apply_r1_to_out_projection(w, hidden_size)
+
+    # --- R4 rotation (pre-rotate down_proj input side). Stay fp32 ---
+    # enable_r4 can be "shared" / "experts" / "all" / False for bisect.
+    r4_shared = enable_r4 is True or enable_r4 == "shared" or enable_r4 == "all"
+    r4_experts = enable_r4 is True or enable_r4 == "experts" or enable_r4 == "all"
+    if r4_shared and role == "shared_down":
+        w = apply_r4_to_down_proj(w, intermediate_size)
+    elif r4_experts and role == "expert_down":
+        w = mx.hadamard_transform(w.astype(mx.float32))
+
+    # --- Norm weights: format=mlx skips sanitize, so we must bake +1.0 here.
+    if role in ("input_norm", "post_norm", "final_norm"):
+        if fold_norms:
+            w = mx.ones_like(w)  # folded into projections
+        else:
+            w = (w.astype(mx.float32) + 1.0).astype(orig_dtype)  # PROD-like
+    elif role == "self_qk_norm":
+        # q_norm / k_norm are NOT folded (internal head-space norms), but
+        # they DO need the +1.0 sanitize offset baked in.
+        w = (w.astype(mx.float32) + 1.0).astype(orig_dtype)
+
+    # --- Quantization decision ---
+    # MoE routed experts: 4-bit (or 8 if expert_bits=8 diagnostic).
+    if role in ("expert_gate", "expert_up", "expert_down"):
+        return w, ("q4" if expert_bits == 4 else "q8")
+
+    # Dense MLP: mixed_4_8-style — 4-bit base + 8-bit on sensitive layers'
+    # down_proj. Matches PROD predicate for Qwen3.6-27B for throughput parity.
+    if role == "dense_down":
+        return w, ("q8" if _is_sensitive_layer(layer, num_layers) else "q4")
+    if role in ("dense_gate", "dense_up"):
+        return w, "q4"
+
+    # Attention: 4-bit base + 8-bit on v_proj of sensitive layers (mixed_4_8).
+    if role == "self_v":
+        return w, ("q8" if _is_sensitive_layer(layer, num_layers) else "q4")
+    if role in ("self_q", "self_k", "self_o"):
+        return w, "q4"
+
+    # GatedDeltaNet projections: 4-bit base (no sensitive split in mixed_4_8).
+    if role in (
+        "linear_in_qkv",
+        "linear_in_z",
+        "linear_in_a",
+        "linear_in_b",
+        "linear_out",
+    ):
+        return w, "q4"
+
+    # Shared expert (MoE only): 4-bit + 8-bit on sensitive down_proj.
+    if role == "shared_down":
+        return w, ("q8" if _is_sensitive_layer(layer, num_layers) else "q4")
+    if role in ("shared_gate", "shared_up"):
+        return w, "q4"
+
+    # Embeddings + LM head: always 8-bit (high outlier sensitivity).
+    if role in ("embed", "lm_head"):
+        return w, "q8"
+    # Router / norms / small fp16-passthrough tensors.
+    if role in (
+        "router_gate",
+        "shared_expert_gate",
+        "self_qk_norm",
+        "linear_inner_norm",
+        "input_norm",
+        "post_norm",
+        "final_norm",
+        "linear_dt_bias",
+        "linear_A_log",
+        "linear_conv",
+    ):
+        return w, "fp16"
+    if role in ("vision_passthrough", "mtp_passthrough"):
+        return w, "skip"
+    return w, "fp16"  # default: keep as is
+
+
+def quantize_tensor(
+    w: mx.array, mode: str, group_size: int = 64
+) -> Dict[str, mx.array]:
+    """Apply mx.quantize with given bits. Returns dict of tensors (weight, scales, biases).
+
+    mode: "q4" → 4-bit affine, "q8" → 8-bit affine, "fp16" → keep as bf16 (no quant).
+    """
+    if mode == "q4":
+        bits = 4
+    elif mode == "q8":
+        bits = 8
+    else:
+        return {"": w}  # raw (single key)
+
+    # Quantize from fp32 if w is fp32 (preserves precision from rotation).
+    # mx.quantize requires fp16/bf16/fp32; fp32 gives best scale fit.
+    qin_dtype = mx.float32 if w.dtype == mx.float32 else mx.bfloat16
+
+    if w.ndim == 2:
+        if w.shape[-1] % group_size != 0:
+            return {"": w.astype(mx.bfloat16)}
+        qw, scales, biases = mx.quantize(
+            w.astype(qin_dtype), group_size=group_size, bits=bits
+        )
+        return {".weight": qw, ".scales": scales, ".biases": biases}
+    elif w.ndim == 3:
+        E = w.shape[0]
+        qws, scs, bss = [], [], []
+        for e in range(E):
+            qw, sc, bi = mx.quantize(
+                w[e].astype(qin_dtype), group_size=group_size, bits=bits
+            )
+            qws.append(qw)
+            scs.append(sc)
+            bss.append(bi)
+        return {
+            ".weight": mx.stack(qws, axis=0),
+            ".scales": mx.stack(scs, axis=0),
+            ".biases": mx.stack(bss, axis=0),
+        }
+    else:
+        return {"": w.astype(mx.bfloat16)}
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline.
+# ---------------------------------------------------------------------------
+
+
+def convert(
+    src: Path,
+    dst: Path,
+    max_shard_gb: float = 5.0,
+    layer_limit: int | None = None,
+    skip_rotations: bool = False,
+    fold_norms: bool = True,
+    r1_roles: set | None = None,
+    enable_r4: bool = False,  # R4 default OFF (not needed for weight-only quant per QuaRot)
+    expert_bits: int = 4,
+) -> None:
+    src = src.expanduser().resolve()
+    dst = dst.expanduser().resolve()
+    dst.mkdir(parents=True, exist_ok=True)
+    print(f"[main] src = {src}")
+    print(f"[main] dst = {dst}")
+
+    # Load config to find hidden_size, intermediate_size, layer count.
+    cfg = json.loads((src / "config.json").read_text())
+    text_cfg = cfg.get("text_config", cfg)
+    hidden = text_cfg.get("hidden_size") or text_cfg.get("dim")
+    intermediate = text_cfg.get("moe_intermediate_size") or text_cfg.get(
+        "intermediate_size"
+    )
+    num_layers = text_cfg.get("num_hidden_layers")
+    num_experts = text_cfg.get("num_experts", 0)
+    print(
+        f"[main] hidden={hidden}, moe_intermediate={intermediate}, layers={num_layers}, experts={num_experts}"
+    )
+    if layer_limit is not None:
+        print(f"[main] LAYER LIMIT for sanity test: {layer_limit}")
+
+    # Map all keys to shards.
+    keys = load_all_keys(src)
+    print(f"[main] total tensors: {len(keys)}")
+
+    # Collect norms (small, fits in RAM easily).
+    print("[main] pre-loading norm weights...")
+    norms = collect_norm_weights(src, keys)
+    print(f"  collected {len(norms)} norm tensors")
+
+    # Process tensors per shard, save in batches sized by max_shard_gb.
+    out_shards: List[Dict[str, np.ndarray]] = [{}]
+    cur_size = 0
+    max_size = int(max_shard_gb * 1e9)
+    out_weight_map: Dict[str, str] = {}
+
+    quant_cfg = {
+        "type": "turboquant_v1" if not skip_rotations else "turboquant_v1_norot_diag",
+        "r1": "hadamard" if not skip_rotations else "none",
+        "r4": "hadamard_intermediate" if (not skip_rotations and enable_r4) else "none",
+        "r1_roles": list(r1_roles) if r1_roles is not None else "all",
+        "expert_bits": expert_bits,
+        "attn_bits": 8,
+        "group_size": 64,
+        "fold_offset_norms": True,
+        "skip_r2": "qwen3_5_gated_attention",
+    }
+    quant_per_path: Dict[str, dict] = {}
+
+    by_shard: Dict[str, List[Tuple[str, str]]] = {}
+    for sanitized_k, (shard, orig_k) in keys.items():
+        by_shard.setdefault(shard, []).append((sanitized_k, orig_k))
+
+    # out_shards is a list of dicts of mx.arrays; written via mx.save_safetensors per shard
+    out_shards_mx: List[Dict[str, mx.array]] = [{}]
+    cur_size = 0
+
+    t_start = time.time()
+    tensor_count = 0
+    skipped = 0
+
+    def emit_quantized(out_key: str, w: mx.array, qmode: str):
+        nonlocal cur_size
+        parts = quantize_tensor(w, qmode, group_size=quant_cfg["group_size"])
+        bits = 4 if qmode == "q4" else 8
+        base_key = (
+            out_key[: -len(".weight")] if out_key.endswith(".weight") else out_key
+        )
+        for suf, t in parts.items():
+            ok = base_key + suf if suf else out_key
+            mx.eval(t)
+            sz = t.nbytes
+            if cur_size + sz > max_size:
+                out_shards_mx.append({})
+                cur_size = 0
+            out_shards_mx[-1][ok] = t
+            cur_size += sz
+        # Per-path key in config must match module path (no .weight suffix).
+        config_key = base_key
+        quant_per_path[config_key] = {
+            "group_size": quant_cfg["group_size"],
+            "bits": bits,
+            "mode": "affine",
+        }
+
+    def emit_raw(out_key: str, t: mx.array):
+        nonlocal cur_size
+        mx.eval(t)
+        sz = t.nbytes
+        if cur_size + sz > max_size:
+            out_shards_mx.append({})
+            cur_size = 0
+        out_shards_mx[-1][out_key] = t
+        cur_size += sz
+
+    for shard_name in sorted(by_shard.keys()):
+        items = by_shard[shard_name]
+        print(f"\n[shard] processing {shard_name} ({len(items)} tensors)...")
+        data = mx.load(str(src / shard_name))
+        for k, orig_k in items:
+            role, layer = classify(k)
+            if layer_limit is not None and layer >= 0 and layer >= layer_limit:
+                skipped += 1
+                continue
+            tensor = data[orig_k]
+
+            # Special case: fused gate+up needs to be split into two separate
+            # weights BEFORE fold/rotation (each half gets identical treatment).
+            if role == "expert_gate_up_fused":
+                mid = tensor.shape[-2] // 2  # split out_dim in half
+                gate_w = tensor[..., :mid, :]
+                up_w = tensor[..., mid:, :]
+                base_prefix = k.replace(
+                    ".switch_mlp.gate_up_proj.weight", ".switch_mlp"
+                )
+                # Process each half as expert_gate / expert_up respectively.
+                for half_w, half_role, half_name in [
+                    (gate_w, "expert_gate", "gate_proj"),
+                    (up_w, "expert_up", "up_proj"),
+                ]:
+                    new_w, qmode = apply_fold_and_rotate(
+                        k,
+                        half_w,
+                        half_role,
+                        layer,
+                        norms,
+                        hidden,
+                        intermediate,
+                        skip_rotations=skip_rotations,
+                        fold_norms=fold_norms,
+                        r1_roles=r1_roles,
+                        enable_r4=enable_r4,
+                        expert_bits=expert_bits,
+                        num_layers=num_layers,
+                    )
+                    out_key = f"{base_prefix}.{half_name}.weight"
+                    if qmode in ("q4", "q8"):
+                        emit_quantized(out_key, new_w, qmode)
+                    elif qmode == "fp16":
+                        emit_raw(out_key, new_w)
+                tensor_count += 2
+                continue
+
+            # Apply mlx_vlm/mlx_lm sanitize-style tensor transformations.
+            # 1) conv1d.weight: moveaxis(2, 1) — matches qwen3_5.py sanitize.
+            if "conv1d.weight" in k and tensor.ndim == 3 and tensor.shape[-1] != 1:
+                tensor = mx.moveaxis(tensor, 2, 1)
+
+            new_w, qmode = apply_fold_and_rotate(
+                k,
+                tensor,
+                role,
+                layer,
+                norms,
+                hidden,
+                intermediate,
+                skip_rotations=skip_rotations,
+                fold_norms=fold_norms,
+                r1_roles=r1_roles,
+                enable_r4=enable_r4,
+                expert_bits=expert_bits,
+                num_layers=num_layers,
+            )
+
+            if qmode in ("q4", "q8"):
+                emit_quantized(k, new_w, qmode)
+            elif qmode == "fp16":
+                emit_raw(k, new_w)
+            elif qmode == "skip":
+                # Vision sanitize transformations:
+                # - patch_embed.proj.weight: PyTorch → MLX layout transpose
+                # - position_ids: drop (not a real weight)
+                if "patch_embed.proj.weight" in k:
+                    if tensor.ndim == 5 and tensor.shape[-1] != 3:
+                        tensor = mx.transpose(tensor, (0, 2, 3, 4, 1))
+                if "position_ids" in k:
+                    continue
+                emit_raw(k, tensor)
+
+            tensor_count += 1
+            if tensor_count % 100 == 0:
+                elapsed = time.time() - t_start
+                print(f"  ...{tensor_count} tensors, {elapsed:.0f}s elapsed")
+
+        del data  # free original shard from memory
+
+    elapsed = time.time() - t_start
+    print(
+        f"\n[main] processed {tensor_count} tensors in {elapsed:.1f}s "
+        f"(skipped {skipped} due to --layer-limit)"
+    )
+
+    # Save shards via mx.save_safetensors.
+    out_shards = out_shards_mx
+    print(f"[main] writing {len(out_shards)} output shards...")
+    for i, shard in enumerate(out_shards):
+        name = f"model-{i+1:05d}-of-{len(out_shards):05d}.safetensors"
+        mx.save_safetensors(str(dst / name), shard, metadata={"format": "mlx"})
+        for k in shard:
+            out_weight_map[k] = name
+        total_bytes = sum(v.nbytes for v in shard.values())
+        print(f"  wrote {name} ({len(shard)} tensors, {total_bytes/1e9:.2f} GB)")
+
+    # Write index.
+    total_size = sum(v.nbytes for s in out_shards for v in s.values())
+    index = {
+        "metadata": {"total_size": int(total_size)},
+        "weight_map": out_weight_map,
+    }
+    (dst / "model.safetensors.index.json").write_text(json.dumps(index, indent=2))
+
+    # Copy config + add quantization metadata.
+    out_cfg = dict(cfg)
+    out_cfg["quantization"] = {
+        **quant_cfg,
+        "group_size": quant_cfg["group_size"],
+        "bits": 4,
+        "mode": "affine",
+    }
+    for k, v in quant_per_path.items():
+        out_cfg["quantization"][k] = v
+    out_cfg["quantization_config"] = out_cfg["quantization"]
+    (dst / "config.json").write_text(json.dumps(out_cfg, indent=2))
+
+    # Copy auxiliary files (tokenizer etc).
+    for fname in [
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "generation_config.json",
+        "configuration.json",
+        "chat_template.jinja",
+        "preprocessor_config.json",
+        "processor_config.json",
+        "video_preprocessor_config.json",
+        "vocab.json",
+        "README.md",
+    ]:
+        src_f = src / fname
+        if src_f.exists():
+            shutil.copy(src_f, dst / fname)
+
+    # Disk size summary.
+    import subprocess
+
+    r = subprocess.run(["du", "-sh", str(dst)], capture_output=True, text=True)
+    print(f"\n[main] DONE: {dst}")
+    print(f"  total size: {r.stdout.strip()}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True, type=Path)
+    ap.add_argument("--dst", required=True, type=Path)
+    ap.add_argument("--max-shard-gb", default=5.0, type=float)
+    ap.add_argument(
+        "--layer-limit",
+        type=int,
+        default=None,
+        help="Process only first N layers (for sanity test).",
+    )
+    ap.add_argument(
+        "--skip-rotations",
+        action="store_true",
+        help="DIAGNOSTIC: skip R1/R4, only fold/keep norms + quantize.",
+    )
+    ap.add_argument(
+        "--no-fold-norms",
+        action="store_true",
+        help="DIAGNOSTIC: keep (1+raw) in norm weight (PROD-like).",
+    )
+    ap.add_argument(
+        "--r1-roles",
+        default=None,
+        help="DIAGNOSTIC bisect: comma-separated role names to apply R1 to. None=all in/out_axis roles.",
+    )
+    ap.add_argument(
+        "--enable-r4",
+        action="store_true",
+        help="EXPERIMENTAL: enable R4 (online Hadamard before down_proj). "
+        "NOT recommended — per QuaRot paper, R4 is only needed for "
+        "ACTIVATION quantization. Weight-only quant works correctly with R1 only.",
+    )
+    ap.add_argument(
+        "--no-r4",
+        action="store_true",
+        help="(deprecated, default — R4 disabled). Kept for backward compat.",
+    )
+    ap.add_argument(
+        "--r4-scope",
+        default="all",
+        choices=["all", "shared", "experts"],
+        help="DIAGNOSTIC: limit R4 to shared (only shared_expert.down_proj) or experts (only switch_mlp.down_proj). Default: all.",
+    )
+    ap.add_argument(
+        "--expert-bits",
+        type=int,
+        default=4,
+        help="Bits for routed MoE expert weights (default 4).",
+    )
+    args = ap.parse_args()
+    r1_set = None
+    if args.r1_roles:
+        r1_set = set(r.strip() for r in args.r1_roles.split(",") if r.strip())
+    # R4 default OFF (per QuaRot: R4 only needed for activation quantization, not weight-only).
+    if args.enable_r4:
+        r4_arg = args.r4_scope
+    else:
+        r4_arg = False
+    convert(
+        args.src,
+        args.dst,
+        args.max_shard_gb,
+        args.layer_limit,
+        args.skip_rotations,
+        fold_norms=not args.no_fold_norms,
+        r1_roles=r1_set,
+        enable_r4=r4_arg,
+        expert_bits=args.expert_bits,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/turboquant_rotations.py
+++ b/scripts/turboquant_rotations.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""TurboQuant rotation pipeline — R1, R2, R4 for outlier-free quantization.
+
+Principle (QuaRot 2024 + JANGTQ generalization):
+
+R1 — Hadamard rotation of the residual stream. Fused offline into:
+    embed_tokens.weight  →  embed @ R1.T
+    lm_head.weight       →  lm_head @ diag(1 + norm_final) @ R1.T
+    every block.in_proj  →  W_in @ diag(1 + norm_block) @ R1.T
+    every block.out_proj →  R1 @ W_out
+
+R2 — per-head Hadamard rotation in attention head_dim. Fused offline into:
+    q_proj / k_proj / v_proj  (output side: rotation per head)
+    o_proj                    (input side: inverse rotation per head)
+NOT applicable to "gated attention" (Qwen3.5/3.6) where output = o_proj(attn*sigmoid(gate))
+because element-wise gate breaks the rotation cancellation.
+
+R4 — Hadamard rotation of the intermediate activation, before down_proj.
+    Fused offline: down_proj.weight @= R4_hadamard.T (input side rotation)
+    Applied online (runtime patch): intermediate' = mx.hadamard_transform(intermediate)
+
+Math:
+    Pure RMSNorm: norm(R @ x) = R @ norm(x)  (rotation preserves norm)
+    With +1.0 offset (qwen3.5/3.6): fold (1 + norm_weight) into downstream W first,
+    then apply rotation, then set norm weight to 0 (so 1 + 0 = identity).
+
+This module only contains the helpers and a self-test on a 64-dim toy model.
+The actual model-walking conversion lives in turboquant_quantize.py.
+"""
+
+from __future__ import annotations
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from typing import Tuple
+
+
+def hadamard_native_or_padded(x: mx.array, axis: int = -1) -> mx.array:
+    """Apply Hadamard transform along `axis`. Falls back to padded RHT if size
+    is not directly supported.
+
+    mx.hadamard_transform supports n = m * 2^k for m in {1, 12, 20, 28}.
+    For other sizes (rare), pad with zeros, transform, truncate.
+    Returns array of same shape (or padded one if needed; caller must handle).
+    """
+    n = x.shape[axis]
+    # Check native support.
+    for m in (1, 12, 20, 28):
+        if n % m == 0 and ((n // m) & (n // m - 1)) == 0:
+            return mx.hadamard_transform(x)
+    # No native support — try padded RHT (next-larger m·2^k).
+    # For now raise; padding rarely needed for our target hidden sizes.
+    raise NotImplementedError(
+        f"Hadamard size {n} not natively supported; implement padded RHT"
+    )
+
+
+def random_hadamard_matrix(n: int, seed: int = 0) -> mx.array:
+    """Build an n×n orthogonal matrix = diag(s) · H(n) / sqrt(n),
+    where s ∈ {-1, +1}^n is sampled deterministically from `seed`.
+
+    Used when we need an explicit R matrix (e.g. for offline weight fusion
+    when we can't reshape the operand to apply mx.hadamard_transform directly).
+    """
+    rng = np.random.RandomState(seed)
+    sign = rng.choice([-1.0, 1.0], size=n).astype(np.float32)
+    # Build H(n) by applying mx.hadamard_transform to identity columns.
+    I_n = mx.eye(n, dtype=mx.float32)  # noqa: E741 (matrix identity)
+    H = mx.hadamard_transform(I_n)  # equivalent to H @ I = H
+    # H is already 1/sqrt(n)-scaled by mx.hadamard_transform? Verify:
+    # mx.hadamard_transform docs: applies (1/sqrt(n)) H_n. We want unitary so OK.
+    R = H * mx.array(sign, dtype=mx.float32)[None, :]
+    return R
+
+
+# ---------------------------------------------------------------------------
+# RMSNorm fold helpers — qwen3.5/3.6 store norm weight as offset (effective = 1+w).
+# ---------------------------------------------------------------------------
+
+
+def fold_rmsnorm_into_linear(
+    norm_weight: mx.array,
+    linear_weight: mx.array,
+    has_offset: bool = True,
+) -> Tuple[mx.array, mx.array]:
+    """Fold diag(scale) into a downstream Linear so the norm becomes identity.
+
+    `scale = (1 + norm_weight) if has_offset else norm_weight`.
+    `linear_weight` shape (out, in); we left-multiply by diag(scale) on input axis:
+        W_new[o, i] = W_old[o, i] * scale[i]
+    Returns (new_norm_weight=zeros_or_ones, new_linear_weight).
+    """
+    if has_offset:
+        scale = 1.0 + norm_weight.astype(mx.float32)
+        # New norm weight = 0 so that runtime computes (1 + 0) = identity.
+        new_norm = mx.zeros_like(norm_weight)
+    else:
+        scale = norm_weight.astype(mx.float32)
+        new_norm = mx.ones_like(norm_weight)
+    new_lin = (linear_weight.astype(mx.float32) * scale[None, :]).astype(
+        linear_weight.dtype
+    )
+    return new_norm, new_lin
+
+
+# ---------------------------------------------------------------------------
+# R1 fusion — global rotation of residual stream.
+# ---------------------------------------------------------------------------
+
+
+def apply_r1_to_in_projection(weight: mx.array, hadamard_axis_size: int) -> mx.array:
+    """W_in @= R1.T equivalently: rotate input side via Hadamard on the in-axis.
+
+    weight: (out, in). hadamard_axis_size: in.
+    Returns rotated weight with same shape.
+    """
+    # mx.hadamard_transform applies on last axis: H(W^T) = W @ H.T (since H is orthogonal symmetric).
+    # We want W @ R1.T which is identical to applying Hadamard to W (last axis).
+    assert weight.shape[1] == hadamard_axis_size
+    # Stay in fp32 after rotation — bf16 round-trip loses precision when
+    # 2048-channel Hadamard accumulates ~sqrt(2048)*eps relative error.
+    return mx.hadamard_transform(weight.astype(mx.float32))
+
+
+def apply_r1_to_out_projection(weight: mx.array, hadamard_axis_size: int) -> mx.array:
+    """W_out = R1 @ W_out, equivalently: rotate output side.
+
+    weight: (out, in). hadamard_axis_size: out.
+    Transpose, apply Hadamard on last axis, transpose back.
+    """
+    assert weight.shape[0] == hadamard_axis_size
+    wT = mx.swapaxes(weight.astype(mx.float32), 0, 1)  # (in, out)
+    wT_rot = mx.hadamard_transform(wT)  # H @ W^T = (W @ H)^T... careful
+    # Actually mx.hadamard_transform applied to last axis of (in, out) gives:
+    # result[i, :] = H @ wT[i, :] is INCORRECT — mx applies H to last dim as vector.
+    # Equivalent to W^T @ H^T (i.e. left-multiplication on the transposed axis).
+    # We want R1 @ W_out → (R1 @ W_out).T = W_out.T @ R1.T → apply Hadamard to last axis of W^T.
+    rotated = mx.swapaxes(wT_rot, 0, 1)  # back to (out, in)
+    return rotated  # stay fp32, no down-cast
+
+
+# ---------------------------------------------------------------------------
+# R4 fusion (offline part) — input-side rotation of down_proj.
+# ---------------------------------------------------------------------------
+
+
+def apply_r4_to_down_proj(weight: mx.array, intermediate_size: int) -> mx.array:
+    """down_proj.weight @= R4.T  (input-axis rotation).
+
+    weight: (hidden_size, intermediate_size). Same as apply_r1_to_in_projection.
+    """
+    return apply_r1_to_in_projection(weight, intermediate_size)
+
+
+# ---------------------------------------------------------------------------
+# Self-test — tiny model: norm → linear → activation → norm → linear.
+# Validate forward equivalence pre/post-rotation.
+# ---------------------------------------------------------------------------
+
+
+class _ToyRMSNorm(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.weight = mx.random.normal((dim,)) * 0.1  # like Qwen3.5/3.6 offset
+
+    def __call__(self, x):
+        # Effective norm: (x / rms(x)) * (1 + weight)  -- offset semantics
+        rms = mx.sqrt(mx.mean(x * x, axis=-1, keepdims=True) + 1e-6)
+        return (x / rms) * (1.0 + self.weight)
+
+
+class _ToyBlock(nn.Module):
+    """Minimal block: norm → up_proj → SiLU → down_proj → residual."""
+
+    def __init__(self, dim: int, intermediate: int):
+        super().__init__()
+        self.norm = _ToyRMSNorm(dim)
+        self.up_proj = nn.Linear(dim, intermediate, bias=False)
+        self.down_proj = nn.Linear(intermediate, dim, bias=False)
+
+    def __call__(self, x):
+        h = self.norm(x)
+        h = self.up_proj(h)
+        h = nn.silu(h)
+        h = self.down_proj(h)
+        return x + h
+
+
+def _fold_block_norm(block: _ToyBlock):
+    """Fold (1 + norm.weight) into up_proj input side, set norm to zero."""
+    new_norm, new_up = fold_rmsnorm_into_linear(
+        block.norm.weight, block.up_proj.weight, has_offset=True
+    )
+    block.norm.weight = new_norm
+    block.up_proj.weight = new_up
+
+
+def _fuse_r1(block: _ToyBlock, dim: int):
+    """Fuse R1 (Hadamard) into block: up_proj input-side, down_proj output-side."""
+    # In this toy, R1 acts on residual stream which is `dim`.
+    # up_proj input has `dim` → rotate input.
+    block.up_proj.weight = apply_r1_to_in_projection(block.up_proj.weight, dim)
+    # down_proj output has `dim` → rotate output.
+    block.down_proj.weight = apply_r1_to_out_projection(block.down_proj.weight, dim)
+
+
+def _fuse_r4(block: _ToyBlock, intermediate: int):
+    """Fuse R4 into block: down_proj input-side rotation. R4 must be applied
+    online to the activation before down_proj (runtime patch)."""
+    block.down_proj.weight = apply_r4_to_down_proj(block.down_proj.weight, intermediate)
+
+
+class _ToyBlockWithR4(_ToyBlock):
+    """Same as _ToyBlock but applies R4 online before down_proj."""
+
+    def __call__(self, x):
+        h = self.norm(x)
+        h = self.up_proj(h)
+        h = nn.silu(h)
+        h = mx.hadamard_transform(h)  # R4 online
+        h = self.down_proj(h)
+        return x + h
+
+
+def self_test():
+    """Verify forward equivalence: R1 alone, R4 alone, R1+R4 combined."""
+    mx.random.seed(42)
+    dim = 64  # 64 = 1 * 2^6, native Hadamard
+    intermediate = 256  # 256 = 1 * 2^8, native Hadamard
+    batch, seq = 2, 4
+
+    # Build reference block + input.
+    ref = _ToyBlock(dim, intermediate)
+    x_in = mx.random.normal((batch, seq, dim))
+    y_ref = ref(x_in)
+    mx.eval(y_ref)
+
+    # Build rotated version (clone state, then fold + rotate).
+
+    def clone_block(template):
+        b = _ToyBlock(dim, intermediate)
+        b.norm.weight = template.norm.weight + 0  # copy
+        b.up_proj.weight = template.up_proj.weight + 0
+        b.down_proj.weight = template.down_proj.weight + 0
+        return b
+
+    # === R1 alone ===
+    b1 = clone_block(ref)
+    _fold_block_norm(b1)
+    _fuse_r1(b1, dim)
+    # R1 changes residual stream basis: pre-rotate input, post-rotate output.
+    x_rot = mx.hadamard_transform(x_in.astype(mx.float32))
+    y_rot = b1(x_rot)
+    y_back = mx.hadamard_transform(y_rot)  # H is involutive (H @ H = I), un-rotate
+    diff_r1 = mx.abs(y_back - y_ref).max().item()
+    print(f"  R1 only:  max abs diff = {diff_r1:.3e}  (expect < 1e-4)")
+
+    # === R4 alone ===
+    b4 = clone_block(ref)
+    _fold_block_norm(b4)
+    _fuse_r4(b4, intermediate)
+    # R4 acts inside the block — output should be IDENTICAL to ref (no input change needed).
+    b4_with_runtime = _ToyBlockWithR4(dim, intermediate)
+    b4_with_runtime.norm.weight = b4.norm.weight + 0
+    b4_with_runtime.up_proj.weight = b4.up_proj.weight + 0
+    b4_with_runtime.down_proj.weight = b4.down_proj.weight + 0
+    y_r4 = b4_with_runtime(x_in)
+    diff_r4 = mx.abs(y_r4 - y_ref).max().item()
+    print(f"  R4 only:  max abs diff = {diff_r4:.3e}  (expect < 1e-4)")
+
+    # === R1 + R4 combined ===
+    b14 = clone_block(ref)
+    _fold_block_norm(b14)
+    _fuse_r1(b14, dim)
+    _fuse_r4(b14, intermediate)
+    b14_with_runtime = _ToyBlockWithR4(dim, intermediate)
+    b14_with_runtime.norm.weight = b14.norm.weight + 0
+    b14_with_runtime.up_proj.weight = b14.up_proj.weight + 0
+    b14_with_runtime.down_proj.weight = b14.down_proj.weight + 0
+    x_rot = mx.hadamard_transform(x_in.astype(mx.float32))
+    y_14 = b14_with_runtime(x_rot)
+    y_14_back = mx.hadamard_transform(y_14)
+    diff_14 = mx.abs(y_14_back - y_ref).max().item()
+    print(f"  R1 + R4:  max abs diff = {diff_14:.3e}  (expect < 1e-4)")
+
+    # Pass criterion: all rotations must give numerically equivalent forward.
+    ok = max(diff_r1, diff_r4, diff_14) < 1e-3
+    print(f"\n  {'✓ PASS' if ok else '✗ FAIL'} — rotation equivalence")
+    return ok
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("TurboQuant rotation pipeline — toy block equivalence test")
+    print("=" * 60)
+    self_test()

--- a/tests/test_turboquant_r4_patch.py
+++ b/tests/test_turboquant_r4_patch.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the TurboQuant R4 runtime patch.
+
+R4 is an experimental, opt-in patch (env-gated via VLLM_MLX_TURBOQUANT_R4).
+It is NOT applied by default because R4 is only needed for activation
+quantization (per QuaRot paper); weight-only quantization works correctly
+with R1 alone.
+
+These tests verify:
+1. Patch is idempotent (safe to call multiple times).
+2. Patch correctly inserts Hadamard before down_proj in Qwen3NextMLP.
+3. Patch correctly inserts Hadamard before down_proj in SwitchGLU.
+4. Patch is no-op when its modules are unavailable.
+"""
+
+import pytest
+
+
+from vllm_mlx.patches.turboquant_r4 import (
+    install_turboquant_r4,
+    is_turboquant_model,
+)
+
+
+def _reset_patches():
+    """Clear sentinel attributes so tests can re-patch from scratch."""
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextMLP
+
+        if hasattr(Qwen3NextMLP, "_turboquant_r4_patched"):
+            delattr(Qwen3NextMLP, "_turboquant_r4_patched")
+    except ImportError:
+        pass
+    try:
+        from mlx_lm.models.switch_layers import SwitchGLU
+
+        if hasattr(SwitchGLU, "_turboquant_r4_patched"):
+            delattr(SwitchGLU, "_turboquant_r4_patched")
+    except ImportError:
+        pass
+
+
+def test_idempotent_install():
+    """Calling install_turboquant_r4 twice must not double-wrap."""
+    _reset_patches()
+    install_turboquant_r4("all")
+    install_turboquant_r4("all")  # second call must be a no-op
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextMLP
+
+        assert getattr(Qwen3NextMLP, "_turboquant_r4_patched", False) is True
+    except ImportError:
+        pytest.skip("mlx_lm.qwen3_next not importable")
+
+
+def test_scope_shared_only():
+    """scope='shared' patches Qwen3NextMLP but NOT SwitchGLU."""
+    _reset_patches()
+    install_turboquant_r4("shared")
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextMLP
+
+        assert getattr(Qwen3NextMLP, "_turboquant_r4_patched", False) is True
+    except ImportError:
+        pytest.skip("mlx_lm.qwen3_next not importable")
+    try:
+        from mlx_lm.models.switch_layers import SwitchGLU
+
+        assert getattr(SwitchGLU, "_turboquant_r4_patched", False) is False
+    except ImportError:
+        pass
+
+
+def test_scope_experts_only():
+    """scope='experts' patches SwitchGLU but NOT Qwen3NextMLP."""
+    _reset_patches()
+    install_turboquant_r4("experts")
+    try:
+        from mlx_lm.models.switch_layers import SwitchGLU
+
+        assert getattr(SwitchGLU, "_turboquant_r4_patched", False) is True
+    except ImportError:
+        pytest.skip("mlx_lm.switch_layers not importable")
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextMLP
+
+        assert getattr(Qwen3NextMLP, "_turboquant_r4_patched", False) is False
+    except ImportError:
+        pass
+
+
+def test_is_turboquant_model():
+    """Detect TurboQuant via quantization.type config key."""
+    assert is_turboquant_model({"quantization": {"type": "turboquant_v1"}}) is True
+    assert (
+        is_turboquant_model({"quantization_config": {"type": "turboquant_v1"}}) is True
+    )
+    assert is_turboquant_model({"quantization": {"type": "affine"}}) is False
+    assert is_turboquant_model({}) is False
+    assert is_turboquant_model({"quantization": None}) is False

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -456,10 +456,26 @@ class MLLMBatchGenerator:
         from .patches.qwen3_5_mllm import patch_qwen35_attention_for_batching
         from .patches.gemma4_mllm import patch_gemma4_attention_for_batching
         from .patches.glm4v_moe_mllm import patch_glm4v_moe_for_batching
+        from .patches.turboquant_r4 import install_turboquant_r4
 
         patch_qwen35_attention_for_batching()
         patch_gemma4_attention_for_batching()
         patch_glm4v_moe_for_batching()
+        # TurboQuant R4 patch is idempotent — safe to install unconditionally.
+        # Activates only for models loaded with quantization.type=="turboquant_v1".
+        # For non-turboquant models the patched code path is functionally identical
+        # to the original because their weights are not pre-rotated by R4 —
+        # but the patch DOES still apply mx.hadamard_transform which would CORRUPT
+        # a non-turboquant model. So we gate on env var instead.
+        import os
+
+        r4_env = os.environ.get("VLLM_MLX_TURBOQUANT_R4")
+        if r4_env in ("1", "all"):
+            install_turboquant_r4("all")
+        elif r4_env == "shared":
+            install_turboquant_r4("shared")
+        elif r4_env == "experts":
+            install_turboquant_r4("experts")
 
         self.max_tokens = max_tokens
         self.stop_tokens = stop_tokens or set()

--- a/vllm_mlx/patches/turboquant_r4.py
+++ b/vllm_mlx/patches/turboquant_r4.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Runtime patch for TurboQuant R4 — online Hadamard rotation before down_proj.
+
+TurboQuant fuses three rotations into model weights offline:
+    R1 — residual stream Hadamard, into embed/lm_head + all in/out projections
+    R2 — head-space rotation (skipped for gated attention models like Qwen3.5/3.6)
+    R4 — intermediate-axis Hadamard, into down_proj input side ONLY (offline);
+         the matching online Hadamard on the intermediate activation must be
+         applied at runtime, which is what this patch does.
+
+For a SwiGLU MLP:
+    intermediate = silu(gate_proj(x)) * up_proj(x)
+    intermediate_rotated = mx.hadamard_transform(intermediate)   # R4 online
+    out = down_proj(intermediate_rotated)                         # weights pre-rotated
+
+This patch wraps Qwen3NextMLP.__call__ (shared expert) and SwitchGLU.__call__
+(routed experts) to inject mx.hadamard_transform on the intermediate axis.
+
+Activation only — does NOT touch weights. The patch is idempotent (sentinel
+attribute prevents double-wrap) and is a no-op if mlx_lm is not importable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCHED_ATTR = "_turboquant_r4_patched"
+
+
+def patch_qwen3_next_mlp_r4() -> bool:
+    """Patch Qwen3NextMLP.__call__ to apply R4 Hadamard before down_proj.
+
+    Idempotent. Returns True if patched (or already patched).
+    """
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextMLP
+    except ImportError as e:
+        logger.warning("[TurboQuant R4] Qwen3NextMLP not importable: %s", e)
+        return False
+
+    if getattr(Qwen3NextMLP, _PATCHED_ATTR, False):
+        return True
+
+    from mlx_lm.models.qwen3_next import swiglu as _swiglu
+
+    def _patched_call(self, x: mx.array) -> mx.array:
+        intermediate = _swiglu(self.gate_proj(x), self.up_proj(x))
+        # Force contiguous + fp32 to avoid lazy-eval / strided issues with Hadamard.
+        intermediate = mx.contiguous(intermediate.astype(mx.float32))
+        intermediate = mx.hadamard_transform(intermediate)
+        return self.down_proj(intermediate.astype(x.dtype))
+
+    Qwen3NextMLP.__call__ = _patched_call
+    setattr(Qwen3NextMLP, _PATCHED_ATTR, True)
+    logger.info(
+        "[TurboQuant R4] Qwen3NextMLP patched (online Hadamard before down_proj)"
+    )
+    return True
+
+
+def patch_switch_glu_r4() -> bool:
+    """Patch SwitchGLU.__call__ (routed MoE experts) to apply R4 Hadamard
+    on the intermediate before down_proj.
+
+    SwitchGLU's standard forward:
+        x_up = self.up_proj(x, idx)
+        x_gate = self.gate_proj(x, idx)
+        x = self.down_proj(self.activation(x_up, x_gate), idx)
+
+    Patched: insert mx.hadamard_transform between activation and down_proj.
+    """
+    try:
+        from mlx_lm.models.switch_layers import SwitchGLU
+        from mlx_lm.models.switch_layers import _gather_sort, _scatter_unsort
+    except ImportError as e:
+        logger.warning("[TurboQuant R4] SwitchGLU not importable: %s", e)
+        return False
+
+    if getattr(SwitchGLU, _PATCHED_ATTR, False):
+        return True
+
+    def _patched_call(self, x: mx.array, indices: mx.array) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+        x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+        intermediate = self.activation(x_up, x_gate)
+        # Force contiguous + fp32 for Hadamard correctness on strided tensors.
+        intermediate = mx.contiguous(intermediate.astype(mx.float32))
+        intermediate = mx.hadamard_transform(intermediate)
+        intermediate = intermediate.astype(x.dtype)
+        x = self.down_proj(intermediate, idx, sorted_indices=do_sort)
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)
+
+    SwitchGLU.__call__ = _patched_call
+    setattr(SwitchGLU, _PATCHED_ATTR, True)
+    logger.info("[TurboQuant R4] SwitchGLU patched (online Hadamard on intermediate)")
+    return True
+
+
+def install_turboquant_r4(scope: str = "all") -> None:
+    """Install R4 patches. Safe to call multiple times.
+
+    scope:
+      "all"     — patch both Qwen3NextMLP (shared expert) and SwitchGLU (routed)
+      "shared"  — patch only Qwen3NextMLP
+      "experts" — patch only SwitchGLU
+    """
+    if scope in ("all", "shared"):
+        patch_qwen3_next_mlp_r4()
+    if scope in ("all", "experts"):
+        patch_switch_glu_r4()
+
+
+def is_turboquant_model(config: dict) -> bool:
+    """Detect TurboQuant model from its quantization config."""
+    q = config.get("quantization") or config.get("quantization_config") or {}
+    return q.get("type") == "turboquant_v1"

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -61,8 +61,25 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
         Tuple of (model, tokenizer)
     """
     from mlx_lm import load
+    from mlx_lm.utils import _download, load_config
 
     tokenizer_config = tokenizer_config or {}
+
+    # TurboQuant detection: install R4 online-Hadamard runtime patch BEFORE
+    # any model class instantiation so SwitchGLU / Qwen3NextMLP forward uses
+    # the patched __call__. Patches are idempotent + no-op for non-turboquant.
+    try:
+        model_path = _download(model_name)
+        cfg = load_config(model_path)
+        q = cfg.get("quantization") or cfg.get("quantization_config") or {}
+        if isinstance(q, dict) and q.get("type") == "turboquant_v1":
+            from vllm_mlx.patches.turboquant_r4 import install_turboquant_r4
+
+            install_turboquant_r4()
+            logger.info("TurboQuant model detected — R4 runtime patch installed")
+    except Exception as e:
+        # Don't block model load if probe fails; non-turboquant path continues.
+        logger.debug(f"TurboQuant probe failed (non-fatal): {e}")
 
     # Check if model needs fallback (e.g., Nemotron)
     if _needs_tokenizer_fallback(model_name):


### PR DESCRIPTION
## Summary

Adds support for **TurboQuant**, a QuaRot-style R1 (residual stream Hadamard) rotation fused offline into model weights. Enables 4-bit weight quantization on hybrid-attention Qwen3.5/3.6 models (dense and MoE) without quality degradation.

R1 fusion is mathematically transparent — the rotation cancels through the forward pass — so the model produces equivalent-up-to-quantization-noise logits at inference but with quantization-friendly weight distributions (outlier channels spread by the Hadamard rotation).

## What's included

| File | Purpose |
|------|---------|
| `scripts/turboquant_rotations.py` | Hadamard primitives, RMSNorm fold (handles Qwen3.5/3.6 `(1 + raw)` offset), R1/R2/R4 rotation helpers, toy-block forward equivalence test |
| `scripts/turboquant_quantize.py` | End-to-end BF16 → TurboQuant safetensors conversion (per-shard, low memory). Supports both dense (Qwen3.6-27B) and MoE (Qwen3.6-35B-A3B) architectures with sensitive-layer 8-bit logic matching `mixed_4_8`. Handles fused `experts.gate_up_proj` split + GatedDeltaNet + 3D `switch_mlp` weights |
| `scripts/TURBOQUANT.md` | Usage docs + recipe explanation |
| `vllm_mlx/utils/tokenizer.py` | Loader hook detecting `quantization.type == "turboquant_v1"` |
| `vllm_mlx/patches/turboquant_r4.py` | Opt-in monkey-patch for online R4 Hadamard — only useful when paired with activation quantization (NOT applied by default) |
| `vllm_mlx/mllm_batch_generator.py` | Registers R4 patch when `VLLM_MLX_TURBOQUANT_R4` env var is set |
| `tests/test_turboquant_r4_patch.py` | Unit tests for R4 patch idempotency + scope filtering |

## Recipe (default, weight-only)

- **R1** (residual stream Hadamard) — fused offline into `embed_tokens`, `lm_head`, ALL in/out projections.
- **R2** (head-space rotation) — SKIPPED for Qwen3.5/3.6 because gated attention breaks offline R2 cancellation. Applicable to standard-attention models (MiniMax-M2 etc.) — future work.
- **R4** (online Hadamard before down_proj) — **NOT applied by default**. Per [QuaRot paper](https://arxiv.org/abs/2404.00456) + [AMD Quark docs](https://quark.docs.amd.com/release-0.9/pytorch/tutorial_quarot.html): R4 is only needed for activation quantization. Opt-in via `--enable-r4` + `VLLM_MLX_TURBOQUANT_R4=all`.
- **Quantization**: matches `mixed_4_8` — 4-bit affine base on dense MLP / routed experts / attention, 8-bit on sensitive layers (first 1/8, last 1/8, every 3rd middle for `down_proj` + `v_proj`), 8-bit on `embed_tokens` + `lm_head`. Router gate (`mlp.gate`) and norms kept in fp16.
- **RMSNorm fold**: `(1 + raw_norm)` (Qwen3.5/3.6 offset semantics) folded into downstream projections; norm stored as 1.0 (identity).

## Validation

### Qwen3.6-35B-A3B (MoE, 256 routed experts, 40 layers)
- **Disk size**: 22 GB (compared to baseline `mixed_4_8` at 24 GB)
- **Quality**: 12/12 coherent answers on a deterministic prompt suite (math, code, reasoning, tool-call style)
- **Architecture coverage exercised**: GatedDeltaNet (linear_attn) + full attention hybrid + MoE SparseMoeBlock with router + shared_expert + 256 routed experts via SwitchGLU

### Qwen3.6-27B Heretic (dense, 64 layers)
- **Disk size**: 19 GB (compared to baseline `mixed_4_8` at 22 GB)
- **Quality**: 12/12 coherent answers on the same deterministic prompt suite
- **Architecture coverage exercised**: dense Qwen3NextMLP (`gate_proj`/`up_proj`/`down_proj`) + GatedDeltaNet + full attention hybrid

## Test plan

- [x] Toy-block forward equivalence test (R1, R4, R1+R4): all < 1e-6 max abs diff in fp32.
- [x] Hadamard math validation: H(H(x)) ≤ 1e-6, R4 cancellation ≤ 1e-4.
- [x] End-to-end conversion of Qwen3.6-35B-A3B BF16 → 22 GB TurboQuant.
- [x] End-to-end conversion of Qwen3.6-27B Heretic BF16 → 19 GB TurboQuant.
- [x] Model load via `vllm_mlx serve` for both architectures: correct `QuantizedLinear` / `QuantizedSwitchLinear` / `QuantizedEmbedding` bit assignments verified.
- [x] 12 deterministic prompt quality test on both models.
- [x] Unit tests for R4 patch idempotency + scope filtering.
- [x] CI: lint, type-check, test-apple-silicon (3.11, 3.13), test-matrix (3.10–3.13) all green.

## Validated on

- Apple M3 Ultra 256 GB.
- mlx 0.31.2, mlx_lm 0.31.3, mlx_vlm 0.5.0.
- BF16 source shards SHA256-verified against HuggingFace LFS pointers before conversion (silent shard corruption from aria2c resume can produce broken-but-converting weights).

## Notes

- Conversion is fast: ~15 s for Qwen3.6-35B-A3B, ~30 s for Qwen3.6-27B Heretic on M3 Ultra.
- Sensitive-layer 8-bit logic matches the PROD `mixed_4_8` predicate, so the recipe is a strict superset (same bit allocation + R1 rotation on top).

## Future work

- R3 (online Q/K Hadamard) for KV cache outlier suppression.
- Lloyd-Max codebook quantization on rotated experts (JANGTQ-style).
- R2 head-space rotation for standard-attention models like MiniMax-M2.
- Throughput benchmarks under controlled load (in isolation from other servers competing for the same GPU).