### PR TITLE
Fix hybrid cache snapshot aliasing

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1689,6 +1689,69 @@ class TestSimpleEngineConcurrency:
         ]
 
     @pytest.mark.anyio
+    async def test_stream_generate_text_skips_system_cache_when_text_model_not_safe(
+        self,
+    ):
+        """MLLM TextModel routing must not snapshot hybrid ArraysCache state."""
+        from types import SimpleNamespace
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = (
+            "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+            "<|im_start|>user\nhello<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+        tokenizer.encode = MagicMock(
+            side_effect=[
+                list(range(10)),  # full prompt
+                list(range(5)),  # system prefix
+            ]
+        )
+
+        captured_prompts = []
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_prompts.append(prompt)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        def fail_if_manual_cache_path_runs(*args, **kwargs):
+            raise AssertionError("manual system-cache path must be skipped")
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        engine._text_tokenizer = tokenizer
+        engine._supports_system_kv_cache = False
+
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch(
+                "mlx_lm.models.cache.make_prompt_cache",
+                side_effect=fail_if_manual_cache_path_runs,
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "hello"},
+                    ],
+                    max_tokens=16,
+                    temperature=0.3,
+                    top_p=0.8,
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert captured_prompts == [tokenizer.apply_chat_template.return_value]
+
+    @pytest.mark.anyio
     async def test_stream_generate_text_disables_mtp_when_logits_processors_active(
         self,
     ):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -996,6 +996,109 @@ class TestSimpleEngineConcurrency:
         }
 
     @pytest.mark.anyio
+    async def test_stream_chat_system_cache_copies_arrays_cache_state(self):
+        """Hybrid cache snapshots must not alias ``ArraysCache.state`` lists."""
+        import mlx.core as mx
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        def apply_chat_template_side_effect(messages, **kwargs):
+            user_content = ""
+            for m in reversed(messages):
+                if m.get("role") == "user":
+                    user_content = m.get("content") or ""
+                    break
+            return (
+                "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+                f"<|im_start|>user\n{user_content}<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            )
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.side_effect = apply_chat_template_side_effect
+        tokenizer.bos_token = None
+        tokenizer.encode = MagicMock(side_effect=[list(range(10)), list(range(5))])
+
+        model = MagicMock()
+        model.tokenizer = tokenizer
+
+        class MutableListCache:
+            def __init__(self):
+                self.cache = [None]
+
+            @property
+            def state(self):
+                return self.cache
+
+            @state.setter
+            def state(self, value):
+                self.cache = value
+
+            @property
+            def nbytes(self):
+                return sum(c.nbytes for c in self.cache if c is not None)
+
+        cache_entry = MutableListCache()
+
+        def fake_model(tokens, cache):
+            cache[0].cache[0] = mx.array([[1, 2, 3]])
+            return MagicMock()
+
+        model.model = fake_model
+
+        def fake_stream_generate(model_arg, tokenizer_arg, prompt, **kwargs):
+            # Simulate suffix/decode state advancing after the system-prefix
+            # snapshot has been stored. The saved snapshot must not follow this
+            # mutable list change.
+            prompt_cache = kwargs["prompt_cache"]
+            prompt_cache[0].cache[0] = mx.array([[9, 9, 9]])
+            yield SimpleNamespace(text="ok", token=7, finish_reason="stop")
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+            engine._model = model
+            engine._loaded = True
+            engine._supports_system_kv_cache = True
+
+            with (
+                patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+                patch(
+                    "mlx_lm.models.cache.make_prompt_cache",
+                    return_value=[cache_entry],
+                ),
+                patch("mlx_lm.sample_utils.make_sampler"),
+            ):
+                chunks = [
+                    c
+                    async for c in engine.stream_chat(
+                        messages=[
+                            {"role": "system", "content": "You are helpful."},
+                            {"role": "user", "content": "hello"},
+                        ],
+                    )
+                ]
+
+        assert chunks[-1].text == "ok"
+        assert engine._system_kv_cache
+        saved_snapshot, saved_token_count = next(iter(engine._system_kv_cache.values()))
+        assert saved_token_count == 5
+        saved = saved_snapshot[0][0]
+        assert saved.tolist() == [[1, 2, 3]]
+        assert cache_entry.cache[0].tolist() == [[9, 9, 9]]
+
+    def test_system_cache_probe_allows_arrays_cache_and_rejects_rotating(self):
+        """Hybrid ArraysCache is snapshot-safe; rotating cache still is not."""
+        from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        assert SimpleEngine._cache_class_is_system_snapshot_safe(KVCache())
+        assert SimpleEngine._cache_class_is_system_snapshot_safe(ArraysCache(size=2))
+        assert not SimpleEngine._cache_class_is_system_snapshot_safe(
+            RotatingKVCache(max_size=128)
+        )
+
+    @pytest.mark.anyio
     async def test_stream_chat_uses_gate_time_snapshot_under_concurrent_mutation(
         self,
     ):

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1681,18 +1681,21 @@ class SimpleEngine(BaseEngine):
         system_tokens = None
         suffix_tokens = None
         full_tokens_list = None
+        cache_blocking_controls = []
+        if not self._supports_system_kv_cache:
+            cache_blocking_controls.append("non_kv_cache_class")
+        if cache_blocking_controls:
+            logger.info(
+                "System KV cache SKIP (text route): request or engine has "
+                "controls/features the cache branch cannot honor (%s); using "
+                "uncached path",
+                cache_blocking_controls,
+            )
 
         # Extract system messages for caching
         has_system = any(m.get("role") == "system" for m in messages)
 
-        # Snapshot-safety: only enter the system-KV cache branch when start()'s
-        # probe verified the derived TextModel returns KVCache entries (and not
-        # RotatingKVCache, which aliases buffers mutated in place).
-        if (
-            has_system
-            and self._text_model is not None
-            and self._supports_system_kv_cache
-        ):
+        if has_system and self._text_model is not None and not cache_blocking_controls:
             # Find system prefix boundary in full prompt text.
             # ChatML format: system section ends where first non-system message begins.
             # Works with tools (rendered inside system section by Qwen templates).

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -205,12 +205,87 @@ class SimpleEngine(BaseEngine):
             "stores": 0,
             "evictions": 0,
         }
-        # True only when the model's prompt cache is composed entirely of
-        # plain ``KVCache`` entries. Sliding-window models (gemma3_text,
-        # olmo3, recurrent_gemma) return ``RotatingKVCache`` whose ``.state``
-        # aliases buffers ``update_and_fetch`` mutates in place — snapshot
-        # restore would silently desynchronize. Probed once in ``start()``.
+        # True only when the model's prompt cache can be snapshotted and
+        # restored for the manual system-prefix cache branch. Plain KV caches
+        # and hybrid ``ArraysCache`` entries are safe when their state
+        # containers are copied at snapshot/restore boundaries. Sliding-window
+        # cache classes such as ``RotatingKVCache`` remain disabled because
+        # their extra cursor metadata is not captured by ``.state`` alone.
         self._supports_system_kv_cache: bool = False
+
+    @staticmethod
+    def _clone_cache_state(value: Any) -> Any:
+        """Copy cache state containers without duplicating immutable MLX arrays."""
+        if isinstance(value, tuple):
+            return tuple(SimpleEngine._clone_cache_state(v) for v in value)
+        if isinstance(value, list):
+            return [SimpleEngine._clone_cache_state(v) for v in value]
+        return value
+
+    @classmethod
+    def _snapshot_prompt_cache(cls, prompt_cache: list[Any]) -> list[Any]:
+        """Capture cache states without aliasing mutable state containers."""
+        return [cls._clone_cache_state(c.state) for c in prompt_cache]
+
+    @classmethod
+    def _restore_prompt_cache(
+        cls, prompt_cache: list[Any], snapshot: list[Any]
+    ) -> None:
+        """Restore cache states without letting decode mutate the saved snapshot."""
+        for i, saved_state in enumerate(snapshot):
+            prompt_cache[i].state = cls._clone_cache_state(saved_state)
+
+    @staticmethod
+    def _iter_cache_state_arrays(value: Any):
+        if isinstance(value, (tuple, list)):
+            for item in value:
+                yield from SimpleEngine._iter_cache_state_arrays(item)
+        elif hasattr(value, "shape") and hasattr(value, "dtype"):
+            yield value
+
+    @classmethod
+    def _eval_cache_snapshot(cls, snapshot: list[Any]) -> None:
+        arrays = list(cls._iter_cache_state_arrays(snapshot))
+        if arrays:
+            mx.eval(arrays)
+
+    @staticmethod
+    def _cache_class_is_system_snapshot_safe(cache_entry: Any) -> bool:
+        try:
+            from mlx_lm.models.cache import ArraysCache, KVCache
+
+            return isinstance(cache_entry, (KVCache, ArraysCache))
+        except Exception:
+            cache_type = type(cache_entry).__name__
+            return cache_type in {"KVCache", "ArraysCache"}
+
+    @classmethod
+    def _probe_system_kv_cache_support(cls, model: Any, route: str) -> bool:
+        try:
+            from mlx_lm.models.cache import make_prompt_cache
+
+            probe_cache = make_prompt_cache(model)
+            supported = bool(probe_cache) and all(
+                cls._cache_class_is_system_snapshot_safe(c) for c in probe_cache
+            )
+            if not supported:
+                cache_types = sorted({type(c).__name__ for c in probe_cache})
+                logger.info(
+                    "System KV cache snapshot disabled (%s): model returned "
+                    "unsupported cache entries (%s); requests will use the "
+                    "uncached path",
+                    route,
+                    cache_types,
+                )
+            return supported
+        except Exception as e:
+            logger.debug(
+                "System KV cache support probe failed (%s, %s); "
+                "disabling snapshot path",
+                route,
+                e,
+            )
+            return False
 
     @property
     def model_name(self) -> str:
@@ -290,34 +365,14 @@ class SimpleEngine(BaseEngine):
                 )
 
             # Probe whether this model's prompt cache is snapshot-safe for the
-            # stream_chat system-prefix cache branch. Sliding-window models
-            # (gemma3_text, olmo3, recurrent_gemma) return RotatingKVCache
-            # entries whose ``.state`` aliases in-place-mutated buffers.
-            # Only relevant for the LLM path; MLLM never enters the cache
-            # branch.
+            # stream_chat system-prefix cache branch. This is also refreshed
+            # below for MLLM text routing after the parallel TextModel exists.
             if not self._is_mllm and self._model is not None:
-                try:
-                    from mlx_lm.models.cache import KVCache, make_prompt_cache
-
-                    probe_cache = make_prompt_cache(self._model.model)
-                    self._supports_system_kv_cache = bool(probe_cache) and all(
-                        isinstance(c, KVCache) for c in probe_cache
-                    )
-                    if not self._supports_system_kv_cache:
-                        cache_types = sorted({type(c).__name__ for c in probe_cache})
-                        logger.info(
-                            "System KV cache snapshot disabled: model returned "
-                            "non-KVCache entries (%s); stream_chat will use the "
-                            "uncached path",
-                            cache_types,
-                        )
-                except Exception as e:
-                    logger.debug(
-                        "System KV cache support probe failed (%s); "
-                        "disabling snapshot path",
-                        e,
-                    )
-                    self._supports_system_kv_cache = False
+                backing_model = getattr(self._model, "model", self._model)
+                self._supports_system_kv_cache = self._probe_system_kv_cache_support(
+                    backing_model,
+                    "stream_chat",
+                )
 
             # Build parallel mlx_lm TextModel for text-only routing.
             # Even when MTP is disabled, text-only requests should not be trapped
@@ -332,6 +387,12 @@ class SimpleEngine(BaseEngine):
 
                     if self._text_model is not None:
                         self._text_tokenizer = self._model.get_tokenizer()
+                        self._supports_system_kv_cache = (
+                            self._probe_system_kv_cache_support(
+                                self._text_model,
+                                "mllm_text",
+                            )
+                        )
 
                         # Apply Qwen3.5 eos_token fix (matches MLXLanguageModel.load)
                         if "qwen3" in self._model_name.lower():
@@ -1233,9 +1294,10 @@ class SimpleEngine(BaseEngine):
                     # Restore from the closure-local reference captured at the
                     # gate, never from ``self._system_kv_cache`` directly:
                     # a concurrent MISS could have evicted the entry between
-                    # the gate check and this point.
-                    for i, saved_state in enumerate(hit_snapshot):
-                        bc[i].state = saved_state
+                    # the gate check and this point. Restore clones mutable
+                    # state containers so decode cannot mutate the saved LRU
+                    # snapshot by reference.
+                    self._restore_prompt_cache(bc, hit_snapshot)
                     # Bump LRU position. Safe to mutate here because the
                     # worker is serialized under ``_generation_lock``.
                     if system_hash in self._system_kv_cache:
@@ -1247,12 +1309,12 @@ class SimpleEngine(BaseEngine):
                     step = self._prefill_step_size
                     while sys_arr.size > step:
                         model(sys_arr[:step][None], cache=bc)
-                        mx.eval([c.state for c in bc])
+                        self._eval_cache_snapshot([c.state for c in bc])
                         sys_arr = sys_arr[step:]
                         mx.clear_cache()
                     if sys_arr.size > 0:
                         model(sys_arr[None], cache=bc)
-                        mx.eval([c.state for c in bc])
+                        self._eval_cache_snapshot([c.state for c in bc])
 
                     # Free intermediate prefill activations before snapshotting.
                     # Intentionally stricter than the MLLM path, which does not
@@ -1261,8 +1323,8 @@ class SimpleEngine(BaseEngine):
                     # the KV state, not residual activations from prefill.
                     mx.clear_cache()
 
-                    snapshot = [c.state for c in bc]
-                    mx.eval([s for pair in snapshot for s in pair])
+                    snapshot = self._snapshot_prompt_cache(bc)
+                    self._eval_cache_snapshot(snapshot)
                     self._system_kv_cache[system_hash] = (snapshot, system_token_count)
                     self._system_kv_cache.move_to_end(system_hash)
                     evicted_count = 0
@@ -1754,8 +1816,10 @@ class SimpleEngine(BaseEngine):
                             backbone_cache = make_prompt_cache(
                                 text_model, max_kv_size=_max_kv_size or None
                             )
-                            for i, saved_state in enumerate(system_kv_snapshot):
-                                backbone_cache[i].state = saved_state
+                            SimpleEngine._restore_prompt_cache(
+                                backbone_cache,
+                                system_kv_snapshot,
+                            )
 
                             prompt_to_send = mx.array(suffix_tokens)
                             return backbone_cache, prompt_to_send
@@ -1935,16 +1999,18 @@ class SimpleEngine(BaseEngine):
                 step = self._prefill_step_size
                 while sys_arr.size > step:
                     model(sys_arr[:step][None], cache=mc)
-                    mx.eval([c.state for c in mc])
+                    self._eval_cache_snapshot([c.state for c in mc])
                     sys_arr = sys_arr[step:]
                     mx.clear_cache()
                 if sys_arr.size > 0:
                     model(sys_arr[None], cache=mc)
-                    mx.eval([c.state for c in mc])
+                    self._eval_cache_snapshot([c.state for c in mc])
 
-                # Snapshot backbone cache (immutable mx.arrays, safe to reuse)
-                snapshot = [c.state for c in mc]
-                mx.eval([s for pair in snapshot for s in pair])
+                # Snapshot backbone cache. Cache arrays are treated as immutable;
+                # mutable state containers are copied so hybrid ArraysCache
+                # entries cannot alias the saved system-prefix state.
+                snapshot = self._snapshot_prompt_cache(mc)
+                self._eval_cache_snapshot(snapshot)
 
                 self._system_kv_cache[system_hash] = (snapshot, system_token_count)
                 self._system_kv_cache.move_to_end(system_hash)


### PR DESCRIPTION
## Summary

Fixes #575.

This follows the guard in #573. The guard keeps unsupported cache classes off the manual system-prefix cache branch; this patch fixes the underlying hybrid-cache snapshot aliasing case so `ArraysCache` can be snapshotted safely.

## Problem

`ArraysCache.state` returns the cache's mutable state list. The manual system-prefix cache path stored `c.state` directly, so later suffix/decode cache updates could mutate the saved system-prefix snapshot by reference.

That is not the same shape as plain `KVCache`, where `state` returns a tuple of arrays. Hybrid models that mix `ArraysCache` and `KVCache` need the state containers copied at snapshot and restore boundaries.

## Change

- Add explicit `SimpleEngine` snapshot/restore helpers for prompt-cache state.
- Copy mutable list/tuple state containers while reusing immutable MLX arrays.
- Evaluate nested cache-state arrays without assuming every state is a `(keys, values)` tuple.
- Treat `KVCache` and `ArraysCache` as system-prefix snapshot-safe.
- Keep unsupported cache classes, including rotating/sliding-window cache classes, guarded off.
- Probe MLLM TextModel cache support after the TextModel is built.

## Tests

```sh
.venv/bin/python -m pytest tests/test_simple_engine.py -q
.venv/bin/python -m pytest -q --ignore=tests/test_ssd_cache.py
.venv/bin/python -m ruff check vllm_mlx/engine/simple.py tests/test_simple_engine.py
.venv/bin/python -m black --check vllm_mlx/engine/simple.py tests/test_simple_engine.py
git diff --check
/opt/ai-runtime/bin/lint-upstream-claims --root /Users/David/code/vllm-mlx vllm_mlx/engine/simple.py tests/test_simple_engine.py
```

Local full-suite note: `tests/test_ssd_cache.py` still has inherited local failures that reproduce on clean `upstream/main`; this PR was verified with that file excluded.

## What is not claimed

- No model-quality claim.
- No claim that every cache class is snapshot-safe.
- No change to MTP, SpecPrefill, continuous batching, KV quantization, or constrained decoding semantics.
- No runtime certification claim for every Qwen3.6 artifact.

## Dependency note

This branch is stacked on #573 so the follow-up can be reviewed with the guard context visible. If #573 lands first, this PR should reduce to the snapshot/restore helper changes and focused tests.
