### PR TITLE
fix(engine): stop MLLM text route at the model's full config EOS set

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -282,6 +282,10 @@ async def test_simple_engine_stream_generate_text_applies_chat_template_kwargs()
         engine._is_mllm = True
         engine._text_tokenizer = MagicMock()
         engine._text_tokenizer.apply_chat_template.return_value = "prompt"
+        # Realistic tokenizer attrs: the up-front usage tokenization reads
+        # bos_token and encode() on every request.
+        engine._text_tokenizer.bos_token = None
+        engine._text_tokenizer.encode.return_value = [1, 2, 3]
         engine._text_model = MagicMock()
         engine._text_model.model = MagicMock()
 

--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -386,3 +386,153 @@ async def test_stream_anthropic_skips_reasoning_parser_when_thinking_disabled():
     assert '"type": "thinking"' not in body
     assert "HEL" in body and "LO" in body
     assert '"type": "text_delta"' in body
+
+
+# Explicit-marker guard: thinking disabled must not leak raw reasoning
+# markers (Gemma 4 opens <|channel>thought regardless of the template
+# kwarg). Non-streaming parses iff explicit markers are present; the
+# streaming paths latch the parser on when a marker appears and emit only
+# the parsed content (reasoning is suppressed — the request disabled it).
+
+_GEMMA_OUTPUT = "<|channel>thought\nLet me think.<channel|>The answer is 42."
+_GEMMA_DELTAS = (
+    "<|channel>thought\n",
+    "Let me think.",
+    "<channel|>",
+    "The answer is 42.",
+)
+
+
+def _gemma_parser():
+    from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+
+    return Gemma4ReasoningParser()
+
+
+def test_extract_reasoning_parses_explicit_markers_when_thinking_disabled():
+    saved = srv._reasoning_parser
+    srv._reasoning_parser = _gemma_parser()
+    try:
+        reasoning, content, tool_calls = srv._extract_reasoning_and_tool_calls(
+            _GEMMA_OUTPUT, None, allow_reasoning=False
+        )
+    finally:
+        srv._reasoning_parser = saved
+
+    assert tool_calls is None
+    assert content == "The answer is 42."
+    assert reasoning and "Let me think." in reasoning
+    assert "<|channel>" not in content and "<channel|>" not in content
+
+
+def test_extract_reasoning_stays_disabled_without_markers():
+    # No explicit markers: the parser must remain skipped so implicit-mode
+    # parsers can't swallow plain content into reasoning (PR #537 hazard).
+    saved = srv._reasoning_parser
+    srv._reasoning_parser = _gemma_parser()
+    try:
+        reasoning, content, _ = srv._extract_reasoning_and_tool_calls(
+            "Plain answer.", None, allow_reasoning=False
+        )
+    finally:
+        srv._reasoning_parser = saved
+
+    assert reasoning is None
+    assert content == "Plain answer."
+
+
+@pytest.mark.anyio
+async def test_stream_anthropic_strips_markers_when_thinking_disabled():
+    async def fake_stream_chat(messages, **kwargs):
+        for piece in _GEMMA_DELTAS:
+            yield SimpleNamespace(new_text=piece, prompt_tokens=4, completion_tokens=1)
+
+    engine = MagicMock(stream_chat=fake_stream_chat)
+    msgs = [{"role": "user", "content": "What is the answer?"}]
+    openai_request = srv.ChatCompletionRequest(
+        model="test-model", messages=[srv.Message(**msgs[0])], max_tokens=8
+    )
+    anthropic_request = srv.AnthropicRequest(
+        model="test-model", max_tokens=8, messages=msgs
+    )
+    prepared = srv.PreparedChatInvocation(
+        messages=msgs,
+        chat_kwargs={"chat_template_kwargs": {"enable_thinking": False}},
+        response_format=None,
+        json_logits_processor=None,
+    )
+
+    saved = (srv._reasoning_parser, srv._model_name)
+    srv._reasoning_parser, srv._model_name = _gemma_parser(), "test-model"
+    try:
+        body = "".join(
+            [
+                c
+                async for c in srv._stream_anthropic_messages(
+                    engine, openai_request, anthropic_request, prepared
+                )
+            ]
+        )
+    finally:
+        srv._reasoning_parser, srv._model_name = saved
+
+    # Raw markers and the thought text must not reach the text block.
+    assert "<|channel>" not in body and "<channel|>" not in body
+    assert "Let me think." not in body
+    # Thinking was disabled — no thinking block, only cleaned content.
+    assert "thinking_delta" not in body
+    assert "The answer is 42." in body
+    assert '"type": "text_delta"' in body
+
+
+@pytest.mark.anyio
+async def test_stream_chat_completion_strips_markers_when_thinking_disabled():
+    import json as _json
+
+    async def fake_stream_chat(messages, **kwargs):
+        for i, piece in enumerate(_GEMMA_DELTAS):
+            yield SimpleNamespace(
+                new_text=piece,
+                prompt_tokens=4,
+                completion_tokens=i + 1,
+                finished=i == len(_GEMMA_DELTAS) - 1,
+                finish_reason="stop" if i == len(_GEMMA_DELTAS) - 1 else None,
+            )
+
+    engine = MagicMock(stream_chat=fake_stream_chat)
+    request = srv.ChatCompletionRequest(
+        model="test-model",
+        messages=[srv.Message(role="user", content="What is the answer?")],
+        max_tokens=8,
+    )
+
+    saved = (srv._reasoning_parser, srv._model_name)
+    srv._reasoning_parser, srv._model_name = _gemma_parser(), "test-model"
+    try:
+        chunks = [
+            c
+            async for c in srv.stream_chat_completion(
+                engine,
+                request.messages,
+                request,
+                chat_template_kwargs={"enable_thinking": False},
+            )
+        ]
+    finally:
+        srv._reasoning_parser, srv._model_name = saved
+
+    body = "".join(chunks)
+    assert "<|channel>" not in body and "<channel|>" not in body
+
+    contents, reasonings = [], []
+    for line in body.splitlines():
+        if not line.startswith("data: ") or line == "data: [DONE]":
+            continue
+        delta = _json.loads(line[len("data: ") :])["choices"][0]["delta"]
+        if delta.get("content"):
+            contents.append(delta["content"])
+        if delta.get("reasoning"):
+            reasonings.append(delta["reasoning"])
+
+    assert "".join(contents) == "The answer is 42."
+    assert reasonings == []  # reasoning suppressed when thinking disabled

--- a/tests/test_collect_eos_token_ids.py
+++ b/tests/test_collect_eos_token_ids.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for collect_eos_token_ids — the shared EOS/stop-token-set helper.
+
+Regression context: the SimpleEngine MLLM text route passed the raw HF
+processor tokenizer to mlx_lm.stream_generate, which defaults its stop set
+to {tokenizer.eos_token_id} — dropping turn terminators that chat models
+declare only in the config EOS list (Gemma 4: <turn|>=106,
+<|tool_response>=50). Generation then ran straight through end-of-turn
+until max_tokens on every request.
+"""
+
+import json
+
+from vllm_mlx.utils.tokenizer import collect_eos_token_ids
+
+
+class FakeTokenizer:
+    def __init__(self, eos_token_id=None, eos_token_ids=None, name_or_path=None):
+        if eos_token_id is not None:
+            self.eos_token_id = eos_token_id
+        if eos_token_ids is not None:
+            self.eos_token_ids = eos_token_ids
+        if name_or_path is not None:
+            self.name_or_path = name_or_path
+
+
+def _write_config(path, name, eos):
+    (path / name).write_text(json.dumps({"eos_token_id": eos}))
+
+
+def test_tokenizer_int_eos_only():
+    assert collect_eos_token_ids(FakeTokenizer(eos_token_id=2)) == {2}
+
+
+def test_tokenizer_list_eos():
+    assert collect_eos_token_ids(FakeTokenizer(eos_token_id=[2, 7])) == {2, 7}
+
+
+def test_wrapper_eos_token_ids_attr():
+    tok = FakeTokenizer(eos_token_id=2, eos_token_ids={2, 5})
+    assert collect_eos_token_ids(tok) == {2, 5}
+
+
+def test_no_eos_anywhere_returns_empty():
+    assert collect_eos_token_ids(FakeTokenizer()) == set()
+
+
+def test_gemma4_config_eos_list_unioned(tmp_path):
+    """The bug: <turn|>=106 / <|tool_response>=50 live only in the config."""
+    _write_config(tmp_path, "config.json", [1, 106, 50])
+    tok = FakeTokenizer(eos_token_id=1)
+    assert collect_eos_token_ids(tok, tmp_path) == {1, 106, 50}
+
+
+def test_generation_config_eos_unioned(tmp_path):
+    _write_config(tmp_path, "generation_config.json", [1, 106])
+    tok = FakeTokenizer(eos_token_id=1)
+    assert collect_eos_token_ids(tok, tmp_path) == {1, 106}
+
+
+def test_both_configs_unioned(tmp_path):
+    _write_config(tmp_path, "config.json", [1, 106])
+    _write_config(tmp_path, "generation_config.json", [1, 50])
+    tok = FakeTokenizer(eos_token_id=1)
+    assert collect_eos_token_ids(tok, tmp_path) == {1, 50, 106}
+
+
+def test_model_path_falls_back_to_name_or_path(tmp_path):
+    _write_config(tmp_path, "config.json", [1, 106, 50])
+    tok = FakeTokenizer(eos_token_id=1, name_or_path=str(tmp_path))
+    assert collect_eos_token_ids(tok) == {1, 106, 50}
+
+
+def test_scalar_config_eos(tmp_path):
+    _write_config(tmp_path, "generation_config.json", 7)
+    assert collect_eos_token_ids(FakeTokenizer(), tmp_path) == {7}
+
+
+def test_corrupt_config_ignored(tmp_path):
+    (tmp_path / "config.json").write_text("{not json")
+    tok = FakeTokenizer(eos_token_id=2)
+    assert collect_eos_token_ids(tok, tmp_path) == {2}
+
+
+def test_missing_model_path_ok():
+    tok = FakeTokenizer(eos_token_id=2)
+    assert collect_eos_token_ids(tok, "/nonexistent/path") == {2}

--- a/tests/test_collect_eos_token_ids.py
+++ b/tests/test_collect_eos_token_ids.py
@@ -85,3 +85,29 @@ def test_corrupt_config_ignored(tmp_path):
 def test_missing_model_path_ok():
     tok = FakeTokenizer(eos_token_id=2)
     assert collect_eos_token_ids(tok, "/nonexistent/path") == {2}
+
+
+def test_mllm_scheduler_batched_path_pins_gemma4_stop_set(tmp_path):
+    """Pin the Gemma 4 stop set {1, 106, 50} through the batched path.
+
+    Behavioral change vs the old MLLMScheduler._get_stop_tokens: that
+    implementation read only generation_config.json, while the shared
+    helper also reads config.json — Gemma 4 (MLX export) declares
+    eos_token_id [1, 106, 50] in config.json only. Models that list extra
+    ids (e.g. pad/bos) in the config EOS set now stop on tokens the
+    batched path previously ignored; that union is the point of the fix.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+    _write_config(tmp_path, "config.json", [1, 106, 50])
+    tokenizer = FakeTokenizer(eos_token_id=1, name_or_path=str(tmp_path))
+
+    # Processor wrapping a tokenizer (the usual MLLM shape)
+    scheduler = SimpleNamespace(processor=SimpleNamespace(tokenizer=tokenizer))
+    assert MLLMScheduler._get_stop_tokens(scheduler) == {1, 106, 50}
+
+    # Bare tokenizer as processor (no .tokenizer attribute)
+    scheduler = SimpleNamespace(processor=tokenizer)
+    assert MLLMScheduler._get_stop_tokens(scheduler) == {1, 106, 50}

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1469,7 +1469,14 @@ class TestSimpleEngineConcurrency:
             await engine.start()
 
         assert engine._text_model is text_model
-        assert engine._text_tokenizer is tokenizer
+        # The text route wraps the processor tokenizer with the model's
+        # full EOS set; the wrapper must delegate to the original.
+        from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+        assert isinstance(engine._text_tokenizer, TokenizerWrapper)
+        assert engine._text_tokenizer._tokenizer is tokenizer
+        # Qwen3 <|im_end|> fix feeds the wrapper's stop set
+        assert 42 in engine._text_tokenizer.eos_token_ids
 
     @pytest.mark.anyio
     async def test_mllm_nonstream_text_only_routes_without_mtp(self):

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -477,7 +477,7 @@ class SimpleEngine(BaseEngine):
                     )
 
                     if self._text_model is not None:
-                        self._text_tokenizer = self._model.get_tokenizer()
+                        raw_tokenizer = self._model.get_tokenizer()
                         self._supports_system_kv_cache = (
                             self._probe_system_kv_cache_support(
                                 self._text_model,
@@ -487,10 +487,35 @@ class SimpleEngine(BaseEngine):
 
                         # Apply Qwen3.5 eos_token fix (matches MLXLanguageModel.load)
                         if "qwen3" in self._model_name.lower():
-                            self._text_tokenizer.eos_token = "<|im_end|>"
-                            self._text_tokenizer.eos_token_id = (
-                                self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
+                            raw_tokenizer.eos_token = "<|im_end|>"
+                            raw_tokenizer.eos_token_id = (
+                                raw_tokenizer.convert_tokens_to_ids("<|im_end|>")
                             )
+
+                        # Wrap with the full EOS set (tokenizer attrs +
+                        # config.json + generation_config.json). Passing the
+                        # raw HF tokenizer to mlx_lm.stream_generate makes it
+                        # wrap with eos_token_ids={tokenizer.eos_token_id},
+                        # dropping turn terminators declared only in the
+                        # config EOS list (Gemma 4's <turn|>=106,
+                        # <|tool_response>=50) — the model then generates
+                        # straight through end-of-turn until max_tokens.
+                        # Mirrors MLLMScheduler stop-token handling on the
+                        # batched path.
+                        from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+                        from ..utils.tokenizer import collect_eos_token_ids
+
+                        eos_ids = collect_eos_token_ids(
+                            raw_tokenizer, self._model_name
+                        )
+                        self._text_tokenizer = TokenizerWrapper(
+                            raw_tokenizer,
+                            eos_token_ids=eos_ids or None,
+                        )
+                        logger.info(
+                            "Text route stop tokens: %s", sorted(eos_ids)
+                        )
 
                         # Probe the derived TextModel's prompt cache for snapshot-safety
                         # (same gate stream_chat uses for the pure-LLM path).
@@ -2043,11 +2068,9 @@ class SimpleEngine(BaseEngine):
         prompt_to_send = full_prompt  # Default: send full prompt text
         cache_hit = False
         system_token_count = 0
-        full_token_count = 0
         system_hash = None
         system_tokens = None
         suffix_tokens = None
-        full_tokens_list = None
         cache_blocking_controls = []
         if not self._supports_system_kv_cache:
             cache_blocking_controls.append("non_kv_cache_class")
@@ -2058,6 +2081,18 @@ class SimpleEngine(BaseEngine):
                 "uncached path",
                 cache_blocking_controls,
             )
+
+        # Tokenize the full prompt up front so usage.prompt_tokens is always
+        # reported. Previously this only happened inside the system-KV-cache
+        # branch (which requires a system message AND ChatML markers) or for
+        # specprefill — every other request reported prompt_tokens=0.
+        _add_special = self._text_tokenizer.bos_token is None or not (
+            full_prompt.startswith(self._text_tokenizer.bos_token)
+        )
+        full_tokens_list = self._text_tokenizer.encode(
+            full_prompt, add_special_tokens=_add_special
+        )
+        full_token_count = len(full_tokens_list)
 
         # Extract system messages for caching
         has_system = any(m.get("role") == "system" for m in messages)
@@ -2079,18 +2114,10 @@ class SimpleEngine(BaseEngine):
                     :16
                 ]
 
-                # Tokenize both (matching stream_generate's tokenization logic)
-                tokenizer = self._text_tokenizer
-                add_special = tokenizer.bos_token is None or not full_prompt.startswith(
-                    tokenizer.bos_token
-                )
-                full_tokens_list = tokenizer.encode(
-                    full_prompt, add_special_tokens=add_special
-                )
-                full_token_count = len(full_tokens_list)
-
-                system_tokens_list = tokenizer.encode(
-                    system_prefix_text, add_special_tokens=add_special
+                # Tokenize the system prefix (full prompt is tokenized above,
+                # matching stream_generate's tokenization logic)
+                system_tokens_list = self._text_tokenizer.encode(
+                    system_prefix_text, add_special_tokens=_add_special
                 )
                 system_token_count = len(system_tokens_list)
 
@@ -2175,18 +2202,8 @@ class SimpleEngine(BaseEngine):
         else:
             use_specprefill = self._draft_model is not None
 
-        # For specprefill, ensure we have token IDs (not just prompt text)
-        if use_specprefill and suffix_tokens is None and full_tokens_list is None:
-            tokenizer = self._text_tokenizer
-            add_special = tokenizer.bos_token is None or not full_prompt.startswith(
-                tokenizer.bos_token
-            )
-            full_tokens_list = tokenizer.encode(
-                full_prompt, add_special_tokens=add_special
-            )
-            full_token_count = len(full_tokens_list)
-
         # Tokens for specprefill: suffix (if system KV) or full prompt
+        # (full_tokens_list is always populated by the up-front tokenization)
         specprefill_tokens = (
             suffix_tokens if suffix_tokens is not None else full_tokens_list
         )

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -506,16 +506,12 @@ class SimpleEngine(BaseEngine):
 
                         from ..utils.tokenizer import collect_eos_token_ids
 
-                        eos_ids = collect_eos_token_ids(
-                            raw_tokenizer, self._model_name
-                        )
+                        eos_ids = collect_eos_token_ids(raw_tokenizer, self._model_name)
                         self._text_tokenizer = TokenizerWrapper(
                             raw_tokenizer,
                             eos_token_ids=eos_ids or None,
                         )
-                        logger.info(
-                            "Text route stop tokens: %s", sorted(eos_ids)
-                        )
+                        logger.info("Text route stop tokens: %s", sorted(eos_ids))
 
                         # Probe the derived TextModel's prompt cache for snapshot-safety
                         # (same gate stream_chat uses for the pure-LLM path).

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -506,7 +506,7 @@ class SimpleEngine(BaseEngine):
 
                         from ..utils.tokenizer import collect_eos_token_ids
 
-                        eos_ids = collect_eos_token_ids(raw_tokenizer, self._model_name)
+                        eos_ids = collect_eos_token_ids(raw_tokenizer)
                         self._text_tokenizer = TokenizerWrapper(
                             raw_tokenizer,
                             eos_token_ids=eos_ids or None,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -243,46 +243,19 @@ class MLLMScheduler:
         self._clear_cache_interval = 32
 
     def _get_stop_tokens(self) -> Set[int]:
-        """Get stop token IDs from tokenizer and generation_config.json."""
-        stop_tokens = set()
+        """Get stop token IDs from tokenizer and config/generation_config.
+
+        (e.g., Gemma 4 has <turn|>=106, <|tool_response>=50 as EOS, declared
+        only in the config EOS list — never as ``tokenizer.eos_token``.)
+        """
+        from .utils.tokenizer import collect_eos_token_ids
+
         tokenizer = (
             self.processor.tokenizer
             if hasattr(self.processor, "tokenizer")
             else self.processor
         )
-
-        if hasattr(tokenizer, "eos_token_id") and tokenizer.eos_token_id is not None:
-            if isinstance(tokenizer.eos_token_id, list):
-                stop_tokens.update(tokenizer.eos_token_id)
-            else:
-                stop_tokens.add(tokenizer.eos_token_id)
-
-        if hasattr(tokenizer, "eos_token_ids") and tokenizer.eos_token_ids is not None:
-            if isinstance(tokenizer.eos_token_ids, (list, set, tuple)):
-                stop_tokens.update(tokenizer.eos_token_ids)
-            else:
-                stop_tokens.add(tokenizer.eos_token_ids)
-
-        # Also read generation_config.json which may have additional EOS tokens
-        # (e.g., Gemma 4 has <turn|>=106, <|tool_response>=50 as EOS)
-        model_path = getattr(tokenizer, "name_or_path", None)
-        if model_path:
-            import json
-            from pathlib import Path
-
-            gc_path = Path(model_path) / "generation_config.json"
-            if gc_path.exists():
-                try:
-                    gc = json.loads(gc_path.read_text())
-                    gc_eos = gc.get("eos_token_id")
-                    if isinstance(gc_eos, list):
-                        stop_tokens.update(gc_eos)
-                    elif gc_eos is not None:
-                        stop_tokens.add(gc_eos)
-                except Exception:
-                    pass
-
-        return stop_tokens
+        return collect_eos_token_ids(tokenizer)
 
     def _ensure_batch_generator(self) -> None:
         """Ensure batch generator exists."""

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2841,6 +2841,21 @@ def _extract_reasoning_and_tool_calls(
     reasoning_text = None
     text_for_tool_parse = output_text
 
+    if _reasoning_parser and not allow_reasoning:
+        # Thinking is disabled for this request, but models can open an
+        # explicit reasoning block regardless (Gemma 4 emits
+        # <|channel>thought even when the template disables thinking).
+        # The allow_reasoning gate exists to keep implicit-thinking
+        # parsers from swallowing plain content into reasoning — with
+        # explicit markers present that hazard cannot occur, while
+        # skipping the parser leaks the raw markers into content.
+        # Parse iff markers are present.
+        start = getattr(_reasoning_parser, "start_token", None)
+        end = getattr(_reasoning_parser, "end_token", None)
+        allow_reasoning = bool(
+            (start and start in output_text) or (end and end in output_text)
+        )
+
     if _reasoning_parser and allow_reasoning:
         reasoning_text, cleaned_reasoning_text = _reasoning_parser.extract_reasoning(
             output_text

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2523,6 +2523,15 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
     if _reasoning_parser:
         _reasoning_parser.reset_state()
 
+    # Streaming counterpart of the explicit-marker guard in
+    # _extract_reasoning_and_tool_calls: with thinking disabled the parser
+    # stays off until the model emits an explicit reasoning marker; from
+    # that point deltas are parsed so raw markers don't leak into the text
+    # output. Parsed reasoning is suppressed — the request disabled
+    # thinking, so only cleaned content is emitted.
+    thinking_off = _thinking_disabled(request, chat_kwargs)
+    disabled_reasoning_latched = False
+
     global _tool_parser_instance
     tool_parser = None
     tool_accumulated_text = ""
@@ -2562,14 +2571,21 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if _reasoning_parser and not _thinking_disabled(request, chat_kwargs):
+        if (
+            thinking_off
+            and not disabled_reasoning_latched
+            and _explicit_reasoning_markers_present(raw_accumulated_text)
+        ):
+            disabled_reasoning_latched = True
+
+        if _reasoning_parser and (not thinking_off or disabled_reasoning_latched):
             delta_msg = _reasoning_parser.extract_reasoning_streaming(
                 previous_text, raw_accumulated_text, delta_text
             )
             if delta_msg is None:
                 continue
 
-            if delta_msg.reasoning:
+            if delta_msg.reasoning and not thinking_off:
                 for event in _start_reasoning_item():
                     yield event
                 accumulated_reasoning += delta_msg.reasoning
@@ -2822,6 +2838,27 @@ def _responses_sse_event(event_type: str, payload: BaseModel | dict) -> str:
     return f"event: {event_type}\ndata: {data}\n\n"
 
 
+def _explicit_reasoning_markers_present(text: str) -> bool:
+    """
+    True when the active reasoning parser's explicit start/end markers
+    appear in ``text``.
+
+    The allow_reasoning gate (PR #537) exists to keep implicit-thinking
+    parsers from swallowing plain content into reasoning when thinking is
+    disabled. But models can open an explicit reasoning block regardless of
+    the template kwarg (Gemma 4 emits <|channel>thought even when thinking
+    is disabled) — with explicit markers present the implicit-swallowing
+    hazard cannot occur, while skipping the parser leaks the raw markers
+    into content. Non-streaming checks the complete output; streaming paths
+    use this as a latch on the accumulated raw text.
+    """
+    if not _reasoning_parser:
+        return False
+    start = getattr(_reasoning_parser, "start_token", None)
+    end = getattr(_reasoning_parser, "end_token", None)
+    return bool((start and start in text) or (end and end in text))
+
+
 def _extract_reasoning_and_tool_calls(
     output_text: str,
     request: ChatCompletionRequest | None = None,
@@ -2842,19 +2879,10 @@ def _extract_reasoning_and_tool_calls(
     text_for_tool_parse = output_text
 
     if _reasoning_parser and not allow_reasoning:
-        # Thinking is disabled for this request, but models can open an
-        # explicit reasoning block regardless (Gemma 4 emits
-        # <|channel>thought even when the template disables thinking).
-        # The allow_reasoning gate exists to keep implicit-thinking
-        # parsers from swallowing plain content into reasoning — with
-        # explicit markers present that hazard cannot occur, while
-        # skipping the parser leaks the raw markers into content.
-        # Parse iff markers are present.
-        start = getattr(_reasoning_parser, "start_token", None)
-        end = getattr(_reasoning_parser, "end_token", None)
-        allow_reasoning = bool(
-            (start and start in output_text) or (end and end in output_text)
-        )
+        # Thinking is disabled, but the model opened an explicit reasoning
+        # block anyway — parse iff markers are present (see
+        # _explicit_reasoning_markers_present).
+        allow_reasoning = _explicit_reasoning_markers_present(output_text)
 
     if _reasoning_parser and allow_reasoning:
         reasoning_text, cleaned_reasoning_text = _reasoning_parser.extract_reasoning(
@@ -5614,13 +5642,22 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
-    use_reasoning = (
-        _reasoning_parser is not None
-        and not chat_kwargs.get("logits_processors")
-        and not _thinking_disabled(openai_request, chat_kwargs)
+    parser_eligible = _reasoning_parser is not None and not chat_kwargs.get(
+        "logits_processors"
     )
+    thinking_off = _thinking_disabled(openai_request, chat_kwargs)
+    use_reasoning = parser_eligible and not thinking_off
 
-    if use_reasoning:
+    # Streaming counterpart of the explicit-marker guard in
+    # _extract_reasoning_and_tool_calls: with thinking disabled the parser
+    # stays off until the model emits an explicit reasoning marker; from
+    # that point deltas are parsed so raw markers don't leak into the text
+    # block. Parsed reasoning is suppressed — the request disabled
+    # thinking, so only cleaned content is emitted into the already-open
+    # text block (no thinking block is started).
+    disabled_reasoning_latched = False
+
+    if parser_eligible:
         _reasoning_parser.reset_state()
 
     # Block index tracking: with reasoning parser we use index 0 for
@@ -5667,7 +5704,15 @@ async def _stream_anthropic_messages(
             if not filtered:
                 continue
 
-            if not use_reasoning:
+            if (
+                parser_eligible
+                and thinking_off
+                and not disabled_reasoning_latched
+                and _explicit_reasoning_markers_present(accumulated_text + filtered)
+            ):
+                disabled_reasoning_latched = True
+
+            if not (use_reasoning or disabled_reasoning_latched):
                 # Simple path — no reasoning parsing
                 accumulated_text += filtered
                 content_to_emit = filtered
@@ -5713,7 +5758,7 @@ async def _stream_anthropic_messages(
             if delta_msg is None:
                 continue
 
-            if delta_msg.reasoning:
+            if delta_msg.reasoning and not thinking_off:
                 if not thinking_block_started:
                     yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': thinking_index, 'content_block': {'type': 'thinking', 'thinking': ''}})}\n\n"
                     thinking_block_started = True
@@ -5972,6 +6017,19 @@ async def stream_chat_completion(
     # Track accumulated text for reasoning parser
     accumulated_text = ""
 
+    # Raw engine output accumulated across all deltas (the reasoning branch
+    # below only updates accumulated_text when it runs, so it can't serve as
+    # full-stream context). Used as parser context and for the
+    # disabled-thinking marker latch: the streaming counterpart of the
+    # explicit-marker guard in _extract_reasoning_and_tool_calls. With
+    # thinking disabled the parser stays off until the model emits an
+    # explicit reasoning marker; from that point deltas are parsed so raw
+    # markers don't leak into content. Parsed reasoning is suppressed — the
+    # request disabled thinking, so only cleaned content is emitted.
+    raw_stream_text = ""
+    thinking_off = _thinking_disabled(request, kwargs)
+    disabled_reasoning_latched = False
+
     # Track token counts for usage reporting
     prompt_tokens = 0
     completion_tokens = 0
@@ -6013,18 +6071,28 @@ async def stream_chat_completion(
             if hasattr(output, "completion_tokens") and output.completion_tokens:
                 completion_tokens = output.completion_tokens
 
+            if _reasoning_parser and delta_text:
+                previous_raw = raw_stream_text
+                raw_stream_text += delta_text
+                if (
+                    thinking_off
+                    and not disabled_reasoning_latched
+                    and _explicit_reasoning_markers_present(raw_stream_text)
+                ):
+                    disabled_reasoning_latched = True
+
             # Use reasoning parser if enabled (skip when enable_thinking=False
             # is set either on the request or via the resolved chat template
-            # kwargs / server default).
+            # kwargs / server default — unless the disabled-thinking marker
+            # latch above has fired).
             if (
                 _reasoning_parser
                 and delta_text
-                and not _thinking_disabled(request, kwargs)
+                and (not thinking_off or disabled_reasoning_latched)
             ):
-                previous_text = accumulated_text
                 accumulated_text += delta_text
                 delta_msg = _reasoning_parser.extract_reasoning_streaming(
-                    previous_text, accumulated_text, delta_text
+                    previous_raw, raw_stream_text, delta_text
                 )
 
                 if delta_msg is None:
@@ -6050,6 +6118,13 @@ async def stream_chat_completion(
                     ):
                         content = reasoning
                         reasoning = None
+
+                if thinking_off and reasoning:
+                    # The request disabled thinking — surface only parsed
+                    # content; drop reasoning the model emitted anyway.
+                    reasoning = None
+                    if not content:
+                        continue
 
                 # Tool call parsing on content portion
                 if tool_parser and content:

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -28,6 +28,60 @@ def _needs_tokenizer_fallback(model_name: str) -> bool:
     return any(pattern.lower() in model_lower for pattern in FALLBACK_MODELS)
 
 
+def collect_eos_token_ids(tokenizer, model_path=None) -> set:
+    """Collect the full EOS/stop token-id set for a model.
+
+    Unions every place an EOS id can be declared:
+    - ``tokenizer.eos_token_id`` (int or list)
+    - ``tokenizer.eos_token_ids`` (mlx_lm TokenizerWrapper attribute)
+    - ``config.json`` / ``generation_config.json`` ``eos_token_id``
+
+    Chat models routinely declare turn terminators only in the config EOS
+    list, not as the tokenizer's single ``eos_token`` (e.g. Gemma 4 ends
+    chat turns with ``<turn|>``=106 and tool responses with
+    ``<|tool_response>``=50 while ``tokenizer.eos_token`` stays ``<eos>``=1).
+    Generating with only ``{tokenizer.eos_token_id}`` makes such models run
+    straight through end-of-turn until max_tokens.
+
+    Args:
+        tokenizer: HF tokenizer (or processor.tokenizer) to read attributes
+            from.
+        model_path: Model directory containing the config files. Falls back
+            to ``tokenizer.name_or_path`` when omitted.
+
+    Returns:
+        Set of EOS token ids; may be empty if nothing is declared anywhere.
+    """
+    eos_ids = set()
+
+    for attr in ("eos_token_id", "eos_token_ids"):
+        value = getattr(tokenizer, attr, None)
+        if value is None:
+            continue
+        if isinstance(value, (list, set, tuple)):
+            eos_ids.update(int(v) for v in value)
+        else:
+            eos_ids.add(int(value))
+
+    if model_path is None:
+        model_path = getattr(tokenizer, "name_or_path", None)
+    if model_path:
+        for config_name in ("config.json", "generation_config.json"):
+            config_path = Path(model_path) / config_name
+            if not config_path.exists():
+                continue
+            try:
+                config_eos = json.loads(config_path.read_text()).get("eos_token_id")
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(config_eos, list):
+                eos_ids.update(int(v) for v in config_eos)
+            elif config_eos is not None:
+                eos_ids.add(int(config_eos))
+
+    return eos_ids
+
+
 def _needs_strict_false(model_name: str) -> bool:
     """Check if model needs strict=False loading (VLM models with extra weights).
 


### PR DESCRIPTION
## Problem

On the SimpleEngine MLLM text route (`text-only -> mlx_lm TextModel`), generation never stops at the model's chat end-of-turn token. The route passes the raw HF processor tokenizer to `mlx_lm.stream_generate`, which wraps it with `eos_token_ids={tokenizer.eos_token_id}` — dropping turn terminators that chat models declare only in the config EOS list.

Gemma 4 is the clearest case: `config.json` declares `eos_token_id: [1, 106, 50]`, where `<turn|>`=106 terminates chat turns and `<|tool_response>`=50 terminates tool responses, while `tokenizer.eos_token` stays `<eos>`=1. The model emits 106, the sampler doesn't stop, the marker detokenizes into visible text, and generation free-runs until `max_tokens` — every text-route response ends with `finish_reason: "length"` and trailing garbage:

```
<|channel>thought
<channel|>Yes, there is a file named `asitop_powermetrics…` in /tmp.<turn|>
C'est parti ! On va s'occuper de ton projet de site web. …   ← free-running
```

The hard-coded Qwen3.5 `<|im_end|>` patch already in that block is this same bug, previously fixed per-model.

Two adjacent defects in the same path, included here because they surface in the same repro:

- **`usage.prompt_tokens` is 0** on the text route unless the system-KV-cache branch (requires a system message *and* ChatML `<|im_start|>` markers — never true for Gemma templates) or specprefill happens to run.
- **Reasoning markers leak into `content` when thinking is disabled.** The `allow_reasoning` gate (#537) skips the reasoning parser entirely under `enable_thinking=false`, but Gemma 4 opens `<|channel>thought` regardless, so raw channel markers end up in `message.content`.

## Fix

1. **`collect_eos_token_ids()`** (new, `utils/tokenizer.py`): unions `tokenizer.eos_token_id` / `.eos_token_ids` with the `config.json` + `generation_config.json` EOS lists. The text route now wraps its tokenizer in `mlx_lm.TokenizerWrapper` with that set. `MLLMScheduler._get_stop_tokens` (the batched path) is refactored onto the same helper.

   ⚠️ **Behavioral change on the batched path**: the old `_get_stop_tokens` read only `generation_config.json`; the shared helper also reads `config.json`. Models that list extra ids (e.g. pad/bos) in the config EOS set will now stop on tokens the batched path previously ignored — that union is the point of the fix. The Gemma 4 set `{1, 106, 50}` is pinned through `MLLMScheduler._get_stop_tokens` in `tests/test_collect_eos_token_ids.py`.

2. **Up-front prompt tokenization** in `_stream_generate_text` so `usage.prompt_tokens` is always reported; the system-KV and specprefill branches reuse the tokens instead of re-encoding.

3. **Refined `allow_reasoning` gate — non-streaming and streaming**:
   - Non-streaming: when thinking is disabled, run `extract_reasoning` iff the parser's explicit start/end markers are present in the output. With explicit markers, the implicit-thinking-swallows-content hazard #537 guards against cannot occur; without them, behavior is unchanged.
   - Streaming (chat completions, Anthropic messages, Responses): with thinking disabled the parser stays off until the model emits the parser's explicit marker in the accumulated raw stream; from that point deltas are routed through the parser. Parsed reasoning is suppressed (the request disabled thinking) and only cleaned content is emitted — this also keeps the Anthropic block choreography valid when the text block is already open. Implicit-thinking parsers without explicit marker attributes never latch, so #537 behavior is unchanged.

## Verification

Live against `gemma-4-31b-it` 4-bit MLX on SimpleEngine (M3 Ultra):

- Canonical 3-turn tool flow (`user → assistant(tool_call) → tool(long result)`): **before** — correct sentence, then `<turn|>` leak, then drift to the 256-token cap, `finish_reason: "length"`, `prompt_tokens: 0`; **after** — one-sentence answer, `finish_reason: "stop"`, 25 completion tokens, real `prompt_tokens`.
- Tool-call emission leg: `finish_reason: "tool_calls"` with well-formed `arguments`, `usage` populated.
- 12 hermetic unit tests for `collect_eos_token_ids` incl. the batched-path Gemma 4 pin (`tests/test_collect_eos_token_ids.py`).
- Marker-guard tests for the reasoning leak in both paths (`tests/test_chat_template_kwargs.py`): non-streaming extractor with/without markers, plus chat-completions and Anthropic streaming with Gemma 4 channel markers under `enable_thinking=false`. The streaming tests fail without the streaming commit.
- Rebased onto current `main` (post-#576); full suite: 2195 passed, 11 skipped.
