### PR TITLE
fix(qwen3-xml): parse bare <function=> without <tool_call> wrapper

### DIFF
--- a/tests/test_qwen3_xml_streaming_chunks.py
+++ b/tests/test_qwen3_xml_streaming_chunks.py
@@ -370,3 +370,99 @@ def test_object_parameter_with_single_quotes_split_mid_literal():
         if v["name"]
     ]
     assert streamed_calls == expected
+
+
+# ---------------------------------------------------------------------------
+# Bare <function=...> (no <tool_call> wrapper)
+#
+# Qwen3-Coder under heavy load (large system prompt + many tools) sometimes
+# drops the outer `<tool_call></tool_call>` wrapper and emits only the inner
+# `<function=NAME><parameter=...>...</function>` block. The streaming parser
+# must still recognise these as tool calls without misclassifying prose that
+# merely contains `<function=foo>` as text (covered by
+# `test_streaming_plain_text_is_not_misclassified_as_tool_call` above).
+# ---------------------------------------------------------------------------
+
+
+_BARE_SINGLE = (
+    "Thinking.\n<function=Agent>\n"
+    "<parameter=description>\nfind bug\n</parameter>\n"
+    "<parameter=prompt>\nlook at code\n</parameter>\n"
+    "<parameter=subagent_type>\nExplore\n</parameter>\n"
+    "</function>"
+)
+
+_BARE_TWO = (
+    "Step 1.\n<function=Read>\n<parameter=file_path>\n/a.py\n</parameter>\n</function>\n"
+    "Step 2.\n<function=Agent>\n<parameter=description>\nfind bug\n</parameter>\n"
+    "<parameter=prompt>\nlook\n</parameter>\n<parameter=subagent_type>\nExplore\n</parameter>\n"
+    "</function>"
+)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 5, 7, 24, 256])
+def test_streaming_bare_function_without_tool_call_wrapper(chunk_size):
+    """A bare <function=...> block must stream into a structured tool call.
+
+    Pins down the contract that the model can drop the outer <tool_call>
+    wrapper (a documented Qwen3-Coder failure mode under heavy CC load)
+    and the streaming parser still emits a correct tool call with
+    name + arguments, regardless of how the input is chunked.
+    """
+    parser = Qwen3XMLToolParser(None)
+    expected = _expected_calls(_BARE_SINGLE, parser)
+    assert expected == [
+        {
+            "name": "Agent",
+            "arguments": {
+                "description": "find bug",
+                "prompt": "look at code",
+                "subagent_type": "Explore",
+            },
+        }
+    ]
+    parser = Qwen3XMLToolParser(None)
+    streamed = _stream(parser, _fixed_chunks(_BARE_SINGLE, chunk_size))
+    streamed_calls = [
+        {"name": tc["name"], "arguments": json.loads(tc["arguments"])}
+        for tc in streamed["tool_calls"]
+        if tc["name"]
+    ]
+    assert streamed_calls == expected
+    # No leaked tag fragments in user-visible content.
+    for fragment in ("<function=", "</function>", "<parameter=", "</parameter>"):
+        assert fragment not in streamed["content"], (
+            f"leaked tag fragment {fragment!r} in streamed content"
+        )
+
+
+@pytest.mark.parametrize("chunk_size", [1, 5, 7, 24, 256])
+def test_streaming_two_sequential_bare_functions(chunk_size):
+    """Two bare <function=...> blocks back-to-back must become two distinct
+    tool calls with independent indexes and ids.
+
+    Without the implicit-wrapper close, the second function would reuse
+    the first call's id/index and the merged stream would emit a single
+    malformed call with doubled brace closers.
+    """
+    parser = Qwen3XMLToolParser(None)
+    expected = _expected_calls(_BARE_TWO, parser)
+    assert expected == [
+        {"name": "Read", "arguments": {"file_path": "/a.py"}},
+        {
+            "name": "Agent",
+            "arguments": {
+                "description": "find bug",
+                "prompt": "look",
+                "subagent_type": "Explore",
+            },
+        },
+    ]
+    parser = Qwen3XMLToolParser(None)
+    streamed = _stream(parser, _fixed_chunks(_BARE_TWO, chunk_size))
+    streamed_calls = [
+        {"name": tc["name"], "arguments": json.loads(tc["arguments"])}
+        for tc in streamed["tool_calls"]
+        if tc["name"]
+    ]
+    assert streamed_calls == expected

--- a/tests/test_qwen3_xml_streaming_chunks.py
+++ b/tests/test_qwen3_xml_streaming_chunks.py
@@ -271,6 +271,27 @@ def test_streaming_plain_text_is_not_misclassified_as_tool_call():
     assert aggregated_calls == []
 
 
+@pytest.mark.parametrize("chunk_size", [1, 2, 4, 8, 256])
+def test_streaming_plain_text_preserves_content_across_chunk_sizes(chunk_size):
+    """
+    Regression for the bare-<function=> rollback path swallowing user-
+    visible prose. When the model emits something like
+        "I considered using <function=foo> but decided against it."
+    the parser must (a) not emit any tool_call AND (b) stream back the
+    full original text as content — no characters dropped or rewritten.
+    Pre-fix, the abandonment path in _char_data dropped both the raw
+    `<function=foo>` fragment and the char-data event that triggered the
+    rollback, leaving the response truncated.
+    """
+    parser = Qwen3XMLToolParser(None)
+    text = (
+        "I considered using <function=foo> but decided against it. " "The answer is 42."
+    )
+    streamed = _stream(parser, _fixed_chunks(text, chunk_size))
+    assert streamed["tool_calls"] == []
+    assert streamed["content"] == text
+
+
 # ---------------------------------------------------------------------------
 # Malformed / truncated input
 # ---------------------------------------------------------------------------
@@ -431,9 +452,9 @@ def test_streaming_bare_function_without_tool_call_wrapper(chunk_size):
     assert streamed_calls == expected
     # No leaked tag fragments in user-visible content.
     for fragment in ("<function=", "</function>", "<parameter=", "</parameter>"):
-        assert fragment not in streamed["content"], (
-            f"leaked tag fragment {fragment!r} in streamed content"
-        )
+        assert (
+            fragment not in streamed["content"]
+        ), f"leaked tag fragment {fragment!r} in streamed content"
 
 
 @pytest.mark.parametrize("chunk_size", [1, 5, 7, 24, 256])

--- a/vllm_mlx/tool_parsers/qwen3_xml_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3_xml_tool_parser.py
@@ -168,8 +168,15 @@ class StreamingXMLToolCallParser:
         # we hold the function-name delta in _pending_implicit_delta until
         # something confirms a real tool call (parameter open or function
         # close). If non-whitespace character data arrives first, the
-        # `<function=...>` was prose and we abandon (no tool_call emitted).
+        # `<function=...>` was prose and we abandon — the original raw tag
+        # text + any buffered inter-token whitespace + the prose data must
+        # all be emitted as user-visible content (not swallowed).
         self._pending_implicit_delta = None
+        self._pending_implicit_raw_text: str | None = None
+        self._pending_implicit_text_buffer: str = ""
+        # Set transiently around expat parse so _start_element can capture
+        # the raw input fragment in case it ends up needing rollback.
+        self._current_raw_element: str | None = None
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""
@@ -405,8 +412,15 @@ class StreamingXMLToolCallParser:
                     self._emit_delta(final_delta)
                     # Reset XML parser and current call state
                     self._reset_xml_parser_after_tool_call()
-                # Parse preprocessed element
-                self.parser.Parse(preprocessed_element, False)
+                # Parse preprocessed element. Expose the original raw
+                # element so _start_element can stash it on the pending
+                # implicit delta — needed to reconstruct prose if the
+                # bare-<function=> turns out not to be a tool call.
+                self._current_raw_element = element
+                try:
+                    self.parser.Parse(preprocessed_element, False)
+                finally:
+                    self._current_raw_element = None
                 found_any = True
 
             except Exception as e:
@@ -802,7 +816,15 @@ class StreamingXMLToolCallParser:
                 if implicit_open:
                     # Defer until <parameter=> or </function> confirms this is
                     # a real tool call, not prose mentioning `<function=...>`.
+                    # Stash the raw fragment so abandonment can restore it
+                    # as user-visible content instead of swallowing it.
                     self._pending_implicit_delta = delta
+                    self._pending_implicit_raw_text = (
+                        self._current_raw_element
+                        if self._current_raw_element is not None
+                        else f"<function={function_name}>"
+                    )
+                    self._pending_implicit_text_buffer = ""
                 else:
                     self._emit_delta(delta)
         elif name.startswith("parameter") or (name == "parameter"):
@@ -864,15 +886,27 @@ class StreamingXMLToolCallParser:
         if self._pending_implicit_delta is not None:
             delta = self._pending_implicit_delta
             self._pending_implicit_delta = None
+            # Drop the rollback context: the call is confirmed real, so the
+            # raw `<function=...>` tag is structural (not prose) and any
+            # buffered inter-token whitespace belongs to the tool-call frame.
+            self._pending_implicit_raw_text = None
+            self._pending_implicit_text_buffer = ""
             self._emit_delta(delta)
 
-    def _abandon_pending_implicit_tool_call(self) -> None:
+    def _abandon_pending_implicit_tool_call(self) -> tuple[str, str]:
         """Roll back a deferred bare-<function=> auto-open: prose followed.
 
         Drops the pending function-name delta and unwinds the synthesised
         wrapper state so no tool_call is ever emitted for this fragment.
+        Returns ``(raw_text, buffered_text)`` so the caller can restore the
+        original prose (raw `<function=...>` tag + any whitespace held while
+        waiting on commitment) as user-visible content.
         """
+        raw_text = self._pending_implicit_raw_text or ""
+        buffered_text = self._pending_implicit_text_buffer
         self._pending_implicit_delta = None
+        self._pending_implicit_raw_text = None
+        self._pending_implicit_text_buffer = ""
         # Unwind the tool_call/function we synth-opened.
         self.implicit_tool_call_wrapper = False
         self.current_function_name = None
@@ -885,19 +919,31 @@ class StreamingXMLToolCallParser:
         # Reset expat so character data that wasn't a tool call doesn't
         # accumulate inside a phantom open element.
         self._reset_xml_parser_after_tool_call()
+        return raw_text, buffered_text
 
     def _char_data(self, data: str):
         """Handle XML character data events"""
-        # Bare-<function=> commitment: character data that ISN'T inside a
-        # parameter and isn't pure whitespace means the `<function=...>` was
-        # prose, not a tool call. Roll back before any user-visible delta.
+        # Bare-<function=> commitment window: until <parameter=> or </function>
+        # confirms, every character data event has to be reasoned about
+        # against the possibility that the `<function=...>` was prose.
         if (
             self._pending_implicit_delta is not None
             and self.current_param_name is None
             and data
-            and data.strip()
         ):
-            self._abandon_pending_implicit_tool_call()
+            if data.strip():
+                # Non-whitespace → commit was wrong, this is prose. Roll back
+                # and emit (raw tag + buffered whitespace + this data) as
+                # user-visible content so we don't swallow the original text.
+                raw_text, buffered_text = self._abandon_pending_implicit_tool_call()
+                restored = raw_text + buffered_text + data
+                if restored:
+                    self._emit_delta(DeltaMessage(content=restored))
+                return
+            # Pure whitespace (newlines between <function=> and <parameter=>
+            # in a real call). Buffer in case we end up abandoning so the
+            # restored prose preserves it; flush will discard it on commit.
+            self._pending_implicit_text_buffer += data
             return
         if data and self.current_param_name:
             # If preprocessing stage determines deferred parsing is needed,

--- a/vllm_mlx/tool_parsers/qwen3_xml_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen3_xml_tool_parser.py
@@ -159,6 +159,17 @@ class StreamingXMLToolCallParser:
         self.last_completed_call_id = None
         self.current_function_name = None
         self.current_function_open = False
+        # True when the current tool_call was synthesised because the model
+        # emitted a bare <function=> with no <tool_call> wrapper. The matching
+        # </function> closes the implicit wrapper too so the next bare
+        # <function=> opens a fresh tool_call.
+        self.implicit_tool_call_wrapper = False
+        # Bare-function commitment delay. When auto-opening on <function=Name>,
+        # we hold the function-name delta in _pending_implicit_delta until
+        # something confirms a real tool call (parameter open or function
+        # close). If non-whitespace character data arrives first, the
+        # `<function=...>` was prose and we abandon (no tool_call emitted).
+        self._pending_implicit_delta = None
         self.parameters = {}
         self.current_param_name = None
         self.current_param_value = ""
@@ -442,6 +453,33 @@ class StreamingXMLToolCallParser:
         # Skip blank content
         return not element
 
+    # Known tool-related tag heads — any of these arriving partially in the
+    # streaming buffer should make us wait for more data instead of emitting
+    # the fragment as text or feeding it to expat.
+    _TOOL_TAG_PREFIXES = (
+        "<tool_call>",
+        "</tool_call>",
+        "<function=",
+        "</function>",
+        "<parameter=",
+        "</parameter>",
+    )
+
+    def _looks_like_partial_tool_open(self, fragment: str) -> bool:
+        """True if `fragment` could complete into a tool-related XML tag.
+
+        Covers two shapes:
+          * `fragment` is a prefix of a known tag head (e.g. ``<funct``).
+          * `fragment` already past the ``=`` marker and accumulating the
+            attribute name (e.g. ``<function=Ag``) — waiting on ``>``.
+        """
+        if not fragment.startswith("<"):
+            return False
+        for prefix in self._TOOL_TAG_PREFIXES:
+            if prefix.startswith(fragment) or fragment.startswith(prefix):
+                return True
+        return False
+
     def _find_next_complete_element(self, start_pos: int) -> tuple[Optional[str], int]:
         """
         Find next complete XML element from specified position
@@ -466,29 +504,37 @@ class StreamingXMLToolCallParser:
             if tag_end != -1 and tag_end2 != -1:
                 # Next nearest is <
                 if tag_end < tag_end2:
+                    # If the prefix is the start of a tool-related opening tag
+                    # awaiting its closing '>', wait for more data instead of
+                    # emitting it as an unclosed fragment (which would either
+                    # leak as text or crash expat). Required so the model can
+                    # drop the <tool_call> wrapper and emit a bare <function=>
+                    # block; without it, partial <function=Name fragments leak.
+                    if self._looks_like_partial_tool_open(buffer[:tag_end]):
+                        return None, start_pos
                     return buffer[:tag_end], start_pos + tag_end
                 # Next nearest is >, means found XML element
                 else:
                     return buffer[: tag_end2 + 1], start_pos + tag_end2 + 1
             elif tag_end != -1:
+                if self._looks_like_partial_tool_open(buffer[:tag_end]):
+                    return None, start_pos
                 return buffer[:tag_end], start_pos + tag_end
             elif tag_end2 != -1:
                 return buffer[: tag_end2 + 1], start_pos + tag_end2 + 1
             else:
-                # If currently not parsing tool calls (entering a tool_call),
-                # check if starts with <tool_call>
-                if self.current_call_id is None:
-                    # Check if might be start of <tool_call>
-                    if buffer == "<tool_call>"[: len(buffer)]:
-                        # Might be start of <tool_call>, wait for more data
-                        return None, start_pos
-                    else:
-                        # Not start of <tool_call>, treat as text
-                        return buffer, start_pos + len(buffer)
-                else:
-                    # When parsing tool calls,
-                    # wait for more data to get complete tag
+                # Buffer is `<...` with neither a `>` nor a second `<` yet.
+                # Wait for more data if the buffer could complete into ANY
+                # known tool-related tag (not just <tool_call>) — bare
+                # <function=NAME> / <parameter=NAME> may have dropped the
+                # outer wrapper, and partial chunks of them must not be
+                # emitted as text.
+                if self._looks_like_partial_tool_open(buffer):
                     return None, start_pos
+                if self.current_call_id is None:
+                    return buffer, start_pos + len(buffer)
+                # Inside a tool call, partial non-tag bytes must wait too.
+                return None, start_pos
         else:
             # Find text content (until next < or buffer end)
             next_tag_pos = buffer.find("<")
@@ -727,8 +773,13 @@ class StreamingXMLToolCallParser:
             self.tool_call_index += 1
         elif name.startswith("function") or (name == "function"):
             # If missing tool_call, manually complete
+            implicit_open = False
             if not self.current_call_id:
                 self._start_element("tool_call", {})
+                # Remember the wrapper was synthesised, so </function> can
+                # also close it (the model didn't / won't emit </tool_call>).
+                self.implicit_tool_call_wrapper = True
+                implicit_open = True
             # Before opening new function,
             # automatically complete previous unclosed tags (parameter/function)
             self._auto_close_open_parameter_if_needed("function")
@@ -748,8 +799,16 @@ class StreamingXMLToolCallParser:
                         )
                     ]
                 )
-                self._emit_delta(delta)
+                if implicit_open:
+                    # Defer until <parameter=> or </function> confirms this is
+                    # a real tool call, not prose mentioning `<function=...>`.
+                    self._pending_implicit_delta = delta
+                else:
+                    self._emit_delta(delta)
         elif name.startswith("parameter") or (name == "parameter"):
+            # First <parameter=> after a deferred bare <function=> confirms
+            # this really is a tool call — emit the held function delta.
+            self._flush_pending_implicit_delta()
             # If previous parameter hasn't ended normally,
             # complete its end first, then start new parameter
             self._auto_close_open_parameter_if_needed("parameter")
@@ -800,8 +859,46 @@ class StreamingXMLToolCallParser:
                     self._emit_delta(delta)
                     self.current_param_is_first = False
 
+    def _flush_pending_implicit_delta(self) -> None:
+        """Emit a deferred bare-<function=> delta now that the call is confirmed."""
+        if self._pending_implicit_delta is not None:
+            delta = self._pending_implicit_delta
+            self._pending_implicit_delta = None
+            self._emit_delta(delta)
+
+    def _abandon_pending_implicit_tool_call(self) -> None:
+        """Roll back a deferred bare-<function=> auto-open: prose followed.
+
+        Drops the pending function-name delta and unwinds the synthesised
+        wrapper state so no tool_call is ever emitted for this fragment.
+        """
+        self._pending_implicit_delta = None
+        # Unwind the tool_call/function we synth-opened.
+        self.implicit_tool_call_wrapper = False
+        self.current_function_name = None
+        self.current_function_open = False
+        if self.tool_call_index > 0:
+            self.tool_call_index -= 1
+        if self.current_call_id:
+            self.last_completed_call_id = None
+            self.current_call_id = None
+        # Reset expat so character data that wasn't a tool call doesn't
+        # accumulate inside a phantom open element.
+        self._reset_xml_parser_after_tool_call()
+
     def _char_data(self, data: str):
         """Handle XML character data events"""
+        # Bare-<function=> commitment: character data that ISN'T inside a
+        # parameter and isn't pure whitespace means the `<function=...>` was
+        # prose, not a tool call. Roll back before any user-visible delta.
+        if (
+            self._pending_implicit_delta is not None
+            and self.current_param_name is None
+            and data
+            and data.strip()
+        ):
+            self._abandon_pending_implicit_tool_call()
+            return
         if data and self.current_param_name:
             # If preprocessing stage determines deferred parsing is needed,
             # only cache character data, no streaming output
@@ -990,6 +1087,9 @@ class StreamingXMLToolCallParser:
             self.start_quote_emitted = False
 
         elif name.startswith("function") or name == "function":
+            # </function> after a deferred bare <function=Name> with no
+            # parameters also confirms a real (parameterless) tool call.
+            self._flush_pending_implicit_delta()
             # if there are parameters, close JSON object
             if self.parameters:
                 delta = DeltaMessage(
@@ -1017,6 +1117,12 @@ class StreamingXMLToolCallParser:
                 )
                 self._emit_delta(delta)
             self.current_function_open = False
+            # If the surrounding <tool_call> was synthesised (bare <function=>
+            # with no wrapper), close it now so the next <function=> opens a
+            # fresh tool_call rather than reusing this id/index.
+            if self.implicit_tool_call_wrapper:
+                self.implicit_tool_call_wrapper = False
+                self._end_element("tool_call")
 
         elif name == "tool_call":
             # Before ending tool_call,


### PR DESCRIPTION
> Note: just back from vacation — should be responsive on review feedback or follow-ups.

## Summary

Qwen3-Coder under load (large system prompt + many tools) sometimes drops the outer
`<tool_call></tool_call>` wrapper and emits only the inner
`<function=NAME><parameter=...>...</function>` block. The current parser is
wrapper-gated and leaks these tool calls into the response as raw text. Local
Claude Code sessions hitting Qwen3-Coder-30B-A3B-Instruct show this as
`<function=Agent>` printed as prose followed by hung 0-token subagents.

Same bug class as upstream vLLM PR #26345 ("[Bugfix]fix Qwen3 xml tool parser",
merged 2025-10-15), which was never backported here. This PR is broader: it
also covers the prose-misclassification and multi-sequential-bare-call cases
that #26345's eager-commit approach would regress.

Three coordinated changes in `StreamingXMLToolCallParser`:

1. **Buffer-wait for any partial tool tag.** `_looks_like_partial_tool_open` extends
   the wait-for-more-data branch (and the `tag_end < tag_end2` text-fragment branch)
   to cover `<function=`, `<parameter=`, and the closing variants — not just
   `<tool_call>`. Without this, partial `<function=Ag` chunks either leak as text
   or crash expat with `not well-formed (invalid token)`.

2. **Deferred commitment on bare `<function=Name>`.** When auto-opening a
   `<tool_call>` because the model dropped the wrapper, the function-name delta
   is held in `_pending_implicit_delta` until `<parameter=` opens (or `</function>`
   closes a parameterless call). If non-whitespace character data arrives outside
   any parameter, the `<function=...>` was prose — roll back via
   `_abandon_pending_implicit_tool_call` so no tool_call delta is ever emitted.
   This is what keeps the existing `test_streaming_plain_text_is_not_misclassified_as_tool_call`
   regression test green.

3. **Implicit-wrapper close on `</function>`.** When the surrounding `<tool_call>`
   was synthesised, also close it on `</function>` so the next bare `<function=...>`
   opens a fresh tool_call with an independent id/index instead of merging into
   the previous call (which would emit `}}` and `name=None` for the second call).

## Type of change

- Bug fix

## Surface touched

- MCP / tool calling

## Test plan

\`\`\`bash
pytest tests/test_qwen3_xml_parser.py \\
       tests/test_qwen3_xml_streaming_chunks.py \\
       tests/test_qwen3_xml_registration.py -q
\`\`\`

Two new parametrized tests added:

- `test_streaming_bare_function_without_tool_call_wrapper[1/5/7/24/256]`
- `test_streaming_two_sequential_bare_functions[1/5/7/24/256]`

## Test results

\`\`\`
tests/test_qwen3_xml_parser.py ........... (11 passed)
tests/test_qwen3_xml_streaming_chunks.py .............................. (32 passed, +10 new)
tests/test_qwen3_xml_registration.py .... (4 passed)
============================== 47 passed in 1.11s ==============================
\`\`\`

Real-session repro (Claude Code → ccr → LiteLLM → vllm-mlx Qwen3-Coder-30B-A3B-Instruct-MLX-4bit):

- Before: `<function=Agent>` printed as prose, 41-min/0-token runaway subagent.
- After: structured tool_calls emitted, Agent executes normally. (Server restart required to pick up the parser change.)

## Performance impact

N/A, parser-only change on the tool-call hot path. The added work is one
prefix-list iteration per partial-buffer resolve and one boolean check per
`_char_data` callback when an implicit wrapper is open. No allocations on
the common (wrapped) path.

## Output parity

Wrapped calls (`<tool_call>...<function=...>...</tool_call>`) produce
byte-identical streamed output before and after this patch — verified by the
unchanged-and-still-green existing test suite. Bare-function calls now produce
output where previously the parser produced unparseable text.

## Risk notes

- Parser-only; no scheduler / KV cache / sampler interaction.
- Three new internal state fields (`implicit_tool_call_wrapper`,
  `_pending_implicit_delta`, plus the helper methods); all reset by
  `reset_streaming_state`.
- The deferred-commitment design means a bare `<function=Name>` followed only
  by whitespace and then truncated (no further data) will NOT emit a tool_call.
  This matches the existing truncation contract from
  `test_streaming_truncated_at_end_of_parameter_recovers_tool_call`
  ("If the name was emitted, that's enough... no spurious extra calls").
- Upstream vLLM PR #26345 fixes the same bug class with a narrower (eager-commit)
  approach. This PR is a strict superset: handles prose disambiguation and
  multi-sequential-bare cases that #26345 would regress on.