### PR TITLE
feat: add request-local Poolside v1 parsers

### DIFF
--- a/tests/test_poolside_v1_parsers.py
+++ b/tests/test_poolside_v1_parsers.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from vllm_mlx.reasoning import get_parser as get_reasoning_parser
+from vllm_mlx.tool_parsers import ToolParserManager
+
+
+def _request():
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"},
+                            "line": {"type": "integer"},
+                        },
+                    },
+                },
+            }
+        ]
+    }
+
+
+def test_poolside_reasoning_parser_handles_explicit_and_injected_thinking():
+    parser = get_reasoning_parser("poolside_v1")()
+
+    assert parser.extract_reasoning("<think>inspect</think>done") == (
+        "inspect",
+        "done",
+    )
+    assert parser.extract_reasoning("inspect</think>done") == ("inspect", "done")
+    assert parser.extract_reasoning("plain final") == (None, "plain final")
+
+
+def test_poolside_tool_parser_preserves_string_content_and_coerces_numbers():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    output = (
+        "I will update it."
+        "<tool_call>write_file"
+        "<arg_key>path</arg_key><arg_value>/tmp/a.py</arg_value>"
+        "<arg_key>content</arg_key><arg_value>  x = 1\n</arg_value>"
+        "<arg_key>line</arg_key><arg_value>7</arg_value>"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls(output, _request())
+
+    assert result.tools_called is True
+    assert result.content == "I will update it."
+    assert result.tool_calls[0]["name"] == "write_file"
+    assert json.loads(result.tool_calls[0]["arguments"]) == {
+        "path": "/tmp/a.py",
+        "content": "  x = 1\n",
+        "line": 7,
+    }
+
+
+def test_poolside_tool_parser_handles_zero_args_and_multiple_calls():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    output = (
+        "<tool_call>status</tool_call>"
+        "<tool_call>write_file"
+        "<arg_key>path</arg_key><arg_value>a.py</arg_value>"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    assert [call["name"] for call in result.tool_calls] == ["status", "write_file"]
+    assert json.loads(result.tool_calls[0]["arguments"]) == {}
+
+
+def test_poolside_tool_parser_suppresses_unclosed_or_unknown_markup():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+
+    truncated = parser.extract_tool_calls(
+        "visible<tool_call>write_file<arg_key>path</arg_key>", _request()
+    )
+    unknown = parser.extract_tool_calls(
+        "<tool_call>delete_everything</tool_call>", _request()
+    )
+
+    assert truncated.tools_called is False
+    assert truncated.content == "visible"
+    assert unknown.tools_called is False
+    assert unknown.content is None
+
+
+def test_poolside_tool_parser_streams_plain_text_and_closed_tool_call():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    chunks = [
+        "<tool_",
+        "call>write_file",
+        "<arg_key>path</arg_key>",
+        "<arg_value>a.py</arg_value></tool_call>",
+    ]
+    accumulated = ""
+    emitted = []
+    for chunk in chunks:
+        previous = accumulated
+        accumulated += chunk
+        delta = parser.extract_tool_calls_streaming(
+            previous, accumulated, chunk, request=_request()
+        )
+        if delta:
+            emitted.append(delta)
+
+    calls = [delta["tool_calls"][0] for delta in emitted]
+    assert calls[0]["function"]["name"] == "write_file"
+    assert json.loads("".join(call["function"]["arguments"] for call in calls)) == {
+        "path": "a.py"
+    }
+
+
+def test_poolside_tool_parser_streaming_uses_declared_tool_schema():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    output = (
+        "<tool_call>write_file"
+        "<arg_key>content</arg_key><arg_value>  x = 1\n</arg_value>"
+        "<arg_key>line</arg_key><arg_value>7</arg_value>"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls_streaming("", output, output, request=_request())
+
+    assert result is not None
+    arguments = json.loads(result["tool_calls"][0]["function"]["arguments"])
+    assert arguments == {"content": "  x = 1\n", "line": 7}
+
+
+def test_poolside_tool_parser_streaming_rejects_unknown_tool():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    output = "<tool_call>delete_everything</tool_call>"
+
+    assert (
+        parser.extract_tool_calls_streaming("", output, output, request=_request())
+        is None
+    )
+
+
+def test_poolside_tool_parser_streaming_emits_each_call_once():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    first = (
+        "<tool_call>write_file"
+        "<arg_key>path</arg_key><arg_value>a.py</arg_value>"
+        "</tool_call>"
+    )
+    second = (
+        "<tool_call>write_file"
+        "<arg_key>path</arg_key><arg_value>b.py</arg_value>"
+        "</tool_call>"
+    )
+
+    first_delta = parser.extract_tool_calls_streaming(
+        "", first, first, request=_request()
+    )
+    second_delta = parser.extract_tool_calls_streaming(
+        first, first + second, second, request=_request()
+    )
+
+    assert first_delta is not None and second_delta is not None
+    assert len(first_delta["tool_calls"]) == 1
+    assert len(second_delta["tool_calls"]) == 1
+    assert first_delta["tool_calls"][0]["index"] == 0
+    assert second_delta["tool_calls"][0]["index"] == 1
+    assert json.loads(first_delta["tool_calls"][0]["function"]["arguments"]) == {
+        "path": "a.py"
+    }
+    assert json.loads(second_delta["tool_calls"][0]["function"]["arguments"]) == {
+        "path": "b.py"
+    }
+
+
+def test_poolside_tool_parser_recovers_after_unknown_streamed_call():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    unknown = "<tool_call>delete_everything</tool_call>"
+
+    assert (
+        parser.extract_tool_calls_streaming("", unknown, unknown, request=_request())
+        is None
+    )
+    assert parser.extract_tool_calls_streaming(
+        unknown, unknown + "after", "after", request=_request()
+    ) == {"content": "after"}
+
+
+def test_poolside_tool_parser_unclosed_markup_cannot_contaminate_next_request():
+    parser_class = ToolParserManager.get_tool_parser("poolside_v1")
+    malformed = parser_class()
+    clean_request = parser_class()
+    output = "<tool_call>unknown<arg_key>path</arg_key>"
+
+    assert (
+        malformed.extract_tool_calls_streaming("", output, output, request=_request())
+        is None
+    )
+    assert clean_request.extract_tool_calls_streaming(
+        "", "visible", "visible", request=_request()
+    ) == {"content": "visible"}
+
+
+def test_poolside_tool_parser_streams_long_string_argument_incrementally():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    chunks = [
+        "<tool_call>write_file<arg_key>content</arg_key><arg_value>abc",
+        "def",
+        "</arg_value></tool_call>",
+    ]
+    accumulated = ""
+    fragments = []
+    for chunk in chunks:
+        previous = accumulated
+        accumulated += chunk
+        delta = parser.extract_tool_calls_streaming(
+            previous, accumulated, chunk, request=_request()
+        )
+        if delta and delta.get("tool_calls"):
+            fragments.extend(
+                call["function"]["arguments"] for call in delta["tool_calls"]
+            )
+
+    assert json.loads("".join(fragments)) == {"content": "abcdef"}
+
+
+def test_poolside_parser_fifty_fifty_valid_malformed_coercion():
+    parser = ToolParserManager.get_tool_parser("poolside_v1")()
+    accepted = 0
+    rejected = 0
+
+    for index in range(50):
+        output = (
+            "<tool_call>write_file"
+            f"<arg_key>path</arg_key><arg_value>file-{index}.py</arg_value>"
+            f"<arg_key>line</arg_key><arg_value>{index}</arg_value>"
+            "</tool_call>"
+        )
+        result = parser.extract_tool_calls(output, _request())
+        accepted += int(result.tools_called)
+        assert json.loads(result.tool_calls[0]["arguments"])["line"] == index
+
+    for index in range(50):
+        output = (
+            f"prefix-{index}<tool_call>unknown"
+            "<arg_key>path</arg_key><arg_value>unsafe</arg_value>"
+        )
+        result = parser.extract_tool_calls(output, _request())
+        rejected += int(not result.tools_called and result.content == f"prefix-{index}")
+
+    assert accepted == 50
+    assert rejected == 50

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -831,6 +831,29 @@ class TestHelperFunctions:
         assert isinstance(parser, FakeParser)
         assert parser.tokenizer is FakeEngine.tokenizer
 
+    def test_build_tool_parser_returns_request_local_instances(self, monkeypatch):
+        import vllm_mlx.server as server
+
+        class FakeParser:
+            def __init__(self, tokenizer=None):
+                self.tokenizer = tokenizer
+
+        class FakeEngine:
+            tokenizer = object()
+
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", True)
+        monkeypatch.setattr(server, "_tool_call_parser", "fake")
+        monkeypatch.setattr(server, "_tool_parser_instance", FakeParser())
+
+        first = server._build_tool_parser(FakeEngine())
+        second = server._build_tool_parser(FakeEngine())
+
+        assert isinstance(first, FakeParser)
+        assert isinstance(second, FakeParser)
+        assert first is not second
+        assert first.tokenizer is FakeEngine.tokenizer
+        assert second.tokenizer is FakeEngine.tokenizer
+
     def test_is_mllm_model_patterns(self):
         """Test MLLM model detection patterns."""
         from vllm_mlx.server import is_mllm_model
@@ -2110,8 +2133,9 @@ class TestStreamChatCompletion:
                 pass
 
             def extract_tool_calls_streaming(
-                self, previous_text, current_text, delta_text
+                self, previous_text, current_text, delta_text, request=None
             ):
+                assert request == {"tools": []}
                 if "</tool_call>" in current_text:
                     return {
                         "tool_calls": [
@@ -2223,7 +2247,7 @@ class TestStreamChatCompletion:
                 pass
 
             def extract_tool_calls_streaming(
-                self, previous_text, current_text, delta_text
+                self, previous_text, current_text, delta_text, request=None
             ):
                 if "<tool_call|>" not in current_text:
                     return None
@@ -2335,7 +2359,7 @@ class TestStreamChatCompletion:
                 self.calls.clear()
 
             def extract_tool_calls_streaming(
-                self, previous_text, current_text, delta_text
+                self, previous_text, current_text, delta_text, request=None
             ):
                 self.calls.append((previous_text, current_text, delta_text))
                 return {"content": delta_text}
@@ -3372,7 +3396,7 @@ class TestChatCompletionStreamingModeSwitching:
                 return None
 
             def extract_tool_calls_streaming(
-                self, previous_text, current_text, delta_text
+                self, previous_text, current_text, delta_text, request=None
             ):
                 return {"content": delta_text}
 

--- a/vllm_mlx/reasoning/__init__.py
+++ b/vllm_mlx/reasoning/__init__.py
@@ -81,6 +81,7 @@ def _register_builtin_parsers():
     from .gpt_oss_parser import GptOssReasoningParser
     from .harmony_parser import HarmonyReasoningParser
     from .mistral_parser import MistralReasoningParser
+    from .poolside_v1_parser import PoolsideV1ReasoningParser
     from .qwen3_parser import Qwen3ReasoningParser
 
     register_parser("qwen3", Qwen3ReasoningParser)
@@ -90,6 +91,7 @@ def _register_builtin_parsers():
     register_parser("gemma4", Gemma4ReasoningParser)
     register_parser("glm4", Glm4ReasoningParser)
     register_parser("mistral", MistralReasoningParser)
+    register_parser("poolside_v1", PoolsideV1ReasoningParser)
 
 
 # Register built-in parsers on module load

--- a/vllm_mlx/reasoning/poolside_v1_parser.py
+++ b/vllm_mlx/reasoning/poolside_v1_parser.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reasoning parser for Poolside Laguna models."""
+
+from .qwen3_parser import Qwen3ReasoningParser
+
+
+class PoolsideV1ReasoningParser(Qwen3ReasoningParser):
+    """Parse Laguna's template-injected ``<think>`` reasoning boundary.
+
+    vllm-mlx reasoning parsers receive only the generated assistant text, not
+    prompt-history token IDs. Historical ``</think>`` markers therefore cannot
+    affect this output-scoped parser as they can in token-aware vLLM serving.
+    """

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1102,14 +1102,16 @@ def _build_tool_parser(engine: BaseEngine | None):
     if not _enable_auto_tool_choice or not _tool_call_parser:
         return None
 
-    if _tool_parser_instance is not None:
-        if hasattr(_tool_parser_instance, "reset"):
-            _tool_parser_instance.reset()
-        return _tool_parser_instance
-
-    parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
-    tokenizer = getattr(engine, "tokenizer", None) if engine is not None else None
-    return parser_cls(tokenizer)
+    parser_cls = (
+        type(_tool_parser_instance)
+        if _tool_parser_instance is not None
+        else ToolParserManager.get_tool_parser(_tool_call_parser)
+    )
+    tokenizer = _get_engine_tokenizer(engine if engine is not None else _engine)
+    try:
+        return parser_cls(tokenizer)
+    except TypeError:
+        return parser_cls()
 
 
 def _build_reasoning_parser(engine: BaseEngine | None = None):
@@ -2420,6 +2422,7 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
     engine, chat_request, messages, chat_kwargs = _prepare_streaming_responses_request(
         request
     )
+    tool_request_context = chat_request.model_dump()
 
     response_id = _new_response_item_id("resp")
     sequence = 1
@@ -2534,32 +2537,13 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             sequence += 1
         return events
 
-    if _reasoning_parser:
-        _reasoning_parser.reset_state()
+    reasoning_parser = _build_reasoning_parser(engine)
+    if reasoning_parser:
+        reasoning_parser.reset_state()
 
-    global _tool_parser_instance
-    tool_parser = None
     tool_accumulated_text = ""
     tool_markup_possible = False
-    if _enable_auto_tool_choice and _tool_call_parser:
-        if _tool_parser_instance is None:
-            try:
-                parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
-                tokenizer = None
-                if _engine is not None and hasattr(_engine, "_tokenizer"):
-                    tokenizer = _engine._tokenizer
-                _tool_parser_instance = parser_cls(tokenizer)
-                logger.info(
-                    "Initialized tool call parser for responses streaming: %s",
-                    _tool_call_parser,
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to init tool parser for responses streaming: %s", e
-                )
-        if _tool_parser_instance is not None:
-            tool_parser = _tool_parser_instance
-            tool_parser.reset()
+    tool_parser = _get_streaming_tool_parser(chat_request, engine)
 
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         last_output = output
@@ -2576,8 +2560,8 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if _reasoning_parser and not _thinking_disabled(request, chat_kwargs):
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+        if reasoning_parser and not _thinking_disabled(request, chat_kwargs):
+            delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, raw_accumulated_text, delta_text
             )
             if delta_msg is None:
@@ -2633,12 +2617,12 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             else:
                 if not tool_markup_possible:
                     tool_markup_possible = True
-                tool_result = tool_parser.extract_tool_calls_streaming(
+                tool_accumulated_text, tool_result = _extract_streaming_tool_delta(
+                    tool_parser,
                     tool_accumulated_text,
-                    tool_accumulated_text + delta_text,
                     delta_text,
+                    tool_request_context,
                 )
-                tool_accumulated_text += delta_text
                 if tool_result is None:
                     continue
                 if "tool_calls" in tool_result:
@@ -2986,17 +2970,14 @@ def _get_streaming_tool_parser(
     tokenizer = _get_engine_tokenizer(engine if engine is not None else _engine)
 
     if _enable_auto_tool_choice and _tool_call_parser:
-        if _tool_parser_instance is None:
-            try:
-                _get_or_init_tool_parser(engine)
-            except Exception as e:
-                logger.warning(
-                    "Failed to init tool parser for streaming: %s",
-                    _sanitize_log_text(e, limit=500),
-                )
-                return None
-        _tool_parser_instance.reset()
-        return _tool_parser_instance
+        try:
+            return _build_tool_parser(engine)
+        except Exception as e:
+            logger.warning(
+                "Failed to init tool parser for streaming: %s",
+                _sanitize_log_text(e, limit=500),
+            )
+            return None
 
     if not getattr(request, "tools", None):
         return None
@@ -3009,6 +2990,51 @@ def _get_streaming_tool_parser(
     except Exception as e:
         logger.warning(f"Failed to init generic streaming tool parser: {e}")
         return None
+
+
+def _extract_streaming_tool_delta(
+    parser,
+    previous_text: str,
+    delta_text: str,
+    request_context: dict,
+) -> tuple[str, dict | None]:
+    """Parse one request-local streaming delta and return new accumulated text."""
+    current_text = previous_text + delta_text
+    result = parser.extract_tool_calls_streaming(
+        previous_text,
+        current_text,
+        delta_text,
+        request=request_context,
+    )
+    return current_text, result
+
+
+def _stream_request_metadata(
+    request: ChatCompletionRequest,
+) -> tuple[dict, list | None, bool]:
+    tools = (
+        request.model_dump(include={"tools"}).get("tools") if request.tools else None
+    )
+    include_usage = bool(
+        request.stream_options and request.stream_options.include_usage
+    )
+    return {"tools": tools or []}, tools, include_usage
+
+
+def _parse_streaming_tool_content(
+    parser,
+    accumulated_text: str,
+    delta_text: str,
+    request_context: dict,
+) -> tuple[str, dict | None, bool]:
+    accumulated_text, result = _extract_streaming_tool_delta(
+        parser,
+        accumulated_text,
+        delta_text,
+        request_context,
+    )
+    suppress = result is None or "tool_calls" in result
+    return accumulated_text, result, suppress
 
 
 def _streaming_tool_markup_possible(text: str) -> bool:
@@ -5652,14 +5678,15 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
+    reasoning_parser = _build_reasoning_parser(engine)
     use_reasoning = (
-        _reasoning_parser is not None
+        reasoning_parser is not None
         and not chat_kwargs.get("logits_processors")
         and not _thinking_disabled(openai_request, chat_kwargs)
     )
 
     if use_reasoning:
-        _reasoning_parser.reset_state()
+        reasoning_parser.reset_state()
 
     # Block index tracking: with reasoning parser we use index 0 for
     # thinking and index 1 for text; without parser, index 0 for text.
@@ -5679,10 +5706,10 @@ async def _stream_anthropic_messages(
 
     # Tool call streaming suppression — prevents raw tool markup from leaking
     # as text_delta events. Mirrors the OpenAI streaming path logic.
-    tool_parser = None
     tool_accumulated_text = ""
     tool_markup_possible = False
     tool_parser = _get_streaming_tool_parser(openai_request, engine)
+    tool_request_context = openai_request.model_dump()
 
     try:
         async for output in engine.stream_chat(messages=messages, **chat_kwargs):
@@ -5722,12 +5749,15 @@ async def _stream_anthropic_messages(
                     else:
                         if not tool_markup_possible:
                             tool_markup_possible = True
-                        tool_previous = tool_accumulated_text
-                        tool_accumulated_text += content_to_emit
-                        tool_result = tool_parser.extract_tool_calls_streaming(
-                            tool_previous, tool_accumulated_text, content_to_emit
+                        tool_accumulated_text, tool_result, suppress_tool_text = (
+                            _parse_streaming_tool_content(
+                                tool_parser,
+                                tool_accumulated_text,
+                                content_to_emit,
+                                tool_request_context,
+                            )
                         )
-                        if tool_result is None or "tool_calls" in tool_result:
+                        if suppress_tool_text:
                             # Inside tool markup or tool calls detected — suppress
                             continue
                         content_to_emit = tool_result.get("content", "")
@@ -5744,7 +5774,8 @@ async def _stream_anthropic_messages(
             # Reasoning parser path
             previous_text = accumulated_text
             accumulated_text += filtered
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+            assert reasoning_parser is not None
+            delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, accumulated_text, filtered
             )
 
@@ -5772,12 +5803,15 @@ async def _stream_anthropic_messages(
                     else:
                         if not tool_markup_possible:
                             tool_markup_possible = True
-                        tool_previous = tool_accumulated_text
-                        tool_accumulated_text += content_to_emit
-                        tool_result = tool_parser.extract_tool_calls_streaming(
-                            tool_previous, tool_accumulated_text, content_to_emit
+                        tool_accumulated_text, tool_result, suppress_tool_text = (
+                            _parse_streaming_tool_content(
+                                tool_parser,
+                                tool_accumulated_text,
+                                content_to_emit,
+                                tool_request_context,
+                            )
                         )
-                        if tool_result is None or "tool_calls" in tool_result:
+                        if suppress_tool_text:
                             # Inside tool markup or tool calls detected — suppress
                             continue
                         content_to_emit = tool_result.get("content", "")
@@ -5975,14 +6009,7 @@ async def stream_chat_completion(
     # Tools schema for argument coercion is invariant for the request;
     # compute once instead of model_dump()-ing the whole request on every
     # tool-call delta during streaming.
-    tools_dict = (
-        request.model_dump(include={"tools"}).get("tools")
-        if request and request.tools
-        else None
-    )
-
-    # Check if we should include usage in the final chunk
-    include_usage = request.stream_options and request.stream_options.include_usage
+    tool_request_context, tools_dict, include_usage = _stream_request_metadata(request)
 
     # First chunk with role
     first_chunk = ChatCompletionChunk(
@@ -5998,14 +6025,15 @@ async def stream_chat_completion(
 
     # Track if we need to add <think> prefix for thinking models (when no reasoning parser)
     # The template adds <think> to the prompt, so the model output starts inside the think block
+    reasoning_parser = _build_reasoning_parser(engine)
     is_thinking_model = (
-        "nemotron" in (engine.model_name or "").lower() and not _reasoning_parser
+        "nemotron" in (engine.model_name or "").lower() and not reasoning_parser
     )
     think_prefix_sent = False
 
     # Reset reasoning parser state for this stream
-    if _reasoning_parser:
-        _reasoning_parser.reset_state()
+    if reasoning_parser:
+        reasoning_parser.reset_state()
 
     # Track accumulated text for reasoning parser
     accumulated_text = ""
@@ -6055,13 +6083,13 @@ async def stream_chat_completion(
             # is set either on the request or via the resolved chat template
             # kwargs / server default).
             if (
-                _reasoning_parser
+                reasoning_parser
                 and delta_text
                 and not _thinking_disabled(request, kwargs)
             ):
                 previous_text = accumulated_text
                 accumulated_text += delta_text
-                delta_msg = _reasoning_parser.extract_reasoning_streaming(
+                delta_msg = reasoning_parser.extract_reasoning_streaming(
                     previous_text, accumulated_text, delta_text
                 )
 
@@ -6098,10 +6126,13 @@ async def stream_chat_completion(
                     else:
                         if not tool_markup_possible:
                             tool_markup_possible = True
-                        tool_previous = tool_accumulated_text
-                        tool_accumulated_text += content
-                        tool_result = tool_parser.extract_tool_calls_streaming(
-                            tool_previous, tool_accumulated_text, content
+                        tool_accumulated_text, tool_result = (
+                            _extract_streaming_tool_delta(
+                                tool_parser,
+                                tool_accumulated_text,
+                                content,
+                                tool_request_context,
+                            )
                         )
 
                         if tool_result is None:
@@ -6217,10 +6248,13 @@ async def stream_chat_completion(
                     else:
                         if not tool_markup_possible:
                             tool_markup_possible = True
-                        tool_previous = tool_accumulated_text
-                        tool_accumulated_text += delta_text
-                        tool_result = tool_parser.extract_tool_calls_streaming(
-                            tool_previous, tool_accumulated_text, delta_text
+                        tool_accumulated_text, tool_result = (
+                            _extract_streaming_tool_delta(
+                                tool_parser,
+                                tool_accumulated_text,
+                                delta_text,
+                                tool_request_context,
+                            )
                         )
 
                         if tool_result is None:
@@ -6297,7 +6331,9 @@ async def stream_chat_completion(
             and not tool_calls_detected
             and _streaming_tool_markup_possible(tool_accumulated_text)
         ):
-            final_parse_result = tool_parser.extract_tool_calls(tool_accumulated_text)
+            final_parse_result = tool_parser.extract_tool_calls(
+                tool_accumulated_text, tool_request_context
+            )
             if final_parse_result.tools_called:
                 tool_chunk = ChatCompletionChunk(
                     id=response_id,

--- a/vllm_mlx/tool_parsers/__init__.py
+++ b/vllm_mlx/tool_parsers/__init__.py
@@ -57,6 +57,7 @@ from .llama_tool_parser import LlamaToolParser
 from .mistral_tool_parser import MistralToolParser
 from .nemotron_tool_parser import NemotronToolParser
 from .qwen_tool_parser import QwenToolParser
+from .poolside_v1_tool_parser import PoolsideV1ToolParser
 from .xlam_tool_parser import xLAMToolParser
 from .glm47_tool_parser import Glm47ToolParser
 from .harmony_tool_parser import HarmonyToolParser
@@ -99,6 +100,7 @@ __all__ = [
     "Gemma4ToolParser",
     "MistralToolParser",
     "QwenToolParser",
+    "PoolsideV1ToolParser",
     "Qwen3XMLToolParser",
     "LlamaToolParser",
     "HermesToolParser",

--- a/vllm_mlx/tool_parsers/poolside_v1_tool_parser.py
+++ b/vllm_mlx/tool_parsers/poolside_v1_tool_parser.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool parser for the Poolside v1 Laguna chat-template format."""
+
+import json
+import re
+from collections.abc import Sequence
+from typing import Any
+
+from .abstract_tool_parser import (
+    ExtractedToolCallInformation,
+    ToolParserManager,
+)
+from .glm47_tool_parser import Glm47ToolParser, generate_tool_id
+
+
+def _consume_stream_state(
+    parser,
+    pending: dict[int, dict[str, Any]],
+    valid_names: set[str],
+    request: dict[str, Any] | None,
+) -> tuple[bool, str]:
+    if not parser._in_tool_call:
+        return parser._consume_text_before_tool()
+    if parser._current_tool_name is None:
+        return parser._consume_tool_name(pending, valid_names), ""
+    if parser._streaming_string_value:
+        return parser._consume_string_value(pending), ""
+    if parser._pending_key is not None:
+        return parser._consume_pending_key(pending, request), ""
+    return parser._consume_tool_body(pending), ""
+
+
+@ToolParserManager.register_module("poolside_v1")
+class PoolsideV1ToolParser(Glm47ToolParser):
+    """Parse Laguna tool calls and stream schema-declared strings incrementally."""
+
+    _UNCLOSED_TOOL_CALL = re.compile(r"<tool_call>.*$", re.DOTALL)
+    _START = "<tool_call>"
+    _END = "</tool_call>"
+    _KEY_START = "<arg_key>"
+    _KEY_END = "</arg_key>"
+    _VALUE_START = "<arg_value>"
+    _VALUE_END = "</arg_value>"
+
+    def __init__(self, tokenizer=None):
+        super().__init__(tokenizer)
+        self.reset()
+
+    def reset(self) -> None:
+        super().reset()
+        self._buffer = ""
+        self._in_tool_call = False
+        self._current_tool_name: str | None = None
+        self._pending_key: str | None = None
+        self._streaming_string_value = False
+        self._reject_current = False
+        self._tool_ids: list[str] = []
+        self._args_started: list[bool] = []
+        self._args_closed: list[bool] = []
+        self._seen_keys: list[set[str]] = []
+
+    @staticmethod
+    def _string_argument_names(
+        request: dict[str, Any] | None, tool_name: str
+    ) -> set[str]:
+        if request is None:
+            return set()
+        for tool in request.get("tools", []):
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            if not isinstance(function, dict) or function.get("name") != tool_name:
+                continue
+            parameters = function.get("parameters")
+            properties = (
+                parameters.get("properties", {}) if isinstance(parameters, dict) else {}
+            )
+            return {
+                name
+                for name, schema in properties.items()
+                if isinstance(schema, dict) and schema.get("type") == "string"
+            }
+        return set()
+
+    @staticmethod
+    def _escape_string_content(value: str) -> str:
+        return json.dumps(value, ensure_ascii=False)[1:-1]
+
+    @staticmethod
+    def _hold_partial_suffix(buffer: str, marker: str) -> tuple[str, str]:
+        for size in range(min(len(marker) - 1, len(buffer)), 0, -1):
+            if buffer.endswith(marker[:size]):
+                return buffer[:-size], buffer[-size:]
+        return buffer, ""
+
+    def extract_tool_calls(
+        self, model_output: str, request: dict[str, Any] | None = None
+    ) -> ExtractedToolCallInformation:
+        cleaned_text = self.strip_think_tags(model_output)
+        valid_names = self._get_tool_names(request)
+        tool_calls: list[dict[str, Any]] = []
+
+        for match in self.FUNC_DETAIL_PATTERN.finditer(cleaned_text):
+            tool_name = match.group(1).strip()
+            if not tool_name or (valid_names and tool_name not in valid_names):
+                continue
+            string_arguments = self._string_argument_names(request, tool_name)
+            arguments: dict[str, Any] = {}
+            for raw_key, raw_value in self.ARG_PATTERN.findall(match.group(2) or ""):
+                key = raw_key.strip()
+                if not key or key in arguments:
+                    continue
+                arguments[key] = (
+                    raw_value
+                    if key in string_arguments
+                    else self._deserialize(raw_value.strip())
+                )
+            tool_calls.append(
+                {
+                    "id": generate_tool_id(),
+                    "name": tool_name,
+                    "arguments": json.dumps(arguments, ensure_ascii=False),
+                }
+            )
+
+        marker = cleaned_text.find(self._START)
+        content = cleaned_text[:marker] if marker >= 0 else cleaned_text
+        content = content.strip() or None
+        if tool_calls:
+            return ExtractedToolCallInformation(True, tool_calls, content)
+
+        if marker >= 0:
+            content = self._UNCLOSED_TOOL_CALL.sub("", cleaned_text).strip() or None
+        return ExtractedToolCallInformation(False, [], content)
+
+    def _begin_tool_call(self) -> None:
+        self.current_tool_id += 1
+        self._tool_ids.append(generate_tool_id())
+        self._args_started.append(False)
+        self._args_closed.append(False)
+        self._seen_keys.append(set())
+        self._in_tool_call = True
+        self._current_tool_name = None
+        self._pending_key = None
+        self._streaming_string_value = False
+        self._reject_current = False
+
+    def _finish_tool_call(self) -> None:
+        self._in_tool_call = False
+        self._current_tool_name = None
+        self._pending_key = None
+        self._streaming_string_value = False
+        self._reject_current = False
+
+    def _delta(
+        self,
+        pending: dict[int, dict[str, Any]],
+        *,
+        name: str | None = None,
+        arguments: str = "",
+    ) -> None:
+        if self._reject_current:
+            return
+        delta = pending.setdefault(
+            self.current_tool_id,
+            {
+                "index": self.current_tool_id,
+                "id": self._tool_ids[self.current_tool_id],
+                "type": "function",
+                "function": {"arguments": ""},
+            },
+        )
+        if name is not None:
+            delta["function"]["name"] = name
+        delta["function"]["arguments"] += arguments
+
+    def _argument_prefix(self, key: str) -> str | None:
+        seen = self._seen_keys[self.current_tool_id]
+        if not key or key in seen:
+            return None
+        seen.add(key)
+        separator = "{" if not self._args_started[self.current_tool_id] else ", "
+        self._args_started[self.current_tool_id] = True
+        return separator + json.dumps(key, ensure_ascii=False) + ": "
+
+    def _close_arguments(self) -> str:
+        if self._args_closed[self.current_tool_id]:
+            return ""
+        self._args_closed[self.current_tool_id] = True
+        return "}" if self._args_started[self.current_tool_id] else "{}"
+
+    def _discard_through_tool_end(self) -> bool:
+        end = self._buffer.find(self._END)
+        if end < 0:
+            return False
+        self._buffer = self._buffer[end + len(self._END) :]
+        self._finish_tool_call()
+        return True
+
+    def _consume_text_before_tool(self) -> tuple[bool, str]:
+        """Consume plain text or enter the next ``<tool_call>`` state."""
+        start = self._buffer.find(self._START)
+        if start < 0:
+            emitted, self._buffer = self._hold_partial_suffix(self._buffer, self._START)
+            return False, emitted
+
+        content = self._buffer[:start]
+        self._buffer = self._buffer[start + len(self._START) :]
+        self._begin_tool_call()
+        return True, content
+
+    def _consume_tool_name(
+        self,
+        pending: dict[int, dict[str, Any]],
+        valid_names: set[str],
+    ) -> bool:
+        """Consume a tool name, or wait for enough input to identify it."""
+        positions = [
+            position
+            for position in (
+                self._buffer.find("\n"),
+                self._buffer.find(self._KEY_START),
+                self._buffer.find(self._END),
+            )
+            if position >= 0
+        ]
+        if not positions:
+            return False
+
+        cut = min(positions)
+        tool_name = self._buffer[:cut].strip()
+        if self._buffer.startswith("\n", cut):
+            self._buffer = self._buffer[cut + 1 :]
+        else:
+            self._buffer = self._buffer[cut:]
+
+        if not tool_name or (valid_names and tool_name not in valid_names):
+            self._reject_current = True
+            return self._discard_through_tool_end()
+
+        self._current_tool_name = tool_name
+        self._delta(pending, name=tool_name)
+        return True
+
+    def _consume_string_value(self, pending: dict[int, dict[str, Any]]) -> bool:
+        """Consume a string argument value, retaining incomplete suffixes."""
+        value_end = self._buffer.find(self._VALUE_END)
+        if value_end >= 0:
+            fragment = self._escape_string_content(self._buffer[:value_end])
+            self._buffer = self._buffer[value_end + len(self._VALUE_END) :]
+            self._delta(pending, arguments=fragment + '"')
+            self._streaming_string_value = False
+            self._pending_key = None
+            return True
+
+        if self._END in self._buffer:
+            self._reject_current = True
+            return self._discard_through_tool_end()
+
+        emitted, self._buffer = self._hold_partial_suffix(self._buffer, self._VALUE_END)
+        if emitted:
+            self._delta(pending, arguments=self._escape_string_content(emitted))
+        return False
+
+    def _consume_pending_key(
+        self,
+        pending: dict[int, dict[str, Any]],
+        request: dict[str, Any] | None,
+    ) -> bool:
+        """Consume the value for the currently buffered argument key."""
+        value_start = self._buffer.find(self._VALUE_START)
+        if value_start < 0:
+            if self._END in self._buffer:
+                self._reject_current = True
+                return self._discard_through_tool_end()
+            return False
+
+        self._buffer = self._buffer[value_start + len(self._VALUE_START) :]
+        key = self._pending_key.strip() if self._pending_key is not None else ""
+        prefix = self._argument_prefix(key)
+        if prefix is None:
+            self._pending_key = None
+            return True
+
+        string_names = self._string_argument_names(request, self._current_tool_name)
+        if key in string_names:
+            self._delta(pending, arguments=prefix + '"')
+            self._streaming_string_value = True
+            return True
+
+        value_end = self._buffer.find(self._VALUE_END)
+        if value_end < 0:
+            self._buffer = self._VALUE_START + self._buffer
+            return False
+
+        raw_value = self._buffer[:value_end].strip()
+        self._buffer = self._buffer[value_end + len(self._VALUE_END) :]
+        self._pending_key = None
+        value = json.dumps(self._deserialize(raw_value), ensure_ascii=False)
+        self._delta(pending, arguments=prefix + value)
+        return True
+
+    def _consume_tool_body(self, pending: dict[int, dict[str, Any]]) -> bool:
+        """Consume an argument key or close the current tool call."""
+        tool_end = self._buffer.find(self._END)
+        key_start = self._buffer.find(self._KEY_START)
+        if tool_end >= 0 and (key_start < 0 or tool_end < key_start):
+            self._buffer = self._buffer[tool_end + len(self._END) :]
+            self._delta(pending, arguments=self._close_arguments())
+            self._finish_tool_call()
+            return True
+
+        if key_start < 0:
+            return False
+
+        self._buffer = self._buffer[key_start + len(self._KEY_START) :]
+        key_end = self._buffer.find(self._KEY_END)
+        if key_end < 0:
+            self._buffer = self._KEY_START + self._buffer
+            return False
+
+        self._pending_key = self._buffer[:key_end]
+        self._buffer = self._buffer[key_end + len(self._KEY_END) :]
+        return True
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int] | None = None,
+        current_token_ids: Sequence[int] | None = None,
+        delta_token_ids: Sequence[int] | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        del previous_text, current_text, previous_token_ids, current_token_ids
+        del delta_token_ids
+        self._buffer += delta_text
+        pending: dict[int, dict[str, Any]] = {}
+        content = ""
+        valid_names = self._get_tool_names(request)
+
+        while True:
+            keep_parsing, emitted = _consume_stream_state(
+                self, pending, valid_names, request
+            )
+            content += emitted
+            if not keep_parsing:
+                break
+
+        payload: dict[str, Any] = {}
+        if content:
+            payload["content"] = content
+        if pending:
+            payload["tool_calls"] = list(pending.values())
+        return payload or None


### PR DESCRIPTION
# PR: Add request-local Poolside v1 parsers

## Problem

Laguna's provider serving recipe requires `poolside_v1` tool and reasoning
parsers. Current `vllm-mlx` main does not provide them, so a user cannot expose
the provider's OpenAI-compatible tool/reasoning contract through the normal
server flags.

## Reproduction

Start the current server with `--tool-call-parser poolside_v1` or
`--reasoning-parser poolside_v1`. The parser names are unavailable. Parsing
recorded Laguna direct, tool, and streamed post-tool output also has no
provider-specific implementation.

## Upstream comparison

Compared `waybarrios/vllm-mlx` main
`0dd115769ef1196a715b96b181353edacd2a4f69`:

- `vllm_mlx/reasoning/**`
- `vllm_mlx/tool_parsers/**`
- `vllm_mlx/server.py`

## Change

- Add `poolside_v1` reasoning and tool parsers.
- Register both parser names.
- Construct parser state per request so incremental streams cannot share state.
- Add direct, tool-call, argument-fragment, and post-tool streaming tests.

## Validation

Focused current-upstream suite: 129 passed.

## Not claimed

This does not add Laguna model loading, DFlash, local Runtime modes, or a model
quality conclusion.
