### PR TITLE
fix(scheduler): normalize empty logits processor slots

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -694,6 +694,45 @@ class TestSchedulerBasic:
         assert scheduler.get_num_running() == 0
         assert not scheduler.has_requests()
 
+    def test_step_normalizes_stale_none_logits_processor_slots(
+        self, mock_model, mock_tokenizer
+    ):
+        """Scheduler should sanitize stale BatchGenerator per-slot None values."""
+
+        class FakeActiveBatch:
+            logits_processors = [None]
+
+        class FakeBatchGenerator:
+            def __init__(self):
+                self.active_batch = FakeActiveBatch()
+                self.called = False
+
+            def next(self):
+                self.called = True
+                assert self.active_batch.logits_processors == [[]]
+                return []
+
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+        )
+        request = Request(
+            request_id="test-1",
+            prompt="Hello",
+            sampling_params=SamplingParams(max_tokens=2),
+        )
+        request.status = RequestStatus.RUNNING
+        scheduler.requests[request.request_id] = request
+        scheduler.running[request.request_id] = request
+        batch_generator = FakeBatchGenerator()
+        scheduler.batch_generator = batch_generator
+
+        output = scheduler.step()
+
+        assert batch_generator.called is True
+        assert output.finished_request_ids == set()
+        assert request.request_id in scheduler.running
+
 
 # Integration tests require actual MLX model
 @pytest.mark.integration

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -42,6 +42,28 @@ CACHE_CORRUPTION_PATTERNS = [
 ]
 
 
+def _normalize_logits_processors(logits_processors):
+    """Normalize empty per-sequence processor slots to lists."""
+    if logits_processors is None:
+        return None
+    return [processors or [] for processors in logits_processors]
+
+
+def _sanitize_batch_generator_logits_processors(batch_generator) -> None:
+    """Sanitize stale BatchGenerator processor state before decode."""
+    active_batch = getattr(batch_generator, "active_batch", None)
+    if active_batch is not None and hasattr(active_batch, "logits_processors"):
+        active_batch.logits_processors = _normalize_logits_processors(
+            active_batch.logits_processors
+        )
+
+    partial = getattr(batch_generator, "_partial", None)
+    if isinstance(partial, dict) and "logits_processors" in partial:
+        partial["logits_processors"] = _normalize_logits_processors(
+            partial["logits_processors"]
+        )
+
+
 class SchedulingPolicy(Enum):
     """Scheduling policy for request ordering."""
 
@@ -786,6 +808,7 @@ def _install_mtp(
             logits = logits[:, -1, :]
 
         # --- Apply logits processors + sample primary ---
+        logits_processors = _normalize_logits_processors(logits_processors) or []
         if any(logits_processors):
             logger.debug(
                 f"[logits_proc] applying {sum(len(lp) for lp in logits_processors)} "
@@ -2497,6 +2520,7 @@ class Scheduler:
 
                 # Run generation step if we have running requests
                 if self.batch_generator is not None and self.running:
+                    _sanitize_batch_generator_logits_processors(self.batch_generator)
                     result = self.batch_generator.next()
                     output.has_work = True
 


### PR DESCRIPTION
## Summary

Fixes a scheduler boundary case where stale `BatchGenerator` state can contain
`None` for a per-sequence `logits_processors` slot. New inserts already pass
empty lists for requests without processors; this patch normalizes existing
active or partial batch state before decode so an empty processor slot stays an
empty list instead of aborting the request.

## Scope

- Normalizes stale active and partial `BatchGenerator` `logits_processors`
  slots before `next()`.
- Applies the same normalization in the local MTP patched step before iterating
  processor slots.
- Adds a regression test proving stale `[None]` is normalized and does not abort
  the running request.

## Validation

- `.venv/bin/python -m pytest tests/test_batching.py::TestSchedulerBasic::test_step_normalizes_stale_none_logits_processor_slots -q`
- `.venv/bin/python -m pytest tests/test_batching.py tests/test_continuous_batching.py tests/test_memory_stability.py tests/test_mllm_continuous_batching.py -q`
- `.venv/bin/ruff check vllm_mlx/scheduler.py tests/test_batching.py`
- `git diff --check`

Full `pytest -q` was also run. It completed with the new batching regression
passing, but the suite still has unrelated existing failures in prefix-cache and
SSD-cache tests that use fake `mx`/SSD expectations.

Closes #592.
