### PR TITLE
fix: thread SpecPrefill backbone policy

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,10 +67,16 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
     from vllm_mlx import cli, server
     from vllm_mlx.utils import download
 
+    loaded = {}
+
     monkeypatch.setattr(
         download, "ensure_model_downloaded", lambda *args, **kwargs: "local-test-model"
     )
-    monkeypatch.setattr(server, "load_model", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "load_model",
+        lambda *args, **kwargs: loaded.update({"args": args, "kwargs": kwargs}),
+    )
     monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
 
     for attr in (
@@ -91,6 +97,7 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
             default_min_p=0.0,
             default_presence_penalty=0.0,
             default_repetition_penalty=1.0,
+            specprefill_backbone_pct=0.25,
         )
     )
 
@@ -100,3 +107,4 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
     assert server._default_min_p == 0.0
     assert server._default_presence_penalty == 0.0
     assert server._default_repetition_penalty == 1.0
+    assert loaded["kwargs"]["specprefill_backbone_pct"] == 0.25

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -74,6 +74,7 @@ def _defaults() -> RegistryServeDefaults:
         specprefill_enabled=False,
         specprefill_threshold=8192,
         specprefill_keep_pct=0.3,
+        specprefill_backbone_pct=0.0,
         specprefill_draft_model=None,
         stream_interval=1,
         gpu_memory_utilization=0.9,

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1544,6 +1544,10 @@ class TestSimpleEngineConcurrency:
             captured["kwargs"] = kwargs
             yield SimpleNamespace(text="B", finish_reason="stop")
 
+        def fake_select_chunks(_importance, **kwargs):
+            captured["select_chunks_kwargs"] = kwargs
+            return mx.array([0, 1, 2], dtype=mx.int32)
+
         tokenizer = MagicMock()
         tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
         tokenizer.bos_token = None
@@ -1588,7 +1592,7 @@ class TestSimpleEngineConcurrency:
             ),
             patch(
                 "vllm_mlx.specprefill.select_chunks",
-                return_value=mx.array([0, 1, 2], dtype=mx.int32),
+                side_effect=fake_select_chunks,
             ),
             patch(
                 "vllm_mlx.specprefill.sparse_prefill",
@@ -1603,6 +1607,7 @@ class TestSimpleEngineConcurrency:
                     max_tokens=4,
                     temperature=0.6,
                     top_p=0.95,
+                    specprefill_backbone_pct=0.25,
                 )
             ]
 
@@ -1618,6 +1623,7 @@ class TestSimpleEngineConcurrency:
         assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
         assert captured["kwargs"]["max_tokens"] == 3
         assert captured["kwargs"]["logits_processors"] is None
+        assert captured["select_chunks_kwargs"]["backbone_pct"] == 0.25
 
     @pytest.mark.anyio
     async def test_stream_generate_text_forwards_logits_processors_and_sampler_args(
@@ -2132,6 +2138,10 @@ class TestSimpleEngineConcurrency:
             captured["prefill"] = cancel_check
             return mx.zeros((1, 1, 8), dtype=mx.float32)
 
+        def fake_select_chunks(_importance, **kwargs):
+            captured["select_chunks_kwargs"] = kwargs
+            return mx.array([0], dtype=mx.int32)
+
         with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
             engine = SimpleEngine("test-model")
             engine._loaded = True
@@ -2154,7 +2164,7 @@ class TestSimpleEngineConcurrency:
                 ),
                 patch(
                     "vllm_mlx.specprefill.select_chunks",
-                    return_value=mx.array([0], dtype=mx.int32),
+                    side_effect=fake_select_chunks,
                 ),
                 patch(
                     "vllm_mlx.specprefill.sparse_prefill",
@@ -2168,12 +2178,14 @@ class TestSimpleEngineConcurrency:
                     max_tokens=4,
                     temperature=0.7,
                     top_p=0.9,
+                    specprefill_backbone_pct=0.25,
                 ):
                     outputs.append(chunk.new_text)
 
         assert outputs == ["A"]
         assert callable(captured["score"])
         assert captured["score"] is captured["prefill"]
+        assert captured["select_chunks_kwargs"]["backbone_pct"] == 0.25
 
     @pytest.mark.anyio
     async def test_cancelling_specprefill_request_stops_during_scoring(self):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -186,6 +186,8 @@ class ChatCompletionRequest(BaseModel):
     specprefill: bool | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
     specprefill_keep_pct: float | None = None
+    # SpecPrefill: per-request evenly spaced backbone percentage.
+    specprefill_backbone_pct: float | None = None
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
     # MLLM assistant-drafter path: opt in to using a configured drafter.
@@ -288,6 +290,8 @@ class CompletionRequest(BaseModel):
     specprefill: bool | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
     specprefill_keep_pct: float | None = None
+    # SpecPrefill: per-request evenly spaced backbone percentage.
+    specprefill_backbone_pct: float | None = None
 
 
 class CompletionChoice(BaseModel):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -250,6 +250,8 @@ def serve_command(args):
 
     # Build scheduler config for batched mode
     scheduler_config = None
+    specprefill_backbone_pct = getattr(args, "specprefill_backbone_pct", 0.0)
+
     if args.continuous_batching:
         from .scheduler import SchedulerConfig
 
@@ -330,7 +332,8 @@ def serve_command(args):
             print(
                 f"SpecPrefill: enabled (draft={args.specprefill_draft_model}, "
                 f"threshold={args.specprefill_threshold}, "
-                f"keep={args.specprefill_keep_pct*100:.0f}%)"
+                f"keep={args.specprefill_keep_pct*100:.0f}%, "
+                f"backbone={specprefill_backbone_pct*100:.0f}%)"
             )
         if mllm_draft_model:
             print(
@@ -348,6 +351,7 @@ def serve_command(args):
             specprefill_enabled=args.specprefill,
             specprefill_threshold=args.specprefill_threshold,
             specprefill_keep_pct=args.specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
             specprefill_draft_model=args.specprefill_draft_model,
             stream_interval=args.stream_interval if args.continuous_batching else 1,
             gpu_memory_utilization=args.gpu_memory_utilization,
@@ -374,6 +378,7 @@ def serve_command(args):
             specprefill_enabled=args.specprefill,
             specprefill_threshold=args.specprefill_threshold,
             specprefill_keep_pct=args.specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
             specprefill_draft_model=args.specprefill_draft_model,
             mllm_draft_model=mllm_draft_model,
             mllm_draft_kind=mllm_draft_kind,
@@ -1239,6 +1244,13 @@ Examples:
         default=0.3,
         help="Fraction of tokens to keep during sparse prefill (default: 0.3). "
         "Lower = faster prefill but more quality loss.",
+    )
+    serve_parser.add_argument(
+        "--specprefill-backbone-pct",
+        type=float,
+        default=0.0,
+        help="Fraction of chunks reserved for evenly spaced sparse-prefill coverage "
+        "(default: 0.0).",
     )
     serve_parser.add_argument(
         "--specprefill-draft-model",

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -126,6 +126,7 @@ class SimpleEngine(BaseEngine):
         specprefill_enabled: bool = False,
         specprefill_threshold: int = 8192,
         specprefill_keep_pct: float = 0.3,
+        specprefill_backbone_pct: float = 0.0,
         specprefill_draft_model: str | None = None,
         max_kv_size: int = 0,
         mllm_draft_model: str | None = None,
@@ -146,6 +147,8 @@ class SimpleEngine(BaseEngine):
             specprefill_enabled: Enable SpecPrefill (attention-based sparse prefill)
             specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill
             specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
+            specprefill_backbone_pct: Fraction of chunks to reserve for evenly
+                spaced coverage (default: 0.0)
             specprefill_draft_model: Path to small draft model for importance scoring
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
             mllm_draft_model: Optional MLLM speculative draft/assistant model path
@@ -165,6 +168,7 @@ class SimpleEngine(BaseEngine):
         self._specprefill_enabled = specprefill_enabled
         self._specprefill_threshold = specprefill_threshold
         self._specprefill_keep_pct = specprefill_keep_pct
+        self._specprefill_backbone_pct = specprefill_backbone_pct
         self._specprefill_draft_model_path = specprefill_draft_model
         self._mllm_draft_model_path = mllm_draft_model
         self._mllm_draft_kind = mllm_draft_kind
@@ -585,6 +589,7 @@ class SimpleEngine(BaseEngine):
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
+        specprefill_backbone_pct_override = kwargs.pop("specprefill_backbone_pct", None)
 
         # SpecPrefill for non-MLLM models (MLLM+MTP handles it in _stream_generate_text)
         if not self._is_mllm and self._draft_model is not None:
@@ -627,6 +632,7 @@ class SimpleEngine(BaseEngine):
                         top_p,
                         stop=stop,
                         specprefill_keep_pct=specprefill_keep_pct_override,
+                        specprefill_backbone_pct=specprefill_backbone_pct_override,
                         **kwargs,
                     ):
                         yield output
@@ -1400,6 +1406,7 @@ class SimpleEngine(BaseEngine):
         top_p: float,
         stop: list[str] | None = None,
         specprefill_keep_pct: float | None = None,
+        specprefill_backbone_pct: float | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """SpecPrefill path for non-MTP models (Nemotron, GPT-OSS, etc).
@@ -1463,7 +1470,16 @@ class SimpleEngine(BaseEngine):
                 # Phase 2: Select important chunks
                 _cancel_check()
                 effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
-                selected = select_chunks(importance, keep_pct=effective_keep)
+                effective_backbone = (
+                    specprefill_backbone_pct
+                    if specprefill_backbone_pct is not None
+                    else self._specprefill_backbone_pct
+                )
+                selected = select_chunks(
+                    importance,
+                    keep_pct=effective_keep,
+                    backbone_pct=effective_backbone,
+                )
                 n_selected = selected.shape[0]
 
                 # Phase 3: Sparse prefill on target model
@@ -1617,6 +1633,7 @@ class SimpleEngine(BaseEngine):
         # Per-request specprefill overrides (from extra_body)
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct = kwargs.pop("specprefill_keep_pct", None)
+        specprefill_backbone_pct = kwargs.pop("specprefill_backbone_pct", None)
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
         top_k = kwargs.pop("top_k", 0)
         min_p = kwargs.pop("min_p", 0.0)
@@ -2096,7 +2113,16 @@ class SimpleEngine(BaseEngine):
 
                 # Phase 2: Select important chunks
                 effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
-                selected = select_chunks(importance, keep_pct=effective_keep)
+                effective_backbone = (
+                    specprefill_backbone_pct
+                    if specprefill_backbone_pct is not None
+                    else self._specprefill_backbone_pct
+                )
+                selected = select_chunks(
+                    importance,
+                    keep_pct=effective_keep,
+                    backbone_pct=effective_backbone,
+                )
                 n_selected = selected.shape[0]
                 n_total = len(specprefill_tokens)
 
@@ -2321,6 +2347,7 @@ class SimpleEngine(BaseEngine):
                 "draft_model": self._specprefill_draft_model_path,
                 "threshold": self._specprefill_threshold,
                 "keep_pct": self._specprefill_keep_pct,
+                "backbone_pct": self._specprefill_backbone_pct,
             }
 
         # System KV cache stats (LRU over multiple system prefixes)

--- a/vllm_mlx/lifecycle.py
+++ b/vllm_mlx/lifecycle.py
@@ -40,6 +40,7 @@ class ModelSpec:
     specprefill_enabled: bool = False
     specprefill_threshold: int = 8192
     specprefill_keep_pct: float = 0.3
+    specprefill_backbone_pct: float = 0.0
     specprefill_draft_model: str | None = None
 
 

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -115,6 +115,7 @@ class RegistryServeDefaults:
     specprefill_enabled: bool
     specprefill_threshold: int
     specprefill_keep_pct: float
+    specprefill_backbone_pct: float
     specprefill_draft_model: str | None
     stream_interval: int
     gpu_memory_utilization: float
@@ -154,6 +155,7 @@ class RegisteredModel:
     specprefill_enabled: bool | None = None
     specprefill_threshold: int | None = None
     specprefill_keep_pct: float | None = None
+    specprefill_backbone_pct: float | None = None
     specprefill_draft_model: str | None = None
     stream_interval: int | None = None
     gpu_memory_utilization: float | None = None
@@ -173,6 +175,7 @@ class ResolvedModelConfig:
     specprefill_enabled: bool
     specprefill_threshold: int
     specprefill_keep_pct: float
+    specprefill_backbone_pct: float
     specprefill_draft_model: str | None
     stream_interval: int
     gpu_memory_utilization: float
@@ -348,6 +351,7 @@ def load_registry_config(
             specprefill_enabled=item.get("specprefill"),
             specprefill_threshold=item.get("specprefill_threshold"),
             specprefill_keep_pct=item.get("specprefill_keep_pct"),
+            specprefill_backbone_pct=item.get("specprefill_backbone_pct"),
             specprefill_draft_model=item.get("specprefill_draft_model"),
             stream_interval=item.get("stream_interval"),
             gpu_memory_utilization=item.get("gpu_memory_utilization"),
@@ -797,6 +801,7 @@ class ModelManager:
                 specprefill_enabled=config.specprefill_enabled,
                 specprefill_threshold=config.specprefill_threshold,
                 specprefill_keep_pct=config.specprefill_keep_pct,
+                specprefill_backbone_pct=config.specprefill_backbone_pct,
                 specprefill_draft_model=config.specprefill_draft_model,
             )
 
@@ -891,6 +896,11 @@ class ModelManager:
             if entry.specprefill_keep_pct is not None
             else self._defaults.specprefill_keep_pct
         )
+        specprefill_backbone_pct = (
+            entry.specprefill_backbone_pct
+            if entry.specprefill_backbone_pct is not None
+            else self._defaults.specprefill_backbone_pct
+        )
         specprefill_draft_model = (
             entry.specprefill_draft_model
             if entry.specprefill_draft_model is not None
@@ -918,6 +928,7 @@ class ModelManager:
             specprefill_enabled=specprefill_enabled,
             specprefill_threshold=specprefill_threshold,
             specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
             specprefill_draft_model=specprefill_draft_model,
             stream_interval=stream_interval,
             gpu_memory_utilization=gpu_memory_utilization,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -748,6 +748,9 @@ def _prepare_chat_completion_invocation(
         chat_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
         chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+    specprefill_backbone_pct = getattr(request, "specprefill_backbone_pct", None)
+    if specprefill_backbone_pct is not None:
+        chat_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
     resolved_chat_template_kwargs = _resolve_chat_template_kwargs(
         request.chat_template_kwargs
     )
@@ -1193,6 +1196,7 @@ def _build_engine(spec: ModelSpec) -> BaseEngine:
         specprefill_enabled=spec.specprefill_enabled,
         specprefill_threshold=spec.specprefill_threshold,
         specprefill_keep_pct=spec.specprefill_keep_pct,
+        specprefill_backbone_pct=spec.specprefill_backbone_pct,
         specprefill_draft_model=spec.specprefill_draft_model,
         max_kv_size=max_kv_size,
     )
@@ -2999,6 +3003,7 @@ def load_model(
     specprefill_enabled: bool = False,
     specprefill_threshold: int = 8192,
     specprefill_keep_pct: float = 0.3,
+    specprefill_backbone_pct: float = 0.0,
     specprefill_draft_model: str = None,
     mllm_draft_model: str | None = None,
     mllm_draft_kind: str | None = None,
@@ -3024,6 +3029,7 @@ def load_model(
         specprefill_enabled: Enable SpecPrefill (SimpleEngine only)
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
+        specprefill_backbone_pct: Fraction of chunks reserved for evenly spaced coverage
         specprefill_draft_model: Path to small draft model for SpecPrefill scoring
         mllm_draft_model: Optional MLLM speculative draft/assistant model path.
         mllm_draft_kind: Optional mlx-vlm draft kind, for example "mtp".
@@ -3120,6 +3126,7 @@ def load_model(
             specprefill_enabled=specprefill_enabled,
             specprefill_threshold=specprefill_threshold,
             specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
             specprefill_draft_model=specprefill_draft_model,
         )
         _residency_manager = ResidencyManager(
@@ -3171,6 +3178,7 @@ def load_model(
             specprefill_enabled=specprefill_enabled,
             specprefill_threshold=specprefill_threshold,
             specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
             specprefill_draft_model=specprefill_draft_model,
             max_kv_size=_max_kv,
             mllm_draft_model=mllm_draft_model,
@@ -4613,6 +4621,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 generate_kwargs["specprefill"] = request.specprefill
             if request.specprefill_keep_pct is not None:
                 generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+            specprefill_backbone_pct = getattr(
+                request, "specprefill_backbone_pct", None
+            )
+            if specprefill_backbone_pct is not None:
+                generate_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
             try:
                 if raw_request is None:
                     output = await engine.generate(**generate_kwargs)
@@ -5776,6 +5789,9 @@ async def stream_completion(
         generate_kwargs["specprefill"] = request.specprefill
     if request.specprefill_keep_pct is not None:
         generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
+    specprefill_backbone_pct = getattr(request, "specprefill_backbone_pct", None)
+    if specprefill_backbone_pct is not None:
+        generate_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
 
     try:
         async for output in engine.stream_generate(**generate_kwargs):

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -396,13 +396,14 @@ def score_tokens(
     return importance
 
 
-def select_chunks(importance, keep_pct=0.3, chunk_size=32):
+def select_chunks(importance, keep_pct=0.3, chunk_size=32, backbone_pct=0.0):
     """Select top-k% token chunks by average importance.
 
     Args:
         importance: (M,) per-token importance scores
         keep_pct: fraction of chunks to keep (default 0.3)
         chunk_size: tokens per chunk (default 32)
+        backbone_pct: fraction of chunks reserved for evenly-spaced coverage
 
     Returns:
         sorted mx.array of kept token indices
@@ -412,7 +413,10 @@ def select_chunks(importance, keep_pct=0.3, chunk_size=32):
         return mx.arange(M)
 
     n_chunks = math.ceil(M / chunk_size)
+    target_tokens = max(1, math.ceil(M * keep_pct))
     keep_n = max(1, math.ceil(n_chunks * keep_pct))
+    backbone_n = max(0, math.ceil(n_chunks * backbone_pct)) if backbone_pct > 0 else 0
+    top_n = max(0, keep_n - backbone_n)
 
     chunk_scores = []
     for i in range(n_chunks):
@@ -420,10 +424,39 @@ def select_chunks(importance, keep_pct=0.3, chunk_size=32):
         end = min(start + chunk_size, M)
         chunk_scores.append(mx.mean(importance[start:end]).item())
 
-    top_chunks = sorted(range(n_chunks), key=lambda i: chunk_scores[i], reverse=True)[
-        :keep_n
-    ]
-    top_chunks.sort()
+    selected_chunks = set(
+        sorted(range(n_chunks), key=lambda i: chunk_scores[i], reverse=True)[:top_n]
+    )
+    if backbone_n > 0:
+        if backbone_n >= n_chunks:
+            selected_chunks.update(range(n_chunks))
+        else:
+            for i in range(backbone_n):
+                selected_chunks.add(round(i * (n_chunks - 1) / max(1, backbone_n - 1)))
+
+    def _selected_token_count(chunks):
+        total = 0
+        for chunk_idx in chunks:
+            start = chunk_idx * chunk_size
+            end = min(start + chunk_size, M)
+            total += end - start
+        return total
+
+    if (
+        len(selected_chunks) < keep_n
+        or _selected_token_count(selected_chunks) < target_tokens
+    ):
+        for chunk_idx in sorted(
+            range(n_chunks), key=lambda i: chunk_scores[i], reverse=True
+        ):
+            selected_chunks.add(chunk_idx)
+            if (
+                len(selected_chunks) >= keep_n
+                and _selected_token_count(selected_chunks) >= target_tokens
+            ):
+                break
+
+    top_chunks = sorted(selected_chunks)
 
     indices = []
     for ci in top_chunks:


### PR DESCRIPTION
## Summary

Threads the SpecPrefill backbone coverage policy through the SimpleEngine SpecPrefill surface.

Related issue: #578

## What changed

- Adds `backbone_pct` to `select_chunks(..., default=0.0)` so current behavior is preserved when unset.
- Adds `specprefill_backbone_pct` to SimpleEngine startup config and per-request kwargs.
- Threads the field through API models, server request forwarding, CLI, lifecycle, and registry config.
- Adds tests proving both SimpleEngine SpecPrefill paths pass `backbone_pct` to `select_chunks`.

## Exact upstream code path compared

Compared against `waybarrios/vllm-mlx` `upstream/main` at `9c83c84f78143811d997802dcfc6649eb491eb7a`:

- `vllm_mlx/specprefill.py::select_chunks`
- `vllm_mlx/engine/simple.py::SimpleEngine.stream_generate`
- `vllm_mlx/engine/simple.py::SimpleEngine._stream_generate_specprefill`
- `vllm_mlx/engine/simple.py::SimpleEngine._stream_generate_text`
- `vllm_mlx/api/models.py`
- `vllm_mlx/server.py`
- `vllm_mlx/cli.py`
- `vllm_mlx/model_registry.py`
- `vllm_mlx/lifecycle.py`

Runtime preflight artifact:

`/opt/ai-runtime/run/upstream-local-repro-preflight/20260524T235045Z-upstream-local-repro-preflight.json`

## Verification

```bash
python -m pytest -q tests/test_simple_engine.py tests/test_cli.py tests/test_model_registry.py tests/test_lifecycle_server.py
# 129 passed, 1 warning

python -m pytest -q --ignore=tests/test_ssd_cache.py
# 2068 passed, 11 skipped, 23 deselected, 1 warning

ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841
# passed

black --check --target-version py312 vllm_mlx/ tests/
# passed

git diff --check
# passed
```

Full `pytest -q` was also run. It now gets past this patch's lifecycle/CLI coverage and reports only the existing SSD-cache test failures in `tests/test_ssd_cache.py` on this machine.

## Not claimed

- No performance claim.
- No model-quality or qualification claim.
- No BatchedEngine SpecPrefill claim.
- No default behavior change when `specprefill_backbone_pct` is unset.
