### PR TITLE
fix(mtp): validate Qwen MTP artifact conversion

### DIFF
--- a/scripts/add_mtp_weights_qwen35.py
+++ b/scripts/add_mtp_weights_qwen35.py
@@ -98,6 +98,18 @@ def identify_mtp_shards(index: dict) -> tuple[dict[str, str], set[str]]:
     return mtp_keys, shards_needed
 
 
+def quantization_companion_key(key: str, suffix: str) -> str:
+    """Return a scale/bias key without overwriting fused Qwen tensors.
+
+    Qwen 3.6 names fused expert tensors ``gate_up_proj`` and ``down_proj``
+    rather than appending ``.weight``.  Quantized artifacts must keep their
+    companion tensors under distinct names for the runtime to dequantize them.
+    """
+    if key.endswith(".weight"):
+        return f"{key[:-len('.weight')]}.{suffix}"
+    return f"{key}.{suffix}"
+
+
 def download_shards(
     shards: set[str], source_model: str, download_dir: Path
 ) -> dict[str, Path]:
@@ -176,6 +188,9 @@ def extract_and_quantize_mtp_weights(
         del shard_data
 
     print(f"Loaded {len(all_mtp_weights)} MTP weight tensors")
+    missing = sorted(set(mtp_keys) - set(all_mtp_weights))
+    if missing:
+        raise RuntimeError(f"MTP source shards omitted tensors: {missing}")
 
     # Norm keys that need +1.0 shift (HF centered ~0 → MLX centered ~1)
     norm_suffixes = (
@@ -221,8 +236,8 @@ def extract_and_quantize_mtp_weights(
             print(f"  Quantize {bits}-bit: {key} {q_w.shape}")
             return {
                 key: q_w,
-                key.replace(".weight", ".scales"): q_s,
-                key.replace(".weight", ".biases"): q_b,
+                quantization_companion_key(key, "scales"): q_s,
+                quantization_companion_key(key, "biases"): q_b,
             }
         else:
             print(f"  Keep FP (small): {key} {weight.shape}")
@@ -320,6 +335,30 @@ def update_config(snapshot_dir: Path):
         print(f"Updated config: num_nextn_predict_layers={num_mtp}")
     else:
         print("WARNING: mtp_num_hidden_layers not found in config")
+
+
+def write_mtp_artifact_manifest(
+    snapshot_dir: Path, source_model: str, mtp_weight_keys: list[str]
+) -> Path:
+    """Record the conversion contract consumed by the runtime injector.
+
+    Qwen source checkpoints store RMSNorm weights as offsets, while this
+    converter writes MLX-ready gamma weights after applying the offset.  The
+    sidecar removes the need for the runtime to infer that state from tensor
+    values, which is unsafe for valid low-mean gamma tensors.
+    """
+    manifest_path = snapshot_dir / "mtp" / "manifest.json"
+    manifest = {
+        "artifact_schema_version": 1,
+        "source_model": source_model,
+        "rmsnorm_weight_format": "mlx_gamma",
+        "weight_keys": sorted(mtp_weight_keys),
+    }
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(f"Wrote MTP artifact manifest: {manifest_path}")
+    return manifest_path
 
 
 def main():
@@ -449,6 +488,9 @@ def main():
 
     # Update config
     update_config(snapshot_dir)
+    manifest_path = write_mtp_artifact_manifest(
+        snapshot_dir, args.source_model, mtp_weight_keys
+    )
 
     # Cleanup downloaded shards
     if not args.keep_shards and not args.skip_download:
@@ -461,6 +503,7 @@ def main():
     print("SUCCESS! MTP weights added to MLX model.")
     print("=" * 60)
     print(f"\nMTP weight file: {mtp_file}")
+    print(f"MTP artifact manifest: {manifest_path}")
     print(f"Total MTP keys: {len(mtp_weight_keys)}")
     print("\nTo use MTP, start the server with --enable-mtp:")
     print(f"  vllm-mlx serve {args.mlx_model_path} --enable-mtp")

--- a/tests/test_qwen35_mtp_patch.py
+++ b/tests/test_qwen35_mtp_patch.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression tests for Qwen3.5/3.6 MTP weight fixups."""
 
+from types import SimpleNamespace
+
+import pytest
+
 import mlx.core as mx
 
 from vllm_mlx.patches.qwen3_5_mtp import (
     _apply_qwen_mtp_rmsnorm_offset_fixups,
     _strip_mtp_key_prefix,
+    _mtp_artifact_uses_mlx_norm_weights,
+    _mtp_quantization_companion_key,
+    _validate_qwen_moe_mtp_tensor_shapes,
 )
 
 
@@ -55,3 +62,57 @@ def test_qwen_mtp_standalone_shards_accept_both_supported_prefixes():
         == "layers.0.fc.weight"
     )
     assert _strip_mtp_key_prefix("language_model.model.norm.weight") is None
+
+
+def test_qwen_mtp_fused_expert_schema_matches_target_dimensions():
+    args = SimpleNamespace(num_experts=2, hidden_size=4, moe_intermediate_size=3)
+    weights = {
+        "layers.0.mlp.experts.gate_up_proj": mx.zeros((2, 6, 4)),
+        "layers.0.mlp.experts.down_proj": mx.zeros((2, 4, 3)),
+    }
+
+    _validate_qwen_moe_mtp_tensor_shapes(weights, args)
+
+
+def test_qwen_mtp_rejects_fused_expert_bias_written_as_weight():
+    args = SimpleNamespace(num_experts=2, hidden_size=4, moe_intermediate_size=3)
+    weights = {
+        "layers.0.mlp.experts.gate_up_proj": mx.zeros((2, 6, 1)),
+        "layers.0.mlp.experts.down_proj": mx.zeros((2, 4, 1)),
+    }
+
+    with pytest.raises(ValueError, match="expert shape mismatch"):
+        _validate_qwen_moe_mtp_tensor_shapes(weights, args)
+
+
+def test_qwen_mtp_quantization_companions_preserve_fused_tensor_key():
+    assert (
+        _mtp_quantization_companion_key("layers.0.mlp.experts.gate_up_proj", "scales")
+        == "layers.0.mlp.experts.gate_up_proj.scales"
+    )
+    assert (
+        _mtp_quantization_companion_key("layers.0.self_attn.q_proj.weight", "biases")
+        == "layers.0.self_attn.q_proj.biases"
+    )
+
+
+def test_qwen_mtp_manifest_marks_converter_norms_as_mlx_gamma(tmp_path):
+    weights_path = tmp_path / "weights.safetensors"
+    weights_path.touch()
+    (tmp_path / "manifest.json").write_text(
+        '{"artifact_schema_version": 1, "rmsnorm_weight_format": "mlx_gamma"}\n'
+    )
+
+    assert _mtp_artifact_uses_mlx_norm_weights(weights_path)
+
+
+def test_qwen_mtp_missing_or_invalid_manifest_keeps_legacy_fixup(tmp_path):
+    weights_path = tmp_path / "weights.safetensors"
+    weights_path.touch()
+
+    assert not _mtp_artifact_uses_mlx_norm_weights(weights_path)
+    (tmp_path / "manifest.json").write_text("not json\n")
+    assert not _mtp_artifact_uses_mlx_norm_weights(weights_path)
+
+    (tmp_path / "manifest.json").write_text("[]\n")
+    assert not _mtp_artifact_uses_mlx_norm_weights(weights_path)

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -19,6 +19,7 @@ The actual MTP scheduling logic lives in:
   - vllm_mlx/scheduler.py  (_install_mtp, _mtp_step, _mtp_next)
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -88,6 +89,101 @@ def _apply_qwen_mtp_rmsnorm_offset_fixups(mtp_weights: dict) -> int:
             mtp_weights[key] = weight + 1.0
             norm_fixup_count += 1
     return norm_fixup_count
+
+
+def _mtp_artifact_uses_mlx_norm_weights(mtp_weights_path: Path) -> bool:
+    """Return whether a converter manifest proves norms already use MLX gamma.
+
+    Missing or malformed manifests deliberately fall back to legacy detection
+    for existing artifacts.  Only the explicit schema version and declared
+    format suppress the offset conversion.
+    """
+    manifest_path = mtp_weights_path.with_name("manifest.json")
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(manifest, dict):
+        return False
+    return (
+        manifest.get("artifact_schema_version") == 1
+        and manifest.get("rmsnorm_weight_format") == "mlx_gamma"
+    )
+
+
+def _mtp_quantization_companion_key(key: str, suffix: str) -> str:
+    """Return the scale/bias key for both standard and fused Qwen tensors."""
+    if key.endswith(".weight"):
+        return f"{key[:-len('.weight')]}.{suffix}"
+    return f"{key}.{suffix}"
+
+
+def _validate_qwen_moe_mtp_tensor_shapes(mtp_weights: dict, args) -> None:
+    """Reject MTP expert tensors that cannot feed the target Qwen decoder.
+
+    Qwen 3.6 publishes fused MTP expert tensors without a ``.weight`` suffix.
+    A malformed quantized artifact previously overwrote those tensors with its
+    bias values, which let injection continue until the first live decode.
+    Validate the pre-split tensor contract before attaching the MTP module.
+    """
+    if getattr(args, "num_experts", 0) <= 0:
+        return
+
+    num_experts = args.num_experts
+    hidden_size = args.hidden_size
+    intermediate_size = args.moe_intermediate_size
+    fused_keys = (
+        "layers.0.mlp.experts.gate_up_proj",
+        "layers.0.mlp.experts.gate_up_proj.weight",
+    )
+    down_keys = (
+        "layers.0.mlp.experts.down_proj",
+        "layers.0.mlp.experts.down_proj.weight",
+    )
+    fused_key = next((key for key in fused_keys if key in mtp_weights), None)
+    down_key = next((key for key in down_keys if key in mtp_weights), None)
+
+    if fused_key is not None or down_key is not None:
+        if fused_key is None or down_key is None:
+            raise ValueError(
+                "Qwen MoE MTP artifact has an incomplete fused expert pair"
+            )
+        expected_fused = (num_experts, 2 * intermediate_size, hidden_size)
+        expected_down = (num_experts, hidden_size, intermediate_size)
+        actual_fused = tuple(mtp_weights[fused_key].shape)
+        actual_down = tuple(mtp_weights[down_key].shape)
+        if actual_fused != expected_fused or actual_down != expected_down:
+            raise ValueError(
+                "Qwen MoE MTP expert shape mismatch: "
+                f"{fused_key}={actual_fused}, expected={expected_fused}; "
+                f"{down_key}={actual_down}, expected={expected_down}"
+            )
+        return
+
+    split_keys = {
+        "gate": "layers.0.mlp.switch_mlp.gate_proj.weight",
+        "up": "layers.0.mlp.switch_mlp.up_proj.weight",
+        "down": "layers.0.mlp.switch_mlp.down_proj.weight",
+    }
+    if not any(key in mtp_weights for key in split_keys.values()):
+        raise ValueError("Qwen MoE MTP artifact has no expert tensors")
+    if not all(key in mtp_weights for key in split_keys.values()):
+        raise ValueError("Qwen MoE MTP artifact has an incomplete split expert set")
+
+    expected_project = (num_experts, intermediate_size, hidden_size)
+    expected_down = (num_experts, hidden_size, intermediate_size)
+    actual = {name: tuple(mtp_weights[key].shape) for name, key in split_keys.items()}
+    if (
+        actual["gate"] != expected_project
+        or actual["up"] != expected_project
+        or actual["down"] != expected_down
+    ):
+        raise ValueError(
+            "Qwen MoE MTP split expert shape mismatch: "
+            f"gate={actual['gate']}, up={actual['up']}, down={actual['down']}; "
+            f"expected gate/up={expected_project}, down={expected_down}"
+        )
 
 
 def _fixup_moe_mtp(mtp, inner_model, loaded_keys: set, mx) -> None:
@@ -281,8 +377,8 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
         if key.endswith(".scales") or key.endswith(".biases"):
             continue
 
-        scales_key = key.replace(".weight", ".scales")
-        biases_key = key.replace(".weight", ".biases")
+        scales_key = _mtp_quantization_companion_key(key, "scales")
+        biases_key = _mtp_quantization_companion_key(key, "biases")
 
         if scales_key != key and scales_key in raw_mtp and biases_key in raw_mtp:
             # Quantized triplet → dequantize to BF16
@@ -300,6 +396,12 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
             mtp_weights[key] = raw_mtp[key]
             processed.add(key)
     del raw_mtp
+
+    try:
+        _validate_qwen_moe_mtp_tensor_shapes(mtp_weights, args)
+    except ValueError as exc:
+        logger.error("[MTP inject] Refusing invalid Qwen MTP artifact: %s", exc)
+        return False
 
     # --- Convert fused expert format to split format ---
     # Qwen3.6 MTP uses fused expert keys:
@@ -332,16 +434,18 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
             )
 
     # --- Fixup RMSNorm weights: HuggingFace offset convention ---
-    # Qwen3.5/3.6 models store RMSNorm weights as offsets (actual = 1 + stored).
-    # The main model's sanitize() handles this, but MTP weights bypass sanitize.
-    # Detect raw-offset weights (mean < 0.5) and apply +1.0; skip if already
-    # in actual-gamma space (as produced by add_mtp_weights_qwen35.py).
-    norm_fixup_count = _apply_qwen_mtp_rmsnorm_offset_fixups(mtp_weights)
-    if norm_fixup_count > 0:
-        logger.info(
-            f"[MTP inject] Applied +1.0 RMSNorm offset to {norm_fixup_count} "
-            f"norm weights (raw HF offset detected)"
-        )
+    # Qwen3.5/3.6 source weights use offsets (actual = 1 + stored), but the
+    # converter writes MLX gamma weights.  Its manifest is authoritative.
+    # Legacy artifacts retain the conservative mean-based compatibility path.
+    if _mtp_artifact_uses_mlx_norm_weights(mtp_file):
+        logger.info("[MTP inject] Converter manifest declares MLX RMSNorm gamma")
+    else:
+        norm_fixup_count = _apply_qwen_mtp_rmsnorm_offset_fixups(mtp_weights)
+        if norm_fixup_count > 0:
+            logger.info(
+                f"[MTP inject] Applied +1.0 RMSNorm offset to {norm_fixup_count} "
+                f"norm weights (legacy raw HF offset detected)"
+            )
 
     mtp.load_weights(list(mtp_weights.items()), strict=False)
     mx.eval(mtp.parameters())


### PR DESCRIPTION
## Summary

Validate Qwen MoE MTP artifacts before they reach decode and preserve fused
tensor names while writing quantization companions.

Refs #658.

The converter previously overwrote fused expert weights because Qwen 3.6
fused keys do not end in `.weight`. The runtime now rejects incompatible
expert shapes before attaching MTP. Converter output carries a small manifest
so already translated RMSNorm gamma tensors are not guessed from their mean.

## Scope

- `scripts/add_mtp_weights_qwen35.py`
- `vllm_mlx/patches/qwen3_5_mtp.py`
- `tests/test_qwen35_mtp_patch.py`

## Validation

```sh
python -m pytest tests/test_qwen35_mtp_patch.py tests/test_text_model_from_vlm.py -q
ruff check scripts/add_mtp_weights_qwen35.py vllm_mlx/patches/qwen3_5_mtp.py tests/test_qwen35_mtp_patch.py
```

Focused result: 12 passed, 4 artifact-dependent tests skipped.

A rebuilt Qwen 3.6 35B artifact contained all 19 upstream MTP tensors and
completed a text request with `finish_reason=stop`.

## Upstream comparison

Compared against `main` at `0dd115769ef1196a715b96b181353edacd2a4f69` in the
converter and runtime injection paths listed above.

## Not claimed

This PR does not change the MTP scheduler, sampling algorithm, or serving
defaults.
