### PR TITLE
fix: detach stored prefix-cache entries from live batch state

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -308,7 +308,12 @@ class TestMemoryAwarePrefixCache:
 
         # Fetch exact match
         result, remaining = small_cache.fetch(tokens)
-        assert result is kv  # Same reference, no copy
+        # store() snapshots layer containers so stored entries never alias
+        # live caches; the underlying arrays are shared (or detached copies
+        # for real MLX arrays).
+        assert result is not kv
+        assert result[0].keys is kv[0].keys
+        assert result[0].values is kv[0].values
         assert remaining == []
 
     def test_short_prefix_reuse_is_rejected(self, model, mock_kv_cache):
@@ -341,7 +346,9 @@ class TestMemoryAwarePrefixCache:
         long_tokens = [1, 2, 3, 4, 5, 6]
         result, remaining = small_cache.fetch(long_tokens)
 
-        assert result is kv
+        assert result is not kv  # snapshot, not alias
+        assert result[0].keys is kv[0].keys
+        assert result[0].values is kv[0].values
         assert remaining == [4, 5, 6]
 
     def test_fetch_miss(self, small_cache, mock_kv_cache):

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -571,3 +571,178 @@ class TestDequantizeCacheSlice:
         # No private data (7.0) visible — only shared prefix (~1.0 with quantization noise)
         assert float(mx.max(tc.keys).item()) < 2.0
         assert remaining == [999, 1000]
+
+
+class TestDetachCacheForStorage:
+    """Tests for ``_detach_cache_for_storage``: stored entries must not alias
+    live batch state or retain lazy computation graphs.
+
+    Regression: ``MemoryAwarePrefixCache.store()`` stored per-request cache
+    layers by reference.  For hybrid models (e.g. Qwen3.5/3.6, whose
+    ``ArraysCache`` layers expose their mutable ``cache`` list via
+    ``.state``), the stored entry aliased the live state container (same
+    class of bug as the SimpleEngine snapshot aliasing, #575) and — because
+    the extracted per-request arrays are lazy slices of batch-wide arrays —
+    retained the entire upstream computation graph.  Under sustained traffic
+    each stored entry pinned Metal buffer handles roughly proportional to
+    generated tokens, until the process hit the device resource limit
+    (``[metal::malloc] Resource limit (N) exceeded``) and aborted.
+    """
+
+    def test_arrays_cache_container_not_aliased(self):
+        """The stored ArraysCache snapshot must not follow later mutation."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        parent = mx.arange(32, dtype=mx.float32).reshape(4, 8)
+        mx.eval(parent)
+        lazy = parent[1:2]
+        for _ in range(5):
+            lazy = lazy + 1
+        expected = [[float(v) + 5 for v in range(8, 16)]]
+
+        layer = ArraysCache(size=1)
+        layer[0] = lazy
+
+        detached = _detach_cache_for_storage([layer])
+
+        assert detached[0] is not layer
+        assert detached[0].cache is not layer.cache
+        assert detached[0][0].tolist() == expected
+
+        # Simulate the batch generator advancing the live state after the
+        # snapshot was stored — the stored copy must not change.
+        layer[0] = mx.zeros((1, 8))
+        assert detached[0][0].tolist() == expected
+
+    def test_kv_cache_layer_snapshotted_with_equal_arrays(self):
+        """KVCache layers are snapshotted; array contents are preserved."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        layer = KVCache()
+        layer.keys = mx.arange(1 * 2 * 4 * 3, dtype=mx.float32).reshape(1, 2, 4, 3)
+        layer.values = mx.ones((1, 2, 4, 3))
+        layer.offset = 4
+
+        detached = _detach_cache_for_storage([layer])
+
+        assert detached[0] is not layer
+        assert detached[0].offset == 4
+        assert detached[0].keys.tolist() == layer.keys.tolist()
+        assert detached[0].values.tolist() == layer.values.tolist()
+
+    def test_lazy_graph_is_cut(self):
+        """Detaching must not retain the upstream lazy graph / parent buffers.
+
+        Builds a long lazy op chain rooted at a large parent array, detaches,
+        then drops every reference except the detached copy.  If the graph
+        were retained, active memory would still include the parent (8MB+);
+        the detached copy itself is only 16KB.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        mx.eval(mx.zeros((1,)))
+        base = mx.get_active_memory()
+
+        big_parent = mx.random.normal((512, 4096))  # ~8MB
+        chain = big_parent[0:1]
+        for _ in range(200):
+            chain = chain * 1.0001
+        layer = ArraysCache(size=1)
+        layer[0] = chain
+
+        detached = _detach_cache_for_storage([layer])
+
+        del big_parent, chain, layer
+        mx.eval(mx.zeros((1,)))
+
+        retained = mx.get_active_memory() - base
+        assert retained < 1_000_000, (
+            f"lazy graph retained: {retained / 1e6:.1f}MB still active "
+            f"after dropping originals (expected < 1MB)"
+        )
+        assert detached[0][0].shape == (1, 4096)
+
+    def test_cache_list_children_snapshotted_without_write_through(self):
+        """CacheList's ``state`` setter writes through to child caches in
+        place; the detach path must snapshot children recursively instead."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import CacheList, KVCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        inner = KVCache()
+        inner.keys = mx.arange(1 * 2 * 3 * 4, dtype=mx.float32).reshape(1, 2, 3, 4)
+        inner.values = mx.ones((1, 2, 3, 4))
+        inner.offset = 3
+        original_keys = inner.keys
+
+        cl = CacheList(inner)
+
+        detached = _detach_cache_for_storage([cl])
+
+        assert detached[0] is not cl
+        assert detached[0].caches is not cl.caches
+        assert detached[0].caches[0] is not inner
+        assert detached[0].caches[0].keys.tolist() == original_keys.tolist()
+        # The live child must be untouched (no setter write-through)
+        assert cl.caches[0] is inner
+        assert inner.keys is original_keys
+
+    def test_slots_class_snapshotted(self):
+        """Layers using ``__slots__`` (no ``__dict__``), like
+        ``_QuantizedCacheWrapper``, must snapshot without crashing."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.memory_cache import (
+            _detach_cache_for_storage,
+            _QuantizedCacheWrapper,
+        )
+
+        kv = KVCache()
+        kv.keys = mx.ones((1, 2, 4, 64))
+        kv.values = mx.ones((1, 2, 4, 64))
+        kv.offset = 4
+        mx.eval(kv.keys, kv.values)
+        wrapper = _QuantizedCacheWrapper(kv, bits=8, group_size=32)
+
+        detached = _detach_cache_for_storage([wrapper])
+
+        assert detached[0] is not wrapper
+        assert isinstance(detached[0], _QuantizedCacheWrapper)
+        assert detached[0].offset == wrapper.offset
+        # mx.quantize returns a (data, scales, biases) container; the
+        # snapshot must preserve its type and contents.
+        assert type(detached[0].keys) is type(wrapper.keys)
+        assert len(detached[0].keys) == len(wrapper.keys)
+        for got, orig in zip(detached[0].keys, wrapper.keys):
+            assert got.tolist() == orig.tolist()
+
+    def test_undetachable_layer_falls_back_to_reference(self):
+        """A layer that cannot be snapshotted is stored by reference with a
+        warning instead of failing the whole store()."""
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        class Undetachable:
+            def __init__(self):
+                self.values = None
+                self.offset = 0
+
+            @property
+            def keys(self):  # read-only: snapshot assignment must fail
+                return None
+
+        layer = Undetachable()
+
+        detached = _detach_cache_for_storage([layer])
+
+        assert detached[0] is layer

--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -727,10 +727,15 @@ class TestDetachCacheForStorage:
         for got, orig in zip(detached[0].keys, wrapper.keys):
             assert got.tolist() == orig.tolist()
 
-    def test_undetachable_layer_falls_back_to_reference(self):
-        """A layer that cannot be snapshotted is stored by reference with a
-        warning instead of failing the whole store()."""
-        from vllm_mlx.memory_cache import _detach_cache_for_storage
+    def test_snapshot_failure_raises_undetachable(self):
+        """A recognized layer whose snapshot fails raises
+        UndetachableCacheError (fail-closed) instead of silently aliasing."""
+        import pytest
+
+        from vllm_mlx.memory_cache import (
+            UndetachableCacheError,
+            _detach_cache_for_storage,
+        )
 
         class Undetachable:
             def __init__(self):
@@ -741,8 +746,532 @@ class TestDetachCacheForStorage:
             def keys(self):  # read-only: snapshot assignment must fail
                 return None
 
-        layer = Undetachable()
+        with pytest.raises(UndetachableCacheError):
+            _detach_cache_for_storage([Undetachable()])
 
+    def test_unknown_array_bearing_layer_raises_undetachable(self):
+        """An unrecognized layer type that carries arrays must fail closed —
+        storing it by reference would reintroduce the retention leak."""
+        import mlx.core as mx
+        import pytest
+
+        from vllm_mlx.memory_cache import (
+            UndetachableCacheError,
+            _detach_cache_for_storage,
+        )
+
+        class ExoticCache:  # no keys/caches/state — matches no branch
+            def __init__(self):
+                self.buffers = [mx.ones((1, 4)), mx.zeros((1, 4))]
+
+        with pytest.raises(UndetachableCacheError):
+            _detach_cache_for_storage([ExoticCache()])
+
+    def test_unknown_array_free_layer_passes_through(self):
+        """An unrecognized layer with no arrays has nothing to pin and is
+        passed through unchanged."""
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        class Metadata:
+            def __init__(self):
+                self.n_tokens = 7
+                self.tag = "prefill"
+
+        layer = Metadata()
         detached = _detach_cache_for_storage([layer])
-
         assert detached[0] is layer
+
+
+class TestStoreFailClosedAndEviction:
+    """store()-level tests requested in review: fail-closed rejection,
+    small-cap eviction with detached entries, a real extracted batch slice,
+    and nested container / dict state."""
+
+    def _make_cache(self, max_memory_mb=2):
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        class _Model:
+            pass
+
+        return MemoryAwarePrefixCache(
+            _Model(),
+            MemoryCacheConfig(max_memory_mb=max_memory_mb, min_prefix_tokens=1),
+        )
+
+    @staticmethod
+    def _kv_layer(n_tokens):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        kv = KVCache()
+        kv.keys = mx.zeros((1, 8, n_tokens, 64))
+        kv.values = mx.zeros((1, 8, n_tokens, 64))
+        kv.offset = n_tokens
+        mx.eval(kv.keys, kv.values)
+        return kv
+
+    def test_store_rejects_undetachable_entry(self):
+        """store() returns False and stores nothing when any layer of the
+        entry cannot be detached."""
+        import mlx.core as mx
+
+        class ExoticCache:
+            def __init__(self):
+                self.buffers = [mx.ones((1, 4))]
+
+        cache = self._make_cache()
+        ok = cache.store([1, 2, 3], [self._kv_layer(4), ExoticCache()])
+
+        assert ok is False
+        assert len(cache) == 0
+        got, remaining = cache.fetch([1, 2, 3])
+        assert got is None
+        assert remaining == [1, 2, 3]
+
+    def test_small_cap_eviction_with_detached_entries(self):
+        """Detached entries are priced by the byte accounting and evicted
+        LRU under a small cap."""
+        # Each entry: keys+values = 2 * (8*224*64*4) bytes ~ 0.875 MB.
+        # Cap 2 MB -> third store must evict the least recently used.
+        cache = self._make_cache(max_memory_mb=2)
+
+        assert cache.store([1], [self._kv_layer(224)])
+        assert cache.store([2], [self._kv_layer(224)])
+        assert cache.store([3], [self._kv_layer(224)])
+
+        stats = cache.get_stats()
+        assert stats["evictions"] >= 1
+        assert stats["current_memory_mb"] <= 2.0
+
+        got, _ = cache.fetch([1])
+        assert got is None  # LRU-evicted
+        got, remaining = cache.fetch([3])
+        assert got is not None
+        assert remaining == []
+
+    def test_store_real_extracted_batch_slice_cuts_batch_retention(self):
+        """Drive store() with what the MLLM path actually produces —
+        BatchKVCache.extract() / ArraysCache.extract() slices, which are
+        LAZY expressions over the batch-wide buffers — and assert the leak
+        dimension: after storing and dropping the batch, resident memory is
+        entry-sized, not batch-sized.  (Extract's output objects are always
+        fresh, so aliasing checks alone cannot fail; retention is what the
+        old store-by-reference code got wrong.)"""
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache, BatchKVCache
+
+        mx.eval(mx.zeros((1,)))
+        base = mx.get_active_memory()
+
+        # 8 rows x 8 heads x 2048 tokens x 128 dims fp32 ~ 67 MB per array.
+        batch_kv = BatchKVCache(left_padding=[0] * 8)
+        keys = mx.random.normal((8, 8, 2048, 128))
+        values = mx.random.normal((8, 8, 2048, 128))
+        mx.eval(keys, values)
+        batch_kv.update_and_fetch(keys, values)
+
+        batch_state = ArraysCache(size=1)
+        state = mx.random.normal((8, 4096))
+        mx.eval(state)
+        batch_state[0] = state
+
+        extracted = [batch_kv.extract(1), batch_state.extract(1)]
+        expected_keys = keys[1:2].tolist()
+        expected_state = state[1:2].tolist()
+        entry_bytes = 2 * (8 * 2048 * 128 * 4) + 4096 * 4  # one row of k+v
+
+        cache = self._make_cache(max_memory_mb=64)
+        assert cache.store([5, 6, 7], extracted)
+
+        # The batch finishes: every batch-wide buffer should now be
+        # releasable.  Store-by-reference kept the stored entry's lazy
+        # extract() expressions rooted in them.
+        del batch_kv, batch_state, keys, values, state, extracted
+        mx.eval(mx.zeros((1,)))
+        retained = mx.get_active_memory() - base
+        assert retained < entry_bytes * 2, (
+            f"stored entry retains {retained / 1e6:.1f}MB — batch-wide "
+            f"buffers pinned (entry itself is {entry_bytes / 1e6:.1f}MB)"
+        )
+
+        got, remaining = cache.fetch([5, 6, 7])
+        assert remaining == []
+        assert got[0].keys.tolist() == expected_keys
+        assert got[0].offset == 2048
+        assert got[1][0].tolist() == expected_state
+
+    def test_store_nested_container_and_dict_state(self):
+        """Nested CacheList (child KVCache + ArraysCache) and extracted
+        dict-state layers round-trip through store()/fetch() as snapshots."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+        inner_kv = KVCache()
+        inner_kv.keys = mx.arange(1 * 2 * 3 * 4, dtype=mx.float32).reshape(1, 2, 3, 4)
+        inner_kv.values = mx.ones((1, 2, 3, 4))
+        inner_kv.offset = 3
+        inner_state = ArraysCache(size=1)
+        inner_state[0] = mx.full((1, 8), 2.0)
+        cl = CacheList(inner_kv, inner_state)
+
+        dict_layer = {
+            "class": "KVCache",
+            "state": (mx.ones((1, 2, 3, 4)), mx.zeros((1, 2, 3, 4))),
+            "meta_state": (),
+        }
+
+        expected_keys = inner_kv.keys.tolist()
+
+        cache = self._make_cache(max_memory_mb=8)
+        assert cache.store([9, 10], [cl, dict_layer])
+
+        # Mutate the live containers after storing.
+        inner_kv.keys = mx.zeros((1, 2, 3, 4))
+        inner_state[0] = mx.zeros((1, 8))
+
+        got, remaining = cache.fetch([9, 10])
+        assert remaining == []
+        assert got[0].caches[0].keys.tolist() == expected_keys
+        assert got[0].caches[1][0].tolist() == [[2.0] * 8]
+        assert got[1]["class"] == "KVCache"
+        assert got[1]["state"][0].tolist() == mx.ones((1, 2, 3, 4)).tolist()
+
+
+class TestOwnerReviewRegressions:
+    """Regressions requested in the #642 owner review: guaranteed-allocation
+    detachment, pre-materialization size preflight, quantize-before-detach
+    graph cut, and nested-mapping state handling."""
+
+    @staticmethod
+    def _make_cache(max_memory_mb=8, **cfg):
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        class _Model:
+            pass
+
+        return MemoryAwarePrefixCache(
+            _Model(),
+            MemoryCacheConfig(max_memory_mb=max_memory_mb, min_prefix_tokens=1, **cfg),
+        )
+
+    def test_rotating_snapshot_immune_to_source_updates(self):
+        """Finding 1: an already-contiguous, evaluated RotatingKVCache must
+        be stored as a freshly allocated copy — continuing update_and_fetch()
+        on the source must not change the fetched entry."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        live = RotatingKVCache(max_size=8)
+        k = mx.random.normal((1, 2, 8, 16))
+        v = mx.random.normal((1, 2, 8, 16))
+        mx.eval(k, v)
+        live.update_and_fetch(k, v)
+        mx.eval(live.keys, live.values)  # source contiguous and evaluated
+
+        cache = self._make_cache()
+        assert cache.store([1, 2, 3], [live])
+        got, _ = cache.fetch([1, 2, 3])
+        before = got[0].keys.tolist()
+
+        # Ring buffer writes in place once wrapped.
+        for _ in range(6):
+            live.update_and_fetch(
+                mx.random.normal((1, 2, 1, 16)), mx.random.normal((1, 2, 1, 16))
+            )
+        mx.eval(live.keys, live.values)
+
+        got, remaining = cache.fetch([1, 2, 3])
+        assert remaining == []
+        assert got[0].keys.tolist() == before
+
+    def test_oversized_lazy_entry_rejected_without_materialization(self):
+        """Finding 2: an over-limit lazy entry must be rejected by the
+        shape-based preflight BEFORE anything materializes it.
+
+        The entry uses ``offset < keys.shape[2]`` deliberately — the normal
+        step-padded shape mlx-lm produces — so the trim path is exercised
+        too: a trim that evaluates its slices would materialize the entry
+        before the preflight can refuse it.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        mx.eval(mx.zeros((1,)))
+        base = mx.get_active_memory()
+
+        kv = KVCache()
+        # ~64 MB promised, never evaluated, with step-chunk padding past
+        # offset (offset 3900 < 4096 slots) as update_and_fetch produces.
+        kv.keys = mx.zeros((1, 8, 4096, 512))
+        kv.values = mx.zeros((1, 8, 4096, 512))
+        kv.offset = 3900
+
+        cache = self._make_cache(max_memory_mb=2)
+        ok = cache.store([1, 2, 3, 4], [kv])
+
+        mx.eval(mx.zeros((1,)))
+        grown = mx.get_active_memory() - base
+        assert ok is False
+        assert len(cache) == 0
+        assert (
+            grown < 5_000_000
+        ), f"rejected entry still materialized {grown / 1e6:.1f}MB"
+
+    def test_padded_rotating_cache_accounted_at_stored_size(self):
+        """Sliding-window layers cannot be sliced to offset, so detachment
+        copies their padded buffers — the estimator must price those same
+        buffers, or the byte cap is silently breached (measured 20-30%
+        resident-vs-accounted drift before the fix)."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        from vllm_mlx.memory_cache import estimate_kv_cache_memory
+
+        mx.eval(mx.zeros((1,)))
+        base = mx.get_active_memory()
+
+        live = RotatingKVCache(max_size=1024)
+        # Grow past a step boundary so keys.shape[2] > offset (padding):
+        # the initial update sizes exactly; subsequent single-token updates
+        # grow the buffer in step-sized chunks.
+        live.update_and_fetch(
+            mx.random.normal((1, 8, 500, 128)), mx.random.normal((1, 8, 500, 128))
+        )
+        for _ in range(5):
+            live.update_and_fetch(
+                mx.random.normal((1, 8, 1, 128)), mx.random.normal((1, 8, 1, 128))
+            )
+        mx.eval(live.keys, live.values)
+        assert live.keys.shape[2] > live.offset  # padded, untrimmable
+
+        projected = estimate_kv_cache_memory([live])
+        raw_bytes = live.keys.size * 4 + live.values.size * 4
+        assert (
+            projected == raw_bytes
+        ), f"estimator prices {projected} but detach will copy {raw_bytes}"
+
+        cache = self._make_cache(max_memory_mb=64)
+        assert cache.store([1, 2], [live])
+        # Drop the live source: what remains resident is the stored copy.
+        del live
+        mx.eval(mx.zeros((1,)))
+        resident = mx.get_active_memory() - base
+
+        stats = cache.get_stats()
+        accounted = stats["current_memory_mb"] * 1024 * 1024
+        assert abs(resident - accounted) < 2_000_000, (
+            f"resident {resident / 1e6:.1f}MB vs accounted "
+            f"{accounted / 1e6:.1f}MB — byte cap not trustworthy"
+        )
+
+    def test_dict_layer_with_arrays_outside_state_fails_closed(self):
+        """A dict layer smuggling arrays outside its 'state' field must be
+        rejected, not stored with those arrays aliased."""
+        import mlx.core as mx
+
+        layer = {
+            "state": (mx.ones((1, 4)),),
+            "aux": mx.zeros((1024, 1024)),  # aliased under the old code
+        }
+        cache = self._make_cache()
+        assert cache.store([5, 6], [layer]) is False
+        assert len(cache) == 0
+
+    def test_detach_preserves_bool_dtype(self):
+        """The guaranteed-allocation copy must be dtype-faithful — bare
+        ``+ 0`` promotes bool to int32."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        layer = ArraysCache(size=1)
+        layer[0] = mx.array([True, False, True])
+        detached = _detach_cache_for_storage([layer])
+        assert detached[0][0].dtype == mx.bool_
+        assert detached[0][0].tolist() == [True, False, True]
+
+    def test_batch_kv_left_padding_detached(self):
+        """Batch cache variants carry per-row metadata arrays the batch
+        generator rebinds; the snapshot must not alias them."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import BatchKVCache
+
+        from vllm_mlx.memory_cache import _detach_cache_for_storage
+
+        batch = BatchKVCache(left_padding=[0, 2])
+        batch.update_and_fetch(
+            mx.random.normal((2, 2, 4, 8)), mx.random.normal((2, 2, 4, 8))
+        )
+        detached = _detach_cache_for_storage([batch])
+
+        assert detached[0].left_padding is not batch.left_padding
+        assert detached[0].left_padding.tolist() == batch.left_padding.tolist()
+        if hasattr(batch.offset, "shape"):
+            assert detached[0].offset is not batch.offset
+
+    def test_quantized_store_does_not_retain_fp_graph(self):
+        """Finding 3: with kv_quantize enabled the stored representation is
+        the quantized one — evaluated and graph-detached — so resident memory
+        tracks the quantized size, not the full-precision source."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        mx.eval(mx.zeros((1,)))
+        base = mx.get_active_memory()
+
+        parent = mx.random.normal((1, 8, 4096, 64))  # 8.4 MB fp32
+        mx.eval(parent)
+        kv = KVCache()
+        kv.keys = parent[:, :, :2048, :]  # lazy slices, as extract() produces
+        kv.values = parent[:, :, 2048:, :]
+        kv.offset = 2048
+        expected = kv.keys.tolist()
+        fp_bytes = 2 * (8 * 2048 * 64 * 4)  # 8.4 MB
+
+        cache = self._make_cache(
+            max_memory_mb=16,
+            kv_quantize=True,
+            kv_min_quantize_tokens=1,
+            kv_bits=8,
+            kv_group_size=64,
+        )
+        assert cache.store([7, 8, 9], [kv])
+
+        del parent, kv
+        mx.eval(mx.zeros((1,)))
+        retained = mx.get_active_memory() - base
+        assert retained < fp_bytes / 2, (
+            f"stored quantized entry retains {retained / 1e6:.1f}MB — "
+            f"full-precision graph not cut (fp size {fp_bytes / 1e6:.1f}MB)"
+        )
+
+        got, remaining = cache.fetch([7, 8, 9])
+        assert remaining == []
+        err = float(mx.max(mx.abs(got[0].keys - mx.array(expected))).item())
+        assert err < 0.1, f"quantization roundtrip error too large: {err}"
+        assert got[0].offset == 2048
+
+    def test_nested_mapping_state_detached_and_accounted(self):
+        """Finding 4: {"state": {"ssm": array}} layers must be deep-detached
+        (mapping rebuilt, arrays copied), priced by the recursive estimator,
+        and evictable under the byte cap."""
+        import mlx.core as mx
+
+        from vllm_mlx.memory_cache import estimate_kv_cache_memory
+
+        def _mapping_layer(fill):
+            parent = mx.full((256, 1024), fill)  # 1 MB fp32
+            mx.eval(parent)
+            return parent, {
+                "class": "SSMCache",
+                "state": {"ssm": parent[0:256] * 1.0, "step": None},
+                "meta_state": (),
+            }
+
+        parent, layer = _mapping_layer(3.0)
+
+        # Accounting: recursive walk prices the nested mapping.
+        assert estimate_kv_cache_memory([layer]) == 256 * 1024 * 4
+
+        cache = self._make_cache(max_memory_mb=8)
+        assert cache.store([1, 2], [layer])
+
+        # Mutation isolation: the fetched mapping is a rebuilt container
+        # holding copied arrays, not the caller's dict.
+        layer["state"]["ssm"] = mx.zeros((256, 1024))
+        got, remaining = cache.fetch([1, 2])
+        assert remaining == []
+        assert got[0]["state"] is not layer["state"]
+        assert got[0]["state"]["step"] is None
+        assert float(got[0]["state"]["ssm"][0, 0].item()) == 3.0
+
+        # Eviction: byte-cap LRU fires on mapping-state entries (~1 MB each,
+        # 2 MB cap -> third store evicts the least recently used).
+        small = self._make_cache(max_memory_mb=2)
+        for i, fill in enumerate([1.0, 2.0, 4.0]):
+            _, lyr = _mapping_layer(fill)
+            assert small.store([10 + i], [lyr])
+        stats = small.get_stats()
+        assert stats["evictions"] >= 1
+        gone, _ = small.fetch([10])
+        assert gone is None
+        kept, remaining = small.fetch([12])
+        assert kept is not None and remaining == []
+
+
+class TestFailClosedPostcondition:
+    """Regressions from the third independent review round: the fail-closed
+    guarantee must hold for ``_BaseCache`` subclasses (which all inherit a
+    default ``state`` property returning ``[]``, making the state branch
+    match any of them), and the estimator must price the metadata arrays
+    detachment copies on state-carrying layers."""
+
+    @staticmethod
+    def _make_cache(max_memory_mb=8):
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        class _Model:
+            pass
+
+        return MemoryAwarePrefixCache(
+            _Model(),
+            MemoryCacheConfig(max_memory_mb=max_memory_mb, min_prefix_tokens=1),
+        )
+
+    def test_base_cache_subclass_with_sidecar_array_fails_closed(self):
+        """A ``_BaseCache`` subclass holding an array in an attribute that
+        ``.state`` does not expose must be rejected, not silently stored as
+        an alias of live memory priced at zero bytes.  The inherited default
+        ``state`` property (returns ``[]``) previously routed such layers
+        through the state branch, past the ``_bears_arrays`` fallback."""
+        import mlx.core as mx
+        import pytest
+        from mlx_lm.models.cache import _BaseCache
+
+        from vllm_mlx.memory_cache import (
+            UndetachableCacheError,
+            _detach_cache_for_storage,
+        )
+
+        class SidecarCache(_BaseCache):
+            def __init__(self, buf):
+                self.buf = buf
+
+        live = mx.zeros((8, 8), dtype=mx.float32)
+        mx.eval(live)
+
+        with pytest.raises(UndetachableCacheError):
+            _detach_cache_for_storage([SidecarCache(live)])
+
+        cache = self._make_cache()
+        ok = cache.store([1, 2, 3], [SidecarCache(live)])
+        assert ok is False
+        assert len(cache) == 0
+        assert cache.get_stats()["store_rejections"] == 1
+        got, remaining = cache.fetch([1, 2, 3])
+        assert got is None
+        assert remaining == [1, 2, 3]
+
+    def test_arrays_cache_metadata_arrays_priced(self):
+        """``estimate_kv_cache_memory`` on a state-carrying layer must price
+        the ``left_padding``/``lengths`` metadata arrays that detachment
+        copies — accounting must equal what the snapshot actually holds."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import ArraysCache
+
+        from vllm_mlx.memory_cache import estimate_kv_cache_memory
+
+        ac = ArraysCache(2, left_padding=[0, 1])
+        ac[0] = mx.random.normal((2, 4))
+        ac[1] = mx.random.normal((2, 4))
+        ac.lengths = mx.array([3, 4])
+        mx.eval(ac[0], ac[1], ac.lengths, ac.left_padding)
+
+        resident = ac[0].nbytes + ac[1].nbytes
+        for attr in ("left_padding", "lengths"):
+            extra = getattr(ac, attr, None)
+            if extra is not None and hasattr(extra, "nbytes"):
+                resident += extra.nbytes
+
+        assert estimate_kv_cache_memory([ac]) == resident

--- a/tests/test_prefix_cache_untrimmable.py
+++ b/tests/test_prefix_cache_untrimmable.py
@@ -61,51 +61,94 @@ class TestPromptOutputEntryIsUseless:
 class TestSnapshotOwnsItsMemory:
     """A snapshot that aliases the live cache is rewritten by the generation
     it is supposed to predate: RotatingKVCache writes into its ring buffer and
-    PoolingCache into its remainder buffer, both in place."""
+    PoolingCache into its remainder buffer, both in place.
 
-    def test_copy_is_not_a_view_of_the_source(self):
-        src = mx.array([1.0, 2.0, 3.0])
-        copy = Scheduler._copy_cache_state(src)
-        mx.eval(copy)
-        assert copy is not src
-        assert mx.array_equal(copy, src)
+    Ownership of copying lives at the storage boundary: ``store()`` detaches
+    every array into a freshly allocated, evaluated copy, so the scheduler
+    hands over a structure mirror whose state deliberately aliases the live
+    caches.  These tests pin the guarantee where it is now enforced.
+    (Container-shape coverage — nested lists/tuples/mappings, pass-through of
+    non-array metadata — lives in tests/test_memory_cache_mlx.py.)
+    """
 
-    def test_copy_survives_in_place_mutation_of_the_source(self):
-        src = mx.zeros((4,))
-        copy = Scheduler._copy_cache_state(src)
-        mx.eval(copy)
-        src[0:4] = mx.array([9.0, 9.0, 9.0, 9.0])
-        mx.eval(src)
-        assert copy.tolist() == [
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        ], "snapshot aliased the live cache and was overwritten by generation"
+    @staticmethod
+    def _store(cache_layers, tokens=(1, 2, 3)):
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 
-    def test_nested_containers_are_copied_through(self):
-        src = [mx.array([1.0]), (mx.array([2.0]), mx.array([3.0])), None, 7]
-        copy = Scheduler._copy_cache_state(src)
+        class _Model:
+            pass
 
-        assert isinstance(copy, list) and isinstance(copy[1], tuple)
-        assert copy[0] is not src[0]
-        assert copy[1][0] is not src[1][0]
-        # Non-arrays are metadata, passed through as-is.
-        assert copy[2] is None and copy[3] == 7
+        mc = MemoryAwarePrefixCache(
+            _Model(), MemoryCacheConfig(max_memory_mb=64, min_prefix_tokens=1)
+        )
+        assert mc.store(list(tokens), cache_layers)
+        return mc
 
-    def test_real_rotating_cache_state_is_detached(self):
+    def test_stored_snapshot_is_not_a_view_of_the_source(self):
         live = cache_mod.RotatingKVCache(max_size=8)
         live.update_and_fetch(mx.ones((1, 1, 4, 4)), mx.ones((1, 1, 4, 4)))
-        snapshot = Scheduler._copy_cache_state(live.state)
-        mx.eval(snapshot)
 
-        before = [mx.sum(a).item() for a in snapshot if isinstance(a, mx.array)]
+        mc = self._store([live])
+        got, remaining = mc.fetch([1, 2, 3])
+
+        assert remaining == []
+        assert got[0] is not live
+        assert got[0].keys is not live.keys
+        assert mx.array_equal(got[0].keys, live.keys)
+
+    def test_stored_snapshot_survives_in_place_mutation_of_the_source(self):
+        live = cache_mod.RotatingKVCache(max_size=8)
+        live.update_and_fetch(mx.zeros((1, 1, 4, 4)), mx.zeros((1, 1, 4, 4)))
+
+        mc = self._store([live])
+        got, _ = mc.fetch([1, 2, 3])
+        before = mx.sum(got[0].keys).item()
+
         # Keep generating: the ring buffer is written in place past max_size.
         for _ in range(6):
             live.update_and_fetch(mx.ones((1, 1, 4, 4)) * 5, mx.ones((1, 1, 4, 4)) * 5)
-        after = [mx.sum(a).item() for a in snapshot if isinstance(a, mx.array)]
 
+        got, _ = mc.fetch([1, 2, 3])
+        after = mx.sum(got[0].keys).item()
         assert before == after, "continued generation mutated the stored snapshot"
+
+    def test_scheduler_mirror_flow_stores_detached_state(self):
+        """The rewired snapshot path end-to-end THROUGH the real scheduler
+        method: _store_prompt_only_cache mirrors structure, aliases state,
+        and relies on store() as the sole copy/eval owner."""
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        # Untrimmable: wrapped past max_size, 12 tokens total.
+        live = cache_mod.RotatingKVCache(max_size=8)
+        live.update_and_fetch(mx.ones((1, 1, 12, 4)), mx.ones((1, 1, 12, 4)))
+
+        class _Model:
+            pass
+
+        sched = _bare_scheduler()
+        sched.memory_aware_cache = MemoryAwarePrefixCache(
+            _Model(), MemoryCacheConfig(max_memory_mb=64, min_prefix_tokens=1)
+        )
+        request = _FakeRequest(list(range(1, 12)))  # 11 prompt tokens
+        response = _FakeResponse(token=77, uid=0)
+        response.prompt_cache = [live]
+
+        Scheduler._store_prompt_only_cache(sched, request, response)
+
+        key = list(range(1, 12)) + [77]  # prompt + first generated token
+        got, remaining = sched.memory_aware_cache.fetch(key)
+        assert got is not None and remaining == [], "snapshot was not stored"
+        before = mx.sum(got[0].keys).item()
+
+        # Ring buffer writes in place once wrapped: continued generation on
+        # the live cache must not reach the stored snapshot.
+        for _ in range(6):
+            live.update_and_fetch(mx.ones((1, 1, 1, 4)) * 5, mx.ones((1, 1, 1, 4)) * 5)
+        mx.eval(live.keys, live.values)
+
+        got, _ = sched.memory_aware_cache.fetch(key)
+        after = mx.sum(got[0].keys).item()
+        assert before == after, "aliasing mirror leaked live mutation into the store"
 
 
 class _FakeRequest:
@@ -223,17 +266,19 @@ class TestSnapshotDestinationTopology:
         ]
 
     def test_state_assignment_round_trips_on_a_rotating_layer(self):
-        """The assignment that used to raise and get swallowed."""
+        """The assignment that used to raise and get swallowed.
+
+        The mirror's state now aliases the live layer on purpose — store()
+        owns the copy — so this pins only the structural round-trip.
+        """
         sched = _bare_scheduler()
         live = _rotating_past_its_window()
         dest = Scheduler._make_snapshot_destination(sched, live)
 
-        state = Scheduler._copy_cache_state(live[0].state)
         meta = getattr(live[0], "meta_state", None)
         if meta is not None:
             dest[0].meta_state = meta
-        dest[0].state = state
-        mx.eval([a for a in state if isinstance(a, mx.array)])
+        dest[0].state = live[0].state
 
         assert dest[0].offset == live[0].offset
 
@@ -292,33 +337,41 @@ class TestNestedCacheListInvariants:
             assert mirrored is not original, "container copied shallowly"
 
     def test_snapshot_survives_continued_generation_on_the_live_cache(self):
-        """The invariant that matters: the snapshot must predate what follows."""
+        """The invariant that matters: the snapshot must predate what follows.
+
+        The mirror's state aliases the live children by design; store() is the
+        sole copy/eval owner, so the invariant is asserted on what fetch()
+        returns after storing the aliasing mirror.
+        """
         sched = _bare_scheduler()
         live = [self._nested(tokens=4, max_size=8)]
         dest = Scheduler._make_snapshot_destination(sched, live)
 
         for mirrored, original in zip(dest[0].caches, live[0].caches):
-            state = Scheduler._copy_cache_state(original.state)
-            mirrored.state = state
-            mx.eval([a for a in state if isinstance(a, mx.array)])
+            meta = getattr(original, "meta_state", None)
+            if meta is not None:
+                mirrored.meta_state = meta
+            mirrored.state = original.state
 
-        before = [
-            mx.sum(a).item()
-            for child in dest[0].caches
-            for a in child.state
-            if isinstance(a, mx.array)
-        ]
+        mc = TestSnapshotOwnsItsMemory._store(dest)
+
+        def _sums(entry):
+            return [
+                mx.sum(a).item()
+                for child in entry[0].caches
+                for a in child.state
+                if isinstance(a, mx.array)
+            ]
+
+        got, _ = mc.fetch([1, 2, 3])
+        before = _sums(got)
         for child in live[0].caches:
             for _ in range(6):
                 child.update_and_fetch(
                     mx.ones((1, 1, 1, 4)) * 5, mx.ones((1, 1, 1, 4)) * 5
                 )
-        after = [
-            mx.sum(a).item()
-            for child in dest[0].caches
-            for a in child.state
-            if isinstance(a, mx.array)
-        ]
+        got, _ = mc.fetch([1, 2, 3])
+        after = _sums(got)
 
         assert before == after, "live generation mutated the stored snapshot"
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -101,6 +101,8 @@ def _nested_array_memory(value: Any) -> int:
     """
     if value is None:
         return 0
+    if isinstance(value, dict):
+        return sum(_nested_array_memory(v) for v in value.values())
     if isinstance(value, (list, tuple)):
         return sum(_nested_array_memory(v) for v in value)
     return _array_memory(value)
@@ -129,10 +131,10 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
         # Handle different cache object types
         # Check dict first since dicts have .keys() method that would match below
         if isinstance(layer_cache, dict) and "state" in layer_cache:
-            # Extracted state dict
-            keys, values = layer_cache["state"]
-            total_bytes += _array_memory(keys)
-            total_bytes += _array_memory(values)
+            # Extracted state dict.  The payload may be a flat (keys, values)
+            # pair or an arbitrarily nested container/mapping — walk it
+            # recursively like the .state-property branch below.
+            total_bytes += _nested_array_memory(layer_cache["state"])
         # Handle QuantizedKVCache: keys/values are tuples of (data, scales, biases)
         elif hasattr(layer_cache, "keys") and isinstance(
             getattr(layer_cache, "keys", None), (list, tuple)
@@ -142,23 +144,49 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
             for arr in layer_cache.values:
                 total_bytes += _array_memory(arr)
             continue
+        elif hasattr(layer_cache, "caches") and isinstance(
+            getattr(layer_cache, "caches", None), (list, tuple)
+        ):
+            # Container caches (CacheList): price the children the same way
+            # storage snapshots them — recursively, per child class.  Walking
+            # the container's .state instead would price sliced views while
+            # detachment copies the children's raw buffers.
+            total_bytes += estimate_kv_cache_memory(list(layer_cache.caches))
+        elif (
+            hasattr(layer_cache, "keys")
+            and hasattr(layer_cache, "values")
+            and not callable(getattr(layer_cache, "keys", None))
+        ):
+            # keys/values-carrying caches (KVCache, RotatingKVCache,
+            # ChunkedKVCache, batch variants).  Price the RAW buffers: that
+            # is exactly what detachment copies.  Pricing the offset-sliced
+            # .state view here under-counts ring/chunked layers whose padded
+            # buffer cannot be sliced without breaking their semantics —
+            # measured 20-30% resident-vs-accounted drift, enough to breach
+            # the byte cap.
+            total_bytes += _array_memory(layer_cache.keys)
+            total_bytes += _array_memory(layer_cache.values)
+            # Batch variants carry per-row metadata arrays (offset is an
+            # mx.array there); detachment copies them, so price them too.
+            for attr in ("left_padding", "lengths", "offset"):
+                extra = getattr(layer_cache, attr, None)
+                if extra is not None and hasattr(extra, "shape"):
+                    total_bytes += _array_memory(extra)
         elif hasattr(layer_cache, "state") and not isinstance(layer_cache, dict):
-            # Cache with a state property. Walk it recursively: the payload may
-            # be a plain (keys, values) pair, but CacheList/PoolingCache nest
-            # further, and the old two-way unpack silently measured those as 0.
+            # Stateful caches without keys/values (ArraysCache, MambaCache).
+            # Walk the state recursively: the payload may nest containers or
+            # mappings, and the old two-way unpack silently measured those
+            # as 0.
             try:
                 total_bytes += _nested_array_memory(layer_cache.state)
             except (TypeError, ValueError):
                 pass
-        elif hasattr(layer_cache, "keys") and hasattr(layer_cache, "values"):
-            # Standard KVCache with keys/values attributes (not dict)
-            keys_attr = layer_cache.keys
-            values_attr = layer_cache.values
-            # Ensure these are arrays, not methods
-            if not callable(keys_attr):
-                total_bytes += _array_memory(keys_attr)
-            if not callable(values_attr):
-                total_bytes += _array_memory(values_attr)
+            # Detachment also copies these metadata arrays on state-carrying
+            # layers; price them so accounting equals snapshot residency.
+            for attr in ("left_padding", "lengths"):
+                extra = getattr(layer_cache, attr, None)
+                if extra is not None and hasattr(extra, "shape"):
+                    total_bytes += _array_memory(extra)
 
     return total_bytes
 
@@ -237,6 +265,10 @@ class CacheStats:
     current_memory_bytes: int = 0
     max_memory_bytes: int = 0
     entry_count: int = 0
+    # Entries refused by store() (over-limit, undetachable, or pipeline
+    # failure).  Fail-closed trades a leak for a cache miss; this makes
+    # those misses observable instead of silent.
+    store_rejections: int = 0
 
     @property
     def hit_rate(self) -> float:
@@ -260,6 +292,7 @@ class CacheStats:
             "max_memory_mb": round(self.max_memory_bytes / _BYTES_PER_MB, 2),
             "memory_utilization": round(self.memory_utilization, 4),
             "entry_count": self.entry_count,
+            "store_rejections": self.store_rejections,
         }
 
 
@@ -494,8 +527,11 @@ def _trim_to_offset(cache: list[Any]) -> list[Any]:
     """Trim KV arrays to their actual used size (offset) before storage.
 
     KV arrays are often pre-allocated larger than needed (e.g. 4096 slots
-    when only 100 are used).  This slices them down to ``offset`` and
-    evaluates the result so the original large buffer can be freed.
+    when only 100 are used).  This slices them down to ``offset`` LAZILY:
+    the slices materialize in ``_detach_cache_for_storage``'s single
+    batched eval, and only for entries the size preflight has accepted.
+    Evaluating here would defeat the preflight — a rejected over-limit
+    entry would still incur an entry-sized allocation.
 
     Args:
         cache: List of cache layer objects (KVCache or other types).
@@ -507,11 +543,9 @@ def _trim_to_offset(cache: list[Any]) -> list[Any]:
     if not any(_needs_kv_trim(layer) for layer in cache):
         return cache
 
-    import mlx.core as mx
     from mlx_lm.models.cache import KVCache
 
     trimmed = []
-    eval_targets = []
     for layer in cache:
         if isinstance(layer, KVCache) and layer.keys is not None:
             offset = layer.offset
@@ -522,18 +556,96 @@ def _trim_to_offset(cache: list[Any]) -> list[Any]:
             tc.keys = layer.keys[:, :, :offset, :]
             tc.values = layer.values[:, :, :offset, :]
             tc.offset = offset
-            eval_targets.extend([tc.keys, tc.values])
             trimmed.append(tc)
         else:
             trimmed.append(layer)
 
-    if eval_targets:
-        mx.eval(*eval_targets)
-
     return trimmed
 
 
-def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
+class UndetachableCacheError(Exception):
+    """Raised when a cache entry cannot be safely detached for storage.
+
+    ``store()`` treats this as a rejection: storing the entry by reference
+    would reintroduce the aliasing / lazy-graph retention leak, so the safe
+    response is to not store it at all (a skipped store costs one cache
+    miss; a leaked store pins live batch buffers until eviction).
+    """
+
+
+def _bears_arrays(value: Any, _seen: set[int] | None = None) -> bool:
+    """True if ``value`` (object or nested container) holds any array,
+    duck-typed as having both ``shape`` and ``dtype``.  Used to decide
+    whether an unrecognized cache layer is safe to pass through unchanged
+    (nothing to pin) or must fail the store (unknown retention risk)."""
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return False
+    if hasattr(value, "shape") and hasattr(value, "dtype"):
+        return True
+    if _seen is None:
+        _seen = set()
+    if id(value) in _seen:
+        return False
+    _seen.add(id(value))
+    if isinstance(value, dict):
+        return any(_bears_arrays(v, _seen) for v in value.values())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_bears_arrays(v, _seen) for v in value)
+    # Object attributes: instance dict plus any __slots__ up the MRO.
+    # vars() (not dir()) so properties are never executed here.
+    attrs = list(vars(value).values()) if hasattr(value, "__dict__") else []
+    for klass in type(value).__mro__:
+        slots = getattr(klass, "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for name in slots:
+            if hasattr(value, name):
+                attrs.append(getattr(value, name))
+    return any(_bears_arrays(v, _seen) for v in attrs)
+
+
+def _collect_mx_array_ids(
+    value: Any, mx: Any, out: set[int], _seen: set[int] | None = None
+) -> None:
+    """Collect ``id()`` of every real ``mx.array`` reachable from ``value``.
+
+    Same traversal as ``_bears_arrays`` (containers, instance dicts,
+    ``__slots__``; properties are never executed).  Only genuine MLX arrays
+    are collected: duck-typed array-likes pass through detachment by
+    reference deliberately and must not trip the identity postcondition."""
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return
+    if isinstance(value, mx.array):
+        out.add(id(value))
+        return
+    if _seen is None:
+        _seen = set()
+    if id(value) in _seen:
+        return
+    _seen.add(id(value))
+    if isinstance(value, dict):
+        for v in value.values():
+            _collect_mx_array_ids(v, mx, out, _seen)
+        return
+    if isinstance(value, (list, tuple, set, frozenset)):
+        for v in value:
+            _collect_mx_array_ids(v, mx, out, _seen)
+        return
+    attrs = list(vars(value).values()) if hasattr(value, "__dict__") else []
+    for klass in type(value).__mro__:
+        slots = getattr(klass, "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for name in slots:
+            if hasattr(value, name):
+                attrs.append(getattr(value, name))
+    for v in attrs:
+        _collect_mx_array_ids(v, mx, out, _seen)
+
+
+def _detach_cache_for_storage(
+    cache: list[Any], _eval_targets: list[Any] | None = None
+) -> list[Any]:
     """Materialize and detach cache arrays before storage.
 
     Per-request caches handed to ``store()`` are built from lazy slices of
@@ -551,17 +663,42 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
       stored entry, until the process hits the device resource limit
       (``[metal::malloc] Resource limit (N) exceeded``) and aborts.
 
-    Force a compact, evaluated copy of every array so the stored entry owns
+    Force a compact, evaluated copy of every MLX array so the stored entry owns
     exactly its own data and nothing else.
-    """
-    import mlx.core as mx
 
-    eval_targets: list[Any] = []
+    Fail-closed: raises ``UndetachableCacheError`` if any layer cannot be
+    safely snapshotted — either an unrecognized layer type that carries
+    arrays, or a recognized layer whose snapshot fails.  Array-free unknown
+    layers pass through unchanged (nothing to pin).
+    """
+    try:
+        import mlx.core as mx
+    except ImportError:
+        # No-MLX environments (e.g. the CI unit-test lane) have no MLX
+        # arrays to materialize; container/attribute snapshotting below
+        # still applies, arrays pass through _detach unchanged.
+        mx = None
+
+    # Recursive calls (CacheList children) share the caller's target list
+    # so the whole entry still materializes in one batched eval.
+    is_root = _eval_targets is None
+    eval_targets: list[Any] = [] if is_root else _eval_targets
 
     def _detach(arr: Any) -> Any:
-        if arr is None or not (hasattr(arr, "shape") and hasattr(arr, "dtype")):
+        # Only real MLX arrays are detached: they alone carry a lazy graph
+        # and Metal buffers.  Duck-typed array-likes (test doubles, numpy)
+        # have nothing to pin and pass through unchanged.
+        if mx is None or not isinstance(arr, mx.array):
             return arr
-        out = mx.contiguous(arr)
+        # ``arr + 0`` guarantees a freshly allocated buffer.  mx.contiguous
+        # is documented to copy only when necessary and may share the input
+        # buffer for an already-row-contiguous input, which would let the
+        # stored snapshot alias live storage.  ``+ 0`` promotes bool to
+        # int32, so cast back — the cast reads the already-fresh buffer, the
+        # allocation guarantee holds either way.
+        out = arr + 0
+        if out.dtype != arr.dtype:
+            out = out.astype(arr.dtype)
         eval_targets.append(out)
         return out
 
@@ -570,6 +707,24 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
             return tuple(_detach_container(v) for v in value)
         if isinstance(value, list):
             return [_detach_container(v) for v in value]
+        if isinstance(value, dict):
+            # Nested mapping state (e.g. {"ssm": array}) — rebuild the
+            # mapping so the snapshot owns its container, preserving the
+            # mapping type.  A mapping type whose constructor rejects an
+            # iterable of pairs raises and fails the store closed.
+            return type(value)((k, _detach_container(v)) for k, v in value.items())
+        if (
+            value is not None
+            and not (hasattr(value, "shape") and hasattr(value, "dtype"))
+            and _bears_arrays(value)
+        ):
+            # A non-array object (or unsupported container, e.g. a set)
+            # smuggling arrays inside a state payload: copying around it
+            # would alias whatever it holds.  Fail closed.
+            raise UndetachableCacheError(
+                f"state payload holds arrays inside an unsupported "
+                f"{type(value).__name__}"
+            )
         return _detach(value)
 
     def _detach_layer(layer: Any) -> Any:
@@ -579,7 +734,16 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
             if "state" in layer:
                 snap_dict = dict(layer)
                 snap_dict["state"] = _detach_container(layer["state"])
+                rest = {k: v for k, v in snap_dict.items() if k != "state"}
+                if _bears_arrays(rest):
+                    raise UndetachableCacheError(
+                        "dict layer carries arrays outside its 'state' field"
+                    )
                 return snap_dict
+            if _bears_arrays(layer):
+                raise UndetachableCacheError(
+                    "dict layer without 'state' carries arrays"
+                )
             return layer
         # copy.copy (not __new__ + __dict__.update) so classes using
         # __slots__ (e.g. _QuantizedCacheWrapper) snapshot correctly too.
@@ -588,6 +752,12 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
             snap = copy.copy(layer)
             snap.keys = _detach_container(layer.keys)
             snap.values = _detach_container(layer.values)
+            # Batch variants also carry per-row metadata arrays that the
+            # batch generator rebinds (offset is an mx.array there).
+            for attr in ("left_padding", "lengths", "offset"):
+                extra = getattr(snap, attr, None)
+                if extra is not None and hasattr(extra, "shape"):
+                    setattr(snap, attr, _detach(extra))
             return snap
         if hasattr(layer, "caches") and isinstance(
             getattr(layer, "caches"), (list, tuple)
@@ -597,7 +767,9 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
             # the setter would mutate the caller's children.  Snapshot the
             # children recursively instead.
             snap = copy.copy(layer)
-            children = _detach_cache_for_storage(list(layer.caches))
+            children = _detach_cache_for_storage(
+                list(layer.caches), _eval_targets=eval_targets
+            )
             snap.caches = (
                 tuple(children) if isinstance(layer.caches, tuple) else children
             )
@@ -612,24 +784,56 @@ def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
                 if getattr(snap, attr, None) is not None:
                     setattr(snap, attr, _detach(getattr(snap, attr)))
             return snap
+        if _bears_arrays(layer):
+            raise UndetachableCacheError(
+                f"unrecognized cache layer type {type(layer).__name__} "
+                "carries arrays"
+            )
         return layer
 
     detached: list[Any] = []
     for layer in cache:
         try:
             detached.append(_detach_layer(layer))
+        except UndetachableCacheError:
+            raise
         except Exception as e:
-            logger.warning(
-                "[cache_store] failed to detach %s (%s: %s); "
-                "storing by reference",
-                type(layer).__name__,
-                type(e).__name__,
-                e,
-            )
-            detached.append(layer)
+            raise UndetachableCacheError(
+                f"failed to snapshot {type(layer).__name__}: "
+                f"{type(e).__name__}: {e}"
+            ) from e
 
-    if eval_targets:
-        mx.eval(*eval_targets)
+    if is_root and mx is not None:
+        # Verified postcondition, not assumed branch coverage: no MLX array
+        # in the snapshot may be the same object as one in the live input.
+        # Branch dispatch above is heuristic (every mlx_lm ``_BaseCache``
+        # subclass inherits a default ``state`` property returning ``[]``,
+        # so the state branch matches layers whose arrays live elsewhere
+        # and would "detach" an empty state, aliasing the rest).  Checking
+        # object identity after the fact closes that hole for any layer
+        # shape, present or future.
+        live_ids: set[int] = set()
+        snap_ids: set[int] = set()
+        for layer in cache:
+            _collect_mx_array_ids(layer, mx, live_ids)
+        for layer in detached:
+            _collect_mx_array_ids(layer, mx, snap_ids)
+        if live_ids & snap_ids:
+            raise UndetachableCacheError(
+                "snapshot still aliases live cache arrays (layer carries "
+                "arrays its state/keys view does not expose)"
+            )
+
+    if is_root and eval_targets:
+        try:
+            mx.eval(*eval_targets)
+        except Exception as e:
+            # e.g. stream-affinity RuntimeError when arrays belong to a
+            # stream whose thread has exited.  store() must reject, not
+            # raise — several call sites have no enclosing try.
+            raise UndetachableCacheError(
+                f"failed to materialize snapshot: {type(e).__name__}: {e}"
+            ) from e
 
     return detached
 
@@ -825,6 +1029,11 @@ class MemoryAwarePrefixCache:
         self._max_memory = self._config.compute_memory_limit()
         self._current_memory = 0
         self._memory_lock = threading.RLock()
+        # Serializes the entry-sized snapshot copy in store().  Separate
+        # from _memory_lock so accounting stays responsive during the GPU
+        # copy, while concurrent stores still materialize one at a time —
+        # N simultaneous entry-sized copies would multiply peak memory by N.
+        self._copy_lock = threading.Lock()
 
         # Statistics
         self._stats = CacheStats(max_memory_bytes=self._max_memory)
@@ -1078,9 +1287,16 @@ class MemoryAwarePrefixCache:
         """
         Store KV cache for future reuse.
 
-        This method stores the cache reference directly (no copy) and
-        tracks memory usage. If memory limit is exceeded, LRU entries
-        are evicted until there's room.
+        The entry is snapshotted before storage: every MLX array is
+        detached into a freshly allocated, evaluated copy (with optional
+        quantization applied first), so the stored entry never aliases the
+        caller's cache objects or retains their lazy graphs.  Entries whose
+        projected size exceeds the memory limit are rejected before
+        anything is materialized.  If the memory limit is exceeded by the
+        new entry, LRU entries are evicted until there's room.
+
+        This method does not raise: any failure while building or storing
+        the snapshot rejects the entry (returns False) with a warning.
 
         Args:
             tokens: Token sequence that was processed.
@@ -1104,22 +1320,29 @@ class MemoryAwarePrefixCache:
             )
             return False
 
-        with self._memory_lock:
-            tokens_key = tuple(tokens)
+        tokens_key = tuple(tokens)
 
-            # If already cached, just update LRU order (skip expensive trim/quantize)
+        # Fast path: already cached — just refresh LRU order.
+        with self._memory_lock:
             if tokens_key in self._entries:
                 self._entries.move_to_end(tokens_key)
                 return True
 
-            # Trim oversized KV arrays to actual used size
+        # Build the snapshot outside _memory_lock: trim (lazy) -> quantize
+        # (lazy) -> preflight (shape-based, no eval) -> detach (the one
+        # entry-sized GPU copy+eval).  Holding _memory_lock across the eval
+        # would serialize try_reserve_memory / remove / clear for the full
+        # copy duration; fetch() is lock-free either way.  store() never
+        # raises: any failure in the pipeline rejects the entry instead.
+        try:
+            # Trim oversized KV arrays to actual used size (lazy slices).
             cache = _trim_to_offset(cache)
 
-            # Detach from live batch buffers and lazy graphs so the stored
-            # entry owns its data (prevents aliasing + Metal handle leak).
-            cache = _detach_cache_for_storage(cache)
-
-            # Quantize if enabled and sequence is long enough
+            # Quantize BEFORE detaching so the detached, evaluated arrays
+            # are the final stored representation.  Quantizing after
+            # detachment would build new lazy quantized arrays on top of
+            # the evaluated full-precision snapshot and retain it as graph
+            # inputs, so resident memory would exceed the accounting.
             if (
                 self._config.kv_quantize
                 and len(tokens) >= self._config.kv_min_quantize_tokens
@@ -1128,60 +1351,99 @@ class MemoryAwarePrefixCache:
                     cache, self._config.kv_bits, self._config.kv_group_size
                 )
 
-            # Create entry and estimate memory
-            entry = _CacheEntry.create(tokens, cache)
-
-            # Check if single entry exceeds limit
-            if entry.memory_bytes > self._max_memory:
+            # Preflight: reject oversized entries BEFORE materializing
+            # anything.  shape×dtype pricing needs no evaluation, and both
+            # trim and quantize above are lazy, so an over-limit entry is
+            # refused without incurring an entry-sized allocation (which
+            # could itself hit Metal resource/memory limits).
+            projected_bytes = estimate_kv_cache_memory(cache)
+            if projected_bytes > self._max_memory:
+                self._stats.store_rejections += 1
                 logger.warning(
-                    f"Cache entry too large: {entry.memory_bytes / _BYTES_PER_MB:.1f}MB "
+                    f"Cache entry too large: "
+                    f"{projected_bytes / _BYTES_PER_MB:.1f}MB "
                     f"exceeds limit {self._max_memory / _BYTES_PER_MB:.1f}MB"
                 )
                 return False
 
-            # Prefix-subset eviction: remove entries whose token sequence
-            # is a strict prefix of the new entry.  Uses sorted index for
-            # O(log N + K) lookup instead of O(N) scan.
-            if evict_prefixes and self._sorted_keys:
-                to_remove = []
-                idx = bisect.bisect_left(self._sorted_keys, tokens_key)
-                # Scan backwards — prefixes of tokens_key are immediately before idx
-                for i in range(idx - 1, -1, -1):
-                    key = self._sorted_keys[i]
-                    klen = len(key)
-                    if klen >= len(tokens_key):
-                        continue
-                    if tokens_key[:klen] == key:
-                        to_remove.append(key)
-                    elif key[0] != tokens_key[0]:
-                        break
-                for key in to_remove:
-                    old = self._entries.pop(key)
-                    self._current_memory -= old.memory_bytes
-                    self._stats.evictions += 1
-                    self._remove_from_sorted(key)
-                    logger.debug(
-                        f"[prefix_evict] removed {len(key)} tokens, "
-                        f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
-                        f"new_entry={len(tokens_key)} tokens"
-                    )
-                if to_remove:
-                    self._stats.entry_count = len(self._entries)
-                    self._stats.current_memory_bytes = self._current_memory
+            # Detach from live batch buffers and lazy graphs so the stored
+            # entry owns its data (prevents aliasing + Metal handle leak).
+            # Fail-closed: an entry that cannot be detached is rejected —
+            # storing it by reference would reintroduce the leak.  The
+            # copy lock keeps concurrent stores from materializing
+            # entry-sized copies simultaneously (N-fold peak), without
+            # blocking _memory_lock users.
+            with self._copy_lock:
+                cache = _detach_cache_for_storage(cache)
+            # Create entry and account the final (detached) representation
+            entry = _CacheEntry.create(tokens, cache)
 
-            # Evict until we have room
-            while (
-                self._current_memory + entry.memory_bytes > self._max_memory
-                or len(self._entries) >= self._config.max_entries
-            ) and self._entries:
-                self._evict_lru()
+            with self._memory_lock:
+                # Re-check under the lock: a concurrent store() may have won
+                # the race while we were detaching.  Keep theirs (drop our
+                # copy) and refresh LRU order.
+                if tokens_key in self._entries:
+                    self._entries.move_to_end(tokens_key)
+                    return True
 
-            # Store entry
-            self._entries[tokens_key] = entry
-            self._current_memory += entry.memory_bytes
-            bisect.insort(self._sorted_keys, tokens_key)
-            self._stats.entry_count = len(self._entries)
-            self._stats.current_memory_bytes = self._current_memory
+                # Prefix-subset eviction: remove entries whose token sequence
+                # is a strict prefix of the new entry.  Uses sorted index for
+                # O(log N + K) lookup instead of O(N) scan.
+                if evict_prefixes and self._sorted_keys:
+                    to_remove = []
+                    idx = bisect.bisect_left(self._sorted_keys, tokens_key)
+                    # Scan backwards — prefixes of tokens_key are immediately
+                    # before idx
+                    for i in range(idx - 1, -1, -1):
+                        key = self._sorted_keys[i]
+                        klen = len(key)
+                        if klen >= len(tokens_key):
+                            continue
+                        if tokens_key[:klen] == key:
+                            to_remove.append(key)
+                        elif key[0] != tokens_key[0]:
+                            break
+                    for key in to_remove:
+                        old = self._entries.pop(key)
+                        self._current_memory -= old.memory_bytes
+                        self._stats.evictions += 1
+                        self._remove_from_sorted(key)
+                        logger.debug(
+                            f"[prefix_evict] removed {len(key)} tokens, "
+                            f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
+                            f"new_entry={len(tokens_key)} tokens"
+                        )
+                    if to_remove:
+                        self._stats.entry_count = len(self._entries)
+                        self._stats.current_memory_bytes = self._current_memory
+
+                # Evict until we have room
+                while (
+                    self._current_memory + entry.memory_bytes > self._max_memory
+                    or len(self._entries) >= self._config.max_entries
+                ) and self._entries:
+                    self._evict_lru()
+
+                # Store entry
+                self._entries[tokens_key] = entry
+                self._current_memory += entry.memory_bytes
+                bisect.insort(self._sorted_keys, tokens_key)
+                self._stats.entry_count = len(self._entries)
+                self._stats.current_memory_bytes = self._current_memory
+        except UndetachableCacheError as e:
+            self._stats.store_rejections += 1
+            logger.warning("[cache_store] rejecting entry: %s", e)
+            return False
+        except Exception as e:
+            # Anything else — malformed input to trim/quantize (e.g.
+            # head_dim not divisible by the quantization group size), or an
+            # eviction-path failure such as an SSD spill hook raising a
+            # stream-affinity RuntimeError — must not crash the caller.
+            # Several call sites have no enclosing try; a rejected store
+            # only costs a cache miss.
+            self._stats.store_rejections += 1
+            logger.warning("[cache_store] rejecting entry: %s: %s", type(e).__name__, e)
+            return False
 
         logger.debug(
             f"Stored cache: {len(tokens)} tokens, "

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -25,6 +25,7 @@ Example:
 from __future__ import annotations
 
 import bisect
+import copy
 import logging
 import math
 import threading
@@ -532,6 +533,107 @@ def _trim_to_offset(cache: list[Any]) -> list[Any]:
     return trimmed
 
 
+def _detach_cache_for_storage(cache: list[Any]) -> list[Any]:
+    """Materialize and detach cache arrays before storage.
+
+    Per-request caches handed to ``store()`` are built from lazy slices of
+    live batch arrays (``extract_cache`` / ``_trim_cache_offset``), and
+    hybrid layers such as ``ArraysCache`` expose their mutable state
+    container by reference via ``.state``.  Storing those references has two
+    failure modes:
+
+    - the stored entry aliases containers/buffers the batch generator keeps
+      mutating (same class of bug as the SimpleEngine snapshot aliasing,
+      #575), and
+    - unevaluated arrays retain their entire lazy computation graph, pinning
+      every upstream batch-wide buffer.  Under sustained traffic this leaks
+      Metal buffer handles roughly proportional to generated tokens per
+      stored entry, until the process hits the device resource limit
+      (``[metal::malloc] Resource limit (N) exceeded``) and aborts.
+
+    Force a compact, evaluated copy of every array so the stored entry owns
+    exactly its own data and nothing else.
+    """
+    import mlx.core as mx
+
+    eval_targets: list[Any] = []
+
+    def _detach(arr: Any) -> Any:
+        if arr is None or not (hasattr(arr, "shape") and hasattr(arr, "dtype")):
+            return arr
+        out = mx.contiguous(arr)
+        eval_targets.append(out)
+        return out
+
+    def _detach_container(value: Any) -> Any:
+        if isinstance(value, tuple):
+            return tuple(_detach_container(v) for v in value)
+        if isinstance(value, list):
+            return [_detach_container(v) for v in value]
+        return _detach(value)
+
+    def _detach_layer(layer: Any) -> Any:
+        if layer is None:
+            return layer
+        if isinstance(layer, dict):
+            if "state" in layer:
+                snap_dict = dict(layer)
+                snap_dict["state"] = _detach_container(layer["state"])
+                return snap_dict
+            return layer
+        # copy.copy (not __new__ + __dict__.update) so classes using
+        # __slots__ (e.g. _QuantizedCacheWrapper) snapshot correctly too.
+        if hasattr(layer, "keys") and not callable(getattr(layer, "keys")):
+            # KVCache / RotatingKVCache / _QuantizedCacheWrapper style.
+            snap = copy.copy(layer)
+            snap.keys = _detach_container(layer.keys)
+            snap.values = _detach_container(layer.values)
+            return snap
+        if hasattr(layer, "caches") and isinstance(
+            getattr(layer, "caches"), (list, tuple)
+        ):
+            # Container caches (e.g. ``CacheList``): their ``state`` setter
+            # writes through to the child caches in place, so going through
+            # the setter would mutate the caller's children.  Snapshot the
+            # children recursively instead.
+            snap = copy.copy(layer)
+            children = _detach_cache_for_storage(list(layer.caches))
+            snap.caches = (
+                tuple(children) if isinstance(layer.caches, tuple) else children
+            )
+            return snap
+        if hasattr(layer, "state"):
+            # Hybrid state-container layers (e.g. ``ArraysCache``): ``.state``
+            # returns the live mutable list — clone the container and detach
+            # its arrays instead of aliasing it.
+            snap = copy.copy(layer)
+            snap.state = _detach_container(layer.state)
+            for attr in ("left_padding", "lengths"):
+                if getattr(snap, attr, None) is not None:
+                    setattr(snap, attr, _detach(getattr(snap, attr)))
+            return snap
+        return layer
+
+    detached: list[Any] = []
+    for layer in cache:
+        try:
+            detached.append(_detach_layer(layer))
+        except Exception as e:
+            logger.warning(
+                "[cache_store] failed to detach %s (%s: %s); "
+                "storing by reference",
+                type(layer).__name__,
+                type(e).__name__,
+                e,
+            )
+            detached.append(layer)
+
+    if eval_targets:
+        mx.eval(*eval_targets)
+
+    return detached
+
+
 class _QuantizedCacheWrapper:
     """Lightweight wrapper storing quantized KV arrays + original cache metadata.
 
@@ -1012,6 +1114,10 @@ class MemoryAwarePrefixCache:
 
             # Trim oversized KV arrays to actual used size
             cache = _trim_to_offset(cache)
+
+            # Detach from live batch buffers and lazy graphs so the stored
+            # entry owns its data (prevents aliasing + Metal handle leak).
+            cache = _detach_cache_for_storage(cache)
 
             # Quantize if enabled and sequence is long enough
             if (

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2275,25 +2275,6 @@ class Scheduler:
 
         return scheduled
 
-    @staticmethod
-    def _copy_cache_state(value: Any) -> Any:
-        """Deep-copy a cache ``state`` payload.
-
-        Sharing the arrays is not safe: RotatingKVCache writes into its ring
-        buffer and PoolingCache writes into its remainder buffer, both in
-        place, so a snapshot that aliases them would be rewritten by the very
-        generation it is supposed to predate. ``x + 0`` forces a fresh array
-        while staying on the GPU.
-        """
-        import mlx.core as mx
-
-        if isinstance(value, mx.array):
-            return value + 0
-        if isinstance(value, (list, tuple)):
-            copied = [Scheduler._copy_cache_state(v) for v in value]
-            return type(value)(copied) if isinstance(value, tuple) else copied
-        return value
-
     # How much a prompt must have grown before its cache snapshot is worth
     # re-taking. Copying the KV cache is O(context), so refreshing every turn
     # dominates prefill on long agentic conversations.
@@ -2524,8 +2505,6 @@ class Scheduler:
             if cache_key is None:
                 return
 
-            import mlx.core as mx
-
             import time as _t
 
             _t0 = _t.monotonic()
@@ -2533,22 +2512,22 @@ class Scheduler:
             _t1 = _t.monotonic()
             if snapshot is None:
                 return
-            states = []
+            # The destination mirrors structure only; its state aliases the
+            # live caches on purpose.  store() is the single owner of
+            # copying and evaluation: its detach pass replaces every array
+            # with a freshly allocated, evaluated copy before the entry is
+            # kept (and rejects the entry instead of storing an alias if it
+            # cannot).
             for dst, src in zip(snapshot, raw_cache):
-                state = self._copy_cache_state(src.state)
                 meta = getattr(src, "meta_state", None)
                 if meta is not None:
                     dst.meta_state = meta
-                dst.state = state
-                states.append(state)
+                dst.state = src.state
             _t2 = _t.monotonic()
-            mx.eval(states)
-            _t3 = _t.monotonic()
             logger.debug(
-                "[snapshot_timing] make=%.2fs copy=%.2fs eval=%.2fs layers=%d",
+                "[snapshot_timing] make=%.2fs mirror=%.2fs layers=%d",
                 _t1 - _t0,
                 _t2 - _t1,
-                _t3 - _t2,
                 len(snapshot),
             )
 


### PR DESCRIPTION
## Summary

Refs #641

`store()` keeps per-request cache layers **by reference**. On the continuous-batching path those layers are lazy slices of live batch-wide arrays, and hybrid layers (`ArraysCache`) expose their mutable state container via `.state`. A stored entry therefore (a) **aliases** containers the batch generator keeps mutating — same bug class as #575, fixed for SimpleEngine in #576 but not here — and (b) **retains each entry's upstream lazy graph**, pinning ~1,700 Metal buffer handles and ~0.9 GB per entry until eviction. On a hybrid model (Qwen3.6-35B-A3B, 30/40 `ArraysCache` layers) at ~350 req/h this exhausts the Metal handle limit (`[metal::malloc] Resource limit (499000) exceeded` — a count, not bytes; 10-line repro in #641) and aborted the server every ~47 minutes. The `shape × dtype` accounting cannot see the retention (it prices a lazy array's promised output, not what its graph pins), so `--cache-memory-mb` never contained it.

**The fix:** `store()` becomes the single owner of copying and evaluation, with the pipeline **trim (lazy) → quantize (lazy) → preflight → detach → account**. The pipeline runs outside `_memory_lock`; the entry-sized copy is serialized by a dedicated copy lock; `store()` never raises — any pipeline failure rejects the entry with a warning (counted in a new `store_rejections` stat).

- **Detach:** every real `mx.array` is replaced with a guaranteed freshly-allocated, dtype-faithful copy (`arr + 0`, per review — `mx.contiguous` may share an already-contiguous input's buffer), with all containers cloned: KVCache-style layers (incl. quantized tuple keys and batch variants' `left_padding`/`lengths`/`offset` metadata arrays), `.state` layers, `CacheList` children (recursively — its `state` setter writes through to live children), extracted state dicts, and nested mappings. One batched `mx.eval` per store; `copy.copy()` so `__slots__` classes work.
- **Preflight before materialization:** `_trim_to_offset` now slices lazily, so over-limit entries are rejected from `shape × dtype` pricing with nothing evaluated — an oversized lazy entry costs ~0 instead of an entry-sized allocation spike.
- **Honest accounting:** keys-carrying layers are priced on their **raw buffers**, byte-exact with what detachment copies (ring/chunked semantics forbid slicing to offset); `CacheList` is priced by recursing into children; state-layer metadata arrays are priced too. The old sliced-view pricing under-counted padded ring/chunked layers by the padding ratio — up to 25.6× on short entries — silently breaching the byte cap. **Consequence:** a given `--cache-memory-mb` now admits fewer heavily-padded entries; the cap tracks real residency. Trimming ring buffers could recover much of that padding — left as a follow-up.
- **Quantize before detach:** with `kv_quantize`, the stored arrays are the final quantized representation; the old order retained the full-precision snapshot as graph input.
- **Fail-closed, as a verified postcondition:** after snapshotting, any `mx.array` in the snapshot that is still the same object as one in the live input rejects the store. (Branch dispatch alone can't guarantee this: every mlx_lm `_BaseCache` subclass inherits a default `state` property returning `[]`, so a layer with arrays outside `.state` would previously "detach" an empty state and store everything else aliased, priced at 0 bytes.) Unknown array-bearing layers, dict layers with arrays outside `state`, and arrays in unsupported containers are rejected; array-free unknown layers pass through.
- **#683 integration:** `Scheduler._copy_cache_state` is removed; the snapshot path hands `store()` a structure mirror whose state deliberately aliases the live caches, and `store()` detaches or rejects. #683's scheduler/key semantics (`_make_snapshot_destination`, `_cache_key_for_snapshot`, usefulness gating, refresh threshold, evict_prefixes) are unchanged.

Follows the approach of #576. With detachment plus recursive accounting, `shape × dtype` pricing matches resident memory, so `--cache-memory-mb` governs real bytes.

## Type of change

- Bug fix

## Surface touched

- KV cache / prefix cache / scheduler snapshot path

## Test plan

```
python -m pytest tests/test_memory_cache.py tests/test_memory_cache_mlx.py \
  tests/test_prefix_cache.py tests/test_prefix_cache_untrimmable.py \
  tests/test_mllm_cache.py tests/test_kv_cache_quantization.py \
  tests/test_ssd_cache.py tests/test_prefix_cache_scheduler_parity.py \
  tests/test_prefix_cache_real_model_parity.py -q
```

New regressions in `tests/test_memory_cache_mlx.py` (`TestDetachCacheForStorage`, `TestStoreFailClosedAndEviction`, `TestOwnerReviewRegressions`, `TestFailClosedPostcondition`) and `tests/test_prefix_cache_untrimmable.py`. Highlights: snapshot isolation for every cache class incl. `__slots__` wrappers; a real extracted batch slice stored, batch dropped — resident memory must be entry-sized, not batch-sized (**fails on main**); a ~64 MB step-padded lazy entry vs a 2 MB cap rejected with < 5 MB of memory movement; quantized store retains quantized-size memory only; nested-mapping state detached, priced, and evicted; a `_BaseCache` subclass with a sidecar array rejected by the identity postcondition (all ten mlx-lm 0.31.3 cache classes swept — no false positives, accounting byte-equal to residency); resident ≈ accounted for padded ring layers; an end-to-end test driving the real `_store_prompt_only_cache` mirror flow. #702's 2 scheduler replay-parity tests pass unmodified; its 4 real-model parity tests are `slow`-marked and were not run. Note: the parity files, `test_kv_cache_quantization.py`, and `test_ssd_cache.py` are in no CI lane.

End-to-end: serve `mlx-community/Qwen3.6-35B-A3B-8bit` with `--continuous-batching --enable-prefix-cache` under sustained traffic — on main `mx.get_active_memory()` ratchets ~0.9 GB per request; with this patch it plateaus.

## Test results

M3 Ultra, fresh clone + fresh venv (mlx 0.32.0, mlx-lm 0.31.3):

```
263 passed, 1 skipped, 4 deselected
```

The no-MLX CI unit lane reproduced locally: results identical to `main`. `black --check` (26.5.1) and `ruff check` (CI flags) pass repo-wide.

Production soak on the crashing workload (same hardware/model/traffic):
- **main:** memory climbs 38.8 → 310 GB over 278 requests, 6,019 malloc failures, abort at minute 47 — reproduced across 5 consecutive crashes.
- **this patch:** 74+ min / ~620 requests, no crash; memory plateaus at 56–57 GB (with dips); `vmmap` IOAccelerator region count frozen at exactly 1,868 for the final hour vs +40/min on main; cache functional throughout (195 entries, LRU evictions, ~27K prefill tokens saved). Soak predates the review revisions; the detachment mechanism is unchanged.

## Performance impact

- M3 Ultra 512 GB, Qwen3.6-35B-A3B-8bit.
- One entry-sized allocating copy + one batched `mx.eval` per `store()` (not per token, not on the decode path), outside `_memory_lock` under a dedicated copy lock. Measured: ~6–50 ms for a deliberately large 128 MB fp16 entry vs ~0.2 ms for main's store-by-reference — whose zero cost *was* the aliasing bug. The scheduler snapshot path is cost-neutral (the copy moved out of the removed helper); the other store call sites (pre-first-token save callback — on the TTFT path — mid-prefill saves, SSD promotions, mllm paths) previously stored by reference and now pay the copy, unthrottled by `SNAPSHOT_REFRESH_TOKENS`. Ring/chunked layers copy their padded buffers (now honestly accounted; see Summary). TTFT / decode tok/s not benchmarked; no kernel, sampling, or scheduler-loop changes.

## Output parity

Cache-miss path untouched. Cache-hit path returns detached copies with identical contents and metadata (`offset`, `_idx`, `max_size`, `keep`, quantization params); #702's replay-parity tests pass unmodified. No sampling, kernel, or tokenization changes — greedy outputs unaffected.

