### PR TITLE
feat(registry): add CLI override for memory budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
             tests/test_simple_engine.py \
             tests/test_simple_engine_prefix_trie_cache.py \
             tests/test_text_model_dispatch.py \
+            tests/test_cli.py \
+            tests/test_model_registry.py \
             tests/test_chat_template_kwargs.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -25,6 +25,10 @@ Keep single-model serving when you want the smallest operational surface and the
 vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --host 0.0.0.0 --port 8000
 ```
 
+Use `--memory-budget-gb` to override `manager.memory_budget_gb` (or the legacy
+`manager.memory_budget`) for a particular launch. The CLI value takes precedence
+over the YAML value and can supply the budget when the YAML field is absent.
+
 You can still use global serve flags such as:
 
 - `--api-key`
@@ -94,6 +98,10 @@ It does not include, and does not reserve room for:
 - other colocated services
 
 On a 128 GB machine, a practical starting point is often `80-100 GB`.
+
+For different host or launch profiles, pass `--memory-budget-gb` instead of
+maintaining duplicate registry files. The override remains a weights-only
+budget and does not change the Metal allocation ceiling described below.
 
 ### Budget vs. the Metal allocation ceiling
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,6 +57,7 @@ vllm-mlx serve --models-config <yaml> [options]
 | `--enable-auto-tool-choice` | Enable automatic tool calling | False |
 | `--tool-call-parser` | Tool call parser (`auto`, `mistral`, `qwen`, `llama`, `hermes`, `deepseek`, `kimi`, `granite`, `nemotron`, `xlam`, `functionary`, `glm47`) | None |
 | `--models-config` | YAML registry file for multi-model serving | None |
+| `--memory-budget-gb` | Override the registry manager model-weight residency budget in GB. This is not a total runtime-memory limit and does not guarantee prevention of Metal/MLX OOM. | YAML manager budget |
 
 ### Examples
 
@@ -116,6 +117,9 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --api-key your-secret-ke
 
 # Registry-backed multi-model serving
 vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --continuous-batching
+
+# Override the registry YAML manager budget at launch time
+vllm-mlx serve --models-config /etc/vllm-mlx/models.yaml --memory-budget-gb 80
 
 # Expose Prometheus metrics
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --enable-metrics

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 
 def _serve_args(**overrides):
     args = {
@@ -34,10 +36,12 @@ def _serve_args(**overrides):
         "max_cache_blocks": 1000,
         "max_num_seqs": 32,
         "max_tokens": 16,
+        "memory_budget_gb": None,
         "mcp_config": None,
         "mllm_prefill_step_size": None,
         "mllm": False,
         "model": "local-test-model",
+        "models_config": None,
         "mtp_num_draft_tokens": 1,
         "mtp_optimistic": False,
         "no_memory_aware_cache": False,
@@ -132,3 +136,54 @@ def test_serve_parser_accepts_registered_step3p5_tool_parser():
     )
 
     assert args.tool_call_parser == "step3p5"
+
+
+def test_memory_budget_help_describes_scope_and_limitations(capsys):
+    from vllm_mlx.cli import create_parser
+
+    with pytest.raises(SystemExit):
+        create_parser().parse_args(["serve", "--help"])
+
+    help_text = " ".join(capsys.readouterr().out.split())
+    assert "registry manager model-weight residency budget" in help_text
+    assert "not a total runtime-memory limit" in help_text
+    assert "does not guarantee prevention of Metal/MLX OOM" in help_text
+
+
+def test_serve_command_rejects_memory_budget_outside_registry_mode(capsys):
+    from vllm_mlx import cli
+
+    with pytest.raises(SystemExit):
+        cli.serve_command(_serve_args(memory_budget_gb=8.0))
+
+    assert "--memory-budget-gb requires --models-config" in capsys.readouterr().out
+
+
+def test_serve_command_applies_memory_budget_override_end_to_end(tmp_path, monkeypatch):
+    from vllm_mlx import cli, server
+
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text("""
+manager:
+  memory_budget_gb: 4
+models:
+  - name: test
+    path: /tmp/test-model
+""".strip())
+    args = cli.create_parser().parse_args(
+        [
+            "serve",
+            "--models-config",
+            str(config_path),
+            "--memory-budget-gb",
+            "6.5",
+            "--offline",
+        ]
+    )
+    monkeypatch.setattr(server, "_model_manager", None)
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    cli.serve_command(args)
+
+    assert server._model_manager is not None
+    assert server._model_manager.memory_budget_bytes == int(6.5 * (1024**3))

--- a/tests/test_cli_arg_types.py
+++ b/tests/test_cli_arg_types.py
@@ -109,9 +109,7 @@ class TestMemoryBudgetGbArg:
             ("1e300", "too large"),
         ],
     )
-    def test_invalid_or_unrepresentable_values_are_rejected(
-        self, bad_value, message
-    ):
+    def test_invalid_or_unrepresentable_values_are_rejected(self, bad_value, message):
         with pytest.raises(argparse.ArgumentTypeError, match=message):
             memory_budget_gb_arg(bad_value)
 
@@ -139,8 +137,6 @@ class TestMemoryBudgetGbCliWiring:
         from vllm_mlx.cli import create_parser
 
         with pytest.raises(SystemExit):
-            create_parser().parse_args(
-                ["serve", "--memory-budget-gb", bad_value]
-            )
+            create_parser().parse_args(["serve", "--memory-budget-gb", bad_value])
 
         assert "--memory-budget-gb" in capsys.readouterr().err

--- a/tests/test_cli_arg_types.py
+++ b/tests/test_cli_arg_types.py
@@ -12,6 +12,7 @@ import pytest
 
 from vllm_mlx.cli_arg_types import (
     make_auto_or_positive_int_arg_parser,
+    memory_budget_gb_arg,
     parse_auto_or_positive_int_arg,
 )
 
@@ -89,3 +90,57 @@ class TestEmbeddingMaxLengthCliWiring:
             ).embedding_max_length
             == 2048
         )
+
+
+class TestMemoryBudgetGbArg:
+    def test_positive_finite_value_is_accepted(self):
+        assert memory_budget_gb_arg("12.5") == 12.5
+
+    @pytest.mark.parametrize(
+        ("bad_value", "message"),
+        [
+            ("0", "positive finite number"),
+            ("-1", "positive finite number"),
+            ("nan", "positive finite number"),
+            ("inf", "positive finite number"),
+            ("-inf", "positive finite number"),
+            ("not-a-number", "must be a number"),
+            ("1e-12", "at least 1 byte"),
+            ("1e300", "too large"),
+        ],
+    )
+    def test_invalid_or_unrepresentable_values_are_rejected(
+        self, bad_value, message
+    ):
+        with pytest.raises(argparse.ArgumentTypeError, match=message):
+            memory_budget_gb_arg(bad_value)
+
+
+class TestMemoryBudgetGbCliWiring:
+    def test_registry_override_parses_successfully(self):
+        from vllm_mlx.cli import create_parser
+
+        args = create_parser().parse_args(
+            [
+                "serve",
+                "--models-config",
+                "/tmp/models.yaml",
+                "--memory-budget-gb",
+                "12.5",
+            ]
+        )
+
+        assert args.memory_budget_gb == 12.5
+
+    @pytest.mark.parametrize("bad_value", ["1e-12", "1e300"])
+    def test_unrepresentable_values_fail_during_argument_parsing(
+        self, bad_value, capsys
+    ):
+        from vllm_mlx.cli import create_parser
+
+        with pytest.raises(SystemExit):
+            create_parser().parse_args(
+                ["serve", "--memory-budget-gb", bad_value]
+            )
+
+        assert "--memory-budget-gb" in capsys.readouterr().err

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -181,9 +181,7 @@ def test_cli_memory_budget_takes_precedence_over_invalid_yaml_value(tmp_path):
 
 @pytest.mark.parametrize("raw_value", [".nan", ".inf", "0", "-0.1"])
 def test_registry_rejects_invalid_manager_memory_budget(tmp_path, raw_value):
-    config_path = _write_registry_config(
-        tmp_path, f"  memory_budget_gb: {raw_value}"
-    )
+    config_path = _write_registry_config(tmp_path, f"  memory_budget_gb: {raw_value}")
 
     with pytest.raises(ValueError, match="must be a positive finite number"):
         load_registry_config(config_path, _defaults())

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -123,6 +123,72 @@ def _registry(tmp_path: Path, sizes_gb: dict[str, float]) -> dict[str, Registere
     return registry
 
 
+def _write_registry_config(tmp_path: Path, manager_yaml: str) -> Path:
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(f"""
+manager:
+{manager_yaml}
+models:
+  - name: test
+    path: /tmp/test-model
+""".strip())
+    return config_path
+
+
+def test_cli_memory_budget_overrides_yaml_value(tmp_path):
+    config_path = _write_registry_config(tmp_path, "  memory_budget_gb: 4")
+
+    manager, _ = load_registry_config(
+        config_path,
+        _defaults(),
+        memory_budget_gb=7.5,
+    )
+
+    assert manager.memory_budget_bytes == int(7.5 * (1024**3))
+
+
+def test_omitting_cli_memory_budget_preserves_yaml_value(tmp_path):
+    config_path = _write_registry_config(tmp_path, "  memory_budget: 2048mb")
+
+    manager, _ = load_registry_config(config_path, _defaults())
+
+    assert manager.memory_budget_bytes == 2048 * (1024**2)
+
+
+def test_cli_memory_budget_works_without_yaml_manager_budget(tmp_path):
+    config_path = _write_registry_config(tmp_path, "  contention_policy: {}")
+
+    manager, _ = load_registry_config(
+        config_path,
+        _defaults(),
+        memory_budget_gb=3.25,
+    )
+
+    assert manager.memory_budget_bytes == int(3.25 * (1024**3))
+
+
+def test_cli_memory_budget_takes_precedence_over_invalid_yaml_value(tmp_path):
+    config_path = _write_registry_config(tmp_path, "  memory_budget_gb: invalid")
+
+    manager, _ = load_registry_config(
+        config_path,
+        _defaults(),
+        memory_budget_gb=2.5,
+    )
+
+    assert manager.memory_budget_bytes == int(2.5 * (1024**3))
+
+
+@pytest.mark.parametrize("raw_value", [".nan", ".inf", "0", "-0.1"])
+def test_registry_rejects_invalid_manager_memory_budget(tmp_path, raw_value):
+    config_path = _write_registry_config(
+        tmp_path, f"  memory_budget_gb: {raw_value}"
+    )
+
+    with pytest.raises(ValueError, match="must be a positive finite number"):
+        load_registry_config(config_path, _defaults())
+
+
 @pytest.mark.parametrize("raw_value", [".nan", ".inf", "0", "-0.1", "1.1"])
 def test_registry_rejects_invalid_per_entry_gpu_memory_utilization(tmp_path, raw_value):
     config_path = tmp_path / "models.yaml"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -20,6 +20,7 @@ from .cli_arg_types import (
     make_auto_or_positive_int_arg_parser,
     make_json_object_arg_parser,
     make_positive_int_arg_parser,
+    memory_budget_gb_arg,
 )
 from .tool_parsers import ToolParserManager
 
@@ -61,6 +62,7 @@ def serve_command(args):
     logger = logging.getLogger(__name__)
     model_arg = getattr(args, "model", None)
     models_config = getattr(args, "models_config", None)
+    memory_budget_gb = getattr(args, "memory_budget_gb", None)
 
     if models_config and model_arg:
         print("Error: use either positional MODEL or --models-config, not both")
@@ -70,6 +72,9 @@ def serve_command(args):
         sys.exit(1)
     if models_config and args.served_model_name:
         print("Error: --served-model-name cannot be used with --models-config")
+        sys.exit(1)
+    if memory_budget_gb is not None and not models_config:
+        print("Error: --memory-budget-gb requires --models-config")
         sys.exit(1)
 
     # Validate tool calling arguments
@@ -400,7 +405,11 @@ def serve_command(args):
             max_tokens=args.max_tokens,
             download_config=download_config,
         )
-        load_model_registry(models_config, defaults=defaults)
+        load_model_registry(
+            models_config,
+            defaults=defaults,
+            memory_budget_gb=memory_budget_gb,
+        )
     else:
         # Load model with unified server
         load_model(
@@ -1055,6 +1064,16 @@ Examples:
         type=str,
         default=None,
         help="YAML file describing a registry of models for lazy multi-model serving",
+    )
+    serve_parser.add_argument(
+        "--memory-budget-gb",
+        type=memory_budget_gb_arg,
+        default=None,
+        help=(
+            "Override the registry manager model-weight residency budget in GB. "
+            "This is not a total runtime-memory limit and does not guarantee "
+            "prevention of Metal/MLX OOM."
+        ),
     )
     serve_parser.add_argument(
         "--served-model-name",

--- a/vllm_mlx/cli_arg_types.py
+++ b/vllm_mlx/cli_arg_types.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -60,6 +61,33 @@ def make_positive_int_arg_parser(option_name: str) -> Callable[[str], int]:
         return parse_positive_int_arg(value, option_name)
 
     return _parser
+
+
+def parse_positive_finite_float(value: Any, value_name: str) -> float:
+    """Parse a numeric value that must be positive and finite."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{value_name} must be a number") from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ValueError(f"{value_name} must be a positive finite number")
+    return parsed
+
+
+def memory_budget_gb_arg(value: str) -> float:
+    """Parse a registry memory budget that can be represented in bytes."""
+    option_name = "--memory-budget-gb"
+    try:
+        parsed = parse_positive_finite_float(value, option_name)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+    bytes_value = parsed * (1024**3)
+    if not math.isfinite(bytes_value):
+        raise argparse.ArgumentTypeError(f"{option_name} is too large")
+    if int(bytes_value) == 0:
+        raise argparse.ArgumentTypeError(f"{option_name} must be at least 1 byte")
+    return parsed
 
 
 def parse_auto_or_positive_int_arg(value: str, option_name: str) -> int | None:

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from .api.utils import is_mllm_model
+from .cli_arg_types import parse_positive_finite_float
 from .engine.base import BaseEngine
 from .engine.batched import BatchedEngine
 from .engine.simple import SimpleEngine
@@ -249,18 +250,32 @@ def _parse_memory_budget_bytes(value: Any) -> int:
     """Parse a memory budget from bytes, MB, or GB."""
     if value is None:
         raise ValueError("models-config manager.memory_budget_gb is required")
+    multiplier = 1024**3
+    amount: str | int | float
     if isinstance(value, (int, float)):
-        return int(float(value) * (1024**3))
-    if isinstance(value, str):
+        amount = value
+    elif isinstance(value, str):
         raw = value.strip().lower()
         if raw.endswith("gb"):
-            return int(float(raw[:-2]) * (1024**3))
-        if raw.endswith("mb"):
-            return int(float(raw[:-2]) * (1024**2))
-        if raw.endswith("b"):
-            return int(float(raw[:-1]))
-        return int(float(raw) * (1024**3))
-    raise TypeError(f"Unsupported memory budget value: {value!r}")
+            amount = raw[:-2]
+        elif raw.endswith("mb"):
+            amount = raw[:-2]
+            multiplier = 1024**2
+        elif raw.endswith("b"):
+            amount = raw[:-1]
+            multiplier = 1
+        else:
+            amount = raw
+    else:
+        raise TypeError(f"Unsupported memory budget value: {value!r}")
+
+    value_name = "models-config manager memory budget"
+    parsed = parse_positive_finite_float(amount, value_name)
+    bytes_value = parse_positive_finite_float(parsed * multiplier, value_name)
+    memory_budget_bytes = int(bytes_value)
+    if memory_budget_bytes == 0:
+        raise ValueError(f"{value_name} must be at least 1 byte")
+    return memory_budget_bytes
 
 
 def _safe_available_memory_bytes() -> int:
@@ -531,6 +546,8 @@ def _estimate_model_bytes_from_source(source: str) -> int:
 def load_registry_config(
     config_path: str | os.PathLike[str],
     defaults: RegistryServeDefaults,
+    *,
+    memory_budget_gb: float | None = None,
 ) -> tuple[RegistryManagerConfig, dict[str, RegisteredModel]]:
     """Load and validate the models registry YAML file."""
     import yaml  # lazy: only needed when a registry config is provided
@@ -566,7 +583,9 @@ def load_registry_config(
 
     manager = RegistryManagerConfig(
         memory_budget_bytes=_parse_memory_budget_bytes(
-            manager_raw.get("memory_budget_gb", manager_raw.get("memory_budget"))
+            memory_budget_gb
+            if memory_budget_gb is not None
+            else manager_raw.get("memory_budget_gb", manager_raw.get("memory_budget"))
         ),
         policy=policy,
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3494,11 +3494,16 @@ def load_model_registry(
     config_path: str,
     *,
     defaults: RegistryServeDefaults,
+    memory_budget_gb: float | None = None,
 ) -> None:
     """Load a registry-backed model manager from YAML configuration."""
     global _engine, _model_manager, _model_name, _model_path, _default_max_tokens
 
-    manager_config, registry = load_registry_config(config_path, defaults)
+    manager_config, registry = load_registry_config(
+        config_path,
+        defaults,
+        memory_budget_gb=memory_budget_gb,
+    )
     _engine = None
     _model_path = None
     _model_name = None


### PR DESCRIPTION
## Summary

Adds an explicit `--memory-budget-gb` CLI override for registry-backed
multi-model serving.

The CLI value takes precedence over:

- `manager.memory_budget_gb`
- the legacy `manager.memory_budget`

When the option is omitted, the existing YAML behavior remains unchanged.
The CLI override can also provide the manager budget when the YAML field is
absent.

This implements the CLI override portion of #627.

## Type of change

- New feature
- Documentation

## Surface touched

- Serve CLI
- Multi-model registry configuration
- Registry manager memory-budget configuration
- Tests
- Documentation

## Behavior

- Accepts only positive finite numeric values.
- Rejects zero, negative values, NaN, infinities, and non-numeric values.
- Rejects `--memory-budget-gb` outside `--models-config` registry mode.
- Uses the existing binary conversion of `GB * 1024^3`.
- Preserves backward compatibility when the option is omitted.

The value controls the resident model-weight budget used for registry
admission and eviction. It is not a total runtime-memory limit and does not
guarantee prevention of Metal/MLX OOM.

## Testing

Automated validation:

- `pytest tests/test_cli.py tests/test_model_registry.py -q`
  - 18 passed
- Broader server tests
  - 116 passed, 3 deselected
- Black checks passed
- Ruff checks passed
- Targeted mypy checks passed
- `git diff --check` passed

Manual end-to-end validation:

- YAML budget absent + CLI budget provided: server started successfully.
- YAML budget absent + no CLI budget: startup failed as before.
- Invalid YAML budget + valid CLI budget: CLI value took precedence and the
  server started successfully.
- Invalid CLI values were rejected.
- Non-registry usage was rejected.
- `/v1/models` returned the configured registry model.

## Out of scope

This PR does not implement:

- automatic Metal allocation-ceiling calculation;
- automatic memory-budget clamping;
- KV-cache or activation-memory accounting;
- startup allocation-ceiling warnings;
- changes to registry admission or eviction algorithms.