### PR TITLE
Validate OpenAI tool function names

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -8,6 +8,9 @@ These are pure Pydantic models with no MLX dependency.
 
 import time
 
+import pytest
+from pydantic import ValidationError
+
 from vllm_mlx.api.models import (
     AssistantMessage,
     AudioSeparationRequest,
@@ -196,6 +199,25 @@ class TestToolCalling:
         assert td.type == "function"
         assert td.function["name"] == "get_weather"
 
+    def test_tool_definition_allows_openai_function_name_characters(self):
+        td = ToolDefinition(
+            function={
+                "name": "get-weather_2",
+                "description": "Get weather",
+            }
+        )
+
+        assert td.function["name"] == "get-weather_2"
+
+    def test_tool_definition_rejects_function_name_with_spaces(self):
+        with pytest.raises(ValidationError, match="function.name"):
+            ToolDefinition(
+                function={
+                    "name": "Answer Tool",
+                    "description": "Return hobbies",
+                }
+            )
+
 
 class TestResponseFormat:
     """Tests for structured output models."""
@@ -273,6 +295,22 @@ class TestChatCompletion:
         assert req.stream_options.include_usage is True
         assert req.tools is not None
         assert req.timeout == 30.0
+
+    def test_request_rejects_tool_name_with_spaces(self):
+        with pytest.raises(ValidationError, match="function.name"):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[Message(role="user", content="Use the Answer Tool.")],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "Answer Tool",
+                            "description": "Return hobbies",
+                        },
+                    }
+                ],
+            )
 
     def test_mllm_request_params(self):
         req = ChatCompletionRequest(

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -9,11 +9,12 @@ These models define the request and response schemas for:
 - MCP (Model Context Protocol) integration
 """
 
+import re
 import time
 import uuid
 from typing import Any
 
-from pydantic import AliasChoices, BaseModel, Field, model_serializer
+from pydantic import AliasChoices, BaseModel, Field, model_serializer, model_validator
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -88,6 +89,9 @@ class Message(BaseModel):
 # =============================================================================
 
 
+_OPENAI_FUNCTION_NAME_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
+
+
 class FunctionCall(BaseModel):
     """A function call with name and arguments."""
 
@@ -108,6 +112,15 @@ class ToolDefinition(BaseModel):
 
     type: str = "function"
     function: dict
+
+    @model_validator(mode="after")
+    def _validate_openai_function_name(self):
+        if self.type != "function":
+            return self
+        name = self.function.get("name")
+        if not isinstance(name, str) or not _OPENAI_FUNCTION_NAME_RE.fullmatch(name):
+            raise ValueError("function.name must match ^[A-Za-z0-9_-]{1,64}$")
+        return self
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- validate OpenAI-compatible function tool names at the request model boundary
- reject names with spaces before template rendering or tool-parser fallback can leak raw tool text into `message.content`
- add regression coverage for accepted function-name characters and invalid spaced names from raw request payloads

Fixes #577.

## Tests

```sh
/Users/David/code/vllm-mlx/.venv/bin/python -m ruff check vllm_mlx/api/models.py tests/test_api_models.py
/Users/David/code/vllm-mlx/.venv/bin/python -m black --check --fast vllm_mlx/api/models.py tests/test_api_models.py
/Users/David/code/vllm-mlx/.venv/bin/python -m pytest tests/test_api_models.py tests/test_tool_choice_forced.py tests/test_tool_choice_none.py tests/test_gemma4_openai_format.py -q
/Users/David/code/vllm-mlx/.venv/bin/python -m pytest -q --ignore=tests/test_ssd_cache.py
git diff --check
/opt/ai-runtime/bin/lint-upstream-claims --root /Users/David/.config/superpowers/worktrees/vllm-mlx/gemma4-invalid-tool-name-validation vllm_mlx/api/models.py tests/test_api_models.py
```

## What is not claimed

- This does not add support for function names containing spaces.
- This does not change Gemma 4 parser behavior for valid function names.
- This is not a model-quality claim.
