### PR TITLE
fix: update gemma4 attention patch for mlx-vlm 0.5.0 compatibility

### DIFF
--- a/vllm_mlx/patches/gemma4_mllm.py
+++ b/vllm_mlx/patches/gemma4_mllm.py
@@ -71,36 +71,41 @@ def patch_gemma4_attention_for_batching() -> bool:
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
-    ) -> mx.array:
+        shared_kv: Optional[tuple] = None,
+        offset: Optional[Any] = None,
+    ) -> tuple:
         B, L, _ = x.shape
 
         queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
         queries = self.q_norm(queries)
 
-        # Snapshot offset BEFORE update_and_fetch can mutate it in-place.
-        # Preserves per-sequence mx.array offsets for correct batched RoPE.
-        offset = _snapshot_cache_offset(cache)
-
-        if self.is_kv_shared_layer and cache is not None:
-            state = cache.state
-            keys, values = state[0], state[1]
+        if shared_kv is not None:
+            keys, values = shared_kv
         else:
-            keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+            # Snapshot offset BEFORE update_and_fetch can mutate it in-place.
+            # Preserves per-sequence mx.array offsets for correct batched RoPE.
+            offset = _snapshot_cache_offset(cache)
 
-            if self.use_k_eq_v:
-                values = keys
+            if self.is_kv_shared_layer and cache is not None:
+                state = cache.state
+                keys, values = state[0], state[1]
             else:
-                values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+                keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
 
-            keys = self.k_norm(keys)
-            values = self.v_norm(values)
-            values = values.transpose(0, 2, 1, 3)
+                if self.use_k_eq_v:
+                    values = keys
+                else:
+                    values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
 
-            keys = keys.transpose(0, 2, 1, 3)
-            keys = self.rope(keys, offset=offset)
+                keys = self.k_norm(keys)
+                values = self.v_norm(values)
+                values = values.transpose(0, 2, 1, 3)
 
-            if cache is not None:
-                keys, values = cache.update_and_fetch(keys, values)
+                keys = keys.transpose(0, 2, 1, 3)
+                keys = self.rope(keys, offset=offset)
+
+                if cache is not None:
+                    keys, values = cache.update_and_fetch(keys, values)
 
         queries = queries.transpose(0, 2, 1, 3)
         queries = self.rope(queries, offset=offset)
@@ -113,7 +118,7 @@ def patch_gemma4_attention_for_batching() -> bool:
             queries, keys, values, cache=cache, scale=self.scale, mask=mask
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-        return self.o_proj(output)
+        return self.o_proj(output), (keys, values), offset
 
     Gemma4Attention.__call__ = _patched_call
     Gemma4Attention._batch_patched = True

--- a/vllm_mlx/patches/gemma4_mllm.py
+++ b/vllm_mlx/patches/gemma4_mllm.py
@@ -95,7 +95,9 @@ def patch_gemma4_attention_for_batching() -> bool:
                 if self.use_k_eq_v:
                     values = keys
                 else:
-                    values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+                    values = self.v_proj(x).reshape(
+                        B, L, self.n_kv_heads, self.head_dim
+                    )
 
                 keys = self.k_norm(keys)
                 values = self.v_norm(values)


### PR DESCRIPTION
## Problem

`mlx-vlm 0.5.0` updated `Attention.__call__` in the Gemma 4 model to accept two new keyword arguments (`shared_kv`, `offset`) and return a tuple `(output, (keys, values), offset)` instead of just `mx.array`.

The existing `patch_gemma4_attention_for_batching` in `vllm_mlx/patches/gemma4_mllm.py` was written against the older API, so at runtime it raises:

```
TypeError: patch_gemma4_attention_for_batching.<locals>._patched_call() got an unexpected keyword argument 'shared_kv'
```

## Fix

- Add `shared_kv` and `offset` parameters to `_patched_call`
- When `shared_kv` is provided, use it directly (skip k/v projection) — matching mlx-vlm's KV-sharing logic for 2B/4B models
- Move the defensive `offset` snapshot inside the `else` branch (only needed when computing fresh k/v)
- Return `(output, (keys, values), offset)` to match the new mlx-vlm signature