### PR TITLE
fix(qwen-tool-parser): extract mixed XML+function calls, strip truncated markup

### DIFF
--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -1295,6 +1295,160 @@ class TestQwenFunctionFormat:
         assert result.tool_calls[0]["name"] == "get_weather"
 
 
+class TestQwenMixedFormatAndTruncation:
+    """Regression tests for multi-format extraction and truncated output.
+
+    Bug 1: previously the function-style pass was guarded by ``if not tool_calls``,
+    so an XML tool call followed by a ``<function=...>`` tool call only yielded the
+    XML one — the function markup leaked into ``content``.
+
+    Bug 2: when generation hit ``max_tokens`` mid tool call (Qwen3.6 emits nested
+    ``<tool_call>\n<function=name>...</function>\n</tool_call>``), the truncated
+    second call's raw markup was returned in ``content``.
+    """
+
+    @pytest.fixture
+    def parser(self):
+        return QwenToolParser()
+
+    def test_xml_then_function_mixed(self, parser):
+        """XML call followed by function-style call — both should be extracted."""
+        text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Prague"}}'
+            "\n</tool_call>\n"
+            "<function=convert_currency>\n"
+            "<parameter=amount>100</parameter>\n"
+            "<parameter=from_currency>EUR</parameter>\n"
+            "<parameter=to_currency>CZK</parameter>\n"
+            "</function>"
+        )
+        result = parser.extract_tool_calls(text)
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert result.tool_calls[1]["name"] == "convert_currency"
+        args = json.loads(result.tool_calls[1]["arguments"])
+        assert args == {
+            "amount": 100,
+            "from_currency": "EUR",
+            "to_currency": "CZK",
+        }
+        # No raw markup left in content
+        assert result.content in (None, "")
+
+    def test_nested_function_in_tool_call_wrappers(self, parser):
+        """Qwen3.6 nests <function=...> inside <tool_call>...</tool_call>."""
+        text = (
+            "<tool_call>\n"
+            "<function=get_weather>\n"
+            "<parameter=city>Prague</parameter>\n"
+            "</function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=convert_currency>\n"
+            "<parameter=amount>100</parameter>\n"
+            "<parameter=from_currency>EUR</parameter>\n"
+            "<parameter=to_currency>CZK</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        result = parser.extract_tool_calls(text)
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0]["name"] == "get_weather"
+        assert result.tool_calls[1]["name"] == "convert_currency"
+        assert result.content in (None, "")
+
+    def test_truncated_second_tool_call_no_leak(self, parser):
+        """One complete + one truncated <tool_call> — only the first call,
+        no raw markup in content."""
+        text = (
+            "<tool_call>\n"
+            "<function=get_weather>\n"
+            "<parameter=city>Prague</parameter>\n"
+            "</function>\n"
+            "</tool_call>\n"
+            "<tool_call>\n"
+            "<function=convert_currency>\n"
+            "<parameter=amount>\n1"
+        )
+        result = parser.extract_tool_calls(text)
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        # The truncated second call must NOT leak into content
+        content = result.content or ""
+        assert "<tool_call>" not in content
+        assert "<function=" not in content
+        assert "<parameter=" not in content
+
+    def test_truncated_only_no_complete_tool_call(self, parser):
+        """No complete tool call — pure plain-text prefix is preserved, but the
+        partial ``<tool_call>`` markup at end is stripped."""
+        text = "Let me check the weather. <tool_call>"
+        result = parser.extract_tool_calls(text)
+        assert not result.tools_called
+        assert len(result.tool_calls) == 0
+        content = result.content or ""
+        assert "<tool_call>" not in content
+        assert content.startswith("Let me check the weather.")
+
+    def test_truncated_function_only(self, parser):
+        """Plain text with truncated <function= and no closing tag."""
+        text = "I'll call: <function=get_weather>"
+        result = parser.extract_tool_calls(text)
+        assert not result.tools_called
+        content = result.content or ""
+        assert "<function=" not in content
+        assert content.startswith("I'll call:")
+
+    def test_truncated_bracket_call(self, parser):
+        """Partial ``[Calling tool: ...`` without closing ``)]`` is stripped."""
+        text = 'Let me check. [Calling tool: get_weather({"city":"Prague"'
+        result = parser.extract_tool_calls(text)
+        assert not result.tools_called
+        content = result.content or ""
+        assert "[Calling tool:" not in content
+        assert content.startswith("Let me check.")
+
+    def test_complete_function_then_truncated_function(self, parser):
+        """Two ``<function=...>`` blocks where the second is truncated."""
+        text = (
+            '<function=get_weather>{"city": "Prague"}</function>\n'
+            "<function=convert_currency><parameter=amount>10"
+        )
+        result = parser.extract_tool_calls(text)
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        content = result.content or ""
+        assert "<function=" not in content
+        assert "<parameter=" not in content
+
+    def test_no_tool_calls_returns_string_not_none(self, parser):
+        """When the parser strips truncated markup to empty, it must return
+        an empty string (not ``None``) so downstream code can tell the parser
+        actually processed the input.
+
+        Without this, the server's fallback path would receive ``content=None``
+        and resurface the raw markup it just stripped (regression observed
+        against Qwen3.6-35B with ``max_tokens`` truncation in the chat handler).
+        """
+        # Fully stripped → empty string
+        result = parser.extract_tool_calls("<tool_call>\n<function=calculate")
+        assert not result.tools_called
+        assert result.content == ""
+        # Partially stripped → non-empty string
+        result = parser.extract_tool_calls("Some text. <tool_call>")
+        assert not result.tools_called
+        assert isinstance(result.content, str)
+        assert result.content == "Some text."
+        # Plain text untouched → original string
+        result = parser.extract_tool_calls("Hello world.")
+        assert not result.tools_called
+        assert result.content == "Hello world."
+
+
 class TestQwenStreamingBuffering:
     """Test Qwen parser streaming with partial-marker buffering."""
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1751,10 +1751,21 @@ def _parse_tool_calls_with_parser(
                 for tc in result.tool_calls
             ]
             return result.content or "", tool_calls
-        else:
-            # Fallback: specific parser didn't find tool calls,
-            # try generic parser which handles more formats (e.g. Nemotron XML)
-            return parse_tool_calls(output_text, request_dict)
+
+        # Specific parser didn't find any tool calls. Try the generic parser
+        # which handles additional formats (e.g. Nemotron XML).
+        fallback_text, fallback_calls = parse_tool_calls(output_text, request_dict)
+        if fallback_calls:
+            return fallback_text, fallback_calls
+
+        # Neither parser found tool calls. Prefer the specific parser's cleaned
+        # content (which may have stripped truncated tool-call markup left by
+        # max_tokens cut-offs) over the raw model output. Falling back to the
+        # raw text here leaks partial <tool_call>/<function= markup into the
+        # response `content` when generation was cut mid-tool-call.
+        if result.content is not None:
+            return result.content, None
+        return fallback_text, None
     except Exception as e:
         logger.warning("Tool parser error: %s", _sanitize_log_text(e, limit=500))
         return parse_tool_calls(output_text, request_dict)

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -134,52 +134,98 @@ class QwenToolParser(ToolParser):
             cleaned_text = self.XML_PATTERN.sub("", cleaned_text).strip()
 
         # Try function-style: <function=name><parameter=key>value</parameter></function>
-        # Qwen3.5 generates this format natively.
-        if not tool_calls:
-            func_matches = self.FUNCTION_PATTERN.findall(cleaned_text)
-            for name, params_block in func_matches:
-                # Try JSON arguments first (e.g. <function=name>{"key": "val"}</function>)
-                params_block_stripped = params_block.strip()
-                if params_block_stripped.startswith("{"):
-                    try:
-                        arguments = json.loads(params_block_stripped)
-                        tool_calls.append(
-                            {
-                                "id": generate_tool_id(),
-                                "name": name.strip(),
-                                "arguments": json.dumps(arguments, ensure_ascii=False),
-                            }
-                        )
-                        continue
-                    except json.JSONDecodeError:
-                        pass
-                # Parse <parameter=key>value</parameter> tags
-                params = self.PARAM_PATTERN.findall(params_block)
-                arguments = {}
-                for p_name, p_value in params:
-                    arguments[p_name.strip()] = _parse_param_value(p_value.strip())
-                tool_calls.append(
-                    {
-                        "id": generate_tool_id(),
-                        "name": name.strip(),
-                        "arguments": json.dumps(arguments, ensure_ascii=False),
-                    }
-                )
-            if func_matches:
-                cleaned_text = self.FUNCTION_PATTERN.sub("", cleaned_text).strip()
+        # Qwen3.5/3.6 emit this format natively, sometimes wrapped in <tool_call>...
+        # </tool_call>. Always run this pass — earlier guards skipped it when an
+        # XML/bracket call had already been extracted, leaking the function-style
+        # markup of subsequent tool calls into `content` (multi-format mixed
+        # responses).
+        func_matches = self.FUNCTION_PATTERN.findall(cleaned_text)
+        for name, params_block in func_matches:
+            # Try JSON arguments first (e.g. <function=name>{"key": "val"}</function>)
+            params_block_stripped = params_block.strip()
+            if params_block_stripped.startswith("{"):
+                try:
+                    arguments = json.loads(params_block_stripped)
+                    tool_calls.append(
+                        {
+                            "id": generate_tool_id(),
+                            "name": name.strip(),
+                            "arguments": json.dumps(arguments, ensure_ascii=False),
+                        }
+                    )
+                    continue
+                except json.JSONDecodeError:
+                    pass
+            # Parse <parameter=key>value</parameter> tags
+            params = self.PARAM_PATTERN.findall(params_block)
+            arguments = {}
+            for p_name, p_value in params:
+                arguments[p_name.strip()] = _parse_param_value(p_value.strip())
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": name.strip(),
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                }
+            )
+        if func_matches:
+            cleaned_text = self.FUNCTION_PATTERN.sub("", cleaned_text).strip()
 
         if tool_calls:
             # Clean up empty <tool_call> wrappers left after function extraction
             cleaned_text = self.EMPTY_TOOL_CALL.sub("", cleaned_text).strip()
+            # Strip any trailing unclosed tool-call markup left when generation
+            # was truncated mid-call (finish_reason="length" hitting max_tokens).
+            cleaned_text = self._strip_unclosed_markup(cleaned_text)
             return ExtractedToolCallInformation(
                 tools_called=True,
                 tool_calls=tool_calls,
                 content=cleaned_text if cleaned_text else None,
             )
         else:
+            # No complete tool calls were extracted. If the output ends with a
+            # truncated tool-call marker (e.g. max_tokens hit mid <tool_call>...),
+            # strip it so callers don't see raw markup in `content`. We only
+            # strip the trailing partial — earlier complete sentences stay.
+            # Always return a string (empty if fully stripped) so the caller
+            # can distinguish "parser processed this" from "parser declined";
+            # `or None` would conflate stripped-to-empty with no-result and let
+            # a fallback path resurface the raw markup.
+            stripped = self._strip_unclosed_markup(model_output)
             return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
+                tools_called=False, tool_calls=[], content=stripped
             )
+
+    @staticmethod
+    def _strip_unclosed_markup(text: str) -> str:
+        """Strip a trailing unclosed tool-call marker (truncated output).
+
+        When generation hits max_tokens mid-tool-call, a partial
+        ``<tool_call>``/``<function=``/``[Calling tool:`` marker remains
+        in the cleaned text. We locate the earliest such *unclosed* marker
+        and drop everything from there to the end so the API response
+        never carries raw markup.
+        """
+        if not text:
+            return text
+        earliest = len(text)
+
+        # <tool_call> without matching </tool_call>
+        idx = text.rfind("<tool_call>")
+        if idx >= 0 and "</tool_call>" not in text[idx:]:
+            earliest = min(earliest, idx)
+
+        # <function=...> without matching </function>
+        idx = text.rfind("<function=")
+        if idx >= 0 and "</function>" not in text[idx:]:
+            earliest = min(earliest, idx)
+
+        # [Calling tool: ... without matching )]
+        idx = text.rfind("[Calling tool:")
+        if idx >= 0 and ")]" not in text[idx:]:
+            earliest = min(earliest, idx)
+
+        return text[:earliest].rstrip()
 
     # Partial marker prefixes — when current_text ends with one of these,
     # we suppress output until the next token confirms or denies a tool call.


### PR DESCRIPTION
## Summary

Three related fixes for `<tool_call>` / `<function=` markup leaking into `content` against Qwen3.6 (and Qwen3.5) in non-streaming chat completions.

### 1. Parser — mixed-format extraction
The function-style pass was gated by `if not tool_calls:`. When the model emitted an XML call followed by a `<function=...>` call in the same response, only the XML call was extracted; the function-style markup was returned in `content`.

### 2. Parser — truncated tool-call markup
Qwen3.6 nests function-style calls inside `<tool_call>` wrappers:

```
<tool_call>
<function=convert_currency>
<parameter=amount>100</parameter>
...
</function>
</tool_call>
```

When generation hits `max_tokens` mid-call, the unclosed `<tool_call>\n<function=...` markup was left in `content`. Neither `XML_PATTERN` (requires `{json}`) nor `FUNCTION_PATTERN` (requires `</function>`) matches the truncated form.

A new `_strip_unclosed_markup()` finds the earliest unmatched `<tool_call>` / `<function=` / `[Calling tool:` marker at the tail and drops everything from there. Applied both on the success path (after extraction) and on the no-tool-call fallback. The no-tool-call path now always returns a string (empty if fully stripped) instead of `or None`, so callers can distinguish "parser processed this" from "parser declined".

### 3. Server fallback — preserve parser's cleaned content
`_parse_tool_calls_with_parser` previously fell straight through to the generic `parse_tool_calls` when the configured parser found no tools. The generic parser does not strip incomplete markup, so the chat handler received the raw model output and leaked the markup even though the configured parser had already cleaned it. The fallback now uses the generic parser only when it actually finds tool calls; otherwise it returns the configured parser's cleaned content.

## Test plan

- [x] 24/24 existing Qwen unit tests still pass.
- [x] 8 new regression tests in `TestQwenMixedFormatAndTruncation` covering mixed XML+function, nested function-in-tool_call, truncated second tool call, truncated `<tool_call>` only, truncated `<function=` only, truncated `[Calling tool:` only, complete-function-then-truncated-function, and the always-string `content` contract.
- [x] 156/156 tests pass across `tests/test_tool_parsers.py`, `tests/test_native_tool_format.py`, `tests/test_tool_choice_forced.py`, and `tests/test_tool_choice_none.py`.
- [x] Live stress test against Qwen3.6-35B-A3B (20 multi-tool requests, varying `max_tokens` 80–1500): 4/20 responses leaked truncated markup into `content` before the fix; 20/20 clean after the fix even when `finish_reason="length"` cut generation mid-tool-call.