### PR TITLE
security: require patched Starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "psutil>=5.9.0",
     # Server
     "fastapi>=0.100.0",
+    "starlette>=1.0.1",
     "uvicorn>=0.23.0",
     "prometheus-client>=0.20.0",
     # MCP (Model Context Protocol) support


### PR DESCRIPTION
## Summary
- Add an explicit `starlette>=1.0.1` dependency floor for the FastAPI server stack.

## Why
Starlette versions below the patched BadHost floor have a Host-header URL parsing vulnerability. `vllm-mlx` already depends on FastAPI, but the project metadata did not directly express a patched Starlette floor.

## Validation
- Checked current source for `request.url` / `request.url.path` usage in server code; none found.
- Resolver dry-run on Python 3.12 completed successfully:
  `uv pip install --python /tmp/vllm-mlx-badhost-resolve/bin/python --dry-run .`
- The resolved set selected `fastapi==0.136.3`, `gradio==6.15.2`, and `starlette==1.2.0`.
- `git diff --check` passed.

## Explicit non-claims
- This PR does not claim an application-level BadHost exploit in `vllm-mlx`.
- This PR does not change server behavior.
- This PR only hardens package resolution so patched Starlette is required.
