### PR TITLE
fix(engine): honor MLX buffer cache limit

### DIFF
--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for BatchedEngine generate() output."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -126,6 +127,54 @@ class TestBatchedEngineCacheRestore:
         assert loaded == 2
         scheduler._ensure_batch_generator.assert_called_once_with()
         prefix_cache.load_from_disk.assert_called_once_with("/tmp/cache")
+
+
+class TestBatchedEngineMetalCacheLimit:
+    def test_prefers_explicit_mlx_buffer_cache_limit(self, monkeypatch):
+        from vllm_mlx.engine.batched import _resolve_metal_buffer_cache_limit
+
+        monkeypatch.setenv("MLX_BUFFER_CACHE_LIMIT", str(2 * 1024**3))
+
+        limit, source = _resolve_metal_buffer_cache_limit(
+            max_recommended=16 * 1024**3,
+            gpu_memory_utilization=0.5,
+        )
+
+        assert limit == 2 * 1024**3
+        assert source == "MLX_BUFFER_CACHE_LIMIT"
+
+    def test_scales_cache_limit_to_device_when_env_unset(self, monkeypatch):
+        from vllm_mlx.engine.batched import _resolve_metal_buffer_cache_limit
+
+        monkeypatch.delenv("MLX_BUFFER_CACHE_LIMIT", raising=False)
+
+        limit, source = _resolve_metal_buffer_cache_limit(
+            max_recommended=16 * 1024**3,
+            gpu_memory_utilization=0.5,
+        )
+
+        assert limit == 8 * 1024**3
+        assert source == "device-scaled"
+
+    def test_ignores_invalid_mlx_buffer_cache_limit(self, monkeypatch):
+        from vllm_mlx.engine.batched import _resolve_metal_buffer_cache_limit
+
+        monkeypatch.setenv("MLX_BUFFER_CACHE_LIMIT", "invalid")
+
+        limit, source = _resolve_metal_buffer_cache_limit(
+            max_recommended=16 * 1024**3,
+            gpu_memory_utilization=0.5,
+        )
+
+        assert limit == 8 * 1024**3
+        assert source == "device-scaled"
+
+    def test_batched_engine_does_not_hardcode_32gb_cache_limit(self):
+        source = Path(__file__).parents[1] / "vllm_mlx" / "engine" / "batched.py"
+        content = source.read_text()
+
+        assert "MLX_BUFFER_CACHE_LIMIT" in content
+        assert "mx.set_cache_limit(32 * 1024 * 1024 * 1024)" not in content
 
 
 class TestBatchedEngineAbortRequest:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -14,6 +14,7 @@ LLM engine), so text-only requests must also be routed through it.
 import asyncio
 import inspect
 import logging
+import os
 import time
 from collections.abc import AsyncIterator
 from typing import Any
@@ -29,6 +30,32 @@ from .base import (
 from .chat_template_safety import normalize_messages_for_chat_template
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_metal_buffer_cache_limit(
+    max_recommended: int,
+    gpu_memory_utilization: float,
+) -> tuple[int, str]:
+    """Resolve the MLX retained-buffer cache cap for Metal startup."""
+    env_limit = os.environ.get("MLX_BUFFER_CACHE_LIMIT")
+    if env_limit:
+        try:
+            limit = int(env_limit)
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid MLX_BUFFER_CACHE_LIMIT=%r; using device-scaled cap",
+                env_limit,
+            )
+        else:
+            if limit > 0:
+                return limit, "MLX_BUFFER_CACHE_LIMIT"
+            logger.warning(
+                "Ignoring non-positive MLX_BUFFER_CACHE_LIMIT=%r; "
+                "using device-scaled cap",
+                env_limit,
+            )
+
+    return int(max_recommended * gpu_memory_utilization), "device-scaled"
 
 
 def _normalize_tool_call_arguments_for_template(messages: list[dict]) -> list[dict]:
@@ -285,14 +312,19 @@ class BatchedEngine(BaseEngine):
                 )
                 if max_recommended > 0:
                     soft_limit = int(max_recommended * self._gpu_memory_utilization)
+                    cache_limit, cache_limit_source = _resolve_metal_buffer_cache_limit(
+                        max_recommended,
+                        self._gpu_memory_utilization,
+                    )
                     mx.set_memory_limit(soft_limit)
-                    mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                    mx.set_cache_limit(cache_limit)
                     pct = self._gpu_memory_utilization * 100
                     logger.info(
                         f"Metal memory limits set: "
                         f"allocation_limit={soft_limit / 1e9:.1f}GB "
                         f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
-                        f"cache_limit=32GB"
+                        f"buffer_cache_limit={cache_limit / 1e9:.1f}GB "
+                        f"({cache_limit_source})"
                     )
         except Exception as e:
             logger.warning(f"Failed to set Metal memory limits: {e}")
@@ -485,14 +517,19 @@ class BatchedEngine(BaseEngine):
                 )
                 if max_recommended > 0:
                     soft_limit = int(max_recommended * self._gpu_memory_utilization)
+                    cache_limit, cache_limit_source = _resolve_metal_buffer_cache_limit(
+                        max_recommended,
+                        self._gpu_memory_utilization,
+                    )
                     mx.set_memory_limit(soft_limit)
-                    mx.set_cache_limit(32 * 1024 * 1024 * 1024)  # 32GB
+                    mx.set_cache_limit(cache_limit)
                     pct = self._gpu_memory_utilization * 100
                     logger.info(
                         f"Metal memory limits set: "
                         f"allocation_limit={soft_limit / 1e9:.1f}GB "
                         f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
-                        f"cache_limit=32GB"
+                        f"buffer_cache_limit={cache_limit / 1e9:.1f}GB "
+                        f"({cache_limit_source})"
                     )
         except Exception as e:
             logger.warning(f"Failed to set Metal memory limits: {e}")


### PR DESCRIPTION
## Summary
- honor explicit `MLX_BUFFER_CACHE_LIMIT` during BatchedEngine Metal startup
- replace the fixed 32GB retained-buffer cache cap with a device-scaled fallback derived from `max_recommended_working_set_size * gpu_memory_utilization`
- apply the same behavior to both MLLM and LLM BatchedEngine startup paths
- add regression coverage for env override, invalid env fallback, device-scaled fallback, and absence of the hardcoded 32GB call

Refs #619.

## Verification
- `python -m pytest tests/test_batched_engine.py -q` -> 16 passed
- `.venv/bin/python -m pytest tests/test_memory_cache_mlx.py -q` -> 15 passed
- `.venv/bin/python -m pytest tests/test_batched_engine.py tests/test_memory_cache.py tests/test_memory_cache_mlx.py -q` -> 78 passed
- `.venv/bin/python -m ruff check --select E,F,W --ignore E402,E501,E731,F811,F841 vllm_mlx/engine/batched.py tests/test_batched_engine.py` -> passed
- `.venv/bin/python -m black --check vllm_mlx/engine/batched.py tests/test_batched_engine.py` -> passed
- `git diff --check` -> passed
- `/opt/ai-runtime/bin/upstream-local-repro-preflight --local-root /opt/ai-runtime/worktrees/vllm-mlx/issue-619-buffer-cache-limit --upstream-root /opt/ai-runtime/worktrees/vllm-mlx/upstream-main-clean --code-path vllm_mlx/engine/batched.py --no-model-artifact` -> passed
