### PR TITLE
fix(gemma4): route streaming tool marker from reasoning

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2175,6 +2175,110 @@ class TestStreamChatCompletion:
         }
 
     @pytest.mark.anyio
+    async def test_reasoning_stream_redirects_gemma4_tool_marker(self, monkeypatch):
+        """Gemma 4 tool markup inside reasoning should reach the tool parser."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning import DeltaMessage
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                chunks = [
+                    GenerationOutput(text="", new_text="<|tool_call>", finished=False),
+                    GenerationOutput(
+                        text="",
+                        new_text='call:read_file{path:<|"|>/tmp/a.py<|"|>}',
+                        finished=False,
+                    ),
+                    GenerationOutput(
+                        text="",
+                        new_text="<tool_call|>",
+                        finished=True,
+                        finish_reason="stop",
+                        prompt_tokens=11,
+                        completion_tokens=5,
+                    ),
+                ]
+                for chunk in chunks:
+                    yield chunk
+
+        class FakeReasoningParser:
+            def reset_state(self):
+                pass
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                return DeltaMessage(reasoning=delta_text)
+
+        class FakeToolParser:
+            def reset(self):
+                pass
+
+            def extract_tool_calls_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                if "<tool_call|>" not in current_text:
+                    return None
+                return {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_gemma4",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"/tmp/a.py"}',
+                            },
+                        }
+                    ]
+                }
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", FakeReasoningParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", True)
+        monkeypatch.setattr(server, "_tool_call_parser", "fake")
+        monkeypatch.setattr(server, "_tool_parser_instance", FakeToolParser())
+
+        request = ChatCompletionRequest(
+            model="request-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+        tool_payloads = [
+            payload
+            for payload in payloads
+            if payload["choices"] and payload["choices"][0]["delta"].get("tool_calls")
+        ]
+
+        assert len(tool_payloads) == 1
+        assert (
+            tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["name"]
+            == "read_file"
+        )
+        assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.anyio
     async def test_reasoning_stream_skips_tool_parser_until_markup_appears(
         self, monkeypatch
     ):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -6028,11 +6028,7 @@ async def stream_chat_completion(
                 # to the content stream so the tool parser can handle it.
                 if tool_parser and reasoning and not content:
                     _check = tool_accumulated_text + reasoning
-                    if (
-                        "<minimax:tool_call>" in _check
-                        or "<tool_call>" in _check
-                        or '<invoke name="' in _check
-                    ):
+                    if _streaming_tool_markup_possible(_check):
                         content = reasoning
                         reasoning = None
 


### PR DESCRIPTION
## Summary
- route reasoning-only streaming chunks through the existing tool-marker detector before the tool parser step
- cover Gemma 4 `<|tool_call>` markup emitted while the reasoning parser is still returning reasoning
- keep the existing MiniMax / standard tool-call redirect behavior by reusing the shared marker helper

Refs #609

## Tests
- RED: `uv run --with-editable . --with pytest --with anyio --with pytest-asyncio --with fastapi --with httpx --with pydantic --with jsonschema --with psutil --with transformers --with requests --with mlx-lm --with mlx-vlm --with starlette --with uvicorn python -m pytest tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_redirects_gemma4_tool_marker -q` failed with `assert 0 == 1` before the server change
- `uv run --with-editable . --with pytest --with anyio --with pytest-asyncio --with fastapi --with httpx --with pydantic --with jsonschema --with psutil --with transformers --with requests --with mlx-lm --with mlx-vlm --with starlette --with uvicorn python -m pytest tests/test_server.py::TestStreamChatCompletion -q`
- `uv run --with black black --check vllm_mlx/server.py tests/test_server.py`
- `uv run --with ruff ruff check vllm_mlx/server.py tests/test_server.py`
- `git diff --check`

## Not claimed
- no model-quality claim
- no non-streaming parser behavior change
- no new Gemma template behavior
