### PR TITLE
Keep assistant tool_calls and tool messages on the MLLM chat path

### DIFF
--- a/tests/test_mllm_message_ordering.py
+++ b/tests/test_mllm_message_ordering.py
@@ -1,3 +1,5 @@
+import json
+
 from vllm_mlx.models.mllm import _build_mllm_chat_messages
 
 
@@ -108,3 +110,152 @@ def test_mllm_chat_messages_preserve_audio_text_order():
         },
     ]
     assert all_image_urls == []
+
+
+def test_mllm_chat_messages_keep_assistant_tool_calls_without_text():
+    # Issue #608: the standard OpenAI shape for an assistant tool-call turn is
+    # {content: None, tool_calls: [...]} and it must not be dropped.
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": "Lima"}',
+                    },
+                }
+            ],
+            "reasoning_content": "User wants the weather.",
+        }
+    ]
+
+    chat_messages = _build_mllm_chat_messages(
+        messages,
+        all_image_urls=[],
+        video_frame_counts={},
+    )
+
+    assert chat_messages == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        # JSON argument strings are parsed to mappings for
+                        # templates that iterate argument keys.
+                        "arguments": {"city": "Lima"},
+                    },
+                }
+            ],
+            "reasoning_content": "User wants the weather.",
+        }
+    ]
+
+
+def test_mllm_chat_messages_keep_tool_call_id_on_tool_messages():
+    messages = [
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_c": 19}'}
+    ]
+
+    chat_messages = _build_mllm_chat_messages(
+        messages,
+        all_image_urls=[],
+        video_frame_counts={},
+    )
+
+    assert chat_messages == [
+        {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "text",
+                    "text": '{"temp_c": 19}',
+                    "content": '{"temp_c": 19}',
+                }
+            ],
+            "tool_call_id": "call_1",
+        }
+    ]
+
+
+def test_mllm_chat_messages_keep_empty_tool_results():
+    """Tools may return empty output; the anchored message must survive."""
+    for empty_content in ("", None):
+        messages = [
+            {"role": "tool", "tool_call_id": "call_1", "content": empty_content}
+        ]
+
+        chat_messages = _build_mllm_chat_messages(
+            messages,
+            all_image_urls=[],
+            video_frame_counts={},
+        )
+
+        assert chat_messages == [
+            {"role": "tool", "content": "", "tool_call_id": "call_1"}
+        ]
+
+
+def test_mllm_chat_messages_keep_tool_exchange():
+    fresh = [
+        {"role": "system", "content": "You can call tools."},
+        {"role": "user", "content": "What is the weather in Lima?"},
+    ]
+    tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city": "Lima"}'},
+    }
+    continuation = fresh + [
+        {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_c": 19}'},
+    ]
+
+    fresh_out = _build_mllm_chat_messages(
+        fresh, all_image_urls=[], video_frame_counts={}
+    )
+    cont_out = _build_mllm_chat_messages(
+        continuation, all_image_urls=[], video_frame_counts={}
+    )
+
+    # The 4-message tool exchange must render strictly more prompt content
+    # than the fresh exchange (issue #608: it rendered byte-identical).
+    assert len(cont_out) == len(fresh_out) + 2
+    assert json.dumps(cont_out, sort_keys=True) != json.dumps(fresh_out, sort_keys=True)
+    assert len(json.dumps(cont_out)) > len(json.dumps(fresh_out))
+
+    # Assistant tool_calls survive even with empty text content.
+    assistant_msg = cont_out[2]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    # Tool result keeps its anchor for template forward-scans.
+    tool_msg = cont_out[3]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == "call_1"
+
+
+def test_mllm_chat_messages_still_drop_empty_messages_without_tool_calls():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+        {"role": "assistant", "content": None},
+    ]
+
+    chat_messages = _build_mllm_chat_messages(
+        messages,
+        all_image_urls=[],
+        video_frame_counts={},
+    )
+
+    assert [msg["role"] for msg in chat_messages] == ["user"]
+    # Kept messages carry only the rebuilt role/content keys.
+    assert set(chat_messages[0]) == {"role", "content"}

--- a/tests/test_mllm_message_ordering.py
+++ b/tests/test_mllm_message_ordering.py
@@ -161,9 +161,7 @@ def test_mllm_chat_messages_keep_assistant_tool_calls_without_text():
 
 
 def test_mllm_chat_messages_keep_tool_call_id_on_tool_messages():
-    messages = [
-        {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_c": 19}'}
-    ]
+    messages = [{"role": "tool", "tool_call_id": "call_1", "content": '{"temp_c": 19}'}]
 
     chat_messages = _build_mllm_chat_messages(
         messages,

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -32,6 +32,7 @@ from urllib.parse import urljoin, urlparse
 import numpy as np
 import requests
 
+from vllm_mlx.engine.chat_template_safety import normalize_messages_for_chat_template
 from vllm_mlx.mllm_cache import MLLMPrefixCacheManager
 
 logger = logging.getLogger(__name__)
@@ -253,6 +254,20 @@ def _build_ordered_mllm_message_content(
     return built_parts, bool(built_parts)
 
 
+def _normalize_mllm_tool_calls(tool_calls: list) -> list:
+    """Normalize replayed assistant tool calls for chat templates.
+
+    Mirrors ``_normalize_tool_call_arguments_for_template`` in
+    ``vllm_mlx/engine/batched.py``: JSON argument strings become mappings so
+    templates that iterate argument keys render correctly.
+    """
+    plain_calls = [_normalize_content_part(call) for call in tool_calls]
+    normalized = normalize_messages_for_chat_template(
+        [{"role": "assistant", "tool_calls": plain_calls}]
+    )
+    return normalized[0].get("tool_calls", plain_calls)
+
+
 def _build_mllm_chat_messages(
     messages: list[dict],
     *,
@@ -272,8 +287,31 @@ def _build_mllm_chat_messages(
             all_image_urls=all_image_urls,
             video_frame_count=video_frame_counts.get(msg_idx, 0),
         )
+        chat_message = {"role": role, "content": content}
+
+        if role == "assistant":
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list) and tool_calls:
+                # Keep tool-call turns even when text content is empty so
+                # templates render the assistant -> tool exchange (issue #608).
+                chat_message["tool_calls"] = _normalize_mllm_tool_calls(tool_calls)
+                reasoning_content = msg.get("reasoning_content")
+                if reasoning_content:
+                    chat_message["reasoning_content"] = reasoning_content
+                has_content = True
+        elif role == "tool":
+            tool_call_id = msg.get("tool_call_id")
+            if tool_call_id:
+                chat_message["tool_call_id"] = tool_call_id
+                # Tools may legitimately return empty output; keep the message
+                # anyway so the assistant tool_call still has its anchor and
+                # template forward-scans pair calls to responses (issue #608).
+                if not has_content:
+                    chat_message["content"] = ""
+                    has_content = True
+
         if has_content:
-            chat_messages.append({"role": role, "content": content})
+            chat_messages.append(chat_message)
     return chat_messages
 
 


### PR DESCRIPTION
## Summary

Fixes #608. On the MLLM path, `_build_mllm_chat_messages` rebuilt every message as `{role, content}` and dropped any message without renderable text. An OpenAI assistant message with `content: null` + `tool_calls` was removed entirely, and `role:"tool"` messages lost their `tool_call_id`. The rendered continuation prompt came out byte-identical to the fresh prompt, so agent clients looped on the same tool call forever.

## What changed

All in `_build_mllm_chat_messages` (shared by `chat()` and `stream_chat()`, so both routes are covered with no call-site changes):

- Assistant messages carrying `tool_calls` survive even with empty text. Arguments are normalized str -> mapping via the same `normalize_messages_for_chat_template` helper the batched engine path wraps, so both paths render identically. `reasoning_content` is forwarded when present.
- `role:"tool"` messages keep their `tool_call_id`. Empty tool results (legit for action tools) survive with `content: ""` instead of being dropped, so template forward-scans can still pair calls to responses.
- Everything else is byte-identical to before: image/audio/video part ordering, plain-text messages, and the drop rule for genuinely empty messages (verified pre/post on the same inputs).

`SUPPORTS_NATIVE_TOOL_FORMAT` on `Gemma4ToolParser` (issue suggestion 3) is intentionally left out of scope.

## Tests

5 new regression tests in `tests/test_mllm_message_ordering.py` (written first, 3 failed on main for the exact bug reasons):

- assistant `{content: null, tool_calls}` survives with normalized arguments
- tool messages keep `tool_call_id` + content
- empty tool results survive with their anchor
- a 4-message tool exchange rebuilds strictly more messages than the fresh 3-message turn
- genuinely empty messages without `tool_calls` are still dropped

```
pytest tests/test_mllm_message_ordering.py -q   -> 8 passed
pytest tests/test_mllm*.py tests/test_server.py -> 256 passed
pytest tests/ -k "not slow"                     -> 2185 passed, 0 failed
ruff check                                       -> clean
```

## Live verification (issue repro)

Served `mlx-community/Qwen3-VL-8B-Instruct-4bit` with `--mllm --enable-auto-tool-choice --tool-call-parser hermes`, M4 Max:

- Probe A (fresh: system + user + 1 tool): tool_call emitted, `prompt_tokens = 166`
- Probe B (continuation: + assistant{content:null, tool_calls} + tool{result}): `prompt_tokens = 213 > 166` (history now contributes tokens), no repeated tool_call, final answer uses the tool result: "The weather in Paris is currently 19°C with sunny conditions."

On main, probe B renders the same prompt as probe A and re-issues the identical tool call.