### PR TITLE
fix(server): make streaming reasoning/tool parsers request-local to fix concurrency

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1102,19 +1102,17 @@ def _build_tool_parser(engine: BaseEngine | None):
     if not _enable_auto_tool_choice or not _tool_call_parser:
         return None
 
-    if _tool_parser_instance is not None:
-        if hasattr(_tool_parser_instance, "reset"):
-            _tool_parser_instance.reset()
-        return _tool_parser_instance
-
     parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
-    tokenizer = getattr(engine, "tokenizer", None) if engine is not None else None
-    return parser_cls(tokenizer)
+    tokenizer = _get_engine_tokenizer(engine if engine is not None else _engine)
+    parser = parser_cls(tokenizer)
+    if hasattr(parser, "reset"):
+        parser.reset()
+    return parser
 
 
 def _build_reasoning_parser(engine: BaseEngine | None = None):
     """Create a fresh reasoning parser instance for a single request/stream."""
-    tokenizer = getattr(engine, "tokenizer", None) if engine is not None else None
+    tokenizer = _get_engine_tokenizer(engine if engine is not None else _engine)
     if _reasoning_parser_name is not None:
         parser_cls = get_reasoning_parser(_reasoning_parser_name)
         try:
@@ -2534,32 +2532,10 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             sequence += 1
         return events
 
-    if _reasoning_parser:
-        _reasoning_parser.reset_state()
-
-    global _tool_parser_instance
-    tool_parser = None
+    reasoning_parser = _build_reasoning_parser(engine)
+    tool_parser = _build_tool_parser(engine)
     tool_accumulated_text = ""
     tool_markup_possible = False
-    if _enable_auto_tool_choice and _tool_call_parser:
-        if _tool_parser_instance is None:
-            try:
-                parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
-                tokenizer = None
-                if _engine is not None and hasattr(_engine, "_tokenizer"):
-                    tokenizer = _engine._tokenizer
-                _tool_parser_instance = parser_cls(tokenizer)
-                logger.info(
-                    "Initialized tool call parser for responses streaming: %s",
-                    _tool_call_parser,
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to init tool parser for responses streaming: %s", e
-                )
-        if _tool_parser_instance is not None:
-            tool_parser = _tool_parser_instance
-            tool_parser.reset()
 
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         last_output = output
@@ -2576,8 +2552,8 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if _reasoning_parser and not _thinking_disabled(request, chat_kwargs):
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+        if reasoning_parser and not _thinking_disabled(request, chat_kwargs):
+            delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, raw_accumulated_text, delta_text
             )
             if delta_msg is None:
@@ -2976,8 +2952,6 @@ def _get_streaming_tool_parser(
     back to the generic auto parser so streaming still matches the generic
     non-streaming tool parsing behavior.
     """
-    global _tool_parser_instance
-
     if request is None:
         return None
     if _tool_choice_disabled(request):
@@ -2986,17 +2960,17 @@ def _get_streaming_tool_parser(
     tokenizer = _get_engine_tokenizer(engine if engine is not None else _engine)
 
     if _enable_auto_tool_choice and _tool_call_parser:
-        if _tool_parser_instance is None:
-            try:
-                _get_or_init_tool_parser(engine)
-            except Exception as e:
-                logger.warning(
-                    "Failed to init tool parser for streaming: %s",
-                    _sanitize_log_text(e, limit=500),
-                )
-                return None
-        _tool_parser_instance.reset()
-        return _tool_parser_instance
+        try:
+            parser_cls = ToolParserManager.get_tool_parser(_tool_call_parser)
+            parser = parser_cls(tokenizer)
+            parser.reset()
+            return parser
+        except Exception as e:
+            logger.warning(
+                "Failed to init tool parser for streaming: %s",
+                _sanitize_log_text(e, limit=500),
+            )
+            return None
 
     if not getattr(request, "tools", None):
         return None
@@ -5658,8 +5632,7 @@ async def _stream_anthropic_messages(
         and not _thinking_disabled(openai_request, chat_kwargs)
     )
 
-    if use_reasoning:
-        _reasoning_parser.reset_state()
+    reasoning_parser = _build_reasoning_parser(engine) if use_reasoning else None
 
     # Block index tracking: with reasoning parser we use index 0 for
     # thinking and index 1 for text; without parser, index 0 for text.
@@ -5744,7 +5717,7 @@ async def _stream_anthropic_messages(
             # Reasoning parser path
             previous_text = accumulated_text
             accumulated_text += filtered
-            delta_msg = _reasoning_parser.extract_reasoning_streaming(
+            delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, accumulated_text, filtered
             )
 
@@ -6003,9 +5976,8 @@ async def stream_chat_completion(
     )
     think_prefix_sent = False
 
-    # Reset reasoning parser state for this stream
-    if _reasoning_parser:
-        _reasoning_parser.reset_state()
+    # Parser state must be request-local because streams run concurrently.
+    reasoning_parser = _build_reasoning_parser(engine)
 
     # Track accumulated text for reasoning parser
     accumulated_text = ""
@@ -6055,13 +6027,13 @@ async def stream_chat_completion(
             # is set either on the request or via the resolved chat template
             # kwargs / server default).
             if (
-                _reasoning_parser
+                reasoning_parser
                 and delta_text
                 and not _thinking_disabled(request, kwargs)
             ):
                 previous_text = accumulated_text
                 accumulated_text += delta_text
-                delta_msg = _reasoning_parser.extract_reasoning_streaming(
+                delta_msg = reasoning_parser.extract_reasoning_streaming(
                     previous_text, accumulated_text, delta_text
                 )
 


### PR DESCRIPTION
## Problem

The reasoning parser and tool parser used module-level global state (`_reasoning_parser`, `_tool_parser_instance`) that was shared across all concurrent streaming requests. This caused parser state corruption when multiple requests ran simultaneously — reasoning text leaked into content with raw `` tags, and tool-call markup could be corrupted.

## Fix

Create a fresh parser instance per-request via `_build_reasoning_parser()` and `_build_tool_parser()`, eliminating shared mutable state between streams.

Fixes #649