### PR TITLE
Fix Mistral tool parser for the [ARGS]-marker format (Ministral 3, Devstral Small 2)

### DIFF
--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -139,6 +139,24 @@ class TestMistralToolParser:
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0]["name"] == "get_weather"
 
+    def test_args_token_format(self, parser):
+        """Test parsing the newest Mistral format with an explicit [ARGS]
+        marker between the function name and its arguments, used by Ministral
+        3 and Devstral Small 2 (Dec 2025) tokenizers — confirmed directly in
+        their chat_template.jinja: '[TOOL_CALLS]' + name + '[ARGS]' + args.
+
+        Regression test: without recognizing the marker, the name previously
+        came back as "get_weather[ARGS]" instead of "get_weather".
+        """
+        text = '[TOOL_CALLS]get_weather[ARGS]{"city": "Paris"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["city"] == "Paris"
+
     def test_no_tool_call(self, parser):
         """Test that regular text is not parsed as tool call."""
         text = "Hello, how can I help you today?"
@@ -754,6 +772,85 @@ class TestStreamingParsing:
             delta_text="[TOOL_CALLS]",
         )
         # Should start tool call parsing
+
+    def test_mistral_streaming_args_token(self):
+        """Regression test: streaming reconstruction of the [ARGS]-marker
+        format must never misclassify mid-argument JSON fragments as more
+        of the function name.
+
+        This replays the literal delta sequence captured from a live
+        vllm-mlx server response for mlx-community/Ministral-3-14B-Instruct-2512-4bit
+        (--tool-call-parser mistral), which previously reconstructed as
+        name="get_weather[ARGS]city\":\"Paris\"}" / arguments='[ARGS]{"'
+        instead of the correct name="get_weather" / arguments='{"city": "Paris"}'.
+        """
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get",
+            "_",
+            "weather",
+            "[ARGS]",
+            '{"',
+            "city",
+            '":',
+            '"',
+            "Paris",
+            '"}',
+        ]
+
+        name_parts: list[str] = []
+        args_parts: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                func = tc.get("function", {})
+                if "name" in func:
+                    name_parts.append(func["name"])
+                if "arguments" in func:
+                    args_parts.append(func["arguments"])
+
+        assert "".join(name_parts) == "get_weather"
+        assert "".join(args_parts) == '{"city":"Paris"}'
+
+    def test_mistral_streaming_args_token_split_across_deltas(self):
+        """The [ARGS] marker itself may be split across two deltas
+        (e.g. tokenizer boundaries don't align with the marker). The parser
+        must still find it once both halves have arrived, rather than ever
+        misclassifying the fragments."""
+        parser = MistralToolParser()
+        deltas = ["[TOOL_CALLS]get_weather[AR", 'GS]{"city": "Paris"}']
+
+        name_parts: list[str] = []
+        args_parts: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                func = tc.get("function", {})
+                if "name" in func:
+                    name_parts.append(func["name"])
+                if "arguments" in func:
+                    args_parts.append(func["arguments"])
+
+        assert "".join(name_parts) == "get_weather"
+        assert "".join(args_parts) == '{"city": "Paris"}'
 
     def test_auto_streaming(self):
         """Test auto parser streaming."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -895,7 +895,8 @@ class TestStreamingParsing:
         rather than dropping it entirely."""
         parser = MistralToolParser()
         deltas = [
-            "[TOOL_CALLS]get",
+            "[TOOL_CALLS]",
+            "get",
             "_",
             "weather",
             "[ARGS]",
@@ -908,6 +909,7 @@ class TestStreamingParsing:
         ]
 
         ids_seen: list[str] = []
+        id_function: list[dict] = []
         current = ""
         for delta in deltas:
             previous = current
@@ -922,9 +924,53 @@ class TestStreamingParsing:
             for tc in result.get("tool_calls", []):
                 if "id" in tc:
                     ids_seen.append(tc["id"])
+                    id_function.append(tc.get("function", {}))
 
         assert len(ids_seen) == 1
         assert ids_seen[0]
+        # The id must ride the first delta that carries real content (the
+        # complete buffered name), never the empty BOT_TOKEN delta.
+        assert id_function[0].get("name") == "get_weather"
+
+    def test_mistral_streaming_legacy_brace_reconstruction(self):
+        """The rewritten streaming parser also owns the legacy `{` boundary.
+        Replaying the old format delta by delta must reconstruct the name and
+        arguments correctly — removing "{" from the marker scan must fail
+        this test."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get",
+            "_",
+            "weather",
+            '{"',
+            "city",
+            '": "',
+            "London",
+            '"}',
+        ]
+
+        name_parts: list[str] = []
+        args_parts: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                func = tc.get("function", {})
+                if "name" in func:
+                    name_parts.append(func["name"])
+                if "arguments" in func:
+                    args_parts.append(func["arguments"])
+
+        assert "".join(name_parts) == "get_weather"
+        assert "".join(args_parts) == '{"city": "London"}'
 
     def test_mistral_streaming_marker_in_arguments_does_not_reset(self):
         """Once the name/arguments boundary was passed, a [TOOL_CALLS] marker

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -852,6 +852,46 @@ class TestStreamingParsing:
         assert "".join(name_parts) == "get_weather"
         assert "".join(args_parts) == '{"city": "Paris"}'
 
+    def test_mistral_streaming_args_token_has_stable_id(self):
+        """Regression test: the [ARGS] marker defers the name/arguments
+        boundary past the delta containing BOT_TOKEN, so the tool-call id
+        must not be tied to that specific delta — it needs to land on
+        whichever delta is actually first to carry name/arguments, and only
+        once, so accumulation on the client produces a single stable id
+        rather than dropping it entirely."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get",
+            "_",
+            "weather",
+            "[ARGS]",
+            '{"',
+            "city",
+            '":',
+            '"',
+            "Paris",
+            '"}',
+        ]
+
+        ids_seen: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                if "id" in tc:
+                    ids_seen.append(tc["id"])
+
+        assert len(ids_seen) == 1
+        assert ids_seen[0]
+
     def test_auto_streaming(self):
         """Test auto parser streaming."""
         parser = AutoToolParser()

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -157,6 +157,40 @@ class TestMistralToolParser:
         args = json.loads(result.tool_calls[0]["arguments"])
         assert args["city"] == "Paris"
 
+    def test_args_token_inside_json_arguments_uses_brace_boundary(self, parser):
+        """The [ARGS] marker is only the name/arguments boundary when it
+        comes before the first `{`. A legacy-format call whose JSON arguments
+        contain the literal "[ARGS]" substring must keep the `{` boundary."""
+        text = '[TOOL_CALLS]get_weather{"k": "[ARGS]"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["k"] == "[ARGS]"
+
+    def test_marker_inside_json_string_does_not_forge_call(self, parser):
+        """A [TOOL_CALLS] marker inside a quoted JSON string value is
+        argument data, not a new call — it must never split into a second
+        dispatchable tool call."""
+        text = '[TOOL_CALLS]get_weather[ARGS]{"city": "[TOOL_CALLS]rm"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args["city"] == "[TOOL_CALLS]rm"
+
+    def test_args_token_rejects_non_json_arguments(self, parser):
+        """The [ARGS] format must not emit calls whose arguments do not
+        parse as JSON — rejecting beats dispatching corrupted arguments."""
+        text = "[TOOL_CALLS]get_weather[ARGS]not-json"
+        result = parser.extract_tool_calls(text)
+
+        assert not result.tools_called
+
     def test_no_tool_call(self, parser):
         """Test that regular text is not parsed as tool call."""
         text = "Hello, how can I help you today?"
@@ -891,6 +925,69 @@ class TestStreamingParsing:
 
         assert len(ids_seen) == 1
         assert ids_seen[0]
+
+    def test_mistral_streaming_marker_in_arguments_does_not_reset(self):
+        """Once the name/arguments boundary was passed, a [TOOL_CALLS] marker
+        inside the arguments text is data, not a new call — it must never
+        reset the streaming state or forge a second call."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get",
+            "_weather",
+            "[ARGS]",
+            '{"city": "',
+            "[TOOL_CALLS]rm",
+            '"}',
+        ]
+
+        name_parts: list[str] = []
+        args_parts: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                func = tc.get("function", {})
+                if "name" in func:
+                    name_parts.append(func["name"])
+                if "arguments" in func:
+                    args_parts.append(func["arguments"])
+
+        assert "".join(name_parts) == "get_weather"
+        assert "".join(args_parts) == '{"city": "[TOOL_CALLS]rm"}'
+
+    def test_mistral_streaming_marker_never_arrives_emits_content(self):
+        """If the boundary marker never arrives (truncation or the model
+        deviating into prose after [TOOL_CALLS]), the withheld text must be
+        flushed as content instead of silently lost, and the name buffer
+        must stay bounded."""
+        parser = MistralToolParser()
+        deltas = ["[TOOL_CALLS]get", "_weather", " then", " prose"] + ["word"] * 80
+
+        content_parts: list[str] = []
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if result and "content" in result:
+                content_parts.append(result["content"])
+
+        assert content_parts
+        assert "".join(content_parts).startswith("get_weather then prose")
+        assert parser._name_buffer == ""
+        assert parser._name_buffer_overflow
 
     def test_auto_streaming(self):
         """Test auto parser streaming."""

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -207,6 +207,30 @@ class TestMistralToolParser:
         assert result.tools_called
         assert result.content == "Let me check the weather for you."
 
+    def test_odd_quotes_in_prose_before_marker(self, parser):
+        """Prose before the first [TOOL_CALLS] marker is not JSON. An odd
+        number of double quotes in that prose must not leave the marker
+        treated as inside a string (which would hide the call entirely)."""
+        text = (
+            'The column is called "id.[TOOL_CALLS]get_schema[ARGS]' '{"table":"users"}'
+        )
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_schema"
+        args = json.loads(result.tool_calls[0]["arguments"])
+        assert args == {"table": "users"}
+
+    def test_odd_quotes_in_prose_legacy_format(self, parser):
+        """Same odd-quote prose guard for the legacy `{` boundary format."""
+        text = 'The column is called "id.[TOOL_CALLS]get_schema' '{"table":"users"}'
+        result = parser.extract_tool_calls(text)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_schema"
+
 
 class TestQwenToolParser:
     """Test the Qwen tool parser."""
@@ -1034,6 +1058,116 @@ class TestStreamingParsing:
         assert "".join(content_parts).startswith("get_weather then prose")
         assert parser._name_buffer == ""
         assert parser._name_buffer_overflow
+
+    def test_mistral_streaming_parallel_args_calls(self):
+        """Two consecutive [ARGS] tool calls in one streamed response must
+        open separate indices instead of collapsing into a single call with
+        malformed concatenated arguments. Regression: the `_args_started`
+        early return used to swallow the second [TOOL_CALLS] delta."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]",
+            "get_weather",
+            "[ARGS]",
+            '{"city":"Madrid"}',
+            "[TOOL_CALLS]",
+            "get_time",
+            "[ARGS]",
+            '{"tz":"CET"}',
+        ]
+
+        indices: list[int] = []
+        args: dict[int, str] = {}
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                idx = tc["index"]
+                indices.append(idx)
+                args[idx] = args.get(idx, "") + tc.get("function", {}).get(
+                    "arguments", ""
+                )
+
+        assert sorted(set(indices)) == [0, 1]
+        assert json.loads(args[0]) == {"city": "Madrid"}
+        assert json.loads(args[1]) == {"tz": "CET"}
+
+    def test_mistral_streaming_parallel_legacy_calls(self):
+        """Same regression check for the legacy `{` boundary format, which
+        main already streamed as separate indices."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get_weather",
+            '{"city":"Madrid"}',
+            "[TOOL_CALLS]get_time",
+            '{"tz":"CET"}',
+        ]
+
+        indices: list[int] = []
+        args: dict[int, str] = {}
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                idx = tc["index"]
+                indices.append(idx)
+                args[idx] = args.get(idx, "") + tc.get("function", {}).get(
+                    "arguments", ""
+                )
+
+        assert sorted(set(indices)) == [0, 1]
+        assert json.loads(args[0]) == {"city": "Madrid"}
+        assert json.loads(args[1]) == {"tz": "CET"}
+
+    def test_mistral_streaming_second_call_in_same_delta(self):
+        """A new call may begin inside an argument delta (the marker is not
+        its own token). The pre-marker text closes the current call and the
+        remainder opens the next index."""
+        parser = MistralToolParser()
+        deltas = [
+            "[TOOL_CALLS]get_weather[ARGS]",
+            '{"city":"Madrid"}[TOOL_CALLS]get_time[ARGS]{"tz":"CET"}',
+        ]
+
+        indices: list[int] = []
+        args: dict[int, str] = {}
+        current = ""
+        for delta in deltas:
+            previous = current
+            current += delta
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+            )
+            if not result:
+                continue
+            for tc in result.get("tool_calls", []):
+                idx = tc["index"]
+                indices.append(idx)
+                args[idx] = args.get(idx, "") + tc.get("function", {}).get(
+                    "arguments", ""
+                )
+
+        assert sorted(set(indices)) == [0, 1]
+        assert json.loads(args[0]) == {"city": "Madrid"}
+        assert json.loads(args[1]) == {"tz": "CET"}
 
     def test_auto_streaming(self):
         """Test auto parser streaming."""

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -5,8 +5,12 @@ Mistral tool call parser for vllm-mlx.
 Handles Mistral's tool calling format:
 - Format: [TOOL_CALLS] [{"name": "func", "arguments": {...}}]
 - Or newer: [TOOL_CALLS]func_name{"arg": "value"}
+- Or newest (Ministral 3, Devstral Small 2, Dec 2025 tokenizers):
+  [TOOL_CALLS]func_name[ARGS]{"arg": "value"}
+  Confirmed directly in these models' chat_template.jinja:
+  {{- '[TOOL_CALLS]' + tool['function']['name'] + '[ARGS]' + arguments }}
 
-Used with models like Mistral-7B-Instruct, Devstral, etc.
+Used with models like Mistral-7B-Instruct, Devstral, Ministral 3, etc.
 """
 
 import json
@@ -50,11 +54,21 @@ class MistralToolParser(ToolParser):
     SUPPORTS_NATIVE_TOOL_FORMAT = True
 
     BOT_TOKEN = "[TOOL_CALLS]"
+    ARGS_TOKEN = "[ARGS]"
     TOOL_CALL_REGEX = re.compile(r"\[{.*}\]", re.DOTALL)
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
         self.bot_token_id = self.vocab.get(self.BOT_TOKEN) if self.vocab else None
+        # Streaming state for the name/arguments boundary within the current
+        # tool call. See _parse_streaming_tool_delta.
+        self._args_started: bool = False
+        self._name_buffer: str = ""
+
+    def reset(self) -> None:
+        super().reset()
+        self._args_started = False
+        self._name_buffer = ""
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -86,7 +100,22 @@ class MistralToolParser(ToolParser):
             if not raw_tool_call:
                 continue
 
-            # Try new format first: func_name{"arg": "value"}
+            # Try newest format first: func_name[ARGS]{"arg": "value"}
+            if not raw_tool_call.startswith("[") and self.ARGS_TOKEN in raw_tool_call:
+                tool_name, _, args_str = raw_tool_call.partition(self.ARGS_TOKEN)
+                tool_name = tool_name.strip()
+
+                if tool_name:
+                    tool_calls.append(
+                        {
+                            "id": generate_mistral_tool_id(),
+                            "name": tool_name,
+                            "arguments": args_str,
+                        }
+                    )
+                continue
+
+            # Try new format: func_name{"arg": "value"}
             if not raw_tool_call.startswith("[") and "{" in raw_tool_call:
                 end_name = raw_tool_call.find("{")
                 tool_name = raw_tool_call[:end_name].strip()
@@ -200,6 +229,8 @@ class MistralToolParser(ToolParser):
 
             # Start tracking tool call
             self.current_tool_id += 1
+            self._args_started = False
+            self._name_buffer = ""
 
             if tool_part:
                 # Try to parse the tool part
@@ -233,25 +264,39 @@ class MistralToolParser(ToolParser):
         return None
 
     def _parse_streaming_tool_delta(self, text: str) -> dict[str, str] | None:
-        """Parse a streaming delta for tool call information."""
+        """Parse a streaming delta for tool call information.
+
+        Once the name/arguments boundary (the `[ARGS]` marker, or a bare `{`
+        for older checkpoints) has been seen for the current tool call, every
+        subsequent delta is argument text and is never re-classified — JSON
+        string content (bare keys/values like `city` or `Paris`) has no
+        distinguishing leading punctuation, so re-evaluating each delta in
+        isolation (the previous approach) misclassified mid-argument
+        fragments as more of the function name.
+        """
         if not text:
             return None
 
-        result: dict[str, str] = {}
+        if self._args_started:
+            return {"arguments": text}
 
-        # Check for function name (before {)
-        if "{" in text:
-            name_part = text[: text.find("{")]
-            args_part = text[text.find("{") :]
-            if name_part.strip():
-                result["name"] = name_part.strip()
-            if args_part:
-                result["arguments"] = args_part
-        else:
-            # Could be name or arguments continuation
-            if text.strip() and not text.startswith(("{", "}", "[", "]", ",")):
-                result["name"] = text.strip()
-            else:
-                result["arguments"] = text
+        # Buffer until we can find the boundary marker — it may itself be
+        # split across two deltas (e.g. "...[AR" / "GS]...").
+        self._name_buffer += text
+        for marker in (self.ARGS_TOKEN, "{"):
+            idx = self._name_buffer.find(marker)
+            if idx == -1:
+                continue
+            name = self._name_buffer[:idx].strip()
+            args_start = idx + len(marker) if marker == self.ARGS_TOKEN else idx
+            args = self._name_buffer[args_start:]
+            self._args_started = True
+            result: dict[str, str] = {}
+            if name:
+                result["name"] = name
+            if args:
+                result["arguments"] = args
+            return result if result else None
 
-        return result if result else None
+        # Marker not seen yet — withhold rather than guess.
+        return None

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -71,6 +71,12 @@ class MistralToolParser(ToolParser):
         # Streaming state for the name/arguments boundary within the current
         # tool call. See _parse_streaming_tool_delta.
         self._args_started: bool = False
+        # Quote state carried across argument deltas, used to tell a
+        # [TOOL_CALLS] marker inside a JSON string (argument data) from a
+        # marker between two calls (a new index). See
+        # _scan_args_for_new_call.
+        self._args_in_string: bool = False
+        self._args_escaped: bool = False
         self._name_buffer: str = ""
         # Set when the boundary marker never arrives and the withheld text
         # was flushed as content; subsequent deltas pass through as content.
@@ -86,10 +92,56 @@ class MistralToolParser(ToolParser):
     def reset(self) -> None:
         super().reset()
         self._args_started = False
+        self._args_in_string = False
+        self._args_escaped = False
         self._name_buffer = ""
         self._name_buffer_overflow = False
         self._current_tool_call_id = None
         self._tool_call_id_emitted = False
+
+    def _start_new_tool_call(self) -> None:
+        """Begin a new streaming tool call: bump the index and reset the
+        per-call name/arguments and id state."""
+        self.current_tool_id += 1
+        self._args_started = False
+        self._args_in_string = False
+        self._args_escaped = False
+        self._name_buffer = ""
+        self._name_buffer_overflow = False
+        self._current_tool_call_id = generate_mistral_tool_id()
+        self._tool_call_id_emitted = False
+
+    def _scan_args_for_new_call(self, text: str) -> int:
+        """Scan an argument delta, updating the persistent JSON string state,
+        and return the position of the first [TOOL_CALLS] marker that sits
+        outside a string (a new call), or -1 when there is none.
+
+        Quote state is carried across deltas so a marker inside a quoted
+        value (e.g. ``{"city": "[TOOL_CALLS]rm"}``) stays argument data while
+        a marker between two calls opens the next index.
+        """
+        i = 0
+        while i < len(text):
+            ch = text[i]
+            if self._args_escaped:
+                self._args_escaped = False
+                i += 1
+                continue
+            if self._args_in_string:
+                if ch == "\\":
+                    self._args_escaped = True
+                elif ch == '"':
+                    self._args_in_string = False
+                i += 1
+                continue
+            if ch == '"':
+                self._args_in_string = True
+                i += 1
+                continue
+            if text.startswith(self.BOT_TOKEN, i):
+                return i
+            i += 1
+        return -1
 
     def _split_on_tool_call_markers(self, text: str) -> list[str]:
         """Split on [TOOL_CALLS] occurrences that are outside JSON strings.
@@ -97,13 +149,22 @@ class MistralToolParser(ToolParser):
         A marker appearing inside a quoted string value is argument data,
         not a new call — splitting there would let untrusted model output
         forge a second dispatchable call.
+
+        The quote-state scan starts at the first marker, not at index 0: the
+        text before the first marker is prose, not JSON, so an odd number of
+        double quotes there must not leave ``in_string`` set when the marker
+        arrives (that would hide the call entirely).
         """
-        parts: list[str] = []
-        start = 0
+        token = self.BOT_TOKEN
+        first = text.find(token)
+        if first == -1:
+            return [text]
+
+        parts: list[str] = [text[:first]]
+        start = first + len(token)
         in_string = False
         escaped = False
-        i = 0
-        token = self.BOT_TOKEN
+        i = start
         while i < len(text):
             ch = text[i]
             if in_string:
@@ -284,22 +345,49 @@ class MistralToolParser(ToolParser):
         For streaming, we detect when [TOOL_CALLS] appears and start
         accumulating tool call data.
         """
-        # Everything after the name/arguments boundary is arguments text —
-        # never re-scan for new [TOOL_CALLS] markers inside it (a marker in
-        # a quoted string value is data, not a new call). A genuine new call
-        # starts with its own [TOOL_CALLS] delta and is handled below; the
-        # end-of-stream non-streaming re-parse recovers calls that arrive
-        # inside a shared delta.
+        # Everything after the name/arguments boundary is arguments text.
+        # A [TOOL_CALLS] marker inside a quoted JSON string value is argument
+        # data, not a new call; a marker outside a string starts the next
+        # call (its own index). The end-of-stream non-streaming re-parse
+        # recovers calls that arrive inside a shared delta.
         if self._args_started:
-            return {
-                "tool_calls": [
+            new_call_pos = self._scan_args_for_new_call(delta_text)
+            if new_call_pos == -1:
+                return {
+                    "tool_calls": [
+                        {
+                            "index": self.current_tool_id,
+                            "type": "function",
+                            "function": {"arguments": delta_text},
+                        }
+                    ]
+                }
+            # A new call begins inside this delta: close the current call with
+            # the pre-marker text, then start the next one.
+            result: dict[str, Any] = {}
+            pre = delta_text[:new_call_pos]
+            if pre:
+                result["tool_calls"] = [
                     {
                         "index": self.current_tool_id,
                         "type": "function",
-                        "function": {"arguments": delta_text},
+                        "function": {"arguments": pre},
                     }
                 ]
-            }
+            self._start_new_tool_call()
+            tool_delta = self._parse_streaming_tool_delta(
+                delta_text[new_call_pos + len(self.BOT_TOKEN) :]
+            )
+            if tool_delta:
+                tool_call: dict[str, Any] = {
+                    "index": self.current_tool_id,
+                    "type": "function",
+                    "function": tool_delta,
+                }
+                tool_call["id"] = self._current_tool_call_id
+                self._tool_call_id_emitted = True
+                result["tool_calls"] = (result.get("tool_calls") or []) + [tool_call]
+            return result if result else None
 
         # Check if tool call token is in current output
         if self.BOT_TOKEN not in current_text:
@@ -318,12 +406,7 @@ class MistralToolParser(ToolParser):
                 result["content"] = content_part
 
             # Start tracking tool call
-            self.current_tool_id += 1
-            self._args_started = False
-            self._name_buffer = ""
-            self._name_buffer_overflow = False
-            self._current_tool_call_id = generate_mistral_tool_id()
-            self._tool_call_id_emitted = False
+            self._start_new_tool_call()
 
             if tool_part:
                 # Try to parse the tool part

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -64,11 +64,20 @@ class MistralToolParser(ToolParser):
         # tool call. See _parse_streaming_tool_delta.
         self._args_started: bool = False
         self._name_buffer: str = ""
+        # One id per active tool call, generated when the call starts and
+        # attached to whichever delta is the first to carry real content
+        # (name and/or arguments) — that may not be the delta containing
+        # BOT_TOKEN itself, since the name can still be buffered pending the
+        # [ARGS]/`{` boundary. See _parse_streaming_tool_delta.
+        self._current_tool_call_id: str | None = None
+        self._tool_call_id_emitted: bool = False
 
     def reset(self) -> None:
         super().reset()
         self._args_started = False
         self._name_buffer = ""
+        self._current_tool_call_id = None
+        self._tool_call_id_emitted = False
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -231,19 +240,21 @@ class MistralToolParser(ToolParser):
             self.current_tool_id += 1
             self._args_started = False
             self._name_buffer = ""
+            self._current_tool_call_id = generate_mistral_tool_id()
+            self._tool_call_id_emitted = False
 
             if tool_part:
                 # Try to parse the tool part
                 tool_delta = self._parse_streaming_tool_delta(tool_part)
                 if tool_delta:
-                    result["tool_calls"] = [
-                        {
-                            "index": self.current_tool_id,
-                            "id": generate_mistral_tool_id(),
-                            "type": "function",
-                            "function": tool_delta,
-                        }
-                    ]
+                    tool_call: dict[str, Any] = {
+                        "index": self.current_tool_id,
+                        "type": "function",
+                        "function": tool_delta,
+                    }
+                    tool_call["id"] = self._current_tool_call_id
+                    self._tool_call_id_emitted = True
+                    result["tool_calls"] = [tool_call]
 
             return result if result else None
 
@@ -251,15 +262,19 @@ class MistralToolParser(ToolParser):
         if self.current_tool_id >= 0:
             tool_delta = self._parse_streaming_tool_delta(delta_text)
             if tool_delta:
-                return {
-                    "tool_calls": [
-                        {
-                            "index": self.current_tool_id,
-                            "type": "function",
-                            "function": tool_delta,
-                        }
-                    ]
+                tool_call = {
+                    "index": self.current_tool_id,
+                    "type": "function",
+                    "function": tool_delta,
                 }
+                # The name may still have been buffered pending the
+                # [ARGS]/`{` boundary when the BOT_TOKEN delta arrived, so
+                # this may be the first delta with real content — attach the
+                # id exactly once, whichever delta that turns out to be.
+                if not self._tool_call_id_emitted:
+                    tool_call["id"] = self._current_tool_call_id
+                    self._tool_call_id_emitted = True
+                return {"tool_calls": [tool_call]}
 
         return None
 

--- a/vllm_mlx/tool_parsers/mistral_tool_parser.py
+++ b/vllm_mlx/tool_parsers/mistral_tool_parser.py
@@ -28,6 +28,8 @@ from .abstract_tool_parser import (
 
 ALPHANUMERIC = ascii_letters + digits
 
+_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+
 
 def generate_mistral_tool_id() -> str:
     """
@@ -36,6 +38,11 @@ def generate_mistral_tool_id() -> str:
     Mistral Tool Call IDs must be alphanumeric with a length of 9.
     """
     return "".join(choices(ALPHANUMERIC, k=9))
+
+
+def _is_plain_tool_name(name: str) -> bool:
+    """Return True for names that are safe to dispatch as function calls."""
+    return bool(_TOOL_NAME_PATTERN.match(name))
 
 
 @ToolParserManager.register_module("mistral")
@@ -56,6 +63,7 @@ class MistralToolParser(ToolParser):
     BOT_TOKEN = "[TOOL_CALLS]"
     ARGS_TOKEN = "[ARGS]"
     TOOL_CALL_REGEX = re.compile(r"\[{.*}\]", re.DOTALL)
+    _NAME_BUFFER_LIMIT = 256
 
     def __init__(self, tokenizer=None):
         super().__init__(tokenizer)
@@ -64,6 +72,9 @@ class MistralToolParser(ToolParser):
         # tool call. See _parse_streaming_tool_delta.
         self._args_started: bool = False
         self._name_buffer: str = ""
+        # Set when the boundary marker never arrives and the withheld text
+        # was flushed as content; subsequent deltas pass through as content.
+        self._name_buffer_overflow: bool = False
         # One id per active tool call, generated when the call starts and
         # attached to whichever delta is the first to carry real content
         # (name and/or arguments) — that may not be the delta containing
@@ -76,8 +87,46 @@ class MistralToolParser(ToolParser):
         super().reset()
         self._args_started = False
         self._name_buffer = ""
+        self._name_buffer_overflow = False
         self._current_tool_call_id = None
         self._tool_call_id_emitted = False
+
+    def _split_on_tool_call_markers(self, text: str) -> list[str]:
+        """Split on [TOOL_CALLS] occurrences that are outside JSON strings.
+
+        A marker appearing inside a quoted string value is argument data,
+        not a new call — splitting there would let untrusted model output
+        forge a second dispatchable call.
+        """
+        parts: list[str] = []
+        start = 0
+        in_string = False
+        escaped = False
+        i = 0
+        token = self.BOT_TOKEN
+        while i < len(text):
+            ch = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+                i += 1
+                continue
+            if ch == '"':
+                in_string = True
+                i += 1
+                continue
+            if text.startswith(token, i):
+                parts.append(text[start:i])
+                start = i + len(token)
+                i += len(token)
+                continue
+            i += 1
+        parts.append(text[start:])
+        return parts
 
     def extract_tool_calls(
         self, model_output: str, request: dict[str, Any] | None = None
@@ -98,7 +147,7 @@ class MistralToolParser(ToolParser):
                 tools_called=False, tool_calls=[], content=model_output
             )
 
-        content_and_raw_tool_calls = model_output.split(self.BOT_TOKEN)
+        content_and_raw_tool_calls = self._split_on_tool_call_markers(model_output)
         content = content_and_raw_tool_calls[0].strip()
         raw_tool_calls = content_and_raw_tool_calls[1:]
 
@@ -109,12 +158,27 @@ class MistralToolParser(ToolParser):
             if not raw_tool_call:
                 continue
 
-            # Try newest format first: func_name[ARGS]{"arg": "value"}
-            if not raw_tool_call.startswith("[") and self.ARGS_TOKEN in raw_tool_call:
-                tool_name, _, args_str = raw_tool_call.partition(self.ARGS_TOKEN)
-                tool_name = tool_name.strip()
+            # Try newest format first: func_name[ARGS]{"arg": "value"}.
+            # The marker is the boundary only when it comes before the first
+            # `{` — a legacy call whose JSON arguments contain the literal
+            # "[ARGS]" substring must keep the `{` boundary.
+            args_idx = raw_tool_call.find(self.ARGS_TOKEN)
+            brace_idx = raw_tool_call.find("{")
+            if (
+                not raw_tool_call.startswith("[")
+                and args_idx != -1
+                and (brace_idx == -1 or args_idx < brace_idx)
+            ):
+                tool_name = raw_tool_call[:args_idx].strip()
+                args_str = raw_tool_call[args_idx + len(self.ARGS_TOKEN) :]
 
-                if tool_name:
+                if tool_name and _is_plain_tool_name(tool_name):
+                    try:
+                        json.loads(args_str)
+                    except json.JSONDecodeError:
+                        # Malformed arguments — reject rather than emit a
+                        # corrupted or forged call.
+                        continue
                     tool_calls.append(
                         {
                             "id": generate_mistral_tool_id(),
@@ -220,6 +284,23 @@ class MistralToolParser(ToolParser):
         For streaming, we detect when [TOOL_CALLS] appears and start
         accumulating tool call data.
         """
+        # Everything after the name/arguments boundary is arguments text —
+        # never re-scan for new [TOOL_CALLS] markers inside it (a marker in
+        # a quoted string value is data, not a new call). A genuine new call
+        # starts with its own [TOOL_CALLS] delta and is handled below; the
+        # end-of-stream non-streaming re-parse recovers calls that arrive
+        # inside a shared delta.
+        if self._args_started:
+            return {
+                "tool_calls": [
+                    {
+                        "index": self.current_tool_id,
+                        "type": "function",
+                        "function": {"arguments": delta_text},
+                    }
+                ]
+            }
+
         # Check if tool call token is in current output
         if self.BOT_TOKEN not in current_text:
             # Not a tool call yet, return content delta
@@ -240,6 +321,7 @@ class MistralToolParser(ToolParser):
             self.current_tool_id += 1
             self._args_started = False
             self._name_buffer = ""
+            self._name_buffer_overflow = False
             self._current_tool_call_id = generate_mistral_tool_id()
             self._tool_call_id_emitted = False
 
@@ -260,8 +342,15 @@ class MistralToolParser(ToolParser):
 
         # We're in the middle of a tool call
         if self.current_tool_id >= 0:
+            if self._name_buffer_overflow:
+                # The boundary never arrived; everything is plain text now.
+                return {"content": delta_text}
             tool_delta = self._parse_streaming_tool_delta(delta_text)
             if tool_delta:
+                if self._name_buffer_overflow:
+                    # The withheld name text was flushed as content instead
+                    # of a tool call — pass it through unlabeled.
+                    return {"content": tool_delta["content"]}
                 tool_call = {
                     "index": self.current_tool_id,
                     "type": "function",
@@ -298,12 +387,26 @@ class MistralToolParser(ToolParser):
         # Buffer until we can find the boundary marker — it may itself be
         # split across two deltas (e.g. "...[AR" / "GS]...").
         self._name_buffer += text
-        for marker in (self.ARGS_TOKEN, "{"):
-            idx = self._name_buffer.find(marker)
-            if idx == -1:
-                continue
+        args_idx = self._name_buffer.find(self.ARGS_TOKEN)
+        brace_idx = self._name_buffer.find("{")
+        if args_idx != -1 and (brace_idx == -1 or args_idx < brace_idx):
+            # The [ARGS] marker is the boundary when it precedes the first
+            # `{`. A legacy call whose JSON arguments contain the literal
+            # "[ARGS]" substring must keep the `{` boundary.
+            boundary = self.ARGS_TOKEN
+            idx = args_idx
+            args_start = idx + len(boundary)
+        elif brace_idx != -1:
+            boundary = "{"
+            idx = brace_idx
+            args_start = idx
+        else:
+            boundary = None
+            idx = -1
+            args_start = -1
+
+        if boundary is not None:
             name = self._name_buffer[:idx].strip()
-            args_start = idx + len(marker) if marker == self.ARGS_TOKEN else idx
             args = self._name_buffer[args_start:]
             self._args_started = True
             result: dict[str, str] = {}
@@ -313,5 +416,12 @@ class MistralToolParser(ToolParser):
                 result["arguments"] = args
             return result if result else None
 
-        # Marker not seen yet — withhold rather than guess.
+        # Marker not seen yet — withhold rather than guess. If it never
+        # arrives (truncation, or the model deviating into prose), flush the
+        # withheld text as content so the response is not silently lost.
+        if len(self._name_buffer) > self._NAME_BUFFER_LIMIT:
+            overflowed = self._name_buffer
+            self._name_buffer = ""
+            self._name_buffer_overflow = True
+            return {"content": overflowed}
         return None


### PR DESCRIPTION
## Summary

Ministral 3 14B and Devstral Small 2 (Dec 2025 tokenizers) emit tool calls as
`[TOOL_CALLS]<name>[ARGS]<json arguments>` — confirmed directly in their
`chat_template.jinja`:

```
{{- '[TOOL_CALLS]' + tool['function']['name'] + '[ARGS]' + arguments }}
```

The `mistral` tool parser only knew about the old bracket-JSON-array format and a
`name{args}` format with no separator, so it mishandled this one in two ways:

- **Non-streaming** (`extract_tool_calls`): split on the first `{`, so the parsed
  function name came back as `"get_weather[ARGS]"` instead of `"get_weather"`.
- **Streaming** (`_parse_streaming_tool_delta`): re-classified *every incoming delta
  independently*, using a "does this chunk start with JSON punctuation" heuristic,
  with no memory of having already passed the name/arguments boundary. Bare-word
  JSON string fragments (e.g. `city`, `Paris`) have no distinguishing leading
  punctuation, so once already inside the arguments blob they got misclassified as
  more of the function name — reconstructing garbage from any standard OpenAI-style
  delta accumulator (e.g. `name` ending up as `"get_weather[ARGS]city":"Paris"}"` and
  `arguments` as `'[ARGS]{"'`).

## Fix

- Recognize the `[ARGS]` marker explicitly in both code paths (checked before
  falling back to the older `{`-only split, so older Mistral checkpoints are
  unaffected).
- Give the streaming parser persistent per-tool-call state (`_args_started`,
  `_name_buffer`), reset whenever a new tool call starts. The name/arguments
  boundary is decided exactly once — text is buffered until the marker is found
  (this also handles the marker itself being split across two deltas), then every
  subsequent delta for that tool call is unconditionally `arguments`, never
  re-classified.

## Testing

Verified against a live `vllm-mlx serve mlx-community/Ministral-3-14B-Instruct-2512-4bit --enable-auto-tool-choice --tool-call-parser mistral` instance, both streaming and non-streaming:

**Before** (streaming, delta-by-delta):
```
name: "get" / "_" / "weather"
arguments: "[ARGS]" / "{\""
name: "city" / "\":" / "\"" / "Paris" / "\"}"   # <- wrong, these are arguments
```

**After**:
```
name: "get_weather"                              # single clean chunk
arguments: "{\"" / "city" / "\":" / " \"" / "Paris" / "\"}"   # reconstructs to {"city": "Paris"}
```

Added two regression tests replaying the exact delta sequences captured from that
server (including a marker-split-across-deltas case), plus a non-streaming format
test. Full existing suite passes: `113 passed`.

## Test plan
- [x] `pytest tests/test_tool_parsers.py -k mistral` — new + existing Mistral tests pass
- [x] `pytest tests/test_tool_parsers.py` — full suite, 113 passed, no regressions
- [x] Live streaming + non-streaming smoke test against `Ministral-3-14B-Instruct-2512-4bit`