### PR TITLE
fix(text-model-from-vlm): eval() the derived TextModel so hybrid layers use the fast kernel

### DIFF
--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -116,6 +116,14 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         else:
             logger.info("TextModel built without MTP")
 
+        # Put the derived TextModel in eval mode. mlx_lm.load / mlx_vlm.load both
+        # eval() their models (this is also what LM Studio's mlx-engine does), but
+        # this freshly-constructed TextModel defaults to training=True. Hybrid
+        # layers (Qwen3.5/3.6 gated-delta) select their compute path with
+        # `use_kernel = not self.training`, so in training mode prefill/decode fall
+        # to the slow Python recurrence instead of the Metal kernel.
+        text_model.train(False)
+
         return text_model
 
     except ImportError as e:


### PR DESCRIPTION
Updated on second look — this turned out to be a one-line eval-mode fix with an outsized effect on hybrid models.

### Problem
`build_text_model()` constructs a fresh `TextModel` to serve text-only requests for VLMs, but never puts it in eval mode — so it stays at mlx’s default `training=True`. Hybrid models (Qwen3.5/3.6 gated-delta linear attention) pick their compute path with `use_kernel = not self.training`. Left in training mode, every gated-delta call falls through to the slow reference path (a Python `for t in range(T)` recurrence) instead of the Metal kernel — a large, **context-length-scaling** prefill penalty, plus a decode hit, on the VLM→text path only.

`mlx_lm.load` and `mlx_vlm.load` both `eval()` their models — **the same thing LM Studio’s mlx-engine does** — which is why neither hits this slowdown on the same model. This path was simply the one that skipped it.

### Fix
One line — match the other loaders and eval() before returning:
```python
text_model.train(False)
```
Numerically identical output (the kernel is the optimized form of the same recurrence); only the path selection changes.

### Performance (Qwen3.6-35B-A3B, 4-bit, M-series)
| | before | after |
|---|---|---|
| prefill @ ~2k tokens | 2.78s | **0.47s** |
| prefill @ ~5k tokens | 6.92s | **1.13s** |
| decode | 116.8 tok/s | **133.8 tok/s** |

Prefill no longer scales poorly with context, and decode matches a non-hybrid model of the same active size.

### Scope
Affects only models served through `build_text_model` whose layers gate kernel selection on training mode (hybrid / gated-delta, e.g. Qwen3.5/3.6). No behavior change beyond path selection — eval mode is the correct inference state regardless.