### PR TITLE
fix(server): flush reasoning parser at stream end

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1973,6 +1973,94 @@ class TestStreamChatCompletion:
         assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 
     @pytest.mark.anyio
+    async def test_gemma_stream_flushes_pending_content_before_length_finish(
+        self, monkeypatch
+    ):
+        """A terminal length stop must not discard Gemma's buffered tail."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "gemma4-31b-it-8bit"
+
+            async def stream_chat(self, messages, **kwargs):
+                chunks = [
+                    GenerationOutput(
+                        text="<|channel>thought\n",
+                        new_text="<|channel>thought\n",
+                        finished=False,
+                        prompt_tokens=4,
+                        completion_tokens=3,
+                    ),
+                    GenerationOutput(
+                        text="<|channel>thought\nplan",
+                        new_text="plan",
+                        finished=False,
+                        prompt_tokens=4,
+                        completion_tokens=5,
+                    ),
+                    GenerationOutput(
+                        text="<|channel>thought\nplan<channel|>FINAL<|chan",
+                        new_text="<channel|>FINAL<|chan",
+                        finished=True,
+                        finish_reason="length",
+                        prompt_tokens=4,
+                        completion_tokens=9,
+                    ),
+                ]
+                for chunk in chunks:
+                    yield chunk
+
+        monkeypatch.setattr(server, "_model_name", "gemma4-31b-it-8bit")
+        monkeypatch.setattr(server, "_reasoning_parser", Gemma4ReasoningParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="gemma4-31b-it-8bit",
+            messages=[Message(role="user", content="Write a cover letter.")],
+            stream=True,
+        )
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request, enable_thinking=True
+            )
+        ]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+        content = "".join(
+            choice["delta"].get("content") or ""
+            for payload in payloads
+            for choice in payload["choices"]
+        )
+        reasoning = "".join(
+            choice["delta"].get("reasoning_content") or ""
+            for payload in payloads
+            for choice in payload["choices"]
+        )
+        finish_reasons = [
+            choice["finish_reason"]
+            for payload in payloads
+            for choice in payload["choices"]
+            if choice["finish_reason"]
+        ]
+
+        assert reasoning == "plan"
+        assert content == "FINAL<|chan"
+        assert finish_reasons == ["length"]
+
+    @pytest.mark.anyio
     async def test_auto_parser_streams_bare_bracket_tool_calls(self, monkeypatch):
         """Bare bracket tool calls should stream as structured tool_calls."""
         from vllm_mlx.engine.base import GenerationOutput

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4214,6 +4214,31 @@ async def _ensure_sse_terminal(
             yield terminal_frame
 
 
+def _resolve_reasoning_stream_delta(reasoning_parser, output, delta_msg, request):
+    """Return a stream delta, including parser state buffered at stream end."""
+    if delta_msg is None:
+        if not output.finished:
+            return None
+        content = None
+        reasoning = None
+    else:
+        content = delta_msg.content
+        reasoning = delta_msg.reasoning
+
+    if output.finished:
+        # finalize_stream is defined by ReasoningParser base as a no-op, but
+        # third-party or test-only reasoning parsers may not inherit from it.
+        # Guard so a duck-typed parser without the method still streams.
+        finalize = getattr(reasoning_parser, "finalize_stream", None)
+        final_delta = finalize() if callable(finalize) else None
+        if final_delta is not None:
+            if final_delta.content:
+                content = (content or "") + final_delta.content
+            if final_delta.reasoning:
+                reasoning = (reasoning or "") + final_delta.reasoning
+    return _promote_streaming_response_format_delta(content, reasoning, request)
+
+
 def _find_uvicorn_cycle(obj, depth=0, visited=None):
     """Walk through middleware wrappers to find uvicorn's RequestResponseCycle.
 
@@ -6093,15 +6118,12 @@ async def stream_chat_completion(
                     previous_text, accumulated_text, delta_text
                 )
 
-                if delta_msg is None:
-                    # Skip this chunk (e.g., <think> token itself)
-                    continue
-
-                content = delta_msg.content
-                reasoning = delta_msg.reasoning
-                content, reasoning = _promote_streaming_response_format_delta(
-                    content, reasoning, request
+                resolved_delta = _resolve_reasoning_stream_delta(
+                    reasoning_parser, output, delta_msg, request
                 )
+                if resolved_delta is None:
+                    continue
+                content, reasoning = resolved_delta
 
                 # Some models (e.g. MiniMax) wrap tool calls in <think>
                 # blocks, so reasoning parser captures tool call XML as


### PR DESCRIPTION
## Summary

Flush parser-buffered terminal text before emitting a streamed completion's
terminal chunk.

Gemma 4's reasoning parser already implements `finalize_stream()` for a
truncated channel marker, but `stream_chat_completion()` did not invoke it.
The finalizer is now called only for the terminal output and its content or
reasoning is merged into that terminal delta.

## Reproduction

With Gemma 4 reasoning enabled, a stream that ends at `finish_reason=length`
after the parser has buffered a partial channel marker could omit that buffered
tail from the client stream.

The regression simulates a Gemma thought-to-response transition that ends at a
length boundary. It verifies the thought text, the buffered final content, and
the terminal `length` reason all reach the emitted stream.

## Scope

- Preserves template selection, sampling, request limits, and scheduler behavior.
- Does not change Jobs integration, model configuration, or constrained decoding.
- Does not claim that every length-bound Gemma generation produces final content;
  it preserves parser-buffered terminal content when it exists.

## Validation

- `pytest -q tests/test_server.py -k 'gemma_stream_flushes_pending_content_before_length_finish or stream_without_parser_flags_keeps_plain_text'`
- `ruff check vllm_mlx/server.py tests/test_server.py --select E,F,W --ignore E402,E501,E731,F811,F841`
- Live Gemma 4 streaming boundary evidence is retained locally at
  `/opt/ai-runtime/run/gemma4-stream-finalizer-certification/20260728T183900Z-live-manifest-replay/summary.json`.
