### PR TITLE
fix: honor disabled MTP in VLM text routing

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1469,8 +1469,9 @@ class TestSimpleEngineConcurrency:
         mock_mllm.model = MagicMock()
         mock_mllm.get_tokenizer.return_value = tokenizer
 
-        def build_text_model(*_args, **_kwargs):
+        def build_text_model(*_args, **kwargs):
             captured["build_thread"] = threading.get_ident()
+            captured["enable_mtp"] = kwargs["enable_mtp"]
             return text_model
 
         with (
@@ -1494,6 +1495,7 @@ class TestSimpleEngineConcurrency:
                 assert engine._text_tokenizer is tokenizer
                 assert captured["build_thread"] == worker_thread
                 assert captured["build_thread"] != event_loop_thread
+                assert captured["enable_mtp"] is False
             finally:
                 await engine.stop()
 

--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import inspect
 import sys
 import types
 from pathlib import Path
@@ -38,6 +39,12 @@ def test_build_text_model_none_vlm():
     """Returns None when vlm_model is None."""
     result = build_text_model(None, TEXT_MTP_MODEL)
     assert result is None
+
+
+def test_build_text_model_accepts_engine_mtp_decision():
+    parameter = inspect.signature(build_text_model).parameters["enable_mtp"]
+
+    assert parameter.default is True
 
 
 def test_build_text_model_dispatches_gemma4_text_model(tmp_path, monkeypatch):

--- a/tests/test_text_model_from_vlm.py
+++ b/tests/test_text_model_from_vlm.py
@@ -47,6 +47,69 @@ def test_build_text_model_accepts_engine_mtp_decision():
     assert parameter.default is True
 
 
+def test_build_text_model_disabled_mtp_skips_draft_loading_and_injection(
+    tmp_path, monkeypatch
+):
+    """The non-speculative SimpleEngine path must not touch MTP state."""
+
+    model_path = tmp_path / "qwen"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3_5",
+                "mtp_num_hidden_layers": 1,
+            }
+        )
+    )
+
+    class FakeLanguageModel:
+        def parameters(self):
+            return {}
+
+    class FakeVlmModel:
+        language_model = FakeLanguageModel()
+
+    class FakeTextModelArgs:
+        @classmethod
+        def from_dict(cls, config):
+            return config
+
+    class FakeTextModel:
+        def __init__(self, args):
+            self.args = args
+            self.mtp = None
+            self.loaded_weights = []
+
+        def load_weights(self, weights, strict=False):
+            self.loaded_weights.append((weights, strict))
+
+        def train(self, mode=True):
+            self.training = mode
+            return self
+
+    qwen_module = types.ModuleType("mlx_lm.models.qwen3_5")
+    qwen_module.TextModel = FakeTextModel
+    qwen_module.TextModelArgs = FakeTextModelArgs
+
+    mtp_loads = []
+
+    def record_mtp_load(path):
+        mtp_loads.append(path)
+        return [("mtp.layers.0.weight", object())]
+
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3_5", qwen_module)
+    monkeypatch.setattr(text_model_from_vlm.mlx.utils, "tree_flatten", lambda _p: [])
+    monkeypatch.setattr(text_model_from_vlm, "_load_mtp_weights", record_mtp_load)
+
+    text_model = build_text_model(FakeVlmModel(), model_path, enable_mtp=False)
+
+    assert isinstance(text_model, FakeTextModel)
+    assert mtp_loads == []
+    assert text_model.mtp is None
+    assert text_model.loaded_weights == [([], False)]
+
+
 def test_build_text_model_dispatches_gemma4_text_model(tmp_path, monkeypatch):
     """Gemma 4 text configs should use mlx_lm.models.gemma4_text classes."""
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -908,7 +908,11 @@ class SimpleEngine(BaseEngine):
         try:
             from ..text_model_from_vlm import build_text_model
 
-            self._text_model = build_text_model(self._model.model, self._model_name)
+            self._text_model = build_text_model(
+                self._model.model,
+                self._model_name,
+                enable_mtp=self._mtp,
+            )
 
             if self._text_model is None:
                 self._text_tokenizer = None

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -66,12 +66,15 @@ def _import_text_model_classes(model_type: str):
     return getattr(module, model_attr), getattr(module, args_attr)
 
 
-def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
+def build_text_model(
+    vlm_model: Any, model_path: str | Path, *, enable_mtp: bool = True
+) -> Any | None:
     """Build an mlx_lm TextModel from a vlm-loaded model's weights.
 
     Args:
         vlm_model: The mlx_vlm-loaded model (has .language_model attribute)
         model_path: Path to the model directory (contains config.json + safetensors)
+        enable_mtp: Whether the serving engine requested speculative MTP decoding.
 
     Returns:
         mlx_lm TextModel with MTP support, or None on failure.
@@ -100,10 +103,11 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         args = TextModelArgs.from_dict(text_config)
         text_model = TextModel(args)
 
-        # Collect all weights first: backbone from vlm + MTP from safetensors
+        # Keep the ordinary text route independent from draft tensors unless
+        # the serving engine explicitly enabled speculative MTP decoding.
         vlm_lm = vlm_model.language_model
         vlm_weights = mlx.utils.tree_flatten(vlm_lm.parameters())
-        mtp_weights = _load_mtp_weights(model_path)
+        mtp_weights = _load_mtp_weights(model_path) if enable_mtp else []
 
         all_weight_names = set(name for name, _ in vlm_weights)
         all_weight_names.update(name for name, _ in mtp_weights)
@@ -151,17 +155,17 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
             "Transferred %d weight arrays from vlm language_model", len(vlm_weights)
         )
 
-        # Load MTP weights from safetensors
-        if mtp_weights:
+        # Load and inject draft weights only when the engine requested MTP.
+        if enable_mtp and mtp_weights:
             text_model.load_weights(mtp_weights, strict=False)
             logger.info("Loaded %d MTP weights from safetensors", len(mtp_weights))
-        else:
+        elif enable_mtp:
             logger.warning("No MTP weights found in %s", model_path.name)
 
         # Inject MTP if TextModel doesn't have native MTP support.
         # mlx_lm's qwen3_5.TextModel strips MTP weights in sanitize(),
         # so we inject MTP module + methods at runtime.
-        if not hasattr(text_model, "mtp") or text_model.mtp is None:
+        if enable_mtp and (not hasattr(text_model, "mtp") or text_model.mtp is None):
             num_mtp = text_config.get("mtp_num_hidden_layers", 0)
             if num_mtp == 0:
                 num_mtp = text_config.get("num_nextn_predict_layers", 0)


### PR DESCRIPTION
## Summary

Make the VLM-derived text route honor the serving engine MTP setting. When `--disable-mtp` is selected, Runtime now builds an ordinary TextModel without loading or injecting draft MTP tensors.

The helper remains backward compatible for direct callers; SimpleEngine passes its explicit MTP state.

## Tests

Adds coverage that the TextModel builder accepts the engine MTP decision. Existing TextModel tests continue to cover the default MTP-capable build path.

## Reproduction boundary

Validated locally with a Qwen 3.6 35B-A3B VLM MTP composite artifact. This PR does not alter model sampling, chat templates, MTP verification, or scheduling.