### PR TITLE
fix(gemma4): parse paren and tool_code fallback tool-call forms

### DIFF
--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -205,6 +205,99 @@ class TestGemma4ToolParserExtract:
         assert args == {"tags": ["alpha", "beta", "gamma"]}
 
 
+class TestGemma4ToolParserFallbackForms:
+    """Fallback Python-style forms Gemma 4 emits under load (issue #80).
+
+    Under a long system prompt + multi-turn + several tools, Gemma 4 stops using
+    the canonical <|"|>-brace form and leaks its call as plain content using
+    Python call syntax. These must still parse into tool_calls.
+    """
+
+    def setup_method(self):
+        self.parser = Gemma4ToolParser()
+
+    def test_e4b_paren_form_with_tool_call_marker(self):
+        """e4b: <|tool_call>call:fn(kwargs) — parens instead of braces, no end."""
+        output = '<|tool_call>call:radarr_get_movies(search="Dune")'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc["name"] == "radarr_get_movies"
+        assert json.loads(tc["arguments"]) == {"search": "Dune"}
+        assert result.content is None
+
+    def test_e2b_tool_code_block(self):
+        """e2b: ```tool_code\\nfn(kwargs)\\n``` — bare call in a code fence."""
+        output = '```tool_code\nradarr_get_movies(search="Dune")\n```'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc["name"] == "radarr_get_movies"
+        assert json.loads(tc["arguments"]) == {"search": "Dune"}
+        assert result.content is None
+
+    def test_paren_form_mixed_arg_types(self):
+        output = '<|tool_call>call:search(query="hello world", limit=10, verbose=False)'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"query": "hello world", "limit": 10, "verbose": False}
+
+    def test_paren_form_paren_inside_string(self):
+        """A ) inside a string value must not end the arg list early."""
+        output = '<|tool_call>call:run(code="f(x) + g(y)")'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"code": "f(x) + g(y)"}
+
+    def test_tool_code_block_with_content_before(self):
+        output = (
+            "Let me look that up.\n"
+            "```tool_code\nget_weather(city=\"Paris\")\n```"
+        )
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert result.content == "Let me look that up."
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"city": "Paris"}
+
+    def test_tool_code_block_multiple_calls(self):
+        output = (
+            "```tool_code\n"
+            'radarr_get_movies(search="Dune")\n'
+            'radarr_get_movies(search="Arrival")\n'
+            "```"
+        )
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 2
+        assert json.loads(result.tool_calls[0]["arguments"]) == {"search": "Dune"}
+        assert json.loads(result.tool_calls[1]["arguments"]) == {"search": "Arrival"}
+
+    def test_canonical_still_preferred_over_fallback(self):
+        """A well-formed brace call must not be double-counted by the fallback."""
+        output = '<|tool_call>call:read_file{path:<|"|>/tmp/foo<|"|>}<tool_call|>'
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "read_file"
+
+    def test_prose_with_function_mention_is_not_a_call(self):
+        """Ordinary prose mentioning a function must stay content."""
+        output = "You can call foo() to do that, or use bar(x)."
+        result = self.parser.extract_tool_calls(output)
+        assert result.tools_called is False
+        assert result.content == output
+
+    def test_paren_form_id_generated(self):
+        output = '<|tool_call>call:ping(host="a")'
+        tc = self.parser.extract_tool_calls(output).tool_calls[0]
+        assert tc["id"].startswith("call_")
+
+
 class TestGemma4ToolParserStreaming:
     """Test streaming tool call extraction."""
 
@@ -261,6 +354,50 @@ class TestGemma4ToolParserStreaming:
         assert tc["function"]["name"] == "read_file"
         assert tc["type"] == "function"
         assert tc["index"] == 0
+
+    def test_streaming_paren_form_emits_when_complete(self):
+        """e4b paren form has no end delimiter — emit when parens balance."""
+        # Partial: parens not yet closed -> suppress.
+        r1 = self.parser.extract_tool_calls_streaming(
+            previous_text="<|tool_call>call:search",
+            current_text='<|tool_call>call:search(query="Du',
+            delta_text='(query="Du',
+        )
+        assert r1 is None
+
+        # Completing delta closes the call -> emit tool_calls.
+        r2 = self.parser.extract_tool_calls_streaming(
+            previous_text='<|tool_call>call:search(query="Du',
+            current_text='<|tool_call>call:search(query="Dune")',
+            delta_text='ne")',
+        )
+        assert r2 is not None
+        assert r2["tool_calls"][0]["function"]["name"] == "search"
+        assert json.loads(r2["tool_calls"][0]["function"]["arguments"]) == {
+            "query": "Dune"
+        }
+
+    def test_streaming_paren_form_emits_once(self):
+        """Once emitted, later deltas must not re-emit the same call."""
+        prev = '<|tool_call>call:search(query="Dune")'
+        r = self.parser.extract_tool_calls_streaming(
+            previous_text=prev,
+            current_text=prev + " ",
+            delta_text=" ",
+        )
+        assert r is None
+
+    def test_streaming_tool_code_block_emits_on_close(self):
+        """e2b code-fence form: emit when the fenced call first parses."""
+        prev = "```tool_code\nget_weather(city="
+        cur = '```tool_code\nget_weather(city="Paris")\n```'
+        r = self.parser.extract_tool_calls_streaming(
+            previous_text=prev,
+            current_text=cur,
+            delta_text='"Paris")\n```',
+        )
+        assert r is not None
+        assert r["tool_calls"][0]["function"]["name"] == "get_weather"
 
 
 class TestGemma4Registration:

--- a/tests/test_gemma4_tool_parser.py
+++ b/tests/test_gemma4_tool_parser.py
@@ -254,10 +254,7 @@ class TestGemma4ToolParserFallbackForms:
         assert args == {"code": "f(x) + g(y)"}
 
     def test_tool_code_block_with_content_before(self):
-        output = (
-            "Let me look that up.\n"
-            "```tool_code\nget_weather(city=\"Paris\")\n```"
-        )
+        output = "Let me look that up.\n" '```tool_code\nget_weather(city="Paris")\n```'
         result = self.parser.extract_tool_calls(output)
         assert result.tools_called is True
         assert result.content == "Let me look that up."

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -373,9 +373,7 @@ class Gemma4ToolParser(ToolParser):
 
         return tool_calls, content_before
 
-    def _extract_fallback(
-        self, cleaned: str
-    ) -> ExtractedToolCallInformation | None:
+    def _extract_fallback(self, cleaned: str) -> ExtractedToolCallInformation | None:
         """Parse the Python-style fallback forms (issue #80).
 
         Handles ```tool_code``` blocks (bare `fn(...)` calls) and the
@@ -430,9 +428,7 @@ class Gemma4ToolParser(ToolParser):
             tools_called=True, tool_calls=tool_calls, content=content
         )
 
-    def _format_streaming(
-        self, result: ExtractedToolCallInformation
-    ) -> dict[str, Any]:
+    def _format_streaming(self, result: ExtractedToolCallInformation) -> dict[str, Any]:
         """Render extracted tool calls into the streaming delta shape."""
         return {
             "tool_calls": [
@@ -475,9 +471,7 @@ class Gemma4ToolParser(ToolParser):
 
         # Fallback forms (`call:fn(...)` / ```tool_code```) have no end delimiter.
         # Emit once, on the delta that first makes the call parseable.
-        if has_fallback and not self.extract_tool_calls(
-            previous_text
-        ).tools_called:
+        if has_fallback and not self.extract_tool_calls(previous_text).tools_called:
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
                 return self._format_streaming(result)

--- a/vllm_mlx/tool_parsers/gemma4_tool_parser.py
+++ b/vllm_mlx/tool_parsers/gemma4_tool_parser.py
@@ -11,12 +11,26 @@ Gemma 4 uses special tokens instead of JSON:
 - Keys are unquoted bare identifiers
 - Multiple call:name{...} can appear in a single block
 
+Fallback forms (issue #80): under long system prompts + multi-turn + several
+tools, Gemma 4 frequently abandons the canonical brace form and instead emits
+its call as plain text in `content`, using Python-style call syntax:
+
+  e4b: <|tool_call>call:radarr_get_movies(search="Dune")
+  e2b: ```tool_code
+       radarr_get_movies(search="Dune")
+       ```
+
+These are parsed by a fallback layer (ast-based) when the canonical parse finds
+no calls, so the host can still dispatch the tool.
+
 Reference: mlx-lm PR #1105, vllm PR #38837
 """
 
+import ast
 import json
 import logging
 import re
+import textwrap
 import uuid
 from collections.abc import Sequence
 from typing import Any
@@ -57,6 +71,15 @@ _JSON_LITERALS = frozenset({"true", "false", "null"})
 # Max arg block length to prevent runaway parsing on malformed input (1 MB)
 _MAX_ARG_BLOCK_LEN = 1_048_576
 
+# --- Fallback forms (issue #80) ---------------------------------------------
+# Parenthesized form: `call:fn(...)` — the `call:` prefix is required outside a
+# code fence so we never mistake ordinary prose like "see foo()" for a call.
+_CALL_PAREN_RE = re.compile(r"call:(\w+)\s*\(")
+# ```tool_code ... ``` fenced block (Gemma's code-call convention).
+_TOOL_CODE_FENCE_RE = re.compile(r"```tool_code\b[^\n]*\n(.*?)```", re.DOTALL)
+# Cheap marker used by the streaming path to know a fallback call may be forming.
+_FALLBACK_MARKER_RE = re.compile(r"```tool_code\b|call:\w+\s*\(")
+
 
 def _find_balanced_brace(text: str, start: int) -> int:
     """Find the index of the closing } that balances the { at `start`.
@@ -90,6 +113,40 @@ def _find_balanced_brace(text: str, start: int) -> int:
                 depth -= 1
                 if depth == 0:
                     return i
+        i += 1
+    return -1
+
+
+def _find_balanced_paren(text: str, start: int) -> int:
+    """Find the index of the closing ) that balances the ( at `start`.
+
+    Python string literals ('...'/"...") are treated as opaque so that parens
+    inside string argument values don't affect depth counting.
+
+    Returns the index of the matching ) in `text`, or -1 if not found.
+    """
+    if len(text) - start > _MAX_ARG_BLOCK_LEN:
+        return -1
+
+    depth = 0
+    i = start
+    quote: str | None = None
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in ("'", '"'):
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i
         i += 1
     return -1
 
@@ -142,6 +199,74 @@ def _gemma4_args_to_json(text: str) -> str:
     return text
 
 
+def _call_node_to_tool(call: ast.Call) -> tuple[str, dict[str, Any]] | None:
+    """Map a Python `ast.Call` node to (function_name, kwargs_dict).
+
+    Only keyword arguments are mapped (Gemma emits its tool calls as kwargs);
+    positional args are ignored because the parameter names aren't recoverable.
+    Returns None if the name or any argument value isn't a plain literal.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr  # e.g. module.fn -> fn
+    else:
+        return None
+
+    args: dict[str, Any] = {}
+    for kw in call.keywords:
+        if kw.arg is None:  # **kwargs splat — can't represent
+            continue
+        try:
+            args[kw.arg] = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError):
+            return None
+    return name, args
+
+
+def _parse_python_call(src: str) -> tuple[str, dict[str, Any]] | None:
+    """Parse a single `fn(...)` Python call expression into (name, kwargs)."""
+    try:
+        node = ast.parse(src.strip(), mode="eval")
+    except SyntaxError:
+        return None
+    if not isinstance(node.body, ast.Call):
+        return None
+    return _call_node_to_tool(node.body)
+
+
+def _parse_calls_from_code(code: str) -> list[tuple[str, dict[str, Any]]]:
+    """Parse every top-level `fn(...)` call statement in a code-fence body."""
+    results: list[tuple[str, dict[str, Any]]] = []
+    try:
+        module = ast.parse(textwrap.dedent(code).strip(), mode="exec")
+    except SyntaxError:
+        return results
+    for stmt in module.body:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            parsed = _call_node_to_tool(stmt.value)
+            if parsed is not None:
+                results.append(parsed)
+    return results
+
+
+def _strip_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    """Remove the given [start, end) spans from `text` (handles overlaps)."""
+    if not spans:
+        return text
+    out: list[str] = []
+    last = 0
+    for start, end in sorted(spans):
+        if start < last:  # overlapping / contained — extend the cut
+            last = max(last, end)
+            continue
+        out.append(text[last:start])
+        last = end
+    out.append(text[last:])
+    return "".join(out)
+
+
 def generate_tool_id() -> str:
     """Generate a unique tool call ID."""
     return f"call_{uuid.uuid4().hex[:8]}"
@@ -170,11 +295,37 @@ class Gemma4ToolParser(ToolParser):
         """Extract tool calls from a complete Gemma 4 model response."""
         cleaned = self.strip_think_tags(model_output)
 
+        # 1. Canonical <|"|>-delimited brace form.
+        tool_calls, content_before = self._extract_canonical(cleaned)
+        if tool_calls:
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content_before,
+            )
+
+        # 2. Fallback: Gemma often emits the call as plain content using Python
+        #    call syntax — `call:fn(...)` or a ```tool_code``` block — instead of
+        #    the brace form. Recover those so the host can dispatch. Ref: #80.
+        fallback = self._extract_fallback(cleaned)
+        if fallback is not None:
+            return fallback
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def _extract_canonical(
+        self, cleaned: str
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Parse the canonical <|tool_call>call:fn{...}<tool_call|> form.
+
+        Returns (tool_calls, content_before). tool_calls is empty when the
+        canonical markers/braces aren't present.
+        """
         start_idx = cleaned.find(TOOL_CALL_START)
         if start_idx == -1:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
-            )
+            return [], None
 
         content_before = cleaned[:start_idx].strip() or None
 
@@ -220,16 +371,83 @@ class Gemma4ToolParser(ToolParser):
 
             pos = brace_end + 1
 
-        if tool_calls:
-            return ExtractedToolCallInformation(
-                tools_called=True,
-                tool_calls=tool_calls,
-                content=content_before,
+        return tool_calls, content_before
+
+    def _extract_fallback(
+        self, cleaned: str
+    ) -> ExtractedToolCallInformation | None:
+        """Parse the Python-style fallback forms (issue #80).
+
+        Handles ```tool_code``` blocks (bare `fn(...)` calls) and the
+        parenthesized `call:fn(...)` form. Returns None if neither is present.
+        """
+        tool_calls: list[dict[str, Any]] = []
+        spans: list[tuple[int, int]] = []
+
+        # ```tool_code``` fenced blocks — may contain one or more bare calls.
+        for m in _TOOL_CODE_FENCE_RE.finditer(cleaned):
+            for name, args in _parse_calls_from_code(m.group(1)):
+                tool_calls.append(
+                    {
+                        "id": generate_tool_id(),
+                        "name": name,
+                        "arguments": json.dumps(args),
+                    }
+                )
+            spans.append((m.start(), m.end()))
+
+        # Parenthesized `call:fn(...)` form (outside any code fence).
+        for m in _CALL_PAREN_RE.finditer(cleaned):
+            if any(s <= m.start() < e for s, e in spans):
+                continue  # already covered by a code-fence span
+            paren_open = m.end() - 1
+            paren_close = _find_balanced_paren(cleaned, paren_open)
+            if paren_close == -1:
+                continue
+            call_src = m.group(1) + cleaned[paren_open : paren_close + 1]
+            parsed = _parse_python_call(call_src)
+            if parsed is None:
+                continue
+            name, args = parsed
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": name,
+                    "arguments": json.dumps(args),
+                }
             )
-        else:
-            return ExtractedToolCallInformation(
-                tools_called=False, tool_calls=[], content=model_output
-            )
+            spans.append((m.start(), paren_close + 1))
+
+        if not tool_calls:
+            return None
+
+        content = _strip_spans(cleaned, spans)
+        # Drop any stray Gemma tool-call markers left in the surrounding text.
+        content = content.replace(TOOL_CALL_START, "").replace(TOOL_CALL_END, "")
+        content = content.strip() or None
+
+        return ExtractedToolCallInformation(
+            tools_called=True, tool_calls=tool_calls, content=content
+        )
+
+    def _format_streaming(
+        self, result: ExtractedToolCallInformation
+    ) -> dict[str, Any]:
+        """Render extracted tool calls into the streaming delta shape."""
+        return {
+            "tool_calls": [
+                {
+                    "index": i,
+                    "id": tc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["arguments"],
+                    },
+                }
+                for i, tc in enumerate(result.tool_calls)
+            ]
+        }
 
     def extract_tool_calls_streaming(
         self,
@@ -242,27 +460,26 @@ class Gemma4ToolParser(ToolParser):
         request: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Extract tool calls from streaming Gemma 4 model output."""
-        has_start = TOOL_CALL_START in current_text
+        has_canonical = TOOL_CALL_START in current_text
+        has_fallback = bool(_FALLBACK_MARKER_RE.search(current_text))
 
-        if not has_start:
+        if not has_canonical and not has_fallback:
             return {"content": delta_text}
 
-        if TOOL_CALL_END in delta_text:
+        # Canonical brace form: emit when the end delimiter arrives in this delta.
+        if has_canonical and TOOL_CALL_END in delta_text:
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["name"],
-                                "arguments": tc["arguments"],
-                            },
-                        }
-                        for i, tc in enumerate(result.tool_calls)
-                    ]
-                }
+                return self._format_streaming(result)
+            return None
+
+        # Fallback forms (`call:fn(...)` / ```tool_code```) have no end delimiter.
+        # Emit once, on the delta that first makes the call parseable.
+        if has_fallback and not self.extract_tool_calls(
+            previous_text
+        ).tools_called:
+            result = self.extract_tool_calls(current_text)
+            if result.tools_called:
+                return self._format_streaming(result)
 
         return None


### PR DESCRIPTION
## Problem

Under long system prompts, multi-turn conversations, or when several tools are
registered, Gemma 4 frequently abandons its canonical brace form:

```
<|tool_call>call:fn{key:<|"|>val<|"|>}<tool_call|>
```

and instead emits the call as plain content using Python-style syntax. Two forms
are seen in practice:

**e4b — parenthesized with `call:` prefix:**
```
<|tool_call>call:get_weather(city="Tokyo", unit="celsius")
```

**e2b — fenced `tool_code` block:**
````
```tool_code
get_weather(city="Tokyo", unit="celsius")
```
````

When the canonical parser finds neither `<|tool_call>` nor a parseable brace
block it returns `tools_called=False`, causing the host to treat the output as
plain text and never dispatch the tool.

## Fix

Adds a fallback layer in `Gemma4ToolParser.extract_tool_calls` that fires when
the canonical parse yields no calls. The fallback handles:

- **`call:fn(...)`** — parenthesized call with required `call:` prefix (prevents
  ordinary prose like `"see foo()"` from being mistaken for a tool call).
- **``` ```tool_code``` blocks** — one or more bare `fn(...)` call statements
  inside a fenced block; uses `ast.parse` in exec mode so multiple calls in one
  block are all dispatched.

Each form is detected with a narrow regex, then the call expression is parsed via
`ast.literal_eval` on every argument value — no `eval`, no exec.

Matching spans are stripped from the returned `content` so the host doesn't echo
the raw call text back to the client.

The streaming path gains a cheap `_FALLBACK_MARKER_RE` guard so it doesn't stall
waiting for `<tool_call|>` on the fallback forms.

## Tests

`tests/test_gemma4_tool_parser.py` — covers both fallback forms plus the
canonical brace form, multi-call blocks, and streaming path.

Live-tested against `mlx-community/gemma-4-e2b-it-4bit` and
`mlx-community/gemma-4-e4b-it-4bit` via an OpenAI-compatible tool-call round-trip
(`tool_choice: required` → tool result → natural-language summary).

Ref: #80