### PR TITLE
Add Mistral/Ministral [THINK] reasoning parser

### DIFF
--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -80,6 +80,7 @@ def _register_builtin_parsers():
     from .glm4_parser import Glm4ReasoningParser
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
+    from .mistral_parser import MistralReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
 
     register_parser("qwen3", Qwen3ReasoningParser)
@@ -88,6 +89,7 @@ def _register_builtin_parsers():
     register_parser("harmony", HarmonyReasoningParser)
     register_parser("gemma4", Gemma4ReasoningParser)
     register_parser("glm4", Glm4ReasoningParser)
+    register_parser("mistral", MistralReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/mistral_parser.py
+++ b/vllm_mlx/reasoning/mistral_parser.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reasoning parser for Mistral / Ministral reasoning models.
+
+Models such as Magistral and Ministral-3-*-Reasoning wrap their reasoning in
+[THINK]...[/THINK] delimiters (registered as special tokens in the tokenizer)
+and support a strict switch via 'enable_thinking=False' in chat template kwargs.
+
+This mirrors the Qwen3 parser, which uses <think>...</think>, but with the
+Mistral bracket-token delimiters.
+
+Supports implicit reasoning mode where [THINK] is injected in the prompt and
+only [/THINK] appears in the output.
+"""
+
+from .think_parser import BaseThinkingReasoningParser
+
+
+class MistralReasoningParser(BaseThinkingReasoningParser):
+    """
+    Reasoning parser for Mistral/Ministral reasoning models.
+
+    Uses [THINK]...[/THINK] tokens to denote reasoning text.
+
+    Supports three scenarios:
+    1. Both tags in output: [THINK]reasoning[/THINK]content
+    2. Only closing tag (think in prompt): reasoning[/THINK]content
+    3. No tags: pure content
+
+    Example (normal):
+        Input: "[THINK]Let me analyze this...[/THINK]The answer is 42."
+        Output: reasoning="Let me analyze this...", content="The answer is 42."
+
+    Example (think in prompt):
+        Input: "Let me analyze this...[/THINK]The answer is 42."
+        Output: reasoning="Let me analyze this...", content="The answer is 42."
+    """
+
+    @property
+    def start_token(self) -> str:
+        return "[THINK]"
+
+    @property
+    def end_token(self) -> str:
+        return "[/THINK]"
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+    ) -> tuple[str | None, str | None]:
+        """
+        Extract reasoning from Mistral/Ministral output.
+
+        Handles both explicit [THINK]...[/THINK] tags and implicit mode
+        where [THINK] was in the prompt (only [/THINK] in output).
+
+        Args:
+            model_output: Complete model output text.
+
+        Returns:
+            (reasoning, content) tuple.
+        """
+        # If no end token at all, treat as pure content
+        if self.end_token not in model_output:
+            return None, model_output
+
+        # Use base class implementation (handles both explicit and implicit)
+        return super().extract_reasoning(model_output)


### PR DESCRIPTION
## Problem
Mistral reasoning models (Magistral, Ministral-3-*-Reasoning) wrap reasoning in `[THINK]…[/THINK]`
special tokens. The existing `--reasoning-parser` choices are all `<think>`/channel based
(`qwen3`, `deepseek_r1`, `gpt_oss`, `harmony`, `gemma4`, `glm4`), so there is no parser that
extracts Mistral reasoning — `--reasoning-parser deepseek_r1` is a silent no-op on these models and
the reasoning leaks into `content`.

## Change
Adds `vllm_mlx/reasoning/mistral_parser.py` — `MistralReasoningParser`, a ~25-line subclass of the
existing `BaseThinkingReasoningParser` with `[THINK]`/`[/THINK]` delimiters (mirrors `qwen3_parser.py`,
incl. the implicit "only closing tag" case). Registered as `"mistral"`; the `--reasoning-parser` CLI
choices auto-populate from the registry, so no CLI change is needed.

## Validation
Serving `Ministral-3-3B-Reasoning-2512-4bit` with `--reasoning-parser mistral`: the `[THINK]…[/THINK]`
span is moved into `reasoning_content` and `content` is left clean (e.g. `reasoning_content` =
"Okay, I need to calculate 17×23…", `content` = "391"). Verified the `[THINK]`/`[/THINK]` tokens against
the model's `tokenizer_config.json` special tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)