### PR TITLE
fix(engine): preserve SimpleEngine wait admission

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -186,6 +186,18 @@ class TestSimpleEngineConcurrency:
             release.set()
             await first
 
+    def test_lock_admission_env_wait_is_preserved(self, monkeypatch):
+        """VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait keeps queued behavior."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        monkeypatch.setenv("VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION", "wait")
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+
+        assert engine._generation_lock_admission == "wait"
+        assert engine.get_stats()["generation_lock"]["admission"] == "wait"
+
     @pytest.mark.anyio
     async def test_blocking_serialized_tracks_active_request(self):
         """Busy errors include the current blocking serialized holder."""

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -225,7 +225,7 @@ class SimpleEngine(BaseEngine):
                 "Invalid VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=%r; using fail_fast",
                 self._generation_lock_admission,
             )
-        self._generation_lock_admission = "fail_fast"
+            self._generation_lock_admission = "fail_fast"
         self._generation_waiters = 0
         self._generation_busy_rejections = 0
 


### PR DESCRIPTION
## Summary

- Preserve `VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait` after `SimpleEngine` validates the env value.
- Add a regression test that checks both the internal admission mode and `get_stats()` reporting.

## Root cause

`SimpleEngine.__init__` read and validated `VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION`, but then unconditionally reassigned `_generation_lock_admission = "fail_fast"` immediately after the invalid-value warning block. That made the documented `wait` opt-in unreachable.

## Repro

Before the fix, this focused regression failed because the engine reported `fail_fast` even with the env set to `wait`:

```sh
VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait pytest tests/test_simple_engine.py::TestSimpleEngineConcurrency::test_lock_admission_env_wait_is_preserved -q
```

## Expected behavior

`VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait` should preserve queued admission behavior, while invalid values should still fall back to `fail_fast`.

## Validation

```sh
uv run --python 3.12 --extra dev --extra vision python -m pytest tests/test_simple_engine.py -q
uv run --python 3.12 --with ruff ruff check vllm_mlx/engine/simple.py tests/test_simple_engine.py --select E,F,W --ignore E402,E501,E731,F811,F841
uv run --python 3.12 --with black black --check vllm_mlx/engine/simple.py tests/test_simple_engine.py
git diff --check upstream/main..HEAD
```

## Not claimed

This does not address the separate streaming pre-admission probe question from the #540 follow-up comment. This PR only restores the existing `wait` env contract.
