### PR TITLE
fix(text-model): dispatch gemma4 text models

### DIFF
--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -2,10 +2,13 @@
 """Tests for building mlx_lm TextModel from mlx_vlm-loaded weights."""
 
 import json
+import sys
+import types
 from pathlib import Path
 
 import pytest
 
+import vllm_mlx.text_model_from_vlm as text_model_from_vlm
 from vllm_mlx.text_model_from_vlm import build_text_model
 
 # VLM+MTP model (created by merging mlx-community VLM + our MTP weights)
@@ -25,6 +28,65 @@ def test_build_text_model_none_vlm():
     """Returns None when vlm_model is None."""
     result = build_text_model(None, TEXT_MTP_MODEL)
     assert result is None
+
+
+def test_build_text_model_dispatches_gemma4_text_model(tmp_path, monkeypatch):
+    """Gemma 4 text configs should use mlx_lm.models.gemma4_text classes."""
+
+    model_path = tmp_path / "gemma4"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps({"text_config": {"model_type": "gemma4_text"}})
+    )
+
+    class FakeLanguageModel:
+        def parameters(self):
+            return {}
+
+    class FakeVlmModel:
+        language_model = FakeLanguageModel()
+
+    class QwenTextModelArgs:
+        @classmethod
+        def from_dict(cls, _config):
+            raise AssertionError("qwen3_5 dispatch should not be used for gemma4_text")
+
+    class QwenTextModel:
+        pass
+
+    qwen_module = types.ModuleType("mlx_lm.models.qwen3_5")
+    qwen_module.TextModel = QwenTextModel
+    qwen_module.TextModelArgs = QwenTextModelArgs
+
+    class GemmaModelArgs:
+        seen_config = None
+
+        @classmethod
+        def from_dict(cls, config):
+            cls.seen_config = config
+            return "gemma4-args"
+
+    class GemmaModel:
+        def __init__(self, args):
+            self.args = args
+            self.loaded_weights = []
+
+        def load_weights(self, weights, strict=False):
+            self.loaded_weights.append((weights, strict))
+
+    gemma_module = types.ModuleType("mlx_lm.models.gemma4_text")
+    gemma_module.Model = GemmaModel
+    gemma_module.ModelArgs = GemmaModelArgs
+
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3_5", qwen_module)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.gemma4_text", gemma_module)
+    monkeypatch.setattr(text_model_from_vlm.mlx.utils, "tree_flatten", lambda _p: [])
+
+    text_model = build_text_model(FakeVlmModel(), model_path)
+
+    assert isinstance(text_model, GemmaModel)
+    assert text_model.args == "gemma4-args"
+    assert GemmaModelArgs.seen_config == {"model_type": "gemma4_text"}
 
 
 @pytest.mark.skipif(not VLM_MTP_MODEL.exists(), reason="VLM+MTP model not on disk")

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -22,6 +22,19 @@ import mlx.utils
 logger = logging.getLogger(__name__)
 
 
+def _import_text_model_classes(model_type: str):
+    if model_type == "gemma4_text":
+        from mlx_lm.models.gemma4_text import Model, ModelArgs
+
+        return Model, ModelArgs
+
+    # qwen3_5.TextModel and TextModelArgs handle both dense and MoE natively
+    # (MTPDecoderLayer auto-selects SparseMoeBlock when args.num_experts > 0).
+    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+    return TextModel, TextModelArgs
+
+
 def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
     """Build an mlx_lm TextModel from a vlm-loaded model's weights.
 
@@ -42,11 +55,8 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
     try:
         config = json.loads((model_path / "config.json").read_text())
         text_config = config.get("text_config", config)
-
-        # Always import from qwen3_5 — TextModel and TextModelArgs handle both
-        # dense and MoE natively (MTPDecoderLayer auto-selects SparseMoeBlock
-        # when args.num_experts > 0). qwen3_5_moe.py does NOT export these.
-        from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+        model_type = text_config.get("model_type") or config.get("model_type", "")
+        TextModel, TextModelArgs = _import_text_model_classes(model_type)
 
         # Build args with proper __post_init__ (handles partial_rotary_factor,
         # rope_scaling, head_dim derivation)


### PR DESCRIPTION
## Summary

Adds model-type dispatch in `text_model_from_vlm` so Gemma 4 text configs use
`mlx_lm.models.gemma4_text` instead of always going through the Qwen 3.5 text
model classes.

## Scope

- Dispatches `text_config.model_type == "gemma4_text"` to
  `mlx_lm.models.gemma4_text.Model` and `ModelArgs`.
- Preserves the existing Qwen 3.5 / Qwen 3.5 MoE path as the default.
- Adds a no-model unit test that proves Gemma 4 dispatch does not use the Qwen
  classes.

This PR only addresses the Gemma 4 TextModel dispatch part of #590. It does not
add `logit_bias` API support and does not change the Gemma attention mask patch
or dependency floor.

## Validation

- `.venv/bin/python -m pytest tests/test_text_model_from_vlm.py::test_build_text_model_dispatches_gemma4_text_model -q`
- `.venv/bin/python -m pytest tests/test_text_model_from_vlm.py -q`
- `.venv/bin/python -m pytest tests/test_simple_engine.py tests/test_gemma4_mllm_patch.py tests/test_gemma4_streaming_edge.py -q`
- `.venv/bin/ruff check vllm_mlx/text_model_from_vlm.py tests/test_text_model_from_vlm.py`
- `git diff --check`

Partial fix for #590.
