### PR TITLE
fix(deps): exclude corrupt mlx-vlm 0.6.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "mlx>=0.29.0",
     "mlx-lm>=0.31.3",  # 0.31.3+ required by current mlx-vlm runtime support
-    "mlx-vlm>=0.6.2",  # 0.6.2+ includes Step 3.7 Flash and follow-up fixes
+    "mlx-vlm>=0.6.2,!=0.6.4",  # 0.6.4 corrupts converted Qwen3.5 MLX weights (#632)
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -32,10 +32,20 @@ def _has_minimum(requirement: str, minimum: str) -> bool:
     return _version_tuple(version) >= _version_tuple(minimum)
 
 
+def _excludes_version(requirement: str, version: str) -> bool:
+    return f"!={version}" in {part.strip() for part in requirement.split(",")}
+
+
 def test_mlx_vlm_floor_includes_step37_flash_support_and_followups():
     dependencies = _project_dependencies()
 
     assert _has_minimum(dependencies["mlx-vlm"], "0.6.2")
+
+
+def test_mlx_vlm_excludes_corrupt_qwen35_release():
+    dependencies = _project_dependencies()
+
+    assert _excludes_version(dependencies["mlx-vlm"], "0.6.4")
 
 
 def test_mlx_lm_floor_matches_current_mlx_vlm_runtime_requirement():


### PR DESCRIPTION
Refs #632.

## Problem

`mlx-vlm 0.6.4` re-sanitizes already-converted Qwen3.5 MLX weights. The affected dependency release can therefore produce corrupted Qwen3.5 output when `vllm-mlx` resolves its current unbounded `mlx-vlm>=0.6.2` requirement.

The same Qwen3.5 checkpoint remains coherent with `mlx-vlm 0.6.3`; the reported regression is tracked upstream as `Blaizzy/mlx-vlm#1521`.

## Change

- Exclude exactly `mlx-vlm==0.6.4` while retaining the existing `>=0.6.2` floor.
- Add a dependency-contract test for the exclusion.

## Verification

- `uv run --python 3.12 --extra dev pytest tests/test_dependency_floors.py -q` -> `3 passed`
- `uv run --python 3.12 --extra dev ruff check tests/test_dependency_floors.py` -> passed
- Fresh dependency resolution selected `mlx-vlm 0.6.3`, not 0.6.4.
- `git diff --check` -> passed

## Not claimed

This does not fix the loader regression inside `mlx-vlm`. It prevents `vllm-mlx` installations from resolving the known-bad release until the upstream package ships a corrected version.
