### PR TITLE
fix: accept standard Qwen MTP shard prefixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
             tests/test_mllm.py \
             tests/test_server.py \
             tests/test_paged_cache.py \
+            tests/test_qwen35_mtp_patch.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
             tests/test_optimizations.py \

--- a/tests/test_qwen35_mtp_patch.py
+++ b/tests/test_qwen35_mtp_patch.py
@@ -5,6 +5,7 @@ import mlx.core as mx
 
 from vllm_mlx.patches.qwen3_5_mtp import (
     _apply_qwen_mtp_rmsnorm_offset_fixups,
+    _strip_mtp_key_prefix,
 )
 
 
@@ -45,3 +46,12 @@ def test_qwen_mtp_non_norm_one_dimensional_weights_are_not_shifted():
 
     assert shifted == 0
     assert mx.allclose(weights["layers.0.mlp.shared_expert_gate.weight"], original)
+
+
+def test_qwen_mtp_standalone_shards_accept_both_supported_prefixes():
+    assert _strip_mtp_key_prefix("mtp.layers.0.fc.weight") == "layers.0.fc.weight"
+    assert (
+        _strip_mtp_key_prefix("language_model.mtp.layers.0.fc.weight")
+        == "layers.0.fc.weight"
+    )
+    assert _strip_mtp_key_prefix("language_model.model.norm.weight") is None

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -25,6 +25,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_MTP_KEY_PREFIXES = ("mtp.", "language_model.mtp.")
+
+
+def _strip_mtp_key_prefix(key: str) -> str | None:
+    """Return an MTP-relative key for supported standalone shard layouts."""
+    for prefix in _MTP_KEY_PREFIXES:
+        if key.startswith(prefix):
+            return key.removeprefix(prefix)
+    return None
+
 _QWEN_MTP_RMSNORM_WEIGHT_SUFFIXES = (
     "input_layernorm.weight",
     "post_attention_layernorm.weight",
@@ -231,7 +241,9 @@ def inject_mtp_support(model: Any, model_path, config: dict) -> bool:
     )
     raw = mx.load(str(mtp_file))
     raw_mtp = {
-        k.removeprefix("mtp."): v for k, v in raw.items() if k.startswith("mtp.")
+        clean: value
+        for key, value in raw.items()
+        if (clean := _strip_mtp_key_prefix(key)) is not None
     }
     del raw
 

--- a/vllm_mlx/patches/qwen3_5_mtp.py
+++ b/vllm_mlx/patches/qwen3_5_mtp.py
@@ -35,6 +35,7 @@ def _strip_mtp_key_prefix(key: str) -> str | None:
             return key.removeprefix(prefix)
     return None
 
+
 _QWEN_MTP_RMSNORM_WEIGHT_SUFFIXES = (
     "input_layernorm.weight",
     "post_attention_layernorm.weight",


### PR DESCRIPTION
## Summary

Accept both supported standalone Qwen MTP shard key layouts when injecting MTP into a text model:

- `mtp.*`
- `language_model.mtp.*`

The latter is used by composite VLM artifacts that store their dedicated draft tensors in `model-mtp.safetensors`. Previously the injector found that file but discarded every tensor, leaving MTP unavailable.

## Tests

Adds focused coverage for both accepted prefixes and the unrelated-key rejection case.

## Reproduction boundary

Validated against a local Qwen 3.5 122B-A10B VLM MTP composite artifact. The model loaded and returned correct final text after the prefix was normalized. This PR does not change model sampling, MTP scheduling, or performance claims.