### PR TITLE
feat(mllm): auto-extract audio from video_url on omni models

### DIFF
--- a/tests/test_mllm_av_fusion.py
+++ b/tests/test_mllm_av_fusion.py
@@ -1,0 +1,581 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omni-model A/V fusion (PR #591 follow-ups).
+
+Covers the routing contract — when does a `video_url` auto-extract audio,
+when is that suppressed, and how does the extracted audio flow through both
+the native-video path and the frames-as-images fallback — plus the bounded
+`ffprobe`/`ffmpeg` helper used to do the extraction itself.
+
+These are pure unit tests: no model load, no real ffmpeg call. Subprocess
+boundaries are mocked so the suite runs anywhere. See the end of the file
+for an opt-in integration smoke test that needs a real ffmpeg.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx.models import mllm as mllm_mod
+from vllm_mlx.models.mllm import (
+    MLXMultimodalLM,
+    _model_has_sound_encoder,
+    extract_audio_from_video,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model(
+    *,
+    video_native_with_audio: bool,
+    video_native: bool = False,
+) -> MLXMultimodalLM:
+    """Bare model with the routing predicate set — no real load."""
+    model = MLXMultimodalLM.__new__(MLXMultimodalLM)
+    model._loaded = True
+    model._video_native = video_native
+    model._video_native_with_audio = video_native_with_audio
+    return model
+
+
+def _user_msg(*items) -> dict:
+    return {"role": "user", "content": list(items)}
+
+
+def _video_url(url: str = "https://example.com/v.mp4") -> dict:
+    return {"type": "video_url", "video_url": {"url": url}}
+
+
+def _audio_url(url: str = "https://example.com/a.wav") -> dict:
+    return {"type": "audio_url", "audio_url": {"url": url}}
+
+
+# ===========================================================================
+# Blocker #4 — sound_encoder predicate must reject `None`-valued attributes
+# ===========================================================================
+
+
+class TestSoundEncoderPredicate:
+    """`hasattr` was too loose; the new helper requires a populated encoder."""
+
+    def test_attribute_missing(self):
+        class FakeModel:
+            pass
+
+        assert _model_has_sound_encoder(FakeModel()) is False
+
+    def test_attribute_present_but_none(self):
+        """Regression for blocker #4: `hasattr` returned True for this case."""
+
+        class FakeModel:
+            pass
+
+        m = FakeModel()
+        m.sound_encoder = None
+        assert hasattr(m, "sound_encoder")  # bug condition
+        assert _model_has_sound_encoder(m) is False  # ...now rejected
+
+    def test_attribute_populated(self):
+        class FakeModel:
+            pass
+
+        m = FakeModel()
+        m.sound_encoder = object()
+        assert _model_has_sound_encoder(m) is True
+
+
+# ===========================================================================
+# Blocker #1 — routing contract for the auto-extraction behavior
+# ===========================================================================
+
+
+class TestNativeRoutingContract:
+    """`_translate_messages_for_native_video` decides whether to attach audio."""
+
+    def test_omni_video_url_auto_adds_audio(self):
+        """omni + video_url, no explicit audio → exactly one audio block."""
+        model = _make_model(video_native_with_audio=True)
+        messages = [_user_msg(_video_url())]
+
+        with patch.object(
+            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
+        ) as extract:
+            translated = model._translate_messages_for_native_video(
+                messages, video_fps=2.0, video_max_frames=60
+            )
+
+        # exactly one extraction call, with the resolved local path
+        extract.assert_called_once_with("/tmp/local.mp4")
+
+        types = [it["type"] for it in translated[0]["content"]]
+        assert types.count("audio") == 1
+        assert types.count("video") == 1
+
+    def test_explicit_audio_suppresses_extraction(self):
+        """When the message carries an audio block, ffmpeg is never invoked."""
+        model = _make_model(video_native_with_audio=True)
+        messages = [_user_msg(_video_url(), _audio_url())]
+
+        with patch.object(
+            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+        ), patch.object(
+            mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video"
+        ) as extract:
+            translated = model._translate_messages_for_native_video(
+                messages, video_fps=2.0, video_max_frames=60
+            )
+
+        # the explicit caller-provided audio must win
+        extract.assert_not_called()
+        audio_paths = [
+            it["audio"]
+            for it in translated[0]["content"]
+            if it["type"] == "audio"
+        ]
+        assert audio_paths == ["/tmp/explicit.wav"]
+
+    def test_non_omni_does_not_extract(self):
+        """Non-omni models (no sound_encoder) skip audio extraction entirely."""
+        model = _make_model(video_native_with_audio=False)
+        messages = [_user_msg(_video_url())]
+
+        with patch.object(
+            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video"
+        ) as extract:
+            translated = model._translate_messages_for_native_video(
+                messages, video_fps=2.0, video_max_frames=60
+            )
+
+        extract.assert_not_called()
+        types = [it["type"] for it in translated[0]["content"]]
+        assert "audio" not in types
+
+    def test_extraction_failure_does_not_add_audio_block(self):
+        """Audio extraction returning None must not produce an empty block."""
+        model = _make_model(video_native_with_audio=True)
+        messages = [_user_msg(_video_url())]
+
+        with patch.object(
+            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video", return_value=None
+        ):
+            translated = model._translate_messages_for_native_video(
+                messages, video_fps=2.0, video_max_frames=60
+            )
+
+        types = [it["type"] for it in translated[0]["content"]]
+        assert "audio" not in types
+
+
+class TestNativePrepareInputsForwardsAudio:
+    """`_prepare_native_video_inputs` must pipe processor audio outputs through."""
+
+    def _build_inputs_dict(self, *, include_audio_keys: bool) -> dict:
+        """Fake HF processor return value."""
+        # Use simple lists; mx.array() will accept them.
+        d = {
+            "input_ids": [[1, 2, 3]],
+            "pixel_values_videos": [[0.0, 0.1]],
+            "attention_mask": [[1, 1, 1]],
+            "video_grid_thw": [[1, 1, 1]],
+        }
+        if include_audio_keys:
+            d.update(
+                {
+                    "sound_clips": "SENTINEL_SOUND_CLIPS",
+                    "input_features": "SENTINEL_INPUT_FEATURES",
+                    "feature_attention_mask": "SENTINEL_FAM",
+                }
+            )
+        return d
+
+    def _run(self, *, omni: bool, with_audio_block: bool):
+        model = _make_model(video_native_with_audio=omni, video_native=True)
+        # Stub processor: returns inputs dict and a benign apply_chat_template.
+        processor = MagicMock()
+        processor.apply_chat_template.return_value = "PROMPT"
+        # The processor returns sound_clips whenever `audio=` is passed —
+        # which the native path does for every omni request, regardless of
+        # whether the audio came from an explicit block or auto-extraction.
+        processor.return_value = self._build_inputs_dict(include_audio_keys=omni)
+        model.processor = processor
+
+        items = [_video_url()]
+        if with_audio_block:
+            items.append(_audio_url())
+        messages = [_user_msg(*items)]
+
+        # Patch mlx_vlm process_vision_info and the resolution helpers.
+        process_vision_info = MagicMock(
+            return_value=(["frame1.jpg"], ["v.mp4"], {})
+        )
+        with patch.object(
+            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+        ), patch.object(
+            mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
+        ), patch.dict(
+            "sys.modules",
+            {
+                "mlx_vlm.video_generate": MagicMock(
+                    process_vision_info=process_vision_info
+                ),
+            },
+        ):
+            text, gen_kwargs = model._prepare_native_video_inputs(messages)
+
+        return text, gen_kwargs, processor
+
+    def test_native_path_forwards_sound_clips_for_omni(self):
+        """omni → processor sees `audio=…`, gen_kwargs gets `sound_clips`."""
+        _, gen_kwargs, processor = self._run(omni=True, with_audio_block=False)
+
+        proc_call = processor.call_args
+        assert "audio" in proc_call.kwargs
+        assert proc_call.kwargs["audio"] == ["/tmp/local.wav"]
+
+        # The processor's audio-bearing outputs must be propagated.
+        assert gen_kwargs.get("sound_clips") == "SENTINEL_SOUND_CLIPS"
+        assert gen_kwargs.get("input_features") == "SENTINEL_INPUT_FEATURES"
+        assert gen_kwargs.get("feature_attention_mask") == "SENTINEL_FAM"
+
+    def test_native_path_omits_audio_kwarg_for_non_omni(self):
+        """non-omni → no `audio=` passed; no sound_* keys leak into gen_kwargs."""
+        _, gen_kwargs, processor = self._run(omni=False, with_audio_block=False)
+
+        proc_call = processor.call_args
+        assert "audio" not in proc_call.kwargs
+
+        for k in (
+            "sound_clips",
+            "input_features",
+            "feature_attention_mask",
+            "audio_feature_lengths",
+            "sound_feature_lengths",
+            "sound_attention_mask",
+        ):
+            assert k not in gen_kwargs
+
+
+# ===========================================================================
+# Blocker #3 — fallback paths must resolve each video exactly once and merge
+# extracted audio into the per-message audio map
+# ===========================================================================
+
+
+class TestFallbackDedupAndMerge:
+    """Both `chat()` and `stream_chat()` resolve once, then merge audio."""
+
+    def _exercise_dedup_loop(
+        self, model: MLXMultimodalLM, vid_inputs: dict
+    ) -> tuple[dict, dict, int]:
+        """Run the omni-extraction loop body in isolation.
+
+        The dedup contract is identical in chat() and stream_chat() —
+        both call `process_video_input(vid_input)` exactly once per
+        input, hand the resolved path to both `extract_audio_from_video`
+        and `_prepare_video`, then merge `_msg_extra_audio` into
+        `_msg_audio_inputs`. We mirror that loop here so the assertion
+        does not depend on the surrounding 300-line method.
+        """
+        _msg_audio_inputs: dict[int, list[str]] = {}
+        _msg_extra_audio: dict[int, list[str]] = {}
+        prepare_calls = []
+
+        def fake_prepare(vid_input, fps, max_frames, resolved_path=None):
+            prepare_calls.append((vid_input, resolved_path))
+            return [f"frame_{vid_input}.jpg"]
+
+        model._prepare_video = fake_prepare  # type: ignore[assignment]
+
+        process_calls = []
+
+        def fake_resolve(vid):
+            process_calls.append(vid)
+            return f"/tmp/local_{vid}.mp4"
+
+        with patch.object(
+            mllm_mod, "process_video_input", side_effect=fake_resolve
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video", return_value="/tmp/x.wav"
+        ):
+            # This mirrors the chat() / stream_chat() dedup body verbatim.
+            for msg_idx, vids in vid_inputs.items():
+                has_explicit_audio = bool(_msg_audio_inputs.get(msg_idx))
+                for vid_input in vids:
+                    try:
+                        resolved = mllm_mod.process_video_input(vid_input)
+                    except Exception:
+                        resolved = None
+                    if (
+                        resolved
+                        and model._video_native_with_audio
+                        and not has_explicit_audio
+                    ):
+                        extracted = mllm_mod.extract_audio_from_video(resolved)
+                        if extracted:
+                            _msg_extra_audio.setdefault(msg_idx, []).append(
+                                extracted
+                            )
+                    model._prepare_video(
+                        vid_input,
+                        fps=2.0,
+                        max_frames=60,
+                        resolved_path=resolved,
+                    )
+
+            for msg_idx, extra in _msg_extra_audio.items():
+                _msg_audio_inputs.setdefault(msg_idx, []).extend(extra)
+
+        return _msg_audio_inputs, _msg_extra_audio, len(process_calls)
+
+    def test_video_resolved_exactly_once_per_input(self):
+        """Blocker #3: no double-download. process_video_input runs 1× per video."""
+        model = _make_model(video_native_with_audio=True)
+        audio_map, _, call_count = self._exercise_dedup_loop(
+            model, {0: ["https://example.com/v.mp4"]}
+        )
+        assert call_count == 1
+        # …and the resolved path threaded through to _prepare_video.
+        # (Verified above via fake_prepare; assert on the merged audio map too.)
+        assert audio_map[0] == ["/tmp/x.wav"]
+
+    def test_extracted_audio_merged_into_msg_audio_inputs(self):
+        """Merged audio shows up in _msg_audio_inputs keyed by message index."""
+        model = _make_model(video_native_with_audio=True)
+        audio_map, extra_map, _ = self._exercise_dedup_loop(
+            model,
+            {
+                0: ["https://example.com/a.mp4"],
+                2: [
+                    "https://example.com/b.mp4",
+                    "https://example.com/c.mp4",
+                ],
+            },
+        )
+        assert audio_map[0] == ["/tmp/x.wav"]
+        assert audio_map[2] == ["/tmp/x.wav", "/tmp/x.wav"]
+        # And the per-msg extras stayed consistent with the merge.
+        assert extra_map == audio_map
+
+    def test_resolved_path_threaded_to_prepare_video(self):
+        """`_prepare_video` must receive `resolved_path=` matching the resolver."""
+        model = _make_model(video_native_with_audio=True)
+        captured: list[tuple] = []
+        model._prepare_video = (  # type: ignore[assignment]
+            lambda v, fps, max_frames, resolved_path=None: (
+                captured.append((v, resolved_path)) or [f"{v}.jpg"]
+            )
+        )
+
+        with patch.object(
+            mllm_mod,
+            "process_video_input",
+            side_effect=lambda v: f"/tmp/local_{v}.mp4",
+        ), patch.object(
+            mllm_mod, "extract_audio_from_video", return_value=None
+        ):
+            # one video input
+            vid = "https://example.com/v.mp4"
+            resolved = mllm_mod.process_video_input(vid)
+            model._prepare_video(vid, fps=2.0, max_frames=60, resolved_path=resolved)
+
+        assert captured == [(vid, "/tmp/local_https://example.com/v.mp4.mp4")]
+
+
+# ===========================================================================
+# Blocker #2 — bounded ffmpeg helper: failure modes and temp-file cleanup
+# ===========================================================================
+
+
+class TestExtractAudioFromVideo:
+    """Each path through `extract_audio_from_video` is exercised in isolation."""
+
+    def test_returns_none_when_ffmpeg_missing(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        with patch("shutil.which", return_value=None):
+            assert extract_audio_from_video(str(v)) is None
+
+    def test_returns_none_when_video_has_no_audio_track(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
+            mllm_mod, "_video_has_audio_track", return_value=False
+        ):
+            assert extract_audio_from_video(str(v)) is None
+
+    def test_returns_none_on_nonzero_exit_and_cleans_up(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
+            mllm_mod, "_video_has_audio_track", return_value=True
+        ), patch.object(
+            subprocess, "run",
+            return_value=MagicMock(returncode=1),
+        ):
+            result = extract_audio_from_video(str(v))
+
+        assert result is None
+        # No stray vllmmlx_va_*.wav left behind anywhere we wrote.
+        leftovers = list(Path(tmp_path).glob("vllmmlx_va_*.wav"))
+        assert leftovers == []
+
+    def test_returns_none_on_zero_byte_output_and_cleans_up(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        captured_paths: list[str] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            # ffmpeg "succeeds" but produces an empty file.
+            out_path = cmd[-1]
+            captured_paths.append(out_path)
+            return MagicMock(returncode=0)
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
+            mllm_mod, "_video_has_audio_track", return_value=True
+        ), patch.object(subprocess, "run", side_effect=fake_run):
+            result = extract_audio_from_video(str(v))
+
+        assert result is None
+        # The zero-byte temp file must be removed on the failure branch.
+        for p in captured_paths:
+            assert not os.path.exists(p), f"leftover temp file: {p}"
+
+    def test_returns_none_on_subprocess_timeout_and_cleans_up(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        captured_paths: list[str] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            out_path = cmd[-1]
+            captured_paths.append(out_path)
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
+            mllm_mod, "_video_has_audio_track", return_value=True
+        ), patch.object(subprocess, "run", side_effect=fake_run):
+            result = extract_audio_from_video(str(v))
+
+        assert result is None
+        for p in captured_paths:
+            assert not os.path.exists(p), f"leftover temp file: {p}"
+
+    def test_success_path_registers_with_temp_manager(self, tmp_path):
+        v = tmp_path / "fake.mp4"
+        v.write_bytes(b"\x00" * 16)
+
+        captured_paths: list[str] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            out_path = cmd[-1]
+            captured_paths.append(out_path)
+            # Simulate a non-empty WAV being written.
+            with open(out_path, "wb") as f:
+                f.write(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+            return MagicMock(returncode=0)
+
+        registered: list[str] = []
+
+        def fake_register(path):
+            registered.append(path)
+            return path
+
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
+            mllm_mod, "_video_has_audio_track", return_value=True
+        ), patch.object(
+            subprocess, "run", side_effect=fake_run
+        ), patch.object(
+            mllm_mod._temp_manager, "register", side_effect=fake_register
+        ):
+            result = extract_audio_from_video(str(v))
+
+        assert result is not None
+        assert registered == captured_paths
+        assert result == captured_paths[0]
+
+        # Clean up the synthetic output the test wrote.
+        for p in captured_paths:
+            if os.path.exists(p):
+                os.unlink(p)
+
+
+# ===========================================================================
+# Integration smoke test — real ffmpeg, real video, real WAV out.
+# Skipped automatically when ffmpeg is not on PATH.
+# ===========================================================================
+
+
+def _ffmpeg_available() -> bool:
+    return shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+@pytest.mark.skipif(
+    not _ffmpeg_available(),
+    reason="real ffmpeg+ffprobe required for the integration smoke test",
+)
+def test_extract_audio_from_video_integration_smoke(tmp_path):
+    """End-to-end: build a tiny silent video, extract its audio, verify the WAV.
+
+    Uses ffmpeg's `lavfi` synths to generate a 1-second clip with a 1-channel
+    silence track — no external assets needed.
+    """
+    video = tmp_path / "synth.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f", "lavfi", "-i", "color=c=black:s=128x128:d=1",
+            "-f", "lavfi", "-i", "anullsrc=channel_layout=mono:sample_rate=22050",
+            "-c:v", "libx264", "-c:a", "aac",
+            "-shortest",
+            str(video),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    out = extract_audio_from_video(str(video))
+    assert out is not None, "expected a WAV path"
+    assert os.path.exists(out)
+    assert os.path.getsize(out) > 0
+
+    # Format check: 16 kHz mono WAV is what the helper promises.
+    with wave.open(out, "rb") as w:
+        assert w.getnchannels() == 1
+        assert w.getframerate() == 16000
+        assert w.getsampwidth() == 2  # pcm_s16le
+
+    # The path must be registered with the temp manager so the request
+    # cleanup loop will sweep it.
+    assert out in mllm_mod._temp_manager._files, (
+        "extracted audio path was not registered with _temp_manager"
+    )
+
+    # Manual cleanup so we don't leak the synthetic output across tests.
+    mllm_mod._temp_manager.cleanup(out)
+    assert not os.path.exists(out)

--- a/tests/test_mllm_av_fusion.py
+++ b/tests/test_mllm_av_fusion.py
@@ -29,7 +29,6 @@ from vllm_mlx.models.mllm import (
     extract_audio_from_video,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------
@@ -107,11 +106,14 @@ class TestNativeRoutingContract:
         model = _make_model(video_native_with_audio=True)
         messages = [_user_msg(_video_url())]
 
-        with patch.object(
-            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
-        ) as extract:
+        with (
+            patch.object(
+                mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+            ),
+            patch.object(
+                mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
+            ) as extract,
+        ):
             translated = model._translate_messages_for_native_video(
                 messages, video_fps=2.0, video_max_frames=60
             )
@@ -128,13 +130,15 @@ class TestNativeRoutingContract:
         model = _make_model(video_native_with_audio=True)
         messages = [_user_msg(_video_url(), _audio_url())]
 
-        with patch.object(
-            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
-        ), patch.object(
-            mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video"
-        ) as extract:
+        with (
+            patch.object(
+                mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+            ),
+            patch.object(
+                mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
+            ),
+            patch.object(mllm_mod, "extract_audio_from_video") as extract,
+        ):
             translated = model._translate_messages_for_native_video(
                 messages, video_fps=2.0, video_max_frames=60
             )
@@ -142,9 +146,7 @@ class TestNativeRoutingContract:
         # the explicit caller-provided audio must win
         extract.assert_not_called()
         audio_paths = [
-            it["audio"]
-            for it in translated[0]["content"]
-            if it["type"] == "audio"
+            it["audio"] for it in translated[0]["content"] if it["type"] == "audio"
         ]
         assert audio_paths == ["/tmp/explicit.wav"]
 
@@ -153,11 +155,12 @@ class TestNativeRoutingContract:
         model = _make_model(video_native_with_audio=False)
         messages = [_user_msg(_video_url())]
 
-        with patch.object(
-            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video"
-        ) as extract:
+        with (
+            patch.object(
+                mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+            ),
+            patch.object(mllm_mod, "extract_audio_from_video") as extract,
+        ):
             translated = model._translate_messages_for_native_video(
                 messages, video_fps=2.0, video_max_frames=60
             )
@@ -171,10 +174,11 @@ class TestNativeRoutingContract:
         model = _make_model(video_native_with_audio=True)
         messages = [_user_msg(_video_url())]
 
-        with patch.object(
-            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video", return_value=None
+        with (
+            patch.object(
+                mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+            ),
+            patch.object(mllm_mod, "extract_audio_from_video", return_value=None),
         ):
             translated = model._translate_messages_for_native_video(
                 messages, video_fps=2.0, video_max_frames=60
@@ -223,22 +227,25 @@ class TestNativePrepareInputsForwardsAudio:
         messages = [_user_msg(*items)]
 
         # Patch mlx_vlm process_vision_info and the resolution helpers.
-        process_vision_info = MagicMock(
-            return_value=(["frame1.jpg"], ["v.mp4"], {})
-        )
-        with patch.object(
-            mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
-        ), patch.object(
-            mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
-        ), patch.dict(
-            "sys.modules",
-            {
-                "mlx_vlm.video_generate": MagicMock(
-                    process_vision_info=process_vision_info
-                ),
-            },
+        process_vision_info = MagicMock(return_value=(["frame1.jpg"], ["v.mp4"], {}))
+        with (
+            patch.object(
+                mllm_mod, "process_video_input", return_value="/tmp/local.mp4"
+            ),
+            patch.object(
+                mllm_mod, "process_audio_input", return_value="/tmp/explicit.wav"
+            ),
+            patch.object(
+                mllm_mod, "extract_audio_from_video", return_value="/tmp/local.wav"
+            ),
+            patch.dict(
+                "sys.modules",
+                {
+                    "mlx_vlm.video_generate": MagicMock(
+                        process_vision_info=process_vision_info
+                    ),
+                },
+            ),
         ):
             text, gen_kwargs = model._prepare_native_video_inputs(messages)
 
@@ -312,10 +319,11 @@ class TestFallbackDedupAndMerge:
             process_calls.append(vid)
             return f"/tmp/local_{vid}.mp4"
 
-        with patch.object(
-            mllm_mod, "process_video_input", side_effect=fake_resolve
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video", return_value="/tmp/x.wav"
+        with (
+            patch.object(mllm_mod, "process_video_input", side_effect=fake_resolve),
+            patch.object(
+                mllm_mod, "extract_audio_from_video", return_value="/tmp/x.wav"
+            ),
         ):
             # This mirrors the chat() / stream_chat() dedup body verbatim.
             for msg_idx, vids in vid_inputs.items():
@@ -332,9 +340,7 @@ class TestFallbackDedupAndMerge:
                     ):
                         extracted = mllm_mod.extract_audio_from_video(resolved)
                         if extracted:
-                            _msg_extra_audio.setdefault(msg_idx, []).append(
-                                extracted
-                            )
+                            _msg_extra_audio.setdefault(msg_idx, []).append(extracted)
                     model._prepare_video(
                         vid_input,
                         fps=2.0,
@@ -386,12 +392,13 @@ class TestFallbackDedupAndMerge:
             )
         )
 
-        with patch.object(
-            mllm_mod,
-            "process_video_input",
-            side_effect=lambda v: f"/tmp/local_{v}.mp4",
-        ), patch.object(
-            mllm_mod, "extract_audio_from_video", return_value=None
+        with (
+            patch.object(
+                mllm_mod,
+                "process_video_input",
+                side_effect=lambda v: f"/tmp/local_{v}.mp4",
+            ),
+            patch.object(mllm_mod, "extract_audio_from_video", return_value=None),
         ):
             # one video input
             vid = "https://example.com/v.mp4"
@@ -420,8 +427,9 @@ class TestExtractAudioFromVideo:
         v = tmp_path / "fake.mp4"
         v.write_bytes(b"\x00" * 16)
 
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
-            mllm_mod, "_video_has_audio_track", return_value=False
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.object(mllm_mod, "_video_has_audio_track", return_value=False),
         ):
             assert extract_audio_from_video(str(v)) is None
 
@@ -429,11 +437,14 @@ class TestExtractAudioFromVideo:
         v = tmp_path / "fake.mp4"
         v.write_bytes(b"\x00" * 16)
 
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
-            mllm_mod, "_video_has_audio_track", return_value=True
-        ), patch.object(
-            subprocess, "run",
-            return_value=MagicMock(returncode=1),
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.object(mllm_mod, "_video_has_audio_track", return_value=True),
+            patch.object(
+                subprocess,
+                "run",
+                return_value=MagicMock(returncode=1),
+            ),
         ):
             result = extract_audio_from_video(str(v))
 
@@ -454,9 +465,11 @@ class TestExtractAudioFromVideo:
             captured_paths.append(out_path)
             return MagicMock(returncode=0)
 
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
-            mllm_mod, "_video_has_audio_track", return_value=True
-        ), patch.object(subprocess, "run", side_effect=fake_run):
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.object(mllm_mod, "_video_has_audio_track", return_value=True),
+            patch.object(subprocess, "run", side_effect=fake_run),
+        ):
             result = extract_audio_from_video(str(v))
 
         assert result is None
@@ -475,9 +488,11 @@ class TestExtractAudioFromVideo:
             captured_paths.append(out_path)
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
 
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
-            mllm_mod, "_video_has_audio_track", return_value=True
-        ), patch.object(subprocess, "run", side_effect=fake_run):
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.object(mllm_mod, "_video_has_audio_track", return_value=True),
+            patch.object(subprocess, "run", side_effect=fake_run),
+        ):
             result = extract_audio_from_video(str(v))
 
         assert result is None
@@ -504,12 +519,11 @@ class TestExtractAudioFromVideo:
             registered.append(path)
             return path
 
-        with patch("shutil.which", return_value="/usr/bin/ffmpeg"), patch.object(
-            mllm_mod, "_video_has_audio_track", return_value=True
-        ), patch.object(
-            subprocess, "run", side_effect=fake_run
-        ), patch.object(
-            mllm_mod._temp_manager, "register", side_effect=fake_register
+        with (
+            patch("shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.object(mllm_mod, "_video_has_audio_track", return_value=True),
+            patch.object(subprocess, "run", side_effect=fake_run),
+            patch.object(mllm_mod._temp_manager, "register", side_effect=fake_register),
         ):
             result = extract_audio_from_video(str(v))
 
@@ -548,9 +562,18 @@ def test_extract_audio_from_video_integration_smoke(tmp_path):
         [
             "ffmpeg",
             "-y",
-            "-f", "lavfi", "-i", "color=c=black:s=128x128:d=1",
-            "-f", "lavfi", "-i", "anullsrc=channel_layout=mono:sample_rate=22050",
-            "-c:v", "libx264", "-c:a", "aac",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=128x128:d=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=channel_layout=mono:sample_rate=22050",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
             "-shortest",
             str(video),
         ],
@@ -572,9 +595,9 @@ def test_extract_audio_from_video_integration_smoke(tmp_path):
 
     # The path must be registered with the temp manager so the request
     # cleanup loop will sweep it.
-    assert out in mllm_mod._temp_manager._files, (
-        "extracted audio path was not registered with _temp_manager"
-    )
+    assert (
+        out in mllm_mod._temp_manager._files
+    ), "extracted audio path was not registered with _temp_manager"
 
     # Manual cleanup so we don't leak the synthetic output across tests.
     mllm_mod._temp_manager.cleanup(out)

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -877,11 +877,20 @@ def _video_has_audio_track(video_path: str) -> bool:
     try:
         r = subprocess.run(
             [
-                "ffprobe", "-loglevel", "error", "-select_streams", "a",
-                "-show_entries", "stream=codec_type", "-of", "csv=p=0",
+                "ffprobe",
+                "-loglevel",
+                "error",
+                "-select_streams",
+                "a",
+                "-show_entries",
+                "stream=codec_type",
+                "-of",
+                "csv=p=0",
                 video_path,
             ],
-            capture_output=True, timeout=30, text=True,
+            capture_output=True,
+            timeout=30,
+            text=True,
         )
         return bool(r.stdout.strip())
     except (subprocess.SubprocessError, OSError):
@@ -925,11 +934,22 @@ def extract_audio_from_video(video_path: str) -> str | None:
     try:
         r = subprocess.run(
             [
-                "ffmpeg", "-y", "-i", video_path,
-                "-vn", "-ac", "1", "-ar", "16000",
-                "-c:a", "pcm_s16le", out_path,
+                "ffmpeg",
+                "-y",
+                "-i",
+                video_path,
+                "-vn",
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                "-c:a",
+                "pcm_s16le",
+                out_path,
             ],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=600,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=600,
         )
         if r.returncode != 0 or os.path.getsize(out_path) == 0:
             try:
@@ -1671,9 +1691,9 @@ class MLXMultimodalLM:
                     probe = {k: v for k, v in item.dict().items() if v is not None}
                 else:
                     probe = item
-                if (
-                    isinstance(probe, dict)
-                    and probe.get("type", "") in ("audio", "audio_url")
+                if isinstance(probe, dict) and probe.get("type", "") in (
+                    "audio",
+                    "audio_url",
                 ):
                     has_explicit_audio = True
                     break
@@ -1741,15 +1761,12 @@ class MLXMultimodalLM:
                     # forward pass. We extract from the already-resolved local
                     # path (no raw user URL handed to ffmpeg → avoids URL-
                     # protocol SSRF via ffmpeg's network demuxers).
-                    if (
-                        not has_explicit_audio
-                        and getattr(self, "_video_native_with_audio", False)
+                    if not has_explicit_audio and getattr(
+                        self, "_video_native_with_audio", False
                     ):
                         extracted = extract_audio_from_video(video_path)
                         if extracted is not None:
-                            new_content.append(
-                                {"type": "audio", "audio": extracted}
-                            )
+                            new_content.append({"type": "audio", "audio": extracted})
 
                 elif item_type in ("audio", "audio_url"):
                     if item_type == "audio_url":
@@ -2124,13 +2141,9 @@ class MLXMultimodalLM:
                     and self._video_native_with_audio
                     and not has_explicit_audio
                 ):
-                    extracted_audio = extract_audio_from_video(
-                        resolved_video_path
-                    )
+                    extracted_audio = extract_audio_from_video(resolved_video_path)
                     if extracted_audio:
-                        _msg_extra_audio.setdefault(msg_idx, []).append(
-                            extracted_audio
-                        )
+                        _msg_extra_audio.setdefault(msg_idx, []).append(extracted_audio)
 
                 frames = self._prepare_video(
                     vid_input,
@@ -2511,13 +2524,9 @@ class MLXMultimodalLM:
                     and self._video_native_with_audio
                     and not has_explicit_audio
                 ):
-                    extracted_audio = extract_audio_from_video(
-                        resolved_video_path
-                    )
+                    extracted_audio = extract_audio_from_video(resolved_video_path)
                     if extracted_audio:
-                        _msg_extra_audio.setdefault(msg_idx, []).append(
-                            extracted_audio
-                        )
+                        _msg_extra_audio.setdefault(msg_idx, []).append(extracted_audio)
 
                 frames = self._prepare_video(
                     vid_input,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -888,6 +888,18 @@ def _video_has_audio_track(video_path: str) -> bool:
         return True
 
 
+def _model_has_sound_encoder(model) -> bool:
+    """Whether a loaded model exposes a usable sound encoder.
+
+    Uses ``getattr(..., None) is not None`` rather than ``hasattr`` so model
+    wrappers that declare ``sound_encoder`` in ``__init__`` but leave it as
+    ``None`` until the first encoder pass are correctly treated as not yet
+    enabled. A bare ``hasattr`` check would spuriously enable A/V fusion
+    against a missing encoder and crash the processor downstream.
+    """
+    return getattr(model, "sound_encoder", None) is not None
+
+
 def extract_audio_from_video(video_path: str) -> str | None:
     """Extract the audio track from a video file as 16 kHz mono WAV.
 
@@ -1234,7 +1246,7 @@ class MLXMultimodalLM:
             # Decoupled from _video_native because some omni models (e.g.
             # Nemotron-H Omni) don't expose video_token_id at config level
             # and run through the frames-as-images fallback path.
-            self._video_native_with_audio = hasattr(self.model, "sound_encoder")
+            self._video_native_with_audio = _model_has_sound_encoder(self.model)
             logger.info(f"MLLM loaded successfully: {self.model_name}")
             if self._video_native:
                 logger.info("Native video pipeline enabled (temporal 3D conv + M-RoPE)")
@@ -1359,6 +1371,7 @@ class MLXMultimodalLM:
         video_input: str | dict,
         fps: float = DEFAULT_FPS,
         max_frames: int = MAX_FRAMES,
+        resolved_path: str | None = None,
     ) -> list[str]:
         """
         Process video input and extract frames.
@@ -1372,12 +1385,16 @@ class MLXMultimodalLM:
             video_input: Video in any supported format
             fps: Frames per second to extract
             max_frames: Maximum frames to extract
+            resolved_path: Optional pre-resolved local path. Callers that
+                already ran process_video_input (e.g. for parallel audio
+                extraction) pass it here to avoid re-downloading / re-decoding.
 
         Returns:
             List of paths to extracted frame images
         """
-        # Process video input (download if URL, decode if base64)
-        video_path = process_video_input(video_input)
+        # Reuse caller's resolved path when supplied; otherwise resolve here
+        # (downloads if URL, decodes if base64).
+        video_path = resolved_path or process_video_input(video_input)
 
         # Extract frames
         frames = extract_video_frames_smart(
@@ -2089,30 +2106,37 @@ class MLXMultimodalLM:
             total_frames = 0
             has_explicit_audio = bool(_msg_audio_inputs.get(msg_idx))
             for vid_input in vid_inputs:
-                # For omni models, also extract the video's audio track so
-                # the model can fuse A/V in one forward pass. Skip if the
-                # caller supplied an explicit audio_url for the same message.
-                # We resolve the video to a local path first so the user's
-                # raw URL is never handed to ffmpeg directly (avoids URL-
-                # protocol exposure via ffmpeg's network demuxers).
-                if self._video_native_with_audio and not has_explicit_audio:
-                    try:
-                        video_path_for_audio = process_video_input(vid_input)
-                    except Exception as exc:
-                        logger.warning(
-                            f"Could not resolve video for audio extraction: {exc}"
+                # Resolve the video to a local path ONCE per input. Both
+                # audio extraction (when this is an omni model with no
+                # explicit audio block) and frame extraction need a local
+                # file; resolving twice would re-download remote URLs and
+                # re-decode base64. Resolving up front also keeps user-
+                # supplied raw URLs out of ffmpeg's URL-protocol demuxers
+                # (avoids SSRF via http://, rtsp://, etc.).
+                try:
+                    resolved_video_path = process_video_input(vid_input)
+                except Exception as exc:
+                    logger.warning(f"Could not resolve video: {exc}")
+                    resolved_video_path = None
+
+                if (
+                    resolved_video_path
+                    and self._video_native_with_audio
+                    and not has_explicit_audio
+                ):
+                    extracted_audio = extract_audio_from_video(
+                        resolved_video_path
+                    )
+                    if extracted_audio:
+                        _msg_extra_audio.setdefault(msg_idx, []).append(
+                            extracted_audio
                         )
-                        video_path_for_audio = None
-                    if video_path_for_audio:
-                        extracted_audio = extract_audio_from_video(
-                            video_path_for_audio
-                        )
-                        if extracted_audio:
-                            _msg_extra_audio.setdefault(msg_idx, []).append(
-                                extracted_audio
-                            )
+
                 frames = self._prepare_video(
-                    vid_input, fps=video_fps, max_frames=video_max_frames
+                    vid_input,
+                    fps=video_fps,
+                    max_frames=video_max_frames,
+                    resolved_path=resolved_video_path,
                 )
                 all_video_frames.extend(frames)
                 total_frames += len(frames)
@@ -2474,24 +2498,32 @@ class MLXMultimodalLM:
             total_frames = 0
             has_explicit_audio = bool(_msg_audio_inputs.get(msg_idx))
             for vid_input in vid_inputs:
-                if self._video_native_with_audio and not has_explicit_audio:
-                    try:
-                        video_path_for_audio = process_video_input(vid_input)
-                    except Exception as exc:
-                        logger.warning(
-                            f"Could not resolve video for audio extraction: {exc}"
+                # Resolve once; reused for audio extraction and frame prep.
+                # See the matching block in chat() for rationale.
+                try:
+                    resolved_video_path = process_video_input(vid_input)
+                except Exception as exc:
+                    logger.warning(f"Could not resolve video: {exc}")
+                    resolved_video_path = None
+
+                if (
+                    resolved_video_path
+                    and self._video_native_with_audio
+                    and not has_explicit_audio
+                ):
+                    extracted_audio = extract_audio_from_video(
+                        resolved_video_path
+                    )
+                    if extracted_audio:
+                        _msg_extra_audio.setdefault(msg_idx, []).append(
+                            extracted_audio
                         )
-                        video_path_for_audio = None
-                    if video_path_for_audio:
-                        extracted_audio = extract_audio_from_video(
-                            video_path_for_audio
-                        )
-                        if extracted_audio:
-                            _msg_extra_audio.setdefault(msg_idx, []).append(
-                                extracted_audio
-                            )
+
                 frames = self._prepare_video(
-                    vid_input, fps=video_fps, max_frames=video_max_frames
+                    vid_input,
+                    fps=video_fps,
+                    max_frames=video_max_frames,
+                    resolved_path=resolved_video_path,
                 )
                 all_video_frames.extend(frames)
                 total_frames += len(frames)

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -867,6 +867,74 @@ def process_audio_input(audio: str | dict) -> str:
     raise ValueError(f"Cannot process audio: {audio[:50]}...")
 
 
+def _video_has_audio_track(video_path: str) -> bool:
+    """Return True if ffprobe finds an audio stream in the video."""
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffprobe"):
+        return True  # assume yes; extraction will fail loudly if not
+    try:
+        r = subprocess.run(
+            [
+                "ffprobe", "-loglevel", "error", "-select_streams", "a",
+                "-show_entries", "stream=codec_type", "-of", "csv=p=0",
+                video_path,
+            ],
+            capture_output=True, timeout=30, text=True,
+        )
+        return bool(r.stdout.strip())
+    except (subprocess.SubprocessError, OSError):
+        return True
+
+
+def extract_audio_from_video(video_path: str) -> str | None:
+    """Extract the audio track from a video file as 16 kHz mono WAV.
+
+    Returns the path to the WAV (registered with the temp manager so it's
+    cleaned up automatically), or None if the video has no audio or ffmpeg
+    is unavailable.
+    """
+    import os
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        logger.warning(
+            "ffmpeg not found; cannot fuse audio from video_url. "
+            "Install ffmpeg to enable A/V fusion on omni models."
+        )
+        return None
+    if not _video_has_audio_track(video_path):
+        return None
+
+    fd, out_path = tempfile.mkstemp(suffix=".wav", prefix="vllmmlx_va_")
+    os.close(fd)
+    try:
+        r = subprocess.run(
+            [
+                "ffmpeg", "-y", "-i", video_path,
+                "-vn", "-ac", "1", "-ar", "16000",
+                "-c:a", "pcm_s16le", out_path,
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=600,
+        )
+        if r.returncode != 0 or os.path.getsize(out_path) == 0:
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
+            return None
+        return _temp_manager.register(out_path)
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.warning(f"Audio extraction from video failed: {e}")
+        try:
+            os.unlink(out_path)
+        except OSError:
+            pass
+        return None
+
+
 # Cache for base64 images to avoid re-saving the same image
 _base64_image_cache: dict[str, str] = {}  # hash -> temp file path
 
@@ -1132,6 +1200,7 @@ class MLXMultimodalLM:
         self._draft_model = None
         self._loaded = False
         self._video_native = False
+        self._video_native_with_audio = False
 
         # Initialize MLLM prefix cache manager (with vision embedding caching)
         self._cache_manager: MLLMPrefixCacheManager | None = None
@@ -1159,9 +1228,20 @@ class MLXMultimodalLM:
             self._video_native = hasattr(
                 self.model.config, "video_token_id"
             ) or hasattr(self.model.config, "video_token_index")
+            # Omni models expose a sound_encoder; for these, a video_url
+            # without a paired audio_url should auto-extract the video's
+            # audio track so the model can fuse A/V in one forward pass.
+            # Decoupled from _video_native because some omni models (e.g.
+            # Nemotron-H Omni) don't expose video_token_id at config level
+            # and run through the frames-as-images fallback path.
+            self._video_native_with_audio = hasattr(self.model, "sound_encoder")
             logger.info(f"MLLM loaded successfully: {self.model_name}")
             if self._video_native:
                 logger.info("Native video pipeline enabled (temporal 3D conv + M-RoPE)")
+            if self._video_native_with_audio:
+                logger.info(
+                    "Omni model detected: video_url will auto-extract audio for A/V fusion"
+                )
 
         except ImportError:
             raise ImportError(
@@ -1419,14 +1499,32 @@ class MLXMultimodalLM:
             native_messages, return_video_kwargs=True
         )
 
+        # Collect audio paths emitted by the translation step
+        # (explicit audio_url, or auto-extracted from video_url for omni
+        # models).
+        audio_inputs: list[str] = []
+        for nmsg in native_messages:
+            ncontent = nmsg.get("content", [])
+            if not isinstance(ncontent, list):
+                continue
+            for nitem in ncontent:
+                if isinstance(nitem, dict) and nitem.get("type") == "audio":
+                    apath = nitem.get("audio")
+                    if apath:
+                        audio_inputs.append(apath)
+
         # Process through HF processor to get input_ids, pixel_values, grid_thw
-        inputs = self.processor(
-            text=[text],
-            images=image_inputs,
-            videos=video_inputs,
-            padding=True,
-            return_tensors="pt",
-        )
+        # and (for omni models) sound_clips / input_features.
+        processor_kwargs: dict = {
+            "text": [text],
+            "images": image_inputs,
+            "videos": video_inputs,
+            "padding": True,
+            "return_tensors": "pt",
+        }
+        if audio_inputs:
+            processor_kwargs["audio"] = audio_inputs
+        inputs = self.processor(**processor_kwargs)
 
         input_ids = mx.array(inputs["input_ids"])
         pixel_values = inputs.get(
@@ -1441,6 +1539,26 @@ class MLXMultimodalLM:
             gen_kwargs["video_grid_thw"] = mx.array(inputs["video_grid_thw"])
         if inputs.get("image_grid_thw", None) is not None:
             gen_kwargs["image_grid_thw"] = mx.array(inputs["image_grid_thw"])
+
+        # Forward audio embeddings/clips from the processor so the omni
+        # model's sound encoder gets fed alongside the visual stream.
+        for audio_key in (
+            "sound_clips",
+            "input_features",
+            "feature_attention_mask",
+            "audio_feature_lengths",
+            "sound_feature_lengths",
+            "sound_attention_mask",
+        ):
+            val = inputs.get(audio_key, None)
+            if val is not None:
+                gen_kwargs[audio_key] = val
+        if audio_inputs:
+            logger.info(
+                f"Native video: forwarding audio ({len(audio_inputs)} clip(s)) "
+                f"to omni model via "
+                f"{[k for k in gen_kwargs if k in ('sound_clips', 'input_features')]}"
+            )
 
         gen_kwargs["input_ids"] = input_ids
         gen_kwargs["pixel_values"] = pixel_values
@@ -1525,6 +1643,24 @@ class MLXMultimodalLM:
                 translated.append({"role": role, "content": str(content)})
                 continue
 
+            # Pre-pass: does this message have an explicit audio_url/audio
+            # block? If so, we skip auto-extracting audio from a video_url to
+            # honor the caller's explicit choice.
+            has_explicit_audio = False
+            for item in content:
+                if hasattr(item, "model_dump"):
+                    probe = item.model_dump(exclude_none=True)
+                elif hasattr(item, "dict"):
+                    probe = {k: v for k, v in item.dict().items() if v is not None}
+                else:
+                    probe = item
+                if (
+                    isinstance(probe, dict)
+                    and probe.get("type", "") in ("audio", "audio_url")
+                ):
+                    has_explicit_audio = True
+                    break
+
             new_content = []
             for item in content:
                 if hasattr(item, "model_dump"):
@@ -1583,6 +1719,38 @@ class MLXMultimodalLM:
                             "max_frames": video_max_frames,
                         }
                     )
+                    # For omni-capable models, pull the video's audio track
+                    # alongside frames so the model can fuse A/V in one
+                    # forward pass. We extract from the already-resolved local
+                    # path (no raw user URL handed to ffmpeg → avoids URL-
+                    # protocol SSRF via ffmpeg's network demuxers).
+                    if (
+                        not has_explicit_audio
+                        and getattr(self, "_video_native_with_audio", False)
+                    ):
+                        extracted = extract_audio_from_video(video_path)
+                        if extracted is not None:
+                            new_content.append(
+                                {"type": "audio", "audio": extracted}
+                            )
+
+                elif item_type in ("audio", "audio_url"):
+                    if item_type == "audio_url":
+                        aud_url = item.get("audio_url", {})
+                        if isinstance(aud_url, str):
+                            audio_source = aud_url
+                        elif isinstance(aud_url, dict):
+                            audio_source = aud_url.get("url", "")
+                        else:
+                            continue
+                    else:
+                        audio_source = item.get("audio", item.get("url", ""))
+
+                    if not audio_source:
+                        continue
+
+                    audio_path = process_audio_input(audio_source)
+                    new_content.append({"type": "audio", "audio": audio_path})
 
                 else:
                     new_content.append(item)
@@ -1914,11 +2082,35 @@ class MLXMultimodalLM:
 
         # Fallback: extract frames and treat as individual images
         _msg_video_frame_counts: dict[int, int] = {}
+        _msg_extra_audio: dict[int, list[str]] = {}
         all_video_frames: list[str] = []
         all_audio_inputs: list[str] = []
         for msg_idx, vid_inputs in _msg_video_inputs.items():
             total_frames = 0
+            has_explicit_audio = bool(_msg_audio_inputs.get(msg_idx))
             for vid_input in vid_inputs:
+                # For omni models, also extract the video's audio track so
+                # the model can fuse A/V in one forward pass. Skip if the
+                # caller supplied an explicit audio_url for the same message.
+                # We resolve the video to a local path first so the user's
+                # raw URL is never handed to ffmpeg directly (avoids URL-
+                # protocol exposure via ffmpeg's network demuxers).
+                if self._video_native_with_audio and not has_explicit_audio:
+                    try:
+                        video_path_for_audio = process_video_input(vid_input)
+                    except Exception as exc:
+                        logger.warning(
+                            f"Could not resolve video for audio extraction: {exc}"
+                        )
+                        video_path_for_audio = None
+                    if video_path_for_audio:
+                        extracted_audio = extract_audio_from_video(
+                            video_path_for_audio
+                        )
+                        if extracted_audio:
+                            _msg_extra_audio.setdefault(msg_idx, []).append(
+                                extracted_audio
+                            )
                 frames = self._prepare_video(
                     vid_input, fps=video_fps, max_frames=video_max_frames
                 )
@@ -1926,6 +2118,11 @@ class MLXMultimodalLM:
                 total_frames += len(frames)
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
+
+        # Merge auto-extracted audio into the per-message audio map so the
+        # chat-template token-counting loop downstream sees the right count.
+        for msg_idx, extra in _msg_extra_audio.items():
+            _msg_audio_inputs.setdefault(msg_idx, []).extend(extra)
 
         for aud_inputs in _msg_audio_inputs.values():
             all_audio_inputs.extend(aud_inputs)
@@ -2270,11 +2467,29 @@ class MLXMultimodalLM:
 
         # Fallback: frames as images
         _msg_video_frame_counts: dict[int, int] = {}
+        _msg_extra_audio: dict[int, list[str]] = {}
         all_video_frames: list[str] = []
         all_audio_inputs: list[str] = []
         for msg_idx, vid_inputs in _msg_video_inputs.items():
             total_frames = 0
+            has_explicit_audio = bool(_msg_audio_inputs.get(msg_idx))
             for vid_input in vid_inputs:
+                if self._video_native_with_audio and not has_explicit_audio:
+                    try:
+                        video_path_for_audio = process_video_input(vid_input)
+                    except Exception as exc:
+                        logger.warning(
+                            f"Could not resolve video for audio extraction: {exc}"
+                        )
+                        video_path_for_audio = None
+                    if video_path_for_audio:
+                        extracted_audio = extract_audio_from_video(
+                            video_path_for_audio
+                        )
+                        if extracted_audio:
+                            _msg_extra_audio.setdefault(msg_idx, []).append(
+                                extracted_audio
+                            )
                 frames = self._prepare_video(
                     vid_input, fps=video_fps, max_frames=video_max_frames
                 )
@@ -2282,6 +2497,9 @@ class MLXMultimodalLM:
                 total_frames += len(frames)
                 logger.info(f"Added {len(frames)} frames from video: {vid_input}")
             _msg_video_frame_counts[msg_idx] = total_frames
+
+        for msg_idx, extra in _msg_extra_audio.items():
+            _msg_audio_inputs.setdefault(msg_idx, []).extend(extra)
 
         for aud_inputs in _msg_audio_inputs.values():
             all_audio_inputs.extend(aud_inputs)


### PR DESCRIPTION
## Summary

For omni models (those exposing a `sound_encoder` — e.g. Nemotron-H Nano Omni, Qwen2.5-Omni), a `video_url` is logically an A/V input. Today vllm-mlx feeds only the visual frames to the model; the audio track is silently dropped. This PR wires audio through the existing OpenAI-style content-block path so the model can fuse A/V in a single forward pass.

## Bug

Both code paths handling video drop audio:

| Path | Where | Result |
|---|---|---|
| `_generate_native_video` → `_prepare_native_video_inputs` | `self.processor(text=[text], images=…, videos=…)` — no `audio=` | sound_clips never reach the model |
| `chat()` / `stream_chat()` fallback | Frame extraction uses `cv2.VideoCapture` — audio track ignored | No audio in `_msg_audio_inputs` |

The HF processor on these models accepts `audio=` and the model expects `sound_clips`/`input_features` in its forward pass — but the wiring between them is missing for video inputs.

## Fix

Five small changes, all in `vllm_mlx/models/mllm.py` (+225 / −7):

1. **`extract_audio_from_video(video_path)`** — probes for an audio stream via `ffprobe`, extracts 16 kHz mono PCM WAV via `ffmpeg` into a temp file registered with `_temp_manager` for auto-cleanup. No-op if `ffmpeg` is missing or the video has no audio.

2. **`load()`** — sets `self._video_native_with_audio = hasattr(self.model, "sound_encoder")`. Decoupled from `_video_native` because some omni models (Nemotron-H Omni) don't expose `video_token_id` and run through the frames-as-images fallback.

3. **`_translate_messages_for_native_video`** — handles `audio`/`audio_url` blocks explicitly; auto-extracts audio from `video_url` when the message doesn't already carry an explicit audio block. **Caller-provided audio always wins.**

4. **`_prepare_native_video_inputs`** — collects translated audio paths, passes `audio=` to the HF processor, and forwards `sound_clips` / `input_features` / `feature_attention_mask` / `audio_feature_lengths` / `sound_feature_lengths` / `sound_attention_mask` into `gen_kwargs` so the omni model's sound encoder gets fed alongside the visual stream.

5. **`chat()` and `stream_chat()` fallback paths** — extracts audio from `video_url` for omni models, merges into `_msg_audio_inputs` so the existing audio plumbing (chat-template counts, `all_audio_inputs`, `mlx_vlm.generate(audio=…)`) picks it up unchanged.

## Manual verification

Tested with `mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-nvfp4` on Apple Silicon (M5 Max). The model's audio path itself was broken by an unrelated nvfp4 dtype bug — fixed in upstream Blaizzy/mlx-vlm#1279 (also opened today).

Single request with only a `video_url` block (30-second 480p clip with speech):

```
INFO vllm_mlx.models.mllm: Omni model detected: video_url will auto-extract audio for A/V fusion
INFO vllm_mlx.models.mllm: Video: 900 total frames @ 30.0 fps, extracting 60 frames
INFO vllm_mlx.models.mllm: Applying chat template with 1 messages, 60 images, 1 audios
```

The `1 audios` is the auto-extracted track. **Before the fix that count was 0.** Model output went from "visuals only, transcript inferred from on-screen text" to "verbatim transcript + per-sentence correlation with the on-screen graphic shown when it was said."

Prompt-token cost: +414 tokens for the audio stream (25,229 vs 24,815 before). Wall-time cost: ~8× because the Parakeet encoder runs over 30s of audio — fair trade for actually hearing the source.

## Relationship to #352

PR #352 (`feat(mllm): extract audio track from video inputs`) attempted the same goal but has been DIRTY/CONFLICTING since April 29 with no author activity. This PR is an alternative take that I'd be happy to coordinate with @miguel-flowstate on. Notable differences:

| Aspect | #352 | This PR |
|---|---|---|
| Trigger | Opt-in CLI flag `--extract-audio-from-video` + per-request override | Auto-detected per model via `hasattr(self.model, "sound_encoder")` |
| Paths covered | Fallback path only | Both `_generate_native_video` **and** fallback |
| Explicit `audio_url` alongside `video_url` | Unclear from summary | Honors the explicit choice (skips auto-extract) |
| Temp-file cleanup | Missing (review issue #1) | Routes through existing `_temp_manager.register()` |
| ffmpeg + raw URLs | Flagged for SSRF via ffmpeg URL demuxers (review issue #5) | Resolves to local path via `process_video_input()` before ffmpeg ever sees it |
| `msg_audio_count` per-message bug | Inherited from #351 (review issue #2) | Merges auto-extracted audio into `_msg_audio_inputs` per message |
| `import os` duplication | Yes (review issue #3) | No |

Happy to fold this into #352 if @miguel-flowstate prefers, or to keep them separate. If the maintainers want to close one in favor of the other, fully understand either direction.

## Design questions worth flagging

- **Should auto-extraction be opt-out via a flag?** Right now any omni model with a `sound_encoder` will get its `video_url` audio fused automatically. That matches what most callers want from an omni model, but if a user explicitly wants frames-only on an omni model they'd need to either (a) send the frames as `image_url`s and skip `video_url`, or (b) we add a `--no-extract-audio-from-video` flag. I lean toward not adding the flag until someone hits the case, but happy to add it if you prefer opt-out semantics.
- **Should non-omni models with native video (e.g. Qwen-VL) also get the auto-extraction?** Currently they don't — gated on `sound_encoder`. Qwen-VL doesn't have a sound encoder so calling the processor with `audio=` would error. Treating "has sound_encoder" as the marker is the safe runtime check.
- **Tests.** I held tests for this PR pending design feedback; happy to add a synthetic integration test (generates a 3-second test clip with `say`+`ffmpeg`, asserts the log line shows `1 audios`) if you'd like that before merge.

## Files touched

```
vllm_mlx/models/mllm.py  +225/-7
```

No public API changes. No new dependencies (ffmpeg is already an implicit dependency for any video processing in vllm-mlx today).