### PR TITLE
fix(server): flush reasoning parser at stream end (supersedes #653)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1950,6 +1950,94 @@ class TestStreamChatCompletion:
         assert payloads[2]["choices"][0]["finish_reason"] == "stop"
 
     @pytest.mark.anyio
+    async def test_gemma_stream_flushes_pending_content_before_length_finish(
+        self, monkeypatch
+    ):
+        """A terminal length stop must not discard Gemma's buffered tail."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.reasoning.gemma4_parser import Gemma4ReasoningParser
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "gemma4-31b-it-8bit"
+
+            async def stream_chat(self, messages, **kwargs):
+                chunks = [
+                    GenerationOutput(
+                        text="<|channel>thought\n",
+                        new_text="<|channel>thought\n",
+                        finished=False,
+                        prompt_tokens=4,
+                        completion_tokens=3,
+                    ),
+                    GenerationOutput(
+                        text="<|channel>thought\nplan",
+                        new_text="plan",
+                        finished=False,
+                        prompt_tokens=4,
+                        completion_tokens=5,
+                    ),
+                    GenerationOutput(
+                        text="<|channel>thought\nplan<channel|>FINAL<|chan",
+                        new_text="<channel|>FINAL<|chan",
+                        finished=True,
+                        finish_reason="length",
+                        prompt_tokens=4,
+                        completion_tokens=9,
+                    ),
+                ]
+                for chunk in chunks:
+                    yield chunk
+
+        monkeypatch.setattr(server, "_model_name", "gemma4-31b-it-8bit")
+        monkeypatch.setattr(server, "_reasoning_parser", Gemma4ReasoningParser())
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="gemma4-31b-it-8bit",
+            messages=[Message(role="user", content="Write a cover letter.")],
+            stream=True,
+        )
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request, enable_thinking=True
+            )
+        ]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+        content = "".join(
+            choice["delta"].get("content") or ""
+            for payload in payloads
+            for choice in payload["choices"]
+        )
+        reasoning = "".join(
+            choice["delta"].get("reasoning_content") or ""
+            for payload in payloads
+            for choice in payload["choices"]
+        )
+        finish_reasons = [
+            choice["finish_reason"]
+            for payload in payloads
+            for choice in payload["choices"]
+            if choice["finish_reason"]
+        ]
+
+        assert reasoning == "plan"
+        assert content == "FINAL<|chan"
+        assert finish_reasons == ["length"]
+
+    @pytest.mark.anyio
     async def test_auto_parser_streams_bare_bracket_tool_calls(self, monkeypatch):
         """Bare bracket tool calls should stream as structured tool_calls."""
         from vllm_mlx.engine.base import GenerationOutput

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4188,6 +4188,31 @@ async def _ensure_sse_terminal(
             yield terminal_frame
 
 
+def _resolve_reasoning_stream_delta(reasoning_parser, output, delta_msg, request):
+    """Return a stream delta, including parser state buffered at stream end."""
+    if delta_msg is None:
+        if not output.finished:
+            return None
+        content = None
+        reasoning = None
+    else:
+        content = delta_msg.content
+        reasoning = delta_msg.reasoning
+
+    if output.finished:
+        # finalize_stream is defined by ReasoningParser base as a no-op, but
+        # third-party or test-only reasoning parsers may not inherit from it.
+        # Guard so a duck-typed parser without the method still streams.
+        finalize = getattr(reasoning_parser, "finalize_stream", None)
+        final_delta = finalize() if callable(finalize) else None
+        if final_delta is not None:
+            if final_delta.content:
+                content = (content or "") + final_delta.content
+            if final_delta.reasoning:
+                reasoning = (reasoning or "") + final_delta.reasoning
+    return _promote_streaming_response_format_delta(content, reasoning, request)
+
+
 def _find_uvicorn_cycle(obj, depth=0, visited=None):
     """Walk through middleware wrappers to find uvicorn's RequestResponseCycle.
 
@@ -6065,15 +6090,12 @@ async def stream_chat_completion(
                     previous_text, accumulated_text, delta_text
                 )
 
-                if delta_msg is None:
-                    # Skip this chunk (e.g., <think> token itself)
-                    continue
-
-                content = delta_msg.content
-                reasoning = delta_msg.reasoning
-                content, reasoning = _promote_streaming_response_format_delta(
-                    content, reasoning, request
+                resolved_delta = _resolve_reasoning_stream_delta(
+                    _reasoning_parser, output, delta_msg, request
                 )
+                if resolved_delta is None:
+                    continue
+                content, reasoning = resolved_delta
 
                 # Some models (e.g. MiniMax) wrap tool calls in <think>
                 # blocks, so reasoning parser captures tool call XML as


### PR DESCRIPTION
Supersedes #653 with the CI failure resolved.

## Background

@Thump604 opened #653 on 2026-07-28 to flush parser-buffered terminal text (e.g. Gemma 4's truncated `<|channel>` markers) before emitting the terminal chunk of a stream. The fix is correct and needed — Gemma 4's `finalize_stream()` already implements the fallback, `stream_chat_completion` just wasn't calling it.

CI on that PR broke four existing streaming tests:

```
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_emits_structured_tool_calls
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_redirects_gemma4_tool_marker
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_skips_tool_parser_until_markup_appears
tests/test_server.py::TestStreamChatCompletion::test_response_format_stream_promotes_reasoning_json_to_content
```

All four failed with `AttributeError: 'FakeReasoningParser'/'ReasoningOnlyParser' object has no attribute 'finalize_stream'`.

## Root cause

Those tests declare inline test fixtures (`FakeReasoningParser`, `ReasoningOnlyParser`) that duck-type `extract_reasoning_streaming` and `reset_state` but don't inherit from `ReasoningParser`. The base class provides `finalize_stream()` as a documented no-op, so any parser that *does* inherit gets the default automatically. #653 called `reasoning_parser.finalize_stream()` unconditionally, which broke the duck-typed fixtures.

The alternatives are:
1. Add `hasattr` / `getattr` guard in `_resolve_reasoning_stream_delta`.
2. Add `finalize_stream = lambda self: None` stubs to every fake fixture.

I picked (1). The base class's own docstring establishes `finalize_stream` as an *optional* extension point ("Default implementation is a no-op"), so the calling code should tolerate parsers that don't implement it — that keeps the interface contract loose for third-party parsers as well, not only tests.

## Change

One-line change in `_resolve_reasoning_stream_delta` (`vllm_mlx/server.py`):

```python
# Before (from #653):
final_delta = reasoning_parser.finalize_stream()

# After:
finalize = getattr(reasoning_parser, "finalize_stream", None)
final_delta = finalize() if callable(finalize) else None
```

Everything else is @Thump604's original diff, unchanged. Authorship on this commit is preserved as `Thump604 <...>`; I'm listed as `Co-Authored-By` for the guard change.

## Validation

Ran the 5 relevant tests locally (Python 3.14, macOS ARM64, uv-installed dev extras against fresh clone):

```
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_emits_structured_tool_calls PASSED
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_redirects_gemma4_tool_marker PASSED
tests/test_server.py::TestStreamChatCompletion::test_reasoning_stream_skips_tool_parser_until_markup_appears PASSED
tests/test_server.py::TestStreamChatCompletion::test_response_format_stream_promotes_reasoning_json_to_content PASSED
tests/test_server.py::TestStreamChatCompletion::test_gemma_stream_flushes_pending_content_before_length_finish PASSED
5 passed in 1.72s
```

The four previously-failing tests now pass without modification — the guard tolerates duck-typed fixtures. The new test (@Thump604's Gemma flush regression) still passes as designed.

## Not claimed

Same non-claims as #653:
- Preserves template selection, sampling, request limits, scheduler behavior.
- Does not change Jobs integration, model configuration, constrained decoding.
- Does not claim every length-bound Gemma generation produces final content — only preserves parser-buffered terminal content when it exists.

## Followup

Please close #653 after merging this. The intent is identical; this is just a rebased single-commit variant with the CI regression fixed and the base-class no-op contract respected.

Closes #653.