### PR TITLE
fix(engine): defer unused MLLM TextModel for draft routes

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1497,6 +1497,8 @@ class TestSimpleEngineConcurrency:
             finally:
                 await engine.stop()
 
+        assert engine._text_model_initialization_attempted is False
+
     @pytest.mark.anyio
     async def test_mllm_media_stream_stays_on_owner_thread_with_text_route(self):
         """Media requests must not move mlx_vlm generation to a worker thread."""
@@ -1734,6 +1736,78 @@ class TestSimpleEngineConcurrency:
         assert loop_delay < 0.1
         assert worker_thread != owner_thread
         assert outputs[-1].text == "video described"
+
+    @pytest.mark.anyio
+    async def test_start_defers_text_model_when_mllm_draft_is_configured(
+        self, monkeypatch
+    ):
+        """Draft-backed MLLM startup must not build an unused TextModel."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        class FakeMllmModel:
+            def __init__(self):
+                self.model = object()
+                self.loaded = False
+
+            def load(self):
+                self.loaded = True
+
+        model = FakeMllmModel()
+
+        monkeypatch.setattr(
+            "vllm_mlx.models.mllm.MLXMultimodalLM", lambda *args, **kwargs: model
+        )
+
+        def unexpected_text_model_build(*args, **kwargs):
+            raise AssertionError(
+                "draft-backed startup must defer TextModel construction"
+            )
+
+        monkeypatch.setattr(
+            "vllm_mlx.text_model_from_vlm.build_text_model",
+            unexpected_text_model_build,
+        )
+
+        engine = SimpleEngine(
+            "laguna-test",
+            force_mllm=True,
+            mllm_draft_model="/models/laguna-dflash",
+            mllm_draft_kind="dflash",
+            mllm_draft_block_size=8,
+        )
+        await engine.start()
+
+        assert model.loaded is True
+        assert engine._text_model is None
+
+    @pytest.mark.anyio
+    async def test_non_draft_request_lazily_initializes_mllm_text_model(self):
+        """An explicit draft opt-out retains the existing text-only route."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine(
+            "laguna-test",
+            force_mllm=True,
+            mllm_draft_model="/models/laguna-dflash",
+        )
+        owner_thread = threading.get_ident()
+        initialized: list[int] = []
+
+        def initialize_text_model():
+            initialized.append(threading.get_ident())
+
+        engine._initialize_text_model = initialize_text_model  # type: ignore[method-assign]
+
+        await engine._ensure_text_model_for_request(mllm_draft_requested=True)
+        assert initialized == []
+
+        await engine._ensure_text_model_for_request(mllm_draft_requested=False)
+        assert len(initialized) == 1
+        assert initialized[0] != owner_thread
+
+        engine._text_model_initialization_attempted = True
+        await engine._ensure_text_model_for_request(mllm_draft_requested=False)
+        assert len(initialized) == 1
 
     @pytest.mark.anyio
     async def test_mllm_nonstream_text_only_routes_without_mtp(self):

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -248,6 +248,8 @@ class SimpleEngine(BaseEngine):
         # Per-request routing state (MLLM+MTP mode)
         self._text_model = None
         self._text_tokenizer = None
+        self._text_model_init_lock = asyncio.Lock()
+        self._text_model_initialization_attempted = False
 
         # SpecPrefill draft model (loaded at start if enabled)
         self._draft_model = None
@@ -757,92 +759,15 @@ class SimpleEngine(BaseEngine):
                     "stream_chat",
                 )
 
-            # Build parallel mlx_lm TextModel for text-only routing.
-            # Even when MTP is disabled, text-only requests should not be trapped
-            # on the slower mlx_vlm multimodal path.
-            if self._is_mllm and self._should_route_text_through_text_model():
-                try:
-
-                    def build_text_route():
-                        from ..text_model_from_vlm import build_text_model
-
-                        text_model = build_text_model(
-                            self._model.model, self._model_name
-                        )
-                        if text_model is None:
-                            return None, None
-                        return text_model, self._model.get_tokenizer()
-
-                    (
-                        self._text_model,
-                        self._text_tokenizer,
-                    ) = await self._run_blocking_serialized(build_text_route)
-
-                    if self._text_model is not None:
-                        # Apply Qwen3.5 eos_token fix (matches MLXLanguageModel.load)
-                        if "qwen3" in self._model_name.lower():
-                            self._text_tokenizer.eos_token = "<|im_end|>"
-                            self._text_tokenizer.eos_token_id = (
-                                self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
-                            )
-
-                        # Probe the derived TextModel's prompt cache for snapshot-safety
-                        # (same gate stream_chat uses for the pure-LLM path).
-                        # _stream_generate_text only enters the system-KV cache branch
-                        # when this flag is True, so sliding-window text models won't
-                        # desynchronize on restore.
-                        #
-                        # Probe args must match the runtime constructor in
-                        # _stream_generate_text (max_kv_size=self._max_kv_size or None).
-                        # Under bounded-KV serving (max_kv_size > 0) make_prompt_cache
-                        # returns RotatingKVCache for models without a custom
-                        # make_cache; probing with default args would mis-classify that
-                        # path as snapshot-safe.
-                        try:
-                            from mlx_lm.models.cache import KVCache, make_prompt_cache
-
-                            probe_cache = make_prompt_cache(
-                                self._text_model, max_kv_size=self._max_kv_size or None
-                            )
-                            self._supports_system_kv_cache = bool(probe_cache) and all(
-                                isinstance(c, KVCache) for c in probe_cache
-                            )
-                            if not self._supports_system_kv_cache:
-                                cache_types = sorted(
-                                    {type(c).__name__ for c in probe_cache}
-                                )
-                                logger.info(
-                                    "System KV cache snapshot disabled for MLLM "
-                                    "text routing: TextModel returned non-KVCache "
-                                    "entries (%s); _stream_generate_text will use "
-                                    "the uncached path",
-                                    cache_types,
-                                )
-                        except Exception as e:
-                            logger.debug(
-                                "MLLM TextModel KV cache support probe failed "
-                                "(%s); disabling snapshot path",
-                                e,
-                            )
-                            self._supports_system_kv_cache = False
-
-                        has_mtp = (
-                            hasattr(self._text_model, "mtp")
-                            and self._text_model.mtp is not None
-                        )
-                        logger.info(
-                            "MLLM text routing: text-only -> mlx_lm TextModel "
-                            "(MTP=%s), media -> mlx_vlm",
-                            has_mtp and self._mtp,
-                        )
-                    else:
-                        self._text_model = None
-                        self._text_tokenizer = None
-
-                except Exception as e:
-                    logger.error("MLLM text routing setup failed: %s", e)
-                    self._text_model = None
-                    self._text_tokenizer = None
+            # A configured MLLM speculative drafter routes those requests directly
+            # through mlx_vlm. Do not also allocate a parallel TextModel at startup;
+            # build it lazily only if a later request opts out of the drafter path.
+            if self._is_mllm and self._mllm_draft_model_path is None:
+                await self._run_blocking_serialized(self._initialize_text_model)
+            elif self._is_mllm:
+                logger.info(
+                    "Deferring MLLM TextModel construction until a non-draft request"
+                )
 
             # Load SpecPrefill draft model (small model for importance scoring)
             if self._specprefill_enabled and self._specprefill_draft_model_path:
@@ -926,6 +851,7 @@ class SimpleEngine(BaseEngine):
         self._model = None
         self._text_model = None
         self._text_tokenizer = None
+        self._text_model_initialization_attempted = False
         self._draft_model = None
         self._loaded = False
         self._system_kv_cache.clear()
@@ -974,6 +900,91 @@ class SimpleEngine(BaseEngine):
     ) -> bool:
         """Return whether text-only MLLM requests may use mlx_lm TextModel."""
         return not (mllm_draft_requested and self._mllm_draft_model_path is not None)
+
+    def _initialize_text_model(self) -> None:
+        """Build the optional text-only MLLM route from already-loaded weights."""
+        self._text_model_initialization_attempted = True
+        try:
+            from ..text_model_from_vlm import build_text_model
+
+            self._text_model = build_text_model(self._model.model, self._model_name)
+
+            if self._text_model is None:
+                self._text_tokenizer = None
+                return
+
+            self._text_tokenizer = self._model.get_tokenizer()
+            self._supports_system_kv_cache = self._probe_system_kv_cache_support(
+                self._text_model,
+                "mllm_text",
+            )
+
+            # Apply Qwen3.5 eos_token fix (matches MLXLanguageModel.load).
+            if "qwen3" in self._model_name.lower():
+                self._text_tokenizer.eos_token = "<|im_end|>"
+                self._text_tokenizer.eos_token_id = (
+                    self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
+                )
+
+            # Probe the derived TextModel's prompt cache for snapshot-safety.
+            # Probe args match _stream_generate_text's cache construction so a
+            # bounded-KV route cannot be misclassified as snapshot-safe.
+            try:
+                from mlx_lm.models.cache import KVCache, make_prompt_cache
+
+                probe_cache = make_prompt_cache(
+                    self._text_model, max_kv_size=self._max_kv_size or None
+                )
+                self._supports_system_kv_cache = bool(probe_cache) and all(
+                    isinstance(cache, KVCache) for cache in probe_cache
+                )
+                if not self._supports_system_kv_cache:
+                    cache_types = sorted(
+                        {type(cache).__name__ for cache in probe_cache}
+                    )
+                    logger.info(
+                        "System KV cache snapshot disabled for MLLM text routing: "
+                        "TextModel returned non-KVCache entries (%s); "
+                        "_stream_generate_text will use the uncached path",
+                        cache_types,
+                    )
+            except Exception as e:
+                logger.debug(
+                    "MLLM TextModel KV cache support probe failed (%s); "
+                    "disabling snapshot path",
+                    e,
+                )
+                self._supports_system_kv_cache = False
+
+            has_mtp = (
+                hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
+            )
+            logger.info(
+                "MLLM text routing: text-only -> mlx_lm TextModel (MTP=%s), "
+                "media -> mlx_vlm",
+                has_mtp and self._mtp,
+            )
+        except Exception as e:
+            logger.error("MLLM text routing setup failed: %s", e)
+            self._text_model = None
+            self._text_tokenizer = None
+
+    async def _ensure_text_model_for_request(
+        self, *, mllm_draft_requested: bool
+    ) -> None:
+        """Initialize the optional text route only when the request needs it."""
+        if (
+            not self._is_mllm
+            or mllm_draft_requested
+            or self._mllm_draft_model_path is None
+            or self._text_model is not None
+            or self._text_model_initialization_attempted
+        ):
+            return
+
+        async with self._text_model_init_lock:
+            if not self._text_model_initialization_attempted:
+                await self._run_blocking_serialized(self._initialize_text_model)
 
     async def _run_blocking_serialized(
         self,
@@ -1632,6 +1643,10 @@ class SimpleEngine(BaseEngine):
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
         mllm_draft_requested = bool(kwargs.pop("mllm_draft", False))
         has_media = has_media_content(messages)
+
+        await self._ensure_text_model_for_request(
+            mllm_draft_requested=mllm_draft_requested
+        )
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None


### PR DESCRIPTION
## Problem

`SimpleEngine.start()` eagerly constructs a parallel `TextModel` for every MLLM
instance. When an MLLM speculative drafter is configured, draft-backed requests
route directly through the MLLM path, so that parallel model is unused at
startup.

## Change

Defer `TextModel` construction when an MLLM drafter is configured. If a later
request explicitly opts out of the drafter, initialize the existing text-only
route once under a request-local async lock.

## Validation

- Focused tests: `62 passed` (`test_simple_engine.py`, `test_lifecycle_cli.py`)
- Ruff and `git diff --check` pass.
- Clean-upstream comparison:
  `/opt/ai-runtime/run/upstream-local-repro-preflight/20260728T051403Z-upstream-local-repro-preflight.json`

## Not claimed

This PR does not change model output, speculative-decoding behavior, or
non-draft MLLM routing. It does not claim a measured startup-memory reduction;
the local long-horizon probe was interrupted by a host reboot before health or
inference.
