### PR TITLE
feat: define versioned model profile contract

### DIFF
--- a/docs/development/model-profile-v1.md
+++ b/docs/development/model-profile-v1.md
@@ -1,0 +1,191 @@
+# ModelProfile v1
+
+Status: P1.2 design
+Schema: `schemas/model-profile-v1.schema.json`
+Runtime wiring: none in P1.2
+
+## Purpose
+
+`ModelProfile` is the immutable, versioned input that identifies one model
+artifact and its supported serving behavior. It connects artifact provenance,
+model capabilities, serving defaults, hardware-fit recommendations, and
+qualification evidence without making transient process state part of the
+catalog.
+
+P1.2 defines the contract only. Existing CLI, registry, lifecycle, generation,
+and API behavior must remain unchanged until compatibility mapping and tests are
+implemented in P1.3 and P1.4.
+
+## Documents And State
+
+The product requires four distinct documents:
+
+| Document | Mutability | Responsibility |
+|---|---|---|
+| `ModelProfile` | Immutable per `profile_revision` | Reviewed model/artifact facts and supported serving configuration |
+| Activation request | Local, user-controlled | Selected profile plus permitted advanced overrides |
+| Effective serving configuration | Generated, immutable per launch | Fully resolved values, source of every value, subject digest, overrides, and runtime version |
+| Installation record | Local, mutable | Artifact path, installation health, and last verification time |
+
+P1.2 defines only the profile schema. P1.3 may introduce a bounded legacy-import
+result plus typed activation, effective-configuration, and installation records
+when it maps current producers and consumers. Local paths, live PID, health,
+request counts, and loaded/unloaded state do not belong in `ModelProfile`.
+
+## Four Truth Layers
+
+1. **Provider facts** come from an exact repository revision and hashed config,
+   tokenizer, template, generation config, or model card.
+2. **Derived recommendations** come from a named, versioned resolver rule and
+   identify their source inputs.
+3. **Measured results** bind qualification evidence to the subject digest,
+   hardware fingerprint, workload, and result.
+4. **User overrides** remain outside the immutable profile. Activation overrides
+   require `serving.activation_policy.owner_override_fields`; request-time
+   values require `serving.request_policy.allowed_fields`.
+
+`provenance.records` associates JSON Pointer field paths with the first three
+layers. User overrides are recorded in the effective serving configuration.
+
+## Identity
+
+The schema separates concepts that are currently conflated:
+
+- `repository_id`: provider repository when one exists.
+- `requested_revision`: user-facing tag, branch, or commit request.
+- `resolved_revision`: immutable provider revision when available.
+- `artifact_id`: stable identity for the converted/downloaded artifact.
+- `served_model_name`: canonical API name.
+- `aliases`: optional additional API names.
+
+Catalog profiles for provider-hosted artifacts require an immutable resolved
+revision. Every profile binds config, tokenizer, template, and weights-manifest
+hashes. Local-only artifacts may leave repository fields null but still require
+an `artifact_id`, source URI, and the same artifact hashes.
+
+`subject_digest` is SHA-256 over RFC 8785 canonical JSON containing identity,
+artifact, capabilities, serving, hardware fit, and provenance. It excludes
+`profile_id`, `profile_revision`, `description`, `qualification`, and
+`extensions`. This avoids a recursive evidence digest while binding each
+qualification run to exactly the behavior and artifact under test.
+
+## Serving Contract
+
+The serving section records:
+
+- selected engine and route;
+- template source, hash, and default kwargs;
+- tool and reasoning parser names;
+- provider and profile sampling defaults;
+- advertised context, serving context, output limits, and KV size;
+- feature mode and feature-specific settings;
+- activation overrides plus required, allowed, and forbidden request fields.
+
+The v1 feature vocabulary is closed: continuous batching, constrained JSON,
+KVQ4, KVQ8, MTP, prefix cache, SpecPrefill, and streaming. New semantics require
+a schema revision; namespaced extensions cannot change resolver behavior.
+
+Feature mode and control scope are explicit per profile:
+
+- `enabled_by_default`
+- `available_on_activation`
+- `available_per_request`
+- `diagnostic_only`
+- `guarded_off`
+- `deferred`
+- `not_supported`
+
+An activation-controlled feature names a typed activation field. A
+request-controlled feature names a typed request field. This representation
+prevents a feature proven for one artifact/profile from silently becoming a
+model-family-wide claim or being toggled through the wrong lifecycle boundary.
+
+## Precedence
+
+The effective serving configuration must resolve values in this order:
+
+1. Non-overridable advertised limits, required fields, and guarded-off behavior.
+2. User activation overrides explicitly listed in
+   `activation_policy.owner_override_fields`.
+3. Profile serving defaults and enabled feature settings.
+4. Provider defaults recorded in the profile.
+5. Runtime fallback only when the schema permits the field to be absent.
+
+Request-time values use the closed v1 request-field vocabulary and must pass
+`request_policy`. They cannot change immutable identity, activation settings,
+parsers, template hash, route, engine, qualification, or provenance.
+
+Permitted activation limit overrides remain bounded by the immutable advertised
+limit and the relationships below. Precedence is field-specific where values
+interact. In particular:
+
+- `serving_context` must not exceed `advertised_context`.
+- `max_output_tokens` and `max_request_output_tokens` must not exceed
+  `serving_context`.
+- `max_kv_size`, when present, must support the selected serving context or the
+  resolver must explain the reduced context.
+- Required and forbidden request fields must be disjoint.
+- Every feature control must name a field in the matching activation or request
+  vocabulary and agree with the relevant policy.
+- Required and allowed request fields must be disjoint from forbidden fields.
+- Activation overrides are limited to the schema's activation-field vocabulary;
+  identity, parser, template, route, and engine are not members.
+- `qualified` requires at least one passing evidence artifact with its own hash,
+  hardware fingerprint, workload ID, and matching subject digest.
+
+JSON Schema enforces shape, hosted identity, evidence completeness, closed field
+vocabularies, and passing evidence for `qualified`. P1.4 semantic validation
+must enforce digest equality, set disjointness, feature-policy linkage, context
+and KV relationships, and provenance coverage for optional sections.
+
+P1.4 will implement those semantic checks in a standalone model-profile module
+without importing serving code. That implementation must use RFC 8785
+canonical JSON rather than relying on Python dictionary order or an
+approximate sorted-key encoding. It must also reject inactive feature modes
+that expose request or activation controls and collect deterministic failures
+before raising its validation error.
+
+## Legacy Import Envelope
+
+P1.3 will define `schemas/model-profile-import-result-v1.schema.json` as the
+only compatibility output allowed to contain an incomplete profile fragment.
+It must record exact source files, stable issue codes, affected pointers,
+severity, and conflicts. `complete=true` will be valid only when `profile`
+validates as a full ModelProfile; otherwise the result remains an import report
+and cannot be activated or qualified. Missing values remain issues; importers
+must not synthesize parser, template, capability, context, or qualification
+facts from model names.
+
+## Compatibility Mapping Required Before Runtime Wiring
+
+P1.3 must map existing sources without changing their current behavior:
+
+| Existing source | Initial profile destination |
+|---|---|
+| Acquisition manifest | identity, artifact source, repository revision, hashes |
+| Conversion manifest | artifact format, quantization, conversion provenance |
+| Registration manifest | served name, template defaults, parsers, sampling, declared features |
+| Registry YAML | engine/route feature settings, memory estimates, aliases |
+| CLI/server defaults | maintainer-policy provenance and compatibility fallback |
+| Qualification output | qualification evidence and measured hardware fit |
+
+When sources disagree, P1.3 must report the conflict. It must not silently pick
+the most recent file or treat registration/qualification booleans as proof.
+
+## Versioning
+
+- `schema_version` changes only for an incompatible schema change.
+- `profile_revision` increments for any changed fact, recommendation, default,
+  feature mode, request policy, or evidence set.
+- Qualification evidence binds to the canonical subject digest, not merely a
+  profile ID.
+- Experimental fields belong under namespaced `extensions` and cannot alter v1
+  semantics.
+
+## Explicit Non-Goals
+
+- No runtime, model, API, parser, template, sampling, or feature behavior change.
+- No automatic promotion from benchmark success to `qualified`.
+- No arbitrary model-name inference in the profile contract.
+- No live process or lease state in the profile.
+- No desktop application state in the profile.

--- a/schemas/examples/model-profile-v1.example.json
+++ b/schemas/examples/model-profile-v1.example.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": 1,
+  "profile_id": "example-text-model-default",
+  "profile_revision": 1,
+  "subject_digest": "c1cbd492f88014504d4e28db4541169498945b831c6d11ba937a1d6495a29ade",
+  "description": "Non-production example for schema validation.",
+  "identity": {
+    "provider": "huggingface",
+    "repository_id": "example-org/example-model",
+    "requested_revision": "main",
+    "resolved_revision": "0123456789abcdef0123456789abcdef01234567",
+    "artifact_id": "example-model-mlx-q4",
+    "served_model_name": "example-model",
+    "aliases": []
+  },
+  "artifact": {
+    "source_uri": "https://huggingface.co/example-org/example-model",
+    "format": "mlx",
+    "model_type": "example",
+    "architectures": ["ExampleForCausalLM"],
+    "dtype": "float16",
+    "size_bytes": 4294967296,
+    "quantization": {
+      "method": "affine",
+      "bits": 4,
+      "group_size": 64,
+      "mode": "affine",
+      "source": "conversion_manifest"
+    },
+    "hashes": {
+      "config_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "tokenizer_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "chat_template_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "weights_manifest_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
+  "capabilities": {
+    "modalities": ["text"],
+    "streaming": true,
+    "tools": { "supported": false, "format": null, "notes": null },
+    "reasoning": { "supported": false, "format": null, "notes": null },
+    "structured_output": {
+      "json_object": false,
+      "json_schema": false,
+      "supported_schema_keywords": []
+    },
+    "api_surfaces": ["openai_chat", "anthropic_messages"]
+  },
+  "serving": {
+    "engine": "simple",
+    "route": "text",
+    "template": {
+      "source": "tokenizer",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "default_kwargs": {}
+    },
+    "parsers": { "tool": null, "reasoning": null },
+    "sampling": {
+      "provider_defaults": { "temperature": 0.7, "top_p": 0.9 },
+      "profile_defaults": { "temperature": 0.7, "top_p": 0.9 }
+    },
+    "limits": {
+      "advertised_context": 32768,
+      "serving_context": 32768,
+      "max_output_tokens": 4096,
+      "max_request_output_tokens": 4096,
+      "max_kv_size": 32768
+    },
+    "features": {
+      "continuous_batching": {
+        "mode": "available_on_activation",
+        "control": "activation",
+        "control_field": "features.continuous_batching",
+        "settings": { "max_concurrency": 1 },
+        "reason": null
+      },
+      "constrained_json": {
+        "mode": "not_supported",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not supported by this example"
+      },
+      "kvq4": {
+        "mode": "not_supported",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not supported by this example"
+      },
+      "kvq8": {
+        "mode": "not_supported",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not supported by this example"
+      },
+      "mtp": {
+        "mode": "not_supported",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not supported by this example"
+      },
+      "prefix_cache": {
+        "mode": "guarded_off",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not qualified in this example"
+      },
+      "specprefill": {
+        "mode": "not_supported",
+        "control": "none",
+        "control_field": null,
+        "settings": {},
+        "reason": "Not supported by this example"
+      },
+      "streaming": {
+        "mode": "available_per_request",
+        "control": "request",
+        "control_field": "stream",
+        "settings": {},
+        "reason": null
+      }
+    },
+    "activation_policy": {
+      "owner_override_fields": ["features.continuous_batching", "limits.max_output_tokens"]
+    },
+    "request_policy": {
+      "required_fields": {},
+      "allowed_fields": ["temperature", "top_p", "max_tokens", "stream"],
+      "forbidden_fields": []
+    }
+  },
+  "hardware_fit": [
+    {
+      "hardware_class": "apple-silicon-16gb",
+      "method": "derived",
+      "estimated_peak_memory_bytes": 6442450944,
+      "measured_peak_memory_bytes": null,
+      "serving_context": 32768,
+      "max_concurrency": 1,
+      "notes": "Example only"
+    }
+  ],
+  "qualification": {
+    "status": "not_qualified",
+    "reason": "Example profile",
+    "evidence": []
+  },
+  "provenance": {
+    "records": [
+      {
+        "field_paths": ["/identity", "/artifact", "/serving/sampling/provider_defaults"],
+        "kind": "provider_fact",
+        "source": "https://huggingface.co/example-org/example-model",
+        "revision": "0123456789abcdef0123456789abcdef01234567",
+        "sha256": null,
+        "rule_id": null,
+        "observed_at": "2026-07-21T00:00:00Z"
+      },
+      {
+        "field_paths": [
+          "/capabilities",
+          "/serving/engine",
+          "/serving/route",
+          "/serving/template",
+          "/serving/parsers",
+          "/serving/sampling/profile_defaults",
+          "/serving/limits",
+          "/serving/features",
+          "/serving/activation_policy",
+          "/serving/request_policy",
+          "/hardware_fit"
+        ],
+        "kind": "derived_recommendation",
+        "source": "vllm-mlx-profile-resolver",
+        "revision": "1",
+        "sha256": null,
+        "rule_id": "example-rule-v1",
+        "observed_at": "2026-07-21T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/schemas/model-profile-v1.schema.json
+++ b/schemas/model-profile-v1.schema.json
@@ -1,0 +1,565 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://waybarrios.github.io/vllm-mlx/schemas/model-profile-v1.schema.json",
+  "title": "vllm-mlx ModelProfile v1",
+  "description": "Immutable model and serving profile with explicit provenance and qualification evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "profile_id",
+    "profile_revision",
+    "subject_digest",
+    "identity",
+    "artifact",
+    "capabilities",
+    "serving",
+    "qualification",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "profile_id": { "$ref": "#/$defs/non_empty_string" },
+    "profile_revision": { "type": "integer", "minimum": 1 },
+    "subject_digest": { "$ref": "#/$defs/sha256" },
+    "description": { "type": "string" },
+    "identity": { "$ref": "#/$defs/identity" },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "capabilities": { "$ref": "#/$defs/capabilities" },
+    "serving": { "$ref": "#/$defs/serving" },
+    "hardware_fit": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/hardware_fit" }
+    },
+    "qualification": { "$ref": "#/$defs/qualification" },
+    "provenance": { "$ref": "#/$defs/provenance" },
+    "extensions": {
+      "type": "object",
+      "description": "Namespaced experimental data that cannot alter v1 semantics.",
+      "propertyNames": { "pattern": "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$" },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{64}$"
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "artifact_id", "served_model_name"],
+      "properties": {
+        "provider": { "type": "string", "enum": ["huggingface", "local", "other"] },
+        "repository_id": { "type": ["string", "null"] },
+        "requested_revision": { "type": ["string", "null"] },
+        "resolved_revision": { "type": ["string", "null"] },
+        "artifact_id": { "$ref": "#/$defs/non_empty_string" },
+        "served_model_name": { "$ref": "#/$defs/non_empty_string" },
+        "aliases": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/non_empty_string" },
+          "uniqueItems": true
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "provider": { "const": "huggingface" } } },
+          "then": {
+            "required": ["repository_id", "resolved_revision"],
+            "properties": {
+              "repository_id": { "$ref": "#/$defs/non_empty_string" },
+              "resolved_revision": { "type": "string", "pattern": "^[a-fA-F0-9]{40,64}$" }
+            }
+          }
+        }
+      ]
+    },
+    "quantization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method"],
+      "properties": {
+        "method": { "$ref": "#/$defs/non_empty_string" },
+        "bits": { "type": ["integer", "null"], "minimum": 1 },
+        "group_size": { "type": ["integer", "null"], "minimum": 1 },
+        "mode": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_uri", "format", "model_type", "architectures", "quantization", "hashes"],
+      "properties": {
+        "source_uri": { "$ref": "#/$defs/non_empty_string" },
+        "format": { "$ref": "#/$defs/non_empty_string" },
+        "model_type": { "$ref": "#/$defs/non_empty_string" },
+        "architectures": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/non_empty_string" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "dtype": { "type": ["string", "null"] },
+        "size_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "quantization": { "$ref": "#/$defs/quantization" },
+        "hashes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["config_sha256", "tokenizer_sha256", "chat_template_sha256", "weights_manifest_sha256"],
+          "properties": {
+            "config_sha256": { "$ref": "#/$defs/sha256" },
+            "tokenizer_sha256": { "$ref": "#/$defs/sha256" },
+            "chat_template_sha256": { "$ref": "#/$defs/sha256" },
+            "generation_config_sha256": { "$ref": "#/$defs/sha256" },
+            "weights_manifest_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported"],
+      "properties": {
+        "supported": { "type": "boolean" },
+        "format": { "type": ["string", "null"] },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["modalities", "streaming", "tools", "reasoning", "structured_output", "api_surfaces"],
+      "properties": {
+        "modalities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["text", "image", "video", "audio"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "streaming": { "type": "boolean" },
+        "tools": { "$ref": "#/$defs/capability" },
+        "reasoning": { "$ref": "#/$defs/capability" },
+        "structured_output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["json_object", "json_schema"],
+          "properties": {
+            "json_object": { "type": "boolean" },
+            "json_schema": { "type": "boolean" },
+            "supported_schema_keywords": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/non_empty_string" },
+              "uniqueItems": true
+            }
+          }
+        },
+        "api_surfaces": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["openai_chat", "openai_responses", "anthropic_messages"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "sampling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "temperature": { "type": "number", "minimum": 0 },
+        "top_p": { "type": "number", "minimum": 0, "maximum": 1 },
+        "top_k": { "type": "integer", "minimum": 0 },
+        "min_p": { "type": "number", "minimum": 0, "maximum": 1 },
+        "presence_penalty": { "type": "number" },
+        "repetition_penalty": { "type": "number", "exclusiveMinimum": 0 },
+        "seed": { "type": ["integer", "null"] }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["advertised_context", "serving_context", "max_output_tokens", "max_request_output_tokens"],
+      "properties": {
+        "advertised_context": { "type": "integer", "minimum": 1 },
+        "serving_context": { "type": "integer", "minimum": 1 },
+        "max_output_tokens": { "type": "integer", "minimum": 1 },
+        "max_request_output_tokens": { "type": "integer", "minimum": 1 },
+        "max_kv_size": { "type": ["integer", "null"], "minimum": 1 }
+      }
+    },
+    "request_field": {
+      "type": "string",
+      "enum": [
+        "chat_template_kwargs.enable_thinking",
+        "chat_template_kwargs.preserve_thinking",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stream",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ]
+    },
+    "activation_field": {
+      "type": "string",
+      "enum": [
+        "features.continuous_batching",
+        "features.kvq4",
+        "features.kvq8",
+        "features.mtp",
+        "features.prefix_cache",
+        "features.specprefill",
+        "limits.max_kv_size",
+        "limits.max_output_tokens",
+        "limits.max_request_output_tokens",
+        "limits.serving_context"
+      ]
+    },
+    "feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "control"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["enabled_by_default", "available_on_activation", "available_per_request", "diagnostic_only", "guarded_off", "deferred", "not_supported"]
+        },
+        "control": { "type": "string", "enum": ["activation", "request", "none"] },
+        "control_field": {
+          "oneOf": [
+            { "$ref": "#/$defs/activation_field" },
+            { "$ref": "#/$defs/request_field" },
+            { "type": "null" }
+          ]
+        },
+        "settings": {
+          "type": "object",
+          "propertyNames": {
+            "enum": ["bits", "cache_memory_mb", "cache_type", "draft_model", "group_size", "max_concurrency", "num_draft_tokens"]
+          },
+          "additionalProperties": { "type": ["boolean", "integer", "number", "string", "null"] }
+        },
+        "reason": { "type": ["string", "null"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "control": { "const": "activation" } } },
+          "then": {
+            "required": ["control_field"],
+            "properties": {
+              "control_field": { "$ref": "#/$defs/activation_field" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "control": { "const": "request" } } },
+          "then": {
+            "required": ["control_field"],
+            "properties": {
+              "control_field": { "$ref": "#/$defs/request_field" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "control": { "const": "none" } } },
+          "then": { "properties": { "control_field": { "type": "null" } } }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": { "const": "available_on_activation" }
+            }
+          },
+          "then": { "properties": { "control": { "const": "activation" } } }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": { "const": "available_per_request" }
+            }
+          },
+          "then": { "properties": { "control": { "const": "request" } } }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "enum": [
+                  "enabled_by_default",
+                  "diagnostic_only",
+                  "guarded_off",
+                  "deferred",
+                  "not_supported"
+                ]
+              }
+            }
+          },
+          "then": { "properties": { "control": { "const": "none" } } }
+        }
+      ]
+    },
+    "activation_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner_override_fields"],
+      "properties": {
+        "owner_override_fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/activation_field" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "request_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_fields", "allowed_fields", "forbidden_fields"],
+      "properties": {
+        "required_fields": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/request_field" },
+          "additionalProperties": true
+        },
+        "allowed_fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/request_field" },
+          "uniqueItems": true
+        },
+        "forbidden_fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/request_field" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "serving": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["engine", "route", "template", "parsers", "sampling", "limits", "features", "activation_policy", "request_policy"],
+      "properties": {
+        "engine": { "$ref": "#/$defs/non_empty_string" },
+        "route": { "$ref": "#/$defs/non_empty_string" },
+        "template": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "sha256", "default_kwargs"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["tokenizer", "processor", "profile_override"]
+            },
+            "sha256": { "$ref": "#/$defs/sha256" },
+            "default_kwargs": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "parsers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["tool", "reasoning"],
+          "properties": {
+            "tool": { "type": ["string", "null"] },
+            "reasoning": { "type": ["string", "null"] }
+          }
+        },
+        "sampling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider_defaults", "profile_defaults"],
+          "properties": {
+            "provider_defaults": { "$ref": "#/$defs/sampling" },
+            "profile_defaults": { "$ref": "#/$defs/sampling" }
+          }
+        },
+        "limits": { "$ref": "#/$defs/limits" },
+        "features": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["continuous_batching", "constrained_json", "kvq4", "kvq8", "mtp", "prefix_cache", "specprefill", "streaming"],
+          "properties": {
+            "continuous_batching": { "$ref": "#/$defs/feature" },
+            "constrained_json": { "$ref": "#/$defs/feature" },
+            "kvq4": { "$ref": "#/$defs/feature" },
+            "kvq8": { "$ref": "#/$defs/feature" },
+            "mtp": { "$ref": "#/$defs/feature" },
+            "prefix_cache": { "$ref": "#/$defs/feature" },
+            "specprefill": { "$ref": "#/$defs/feature" },
+            "streaming": { "$ref": "#/$defs/feature" }
+          }
+        },
+        "activation_policy": { "$ref": "#/$defs/activation_policy" },
+        "request_policy": { "$ref": "#/$defs/request_policy" }
+      }
+    },
+    "hardware_fit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hardware_class", "method", "estimated_peak_memory_bytes", "serving_context"],
+      "properties": {
+        "hardware_class": { "$ref": "#/$defs/non_empty_string" },
+        "method": {
+          "type": "string",
+          "enum": ["derived", "measured"]
+        },
+        "estimated_peak_memory_bytes": { "type": "integer", "minimum": 0 },
+        "measured_peak_memory_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "serving_context": { "type": "integer", "minimum": 1 },
+        "max_concurrency": { "type": "integer", "minimum": 1 },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_id", "kind", "location", "artifact_sha256", "result", "hardware_fingerprint", "workload_id", "subject_digest", "created_at"],
+      "properties": {
+        "evidence_id": { "$ref": "#/$defs/non_empty_string" },
+        "kind": { "$ref": "#/$defs/non_empty_string" },
+        "location": { "$ref": "#/$defs/non_empty_string" },
+        "artifact_sha256": { "$ref": "#/$defs/sha256" },
+        "result": {
+          "type": "string",
+          "enum": ["pass", "fail", "incomplete"]
+        },
+        "hardware_fingerprint": { "$ref": "#/$defs/non_empty_string" },
+        "workload_id": { "$ref": "#/$defs/non_empty_string" },
+        "subject_digest": { "$ref": "#/$defs/sha256" },
+        "created_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "qualification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "evidence"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["not_qualified", "qualified", "failed", "blocked"]
+        },
+        "reason": { "type": ["string", "null"] },
+        "evidence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidence" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "qualified" } } },
+          "then": {
+            "properties": {
+              "evidence": {
+                "minItems": 1,
+                "contains": {
+                  "type": "object",
+                  "required": ["result"],
+                  "properties": { "result": { "const": "pass" } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "provenance_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field_paths", "kind", "source"],
+      "properties": {
+        "field_paths": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^/" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["provider_fact", "derived_recommendation", "measured_result", "maintainer_policy"]
+        },
+        "source": { "$ref": "#/$defs/non_empty_string" },
+        "revision": { "type": ["string", "null"] },
+        "sha256": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
+        "rule_id": { "type": ["string", "null"] },
+        "observed_at": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["records"],
+      "properties": {
+        "records": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/provenance_record" },
+          "minItems": 1
+        }
+      },
+      "allOf": [
+        {
+          "properties": {
+            "records": {
+              "contains": {
+                "properties": {
+                  "field_paths": { "contains": { "pattern": "^/identity(?:/|$)" } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "records": {
+              "contains": {
+                "properties": {
+                  "field_paths": { "contains": { "pattern": "^/artifact(?:/|$)" } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "records": {
+              "contains": {
+                "properties": {
+                  "field_paths": { "contains": { "pattern": "^/capabilities(?:/|$)" } }
+                }
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "records": {
+              "contains": {
+                "properties": {
+                  "field_paths": { "contains": { "pattern": "^/serving(?:/|$)" } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_model_profile_schema.py
+++ b/tests/test_model_profile_schema.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).parents[1]
+SCHEMA = json.loads((ROOT / "schemas/model-profile-v1.schema.json").read_text())
+EXAMPLE = json.loads(
+    (ROOT / "schemas/examples/model-profile-v1.example.json").read_text()
+)
+VALIDATOR = Draft202012Validator(SCHEMA, format_checker=FormatChecker())
+
+
+def _errors(profile):
+    return sorted(VALIDATOR.iter_errors(profile), key=lambda error: list(error.path))
+
+
+def test_model_profile_example_matches_v1_schema():
+    Draft202012Validator.check_schema(SCHEMA)
+    assert _errors(EXAMPLE) == []
+
+
+def test_activation_control_requires_activation_field():
+    profile = copy.deepcopy(EXAMPLE)
+    feature = profile["serving"]["features"]["continuous_batching"]
+    feature.update(
+        mode="available_on_activation",
+        control="activation",
+        control_field="stream",
+    )
+
+    assert _errors(profile)
+
+
+def test_request_control_requires_request_field():
+    profile = copy.deepcopy(EXAMPLE)
+    feature = profile["serving"]["features"]["continuous_batching"]
+    feature.update(
+        mode="available_per_request",
+        control="request",
+        control_field="features.continuous_batching",
+    )
+
+    assert _errors(profile)
+
+
+def test_inactive_feature_cannot_expose_control():
+    profile = copy.deepcopy(EXAMPLE)
+    feature = profile["serving"]["features"]["continuous_batching"]
+    feature.update(
+        mode="deferred",
+        control="request",
+        control_field="stream",
+    )
+
+    assert _errors(profile)


### PR DESCRIPTION
## Summary

- add a versioned JSON Schema for immutable model/artifact/serving profiles
- separate provider facts, derived recommendations, measured qualification, and user overrides
- define closed activation/request feature controls and provenance requirements
- include a validating example and focused schema regression tests

This is the first dependency-free slice of a larger product roadmap. It changes no runtime, model, parser, template, sampling, lifecycle, or API behavior.

## Validation

- `uv run --with jsonschema pytest -q tests/test_model_profile_schema.py` (`4 passed`)
- Draft 2020-12 schema check and example validation passed
- `uv tool run ruff check tests/test_model_profile_schema.py`
- `uv tool run black --check tests/test_model_profile_schema.py`
- `git diff --check upstream/main...f79debc`
- Runtime outbound claim lint passed on all four touched files
- touched-file shadow: agent-slop `no violations`; Desloppify mechanical/objective `100.0` with subjective review unassessed

## Explicitly not included

- Python profile validation or canonical digest implementation
- legacy manifest migration
- lifecycle or server wiring
- model downloads or qualification runs
- Jobs/Ops policy or desktop UI

Those are separate, dependency-ordered review units.