### PR TITLE
docs: added caffeinate section into troubleshooting

### DIFF
--- a/docs/es/getting-started/installation.md
+++ b/docs/es/getting-started/installation.md
@@ -87,3 +87,11 @@ Usa un modelo cuantizado más pequeno:
 ```bash
 vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
 ```
+
+### Interrupciones del servidor en ejecuciones largas (suspensión de macOS)
+
+Tu máquina macOS puede entrar en suspensión durante ejecuciones largas como servidor. Prueba usar `caffeinate` para evitar la suspensión:
+
+```bash
+caffeinate -dimsu
+```

--- a/docs/fr/getting-started/installation.md
+++ b/docs/fr/getting-started/installation.md
@@ -87,3 +87,11 @@ Utilisez un modèle quantifié plus petit :
 ```bash
 vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
 ```
+
+### Interruptions du serveur pendant les exécutions longues (mise en veille de macOS)
+
+Votre machine macOS peut passer en veille pendant de longues exécutions en tant que serveur. Essayez d'utiliser `caffeinate` pour empêcher la mise en veille :
+
+```bash
+caffeinate -dimsu
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -94,3 +94,11 @@ Use a smaller quantized model:
 ```bash
 vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
 ```
+
+### Server interruptions during long runs (macOS sleep)
+
+Your macOS machine may go to sleep during long-running server sessions. Try using `caffeinate` to prevent sleep:
+
+```bash
+caffeinate -dimsu
+```

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -87,3 +87,11 @@ huggingface-cli login
 ```bash
 vllm-mlx serve mlx-community/Llama-3.2-1B-Instruct-4bit
 ```
+
+### 长时间运行时服务器可能因 macOS 进入睡眠而中断
+
+长时间作为服务器运行时，macOS 设备可能会进入睡眠。可以使用 `caffeinate` 来阻止进入睡眠：
+
+```bash
+caffeinate -dimsu
+```


### PR DESCRIPTION
## Summary

Connections to `vllm-mlx` sometimes became unstable when macOS entered sleep mode. When this issue occurred, I observed symptoms such as client connections timing out in my environment.
In my case, I was able to resolve the issue by using the `caffeinate` command, so I have added this to the troubleshooting section of the documentation.

## Type of change

- Documentation

## Surface touched

- Docs only

