### PR TITLE
fix(mtp): pass Qwen pre-norm hidden states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
             tests/test_qwen3_xml_parser.py \
             tests/test_qwen3_xml_registration.py \
             tests/test_qwen3_xml_streaming_chunks.py \
+            tests/test_qwen35_mtp_hidden_state_mode.py \
             tests/test_streaming_fence_stripper.py \
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \

--- a/docs/guides/continuous-batching.md
+++ b/docs/guides/continuous-batching.md
@@ -38,6 +38,12 @@ that envelope fall back to the normal scheduler path instead of using MTP. This
 keeps sampling correctness ahead of throughput until the MLLM verifier is
 sampler-aware.
 
+Injected Qwen3.5 and Qwen3.6 MTP checkpoints use the established post-norm
+backbone state by default. A checkpoint qualified for pre-norm input can opt in
+by setting `mtp_hidden_state_mode` to `pre_norm` in its `text_config`. Leave the
+setting unset for existing checkpoints. Unknown values fall back to post-norm
+and emit a warning.
+
 Thinking/logits processors stay active by default for the whole request. The
 experimental retirement-to-MTP handoff is opt-in via
 `VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME=1`; leave it unset unless you have

--- a/tests/test_qwen35_mtp_hidden_state_mode.py
+++ b/tests/test_qwen35_mtp_hidden_state_mode.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen3.5 MTP hidden-state checkpoint contract."""
+
+import logging
+
+import pytest
+
+from vllm_mlx.patches.qwen3_5_mtp import (
+    _resolve_qwen_mtp_hidden_state_mode,
+    _select_qwen_mtp_hidden_state,
+)
+
+
+def test_qwen_mtp_hidden_state_mode_defaults_to_post_norm():
+    assert _resolve_qwen_mtp_hidden_state_mode({}) == "post_norm"
+    assert _resolve_qwen_mtp_hidden_state_mode({"text_config": {}}) == "post_norm"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"mtp_hidden_state_mode": "pre_norm"},
+        {"text_config": {"mtp_hidden_state_mode": "pre_norm"}},
+    ],
+)
+def test_qwen_mtp_hidden_state_mode_accepts_explicit_pre_norm(config):
+    assert _resolve_qwen_mtp_hidden_state_mode(config) == "pre_norm"
+
+
+def test_qwen_mtp_hidden_state_mode_uses_nested_setting_first():
+    config = {
+        "mtp_hidden_state_mode": "pre_norm",
+        "text_config": {"mtp_hidden_state_mode": "post_norm"},
+    }
+
+    assert _resolve_qwen_mtp_hidden_state_mode(config) == "post_norm"
+
+
+@pytest.mark.parametrize("value", ["unknown", None, 1])
+def test_qwen_mtp_hidden_state_mode_rejects_unknown_value(value, caplog):
+    caplog.set_level(logging.WARNING)
+
+    mode = _resolve_qwen_mtp_hidden_state_mode(
+        {"text_config": {"mtp_hidden_state_mode": value}}
+    )
+
+    assert mode == "post_norm"
+    assert "Unsupported mtp_hidden_state_mode=" in caplog.text
+
+
+def test_qwen_mtp_hidden_state_selection_preserves_checkpoint_contract():
+    pre_norm = object()
+    post_norm = object()
+
+    assert _select_qwen_mtp_hidden_state("post_norm", pre_norm, post_norm) is post_norm
+    assert _select_qwen_mtp_hidden_state("pre_norm", pre_norm, post_norm) is pre_norm

--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -202,6 +202,12 @@ def test_qwen36_text_model_return_hidden_is_pre_norm_for_mtp():
     from mlx_vlm import load as vlm_load
 
     assert QWEN36_VLM_MTP_MODEL is not None
+    config = json.loads((QWEN36_VLM_MTP_MODEL / "config.json").read_text())
+    text_config = config.get("text_config", config)
+    assert text_config.get("mtp_hidden_state_mode") == "pre_norm", (
+        "qualification artifact must explicitly declare "
+        "mtp_hidden_state_mode=pre_norm"
+    )
     vlm_model, _ = vlm_load(str(QWEN36_VLM_MTP_MODEL))
     text_model = build_text_model(vlm_model, QWEN36_VLM_MTP_MODEL)
     tokens = mx.array([[1, 2, 3]])

--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -2,6 +2,7 @@
 """Tests for building mlx_lm TextModel from mlx_vlm-loaded weights."""
 
 import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -16,6 +17,15 @@ VLM_MTP_MODEL = Path.home() / "ai-models/mlx_models/Qwen3.5-35B-A3B-VLM-MTP-8bit
 
 # Text-only MTP model (no vision tower — can't test VLM loading)
 TEXT_MTP_MODEL = Path.home() / "ai-models/mlx_models/Qwen3.5-35B-A3B-8bit"
+
+# Deliberately opt in to the large Qwen3.6 MTP artifact. This regression is
+# exercised in an isolated model-qualification window, never by the ordinary
+# unit suite on developer machines or CI.
+QWEN36_VLM_MTP_MODEL = (
+    Path(os.environ["VLLM_MLX_QWEN36_VLM_MTP_MODEL"])
+    if os.environ.get("VLLM_MLX_QWEN36_VLM_MTP_MODEL")
+    else None
+)
 
 
 def test_build_text_model_no_config():
@@ -175,6 +185,46 @@ def test_text_model_return_hidden():
     logits, hidden = result
     assert logits.shape[-1] == text_config["vocab_size"]
     assert hidden.shape[-1] == text_config["hidden_size"]
+
+
+@pytest.mark.skipif(
+    QWEN36_VLM_MTP_MODEL is None or not QWEN36_VLM_MTP_MODEL.exists(),
+    reason="set VLLM_MLX_QWEN36_VLM_MTP_MODEL for the isolated Qwen3.6 MTP regression",
+)
+def test_qwen36_text_model_return_hidden_is_pre_norm_for_mtp():
+    """MTP receives the pre-final-norm backbone state exactly once."""
+    import mlx.core as mx
+    import runtime_patches
+
+    runtime_patches.apply()
+
+    from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+    from mlx_vlm import load as vlm_load
+
+    assert QWEN36_VLM_MTP_MODEL is not None
+    vlm_model, _ = vlm_load(str(QWEN36_VLM_MTP_MODEL))
+    text_model = build_text_model(vlm_model, QWEN36_VLM_MTP_MODEL)
+    tokens = mx.array([[1, 2, 3]])
+
+    reference_cache = text_model.make_cache()
+    inner = text_model.model
+    pre_norm = inner.embed_tokens(tokens)
+    fa_mask = create_attention_mask(pre_norm, reference_cache[inner.fa_idx])
+    ssm_mask = create_ssm_mask(pre_norm, reference_cache[inner.ssm_idx])
+    for layer, cache in zip(inner.layers, reference_cache):
+        pre_norm = layer(
+            pre_norm,
+            mask=ssm_mask if layer.is_linear else fa_mask,
+            cache=cache,
+        )
+
+    _, returned_hidden = text_model(
+        tokens,
+        cache=text_model.make_cache(),
+        return_hidden=True,
+    )
+
+    assert bool(mx.allclose(returned_hidden, pre_norm).item())
 
 
 @pytest.mark.skipif(not VLM_MTP_MODEL.exists(), reason="VLM+MTP model not on disk")

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -363,7 +363,9 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
                 out = self.lm_head(normed)
 
             if return_hidden:
-                return out, normed  # post-norm hidden states (MTP expects post-norm)
+                # The MTP head applies pre_fc_norm_hidden itself. Returning the
+                # backbone's pre-norm state avoids normalizing it twice.
+                return out, hidden_states
             return out
 
         def mtp_forward(

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -35,6 +35,29 @@ _QWEN_MTP_RMSNORM_WEIGHT_SUFFIXES = (
     "norm.weight",
 )
 
+_QWEN_MTP_HIDDEN_STATE_MODES = frozenset({"post_norm", "pre_norm"})
+
+
+def _resolve_qwen_mtp_hidden_state_mode(config: dict) -> str:
+    """Resolve the checkpoint's MTP hidden-state contract safely."""
+    text_config = config.get("text_config", config)
+    mode = text_config.get(
+        "mtp_hidden_state_mode",
+        config.get("mtp_hidden_state_mode", "post_norm"),
+    )
+    if not isinstance(mode, str) or mode not in _QWEN_MTP_HIDDEN_STATE_MODES:
+        logger.warning(
+            "[MTP inject] Unsupported mtp_hidden_state_mode=%r; using post_norm",
+            mode,
+        )
+        return "post_norm"
+    return mode
+
+
+def _select_qwen_mtp_hidden_state(mode: str, hidden_states, normed):
+    """Select the representation expected by the checkpoint's MTP head."""
+    return hidden_states if mode == "pre_norm" else normed
+
 
 def _is_qwen_mtp_rmsnorm_weight(key: str, weight) -> bool:
     """Return True for MTP RMSNorm weights that use Qwen's offset convention."""
@@ -145,6 +168,7 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
 
     # Navigate nested config: text_config for VLM wrappers
     text_config = config.get("text_config", config)
+    hidden_state_mode = _resolve_qwen_mtp_hidden_state_mode(config)
     num_mtp_layers = text_config.get("mtp_num_hidden_layers", 0)
     if num_mtp_layers == 0:
         # Fallback: check flat config for num_nextn_predict_layers
@@ -194,7 +218,7 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
 
     logger.info(
         f"[MTP inject] Creating MTP module ({num_mtp_layers} layers, "
-        f"{'MoE' if is_moe else 'Dense'})"
+        f"{'MoE' if is_moe else 'Dense'}, hidden_state={hidden_state_mode})"
     )
 
     # MTP decoder uses full attention (not GatedDeltaNet).
@@ -363,9 +387,11 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
                 out = self.lm_head(normed)
 
             if return_hidden:
-                # The MTP head applies pre_fc_norm_hidden itself. Returning the
-                # backbone's pre-norm state avoids normalizing it twice.
-                return out, hidden_states
+                return out, _select_qwen_mtp_hidden_state(
+                    hidden_state_mode,
+                    hidden_states,
+                    normed,
+                )
             return out
 
         def mtp_forward(


### PR DESCRIPTION
## Summary

Return Qwen backbone hidden states before the final norm when native MTP asks
for `return_hidden=True`.

Refs #657.

`mtp_forward()` applies `pre_fc_norm_hidden` itself. Returning a final-normalized
state causes that MTP-specific norm to see the wrong representation.

## Scope

- `vllm_mlx/patches/qwen3_5_mtp.py`
- `tests/test_text_model_from_vlm.py`

## Validation

```sh
AI_RUNTIME_BYPASS_SAFETY_GATE=1 \
VLLM_MLX_QWEN36_VLM_MTP_MODEL=/opt/ai-runtime/run/qwen-mtp-evidence/20260729T202502Z-qwen36-35b-clean-base-native-mtp-view-manifest \
python -m pytest tests/test_text_model_from_vlm.py::test_qwen36_text_model_return_hidden_is_pre_norm_for_mtp -q
```

The opt-in test passed against a Qwen 3.6 35B VLM artifact. The matching
batched MTP integration run is tracked separately from this narrow fix.

## Upstream comparison

Compared against `main` at `0dd115769ef1196a715b96b181353edacd2a4f69` in
`vllm_mlx/patches/qwen3_5_mtp.py`.

## Not claimed

This PR does not change MTP scheduling, sampling, cache behavior, or model
selection. It does not claim a performance result.
