### PR TITLE
feat(api): support chat logit_bias

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -296,6 +296,15 @@ class TestChatCompletion:
         assert req.tools is not None
         assert req.timeout == 30.0
 
+    def test_request_accepts_logit_bias(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+            logit_bias={"123": -100.0, "456": 2.5},
+        )
+
+        assert req.logit_bias == {"123": -100.0, "456": 2.5}
+
     def test_request_rejects_tool_name_with_spaces(self):
         with pytest.raises(ValidationError, match="function.name"):
             ChatCompletionRequest(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -209,6 +209,38 @@ class TestPromptCanonicalization:
         )
         assert request.messages[0].content == system_text
 
+    def test_prepare_chat_completion_forwards_logit_bias(self):
+        from unittest.mock import patch
+
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            _prepare_chat_completion_invocation,
+        )
+
+        engine = SimpleNamespace(is_mllm=False, preserve_native_tool_format=False)
+        processor = object()
+        calls = []
+
+        def fake_make_logits_processors(**kwargs):
+            calls.append(kwargs)
+            return [processor]
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+            logit_bias={"123": -100.0, "456": 2.5},
+        )
+
+        with patch(
+            "mlx_lm.sample_utils.make_logits_processors",
+            side_effect=fake_make_logits_processors,
+        ):
+            prepared = _prepare_chat_completion_invocation(engine, request, 128)
+
+        assert calls == [{"logit_bias": {123: -100.0, 456: 2.5}}]
+        assert prepared.chat_kwargs["logits_processors"] == [processor]
+
 
 class TestCompletionRequest:
     """Test CompletionRequest model."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -186,6 +186,8 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict | None = None  # "auto", "none", or specific tool
     # Structured output
     response_format: ResponseFormat | dict | None = None
+    # OpenAI-compatible token bias map: token id string -> bias value
+    logit_bias: dict[str, float] | None = None
     # Extra kwargs forwarded to tokenizer.apply_chat_template
     chat_template_kwargs: dict[str, Any] | None = None
     # MLLM-specific parameters

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -705,6 +705,33 @@ def _attach_response_format_logits_processor(
     return json_logits_processor
 
 
+def _coerce_logit_bias(logit_bias: dict[str, float]) -> dict[int, float]:
+    coerced: dict[int, float] = {}
+    for token_id, bias in logit_bias.items():
+        try:
+            coerced[int(token_id)] = float(bias)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"logit_bias token id must be an integer string: {token_id!r}",
+            ) from exc
+    return coerced
+
+
+def _attach_logit_bias_processor(
+    chat_kwargs: dict, logit_bias: dict[str, float] | None
+):
+    if not logit_bias:
+        return
+
+    from mlx_lm.sample_utils import make_logits_processors
+
+    processors = make_logits_processors(logit_bias=_coerce_logit_bias(logit_bias))
+    if processors:
+        existing = chat_kwargs.get("logits_processors") or []
+        chat_kwargs["logits_processors"] = list(existing) + list(processors)
+
+
 def _prepare_chat_completion_invocation(
     engine: BaseEngine,
     request: ChatCompletionRequest,
@@ -733,6 +760,7 @@ def _prepare_chat_completion_invocation(
         "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
         "repetition_penalty": _resolve_repetition_penalty(request.repetition_penalty),
     }
+    _attach_logit_bias_processor(chat_kwargs, getattr(request, "logit_bias", None))
 
     if has_media:
         chat_kwargs["images"] = images if images else None
@@ -794,7 +822,14 @@ def _prepare_chat_completion_invocation(
         if thinking_proc is not None:
             # Replace the logits_processors list: the thinking processor wraps
             # the JSON processor as its inner delegate, so we don't double-add.
-            chat_kwargs["logits_processors"] = [thinking_proc]
+            existing_processors = list(chat_kwargs.get("logits_processors") or [])
+            if (
+                json_logits_processor is not None
+                and existing_processors
+                and existing_processors[-1] is json_logits_processor
+            ):
+                existing_processors = existing_processors[:-1]
+            chat_kwargs["logits_processors"] = existing_processors + [thinking_proc]
 
     return PreparedChatInvocation(
         messages=messages,


### PR DESCRIPTION
## Summary

Adds OpenAI-compatible `logit_bias` support for chat completions by converting
the request map into a normal request-local logits processor.

## Scope

- Adds `ChatCompletionRequest.logit_bias`.
- Coerces OpenAI token-id string keys to integer token ids before calling
  `mlx_lm.sample_utils.make_logits_processors(logit_bias=...)`.
- Appends the generated processor to existing request-local processors so it can
  coexist with structured-output constraints and other decode controls.
- Keeps this separate from the Gemma 4 TextModel dispatch fix in #595.

This is a partial fix for #590. It does not change Gemma attention/mask handling
or model dependency floors.

## Validation

- `.venv/bin/python -m pytest tests/test_api_models.py::TestChatCompletion::test_request_accepts_logit_bias -q`
- `.venv/bin/python -m pytest tests/test_server.py::TestPromptCanonicalization::test_prepare_chat_completion_forwards_logit_bias -q`
- `.venv/bin/python -m pytest tests/test_api_models.py tests/test_server.py -q`
- `.venv/bin/ruff check vllm_mlx/api/models.py vllm_mlx/server.py tests/test_api_models.py tests/test_server.py`
- `git diff --check`
