### PR TITLE
Guard --mllm against continuous batching (silent empty output)

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1168,6 +1168,11 @@ def _get_cache_dir() -> str:
 
 def _build_engine(spec: ModelSpec) -> BaseEngine:
     """Construct an engine instance from a model spec without starting it."""
+    if spec.use_batching and spec.force_mllm:
+        raise ValueError(
+            "--mllm is not supported with continuous batching (it produces empty "
+            "output). Run the model with SimpleEngine by omitting --continuous-batching."
+        )
     if spec.use_batching:
         from .engine.batched import BatchedEngine
 
@@ -3065,6 +3070,11 @@ def load_model(
         raise ValueError("MLLM draft block size must be a positive integer")
     if mllm_draft_model and use_batching:
         raise ValueError("MLLM draft models are supported only by SimpleEngine")
+    if force_mllm and use_batching:
+        raise ValueError(
+            "--mllm is not supported with continuous batching (it produces empty "
+            "output). Run the model with SimpleEngine by omitting --continuous-batching."
+        )
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
         raise ValueError(
             "MLLM draft models are not supported with lifecycle residency yet"


### PR DESCRIPTION
## Problem
Serving a multimodal model with both `--mllm` and `--continuous-batching` (BatchedEngine) returns
**empty output** for every request, silently — while `--mllm` alone (SimpleEngine) works. The batched
path pre-formats the prompt and hands a string to the MLLM scheduler, which re-processes it with a
mismatched processor/token-injection context.

## Change
Until the batched-MLLM path is fixed, fail loudly: raise a clear `ValueError` when `force_mllm` and
`use_batching` are combined, at both engine-construction entry points (`_build_engine` for the
registry/residency path and `load_model` for the single-model serve path), mirroring the existing
`"MLLM draft models are supported only by SimpleEngine"` guard.

## Validation
`serve <vlm> --mllm --continuous-batching` now errors with a clear message ("use SimpleEngine by
omitting --continuous-batching") instead of serving empty.

(The deeper fix — making the batched-MLLM path actually generate — is a separate, larger change; this
PR is the safe guard.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)