### PR TITLE
Fix fail-open structured-output enforcement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "jsonschema>=4.0.0",
     # Constrained decoding (grammar-guided generation for response_format)
     "lm-format-enforcer>=0.10.9",
+    "llguidance>=1.7.6",
     # pytz is required by gradio but not declared as a dependency
     # See: https://github.com/waybarrios/vllm-mlx/issues/23
     "pytz>=2024.1",

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -20,6 +20,9 @@ running with a minimal dependency set still passes.
 
 from __future__ import annotations
 
+import math
+
+import mlx.core as mx
 import pytest
 
 from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
@@ -398,8 +401,44 @@ class TestSimplifySchema:
 
         result = _simplify_schema(schema)
 
-        assert result["items"] == integer_score
+        assert result["items"] == {
+            **integer_score,
+            "enum": [1, 2, 3, 4, 5],
+        }
         assert "prefixItems" not in result
+
+    @pytestmark_lmfe
+    def test_integer_range_masks_preferred_out_of_range_token(self):
+        """A preferred zero must lose to a legal 1-5 score token."""
+        from vllm_mlx.constrained import JSONSchemaLogitsProcessor
+
+        tokenizer = _FakeTokenizer()
+        processor = JSONSchemaLogitsProcessor(
+            {"type": "integer", "minimum": 1, "maximum": 5},
+            tokenizer,
+        )
+        logits = mx.full((1, tokenizer.vocab_size), -100.0)
+        logits[0, tokenizer._tok_to_id["0"]] = 100.0
+        for score in range(1, 6):
+            logits[0, tokenizer._tok_to_id[str(score)]] = float(6 - score)
+
+        masked = processor(mx.array([999]), logits)
+        values = masked.tolist()[0]
+
+        zero_id = tokenizer._tok_to_id["0"]
+        assert math.isinf(values[zero_id]) and values[zero_id] < 0
+        assert int(mx.argmax(masked, axis=-1).item()) == tokenizer._tok_to_id["1"]
+
+    def test_integer_range_rejects_unenforceable_shapes(self):
+        from vllm_mlx.constrained.json_schema_processor import (
+            UnsupportedJSONSchemaError,
+            _simplify_schema,
+        )
+
+        with pytest.raises(UnsupportedJSONSchemaError, match="lower and upper"):
+            _simplify_schema({"type": "integer", "minimum": 1})
+        with pytest.raises(UnsupportedJSONSchemaError, match="exceeds"):
+            _simplify_schema({"type": "integer", "minimum": 0, "maximum": 5000})
 
     @pytestmark_lmfe
     def test_complete_json_requires_schema_valid_value(self):
@@ -589,9 +628,9 @@ class TestIncrementalCaching:
             inc_text = processor._decode_suffix(suffix)
             # Full decode for reference.
             full_text = tok.decode(suffix)
-            assert (
-                inc_text == full_text
-            ), f"Step {step}: incremental={inc_text!r} != full={full_text!r}"
+            assert inc_text == full_text, (
+                f"Step {step}: incremental={inc_text!r} != full={full_text!r}"
+            )
 
     def test_non_concatenative_tokenizer_decode(self):
         """Regression test: BPE tokenizers where per-token decode differs

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -24,6 +24,8 @@ import math
 
 import mlx.core as mx
 import pytest
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+from transformers import PreTrainedTokenizerFast
 
 from vllm_mlx.api.anthropic_adapter import anthropic_to_openai
 from vllm_mlx.api.anthropic_models import AnthropicMessage, AnthropicRequest
@@ -94,6 +96,28 @@ class _FakeTokenizer:
         return dict(self._tok_to_id)
 
 
+def _fast_json_tokenizer() -> PreTrainedTokenizerFast:
+    backend = Tokenizer(models.BPE(unk_token="<unk>"))
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(
+        add_prefix_space=False,
+        use_regex=False,
+    )
+    backend.decoder = decoders.ByteLevel()
+    backend.train_from_iterator(
+        ['{"p":true,"s":"ok","sc":[1,2,3,4,5,1,2,3,4],"i":[]}'],
+        trainers.BpeTrainer(
+            vocab_size=300,
+            special_tokens=["<unk>", "<eos>"],
+            initial_alphabet=pre_tokenizers.ByteLevel.alphabet(),
+        ),
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        unk_token="<unk>",
+        eos_token="<eos>",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _reset_cache():
     clear_cache()
@@ -157,7 +181,7 @@ class TestBuildJsonLogitsProcessor:
 
     @pytestmark_lmfe
     def test_json_schema_builds_processor(self):
-        tok = _FakeTokenizer()
+        tok = _fast_json_tokenizer()
         response_format = {
             "type": "json_schema",
             "json_schema": {
@@ -177,7 +201,7 @@ class TestBuildJsonLogitsProcessor:
 
     @pytestmark_lmfe
     def test_json_schema_pydantic_model(self):
-        tok = _FakeTokenizer()
+        tok = _fast_json_tokenizer()
         response_format = ResponseFormat(
             type="json_schema",
             json_schema=ResponseFormatJsonSchema(
@@ -188,11 +212,144 @@ class TestBuildJsonLogitsProcessor:
         result = build_json_logits_processor(response_format, tok)
         assert result is not None
 
-    @pytestmark_lmfe
-    def test_heterogeneous_prefix_items_rejected_fail_closed(self):
-        from vllm_mlx.constrained import UnsupportedJSONSchemaError
+    def test_strict_schema_masks_preferred_out_of_range_integer(self):
+        tok = _fast_json_tokenizer()
+        schema = {
+            "type": "array",
+            "minItems": 9,
+            "maxItems": 9,
+            "items": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+            },
+        }
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "scores", "strict": True, "schema": schema},
+        }
+        processor = build_json_logits_processor(response_format, tok)
+        prompt = tok.encode("prompt", add_special_tokens=False)
+        processor(mx.array(prompt), mx.zeros((len(tok),)))
 
-        tok = _FakeTokenizer()
+        prefix = tok.encode("[", add_special_tokens=False)
+        logits = mx.zeros((len(tok),))
+        zero_id = tok.encode("0", add_special_tokens=False)[0]
+        one_id = tok.encode("1", add_special_tokens=False)[0]
+        logits[zero_id] = 100.0
+        masked = processor(mx.array(prompt + prefix), logits)
+
+        assert math.isinf(float(masked[zero_id]))
+        assert float(masked[zero_id]) < 0
+        assert not math.isinf(float(masked[one_id]))
+
+    def test_strict_schema_rejects_early_array_closure(self):
+        tok = _fast_json_tokenizer()
+        schema = {
+            "type": "array",
+            "minItems": 9,
+            "maxItems": 9,
+            "items": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+            },
+        }
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "scores", "strict": True, "schema": schema},
+        }
+        processor = build_json_logits_processor(response_format, tok)
+        prompt = tok.encode("prompt", add_special_tokens=False)
+        processor(mx.array(prompt), mx.zeros((len(tok),)))
+
+        prefix = tok.encode("[1,2,3,4,5", add_special_tokens=False)
+        masked = processor(
+            mx.array(prompt + prefix),
+            mx.zeros((len(tok),)),
+        )
+        close_id = tok.encode("]", add_special_tokens=False)[0]
+
+        assert math.isinf(float(masked[close_id]))
+        assert float(masked[close_id]) < 0
+
+    def test_strict_schema_masks_model_vocab_padding(self):
+        tok = _fast_json_tokenizer()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "result",
+                "strict": True,
+                "schema": {"type": "object"},
+            },
+        }
+        processor = build_json_logits_processor(response_format, tok)
+        prompt = tok.encode("prompt", add_special_tokens=False)
+        padded_vocab_size = len(tok) + 64
+
+        masked = processor(
+            mx.array(prompt),
+            mx.zeros((padded_vocab_size,)),
+        )
+
+        assert masked.shape == (padded_vocab_size,)
+        assert all(
+            math.isinf(float(masked[index]))
+            for index in range(len(tok), padded_vocab_size)
+        )
+
+    def test_strict_schema_accepts_eos_after_complete_value(self):
+        tok = _fast_json_tokenizer()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "result",
+                "strict": True,
+                "schema": {"type": "object"},
+            },
+        }
+        processor = build_json_logits_processor(response_format, tok)
+        prompt = tok.encode("prompt", add_special_tokens=False)
+        value = tok.encode("{}", add_special_tokens=False)
+        processor(mx.array(prompt), mx.zeros((len(tok),)))
+        processor(mx.array(prompt + value), mx.zeros((len(tok),)))
+
+        masked = processor(
+            mx.array(prompt + value + [tok.eos_token_id]),
+            mx.zeros((len(tok),)),
+        )
+
+        assert not math.isinf(float(masked[tok.eos_token_id]))
+
+    def test_strict_schema_stops_nonprogress_whitespace_outside_strings(self):
+        tok = _fast_json_tokenizer()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "result",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "required": ["ok"],
+                    "properties": {"ok": {"type": "boolean"}},
+                },
+            },
+        }
+        processor = build_json_logits_processor(response_format, tok)
+        prompt = tok.encode("prompt", add_special_tokens=False)
+        prefix = tok.encode("{" + (" " * 300), add_special_tokens=False)
+        processor(mx.array(prompt), mx.zeros((len(tok),)))
+
+        masked = processor(
+            mx.array(prompt + prefix),
+            mx.zeros((len(tok),)),
+        )
+        space_id = tok.encode(" ", add_special_tokens=False)[0]
+
+        assert math.isinf(float(masked[space_id]))
+
+    def test_heterogeneous_prefix_items_compile_for_strict_schema(self):
+        tok = _fast_json_tokenizer()
         response_format = {
             "type": "json_schema",
             "json_schema": {
@@ -209,8 +366,7 @@ class TestBuildJsonLogitsProcessor:
             },
         }
 
-        with pytest.raises(UnsupportedJSONSchemaError, match="prefixItems"):
-            build_json_logits_processor(response_format, tok)
+        assert build_json_logits_processor(response_format, tok) is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -748,9 +748,9 @@ class TestIncrementalCaching:
             inc_text = processor._decode_suffix(suffix)
             # Full decode for reference.
             full_text = tok.decode(suffix)
-            assert inc_text == full_text, (
-                f"Step {step}: incremental={inc_text!r} != full={full_text!r}"
-            )
+            assert (
+                inc_text == full_text
+            ), f"Step {step}: incremental={inc_text!r} != full={full_text!r}"
 
     def test_non_concatenative_tokenizer_decode(self):
         """Regression test: BPE tokenizers where per-token decode differs

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -557,44 +557,8 @@ class TestSimplifySchema:
 
         result = _simplify_schema(schema)
 
-        assert result["items"] == {
-            **integer_score,
-            "enum": [1, 2, 3, 4, 5],
-        }
+        assert result["items"] == integer_score
         assert "prefixItems" not in result
-
-    @pytestmark_lmfe
-    def test_integer_range_masks_preferred_out_of_range_token(self):
-        """A preferred zero must lose to a legal 1-5 score token."""
-        from vllm_mlx.constrained import JSONSchemaLogitsProcessor
-
-        tokenizer = _FakeTokenizer()
-        processor = JSONSchemaLogitsProcessor(
-            {"type": "integer", "minimum": 1, "maximum": 5},
-            tokenizer,
-        )
-        logits = mx.full((1, tokenizer.vocab_size), -100.0)
-        logits[0, tokenizer._tok_to_id["0"]] = 100.0
-        for score in range(1, 6):
-            logits[0, tokenizer._tok_to_id[str(score)]] = float(6 - score)
-
-        masked = processor(mx.array([999]), logits)
-        values = masked.tolist()[0]
-
-        zero_id = tokenizer._tok_to_id["0"]
-        assert math.isinf(values[zero_id]) and values[zero_id] < 0
-        assert int(mx.argmax(masked, axis=-1).item()) == tokenizer._tok_to_id["1"]
-
-    def test_integer_range_rejects_unenforceable_shapes(self):
-        from vllm_mlx.constrained.json_schema_processor import (
-            UnsupportedJSONSchemaError,
-            _simplify_schema,
-        )
-
-        with pytest.raises(UnsupportedJSONSchemaError, match="lower and upper"):
-            _simplify_schema({"type": "integer", "minimum": 1})
-        with pytest.raises(UnsupportedJSONSchemaError, match="exceeds"):
-            _simplify_schema({"type": "integer", "minimum": 0, "maximum": 5000})
 
     @pytestmark_lmfe
     def test_complete_json_requires_schema_valid_value(self):

--- a/tests/test_constrained_decoding.py
+++ b/tests/test_constrained_decoding.py
@@ -51,7 +51,7 @@ class _FakeTokenizer:
     """
 
     def __init__(self) -> None:
-        chars = list('0123456789{}[]:," \n\ttrueflasnul')
+        chars = list('0123456789{}[]:," \n\ttrueflasnulpci')
         # Deduplicate while preserving order.
         seen: set[str] = set()
         unique: list[str] = []
@@ -184,6 +184,30 @@ class TestBuildJsonLogitsProcessor:
         )
         result = build_json_logits_processor(response_format, tok)
         assert result is not None
+
+    @pytestmark_lmfe
+    def test_heterogeneous_prefix_items_rejected_fail_closed(self):
+        from vllm_mlx.constrained import UnsupportedJSONSchemaError
+
+        tok = _FakeTokenizer()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "tuple",
+                "strict": True,
+                "schema": {
+                    "type": "array",
+                    "prefixItems": [
+                        {"type": "integer"},
+                        {"type": "string"},
+                    ],
+                    "maxItems": 2,
+                },
+            },
+        }
+
+        with pytest.raises(UnsupportedJSONSchemaError, match="prefixItems"):
+            build_json_logits_processor(response_format, tok)
 
 
 # ---------------------------------------------------------------------------
@@ -359,6 +383,48 @@ class TestSimplifySchema:
         # Nested anyOf should be flattened to 3 branches.
         assert "anyOf" in result
         assert len(result["anyOf"]) == 3
+
+    def test_normalizes_homogeneous_prefix_items(self):
+        """Jobs' compact score array must retain its element constraints."""
+        from vllm_mlx.constrained.json_schema_processor import _simplify_schema
+
+        integer_score = {"type": "integer", "minimum": 1, "maximum": 5}
+        schema = {
+            "type": "array",
+            "prefixItems": [integer_score] * 9,
+            "minItems": 9,
+            "maxItems": 9,
+        }
+
+        result = _simplify_schema(schema)
+
+        assert result["items"] == integer_score
+        assert "prefixItems" not in result
+
+    @pytestmark_lmfe
+    def test_complete_json_requires_schema_valid_value(self):
+        """Syntactically complete JSON must not force EOS before schema validity."""
+        from vllm_mlx.constrained import JSONSchemaLogitsProcessor
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "sc": {
+                    "type": "array",
+                    "items": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "minItems": 1,
+                    "maxItems": 1,
+                }
+            },
+            "required": ["sc"],
+            "additionalProperties": False,
+        }
+        tokenizer = _FakeTokenizer()
+        processor = JSONSchemaLogitsProcessor(schema, tokenizer)
+        suffix = tokenizer.encode('{"sc":["s"]}')
+        processor._get_json_context(suffix)
+
+        assert processor._suffix_is_complete_json(suffix) is False
 
     def test_fact_batch_schema_simplifies_cleanly(self):
         """Regression test: the ``fact_batch`` schema that caused enforcer

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3261,6 +3261,155 @@ class TestStreamChatCompletion:
         assert payloads[1]["choices"][0]["finish_reason"] == "stop"
 
     @pytest.mark.anyio
+    async def test_response_format_stream_rejects_schema_invalid_completion(
+        self,
+    ):
+        """A stream must not complete successfully with schema-invalid JSON."""
+        from fastapi import HTTPException
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="",
+                    new_text='{"sc": [4, "p"]}',
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=4,
+                    completion_tokens=8,
+                )
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="return scores")],
+            stream=True,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "scores",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "sc": {
+                                "type": "array",
+                                "prefixItems": [
+                                    {"type": "integer", "minimum": 1, "maximum": 5},
+                                    {"type": "integer", "minimum": 1, "maximum": 5},
+                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                            }
+                        },
+                        "required": ["sc"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            _ = [
+                chunk
+                async for chunk in stream_chat_completion(
+                    FakeEngine(), request.messages, request
+                )
+            ]
+
+        assert excinfo.value.status_code == 422
+        assert excinfo.value.detail["error"] == "invalid_response_format_output"
+
+    @pytest.mark.anyio
+    async def test_response_format_endpoint_buffers_before_stream_success(
+        self, monkeypatch
+    ):
+        """The HTTP boundary must validate before returning StreamingResponse."""
+        from fastapi import HTTPException
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            PreparedChatInvocation,
+            create_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="",
+                    new_text='{"sc": [4, "p"]}',
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=4,
+                    completion_tokens=8,
+                )
+
+        fake_engine = FakeEngine()
+
+        async def fake_acquire(*_args, **_kwargs):
+            return fake_engine
+
+        async def fake_release(*_args, **_kwargs):
+            return None
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "scores",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "sc": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        }
+                    },
+                    "required": ["sc"],
+                },
+            },
+        }
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="return scores")],
+            stream=True,
+            response_format=response_format,
+        )
+        prepared = PreparedChatInvocation(
+            messages=[{"role": "user", "content": "return scores"}],
+            chat_kwargs={},
+            response_format=response_format,
+            json_logits_processor=object(),
+        )
+
+        monkeypatch.setattr(server, "_validate_model_name", lambda _model: None)
+        monkeypatch.setattr(server, "_acquire_default_engine_for_request", fake_acquire)
+        monkeypatch.setattr(server, "_release_engine_for_request", fake_release)
+        monkeypatch.setattr(
+            server, "_prepare_chat_completion_invocation", lambda *_args: prepared
+        )
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_default_max_tokens", 128)
+        monkeypatch.setattr(server, "_default_timeout", 30.0)
+
+        with pytest.raises(HTTPException) as excinfo:
+            await create_chat_completion(request, raw_request=None)
+
+        assert excinfo.value.status_code == 422
+
+    @pytest.mark.anyio
     async def test_streaming_chat_no_stream_thread_error_after_residency_preload(
         self, monkeypatch, caplog
     ):

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -335,6 +335,17 @@ class TestParseJsonOutput:
         assert is_valid is False
         assert "Failed to extract" in error
 
+    def test_json_object_rejects_array_root(self):
+        """OpenAI json_object requires an object at the root, not any JSON value."""
+        text = '[{"ok": true}]'
+        response_format = {"type": "json_object"}
+
+        _cleaned, parsed, is_valid, error = parse_json_output(text, response_format)
+
+        assert parsed == [{"ok": True}]
+        assert is_valid is False
+        assert "root" in error.lower()
+
     def test_json_schema_valid(self):
         """Test json_schema mode validates against schema."""
         text = '{"name": "Alice", "age": 30}'
@@ -374,6 +385,68 @@ class TestParseJsonOutput:
         assert parsed == {"name": 123}
         assert is_valid is False
         assert "validation failed" in error.lower()
+
+    def test_jobs_compact_schema_rejects_non_integer_scores(self):
+        """Regression for Jobs work item 1167's exact compact score contract."""
+        score = {"type": "integer", "minimum": 1, "maximum": 5}
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["p", "s", "sc", "i"],
+            "properties": {
+                "p": {"type": "boolean"},
+                "s": {"type": "string", "maxLength": 240},
+                "sc": {
+                    "type": "array",
+                    "minItems": 9,
+                    "maxItems": 9,
+                    "prefixItems": [score] * 9,
+                },
+                "i": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["a", "v", "c", "m", "e", "r"],
+                        "properties": {
+                            "a": {"type": "string", "enum": ["r", "c", "p"]},
+                            "v": {"type": "string", "enum": ["b", "w", "i"]},
+                            "c": {"type": "string", "maxLength": 48},
+                            "m": {"type": "string", "maxLength": 280},
+                            "e": {
+                                "type": "array",
+                                "maxItems": 4,
+                                "items": {"type": "string", "maxLength": 80},
+                            },
+                            "r": {
+                                "type": "array",
+                                "maxItems": 4,
+                                "items": {"type": "string", "maxLength": 80},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "qa", "schema": schema, "strict": True},
+        }
+        raw = json.dumps(
+            {
+                "p": False,
+                "s": "review",
+                "sc": [4, "p", "s", "sc", "i", "p", "s", "sc", "i"],
+                "i": [],
+            }
+        )
+
+        _cleaned, parsed, is_valid, error = parse_json_output(raw, response_format)
+
+        assert parsed is not None
+        assert is_valid is False
+        assert "not of type 'integer'" in error
 
     def test_response_format_model(self):
         """Test with ResponseFormat Pydantic model."""

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -789,7 +789,7 @@ class StreamingJsonFenceStripper:
 
 def parse_json_output(
     text: str, response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None
-) -> Tuple[str, Optional[Dict[str, Any]], bool, Optional[str]]:
+) -> Tuple[str, Optional[Any], bool, Optional[str]]:
     """
     Parse JSON from model output when response_format is set.
 
@@ -835,8 +835,10 @@ def parse_json_output(
     if parsed is None:
         return text, None, False, "Failed to extract valid JSON from output"
 
-    # json_object - just verify it's valid JSON (already done by extraction)
+    # json_object requires an object root, not merely any valid JSON value.
     if format_type == "json_object":
+        if not isinstance(parsed, dict):
+            return text, parsed, False, "JSON object root must be an object"
         return text, parsed, True, None
 
     # json_schema - validate against schema
@@ -1007,29 +1009,16 @@ def build_json_logits_processor(
         return None
 
     try:
-        from ..constrained import (
-            JSONSchemaLogitsProcessor,
-            LMFormatEnforcerNotAvailableError,
-            is_available,
-        )
+        from ..constrained import JSONSchemaLogitsProcessor, is_available
     except ImportError:
-        # Constrained decoding module could not be imported; fall back.
-        return None
+        raise RuntimeError("constrained decoding module could not be imported")
 
     if not is_available():
-        # ``lm-format-enforcer`` optional dependency missing; fall back.
-        return None
+        raise RuntimeError("lm-format-enforcer is required for response_format")
 
     # ``json_schema`` without an actual schema degrades to ``json_object``
     # (both paths pass ``schema=None`` to the processor).
     if format_type == "json_object" or (format_type == "json_schema" and not schema):
         schema = None
 
-    try:
-        return JSONSchemaLogitsProcessor(schema=schema, tokenizer=tokenizer)
-    except LMFormatEnforcerNotAvailableError:
-        return None
-    except Exception:
-        # Malformed schema or tokenizer issue — fall back to prompt-only
-        # mode.  Callers still run post-hoc validation as a safety net.
-        return None
+    return JSONSchemaLogitsProcessor(schema=schema, tokenizer=tokenizer)

--- a/vllm_mlx/api/tool_calling.py
+++ b/vllm_mlx/api/tool_calling.py
@@ -1009,16 +1009,24 @@ def build_json_logits_processor(
         return None
 
     try:
-        from ..constrained import JSONSchemaLogitsProcessor, is_available
+        from ..constrained import (
+            JSONSchemaLogitsProcessor,
+            LLGuidanceJSONSchemaLogitsProcessor,
+            is_available,
+            is_strict_json_schema_available,
+        )
     except ImportError:
         raise RuntimeError("constrained decoding module could not be imported")
-
-    if not is_available():
-        raise RuntimeError("lm-format-enforcer is required for response_format")
 
     # ``json_schema`` without an actual schema degrades to ``json_object``
     # (both paths pass ``schema=None`` to the processor).
     if format_type == "json_object" or (format_type == "json_schema" and not schema):
         schema = None
 
+    if schema is not None:
+        if not is_strict_json_schema_available():
+            raise RuntimeError("llguidance is required for strict json_schema")
+        return LLGuidanceJSONSchemaLogitsProcessor(schema=schema, tokenizer=tokenizer)
+    if not is_available():
+        raise RuntimeError("lm-format-enforcer is required for json_object")
     return JSONSchemaLogitsProcessor(schema=schema, tokenizer=tokenizer)

--- a/vllm_mlx/constrained/__init__.py
+++ b/vllm_mlx/constrained/__init__.py
@@ -15,13 +15,19 @@ from .json_schema_processor import (
     UnsupportedJSONSchemaError,
     is_available,
 )
+from .llguidance_schema_processor import (
+    LLGuidanceJSONSchemaLogitsProcessor,
+    is_available as is_strict_json_schema_available,
+)
 from .thinking_processor import ThinkingAwareLogitsProcessor
 
 __all__ = [
     "ConstrainedDecodingError",
     "JSONSchemaLogitsProcessor",
+    "LLGuidanceJSONSchemaLogitsProcessor",
     "LMFormatEnforcerNotAvailableError",
     "ThinkingAwareLogitsProcessor",
     "UnsupportedJSONSchemaError",
     "is_available",
+    "is_strict_json_schema_available",
 ]

--- a/vllm_mlx/constrained/__init__.py
+++ b/vllm_mlx/constrained/__init__.py
@@ -9,15 +9,19 @@ and Anthropic Messages endpoints.
 """
 
 from .json_schema_processor import (
+    ConstrainedDecodingError,
     JSONSchemaLogitsProcessor,
     LMFormatEnforcerNotAvailableError,
+    UnsupportedJSONSchemaError,
     is_available,
 )
 from .thinking_processor import ThinkingAwareLogitsProcessor
 
 __all__ = [
+    "ConstrainedDecodingError",
     "JSONSchemaLogitsProcessor",
     "LMFormatEnforcerNotAvailableError",
     "ThinkingAwareLogitsProcessor",
+    "UnsupportedJSONSchemaError",
     "is_available",
 ]

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -20,10 +20,11 @@ import copy
 import hashlib
 import json
 import logging
-from typing import Any
+from typing import Any, Callable
 
 import mlx.core as mx
 import numpy as np
+from jsonschema.validators import validator_for
 
 from .cache import _get_vocab_size, get_tokenizer_data
 
@@ -32,6 +33,14 @@ logger = logging.getLogger(__name__)
 
 class LMFormatEnforcerNotAvailableError(RuntimeError):
     """Raised when ``lm-format-enforcer`` is required but not installed."""
+
+
+class ConstrainedDecodingError(RuntimeError):
+    """Raised when a declared constrained-output request cannot stay constrained."""
+
+
+class UnsupportedJSONSchemaError(ConstrainedDecodingError):
+    """Raised when schema simplification cannot preserve request semantics."""
 
 
 # Module-level cache of (parser_schema, JsonSchemaParser) keyed by a canonical
@@ -82,16 +91,48 @@ def is_available() -> bool:
     return True
 
 
-# A permissive "any JSON value" schema for ``response_format.type = json_object``.
-# JSON spec allows any of {object, array, string, number, boolean, null} at the
-# top level, but realistic OpenAI ``json_object`` mode expects an object or
-# array at the root.
-_GENERIC_JSON_SCHEMA: dict = {
-    "anyOf": [
-        {"type": "object"},
-        {"type": "array"},
-    ]
-}
+# ``response_format.type = json_object`` requires an object at the root.
+_GENERIC_JSON_SCHEMA: dict = {"type": "object"}
+
+
+def _normalize_prefix_items(
+    node: dict,
+    resolve: Callable[[dict, int], dict],
+    depth: int,
+) -> dict:
+    """Preserve homogeneous bounded prefixItems or reject the schema."""
+    if "prefixItems" not in node:
+        return node
+
+    prefix_items = node["prefixItems"]
+    if not isinstance(prefix_items, list) or not prefix_items:
+        raise UnsupportedJSONSchemaError(
+            "prefixItems must be a non-empty array of schemas"
+        )
+    resolved_prefix = [resolve(item, depth + 1) for item in prefix_items]
+    first = resolved_prefix[0]
+    max_items = node.get("maxItems")
+    if (
+        "items" in node
+        or max_items is None
+        or max_items > len(resolved_prefix)
+        or any(item != first for item in resolved_prefix[1:])
+    ):
+        raise UnsupportedJSONSchemaError(
+            "heterogeneous or open-ended prefixItems is not supported"
+        )
+    node["items"] = first
+    node.pop("prefixItems")
+    return node
+
+
+def _allowed_tokens_or_raise(allowed_result: Any) -> list[int]:
+    allowed = getattr(allowed_result, "allowed_tokens", allowed_result)
+    if allowed is None:
+        raise ConstrainedDecodingError(
+            "JSON schema enforcer returned no allowed-token result"
+        )
+    return list(allowed)
 
 
 def _simplify_schema(schema: dict) -> dict:
@@ -177,6 +218,8 @@ def _simplify_schema(schema: dict) -> dict:
         for key in ("items", "additionalProperties"):
             if key in node and isinstance(node[key], dict):
                 node[key] = _resolve(node[key], depth + 1)
+
+        node = _normalize_prefix_items(node, _resolve, depth)
 
         for key in ("allOf", "anyOf", "oneOf"):
             if key in node and isinstance(node[key], list):
@@ -329,6 +372,10 @@ class JSONSchemaLogitsProcessor:
 
         self._tokenizer = tokenizer
         self._schema = schema
+        validation_schema = schema if schema is not None else _GENERIC_JSON_SCHEMA
+        validator_cls = validator_for(validation_schema)
+        validator_cls.check_schema(validation_schema)
+        self._schema_validator = validator_cls(validation_schema)
         self._tok_data = get_tokenizer_data(tokenizer)
         if self._tok_data is None:
             raise LMFormatEnforcerNotAvailableError(
@@ -343,31 +390,24 @@ class JSONSchemaLogitsProcessor:
         try:
             parser_schema, self._parser = _get_or_build_parser(schema)
             self._enforcer = TokenEnforcer(self._tok_data, self._parser)
+        except UnsupportedJSONSchemaError:
+            raise
         except Exception as exc:
-            logger.warning(
-                "JSONSchemaLogitsProcessor: enforcer init failed (%s); "
-                "falling back to unconstrained generation",
-                exc,
-            )
-            self._disabled = True
-            self._parser = None  # type: ignore[assignment]
-            self._enforcer = None  # type: ignore[assignment]
+            raise ConstrainedDecodingError(
+                f"failed to initialize JSON schema enforcer: {exc}"
+            ) from exc
 
         # Bootstrap the enforcer's ``prefix_states`` with the empty tuple so
         # that subsequent ``get_allowed_tokens([t1, t2, ...])`` calls can find
         # their ``prev_step_tuple`` and apply characters incrementally rather
         # than treating the whole sequence as a prompt and resetting to the
         # root parser.
-        if not self._disabled:
-            try:
-                self._enforcer.get_allowed_tokens([])
-            except Exception as exc:
-                logger.warning(
-                    "TokenEnforcer bootstrap failed (%s); "
-                    "falling back to unconstrained generation",
-                    exc,
-                )
-                self._disabled = True
+        try:
+            self._enforcer.get_allowed_tokens([])
+        except Exception as exc:
+            raise ConstrainedDecodingError(
+                f"failed to bootstrap JSON schema enforcer: {exc}"
+            ) from exc
 
         self._prompt_len: int | None = None
         self._vocab_size: int = _get_vocab_size(tokenizer)
@@ -514,10 +554,10 @@ class JSONSchemaLogitsProcessor:
         if not text:
             return False
         try:
-            json.loads(text)
+            value = json.loads(text)
         except (ValueError, json.JSONDecodeError):
             return False
-        return True
+        return self._schema_validator.is_valid(value)
 
     def _get_json_context(self, suffix: list[int]) -> str:
         """Determine the JSON structural context of the current suffix.
@@ -845,11 +885,7 @@ class JSONSchemaLogitsProcessor:
             # Use prompt_len directly instead of O(n) list comparison.
             pass_to_enforcer = suffix if self._prompt_len else tokens_list
             allowed_result = self._enforcer.get_allowed_tokens(pass_to_enforcer)
-            allowed = getattr(allowed_result, "allowed_tokens", allowed_result)
-            if allowed is None:
-                return logits
-
-            allowed_list = list(allowed)
+            allowed_list = _allowed_tokens_or_raise(allowed_result)
 
             # --- Schema-aware key filter (before EOS guard so that the
             # incremental JSON context state and bracket depth counters
@@ -872,11 +908,8 @@ class JSONSchemaLogitsProcessor:
             ):
                 allowed_list = [t for t in allowed_list if t not in self._eos_set]
 
-            # --- Recovery: if enforcer returns empty set AND output is not
-            # complete JSON, the schema is likely unsupported — disable the
-            # processor and let the model generate freely (system prompt +
-            # post-validation still apply).  Only force EOS if the output
-            # already parses as valid JSON (generation is done).
+            # Empty allowed sets cannot fall back to unconstrained generation:
+            # that would turn a strict response_format request into best effort.
             if not allowed_list:
                 if self._suffix_is_complete_json(suffix) and self._eos_set:
                     allowed_list = sorted(self._eos_set)
@@ -885,16 +918,11 @@ class JSONSchemaLogitsProcessor:
                         decoded = self._tokenizer.decode(suffix)
                     except Exception:
                         decoded = "<decode-error>"
-                    logger.warning(
-                        "JSONLP: enforcer stuck (empty allowed-set at "
-                        "suffix_len=%d, suffix_tokens=%s, decoded=%r); "
-                        "disabling constrained decoding for this request",
-                        len(suffix),
-                        suffix[:10],
-                        decoded[:80],
+                    raise ConstrainedDecodingError(
+                        "JSON schema enforcer reached an empty allowed-token set "
+                        f"at suffix_len={len(suffix)}, suffix_tokens={suffix[:10]}, "
+                        f"decoded={decoded[:80]!r}"
                     )
-                    self._disabled = True
-                    return logits
 
             actual_vocab = logits.shape[-1]
             mask = self._build_allow_mask(allowed_list, actual_vocab)
@@ -902,12 +930,9 @@ class JSONSchemaLogitsProcessor:
                 mask = mask[None, :]
             return logits + mask
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error(
-                "JSONSchemaLogitsProcessor crashed; disabling for this request: %s",
-                exc,
-            )
-            self._disabled = True
-            return logits
+            raise ConstrainedDecodingError(
+                f"JSON schema logits processor failed: {exc}"
+            ) from exc
 
     # Diagnostic helpers -------------------------------------------------
 

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -20,7 +20,6 @@ import copy
 import hashlib
 import json
 import logging
-import math
 from typing import Any, Callable
 
 import mlx.core as mx
@@ -54,7 +53,6 @@ class UnsupportedJSONSchemaError(ConstrainedDecodingError):
 # tool schemas, so unbounded growth is not a realistic concern.
 _parser_cache: dict[str, tuple[dict, Any]] = {}
 _MAX_NONPROGRESS_WHITESPACE_CHARS = 256
-_MAX_INTEGER_ENUM_VALUES = 4096
 _JSON_WHITESPACE = frozenset(" \t\r\n")
 
 
@@ -128,70 +126,6 @@ def _normalize_prefix_items(
     return node
 
 
-def _integer_lower_bound(node: dict) -> int | None:
-    lower: int | None = None
-    if "minimum" in node:
-        lower = math.ceil(node["minimum"])
-    if "exclusiveMinimum" in node:
-        exclusive_lower = math.floor(node["exclusiveMinimum"]) + 1
-        lower = exclusive_lower if lower is None else max(lower, exclusive_lower)
-    return lower
-
-
-def _integer_upper_bound(node: dict) -> int | None:
-    upper: int | None = None
-    if "maximum" in node:
-        upper = math.floor(node["maximum"])
-    if "exclusiveMaximum" in node:
-        exclusive_upper = math.ceil(node["exclusiveMaximum"]) - 1
-        upper = exclusive_upper if upper is None else min(upper, exclusive_upper)
-    return upper
-
-
-def _bounded_integer_values(node: dict) -> list[int]:
-    lower = _integer_lower_bound(node)
-    upper = _integer_upper_bound(node)
-
-    if lower is None or upper is None:
-        raise UnsupportedJSONSchemaError(
-            "integer ranges require finite lower and upper bounds"
-        )
-    if lower > upper:
-        raise UnsupportedJSONSchemaError("integer range contains no legal values")
-    if upper - lower + 1 > _MAX_INTEGER_ENUM_VALUES:
-        raise UnsupportedJSONSchemaError(
-            f"integer range exceeds {_MAX_INTEGER_ENUM_VALUES} enforceable values"
-        )
-    return list(range(lower, upper + 1))
-
-
-def _normalize_integer_bounds(node: dict) -> dict:
-    """Compile finite integer bounds into values the token parser enforces."""
-    range_keys = {
-        "minimum",
-        "maximum",
-        "exclusiveMinimum",
-        "exclusiveMaximum",
-    }
-    if not range_keys.intersection(node):
-        return node
-    if node.get("type") != "integer":
-        raise UnsupportedJSONSchemaError(
-            "numeric ranges are supported only for integer schemas"
-        )
-
-    legal_values = _bounded_integer_values(node)
-    if "enum" in node:
-        legal_set = set(legal_values)
-        legal_values = [value for value in node["enum"] if value in legal_set]
-        if not legal_values:
-            raise UnsupportedJSONSchemaError(
-                "integer enum and range contain no common legal values"
-            )
-    node["enum"] = legal_values
-    return node
-
-
 def _allowed_tokens_or_raise(allowed_result: Any) -> list[int]:
     allowed = getattr(allowed_result, "allowed_tokens", allowed_result)
     if allowed is None:
@@ -262,8 +196,6 @@ def _simplify_schema(schema: dict) -> dict:
         node.pop("examples", None)
         node.pop("title", None)
         node.pop("description", None)
-
-        node = _normalize_integer_bounds(node)
 
         # --- type array → anyOf --------------------------------------------
         if isinstance(node.get("type"), list):

--- a/vllm_mlx/constrained/json_schema_processor.py
+++ b/vllm_mlx/constrained/json_schema_processor.py
@@ -20,6 +20,7 @@ import copy
 import hashlib
 import json
 import logging
+import math
 from typing import Any, Callable
 
 import mlx.core as mx
@@ -53,6 +54,7 @@ class UnsupportedJSONSchemaError(ConstrainedDecodingError):
 # tool schemas, so unbounded growth is not a realistic concern.
 _parser_cache: dict[str, tuple[dict, Any]] = {}
 _MAX_NONPROGRESS_WHITESPACE_CHARS = 256
+_MAX_INTEGER_ENUM_VALUES = 4096
 _JSON_WHITESPACE = frozenset(" \t\r\n")
 
 
@@ -126,6 +128,70 @@ def _normalize_prefix_items(
     return node
 
 
+def _integer_lower_bound(node: dict) -> int | None:
+    lower: int | None = None
+    if "minimum" in node:
+        lower = math.ceil(node["minimum"])
+    if "exclusiveMinimum" in node:
+        exclusive_lower = math.floor(node["exclusiveMinimum"]) + 1
+        lower = exclusive_lower if lower is None else max(lower, exclusive_lower)
+    return lower
+
+
+def _integer_upper_bound(node: dict) -> int | None:
+    upper: int | None = None
+    if "maximum" in node:
+        upper = math.floor(node["maximum"])
+    if "exclusiveMaximum" in node:
+        exclusive_upper = math.ceil(node["exclusiveMaximum"]) - 1
+        upper = exclusive_upper if upper is None else min(upper, exclusive_upper)
+    return upper
+
+
+def _bounded_integer_values(node: dict) -> list[int]:
+    lower = _integer_lower_bound(node)
+    upper = _integer_upper_bound(node)
+
+    if lower is None or upper is None:
+        raise UnsupportedJSONSchemaError(
+            "integer ranges require finite lower and upper bounds"
+        )
+    if lower > upper:
+        raise UnsupportedJSONSchemaError("integer range contains no legal values")
+    if upper - lower + 1 > _MAX_INTEGER_ENUM_VALUES:
+        raise UnsupportedJSONSchemaError(
+            f"integer range exceeds {_MAX_INTEGER_ENUM_VALUES} enforceable values"
+        )
+    return list(range(lower, upper + 1))
+
+
+def _normalize_integer_bounds(node: dict) -> dict:
+    """Compile finite integer bounds into values the token parser enforces."""
+    range_keys = {
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+    }
+    if not range_keys.intersection(node):
+        return node
+    if node.get("type") != "integer":
+        raise UnsupportedJSONSchemaError(
+            "numeric ranges are supported only for integer schemas"
+        )
+
+    legal_values = _bounded_integer_values(node)
+    if "enum" in node:
+        legal_set = set(legal_values)
+        legal_values = [value for value in node["enum"] if value in legal_set]
+        if not legal_values:
+            raise UnsupportedJSONSchemaError(
+                "integer enum and range contain no common legal values"
+            )
+    node["enum"] = legal_values
+    return node
+
+
 def _allowed_tokens_or_raise(allowed_result: Any) -> list[int]:
     allowed = getattr(allowed_result, "allowed_tokens", allowed_result)
     if allowed is None:
@@ -196,6 +262,8 @@ def _simplify_schema(schema: dict) -> dict:
         node.pop("examples", None)
         node.pop("title", None)
         node.pop("description", None)
+
+        node = _normalize_integer_bounds(node)
 
         # --- type array → anyOf --------------------------------------------
         if isinstance(node.get("type"), list):

--- a/vllm_mlx/constrained/llguidance_schema_processor.py
+++ b/vllm_mlx/constrained/llguidance_schema_processor.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strict JSON Schema token masking backed by ``llguidance``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .json_schema_processor import ConstrainedDecodingError
+
+_MAX_NONPROGRESS_WHITESPACE_CHARS = 256
+_tokenizer_cache: dict[int, tuple[Any, Any, frozenset[int]]] = {}
+
+
+def is_available() -> bool:
+    """Return whether the strict JSON Schema backend is importable."""
+    try:
+        import llguidance  # noqa: F401
+        import llguidance.hf  # noqa: F401
+        import llguidance.mlx  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _token_list(tokens: mx.array) -> list[int]:
+    values = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
+    if isinstance(values, int):
+        return [values]
+    if values and isinstance(values[0], list):
+        values = values[0]
+    return [int(token) for token in values]
+
+
+def _ll_tokenizer(tokenizer: Any):
+    import llguidance.hf
+
+    candidates = [tokenizer]
+    for attribute in ("tokenizer", "_tokenizer"):
+        candidate = getattr(tokenizer, attribute, None)
+        if candidate is not None and candidate not in candidates:
+            candidates.append(candidate)
+
+    errors: list[str] = []
+    for candidate in candidates:
+        cached = _tokenizer_cache.get(id(candidate))
+        if cached is not None and cached[0] is candidate:
+            return cached
+        try:
+            ll_tokenizer = llguidance.hf.from_tokenizer(candidate)
+        except (TypeError, ValueError) as exc:
+            errors.append(f"{type(candidate).__name__}: {exc}")
+            continue
+        whitespace_tokens = frozenset(
+            token_id
+            for token_id in range(ll_tokenizer.vocab_size)
+            if _decoded_token_is_whitespace(candidate, token_id)
+        )
+        result = (candidate, ll_tokenizer, whitespace_tokens)
+        _tokenizer_cache[id(candidate)] = result
+        return result
+    detail = "; ".join(errors)
+    raise ConstrainedDecodingError(
+        "strict JSON Schema requires a fast Hugging Face tokenizer"
+        + (f" ({detail})" if detail else "")
+    )
+
+
+def _decoded_token_is_whitespace(tokenizer: Any, token_id: int) -> bool:
+    try:
+        text = tokenizer.decode(
+            [token_id],
+            skip_special_tokens=False,
+            clean_up_tokenization_spaces=False,
+        )
+    except TypeError:
+        text = tokenizer.decode([token_id])
+    except Exception:
+        return False
+    return bool(text) and text.isspace()
+
+
+def _trailing_json_whitespace(text: str) -> int:
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+    if in_string:
+        return 0
+    return len(text) - len(text.rstrip())
+
+
+def _clear_mask_token(mask: np.ndarray, token_id: int) -> None:
+    word_index, bit_index = divmod(token_id, 32)
+    if word_index >= mask.shape[1]:
+        return
+    value = int(np.uint32(mask[0, word_index])) & ~(1 << bit_index)
+    mask[0, word_index] = np.array(value, dtype=np.uint32).view(np.int32)
+
+
+class LLGuidanceJSONSchemaLogitsProcessor:
+    """Apply a request-local JSON Schema grammar to MLX logits."""
+
+    def __init__(self, schema: dict, tokenizer: Any) -> None:
+        if not is_available():
+            raise ConstrainedDecodingError(
+                "llguidance is required for strict JSON Schema response_format"
+            )
+
+        import llguidance
+
+        self._tokenizer, ll_tokenizer, whitespace_tokens = _ll_tokenizer(tokenizer)
+        self._vocab_size = ll_tokenizer.vocab_size
+        self._whitespace_tokens = whitespace_tokens
+        eos_tokens = ll_tokenizer.eos_tokens
+        self._eos_tokens = {int(token) for token in eos_tokens}
+        try:
+            grammar = llguidance.LLMatcher.grammar_from_json_schema(schema)
+            self._matcher = llguidance.LLMatcher(ll_tokenizer, grammar)
+        except Exception as exc:
+            raise ConstrainedDecodingError(
+                f"failed to compile strict JSON Schema grammar: {exc}"
+            ) from exc
+
+        self._prompt_len: int | None = None
+        self._consumed_suffix: list[int] = []
+        self._terminal = False
+
+    def _consume_suffix(self, suffix: list[int]) -> None:
+        previous = self._consumed_suffix
+        if len(suffix) >= len(previous) and suffix[: len(previous)] == previous:
+            delta = suffix[len(previous) :]
+        else:
+            self._matcher.reset()
+            delta = suffix
+
+        if delta and all(token in self._eos_tokens for token in delta):
+            if not self._matcher.is_accepting():
+                raise ConstrainedDecodingError(
+                    "received an EOS token before the JSON Schema was complete"
+                )
+            self._terminal = True
+            self._consumed_suffix = list(suffix)
+            return
+        if delta and not self._matcher.consume_tokens(delta):
+            try:
+                decoded_tail = self._tokenizer.decode(suffix[-12:])
+            except Exception:
+                decoded_tail = "<decode-error>"
+            raise ConstrainedDecodingError(
+                "generated token prefix violated the declared JSON Schema: "
+                f"delta={delta!r}, suffix_tail={suffix[-12:]!r}, "
+                f"decoded_tail={decoded_tail!r}"
+            )
+        if self._matcher.is_error():
+            detail = self._matcher.get_error() or self._matcher.stop_reason()
+            raise ConstrainedDecodingError(
+                f"strict JSON Schema matcher entered an error state: {detail}"
+            )
+        self._consumed_suffix = list(suffix)
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        import llguidance.mlx
+
+        tokens_list = _token_list(tokens)
+        if self._prompt_len is None:
+            self._prompt_len = len(tokens_list)
+        suffix = tokens_list[self._prompt_len :]
+        self._consume_suffix(suffix)
+        if self._terminal:
+            mask = mx.full(logits.shape, -float("inf"))
+            for token in self._eos_tokens:
+                if token < logits.shape[-1]:
+                    if logits.ndim == 1:
+                        mask[token] = 0.0
+                    else:
+                        mask[..., token] = 0.0
+            return logits + mask
+
+        try:
+            mask = llguidance.mlx.allocate_token_bitmask(1, self._vocab_size)
+            llguidance.mlx.fill_next_token_bitmask(self._matcher, mask)
+            decoded = self._tokenizer.decode(
+                suffix,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
+            )
+            if _trailing_json_whitespace(decoded) >= _MAX_NONPROGRESS_WHITESPACE_CHARS:
+                for token_id in self._whitespace_tokens:
+                    _clear_mask_token(mask, token_id)
+            masked = llguidance.mlx.apply_token_bitmask(logits, mask)
+        except Exception as exc:
+            raise ConstrainedDecodingError(
+                f"failed to construct strict JSON Schema token mask: {exc}"
+            ) from exc
+        return masked[0] if logits.ndim == 1 else masked

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -139,7 +139,6 @@ from .api.tool_calling import (
     build_json_logits_processor,
     build_json_system_prompt,
     convert_tools_for_template,
-    parse_json_output,
     parse_tool_calls,
 )
 from .api.utils import (
@@ -473,22 +472,30 @@ def _prepare_json_logits_processor(
     if json_instruction:
         messages = _inject_json_instruction(messages, json_instruction)
 
-    # ``tools`` + ``response_format`` is undefined in OpenAI; skip constraints
-    # when tools are active so tool-call markup can still be emitted.
+    # ``tools`` + ``response_format`` is undefined in OpenAI. Do not silently
+    # downgrade a declared constrained-output request to prompt-only behavior.
     if tools and tool_choice != "none":
-        return messages, json_logits_processor
+        raise HTTPException(
+            status_code=400,
+            detail="tools and response_format cannot be combined",
+        )
 
     tokenizer_obj = _get_engine_tokenizer(engine)
     if tokenizer_obj is None:
-        return messages, json_logits_processor
+        raise HTTPException(
+            status_code=422,
+            detail="response_format is unavailable: serving tokenizer not found",
+        )
 
     try:
         json_logits_processor = build_json_logits_processor(
             response_format, tokenizer_obj
         )
     except Exception as exc:
-        logger.warning("Failed to build JSON logits processor: %s", exc)
-        json_logits_processor = None
+        raise HTTPException(
+            status_code=422,
+            detail=f"response_format is unavailable: {exc}",
+        ) from exc
 
     if json_logits_processor is not None:
         log_label = f" for {log_context}" if log_context else ""
@@ -4395,6 +4402,71 @@ async def _ensure_sse_terminal(
             yield terminal_frame
 
 
+async def _collect_stream_chunks(generator: AsyncIterator[str]) -> list[str]:
+    """Collect a structured-output stream before exposing a success response."""
+    return [chunk async for chunk in generator]
+
+
+async def _build_chat_streaming_response(
+    engine,
+    messages,
+    request,
+    raw_request,
+    metrics_tracker,
+    chat_kwargs,
+    total_timeout,
+    deadline,
+) -> tuple[StreamingResponse | Response, bool]:
+    """Build a chat stream and report whether caller cleanup remains required."""
+    stream_generator = stream_chat_completion(
+        engine,
+        messages,
+        request,
+        metrics_tracker=metrics_tracker,
+        **chat_kwargs,
+    )
+    if _response_format_type(request.response_format) in (
+        "json_object",
+        "json_schema",
+    ):
+        chunks = await _wait_with_disconnect(
+            _collect_stream_chunks(stream_generator),
+            raw_request,
+            timeout=_remaining_request_timeout(total_timeout, deadline),
+            timeout_detail_seconds=total_timeout,
+        )
+        if chunks is None:
+            return Response(status_code=499), True
+        return StreamingResponse(iter(chunks), media_type="text/event-stream"), True
+
+    response = StreamingResponse(
+        _disconnect_guard(
+            _ensure_sse_terminal(stream_generator, "data: [DONE]\n\n"),
+            raw_request,
+            cleanup=_make_release_cleanup(raw_request),
+            timeout=total_timeout,
+        ),
+        media_type="text/event-stream",
+    )
+    return response, False
+
+
+def _record_structured_stream_content(
+    parts: list[str], content: str, enabled: bool, tool_calls_detected: bool
+) -> None:
+    if content and enabled and not tool_calls_detected:
+        parts.append(content)
+
+
+def _validate_structured_stream(
+    request: ChatCompletionRequest,
+    content_parts: list[str],
+    tool_calls_detected: bool,
+) -> None:
+    if request.response_format is not None and not tool_calls_detected:
+        _apply_response_format_or_raise("".join(content_parts), request.response_format)
+
+
 def _find_uvicorn_cycle(obj, depth=0, visited=None):
     """Walk through middleware wrappers to find uvicorn's RequestResponseCycle.
 
@@ -5108,25 +5180,16 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             _raise_remote_media_http_error(exc)
 
         if request.stream:
-            response = StreamingResponse(
-                _disconnect_guard(
-                    _ensure_sse_terminal(
-                        stream_chat_completion(
-                            engine,
-                            prepared.messages,
-                            request,
-                            metrics_tracker=tracker,
-                            **prepared.chat_kwargs,
-                        ),
-                        "data: [DONE]\n\n",
-                    ),
-                    raw_request,
-                    cleanup=_make_release_cleanup(raw_request),
-                    timeout=total_timeout,
-                ),
-                media_type="text/event-stream",
+            response, release_on_exit = await _build_chat_streaming_response(
+                engine,
+                prepared.messages,
+                request,
+                raw_request,
+                tracker,
+                prepared.chat_kwargs,
+                total_timeout,
+                deadline,
             )
-            release_on_exit = False
             return response
 
         start_time = time.perf_counter()
@@ -6245,6 +6308,7 @@ async def stream_chat_completion(
     # ``"```json{...}```"`` instead of ``"{...}"`` for models that wrap
     # their structured output in markdown (e.g. Gemma 4).
     fence_stripper = _streaming_json_fence_stripper(request)
+    response_format_content: list[str] = []
 
     # Tool call streaming state
     tool_parser = None
@@ -6397,6 +6461,13 @@ async def stream_chat_completion(
                         if flush:
                             content = content + flush
 
+                _record_structured_stream_content(
+                    response_format_content,
+                    content,
+                    fence_stripper is not None,
+                    tool_calls_detected,
+                )
+
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=_response_model_name(request.model),
@@ -6521,6 +6592,13 @@ async def stream_chat_completion(
                         if flush:
                             content = content + flush
 
+                _record_structured_stream_content(
+                    response_format_content,
+                    content,
+                    fence_stripper is not None,
+                    tool_calls_detected,
+                )
+
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=_response_model_name(request.model),
@@ -6619,38 +6697,12 @@ async def stream_chat_completion(
             )
             yield f"data: {terminal_chunk.model_dump_json()}\n\n"
 
-        # Safety-net validation: if response_format was requested, verify the
-        # accumulated output still parses.  When constrained decoding is active
-        # this should always succeed; if it fails we log loudly (error) so we
-        # notice grammar-integration regressions.  When constrained decoding was
-        # *not* active (optional dep missing, incompatible tokenizer, combined
-        # with tools), we log at warning level only — the prompt-only path is
-        # best-effort.
-        if (
-            getattr(request, "response_format", None) is not None
-            and not tool_calls_detected
-        ):
-            try:
-                _, _parsed, _is_valid, _err = parse_json_output(
-                    accumulated_text, request.response_format
-                )
-                if not _is_valid:
-                    # Determine whether constrained decoding was wired up.  We
-                    # passed the processor through ``kwargs`` so its presence is
-                    # the signal.
-                    has_constrained = any(
-                        p.__class__.__name__ == "JSONSchemaLogitsProcessor"
-                        for p in (kwargs.get("logits_processors") or [])
-                    )
-                    if has_constrained:
-                        logger.error(
-                            "Streaming constrained decoding produced invalid JSON: %s",
-                            _err,
-                        )
-                    else:
-                        logger.warning("Streaming JSON validation failed: %s", _err)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Streaming JSON validation raised: %s", exc)
+        # Structured streams are buffered by the endpoint until this independent
+        # validation succeeds, so invalid content cannot be returned as a
+        # successful stream.
+        _validate_structured_stream(
+            request, response_format_content, tool_calls_detected
+        )
 
         # Log throughput
         elapsed = time.perf_counter() - start_time


### PR DESCRIPTION
# Fix fail-open structured-output enforcement

## Summary

- require an object root for `response_format.type=json_object`
- route strict `json_schema` through token-level JSON Schema enforcement
- mask numeric-range violations and premature array closure before emission
- require schema-valid completion before EOS or HTTP success
- fail closed when constrained-decoder setup or execution fails

## Exact reproduction

On upstream v0.4.0, a streaming `json_object` request could return an array root with `finish_reason=stop`. A strict compact schema requiring exactly nine integers from 1 through 5 could return strings and report `finish_reason=stop`.

A follow-up full Jobs-shaped request reproduced a second failure: the existing processor emitted nine `0` values despite `minimum: 1` and `maximum: 5`, then reached an empty allowed-token set and returned HTTP 500.

The compared paths are:

- `vllm_mlx/constrained/json_schema_processor.py`
- `vllm_mlx/constrained/llguidance_schema_processor.py`
- `vllm_mlx/api/tool_calling.py`
- `vllm_mlx/server.py`

## Expected behavior

Declared structured output remains constrained for the entire request. Invalid numeric values and premature structural closure are excluded before token selection. If the schema cannot be compiled or the processor fails, the request fails instead of continuing unconstrained.

## Minimal patch shape

`json_object` retains the object-root LMFE path. Strict `json_schema` uses a request-local `llguidance` matcher with MLX token masking, padded-vocabulary handling, schema-aware EOS, and a bounded non-progress whitespace guard. For streaming requests with response_format, the endpoint buffers the complete SSE sequence and validates it before returning a success response. This intentionally changes time-to-first-byte and memory behavior for structured streams; ordinary text streams remain incremental.

## Validation

- full upstream suite: 2,261 passed, 24 skipped, 23 deselected
- focused structured/server suite: 222 passed, 2 skipped, 3 deselected
- Ruff, formatting, and `git diff --check`: passed
- exact 51,014-character live request repeated 3 times: HTTP 200, `finish_reason=stop`, independent schema validation passed, all scores in range
- conflict run where the prompt requested `0`: token masking emitted legal value `1`

Live summary:

`/opt/ai-runtime/run/qwen-constrained-output-investigation/20260713T-live-numeric-range-llguidance-certification-pass/summary.json`

## Explicit non-claims

This does not claim a model-quality fix or universal JSON Schema coverage. Unsupported or invalid constrained-decoder setup remains fail-closed. The patch does not change model templates, sampling, Runtime contracts, Jobs routing, or feature defaults.

Refs #635.

