### PR TITLE
fix(qwen): accept current attention kwargs in batch patch

### DIFF
--- a/tests/test_qwen35_mllm_patch.py
+++ b/tests/test_qwen35_mllm_patch.py
@@ -155,3 +155,26 @@ def test_qwen35_patch_recovers_from_stale_position_ids_between_requests(monkeypa
 
     assert out.shape[1] == 28
     assert call_log[-1] == {"q_len": 28, "cos_len": 28}
+
+
+def test_qwen35_patch_accepts_current_mlx_vlm_attention_kwargs(monkeypatch):
+    """Current mlx-vlm calls attention with position embeddings and target_verify."""
+    attention_cls, cache_cls, call_log = _install_fake_qwen35_modules(monkeypatch)
+
+    assert patch_qwen35_attention_for_batching() is True
+
+    attn = cast(Any, attention_cls())
+    x = mx.zeros((1, 13, 1024), dtype=mx.float32)
+    cache = cache_cls(offset=0)
+    cos = mx.ones((1, 13, 64), dtype=mx.float32)
+    sin = mx.zeros((1, 13, 64), dtype=mx.float32)
+
+    out = attn(
+        x,
+        cache=cache,
+        position_embeddings=(cos, sin),
+        target_verify=True,
+    )
+
+    assert out.shape[1] == 13
+    assert call_log[-1] == {"q_len": 13, "cos_len": 13}

--- a/vllm_mlx/patches/qwen3_5_mllm.py
+++ b/vllm_mlx/patches/qwen3_5_mllm.py
@@ -2,21 +2,28 @@
 """
 Runtime patch for mlx-vlm's Qwen3.5 attention to support BatchKVCache.
 
+Qwen 3.6 artifacts use the mlx-vlm Qwen3.5 language module in this stack.
+The attention patch therefore lives in the Qwen3.5 compatibility module while
+serving Qwen 3.6 27B/35B/122B artifacts.
+
 mlx-vlm's Qwen3_5Attention uses cache.offset directly for kv_seq_len
-computation and mask slicing.  BatchKVCache stores offset as mx.array
+computation and mask slicing. BatchKVCache stores offset as mx.array
 (per-batch-item), not int, causing:
 
     mask = mask[..., :kv_seq_len]
     ValueError: Slice indices must be integers or None.
 
-This patch replaces Qwen3_5Attention.__call__ with a version that
-converts cache.offset to int before using it for arithmetic/slicing,
-while leaving the actual cache.offset untouched so update_and_fetch
-still works correctly with per-batch offsets.
+This patch replaces Qwen3_5Attention.__call__ with a version that converts
+cache.offset to int before using it for arithmetic/slicing, while leaving the
+actual cache.offset untouched so update_and_fetch still works correctly with
+per-batch offsets.
 """
 
+from __future__ import annotations
+
+import importlib
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import mlx.core as mx
 
@@ -35,6 +42,105 @@ def _cache_offset_to_int(cache) -> int:
     return int(off)
 
 
+def _default_target_verify_linears(linears, x, target_verify: bool):
+    return tuple(linear(x) for linear in linears)
+
+
+def _default_target_verify_left_padded_attention(*args, **kwargs):
+    return None
+
+
+def _normalize_position_inputs(
+    position_ids: Optional[mx.array],
+    position_embeddings: Optional[tuple[mx.array, mx.array]],
+    length: int,
+) -> tuple[Optional[mx.array], Optional[tuple[mx.array, mx.array]]]:
+    if position_ids is None or position_ids.shape[-1] == length:
+        return position_ids, position_embeddings
+    logger.debug(
+        "[Qwen3.5 patch] Recomputing stale position_ids: got %s, expected %s",
+        position_ids.shape[-1],
+        length,
+    )
+    return None, None
+
+
+def _position_ids_for_offset(offset: int, length: int) -> mx.array:
+    position_ids = mx.arange(offset, offset + length)
+    position_ids = mx.expand_dims(position_ids, axis=0)
+    return mx.tile(position_ids, (3, 1, 1))
+
+
+def _kv_seq_len(keys: mx.array, cache: Optional[Any], offset: int) -> int:
+    length = keys.shape[-2]
+    return length + offset + 1 if cache is not None else length
+
+
+def _apply_rotary(
+    attention,
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    position_ids: mx.array,
+    position_embeddings: Optional[tuple[mx.array, mx.array]],
+    apply_multimodal_rotary_pos_emb,
+) -> tuple[mx.array, mx.array]:
+    if position_embeddings is not None:
+        cos, sin = position_embeddings
+        return apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
+
+    if hasattr(attention.rotary_emb, "apply_rotary"):
+        return attention.rotary_emb.apply_rotary(
+            queries,
+            keys,
+            position_ids,
+            unsqueeze_dim=1,
+        )
+
+    cos, sin = attention.rotary_emb(values, position_ids)
+    return apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
+
+
+def _slice_attention_mask(
+    mask: Optional[mx.array],
+    cache: Optional[Any],
+    kv_seq_len: int,
+    length: int,
+) -> Optional[mx.array]:
+    if mask is None or not isinstance(mask, mx.array):
+        return mask
+    if cache is not None and hasattr(cache, "_idx") and hasattr(cache, "left_padding"):
+        kv_seq_len = int(cache._idx) + length
+    elif isinstance(kv_seq_len, mx.array):
+        kv_seq_len = int(kv_seq_len.max().item())
+    return mask[..., : int(kv_seq_len)]
+
+
+def _maybe_target_verify_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    *,
+    cache: Optional[Any],
+    mask: Optional[mx.array],
+    scale: float,
+    target_verify: bool,
+    length: int,
+    left_padded_decode: bool,
+    target_verify_left_padded_attention,
+) -> Optional[mx.array]:
+    if not ((target_verify and length > 1) or left_padded_decode):
+        return None
+    return target_verify_left_padded_attention(
+        queries,
+        keys,
+        values,
+        cache=cache,
+        scale=scale,
+        mask=mask,
+    )
+
+
 def patch_qwen35_attention_for_batching() -> bool:
     """Monkey-patch Qwen3_5Attention.__call__ to handle BatchKVCache.
 
@@ -42,14 +148,24 @@ def patch_qwen35_attention_for_batching() -> bool:
     or Qwen3.5 module not available.
     """
     try:
-        from mlx_vlm.models.qwen3_5.language import (
-            Qwen3_5Attention,
-            apply_multimodal_rotary_pos_emb,
-        )
+        qwen35_language = importlib.import_module("mlx_vlm.models.qwen3_5.language")
         from mlx_lm.models.base import scaled_dot_product_attention
     except ImportError:
         logger.debug("[Qwen3.5 patch] mlx-vlm Qwen3.5 module not available")
         return False
+
+    Qwen3_5Attention = qwen35_language.Qwen3_5Attention
+    apply_multimodal_rotary_pos_emb = qwen35_language.apply_multimodal_rotary_pos_emb
+    target_verify_linears = getattr(
+        qwen35_language,
+        "_target_verify_linears",
+        _default_target_verify_linears,
+    )
+    target_verify_left_padded_attention = getattr(
+        qwen35_language,
+        "_target_verify_left_padded_attention",
+        _default_target_verify_left_padded_attention,
+    )
 
     if getattr(Qwen3_5Attention, "_batch_patched", False):
         logger.debug("[Qwen3.5 patch] Already patched")
@@ -59,20 +175,24 @@ def patch_qwen35_attention_for_batching() -> bool:
         self,
         x: mx.array,
         mask: Optional[mx.array] = None,
-        cache=None,
+        cache: Optional[Any] = None,
         position_ids: Optional[mx.array] = None,
+        position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
+        target_verify: bool = False,
     ) -> mx.array:
-        B, L, D = x.shape
+        B, L, _D = x.shape
 
-        q_proj_output = self.q_proj(x)
+        q_proj_output, keys, values = target_verify_linears(
+            (self.q_proj, self.k_proj, self.v_proj),
+            x,
+            target_verify,
+        )
         queries, gate = mx.split(
             q_proj_output.reshape(B, L, self.num_attention_heads, -1),
             2,
             axis=-1,
         )
         gate = gate.reshape(B, L, -1)
-
-        keys, values = self.k_proj(x), self.v_proj(x)
 
         queries = self.q_norm(queries).transpose(0, 2, 1, 3)
         keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
@@ -82,46 +202,60 @@ def patch_qwen35_attention_for_batching() -> bool:
             0, 2, 1, 3
         )
 
-        kv_seq_len = keys.shape[-2]
-
-        # Convert cache.offset to int for slice compatibility.
-        # BatchKVCache stores offset as mx.array (per-batch-item),
-        # but kv_seq_len must be int for mask[..., :kv_seq_len].
-        _offset = _cache_offset_to_int(cache)
-
-        # mlx-vlm caches position_ids on the language model object.
-        # If a subsequent request has a different prompt length, stale
-        # position_ids can be shorter than the current chunk and crash
-        # rotary application with a broadcast shape mismatch.
-        if position_ids is not None and position_ids.shape[-1] != L:
-            logger.debug(
-                "[Qwen3.5 patch] Recomputing stale position_ids: got %s, expected %s",
-                position_ids.shape[-1],
-                L,
-            )
-            position_ids = None
+        offset = _cache_offset_to_int(cache)
+        position_ids, position_embeddings = _normalize_position_inputs(
+            position_ids,
+            position_embeddings,
+            L,
+        )
 
         if position_ids is None:
-            kv_seq_len += _offset + 1
-            position_ids = mx.arange(_offset, _offset + L)
-            position_ids = mx.expand_dims(position_ids, axis=0)
-            position_ids = mx.tile(position_ids, (3, 1, 1))
-        else:
-            kv_seq_len += _offset + 1 if cache is not None else 0
+            position_ids = _position_ids_for_offset(offset, L)
+        kv_seq_len = _kv_seq_len(keys, cache, offset)
 
-        cos, sin = self.rotary_emb(values, position_ids)
+        queries, keys = _apply_rotary(
+            self,
+            queries,
+            keys,
+            values,
+            position_ids,
+            position_embeddings,
+            apply_multimodal_rotary_pos_emb,
+        )
 
-        if mask is not None and isinstance(mask, mx.array):
-            mask = mask[..., :kv_seq_len]
-
-        queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
+        mask = _slice_attention_mask(mask, cache, kv_seq_len, L)
 
         if cache is not None:
             keys, values = cache.update_and_fetch(keys, values)
 
-        output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        left_padded_decode = (
+            mask == "left_padded_decode" if isinstance(mask, str) else False
         )
+        if left_padded_decode:
+            mask = None
+
+        output = _maybe_target_verify_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            mask=mask,
+            scale=self.scale,
+            target_verify=target_verify,
+            length=L,
+            left_padded_decode=left_padded_decode,
+            target_verify_left_padded_attention=target_verify_left_padded_attention,
+        )
+
+        if output is None:
+            output = scaled_dot_product_attention(
+                queries,
+                keys,
+                values,
+                cache=cache,
+                scale=self.scale,
+                mask=mask,
+            )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
         return self.o_proj(output * mx.sigmoid(gate))


### PR DESCRIPTION
## Summary

- update the Qwen3.5/3.6 BatchKVCache attention patch to accept current mlx-vlm `position_embeddings` and `target_verify` kwargs
- preserve the existing BatchKVCache offset handling and stale-position recovery behavior
- add a regression test for the current mlx-vlm attention kwargs

## Local repro / evidence

Before the local Runtime fix, Qwen 35B CB+prefix owner serving hit:

```text
TypeError: patch_qwen35_attention_for_batching.<locals>._patched_call() got an unexpected keyword argument 'position_embeddings'
```

The client saw HTTP 200 with `finish_reason=error`, `content=null`, and zero token accounting.

Post-fix local evidence paths:

- `/opt/ai-runtime/run/non-live-jobs-ab/20260613T114937Z-qwen36_35b_cb_prefix/qwen35-cb-prefix-nothink-canary.json`
- `/opt/ai-runtime/run/non-live-jobs-ab/20260613T114937Z-qwen36_35b_cb_prefix/qwen35-cb-prefix-thinking-default-canary.json`
- `/opt/ai-runtime/run/non-live-jobs-ab/20260613T115016Z-qwen36_27b_cb_prefix/qwen27-cb-prefix-nothink-canary.json`
- `/opt/ai-runtime/run/non-live-jobs-ab/20260613T115016Z-qwen36_27b_cb_prefix/qwen27-cb-prefix-thinking-default-canary.json`

Those returned visible content, `finish_reason=stop`, nonzero token accounting, and `routing=textmodel_cb`.

## Upstream code path compared

- `vllm_mlx/patches/qwen3_5_mllm.py`
- `tests/test_qwen35_mllm_patch.py`

`Qwen3_5Attention.__call__` is patched in vllm-mlx for BatchKVCache. The wrapper needed to match the current mlx-vlm call surface.

## Validation

- `AI_RUNTIME_OFFICIAL_LOAD=1 /opt/ai-runtime/venv-live/bin/python -m pytest tests/test_qwen35_mllm_patch.py -q` -> `4 passed`
- `AI_RUNTIME_OFFICIAL_LOAD=1 /opt/ai-runtime/venv-live/bin/python -m py_compile vllm_mlx/patches/qwen3_5_mllm.py`
- `git diff --check`
- Runtime upstream-local-repro preflight artifact: `/opt/ai-runtime/run/upstream-local-repro-preflight/20260613T120702Z-upstream-local-repro-preflight.json`

## Not claimed

This PR does not make a model-quality claim, does not change sampling, and does not change default/resident routing. It only keeps the Qwen BatchKVCache attention patch compatible with the current mlx-vlm attention kwargs.
