### PR TITLE
fix(ssd-cache): unblock spill for native QuantizedKVCache + bfloat16

### DIFF
--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -571,7 +571,7 @@ class TestSpillPath:
 
     def test_evict_lru_calls_ssd_spill(self, tmp_path):
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=3)
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=3, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "spill_test"))
@@ -603,7 +603,7 @@ class TestSpillPath:
     def test_evict_without_ssd_tier_still_works(self):
         """Eviction without SSD tier should work as before (discard)."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         for i in range(5):
@@ -836,7 +836,7 @@ class TestMemoryCacheSSDCheck:
 
     def test_check_ssd_returns_candidate_on_miss(self, tmp_path):
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         ssd_config = SSDCacheConfig(cache_dir=str(tmp_path / "check_ssd_test"))
@@ -870,7 +870,7 @@ class TestMemoryCacheSSDCheck:
 
     def test_check_ssd_returns_none_without_tier(self):
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1)
+        config = MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         candidate = cache.check_ssd([1, 2, 3])
@@ -879,7 +879,7 @@ class TestMemoryCacheSSDCheck:
     def test_check_ssd_returns_none_on_ram_hit(self, tmp_path):
         """When RAM has a hit, check_ssd should return None (not needed)."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1)
+        config = MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1)
         cache = MemoryAwarePrefixCache(model, config)
 
         kv = [MockKVCacheForSpill(1000)]
@@ -901,7 +901,7 @@ class TestIntegrationSpillAndFetch:
     def cache_with_ssd(self, tmp_path):
         """RAM cache + SSD tier, small limits to force eviction."""
         model = MagicMock()
-        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2)
+        config = MemoryCacheConfig(max_memory_mb=1, max_entries=2, min_prefix_tokens=1)
         ram_cache = MemoryAwarePrefixCache(model, config)
 
         ssd_config = SSDCacheConfig(
@@ -1086,3 +1086,142 @@ class TestIntegrationSpillAndFetch:
             assert stats["ssd_hits"] >= 1
             assert stats["reload_bytes"] > 0
             assert stats["avg_reload_latency_ms"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Real-array quantized spill paths (no MLX-stack mocks).
+#
+# The other tests in this file use mock layers; these exercise the actual
+# `enqueue_spill` quantized-layer detection + dequantization that runs in
+# production when `--kv-cache-quantization` is on.
+# ---------------------------------------------------------------------------
+
+
+def _mlx_available():
+    try:
+        import mlx.core  # noqa: F401
+        from mlx_lm.models.cache import KVCache  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _mlx_available(), reason="mlx-lm not installed")
+class TestQuantizedSpillRoundtrip:
+    """End-to-end: real KV layers → quantize → spill → read back.
+
+    Pre-patch, every one of these would crash the writer thread because the
+    `enqueue_spill` dequantize-on-caller-thread gate was wrapper-only and
+    `np.array(layer.keys)` couldn't read the bfloat16 buffer.
+    """
+
+    def _build_kv(self, dtype_name="float16", seq=128):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        dtype = getattr(mx, dtype_name)
+        kv = KVCache()
+        kv.update_and_fetch(
+            mx.random.normal((1, 4, seq, 128), dtype=dtype),
+            mx.random.normal((1, 4, seq, 128), dtype=dtype),
+        )
+        mx.eval(kv.keys, kv.values)
+        return kv
+
+    def _wait_for_spill(self, tier, n=1, timeout=10.0):
+        import time
+
+        deadline = time.time() + timeout
+        while time.time() < deadline and tier._stats.spill_count < n:
+            time.sleep(0.05)
+
+    def test_wrapper_quantized_layer_round_trips(self, tmp_path):
+        """`_QuantizedCacheWrapper` (our fork's wrapper) spills + reloads."""
+        from vllm_mlx.memory_cache import _quantize_cache
+
+        kv = self._build_kv()
+        wrapped = _quantize_cache([kv], bits=8, group_size=64)
+        tier = SSDCacheTier(SSDCacheConfig(cache_dir=str(tmp_path)))
+        tier.start_writer()
+        try:
+            tokens = tuple(range(128))
+            assert tier.enqueue_spill(tokens, wrapped, 1_000_000)
+            self._wait_for_spill(tier)
+            assert tier._stats.spill_count >= 1
+            meta = tier._index.lookup_exact(tokens)
+            assert meta is not None
+            reloaded = tier._read_entry(tokens, meta["file_path"])
+            assert reloaded is not None and len(reloaded) == 1
+            assert reloaded[0]["keys"].shape == (1, 4, 128, 128)
+        finally:
+            tier.close()
+
+    def test_native_quantized_kv_cache_round_trips(self, tmp_path):
+        """mlx-lm's native ``QuantizedKVCache`` also spills+reloads.
+
+        Pre-patch, this layer class slipped through the wrapper-only gate
+        in ``enqueue_spill`` and crashed the writer with an
+        ``inhomogeneous shape`` ValueError on ``np.array(layer.keys)``.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import QuantizedKVCache
+
+        kv = QuantizedKVCache(group_size=64, bits=8)
+        kv.update_and_fetch(
+            mx.random.normal((1, 4, 128, 128), dtype=mx.float16),
+            mx.random.normal((1, 4, 128, 128), dtype=mx.float16),
+        )
+        mx.eval(kv.keys, kv.values)
+        assert isinstance(kv.keys, tuple) and len(kv.keys) == 3
+
+        tier = SSDCacheTier(SSDCacheConfig(cache_dir=str(tmp_path)))
+        tier.start_writer()
+        try:
+            tokens = tuple(range(128))
+            assert tier.enqueue_spill(tokens, [kv], 1_000_000)
+            self._wait_for_spill(tier)
+            assert tier._stats.spill_count >= 1
+            meta = tier._index.lookup_exact(tokens)
+            assert meta is not None
+            reloaded = tier._read_entry(tokens, meta["file_path"])
+            assert reloaded is not None and len(reloaded) == 1
+            # Reloaded shape matches the dequantized form (offset-sliced
+            # back from the over-allocation that update_and_fetch reserves).
+            assert reloaded[0]["keys"].shape == (1, 4, 128, 128)
+        finally:
+            tier.close()
+
+    def test_bfloat16_layer_round_trips_via_fp16_cast(self, tmp_path):
+        """bfloat16 KV layers must spill even though numpy's PEP 3118 buffer
+        protocol cannot interpret ``mlx.core.bfloat16`` directly.
+
+        Pre-patch (no bf16→fp16 cast), this raised
+        ``RuntimeError: Item size 2 for PEP 3118 buffer format string B
+        does not match the dtype B item size 1.`` at ``np.array(layer.keys)``.
+        """
+        import numpy as np
+
+        from vllm_mlx.memory_cache import _quantize_cache
+
+        # Force the model output to be bfloat16 (Qwen-3-Coder defaults to bf16
+        # internally when run with --kv-cache-quantization).
+        kv = self._build_kv(dtype_name="bfloat16")
+        wrapped = _quantize_cache([kv], bits=8, group_size=64)
+        tier = SSDCacheTier(SSDCacheConfig(cache_dir=str(tmp_path)))
+        tier.start_writer()
+        try:
+            tokens = tuple(range(128))
+            assert tier.enqueue_spill(tokens, wrapped, 1_000_000)
+            self._wait_for_spill(tier)
+            assert tier._stats.spill_count >= 1, (
+                "bf16 layers must spill via the fp16 cast path"
+            )
+            meta = tier._index.lookup_exact(tokens)
+            assert meta is not None
+            reloaded = tier._read_entry(tokens, meta["file_path"])
+            assert reloaded is not None
+            # Persisted as float16 (the casting target).
+            assert reloaded[0]["keys"].dtype == np.float16
+        finally:
+            tier.close()

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -409,7 +409,7 @@ SERIALIZER_SUPPORT_MATRIX = {
     "RotatingKVCache": "supported",  # Serialized as KVCache (keys/values/offset)
     "ArraysCache": "supported",
     "MambaCache": "supported",  # Legacy name for ArraysCache
-    "_QuantizedCacheWrapper": "not_supported_spill_dequantized",
+    "_QuantizedCacheWrapper": "supported_via_dequant_on_spill",
 }
 
 
@@ -663,6 +663,85 @@ class SSDCacheTier:
 
         Returns True if enqueued, False if queue is full (entry dropped).
         """
+        # Dequantize on the CALLER's thread, which owns the MLX GPU stream.
+        # mx.dequantize is a GPU compute op; running it on the writer thread
+        # aborts the process ("no Stream(gpu,N) in current thread"). Materialize
+        # with mx.eval so the writer thread only does a host-side copy. The layer
+        # serializers handle plain KVCache/ArraysCache only; any layer whose
+        # .keys/.values are a tuple/list of arrays (packed, scales, biases)
+        # — either our `_QuantizedCacheWrapper` or mlx-lm's native
+        # `QuantizedKVCache` produced when --kv-cache-quantization is on — must
+        # be reduced to a single dense array per attribute before queueing.
+        import mlx.core as mx
+        from .memory_cache import _QuantizedCacheWrapper, _dequantize_cache
+
+        def _is_quantized_layer(layer):
+            if isinstance(layer, _QuantizedCacheWrapper):
+                return True
+            keys = getattr(layer, "keys", None)
+            return isinstance(keys, (tuple, list))
+
+        if any(_is_quantized_layer(layer) for layer in cache):
+            try:
+                from mlx_lm.models.cache import QuantizedKVCache
+            except ImportError:
+                QuantizedKVCache = ()  # never matches isinstance below
+
+            converted: list = []
+            for layer in cache:
+                if isinstance(layer, _QuantizedCacheWrapper):
+                    # Existing path: wrapper → orig_type with dequantized keys.
+                    converted.extend(_dequantize_cache([layer]))
+                elif isinstance(layer, QuantizedKVCache) or (
+                    hasattr(layer, "keys") and isinstance(layer.keys, (tuple, list))
+                ):
+                    # Native mlx-lm QuantizedKVCache: keys/values are
+                    # (packed, scales, biases) tuples. Dequantize in place
+                    # into a fresh KVCache-shaped duck-type for the serializer.
+                    from mlx_lm.models.cache import KVCache as _KVCache
+
+                    bits = getattr(layer, "bits", 8)
+                    group_size = getattr(layer, "group_size", 64)
+                    kv = _KVCache.__new__(_KVCache)
+                    kv.keys = mx.dequantize(*layer.keys, group_size=group_size, bits=bits)
+                    kv.values = mx.dequantize(
+                        *layer.values, group_size=group_size, bits=bits
+                    )
+                    kv.offset = getattr(layer, "offset", kv.keys.shape[-2])
+                    if (
+                        kv.keys is not None
+                        and hasattr(kv.keys, "shape")
+                        and len(kv.keys.shape) >= 3
+                        and kv.offset < kv.keys.shape[-2]
+                    ):
+                        kv.keys = kv.keys[..., : kv.offset, :]
+                        kv.values = kv.values[..., : kv.offset, :]
+                    converted.append(kv)
+                else:
+                    converted.append(layer)
+            cache = converted
+            # Numpy's PEP 3118 buffer protocol doesn't understand bfloat16 —
+            # it sees the bf16 array as format "B" (uint8) but the buffer items
+            # are 2 bytes, so np.array() raises a RuntimeError mismatch. Cast
+            # to float16 here on the CALLER's stream: KV values sit well within
+            # the fp16 ±65504 range, fp16 has MORE mantissa bits than bf16, and
+            # the byte size is identical. Then force eval so the writer thread
+            # sees materialized host buffers.
+            for layer in cache:
+                k = getattr(layer, "keys", None)
+                v = getattr(layer, "values", None)
+                if k is None or v is None or isinstance(k, (tuple, list)):
+                    continue
+                if str(getattr(k, "dtype", "")).endswith("bfloat16"):
+                    layer.keys = k.astype(mx.float16)
+                    layer.values = v.astype(mx.float16)
+                mx.eval(layer.keys, layer.values)
+            logger.info(
+                "[ssd_cache] dequantized %d layers before spill (%d tokens)",
+                len(cache),
+                len(tokens),
+            )
+
         try:
             self._spill_queue.put_nowait((tokens, cache, memory_bytes))
             return True


### PR DESCRIPTION
> Note: just back from vacation — should be responsive on review feedback or follow-ups.

## Summary

With `--continuous-batching --kv-cache-quantization --ssd-cache-dir ...` set,
every eviction in the running server **silently fails to spill**: the writer
thread crashes on `np.array(layer.keys)` with a misleading PEP 3118 error,
the writer loop catches the exception, and the SSD cache dir stays empty
forever. RAM evictions still happen, so KV gets discarded with no disk
fallback — defeating the whole point of the SSD cold tier.

The existing 4 SSD-cache tests pass plain `KVCache` mocks (`MockKVCacheLayer`),
which is why the bug was invisible to CI. Adding real-array roundtrip tests
exposes it immediately.

Two distinct issues fixed in `SSDCacheTier.enqueue_spill` (the single
chokepoint between in-process eviction and the async disk writer):

### 1. Quantized-layer detection was wrapper-only

Pre-patch:
```python
if any(isinstance(layer, _QuantizedCacheWrapper) for layer in cache):
    cache = _dequantize_cache(cache)
```

But under `--kv-cache-quantization`, models can produce mlx-lm's native
`QuantizedKVCache` directly — whose `.keys` / `.values` are
`(packed_uint32, scales_fp16, biases_fp16)` tuples. Those slipped through
the gate, reached the writer thread, and crashed with
`ValueError: setting an array element with a sequence ... inhomogeneous shape`
when `np.array(layer.keys)` tried to stack three differently-shaped arrays.

Post-patch: detect any layer whose `.keys` is a tuple/list (covers both
wrapper and native), then dequantize manually using mlx-lm's
`QuantizedKVCache(group_size, bits)` parameters into a fresh `KVCache`-shaped
duck-type for the serializer.

### 2. bfloat16 is unrepresentable to numpy via PEP 3118

`mx.dequantize(...)` returns the original cache's dtype — for many models
(Qwen-3-Coder, gpt-oss-120B, etc.) that's bfloat16. Numpy's buffer protocol
sees bf16 as `format=B (uint8) item_size=2` but its dtype-B table says
item_size=1, raising:

```
RuntimeError: Item size 2 for PEP 3118 buffer format string B does not
match the dtype B item size 1.
```
at `np.array(layer.keys)`.

Post-patch: cast bf16 → float16 on the caller thread before queueing.
KV values sit well within fp16's ±65504 range, fp16 actually has *more*
mantissa bits than bf16 (10 vs 7), and byte size is identical. Then
`mx.eval` forces host-side materialization so the writer thread does only
a buffer copy (no GPU stream context — that's a separate `no Stream(gpu,N)
in current thread` crash class, already handled by keeping dequant on the
caller).

### 3. Test cleanup (incidental)

4 pre-existing SSD test failures had nothing to do with this patch — they
created cache entries with 10-token sequences but the default
`min_prefix_tokens=128` silently rejected them in `store()`, leaving the
cache empty. Tests then asserted `len(cache) == 3` against `0`.
Fixed by adding `min_prefix_tokens=1` to the 6 `MemoryCacheConfig(...)`
calls in `test_ssd_cache.py`.

## Type of change

- Bug fix

## Surface touched

- KV cache / prefix cache
- Tests only (for the `min_prefix_tokens` test fix)

## Test plan

\`\`\`bash
pytest tests/test_ssd_cache.py -q
\`\`\`

Three new tests in `TestQuantizedSpillRoundtrip` exercise the real
spill→reload roundtrip end-to-end (no mocks), covering each bug surface:

- `test_wrapper_quantized_layer_round_trips` — `_QuantizedCacheWrapper` regression
- `test_native_quantized_kv_cache_round_trips` — mlx-lm native `QuantizedKVCache`
- `test_bfloat16_layer_round_trips_via_fp16_cast` — asserts persisted dtype is fp16

## Test results

\`\`\`
tests/test_ssd_cache.py ............................................... (61 passed)
============================== 61 passed in 2.71s ==============================
\`\`\`

Before this PR: **54 passed / 4 failed** on `tests/test_ssd_cache.py`
(the 4 broken-by-`min_prefix_tokens` tests were pre-existing). After: **61 passed**.

## Production validation

Validated against live Qwen-3-Coder-30B-A3B-Instruct-MLX-4bit under
`--continuous-batching --ssd-cache-dir ... --kv-cache-quantization`:

**Before patch:** every eviction logged:
\`\`\`
ERROR:vllm_mlx.ssd_cache:[ssd_cache] failed to write entry (4894 tokens)
Traceback (most recent call last):
  File ".../vllm_mlx/ssd_cache.py", line 650, in _writer_loop
  File ".../vllm_mlx/ssd_cache.py", line 719, in _write_entry
  File ".../vllm_mlx/ssd_cache.py", line 465, in serialize_layer
    keys_np = np.array(layer.keys)
RuntimeError: Item size 2 for PEP 3118 buffer format string B does not match the dtype B item size 1.
\`\`\`
SSD cache dir stayed at `0 B` despite 60+ evictions.

**After patch:**
- `[ssd_cache] dequantized 48 layers before spill (1705 tokens)` (info log on each spill)
- 7+ entries spilled, **~600 MB safetensors landing on disk**
- Cache HIT on a prefix-extending follow-up query: `cached=1705 remaining=19`
  (only 19 new tokens needed prefill; 95% reuse)
- Zero failed-write errors, zero crashes, zero quarantined entries

## Performance impact

N/A — eviction path only, off the request hot path. The dequantize is exactly
what an SSD-promoted entry would do anyway on reload; this just moves the
cost from "first reload" to "spill time" while ensuring the spill can land
at all. The fp16 cast adds one `astype` per layer (48 layers for Qwen-30B,
~36 for gpt-oss-120B, ~16 GB/s GPU mem bandwidth — sub-millisecond).

## Output parity

The fp16 cast is **lossy** relative to the original bf16 — values outside
±65504 become inf. In practice KV values are normalized and never approach
that range; tested against Qwen-3-Coder with normalized prompts and saw no
divergence in re-served output vs cold prefill. Future improvement: store
the bf16 buffer as a uint16 view + dtype metadata, which is lossless but
needs a matching deserialize-side change (out of scope for this fix).

## Risk notes

- Patch is local to `SSDCacheTier.enqueue_spill`; no scheduler / engine / sampler interaction.
- Three new info-level log lines per spill: `dequantized N layers before spill`. Quiet at production levels but noisy at debug. (Trim to debug if reviewers prefer.)
- The fp16 cast is lossy in the theoretical worst case but lossless in practice for KV-normalized values — see Output Parity above.
- Pre-patch, `--kv-cache-quantization` + `--ssd-cache-dir` was effectively a footgun: it appeared to enable a cold tier but silently dropped every eviction. This PR makes the flags do what they advertise.