### PR TITLE
fix(text-model-from-vlm): honor per-layer quantization overrides when building the TextModel

### DIFF
--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -66,11 +66,28 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         # This prevents quantizing layers like mtp.fc which are BF16.
         quantization = text_config.get("quantization", config.get("quantization", None))
         if quantization is not None:
+            # Per-layer quantization overrides (e.g. 8-bit MoE gates over a 4-bit
+            # body) may be keyed with the source checkpoint's "language_model."
+            # wrapper prefix, which the extracted TextModel doesn't carry. Index
+            # them by suffix so the prefix-stripped module path resolves to the
+            # correct bits/group_size; without this the override is ignored and the
+            # layer is quantized at the global width, producing a quantized_matmul
+            # shape mismatch at decode.
+            per_layer_overrides = {
+                k: v for k, v in quantization.items() if isinstance(v, dict)
+            }
 
             def _class_predicate(path, module):
                 if not hasattr(module, "to_quantized"):
                     return False
-                return f"{path}.scales" in all_weight_names
+                if f"{path}.scales" not in all_weight_names:
+                    return False
+                if path in quantization:
+                    return quantization[path]
+                for key, override in per_layer_overrides.items():
+                    if key.endswith("." + path):
+                        return override
+                return True
 
             nn.quantize(
                 text_model,


### PR DESCRIPTION
### Problem
`build_text_model()` quantizes the extracted TextModel with a `class_predicate` that only returns `True`/`False`, so every quantizable layer gets the **global** `bits`/`group_size`. Checkpoints with **per-layer overrides** — e.g. Qwen3.5/3.6 MoE, which keep the routing gates at 8-bit over a 4-bit body — therefore quantize those gates at the wrong width.

There is also a key-prefix mismatch: the overrides are keyed with the source checkpoint's `language_model.` wrapper prefix (`language_model.model.layers.N.mlp.gate`), but the extracted TextModel's module paths don't carry it, so even a direct lookup misses.

The result is a decode-time crash — an 8-bit-packed gate matmul'd as 4-bit:
```
ValueError: [quantized_matmul] shapes of weight and scales are incompatible ... bits=4
```
i.e. these mixed-precision Qwen3.6 quants can't be served through the VLM→text path at all.

### Fix
`_class_predicate` returns the per-layer override dict (so `nn.quantize` applies the right bits/group_size), matched by **suffix** to tolerate the `language_model.` prefix, falling back to the global width otherwise. ~18 lines, no behavior change for checkpoints without per-layer overrides.

### Scope
Only affects models with per-layer quantization overrides served via `build_text_model` (e.g. Qwen3.5/3.6 mixed-precision 4-/6-bit). Uniform-quant models are unchanged.