### PR TITLE
fix(server): isolate streaming parser state

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -334,6 +334,59 @@ def test_thinking_disabled_helper(enable_thinking, ctk, expected):
 
 
 @pytest.mark.anyio
+async def test_stream_chat_does_not_add_nemotron_prefix_when_thinking_disabled(
+    monkeypatch,
+):
+    class FakeReasoningParser:
+        def __init__(self, tokenizer=None):
+            self.tokenizer = tokenizer
+
+        def reset_state(self):
+            pass
+
+        def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
+            raise AssertionError("disabled reasoning parser should not consume deltas")
+
+    class FakeEngine:
+        model_name = "Nemotron-test"
+        tokenizer = object()
+
+        async def stream_chat(self, messages, **kwargs):
+            yield GenerationOutput(
+                text="plain answer",
+                new_text="plain answer",
+                finished=True,
+                finish_reason="stop",
+                prompt_tokens=4,
+                completion_tokens=2,
+            )
+
+    monkeypatch.setattr(srv, "_model_name", "test-model")
+    monkeypatch.setattr(srv, "_reasoning_parser_name", "fake")
+    monkeypatch.setattr(srv, "_reasoning_parser", FakeReasoningParser())
+    monkeypatch.setattr(srv, "get_reasoning_parser", lambda _name: FakeReasoningParser)
+    monkeypatch.setattr(srv, "_enable_auto_tool_choice", False)
+    monkeypatch.setattr(srv, "_tool_call_parser", None)
+
+    request = srv.ChatCompletionRequest(
+        model="test-model",
+        messages=[srv.Message(role="user", content="Hello")],
+        stream=True,
+        enable_thinking=False,
+    )
+    chunks = [
+        chunk
+        async for chunk in srv.stream_chat_completion(
+            FakeEngine(), request.messages, request
+        )
+    ]
+
+    body = "".join(chunks)
+    assert "plain answer" in body
+    assert "<think>" not in body
+
+
+@pytest.mark.anyio
 async def test_stream_anthropic_skips_reasoning_parser_when_thinking_disabled():
     from vllm_mlx.reasoning import DeltaMessage
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -832,7 +832,8 @@ class TestHelperFunctions:
         assert isinstance(parser, FakeParser)
         assert parser.tokenizer is FakeEngine.tokenizer
 
-    def test_build_tool_parser_returns_request_local_instances(self, monkeypatch):
+    def test_build_tool_parser_returns_a_fresh_instance_per_stream(self, monkeypatch):
+        """Configured tool parsers must not carry mutable state between streams."""
         import vllm_mlx.server as server
 
         class FakeParser:
@@ -844,7 +845,10 @@ class TestHelperFunctions:
 
         monkeypatch.setattr(server, "_enable_auto_tool_choice", True)
         monkeypatch.setattr(server, "_tool_call_parser", "fake")
-        monkeypatch.setattr(server, "_tool_parser_instance", FakeParser())
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+        monkeypatch.setattr(
+            server.ToolParserManager, "get_tool_parser", lambda name: FakeParser
+        )
 
         first = server._build_tool_parser(FakeEngine())
         second = server._build_tool_parser(FakeEngine())
@@ -1801,6 +1805,113 @@ class TestEndpointSecurityDependencies:
 
 class TestStreamChatCompletion:
     """Tests for streaming chat completion behavior."""
+
+    @pytest.mark.anyio
+    async def test_interleaved_streams_keep_reasoning_parser_state_isolated(
+        self, monkeypatch
+    ):
+        """One stream closing a think block must not reset another stream's parser."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning import DeltaMessage
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class StatefulReasoningParser:
+            def __init__(self, tokenizer=None):
+                self.in_think = False
+
+            def reset_state(self):
+                self.in_think = False
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                if delta_text == "<think>":
+                    self.in_think = True
+                    return None
+                if delta_text == "</think>":
+                    self.in_think = False
+                    return None
+                if self.in_think:
+                    return DeltaMessage(reasoning=delta_text)
+                return DeltaMessage(content=delta_text)
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            def __init__(self, chunks):
+                self.chunks = chunks
+
+            async def stream_chat(self, messages, **kwargs):
+                for chunk in self.chunks:
+                    yield chunk
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser_name", "stateful")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(
+            server, "get_reasoning_parser", lambda name: StatefulReasoningParser
+        )
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+        first_stream = stream_chat_completion(
+            FakeEngine(
+                [
+                    GenerationOutput(text="", new_text="<think>", finished=False),
+                    GenerationOutput(text="", new_text="first", finished=False),
+                    GenerationOutput(text="", new_text="second", finished=False),
+                    GenerationOutput(text="", new_text="</think>", finished=False),
+                    GenerationOutput(
+                        text="",
+                        new_text="answer-a",
+                        finished=True,
+                        finish_reason="stop",
+                    ),
+                ]
+            ),
+            request.messages,
+            request,
+        )
+        second_stream = stream_chat_completion(
+            FakeEngine(
+                [
+                    GenerationOutput(text="", new_text="<think>", finished=False),
+                    GenerationOutput(text="", new_text="other", finished=False),
+                    GenerationOutput(text="", new_text="</think>", finished=False),
+                    GenerationOutput(
+                        text="",
+                        new_text="answer-b",
+                        finished=True,
+                        finish_reason="stop",
+                    ),
+                ]
+            ),
+            request.messages,
+            request,
+        )
+
+        await first_stream.__anext__()  # assistant role
+        first_reasoning = await first_stream.__anext__()
+        second_chunks = [chunk async for chunk in second_stream]
+        second_reasoning = next(
+            chunk for chunk in second_chunks if '"reasoning_content":"other"' in chunk
+        )
+        resumed_reasoning = await first_stream.__anext__()
+
+        assert '"reasoning_content":"first"' in first_reasoning
+        assert '"reasoning_content":"other"' in second_reasoning
+        assert '"reasoning_content":"second"' in resumed_reasoning
 
     @pytest.mark.anyio
     async def test_stream_without_parser_flags_emits_structured_tool_calls(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1154,7 +1154,11 @@ def _prepare_openai_stream_reasoning_state(
 ) -> tuple[object | None, bool]:
     """Return request-local reasoning state and the legacy Nemotron marker state."""
     parser = _prepare_streaming_reasoning_parser(engine, request, chat_kwargs)
-    is_thinking_model = "nemotron" in (engine.model_name or "").lower() and not parser
+    is_thinking_model = (
+        "nemotron" in (engine.model_name or "").lower()
+        and not parser
+        and not _thinking_disabled(request, chat_kwargs)
+    )
     return parser, is_thinking_model
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1131,6 +1131,53 @@ def _build_reasoning_parser(engine: BaseEngine | None = None):
         return type(_reasoning_parser)()
 
 
+def _prepare_streaming_reasoning_parser(
+    engine: BaseEngine,
+    request: ChatCompletionRequest | ResponsesRequest | None,
+    chat_kwargs: dict[str, object],
+    *,
+    allowed: bool = True,
+):
+    """Build and reset request-local reasoning state when thinking is enabled."""
+    if not allowed or _thinking_disabled(request, chat_kwargs):
+        return None
+    parser = _build_reasoning_parser(engine)
+    if parser is not None:
+        parser.reset_state()
+    return parser
+
+
+def _prepare_openai_stream_reasoning_state(
+    engine: BaseEngine,
+    request: ChatCompletionRequest,
+    chat_kwargs: dict[str, object],
+) -> tuple[object | None, bool]:
+    """Return request-local reasoning state and the legacy Nemotron marker state."""
+    parser = _prepare_streaming_reasoning_parser(engine, request, chat_kwargs)
+    is_thinking_model = "nemotron" in (engine.model_name or "").lower() and not parser
+    return parser, is_thinking_model
+
+
+def _request_tool_definitions(request: ChatCompletionRequest) -> list | None:
+    """Return the request tool schema once for streaming argument coercion."""
+    if request and request.tools:
+        return request.model_dump(include={"tools"}).get("tools")
+    return None
+
+
+def _streaming_json_fence_stripper(
+    request: ChatCompletionRequest,
+) -> StreamingJsonFenceStripper | None:
+    """Create a fence stripper only for JSON-constrained streaming responses."""
+    response_format = getattr(request, "response_format", None)
+    response_format_type = getattr(response_format, "type", None)
+    if response_format_type is None and isinstance(response_format, dict):
+        response_format_type = response_format.get("type")
+    if response_format_type in ("json_object", "json_schema"):
+        return StreamingJsonFenceStripper()
+    return None
+
+
 # Lifecycle startup coordination — an Event lets the lifecycle loop block
 # efficiently instead of polling with short sleeps.  Created lazily so
 # it binds to the correct event loop at runtime rather than import time.
@@ -2537,13 +2584,11 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             sequence += 1
         return events
 
-    reasoning_parser = _build_reasoning_parser(engine)
-    if reasoning_parser:
-        reasoning_parser.reset_state()
+    reasoning_parser = _prepare_streaming_reasoning_parser(engine, request, chat_kwargs)
 
+    tool_parser = _get_streaming_tool_parser(chat_request, engine)
     tool_accumulated_text = ""
     tool_markup_possible = False
-    tool_parser = _get_streaming_tool_parser(chat_request, engine)
 
     async for output in engine.stream_chat(messages=messages, **chat_kwargs):
         last_output = output
@@ -2560,7 +2605,7 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if reasoning_parser and not _thinking_disabled(request, chat_kwargs):
+        if reasoning_parser:
             delta_msg = reasoning_parser.extract_reasoning_streaming(
                 previous_text, raw_accumulated_text, delta_text
             )
@@ -2960,8 +3005,6 @@ def _get_streaming_tool_parser(
     back to the generic auto parser so streaming still matches the generic
     non-streaming tool parsing behavior.
     """
-    global _tool_parser_instance
-
     if request is None:
         return None
     if _tool_choice_disabled(request):
@@ -5682,15 +5725,13 @@ async def _stream_anthropic_messages(
     }
     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
-    reasoning_parser = _build_reasoning_parser(engine)
-    use_reasoning = (
-        reasoning_parser is not None
-        and not chat_kwargs.get("logits_processors")
-        and not _thinking_disabled(openai_request, chat_kwargs)
+    reasoning_parser = _prepare_streaming_reasoning_parser(
+        engine,
+        openai_request,
+        chat_kwargs,
+        allowed=not chat_kwargs.get("logits_processors"),
     )
-
-    if use_reasoning:
-        reasoning_parser.reset_state()
+    use_reasoning = reasoning_parser is not None
 
     # Block index tracking: with reasoning parser we use index 0 for
     # thinking and index 1 for text; without parser, index 0 for text.
@@ -6029,15 +6070,10 @@ async def stream_chat_completion(
 
     # Track if we need to add <think> prefix for thinking models (when no reasoning parser)
     # The template adds <think> to the prompt, so the model output starts inside the think block
-    reasoning_parser = _build_reasoning_parser(engine)
-    is_thinking_model = (
-        "nemotron" in (engine.model_name or "").lower() and not reasoning_parser
+    reasoning_parser, is_thinking_model = _prepare_openai_stream_reasoning_state(
+        engine, request, kwargs
     )
     think_prefix_sent = False
-
-    # Reset reasoning parser state for this stream
-    if reasoning_parser:
-        reasoning_parser.reset_state()
 
     # Track accumulated text for reasoning parser
     accumulated_text = ""
@@ -6052,15 +6088,7 @@ async def stream_chat_completion(
     # via ``parse_json_output``; without this, streaming clients see
     # ``"```json{...}```"`` instead of ``"{...}"`` for models that wrap
     # their structured output in markdown (e.g. Gemma 4).
-    fence_stripper: StreamingJsonFenceStripper | None = None
-    _rf = getattr(request, "response_format", None)
-    _rf_type = None
-    if _rf is not None:
-        _rf_type = getattr(_rf, "type", None)
-        if _rf_type is None and isinstance(_rf, dict):
-            _rf_type = _rf.get("type")
-    if _rf_type in ("json_object", "json_schema"):
-        fence_stripper = StreamingJsonFenceStripper()
+    fence_stripper = _streaming_json_fence_stripper(request)
 
     # Tool call streaming state
     tool_parser = None
@@ -6086,11 +6114,7 @@ async def stream_chat_completion(
             # Use reasoning parser if enabled (skip when enable_thinking=False
             # is set either on the request or via the resolved chat template
             # kwargs / server default).
-            if (
-                reasoning_parser
-                and delta_text
-                and not _thinking_disabled(request, kwargs)
-            ):
+            if reasoning_parser and delta_text:
                 previous_text = accumulated_text
                 accumulated_text += delta_text
                 delta_msg = reasoning_parser.extract_reasoning_streaming(


### PR DESCRIPTION
## Summary

Fixes #649.

Streaming adapters currently read and reset module-level reasoning and configured
tool parser instances. Two overlapping streams can therefore reset or append to
the same mutable parser state.

This patch creates fresh parser instances for each streaming request in the
OpenAI Chat Completions, Responses, and Anthropic adapters. Non-streaming parser
behavior is unchanged.

## Regression coverage

- Adds an interleaved-stream test: closing one `<think>` block cannot change
  another stream's reasoning channel.
- Verifies configured tool parser construction returns distinct instances.
- Runs the existing OpenAI, Responses, and Anthropic streaming suites.

## Validation

- `python -m pytest tests/test_server.py tests/test_responses_api.py tests/test_chat_template_kwargs.py -q`
  - `157 passed, 3 deselected`
- `python -m compileall -q vllm_mlx/server.py`
- `git diff --check`
- Clean-upstream code-path comparison:
  `/opt/ai-runtime/run/upstream-local-repro-preflight/20260729T185153Z-upstream-local-repro-preflight.json`

## Scope

This does not claim an independent reproduction of every tool-call corruption
pattern. It removes the shared mutable parser lifecycle that affects all three
streaming adapters and covers the reasoning-state regression directly.
