### PR TITLE
fix(embeddings,rerank): resolve truncation length from model config instead of hardcoded 512

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
             tests/test_dependency_floors.py \
             tests/test_harmony_parsers.py \
             tests/test_endpoint_model_policies.py \
+            tests/test_truncation.py \
             tests/test_gemma4_openai_format.py \
             tests/test_gemma4_streaming_edge.py \
             tests/test_gemma4_tool_parser.py \
@@ -157,6 +158,8 @@ jobs:
             tests/test_tool_choice_forced.py \
             tests/test_tool_choice_none.py \
             tests/test_harmony_render.py \
+            tests/test_embeddings.py \
+            tests/test_rerank.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -131,6 +131,63 @@ class TestEmbeddingEngine:
 
         assert result[0] == [0.1, 0.2]
 
+    def test_embed_uses_config_max_length(self):
+        """Positive: truncation length follows model.config.max_position_embeddings."""
+        import numpy as np
+
+        from vllm_mlx.embedding import EmbeddingEngine
+
+        engine = EmbeddingEngine("test-model")
+
+        mock_output = MagicMock()
+        mock_output.text_embeds.tolist.return_value = [[0.1, 0.2]]
+        mock_model = MagicMock(return_value=mock_output)
+        mock_model.config.max_position_embeddings = 8192
+
+        mock_inner_tokenizer = MagicMock()
+        mock_inner_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2]]),
+            "attention_mask": np.array([[1, 1]]),
+        }
+        mock_tokenizer = MagicMock()
+        mock_tokenizer._tokenizer = mock_inner_tokenizer
+
+        with patch.object(engine, "_ensure_loaded"):
+            engine._model = mock_model
+            engine._tokenizer = mock_tokenizer
+            engine.embed(["hello"])
+
+        assert mock_inner_tokenizer.call_args.kwargs["max_length"] == 8192
+
+    def test_embed_defaults_to_512_without_config(self):
+        """Negative: no usable config/tokenizer value falls back to 512."""
+        import numpy as np
+
+        from vllm_mlx.embedding import EmbeddingEngine
+
+        engine = EmbeddingEngine("test-model")
+
+        mock_output = MagicMock()
+        mock_output.text_embeds.tolist.return_value = [[0.1, 0.2]]
+        mock_model = MagicMock(return_value=mock_output)
+        # .config.max_position_embeddings is a MagicMock (non-int) -> rejected.
+
+        mock_inner_tokenizer = MagicMock()
+        mock_inner_tokenizer.model_max_length = MagicMock()  # non-int -> rejected
+        mock_inner_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2]]),
+            "attention_mask": np.array([[1, 1]]),
+        }
+        mock_tokenizer = MagicMock()
+        mock_tokenizer._tokenizer = mock_inner_tokenizer
+
+        with patch.object(engine, "_ensure_loaded"):
+            engine._model = mock_model
+            engine._tokenizer = mock_tokenizer
+            engine.embed(["hello"])
+
+        assert mock_inner_tokenizer.call_args.kwargs["max_length"] == 512
+
     def test_embed_normalises_single_string(self):
         """Test that a single string input is wrapped into a list."""
         import numpy as np

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -146,13 +146,13 @@ class TestRerankAdapterContract:
             "input_ids": [[101, 2054, 102, 3793, 102]],
             "attention_mask": [[1, 1, 1, 1, 1]],
         }
-        result = adapter.tokenize_pair(mock_tokenizer, "query", "document")
+        result = adapter.tokenize_pair(mock_tokenizer, "query", "document", 8192)
         mock_tokenizer.assert_called_once_with(
             "query",
             "document",
             padding=True,
             truncation=True,
-            max_length=512,
+            max_length=8192,
             return_tensors="np",
         )
         assert "input_ids" in result
@@ -215,6 +215,61 @@ class TestRerankEngine:
         expected_1 = 1.0 / (1.0 + math.exp(1.0))
         assert abs(scores[0] - expected_0) < 1e-6
         assert abs(scores[1] - expected_1) < 1e-6
+
+    def test_score_pairs_resolves_max_length_from_config(self):
+        """Positive: a large-context model tokenizes with its own max_length."""
+        import numpy as np
+
+        from vllm_mlx.rerank import RerankEngine, SigmoidAdapter
+
+        engine = RerankEngine("test-model")
+
+        mock_model = MagicMock()
+        mock_model.config = {"max_position_embeddings": 8192}
+        mock_logits = MagicMock()
+        mock_logits.tolist.return_value = [[1.0, 0.0]]
+        mock_model.return_value = MagicMock(logits=mock_logits)
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2, 3]]),
+            "attention_mask": np.array([[1, 1, 1]]),
+        }
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+        engine._adapter = SigmoidAdapter()
+
+        engine.score_pairs("query", ["doc"])
+        assert mock_tokenizer.call_args.kwargs["max_length"] == 8192
+
+    def test_score_pairs_defaults_to_512_without_config(self):
+        """Negative: no usable config/tokenizer value falls back to 512."""
+        import numpy as np
+
+        from vllm_mlx.rerank import RerankEngine, SigmoidAdapter
+
+        engine = RerankEngine("test-model")
+
+        mock_model = MagicMock()  # .config is a MagicMock (non-int)
+        mock_logits = MagicMock()
+        mock_logits.tolist.return_value = [[1.0, 0.0]]
+        mock_model.return_value = MagicMock(logits=mock_logits)
+
+        mock_tokenizer = MagicMock()
+        # model_max_length as a non-int so the resolver rejects it too
+        mock_tokenizer.model_max_length = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2, 3]]),
+            "attention_mask": np.array([[1, 1, 1]]),
+        }
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+        engine._adapter = SigmoidAdapter()
+
+        engine.score_pairs("query", ["doc"])
+        assert mock_tokenizer.call_args.kwargs["max_length"] == 512
 
     def test_score_pairs_token_budget_batching(self):
         """Test that score_pairs splits work into batches by token budget."""

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared truncation-length resolver."""
+
+from functools import partial
+from types import SimpleNamespace
+
+from vllm_mlx.utils.truncation import (
+    MAX_LENGTH_CAP,
+    MAX_LENGTH_DEFAULT,
+    inner_tokenizer,
+    resolve_max_length,
+)
+
+# Resolve with the shared cap/default unless a test overrides them.
+resolve = partial(resolve_max_length, cap=MAX_LENGTH_CAP, default=MAX_LENGTH_DEFAULT)
+
+
+class _Tok:
+    """Minimal tokenizer stub with a configurable model_max_length."""
+
+    def __init__(self, model_max_length=None):
+        if model_max_length is not None:
+            self.model_max_length = model_max_length
+
+
+def test_resolve_from_dict_config():
+    """Positive: reranker-style dict config is honored."""
+    cfg = {"max_position_embeddings": 8192}
+    assert resolve(cfg, _Tok()) == 8192
+
+
+def test_resolve_from_object_config():
+    """Positive: embeddings-style object config is honored."""
+    cfg = SimpleNamespace(max_position_embeddings=2048)
+    assert resolve(cfg, _Tok()) == 2048
+
+
+def test_resolve_caps_at_8192():
+    """A model reporting a huge window is capped at 8192."""
+    cfg = {"max_position_embeddings": 100000}
+    assert resolve(cfg, _Tok()) == MAX_LENGTH_CAP
+
+
+def test_resolve_falls_back_to_tokenizer():
+    """No config value falls back to tokenizer.model_max_length."""
+    assert resolve(None, _Tok(model_max_length=2048)) == 2048
+
+
+def test_resolve_unwraps_inner_tokenizer():
+    """The inner _tokenizer is consulted when present."""
+    outer = SimpleNamespace(_tokenizer=_Tok(model_max_length=1024))
+    assert resolve(None, outer) == 1024
+
+
+def test_resolve_defaults_to_512():
+    """Negative: no usable value anywhere returns the 512 default."""
+    assert resolve(None, _Tok()) == MAX_LENGTH_DEFAULT
+
+
+def test_resolve_ignores_non_int_and_sentinel():
+    """Non-int config values are rejected; huge sentinels are capped."""
+    # Non-int config -> falls through to a huge tokenizer sentinel -> capped.
+    cfg = {"max_position_embeddings": "nope"}
+    tok = _Tok(model_max_length=10**30)
+    assert resolve(cfg, tok) == MAX_LENGTH_CAP
+
+
+def test_resolve_rejects_bool():
+    """bool is a subclass of int but must not be treated as a length."""
+    cfg = {"max_position_embeddings": True}
+    assert resolve(cfg, _Tok()) == MAX_LENGTH_DEFAULT
+
+
+def test_resolve_honors_call_site_overrides():
+    """cap/default are caller-supplied, so an engine can override them."""
+    # Custom default when nothing usable is found.
+    assert resolve_max_length(None, _Tok(), cap=4096, default=256) == 256
+    # Custom cap clamps the model's window.
+    cfg = {"max_position_embeddings": 100000}
+    assert resolve_max_length(cfg, _Tok(), cap=4096, default=256) == 4096
+
+
+def test_inner_tokenizer_unwraps_and_passes_through():
+    """inner_tokenizer returns the wrapped tokenizer, else the object itself."""
+    inner = _Tok()
+    assert inner_tokenizer(SimpleNamespace(_tokenizer=inner)) is inner
+    plain = _Tok()
+    assert inner_tokenizer(plain) is plain

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -38,6 +38,12 @@ def test_resolve_trusts_large_explicit_config_value():
     assert resolve_max_length(cfg, _Tok()) == 100000
 
 
+def test_resolve_uses_finite_tokenizer_limit_as_safe_upper_bound():
+    """A finite tokenizer limit constrains the architecture table size."""
+    cfg = {"max_position_embeddings": 514}
+    assert resolve_max_length(cfg, _Tok(model_max_length=512)) == 512
+
+
 def test_resolve_falls_back_to_tokenizer():
     """No config value falls back to tokenizer.model_max_length."""
     assert resolve_max_length(None, _Tok(model_max_length=2048)) == 2048

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,18 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the shared truncation-length resolver."""
 
-from functools import partial
 from types import SimpleNamespace
 
 from vllm_mlx.utils.truncation import (
-    MAX_LENGTH_CAP,
     MAX_LENGTH_DEFAULT,
+    TOKENIZER_SENTINEL_THRESHOLD,
     inner_tokenizer,
     resolve_max_length,
 )
-
-# Resolve with the shared cap/default unless a test overrides them.
-resolve = partial(resolve_max_length, cap=MAX_LENGTH_CAP, default=MAX_LENGTH_DEFAULT)
 
 
 class _Tok:
@@ -26,58 +22,71 @@ class _Tok:
 def test_resolve_from_dict_config():
     """Positive: reranker-style dict config is honored."""
     cfg = {"max_position_embeddings": 8192}
-    assert resolve(cfg, _Tok()) == 8192
+    assert resolve_max_length(cfg, _Tok()) == 8192
 
 
 def test_resolve_from_object_config():
     """Positive: embeddings-style object config is honored."""
     cfg = SimpleNamespace(max_position_embeddings=2048)
-    assert resolve(cfg, _Tok()) == 2048
+    assert resolve_max_length(cfg, _Tok()) == 2048
 
 
-def test_resolve_caps_at_8192():
-    """A model reporting a huge window is capped at 8192."""
+def test_resolve_trusts_large_explicit_config_value():
+    """Regression: an explicit model config limit is never silently
+    reduced, no matter how large."""
     cfg = {"max_position_embeddings": 100000}
-    assert resolve(cfg, _Tok()) == MAX_LENGTH_CAP
+    assert resolve_max_length(cfg, _Tok()) == 100000
 
 
 def test_resolve_falls_back_to_tokenizer():
     """No config value falls back to tokenizer.model_max_length."""
-    assert resolve(None, _Tok(model_max_length=2048)) == 2048
+    assert resolve_max_length(None, _Tok(model_max_length=2048)) == 2048
 
 
 def test_resolve_unwraps_inner_tokenizer():
     """The inner _tokenizer is consulted when present."""
     outer = SimpleNamespace(_tokenizer=_Tok(model_max_length=1024))
-    assert resolve(None, outer) == 1024
+    assert resolve_max_length(None, outer) == 1024
 
 
 def test_resolve_defaults_to_512():
     """Negative: no usable value anywhere returns the 512 default."""
-    assert resolve(None, _Tok()) == MAX_LENGTH_DEFAULT
+    assert resolve_max_length(None, _Tok()) == MAX_LENGTH_DEFAULT
 
 
-def test_resolve_ignores_non_int_and_sentinel():
-    """Non-int config values are rejected; huge sentinels are capped."""
-    # Non-int config -> falls through to a huge tokenizer sentinel -> capped.
+def test_resolve_ignores_non_int_config_and_rejects_tokenizer_sentinel():
+    """Non-int config values are rejected and fall through to the
+    tokenizer; a huge tokenizer sentinel is rejected too, in favor of the
+    default -- only the tokenizer-derived value is sentinel-checked."""
     cfg = {"max_position_embeddings": "nope"}
     tok = _Tok(model_max_length=10**30)
-    assert resolve(cfg, tok) == MAX_LENGTH_CAP
+    assert resolve_max_length(cfg, tok) == MAX_LENGTH_DEFAULT
 
 
 def test_resolve_rejects_bool():
     """bool is a subclass of int but must not be treated as a length."""
     cfg = {"max_position_embeddings": True}
-    assert resolve(cfg, _Tok()) == MAX_LENGTH_DEFAULT
+    assert resolve_max_length(cfg, _Tok()) == MAX_LENGTH_DEFAULT
 
 
-def test_resolve_honors_call_site_overrides():
-    """cap/default are caller-supplied, so an engine can override them."""
-    # Custom default when nothing usable is found.
-    assert resolve_max_length(None, _Tok(), cap=4096, default=256) == 256
-    # Custom cap clamps the model's window.
-    cfg = {"max_position_embeddings": 100000}
-    assert resolve_max_length(cfg, _Tok(), cap=4096, default=256) == 4096
+def test_resolve_config_value_bypasses_sentinel_threshold():
+    """An explicit config value at or above the tokenizer sentinel
+    threshold is still trusted -- sentinel detection only applies to the
+    tokenizer-derived fallback, never to an explicit architecture value."""
+    cfg = {"max_position_embeddings": TOKENIZER_SENTINEL_THRESHOLD + 1}
+    assert resolve_max_length(cfg, _Tok()) == TOKENIZER_SENTINEL_THRESHOLD + 1
+
+
+def test_resolve_tokenizer_value_rejected_at_sentinel_threshold():
+    """A tokenizer-derived value at or above the sentinel threshold is
+    treated as an unset HuggingFace placeholder, not a real length."""
+    tok = _Tok(model_max_length=TOKENIZER_SENTINEL_THRESHOLD)
+    assert resolve_max_length(None, tok) == MAX_LENGTH_DEFAULT
+
+
+def test_resolve_honors_default_override():
+    """default is a caller-supplied override."""
+    assert resolve_max_length(None, _Tok(), default=256) == 256
 
 
 def test_inner_tokenizer_unwraps_and_passes_through():

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -11,6 +11,13 @@ import time
 
 import mlx.core as mx
 
+from vllm_mlx.utils.truncation import (
+    MAX_LENGTH_CAP,
+    MAX_LENGTH_DEFAULT,
+    inner_tokenizer,
+    resolve_max_length,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,6 +33,7 @@ class EmbeddingEngine:
         self.model_name = model_name
         self._model = None
         self._tokenizer = None
+        self._max_length: int | None = None
 
     @property
     def is_loaded(self) -> bool:
@@ -44,6 +52,17 @@ class EmbeddingEngine:
     def _ensure_loaded(self) -> None:
         if not self.is_loaded:
             self.load()
+
+    def _resolve_max_length(self) -> int:
+        """Tokenizer truncation length from the model config (cached)."""
+        if self._max_length is None:
+            self._max_length = resolve_max_length(
+                getattr(self._model, "config", None),
+                self._tokenizer,
+                cap=MAX_LENGTH_CAP,
+                default=MAX_LENGTH_DEFAULT,
+            )
+        return self._max_length
 
     def embed(self, texts: str | list[str]) -> list[list[float]]:
         """
@@ -64,12 +83,12 @@ class EmbeddingEngine:
         # which has compatibility issues with newer tokenizers (e.g.
         # GemmaTokenizer lacks batch_encode_plus, and the model's __call__
         # expects positional `inputs` not `input_ids` as a kwarg).
-        inner_tok = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
+        inner_tok = inner_tokenizer(self._tokenizer)
         encoded = inner_tok(
             texts,
             padding=True,
             truncation=True,
-            max_length=512,
+            max_length=self._resolve_max_length(),
             return_tensors="np",
         )
 

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -11,12 +11,7 @@ import time
 
 import mlx.core as mx
 
-from vllm_mlx.utils.truncation import (
-    MAX_LENGTH_CAP,
-    MAX_LENGTH_DEFAULT,
-    inner_tokenizer,
-    resolve_max_length,
-)
+from vllm_mlx.utils.truncation import inner_tokenizer, resolve_max_length
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +54,6 @@ class EmbeddingEngine:
             self._max_length = resolve_max_length(
                 getattr(self._model, "config", None),
                 self._tokenizer,
-                cap=MAX_LENGTH_CAP,
-                default=MAX_LENGTH_DEFAULT,
             )
         return self._max_length
 

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -16,6 +16,12 @@ import asyncio
 
 import mlx.core as mx
 
+from vllm_mlx.utils.truncation import (
+    MAX_LENGTH_CAP,
+    MAX_LENGTH_DEFAULT,
+    resolve_max_length,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,7 +40,9 @@ class RerankAdapter(ABC):
     """
 
     @abstractmethod
-    def tokenize_pair(self, tokenizer, query: str, document: str) -> dict:
+    def tokenize_pair(
+        self, tokenizer, query: str, document: str, max_length: int
+    ) -> dict:
         """
         Tokenize a (query, document) pair for the cross-encoder.
 
@@ -42,6 +50,7 @@ class RerankAdapter(ABC):
             tokenizer: The HuggingFace tokenizer instance.
             query: The query string.
             document: The document string.
+            max_length: Truncation length (from the model's context window).
 
         Returns:
             Dict with 'input_ids' and 'attention_mask' as numpy arrays.
@@ -84,14 +93,16 @@ class SigmoidAdapter(RerankAdapter):
     normalized via sigmoid.
     """
 
-    def tokenize_pair(self, tokenizer, query: str, document: str) -> dict:
+    def tokenize_pair(
+        self, tokenizer, query: str, document: str, max_length: int
+    ) -> dict:
         """Tokenize as a sentence pair (query, document)."""
         return tokenizer(
             query,
             document,
             padding=True,
             truncation=True,
-            max_length=512,
+            max_length=max_length,
             return_tensors="np",
         )
 
@@ -243,11 +254,18 @@ class RerankEngine:
         """
         self._ensure_loaded()
 
+        max_length = resolve_max_length(
+            getattr(self._model, "config", None),
+            self._tokenizer,
+            cap=MAX_LENGTH_CAP,
+            default=MAX_LENGTH_DEFAULT,
+        )
+
         # Tokenize each pair individually to measure token counts
         pair_encodings = []
         pair_token_counts = []
         for doc in documents:
-            enc = self._adapter.tokenize_pair(self._tokenizer, query, doc)
+            enc = self._adapter.tokenize_pair(self._tokenizer, query, doc, max_length)
             pair_encodings.append(enc)
             seq_len = (
                 len(enc["input_ids"][0])

--- a/vllm_mlx/rerank.py
+++ b/vllm_mlx/rerank.py
@@ -16,11 +16,7 @@ import asyncio
 
 import mlx.core as mx
 
-from vllm_mlx.utils.truncation import (
-    MAX_LENGTH_CAP,
-    MAX_LENGTH_DEFAULT,
-    resolve_max_length,
-)
+from vllm_mlx.utils.truncation import resolve_max_length
 
 logger = logging.getLogger(__name__)
 
@@ -257,8 +253,6 @@ class RerankEngine:
         max_length = resolve_max_length(
             getattr(self._model, "config", None),
             self._tokenizer,
-            cap=MAX_LENGTH_CAP,
-            default=MAX_LENGTH_DEFAULT,
         )
 
         # Tokenize each pair individually to measure token counts

--- a/vllm_mlx/utils/__init__.py
+++ b/vllm_mlx/utils/__init__.py
@@ -3,5 +3,11 @@
 
 from .download import DownloadConfig, ensure_model_downloaded
 from .tokenizer import load_model_with_fallback
+from .truncation import resolve_max_length
 
-__all__ = ["DownloadConfig", "ensure_model_downloaded", "load_model_with_fallback"]
+__all__ = [
+    "DownloadConfig",
+    "ensure_model_downloaded",
+    "load_model_with_fallback",
+    "resolve_max_length",
+]

--- a/vllm_mlx/utils/truncation.py
+++ b/vllm_mlx/utils/truncation.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared resolution of the tokenizer truncation length for embedding and
+reranker models.
+
+The input token limit follows each model's own context window
+(``max_position_embeddings``) instead of a hard-coded 512, capped per engine.
+Falls back to the tokenizer's ``model_max_length`` and finally to a default.
+"""
+
+from typing import Any
+
+# Shared bounds for the tokenizer truncation length. Both the embedding and
+# reranker engines mean the same thing here; a per-engine override, if ever
+# needed, is passed at the call site via ``cap=``/``default=``.
+MAX_LENGTH_CAP = 8192
+MAX_LENGTH_DEFAULT = 512
+
+
+def _config_get(config: Any, key: str) -> Any:
+    """Read ``key`` from a model config that may be a dict or an object."""
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(key)
+    return getattr(config, key, None)
+
+
+def inner_tokenizer(tokenizer: Any) -> Any:
+    """Unwrap a wrapping tokenizer to its inner ``_tokenizer`` when present."""
+    return getattr(tokenizer, "_tokenizer", tokenizer)
+
+
+def resolve_max_length(config: Any, tokenizer: Any, *, cap: int, default: int) -> int:
+    """
+    Resolve the tokenizer truncation length for a model.
+
+    Source order: ``config.max_position_embeddings`` →
+    ``tokenizer.model_max_length`` → ``default``. The result is capped at
+    ``cap``, which also guards against the HuggingFace sentinel value
+    (``model_max_length`` is often a huge integer when unset).
+
+    Args:
+        config: Model config as a dict (reranker) or object (embeddings).
+        tokenizer: The tokenizer (possibly wrapping an inner ``_tokenizer``).
+        cap: Upper bound for the resolved length.
+        default: Fallback when no usable value is found.
+
+    Returns:
+        The truncation length to pass as ``max_length``.
+    """
+    val = _config_get(config, "max_position_embeddings")
+    if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+        val = getattr(inner_tokenizer(tokenizer), "model_max_length", None)
+    if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
+        return default
+    return min(val, cap)

--- a/vllm_mlx/utils/truncation.py
+++ b/vllm_mlx/utils/truncation.py
@@ -4,12 +4,10 @@ Shared resolution of the tokenizer truncation length for embedding and
 reranker models.
 
 The input token limit follows each model's own context window
-(``max_position_embeddings``) instead of a hard-coded 512. That value is an
-explicit architecture value supplied by the model config, so it is trusted
-as-is. Only the tokenizer-derived fallback (``model_max_length``) is subject
-to sentinel detection: HuggingFace leaves that field at a huge placeholder
-(commonly ~1e30) when no real limit was ever configured, and such a value
-must not be mistaken for a genuine context length.
+(``max_position_embeddings``) instead of a hard-coded 512. A finite tokenizer
+limit further constrains that architecture value, while HuggingFace's huge
+unset placeholder is ignored. This keeps position-table offsets safe for
+RoBERTa-family models without losing model-derived limits for sentinel values.
 """
 
 from typing import Any
@@ -56,10 +54,10 @@ def resolve_max_length(
 
     Source order:
       1. ``config.max_position_embeddings`` — an explicit value supplied by
-         the model's own architecture. Trusted as-is, uncapped.
-      2. ``tokenizer.model_max_length`` — only used when the config didn't
-         supply a value. Rejected as unreliable when it is at or above
-         ``sentinel_threshold`` (the HuggingFace "unset" placeholder).
+         the model's own architecture.
+      2. A finite ``tokenizer.model_max_length`` further constrains the
+         architecture value. This matters for RoBERTa-family models, whose
+         position table includes reserved padding positions.
       3. ``default``, when neither source yields a usable value.
 
     Args:
@@ -72,14 +70,14 @@ def resolve_max_length(
     Returns:
         The truncation length to pass as ``max_length``.
     """
-    resolved = _positive_int(_config_get(config, "max_position_embeddings"))
-    if resolved is None:
-        tok_val = _positive_int(
-            getattr(inner_tokenizer(tokenizer), "model_max_length", None)
-        )
-        resolved = (
-            tok_val if tok_val is not None and tok_val < sentinel_threshold else None
-        )
+    config_val = _positive_int(_config_get(config, "max_position_embeddings"))
+    tok_val = _positive_int(
+        getattr(inner_tokenizer(tokenizer), "model_max_length", None)
+    )
+    if tok_val is not None and tok_val < sentinel_threshold:
+        resolved = min(config_val, tok_val) if config_val is not None else tok_val
+    else:
+        resolved = config_val
     if resolved is None:
         resolved = default
     return resolved

--- a/vllm_mlx/utils/truncation.py
+++ b/vllm_mlx/utils/truncation.py
@@ -4,17 +4,24 @@ Shared resolution of the tokenizer truncation length for embedding and
 reranker models.
 
 The input token limit follows each model's own context window
-(``max_position_embeddings``) instead of a hard-coded 512, capped per engine.
-Falls back to the tokenizer's ``model_max_length`` and finally to a default.
+(``max_position_embeddings``) instead of a hard-coded 512. That value is an
+explicit architecture value supplied by the model config, so it is trusted
+as-is. Only the tokenizer-derived fallback (``model_max_length``) is subject
+to sentinel detection: HuggingFace leaves that field at a huge placeholder
+(commonly ~1e30) when no real limit was ever configured, and such a value
+must not be mistaken for a genuine context length.
 """
 
 from typing import Any
 
-# Shared bounds for the tokenizer truncation length. Both the embedding and
-# reranker engines mean the same thing here; a per-engine override, if ever
-# needed, is passed at the call site via ``cap=``/``default=``.
-MAX_LENGTH_CAP = 8192
 MAX_LENGTH_DEFAULT = 512
+
+# HuggingFace tokenizers default model_max_length to a huge sentinel (e.g.
+# int(1e30)) when unset. Any tokenizer-derived value at or above this is
+# treated as "unset" rather than a real context length. No real model
+# context window is anywhere near this size, so it does not affect trusted
+# config values.
+TOKENIZER_SENTINEL_THRESHOLD = 1_000_000
 
 
 def _config_get(config: Any, key: str) -> Any:
@@ -31,27 +38,48 @@ def inner_tokenizer(tokenizer: Any) -> Any:
     return getattr(tokenizer, "_tokenizer", tokenizer)
 
 
-def resolve_max_length(config: Any, tokenizer: Any, *, cap: int, default: int) -> int:
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def resolve_max_length(
+    config: Any,
+    tokenizer: Any,
+    *,
+    default: int = MAX_LENGTH_DEFAULT,
+    sentinel_threshold: int = TOKENIZER_SENTINEL_THRESHOLD,
+) -> int:
     """
     Resolve the tokenizer truncation length for a model.
 
-    Source order: ``config.max_position_embeddings`` →
-    ``tokenizer.model_max_length`` → ``default``. The result is capped at
-    ``cap``, which also guards against the HuggingFace sentinel value
-    (``model_max_length`` is often a huge integer when unset).
+    Source order:
+      1. ``config.max_position_embeddings`` — an explicit value supplied by
+         the model's own architecture. Trusted as-is, uncapped.
+      2. ``tokenizer.model_max_length`` — only used when the config didn't
+         supply a value. Rejected as unreliable when it is at or above
+         ``sentinel_threshold`` (the HuggingFace "unset" placeholder).
+      3. ``default``, when neither source yields a usable value.
 
     Args:
         config: Model config as a dict (reranker) or object (embeddings).
         tokenizer: The tokenizer (possibly wrapping an inner ``_tokenizer``).
-        cap: Upper bound for the resolved length.
         default: Fallback when no usable value is found.
+        sentinel_threshold: Tokenizer-derived values at or above this are
+            treated as an unset HuggingFace sentinel, not a real length.
 
     Returns:
         The truncation length to pass as ``max_length``.
     """
-    val = _config_get(config, "max_position_embeddings")
-    if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
-        val = getattr(inner_tokenizer(tokenizer), "model_max_length", None)
-    if not isinstance(val, int) or isinstance(val, bool) or val <= 0:
-        return default
-    return min(val, cap)
+    resolved = _positive_int(_config_get(config, "max_position_embeddings"))
+    if resolved is None:
+        tok_val = _positive_int(
+            getattr(inner_tokenizer(tokenizer), "model_max_length", None)
+        )
+        resolved = (
+            tok_val if tok_val is not None and tok_val < sentinel_threshold else None
+        )
+    if resolved is None:
+        resolved = default
+    return resolved


### PR DESCRIPTION
## Summary

`EmbeddingEngine.embed()` and the reranker's `SigmoidAdapter.tokenize_pair()`
both hardcode `max_length=512` when tokenizing input — regardless of what the
loaded model actually supports. Inputs longer than 512 tokens are silently
truncated (`truncation=True`), with no warning to the caller.

This is invisible for classic BERT-class models (512 is their real window),
but modern embedding/reranker checkpoints support much more:
`mlx-community/nomicai-modernbert-embed-base-8bit` and ModernBERT-base
support **8192** tokens, `embeddinggemma-300m` supports 2048. Any request
using one of these models currently loses everything past token 512 without
the caller knowing.

This PR resolves the truncation length from each model's own
`config.max_position_embeddings`, trusted as-is and uncapped since it's an
explicit architecture value. Only when the config doesn't supply one does it
fall back to `tokenizer.model_max_length` — subject to sentinel detection,
since HuggingFace defaults that field to a huge placeholder (`~1e30`) when
never actually configured (any tokenizer-derived value ≥ 1,000,000 is
treated as unset). Otherwise it defaults to 512. Classic 512-token models are
unaffected — the resolved value stays 512, byte-identical to today's
behavior.

## Type of change

- Bug fix

## Surface touched

- OpenAI API endpoints (`/v1/embeddings`, `/v1/rerank`)

## Test plan

New unit tests cover the resolver in isolation plus both call sites, positive
(model reports a large window → truncation length follows it) and negative
(no usable config/tokenizer value → falls back to 512):

    pytest tests/test_truncation.py tests/test_embeddings.py tests/test_rerank.py -q