### PR TITLE
fix(scheduler): support native mlx-lm chunked prefill API

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -9,6 +9,7 @@ for the vLLM-style continuous batching implementation.
 import asyncio
 import importlib
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 import mlx.core as mx
 
@@ -215,6 +216,26 @@ class TestSchedulerBasic:
     def mock_model(self):
         """Create a mock model."""
         return MagicMock()
+
+    def test_native_batch_generator_uses_chunked_prefill_budget(self):
+        """mlx-lm's current BatchGenerator owns chunking through its step size."""
+        scheduler = Scheduler(
+            model=object(),
+            tokenizer=SimpleNamespace(eos_token_id=0, eos_token_ids={0}),
+            config=SchedulerConfig(
+                enable_prefix_cache=False,
+                prefill_step_size=2048,
+                chunked_prefill_tokens=1024,
+            ),
+        )
+
+        batch_generator = scheduler._create_batch_generator(SamplingParams())
+
+        assert hasattr(batch_generator, "_prompt_batch")
+        assert hasattr(batch_generator, "_generation_batch")
+        assert hasattr(batch_generator, "_unprocessed_sequences")
+        assert batch_generator.prefill_step_size == 1024
+        assert not hasattr(batch_generator, "_partial")
 
     def test_chunked_prefill_accepts_prompt_checkpoints(self, monkeypatch):
         """Chunked prefill must match mlx-lm's 7-field prompt tuples."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -696,6 +696,64 @@ def _install_chunked_prefill(
     logger.info(f"[chunked_prefill] installed with budget={budget} tokens per step")
 
 
+def _configure_chunked_prefill(
+    scheduler: "Scheduler",
+    batch_gen: "BatchGenerator",
+    budget: int,
+    prompt_cache_save,
+) -> None:
+    """Enable the matching legacy or native mlx-lm chunked-prefill API."""
+    legacy_api = hasattr(batch_gen, "_process_prompts") and hasattr(
+        batch_gen, "active_batch"
+    )
+    if legacy_api:
+        save_interval = scheduler.config.mid_prefill_save_interval
+        mid_prefill_save = None
+        if save_interval > 0 and scheduler.memory_aware_cache is not None:
+            mid_prefill_save = scheduler._make_mid_prefill_save_callback(save_interval)
+            logger.info(
+                "[mid_prefill_cache] enabled, interval=%s",
+                save_interval,
+            )
+        _install_chunked_prefill(
+            batch_gen,
+            budget,
+            mid_prefill_save,
+            prompt_cache_save=prompt_cache_save,
+            pending_abort_ids=scheduler._pending_abort_ids,
+            uid_to_request_id=scheduler.uid_to_request_id,
+            requests=scheduler.requests,
+        )
+        return
+
+    native_api = all(
+        hasattr(batch_gen, attribute)
+        for attribute in (
+            "_prompt_batch",
+            "_generation_batch",
+            "_unprocessed_sequences",
+            "_next",
+        )
+    )
+    if native_api:
+        # Native mlx-lm chunking processes at most this many prompt tokens per
+        # scheduler turn and returns to generation between turns. Its internal
+        # API has no safe extension point for the legacy prompt-cache and
+        # mid-prefill callbacks, which were already unavailable on this layout.
+        batch_gen.prefill_step_size = budget
+        logger.info(
+            "Chunked prefill enabled through native mlx-lm BatchGenerator: "
+            "budget=%s tokens per step",
+            budget,
+        )
+        return
+
+    logger.warning(
+        "Chunked prefill disabled: mlx-lm BatchGenerator matches neither "
+        "the legacy nor native chunked-prefill API."
+    )
+
+
 def _install_mtp(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1360,40 +1418,16 @@ class Scheduler:
         chunked_budget = self.config.chunked_prefill_tokens
         need_chunked = chunked_budget > 0
 
-        # The chunked prefill monkey-patch relies on BatchGenerator internals
-        # (_process_prompts, active_batch, _step, etc.) that were refactored
-        # in mlx-lm 0.31.x.  Skip gracefully when the required API is absent.
-        chunked_compatible = hasattr(bg, "_process_prompts") and hasattr(
-            bg, "active_batch"
-        )
-
         prompt_cache_cb = None
         if self.memory_aware_cache is not None:
             prompt_cache_cb = self._make_prompt_cache_save_callback()
 
-        if need_chunked and chunked_compatible:
-            # Full chunked prefill with mid-prefill saves and prompt cache
-            # save wired through the chunked next() and _process_prompts
-            # monkey-patches inside _install_chunked_prefill.
-            mid_prefill_cb = None
-            save_interval = self.config.mid_prefill_save_interval
-            if save_interval > 0 and self.memory_aware_cache is not None:
-                mid_prefill_cb = self._make_mid_prefill_save_callback(save_interval)
-                logger.info(f"[mid_prefill_cache] enabled, interval={save_interval}")
-            _install_chunked_prefill(
+        if need_chunked:
+            _configure_chunked_prefill(
+                self,
                 bg,
                 chunked_budget,
-                mid_prefill_cb,
-                prompt_cache_save=prompt_cache_cb,
-                pending_abort_ids=self._pending_abort_ids,
-                uid_to_request_id=self.uid_to_request_id,
-                requests=self.requests,
-            )
-        elif need_chunked and not chunked_compatible:
-            logger.warning(
-                "Chunked prefill disabled: mlx-lm BatchGenerator lacks required "
-                "internals (_process_prompts, active_batch). Upgrade mlx-lm or "
-                "check compatibility."
+                prompt_cache_cb,
             )
 
         # When chunked prefill is off but memory_aware_cache is active,


### PR DESCRIPTION
# fix(scheduler): support native mlx-lm chunked prefill API

## Problem

`--chunked-prefill-tokens` was disabled on the text scheduler for every
supported `mlx-lm>=0.31.3` installation. The legacy feature check required
`BatchGenerator._process_prompts` and `active_batch`, which were removed by
the mlx-lm batch-generation refactor.

## Code-path comparison

The affected vllm-mlx path is `vllm_mlx/scheduler.py`:
`Scheduler._create_batch_generator()` previously skipped
`_install_chunked_prefill()` when the legacy internals were absent. Current
mlx-lm's `BatchGenerator._next()` instead consumes the instance field
`prefill_step_size` while using `_prompt_batch`, `_generation_batch`, and
`_unprocessed_sequences`.

## Change

Keep the legacy adapter unchanged for old mlx-lm layouts. For the current
native layout, set `BatchGenerator.prefill_step_size` to the configured
`--chunked-prefill-tokens` value. Unknown layouts remain fail-closed with a
warning. The legacy mid-prefill and prompt-cache callbacks are not installed
on the native layout because that API provides no equivalent safe hook.

## Evidence

Focused regression tests use the real installed `mlx_lm.BatchGenerator`:

```text
pytest -q tests/test_batching.py -m 'not integration'
28 passed, 2 deselected
```

An isolated local run used the text-only
`/Users/David/ai-models/mlx_models/Qwen3-1.7B-MLX-8bit` model, one 49,164-token
prefill request, and three short concurrent streams. With the same workload,
the short-stream completion time changed from 10.90s with
`--chunked-prefill-tokens 0` to 3.88s with
`--chunked-prefill-tokens 1024`. The patched server logged native activation,
and all requests completed normally.

Artifact:
`/opt/ai-runtime/run/upstream-local-repro-647/20260728T044114Z-baseline-vs-native-chunked-prefill/summary.json`

This is one controlled local replication. It demonstrates native API
engagement and improved contention in this workload; it does not claim a
general throughput or model-quality result.

## Scope

- No MLLM scheduler change.
- No model-specific logic.
- No API or configuration-default change.
- No MTP change; the reporter's separate MTP observation is out of scope.

Fixes #647
