### PR TITLE
fix(registry): honor auto-unload-idle-seconds and release MLX memory on unload

### DIFF
--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -53,6 +53,7 @@ Example:
 ```yaml
 manager:
   memory_budget_gb: 100
+  idle_unload_seconds: 300
   contention_policy:
     strategy: wait_then_preempt
     wait_timeout_s: 45
@@ -94,6 +95,16 @@ It does not include, and does not reserve room for:
 - other colocated services
 
 On a 128 GB machine, a practical starting point is often `80-100 GB`.
+
+### `idle_unload_seconds`
+
+Automatically unload a model after it has had no active requests for this many
+seconds. Values less than or equal to `0` disable idle unloading.
+
+If this setting is omitted, registry mode inherits
+`--auto-unload-idle-seconds`; that flag defaults to `0`. A value in the YAML
+file takes precedence over the CLI fallback. Preloaded models are also eligible
+for idle unloading after their preload lease is released.
 
 ### Budget vs. the Metal allocation ceiling
 
@@ -263,6 +274,13 @@ Registry-backed responses include the configured model ids and current state suc
 - `loading`
 - `unloaded`
 - `preempting`
+
+Each model entry also includes `last_used_at` when it is loaded. For the
+effective idle timeout together with all model states, inspect `/v1/status`:
+
+```bash
+curl http://localhost:8000/v1/status
+```
 
 ### Verify a cold-load path
 

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -320,3 +320,36 @@ class TestToolCallReplayNormalization:
         normalized = _normalize_tool_call_arguments_for_template([MessageLike()])
 
         assert normalized == [{"role": "assistant", "content": "plain response"}]
+
+
+class TestBatchedEngineStop:
+    """stop() must actually release MLX's Metal buffer cache, not just drop
+    Python references — otherwise idle-unload frees objects but not memory.
+    """
+
+    def _make_engine(self):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        with patch("vllm_mlx.engine.batched.is_mllm_model", return_value=False):
+            engine = BatchedEngine("test-model")
+        engine._loaded = True
+        return engine
+
+    @pytest.mark.anyio
+    async def test_stop_calls_mx_clear_cache(self, monkeypatch):
+        from vllm_mlx.engine import batched as batched_mod
+
+        calls = {"count": 0}
+        monkeypatch.setattr(
+            batched_mod.mx,
+            "clear_cache",
+            lambda: calls.__setitem__("count", calls["count"] + 1),
+        )
+
+        engine = self._make_engine()
+
+        await engine.stop()
+
+        assert calls["count"] == 1
+        assert engine._model is None
+        assert engine._loaded is False

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -390,9 +390,10 @@ class TestLifecycleCli:
 
         captured = {}
 
-        def fake_load_model_registry(config_path, *, defaults):
+        def fake_load_model_registry(config_path, *, defaults, memory_budget_gb=None):
             captured["config_path"] = config_path
             captured["defaults"] = defaults
+            captured["memory_budget_gb"] = memory_budget_gb
 
         monkeypatch.setattr(srv, "load_model_registry", fake_load_model_registry)
         monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: None)
@@ -467,6 +468,7 @@ class TestLifecycleCli:
 
         assert captured["config_path"] == "/tmp/models.yaml"
         assert captured["defaults"].auto_unload_idle_seconds == 300
+        assert captured["memory_budget_gb"] is None
 
     def test_serve_command_preserves_mtp_scheduler_config_with_residency(
         self, monkeypatch

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -29,6 +29,7 @@ def restore_server_globals():
         "_lazy_load_model",
         "_residency_manager",
         "_lifecycle_task",
+        "_registry_idle_reaper_task",
         "_lifespan_active",
         "_mcp_manager",
         "_mcp_executor",
@@ -58,6 +59,16 @@ def restore_server_globals():
         and not leaked_task.done()
     ):
         leaked_task.cancel()
+
+    leaked_reaper = getattr(srv, "_registry_idle_reaper_task", None)
+    original_reaper = snapshot["_registry_idle_reaper_task"]
+    if (
+        leaked_reaper is not sentinel
+        and leaked_reaper is not None
+        and leaked_reaper is not original_reaper
+        and not leaked_reaper.done()
+    ):
+        leaked_reaper.cancel()
 
     for name, value in snapshot.items():
         if value is sentinel:
@@ -364,6 +375,98 @@ class TestLifecycleCli:
         assert captured["kwargs"]["stream_interval"] == 1
         assert captured["kwargs"]["auto_unload_idle_seconds"] == 300
         assert captured["kwargs"]["lazy_load_model"] is True
+
+    def test_serve_command_wires_auto_unload_idle_seconds_into_load_model_registry(
+        self, monkeypatch
+    ):
+        """--auto-unload-idle-seconds must not be silently dropped in
+        --models-config mode: it should reach RegistryServeDefaults so the
+        registry's idle reaper can fall back to it.
+        """
+        import uvicorn
+
+        import vllm_mlx.cli as cli
+        import vllm_mlx.server as srv
+
+        captured = {}
+
+        def fake_load_model_registry(config_path, *, defaults):
+            captured["config_path"] = config_path
+            captured["defaults"] = defaults
+
+        monkeypatch.setattr(srv, "load_model_registry", fake_load_model_registry)
+        monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: None)
+
+        args = SimpleNamespace(
+            model=None,
+            models_config="/tmp/models.yaml",
+            host="127.0.0.1",
+            port=8000,
+            max_num_seqs=256,
+            prefill_batch_size=8,
+            completion_batch_size=32,
+            enable_prefix_cache=True,
+            disable_prefix_cache=False,
+            prefix_cache_size=100,
+            cache_memory_mb=None,
+            cache_memory_percent=0.20,
+            no_memory_aware_cache=False,
+            kv_cache_quantization=False,
+            kv_cache_quantization_bits=8,
+            kv_cache_quantization_group_size=64,
+            kv_cache_min_quantize_tokens=256,
+            stream_interval=7,
+            max_tokens=32768,
+            continuous_batching=False,
+            use_paged_cache=False,
+            paged_cache_block_size=64,
+            max_cache_blocks=1000,
+            chunked_prefill_tokens=0,
+            enable_mtp=False,
+            mtp_num_draft_tokens=1,
+            mtp_optimistic=False,
+            prefill_step_size=2048,
+            specprefill=False,
+            specprefill_threshold=8192,
+            specprefill_keep_pct=0.3,
+            specprefill_draft_model=None,
+            mcp_config=None,
+            api_key=None,
+            rate_limit=0,
+            timeout=300.0,
+            enable_auto_tool_choice=False,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            mllm=False,
+            default_temperature=None,
+            default_top_p=None,
+            default_top_k=None,
+            default_min_p=None,
+            default_presence_penalty=None,
+            default_repetition_penalty=None,
+            default_chat_template_kwargs=None,
+            served_model_name=None,
+            embedding_model=None,
+            gpu_memory_utilization=0.90,
+            enable_metrics=False,
+            download_timeout=120,
+            download_retries=3,
+            mllm_prefill_step_size=None,
+            lazy_load_model=False,
+            auto_unload_idle_seconds=300,
+            default_thinking_token_budget=None,
+            max_kv_size=0,
+            embedding_max_length=None,
+            embedding_overflow_policy="truncate",
+            prefix_trie_cache=False,
+            prefix_trie_cache_size=32,
+            prefix_trie_cache_memory_mb=None,
+        )
+
+        cli.serve_command(args)
+
+        assert captured["config_path"] == "/tmp/models.yaml"
+        assert captured["defaults"].auto_unload_idle_seconds == 300
 
     def test_serve_command_preserves_mtp_scheduler_config_with_residency(
         self, monkeypatch

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -37,6 +37,8 @@ def restore_server_globals():
         "_lazy_load_model",
         "_residency_manager",
         "_lifecycle_task",
+        "_model_manager",
+        "_registry_idle_reaper_task",
         "_lifespan_active",
         "_mcp_manager",
         "_mcp_executor",
@@ -65,6 +67,8 @@ def restore_server_globals():
         "_force_mllm_model": None,
         "_residency_manager": None,
         "_lifecycle_task": None,
+        "_model_manager": None,
+        "_registry_idle_reaper_task": None,
         "_lifespan_active": False,
         "_mcp_manager": None,
         "_mcp_executor": None,
@@ -90,6 +94,16 @@ def restore_server_globals():
         and not leaked_task.done()
     ):
         leaked_task.cancel()
+
+    leaked_reaper = getattr(srv, "_registry_idle_reaper_task", None)
+    original_reaper = snapshot["_registry_idle_reaper_task"]
+    if (
+        leaked_reaper is not sentinel
+        and leaked_reaper is not None
+        and leaked_reaper is not original_reaper
+        and not leaked_reaper.done()
+    ):
+        leaked_reaper.cancel()
 
     for name, value in snapshot.items():
         if value is sentinel:
@@ -1849,6 +1863,89 @@ class TestLifecycleFailureHandling:
             await srv._lifecycle_loop()
 
         assert sleeps == [0.25]
+
+    @pytest.mark.anyio
+    async def test_registry_idle_reaper_task_starts_and_stops_with_lifespan(
+        self, monkeypatch
+    ):
+        """The registry idle reaper must start on lifespan startup when
+        idle_unload_seconds is configured, and be cleanly cancelled on
+        shutdown — mirroring how _lifecycle_task is managed for the
+        single-model residency path.
+        """
+        import vllm_mlx.server as srv
+
+        reaper_started = asyncio.Event()
+        reaper_cancelled = asyncio.Event()
+
+        class FakeModelManager:
+            idle_unload_seconds = 30.0
+
+            async def preload(self):
+                return None
+
+            async def run_idle_reaper(self):
+                reaper_started.set()
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    reaper_cancelled.set()
+                    raise
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(srv, "_engine", None, raising=False)
+        monkeypatch.setattr(srv, "_residency_manager", None, raising=False)
+        monkeypatch.setattr(srv, "_default_model_key", None, raising=False)
+        monkeypatch.setattr(srv, "_mcp_manager", None, raising=False)
+        monkeypatch.setattr(srv, "_lifecycle_task", None, raising=False)
+        monkeypatch.setattr(srv, "_registry_idle_reaper_task", None, raising=False)
+        monkeypatch.setattr(srv, "_model_manager", FakeModelManager(), raising=False)
+
+        lifespan = srv.lifespan(srv.app)
+        await lifespan.__anext__()
+
+        await asyncio.wait_for(reaper_started.wait(), timeout=1.0)
+        assert srv._registry_idle_reaper_task is not None
+
+        with pytest.raises(StopAsyncIteration):
+            await lifespan.__anext__()
+
+        await asyncio.wait_for(reaper_cancelled.wait(), timeout=1.0)
+        assert srv._registry_idle_reaper_task is None
+
+    @pytest.mark.anyio
+    async def test_registry_idle_reaper_task_not_started_when_disabled(
+        self, monkeypatch
+    ):
+        """No background reaper should run when idle_unload_seconds is 0."""
+        import vllm_mlx.server as srv
+
+        class FakeModelManager:
+            idle_unload_seconds = 0.0
+
+            async def preload(self):
+                return None
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(srv, "_engine", None, raising=False)
+        monkeypatch.setattr(srv, "_residency_manager", None, raising=False)
+        monkeypatch.setattr(srv, "_default_model_key", None, raising=False)
+        monkeypatch.setattr(srv, "_mcp_manager", None, raising=False)
+        monkeypatch.setattr(srv, "_lifecycle_task", None, raising=False)
+        monkeypatch.setattr(srv, "_registry_idle_reaper_task", None, raising=False)
+        monkeypatch.setattr(srv, "_model_manager", FakeModelManager(), raising=False)
+
+        lifespan = srv.lifespan(srv.app)
+        await lifespan.__anext__()
+
+        assert srv._registry_idle_reaper_task is None
+
+        with pytest.raises(StopAsyncIteration):
+            await lifespan.__anext__()
 
     @pytest.mark.anyio
     async def test_cache_restore_hook_does_not_block_event_loop(self, monkeypatch):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -808,8 +808,7 @@ class TestLoadRegistryConfigIdleUnload:
         model_dir = tmp_path / "alpha"
         model_dir.mkdir()
         config_path = tmp_path / "models.yaml"
-        config_path.write_text(
-            f"""
+        config_path.write_text(f"""
 manager:
   memory_budget_gb: 16
 {manager_extra}
@@ -817,16 +816,13 @@ models:
   - name: alpha
     path: {model_dir}
     estimated_memory_gb: 4
-"""
-        )
+""")
         return config_path
 
     def test_explicit_yaml_value_wins(self, tmp_path):
         from vllm_mlx.model_registry import load_registry_config
 
-        config_path = self._write_config(
-            tmp_path, "  idle_unload_seconds: 120\n"
-        )
+        config_path = self._write_config(tmp_path, "  idle_unload_seconds: 120\n")
         defaults = _defaults()
         defaults = type(defaults)(
             **{**defaults.__dict__, "auto_unload_idle_seconds": 300.0}

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -335,6 +335,50 @@ def test_unload_idle_unloads_stale_models_and_skips_busy_ones(tmp_path):
     asyncio.run(_run())
 
 
+def test_unload_idle_completes_engine_stop_when_cancelled(tmp_path):
+    """Cancelling an idle sweep must not orphan a half-stopped engine."""
+
+    async def _run():
+        stop_started = asyncio.Event()
+        stop_gate = asyncio.Event()
+        stop_completed = False
+
+        class BlockingStopEngine(FakeEngine):
+            async def stop(self) -> None:
+                nonlocal stop_completed
+                stop_started.set()
+                await stop_gate.wait()
+                stop_completed = True
+                self.stopped += 1
+
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=1),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: BlockingStopEngine(config),
+        )
+
+        lease = await manager.acquire("alpha")
+        await lease.release()
+        manager._loaded["alpha"].last_used_at = time.time() - 2
+
+        unload_task = asyncio.create_task(manager.unload_idle())
+        await stop_started.wait()
+        unload_task.cancel()
+        await asyncio.sleep(0)
+
+        stop_gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await unload_task
+
+        assert stop_completed
+        assert manager.list_models()[0]["status"] == "unloaded"
+        assert manager._unloading == {}
+
+    asyncio.run(_run())
+
+
 # ---------------------------------------------------------------------------
 # Memory budget vs Metal allocation ceiling reconciliation (issue #627)
 # ---------------------------------------------------------------------------

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -7,6 +7,7 @@ import asyncio
 import dataclasses
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any
 
@@ -99,9 +100,11 @@ def _manager_config(
     strategy: str = "wait_then_fail",
     wait_timeout_s: float | None = 1.0,
     preempt_after_s: float | None = None,
+    idle_unload_seconds: float = 0.0,
 ) -> RegistryManagerConfig:
     return RegistryManagerConfig(
         memory_budget_bytes=int(budget_gb * (1024**3)),
+        idle_unload_seconds=idle_unload_seconds,
         policy=ContentionPolicy(
             strategy=strategy,
             wait_timeout_s=wait_timeout_s,
@@ -289,6 +292,45 @@ def test_non_local_registry_entry_requires_explicit_memory_estimate():
 
         with pytest.raises(ValueError, match="estimated_memory_gb"):
             await manager.acquire("remote")
+
+
+def test_unload_idle_unloads_stale_models_and_skips_busy_ones(tmp_path):
+    """Idle-timeout unload must fire without any competing model ever being
+    requested, unlike memory-budget eviction which only triggers on acquire().
+    """
+
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4, "beta": 4})
+        created: dict[str, FakeEngine] = {}
+
+        def engine_factory(config: ResolvedModelConfig) -> FakeEngine:
+            engine = FakeEngine(config)
+            created[config.entry.name] = engine
+            return engine
+
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=999),
+            registry,
+            _defaults(),
+            engine_factory=engine_factory,
+        )
+
+        alpha_lease = await manager.acquire("alpha")
+        await alpha_lease.release()
+
+        # beta stays busy (never released) so it must survive the sweep.
+        await manager.acquire("beta")
+
+        manager._loaded["alpha"].last_used_at = time.time() - 1000
+        manager._loaded["beta"].last_used_at = time.time() - 1000
+
+        unloaded = await manager.unload_idle()
+
+        assert unloaded == ["alpha"]
+        assert "alpha" not in manager._loaded
+        assert "beta" in manager._loaded
+        assert created["alpha"].stopped == 1
+        assert created["beta"].stopped == 0
 
     asyncio.run(_run())
 
@@ -662,3 +704,156 @@ def test_log_memory_budget_report_says_so_when_ceiling_unknown(
     assert not [
         record for record in caplog.records if record.levelno >= logging.WARNING
     ]
+
+
+def test_unload_idle_noop_when_disabled(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=0.0),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease = await manager.acquire("alpha")
+        await lease.release()
+        manager._loaded["alpha"].last_used_at = time.time() - 100000
+
+        unloaded = await manager.unload_idle()
+
+        assert unloaded == []
+        assert "alpha" in manager._loaded
+
+    asyncio.run(_run())
+
+
+def test_unload_idle_leaves_fresh_models_alone(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=999),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease = await manager.acquire("alpha")
+        await lease.release()
+
+        unloaded = await manager.unload_idle()
+
+        assert unloaded == []
+        assert "alpha" in manager._loaded
+
+    asyncio.run(_run())
+
+
+def test_run_idle_reaper_unloads_after_timeout(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        created: dict[str, FakeEngine] = {}
+
+        def engine_factory(config: ResolvedModelConfig) -> FakeEngine:
+            engine = FakeEngine(config)
+            created[config.entry.name] = engine
+            return engine
+
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=0.2),
+            registry,
+            _defaults(),
+            engine_factory=engine_factory,
+        )
+
+        lease = await manager.acquire("alpha")
+        await lease.release()
+
+        reaper = asyncio.create_task(manager.run_idle_reaper())
+        try:
+            for _ in range(50):
+                if "alpha" not in manager._loaded:
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            reaper.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await reaper
+
+        assert "alpha" not in manager._loaded
+        assert created["alpha"].stopped == 1
+
+    asyncio.run(_run())
+
+
+def test_run_idle_reaper_returns_immediately_when_disabled(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=16, idle_unload_seconds=0.0),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        await asyncio.wait_for(manager.run_idle_reaper(), timeout=1.0)
+
+    asyncio.run(_run())
+
+
+class TestLoadRegistryConfigIdleUnload:
+    """YAML-level wiring for the manager.idle_unload_seconds knob."""
+
+    def _write_config(self, tmp_path: Path, manager_extra: str = "") -> Path:
+        model_dir = tmp_path / "alpha"
+        model_dir.mkdir()
+        config_path = tmp_path / "models.yaml"
+        config_path.write_text(
+            f"""
+manager:
+  memory_budget_gb: 16
+{manager_extra}
+models:
+  - name: alpha
+    path: {model_dir}
+    estimated_memory_gb: 4
+"""
+        )
+        return config_path
+
+    def test_explicit_yaml_value_wins(self, tmp_path):
+        from vllm_mlx.model_registry import load_registry_config
+
+        config_path = self._write_config(
+            tmp_path, "  idle_unload_seconds: 120\n"
+        )
+        defaults = _defaults()
+        defaults = type(defaults)(
+            **{**defaults.__dict__, "auto_unload_idle_seconds": 300.0}
+        )
+
+        manager_config, _ = load_registry_config(config_path, defaults)
+
+        assert manager_config.idle_unload_seconds == 120.0
+
+    def test_falls_back_to_cli_default_when_unset(self, tmp_path):
+        from vllm_mlx.model_registry import load_registry_config
+
+        config_path = self._write_config(tmp_path)
+        defaults = _defaults()
+        defaults = type(defaults)(
+            **{**defaults.__dict__, "auto_unload_idle_seconds": 300.0}
+        )
+
+        manager_config, _ = load_registry_config(config_path, defaults)
+
+        assert manager_config.idle_unload_seconds == 300.0
+
+    def test_defaults_to_disabled(self, tmp_path):
+        from vllm_mlx.model_registry import load_registry_config
+
+        config_path = self._write_config(tmp_path)
+
+        manager_config, _ = load_registry_config(config_path, _defaults())
+
+        assert manager_config.idle_unload_seconds == 0.0

--- a/tests/test_registry_idle_unload_real_model.py
+++ b/tests/test_registry_idle_unload_real_model.py
@@ -107,8 +107,7 @@ def run_idle_unload_memory_check(model_name: str) -> None:
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         config_path = Path(tmp_dir) / "models.yaml"
-        config_path.write_text(
-            f"""
+        config_path.write_text(f"""
 manager:
   memory_budget_gb: 32
   idle_unload_seconds: {IDLE_UNLOAD_SECONDS}
@@ -116,11 +115,12 @@ models:
   - name: idle-test
     path: {snapshot_path}
     estimated_memory_gb: 1
-"""
-        )
+""")
 
-        print(f"\nStarting server on port {PORT} "
-              f"(idle_unload_seconds={IDLE_UNLOAD_SECONDS})...")
+        print(
+            f"\nStarting server on port {PORT} "
+            f"(idle_unload_seconds={IDLE_UNLOAD_SECONDS})..."
+        )
         proc = subprocess.Popen(
             [
                 sys.executable,
@@ -147,9 +147,9 @@ models:
             _send_chat_completion(base_url, "Say hi in one word.")
 
             status = _model_status(base_url)
-            assert status["status"] == "loaded", (
-                f"expected model to be loaded after a request, got {status!r}"
-            )
+            assert (
+                status["status"] == "loaded"
+            ), f"expected model to be loaded after a request, got {status!r}"
             rss_loaded = _rss_mb(proc.pid)
             print(
                 f"RSS after load:   {rss_loaded:.1f} MB  "
@@ -167,8 +167,10 @@ models:
                 status = _model_status(base_url)
 
             if status["status"] != "unloaded":
-                print(f"\nFAIL: model did not unload within {UNLOAD_POLL_TIMEOUT_S}s "
-                      f"(status={status['status']!r})")
+                print(
+                    f"\nFAIL: model did not unload within {UNLOAD_POLL_TIMEOUT_S}s "
+                    f"(status={status['status']!r})"
+                )
                 sys.exit(1)
 
             rss_unloaded = _rss_mb(proc.pid)
@@ -181,9 +183,9 @@ models:
             _send_chat_completion(base_url, "Say hi again.")
 
             status = _model_status(base_url)
-            assert status["status"] == "loaded", (
-                f"expected model to reload transparently, got {status!r}"
-            )
+            assert (
+                status["status"] == "loaded"
+            ), f"expected model to reload transparently, got {status!r}"
             rss_reloaded = _rss_mb(proc.pid)
             print(
                 f"RSS after reload: {rss_reloaded:.1f} MB  "

--- a/tests/test_registry_idle_unload_real_model.py
+++ b/tests/test_registry_idle_unload_real_model.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Real-server test for registry-mode idle-unload memory reclaim.
+
+Starts a real `vllm-mlx serve --models-config ...` server subprocess,
+drives it over HTTP exactly like a real client would, and reports real
+process RSS before load, after load, after idle-unload, and after a
+transparent reload -- to demonstrate that mx.clear_cache() in
+SimpleEngine.stop() actually releases memory back to the OS instead of
+only dropping Python references, and that --auto-unload-idle-seconds now
+takes effect in --models-config (registry) mode.
+
+Not a pytest test (see test_paged_cache_real_inference.py for the same
+convention): driving real generation through a bare, directly instantiated
+ModelManager/SimpleEngine (rather than through the full server process)
+hits MLX's worker-thread stream binding in a way that is unrelated to the
+idle-unload logic under test here, so this script goes through the real
+server process instead -- the same path production traffic uses -- and
+must only be invoked directly.
+
+Usage:
+    python tests/test_registry_idle_unload_real_model.py
+    python tests/test_registry_idle_unload_real_model.py --model mlx-community/Qwen3-0.6B-8bit
+"""
+
+import argparse
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Skip if not on Apple Silicon
+if sys.platform != "darwin" or platform.machine() != "arm64":
+    print("This test requires Apple Silicon")
+    sys.exit(0)
+
+PORT = 8971
+IDLE_UNLOAD_SECONDS = 10
+STARTUP_TIMEOUT_S = 60
+UNLOAD_POLL_TIMEOUT_S = 30
+
+
+def _resolve_local_snapshot(model_name: str) -> str:
+    """Return the local HF cache snapshot path for an already-cached model."""
+    from vllm_mlx.utils.download import DownloadConfig, ensure_model_downloaded
+
+    return str(ensure_model_downloaded(model_name, config=DownloadConfig()))
+
+
+def _wait_for_health(base_url: str, timeout_s: float) -> None:
+    import requests
+
+    deadline = time.monotonic() + timeout_s
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(f"{base_url}/health", timeout=2)
+            if resp.status_code == 200:
+                return
+        except requests.exceptions.RequestException as exc:
+            last_error = exc
+        time.sleep(0.5)
+    raise TimeoutError(f"Server did not become healthy in time: {last_error}")
+
+
+def _model_status(base_url: str) -> dict:
+    import requests
+
+    resp = requests.get(f"{base_url}/v1/status", timeout=5)
+    resp.raise_for_status()
+    return resp.json()["model_manager"]["models"][0]
+
+
+def _send_chat_completion(base_url: str, content: str) -> None:
+    import requests
+
+    resp = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json={
+            "model": "idle-test",
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": 8,
+        },
+        timeout=60,
+    )
+    resp.raise_for_status()
+
+
+def _rss_mb(pid: int) -> float:
+    import psutil
+
+    return psutil.Process(pid).memory_info().rss / (1024**2)
+
+
+def run_idle_unload_memory_check(model_name: str) -> None:
+    print("=" * 70)
+    print("  REGISTRY IDLE-UNLOAD - REAL SERVER MEMORY TEST")
+    print("=" * 70)
+    print(f"\nModel: {model_name}")
+    print("Resolving local model snapshot (no download expected)...")
+    snapshot_path = _resolve_local_snapshot(model_name)
+    print(f"  -> {snapshot_path}")
+
+    base_url = f"http://127.0.0.1:{PORT}"
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config_path = Path(tmp_dir) / "models.yaml"
+        config_path.write_text(
+            f"""
+manager:
+  memory_budget_gb: 32
+  idle_unload_seconds: {IDLE_UNLOAD_SECONDS}
+models:
+  - name: idle-test
+    path: {snapshot_path}
+    estimated_memory_gb: 1
+"""
+        )
+
+        print(f"\nStarting server on port {PORT} "
+              f"(idle_unload_seconds={IDLE_UNLOAD_SECONDS})...")
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "vllm_mlx.cli",
+                "serve",
+                "--models-config",
+                str(config_path),
+                "--port",
+                str(PORT),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        ok = True
+        try:
+            _wait_for_health(base_url, STARTUP_TIMEOUT_S)
+
+            rss_before = _rss_mb(proc.pid)
+            print(f"\nRSS before load:  {rss_before:.1f} MB")
+
+            print("Sending first chat completion (triggers load)...")
+            _send_chat_completion(base_url, "Say hi in one word.")
+
+            status = _model_status(base_url)
+            assert status["status"] == "loaded", (
+                f"expected model to be loaded after a request, got {status!r}"
+            )
+            rss_loaded = _rss_mb(proc.pid)
+            print(
+                f"RSS after load:   {rss_loaded:.1f} MB  "
+                f"(+{rss_loaded - rss_before:.1f} MB)"
+            )
+
+            print(
+                f"Waiting for idle-unload (timeout={IDLE_UNLOAD_SECONDS}s, "
+                f"polling up to {UNLOAD_POLL_TIMEOUT_S}s)..."
+            )
+            deadline = time.monotonic() + UNLOAD_POLL_TIMEOUT_S
+            status = _model_status(base_url)
+            while status["status"] != "unloaded" and time.monotonic() < deadline:
+                time.sleep(0.5)
+                status = _model_status(base_url)
+
+            if status["status"] != "unloaded":
+                print(f"\nFAIL: model did not unload within {UNLOAD_POLL_TIMEOUT_S}s "
+                      f"(status={status['status']!r})")
+                sys.exit(1)
+
+            rss_unloaded = _rss_mb(proc.pid)
+            print(
+                f"RSS after unload: {rss_unloaded:.1f} MB  "
+                f"(-{rss_loaded - rss_unloaded:.1f} MB reclaimed)"
+            )
+
+            print("Sending second chat completion (triggers transparent reload)...")
+            _send_chat_completion(base_url, "Say hi again.")
+
+            status = _model_status(base_url)
+            assert status["status"] == "loaded", (
+                f"expected model to reload transparently, got {status!r}"
+            )
+            rss_reloaded = _rss_mb(proc.pid)
+            print(
+                f"RSS after reload: {rss_reloaded:.1f} MB  "
+                f"(+{rss_reloaded - rss_unloaded:.1f} MB)"
+            )
+
+            loaded_growth = rss_loaded - rss_before
+            reclaimed = rss_loaded - rss_unloaded
+            reload_growth = rss_reloaded - rss_unloaded
+
+            print("\n" + "-" * 70)
+            print("SUMMARY")
+            print("-" * 70)
+            print(f"  Load grew RSS by:   {loaded_growth:+.1f} MB")
+            print(f"  Unload reclaimed:   {reclaimed:+.1f} MB")
+            print(f"  Reload grew RSS by: {reload_growth:+.1f} MB")
+
+            if loaded_growth <= 50:
+                print("\n  WARNING: loading did not grow RSS as expected (>50MB).")
+                ok = False
+            if reclaimed <= 0:
+                print(
+                    "\n  WARNING: unload did not reclaim memory -- "
+                    "mx.clear_cache() may not be releasing the Metal buffer cache."
+                )
+                ok = False
+            if reload_growth <= 50:
+                print("\n  WARNING: reload did not grow RSS as expected (>50MB).")
+                ok = False
+
+            if ok:
+                print(
+                    "\n  PASS: registry-mode idle-unload measurably releases "
+                    "and re-acquires memory."
+                )
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    if not ok:
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test registry-mode idle-unload memory reclaim with a real model"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="mlx-community/Qwen3-0.6B-8bit",
+        help="Model to use for testing",
+    )
+    args = parser.parse_args()
+
+    run_idle_unload_memory_check(args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -3015,3 +3015,30 @@ class TestSimpleEngineClearRuntimeCaches:
 
         # Non-MLLM, empty LRU, zeroed counters → nothing to report.
         assert result is None
+
+
+class TestSimpleEngineStop:
+    """stop() must actually release MLX's Metal buffer cache, not just drop
+    Python references — otherwise idle-unload frees objects but not memory.
+    """
+
+    async def test_stop_calls_mx_clear_cache(self, monkeypatch):
+        from vllm_mlx.engine import simple as simple_mod
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        calls = {"count": 0}
+        monkeypatch.setattr(
+            simple_mod.mx, "clear_cache", lambda: calls.__setitem__(
+                "count", calls["count"] + 1
+            )
+        )
+
+        engine = SimpleEngine("test-model")
+        engine._model = object()
+        engine._loaded = True
+
+        await engine.stop()
+
+        assert calls["count"] == 1
+        assert engine._model is None
+        assert engine._loaded is False

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -3028,9 +3028,9 @@ class TestSimpleEngineStop:
 
         calls = {"count": 0}
         monkeypatch.setattr(
-            simple_mod.mx, "clear_cache", lambda: calls.__setitem__(
-                "count", calls["count"] + 1
-            )
+            simple_mod.mx,
+            "clear_cache",
+            lambda: calls.__setitem__("count", calls["count"] + 1),
         )
 
         engine = SimpleEngine("test-model")

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1359,7 +1359,7 @@ Examples:
         "--auto-unload-idle-seconds",
         type=float,
         default=0.0,
-        help="Unload the main model after this many idle seconds (0 = disabled)",
+        help="Unload idle models after this many seconds (0 = disabled)",
     )
     serve_parser.add_argument(
         "--lazy-load-model",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -377,6 +377,7 @@ def serve_command(args):
             scheduler_config=scheduler_config,
             max_tokens=args.max_tokens,
             download_config=download_config,
+            auto_unload_idle_seconds=args.auto_unload_idle_seconds,
         )
         load_model_registry(models_config, defaults=defaults)
     else:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -20,6 +20,8 @@ from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import mlx.core as mx
+
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, extract_multimodal_content, is_mllm_model
 from .base import (
@@ -647,6 +649,7 @@ class BatchedEngine(BaseEngine):
             # The model and its streams lived on this thread; both go with it.
             self._generation_executor.shutdown(wait=True)
             self._generation_executor = None
+        mx.clear_cache()
         logger.info("BatchedEngine stopped")
 
     def _apply_chat_template(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -965,6 +965,7 @@ class SimpleEngine(BaseEngine):
                 executor.shutdown(wait=False, cancel_futures=True)
                 if pre_bind is not None:
                     restore_generation_streams(pre_bind)
+        mx.clear_cache()
         logger.info("SimpleEngine stopped")
 
     def _should_route_text_through_text_model(

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -880,8 +880,7 @@ class ModelManager:
                 if now - loaded.last_used_at >= idle_seconds
             ]
             unloads = [
-                self._begin_unload_locked(loaded.config.entry.name)
-                for loaded in stale
+                self._begin_unload_locked(loaded.config.entry.name) for loaded in stale
             ]
             self._condition.notify_all()
 

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -126,6 +126,7 @@ class RegistryServeDefaults:
     scheduler_config: SchedulerConfig | None
     max_tokens: int
     download_config: DownloadConfig
+    auto_unload_idle_seconds: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -143,6 +144,7 @@ class RegistryManagerConfig:
 
     memory_budget_bytes: int
     policy: ContentionPolicy
+    idle_unload_seconds: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -564,11 +566,17 @@ def load_registry_config(
     }:
         raise ValueError(f"Unsupported contention strategy: {policy.strategy}")
 
+    idle_unload_seconds = manager_raw.get("idle_unload_seconds")
     manager = RegistryManagerConfig(
         memory_budget_bytes=_parse_memory_budget_bytes(
             manager_raw.get("memory_budget_gb", manager_raw.get("memory_budget"))
         ),
         policy=policy,
+        idle_unload_seconds=(
+            float(idle_unload_seconds)
+            if idle_unload_seconds is not None
+            else defaults.auto_unload_idle_seconds
+        ),
     )
 
     registry: dict[str, RegisteredModel] = {}
@@ -657,6 +665,10 @@ class ModelManager:
         return self._config.memory_budget_bytes
 
     @property
+    def idle_unload_seconds(self) -> float:
+        return self._config.idle_unload_seconds
+
+    @property
     def registered_model_names(self) -> list[str]:
         """Return sorted list of all registered model names."""
         return sorted(self._registry.keys())
@@ -700,6 +712,7 @@ class ModelManager:
                     "owned_by": "vllm-mlx",
                     "source": entry.source,
                     "memory_gb": round(estimated / (1024**3), 2) if estimated else None,
+                    "last_used_at": loaded.last_used_at if loaded is not None else None,
                 }
             )
         return data
@@ -847,6 +860,56 @@ class ModelManager:
         if unload is not None:
             await self._run_unloads([unload])
 
+    async def unload_idle(self) -> list[str]:
+        """Unload every loaded model idle past ``idle_unload_seconds``.
+
+        No-op (returns an empty list) if idle-unload is disabled
+        (``idle_unload_seconds <= 0``). Unlike memory-budget eviction, this
+        proactively frees models even when no other model is being requested.
+        Returns the names of models that were unloaded.
+        """
+        idle_seconds = self._config.idle_unload_seconds
+        if idle_seconds <= 0:
+            return []
+
+        now = time.time()
+        async with self._condition:
+            stale = [
+                loaded
+                for loaded in self._idle_candidates_locked()
+                if now - loaded.last_used_at >= idle_seconds
+            ]
+            unloads = [
+                self._begin_unload_locked(loaded.config.entry.name)
+                for loaded in stale
+            ]
+            self._condition.notify_all()
+
+        if unloads:
+            await self._run_unloads(unloads)
+
+        return [loaded.config.entry.name for loaded in unloads]
+
+    async def run_idle_reaper(self) -> None:
+        """Background loop that proactively unloads idle models.
+
+        Mirrors the single-model residency lifecycle loop: sleeps at half the
+        configured idle timeout (bounded to 5s) so short timeouts stay
+        responsive, and a failed pass is logged rather than killing the loop.
+        """
+        idle_seconds = self._config.idle_unload_seconds
+        if idle_seconds <= 0:
+            return
+
+        while True:
+            await asyncio.sleep(min(idle_seconds / 2, 5.0))
+            try:
+                await self.unload_idle()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Idle unload pass failed")
+
     def _claim_loaded_locked(
         self,
         model_name: str,
@@ -951,19 +1014,25 @@ class ModelManager:
         self._unloading[model_name] = loaded
         return loaded
 
+    def _idle_candidates_locked(
+        self, *, exclude: str | None = None
+    ) -> list[LoadedModel]:
+        """Loaded, non-busy models eligible for eviction, oldest-used first."""
+        return sorted(
+            (
+                loaded
+                for name, loaded in self._loaded.items()
+                if name != exclude and loaded.active_requests == 0
+            ),
+            key=lambda item: item.last_used_at,
+        )
+
     def _collect_idle_unloads_locked(
         self, requested_model: str, required_bytes: int
     ) -> list[LoadedModel]:
         selected: list[LoadedModel] = []
         projected_bytes = self._committed_bytes_locked()
-        candidates = sorted(
-            (
-                loaded
-                for name, loaded in self._loaded.items()
-                if name != requested_model and loaded.active_requests == 0
-            ),
-            key=lambda item: item.last_used_at,
-        )
+        candidates = self._idle_candidates_locked(exclude=requested_model)
 
         for loaded in candidates:
             if projected_bytes + required_bytes <= self._config.memory_budget_bytes:

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from .api.utils import is_mllm_model
-from .engine.base import BaseEngine
+from .engine.base import BaseEngine, suspend_cancellation
 from .engine.batched import BatchedEngine
 from .engine.simple import SimpleEngine
 from .scheduler import SchedulerConfig
@@ -990,13 +990,22 @@ class ModelManager:
             await asyncio.wait_for(self._condition.wait(), timeout=timeout)
 
     async def _run_unloads(self, unloads: list[LoadedModel]) -> None:
-        for loaded in unloads:
-            try:
-                await loaded.engine.stop()
-            finally:
-                async with self._condition:
-                    self._unloading.pop(loaded.config.entry.name, None)
-                    self._condition.notify_all()
+        async def _stop_engines() -> None:
+            for loaded in unloads:
+                try:
+                    await loaded.engine.stop()
+                finally:
+                    async with self._condition:
+                        self._unloading.pop(loaded.config.entry.name, None)
+                        self._condition.notify_all()
+
+        unload_task = asyncio.create_task(_stop_engines())
+        try:
+            await asyncio.shield(unload_task)
+        except asyncio.CancelledError:
+            with suspend_cancellation():
+                await unload_task
+            raise
 
     def _reserve_load_locked(self, model_name: str, required_bytes: int) -> PendingLoad:
         future: asyncio.Future[LoadedModel] = asyncio.get_running_loop().create_future()

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -220,6 +220,7 @@ _auto_unload_idle_seconds: float = 0.0
 _lazy_load_model: bool = False
 _residency_manager: ResidencyManager | None = None
 _lifecycle_task: asyncio.Task | None = None
+_registry_idle_reaper_task: asyncio.Task | None = None
 _lifespan_active: bool = False
 
 _FALLBACK_TEMPERATURE = 0.7
@@ -1479,6 +1480,7 @@ async def _release_default_engine(*, count_activity: bool = True) -> None:
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
     global _engine, _mcp_manager, _model_manager, _lifecycle_task, _lifespan_active
+    global _registry_idle_reaper_task
     primary_exc: BaseException | None = None
     try:
         _get_idle_unload_event().clear()
@@ -1495,6 +1497,10 @@ async def lifespan(app: FastAPI):
             await _engine.start()
         if _model_manager is not None:
             await _model_manager.preload()
+            if _model_manager.idle_unload_seconds > 0:
+                _registry_idle_reaper_task = asyncio.create_task(
+                    _model_manager.run_idle_reaper()
+                )
 
         # Load persisted cache from disk (AFTER engine start — AsyncEngineCore must exist)
         if (
@@ -1577,6 +1583,11 @@ async def lifespan(app: FastAPI):
             await _engine.stop()
             _engine = None
             logger.info("Engine stopped")
+        if _registry_idle_reaper_task is not None:
+            _registry_idle_reaper_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await _registry_idle_reaper_task
+            _registry_idle_reaper_task = None
         if _model_manager is not None:
             await _model_manager.shutdown()
             logger.info("Model manager stopped")
@@ -3631,6 +3642,7 @@ async def status():
                 "memory_budget_gb": round(
                     _model_manager.memory_budget_bytes / (1024**3), 2
                 ),
+                "idle_unload_seconds": _model_manager.idle_unload_seconds,
                 "models": _model_manager.list_models(),
             },
             "embedding": _embedding_status(),

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -7030,7 +7030,7 @@ Examples:
         "--auto-unload-idle-seconds",
         type=float,
         default=0.0,
-        help="Unload the main model after this many idle seconds (0 = disabled)",
+        help="Unload idle models after this many seconds (0 = disabled)",
     )
     parser.add_argument(
         "--lazy-load-model",


### PR DESCRIPTION
# fix(registry): honor auto-unload-idle-seconds and release MLX memory on unload

## Summary

`--auto-unload-idle-seconds` already exists and works for the default single-model server, but it is a silent no-op in `--models-config` (multi-model registry) mode, and even where it does work today it doesn't actually release memory back to the OS. This PR fixes both:

- `ModelManager` (registry mode) now proactively unloads idle models via a background timer, matching the behavior already present for the single-model `ResidencyManager` path.
- `SimpleEngine.stop()` / `BatchedEngine.stop()` now call `mx.clear_cache()`, so an unload actually releases MLX's Metal buffer cache instead of only dropping Python references.

This is a bug fix to an existing, incompletely-implemented feature, not a new capability.

## Problem

1. **`--auto-unload-idle-seconds` is silently ignored in registry mode.** `cli.py` only threads `args.auto_unload_idle_seconds` into `load_model()` (the single-model path); the registry branch (`load_model_registry()`) never received it. In registry mode, `ModelManager` only evicts models *reactively* — when a different model is requested and the configured memory budget would be exceeded (`_collect_idle_unloads_locked`, invoked from inside `acquire()`). If a deployment only ever serves one model through `--models-config`, or requests happen infrequently enough that a second model is never concurrently requested, that model stays resident indefinitely, regardless of the configured timeout — with no error or warning that the flag has no effect.
2. **Unload doesn't actually release memory.** Neither `SimpleEngine.stop()` nor `BatchedEngine.stop()` called `mx.clear_cache()` — they only dropped Python references (`self._model = None`, etc.). MLX's Metal buffer-cache pool was never explicitly released, so resident memory did not shrink the way "unload" implies, even in the already-working single-model path.

## Tests

14 new tests across 5 files:

- `tests/test_model_registry.py` — `unload_idle()` unloads stale models and skips busy ones; no-op when disabled; leaves recently-used models alone; `run_idle_reaper()` unloads after the timeout elapses and returns immediately when disabled; YAML parsing of `manager.idle_unload_seconds` (explicit value wins, falls back to the CLI default, defaults to disabled).
- `tests/test_lifecycle_cli.py` — regression test that `--auto-unload-idle-seconds` combined with `--models-config` is now actually threaded through; fixture updated to track/clean up `_registry_idle_reaper_task`.
- `tests/test_lifecycle_server.py` — the reaper task starts and stops correctly via `lifespan()`, both when enabled and when disabled.
- `tests/test_simple_engine.py`, `tests/test_batched_engine.py` — spy-based tests asserting `stop()` calls `mx.clear_cache()` exactly once.
- `tests/test_registry_idle_unload_real_model.py` — new, manual-only real-server/real-model script (see "Manual verification" below). Not collected by pytest.

Full suite: `pytest tests/` — 2260 passed, 23 skipped. Three pre-existing failures are unrelated to this change (verified identical on unpatched `main` via `git stash` before making any changes):

- `tests/test_lifecycle_manager.py::TestResidencyManagerContracts::test_shutdown_canceled_prepare_error_unwinds_to_unloaded`
- `tests/test_simple_engine.py::TestSimpleEngineConcurrency::test_cancelling_specprefill_request_stops_during_scoring`
- `tests/test_simple_engine.py::TestSimpleEngineConcurrency::test_cancelling_specprefill_request_stops_during_sparse_prefill`

These are pre-existing timing-sensitive cancellation tests (SpecPrefill scoring/sparse-prefill cancellation, residency shutdown-during-prepare) unrelated to the registry/idle-unload/engine-stop code paths touched here.

## Manual verification

End-to-end tested against a real model (`mlx-community/Qwen3-0.6B-8bit`) in registry mode: correct idle-unload timing, transparent reload on the next request, and a measurable RSS drop after unload.

This is captured as a repo-committed, manually-runnable script: `tests/test_registry_idle_unload_real_model.py`. It starts a real `vllm-mlx serve --models-config ...` subprocess, drives it over HTTP, and prints RSS at each stage. It intentionally has no `test_`-prefixed function, so `pytest` collects zero items from it — it never runs as part of the normal suite or CI, only via:

```
python tests/test_registry_idle_unload_real_model.py
python tests/test_registry_idle_unload_real_model.py --model mlx-community/Qwen3-0.6B-8bit  # override, same default
```

Sample output:

```
RSS before load:  369.4 MB
RSS after load:   1230.6 MB  (+861.2 MB)
RSS after unload: 606.7 MB  (-623.9 MB reclaimed)
RSS after reload: 1315.2 MB  (+708.5 MB)
```

Also confirmed the script fails as expected against unpatched `main` (model never unloads) and passes once this fix is applied — a real regression check, not just a happy-path run.
