### PR TITLE
Require mlx-vlm 0.6.2 for Step 3.7 Flash support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             tests/test_request.py \
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
+            tests/test_dependency_floors.py \
             tests/test_harmony_parsers.py \
             tests/test_endpoint_model_policies.py \
             tests/test_gemma4_openai_format.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 
 dependencies = [
     "mlx>=0.29.0",
-    "mlx-lm>=0.31.3",  # 0.31.3+ required by mlx-vlm 0.5.0
-    "mlx-vlm>=0.5.0",  # 0.5.0+ required for Step 3.7 Flash support
+    "mlx-lm>=0.31.3",  # 0.31.3+ required by current mlx-vlm runtime support
+    "mlx-vlm>=0.6.2",  # 0.6.2+ includes Step 3.7 Flash and follow-up fixes
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 
 dependencies = [
     "mlx>=0.29.0",
-    "mlx-lm>=0.31.0",  # 0.31+ required for ArraysCache native batching (hybrid models)
-    "mlx-vlm>=0.4.3",  # 0.4.3+ required for Gemma 4 support
+    "mlx-lm>=0.31.3",  # 0.31.3+ required by mlx-vlm 0.5.0
+    "mlx-vlm>=0.5.0",  # 0.5.0+ required for Step 3.7 Flash support
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -28,13 +28,13 @@ def _has_minimum(requirement: str, minimum: str) -> bool:
     return _version_tuple(version) >= _version_tuple(minimum)
 
 
-def test_mlx_vlm_floor_includes_step37_flash_support():
+def test_mlx_vlm_floor_includes_step37_flash_support_and_followups():
     dependencies = _project_dependencies()
 
-    assert _has_minimum(dependencies["mlx-vlm"], "0.5.0")
+    assert _has_minimum(dependencies["mlx-vlm"], "0.6.2")
 
 
-def test_mlx_lm_floor_matches_mlx_vlm_050_runtime_requirement():
+def test_mlx_lm_floor_matches_current_mlx_vlm_runtime_requirement():
     dependencies = _project_dependencies()
 
     assert _has_minimum(dependencies["mlx-lm"], "0.31.3")

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -1,0 +1,40 @@
+"""Dependency floor contracts for upstream model support."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _project_dependencies() -> dict[str, str]:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    dependencies = {}
+    for raw in pyproject["project"]["dependencies"]:
+        name = raw.split("[", 1)[0].split(">", 1)[0].split("=", 1)[0].strip()
+        dependencies[name] = raw
+    return dependencies
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def _has_minimum(requirement: str, minimum: str) -> bool:
+    needle = ">="
+    assert needle in requirement
+    version = requirement.split(needle, 1)[1].split(",", 1)[0].strip()
+    return _version_tuple(version) >= _version_tuple(minimum)
+
+
+def test_mlx_vlm_floor_includes_step37_flash_support():
+    dependencies = _project_dependencies()
+
+    assert _has_minimum(dependencies["mlx-vlm"], "0.5.0")
+
+
+def test_mlx_lm_floor_matches_mlx_vlm_050_runtime_requirement():
+    dependencies = _project_dependencies()
+
+    assert _has_minimum(dependencies["mlx-lm"], "0.31.3")

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
 


### PR DESCRIPTION
## Summary
- Raise `mlx-vlm` floor to `0.6.2`, the latest patch release containing Step 3.7 Flash support plus follow-up fixes.
- Keep the `mlx-lm` floor at `0.31.3`, matching the current `mlx-vlm` runtime support floor used by this package set.
- Add/update dependency-floor regression coverage so future installs do not silently resolve to a Step 3.7-incompatible `mlx-vlm`.

## Evidence
- Step 3.7 Flash support landed in `Blaizzy/mlx-vlm#1245`, which is contained in `mlx-vlm` tags `v0.6.0`, `v0.6.1`, and `v0.6.2`.
- The related ByteLevel streaming detokenizer fix landed in `Blaizzy/mlx-vlm#1246`, also contained in `v0.6.0+`.
- `mlx-vlm v0.6.2` also includes relevant follow-up fixes after `v0.6.0`, including Gemma 4 long-text prefill, structured output with thinking enabled, Qwen3.5 vision model type acceptance, Gemma shared-KV loading, and APC single-request behavior.
- The previous lower floor `mlx-vlm>=0.4.3` can resolve to `0.4.x`, which lacks the Step 3.7 loader surface. The earlier `0.5.0` floor in this PR was also too low for the actual Step 3.7 release placement.
- Resolver dry-run from this branch selects `mlx-vlm-0.6.2` and `mlx-lm-0.31.3`.

## Tests
- `.venv/bin/python -m pytest tests/test_dependency_floors.py -q` — 2 passed
- `.venv/bin/python -m ruff check tests/test_dependency_floors.py` — pass
- `git diff --check` — pass
- `/opt/ai-runtime/venv-live/bin/python -m pip install --dry-run --ignore-installed -e .` — resolves `mlx-vlm-0.6.2` / `mlx-lm-0.31.3`

## Not claimed
- This does not certify Step 3.7 runtime quality or serving behavior.
- This does not start or load any model.
- This only prevents installs from resolving to dependency versions that cannot include the Step 3.7 loader and follow-up support surface.