### PR TITLE
Drop the duplicate cache-guard test and assert tokenizer encode is never called (#655)

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2000,67 +2000,7 @@ class TestSimpleEngineConcurrency:
 
         assert outputs[-1].text == "Hello"
         assert captured_prompts == [tokenizer.apply_chat_template.return_value]
-
-    @pytest.mark.anyio
-    async def test_stream_generate_text_skips_system_cache_when_text_model_not_safe(
-        self,
-    ):
-        """MLLM TextModel routing must not snapshot hybrid ArraysCache state."""
-        from vllm_mlx.engine.simple import SimpleEngine
-
-        tokenizer = MagicMock()
-        tokenizer.apply_chat_template.return_value = (
-            "<|im_start|>system\nYou are helpful.<|im_end|>\n"
-            "<|im_start|>user\nhello<|im_end|>\n"
-            "<|im_start|>assistant\n"
-        )
-        tokenizer.bos_token = None
-        tokenizer.eos_token_id = 42
-        tokenizer.encode = MagicMock(
-            side_effect=[
-                list(range(10)),  # full prompt
-                list(range(5)),  # system prefix
-            ]
-        )
-
-        captured_prompts = []
-
-        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
-            captured_prompts.append(prompt)
-            yield SimpleNamespace(text="Hello", finish_reason="stop")
-
-        def fail_if_manual_cache_path_runs(*args, **kwargs):
-            raise AssertionError("manual system-cache path must be skipped")
-
-        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
-        engine._loaded = True
-        engine._text_model = MagicMock()
-        engine._text_model.mtp = None
-        engine._text_tokenizer = tokenizer
-        engine._supports_system_kv_cache = False
-
-        with (
-            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
-            patch(
-                "mlx_lm.models.cache.make_prompt_cache",
-                side_effect=fail_if_manual_cache_path_runs,
-            ),
-        ):
-            outputs = [
-                chunk
-                async for chunk in engine._stream_generate_text(
-                    messages=[
-                        {"role": "system", "content": "You are helpful."},
-                        {"role": "user", "content": "hello"},
-                    ],
-                    max_tokens=16,
-                    temperature=0.3,
-                    top_p=0.8,
-                )
-            ]
-
-        assert outputs[-1].text == "Hello"
-        assert captured_prompts == [tokenizer.apply_chat_template.return_value]
+        tokenizer.encode.assert_not_called()
 
     @pytest.mark.anyio
     async def test_stream_generate_text_disables_mtp_when_logits_processors_active(

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2002,6 +2002,67 @@ class TestSimpleEngineConcurrency:
         assert captured_prompts == [tokenizer.apply_chat_template.return_value]
 
     @pytest.mark.anyio
+    async def test_stream_generate_text_skips_system_cache_when_text_model_not_safe(
+        self,
+    ):
+        """MLLM TextModel routing must not snapshot hybrid ArraysCache state."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = (
+            "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+            "<|im_start|>user\nhello<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 42
+        tokenizer.encode = MagicMock(
+            side_effect=[
+                list(range(10)),  # full prompt
+                list(range(5)),  # system prefix
+            ]
+        )
+
+        captured_prompts = []
+
+        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+            captured_prompts.append(prompt)
+            yield SimpleNamespace(text="Hello", finish_reason="stop")
+
+        def fail_if_manual_cache_path_runs(*args, **kwargs):
+            raise AssertionError("manual system-cache path must be skipped")
+
+        engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
+        engine._loaded = True
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        engine._text_tokenizer = tokenizer
+        engine._supports_system_kv_cache = False
+
+        with (
+            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch(
+                "mlx_lm.models.cache.make_prompt_cache",
+                side_effect=fail_if_manual_cache_path_runs,
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "hello"},
+                    ],
+                    max_tokens=16,
+                    temperature=0.3,
+                    top_p=0.8,
+                )
+            ]
+
+        assert outputs[-1].text == "Hello"
+        assert captured_prompts == [tokenizer.apply_chat_template.return_value]
+
+    @pytest.mark.anyio
     async def test_stream_generate_text_disables_mtp_when_logits_processors_active(
         self,
     ):


### PR DESCRIPTION
Closes the duplicate coverage review outcome. Refs #570, #541 and the closure note on #573.

## What was wrong

The original revision added a second copy of `test_stream_generate_text_skips_system_cache_when_text_model_not_safe`. That test **already exists on `main`** (added by #576, commit `59b43c4`). A class body defining the same method name twice silently overwrites the earlier definition, so pytest would collect only the new copy and the pre-existing test would become dead code with **zero net new coverage** — the PR claimed coverage that was never lost.

## What this revision does

1. Removes the duplicated 61-line block, restoring a single copy of the test.
2. Strengthens the surviving test with an explicit assertion that the tokenizer is never re-encoded while the hybrid-cache guard is active:

```python
        assert outputs[-1].text == "Hello"
        assert captured_prompts == [tokenizer.apply_chat_template.return_value]
        tokenizer.encode.assert_not_called()
```

## Why the assertion holds

With `_supports_system_kv_cache = False`, the guarded branch in `vllm_mlx/engine/simple.py` (`_stream_generate_text`, the `cache_blocking_controls` check) is skipped, so the `encode` side-effect list is never consumed. If a future refactor removes the guard, `tokenizer.encode` runs and this assertion fails loudly — together with the `make_prompt_cache` tripwire that raises `"manual system-cache path must be skipped"`.

Net effect vs `main`: 1 insertion, 61 deletions — the safety-guard contract stays pinned, without the shadowing duplicate.

## Verification

- `black --check tests/test_simple_engine.py` and ruff pass
- CI re-runs on the updated head