### PR TITLE
fix(embeddings): release MLX buffers after each batch

### DIFF
--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -96,6 +96,41 @@ class TestEmbeddingEngine:
         assert len(result) == 2
         assert result[0] == [0.1, 0.2]
 
+    @patch("vllm_mlx.embedding.EmbeddingEngine.load")
+    @patch(
+        "vllm_mlx.embedding.EmbeddingEngine.is_loaded",
+        new_callable=lambda: property(lambda self: True),
+    )
+    def test_embed_clears_mlx_cache_after_batch(self, _mock_loaded, mock_load):
+        """Test embed releases MLX buffers after converting to Python lists."""
+        import numpy as np
+
+        from vllm_mlx.embedding import EmbeddingEngine
+
+        engine = EmbeddingEngine("test-model")
+
+        mock_output = MagicMock()
+        mock_output.text_embeds.tolist.return_value = [[0.1, 0.2], [0.3, 0.4]]
+
+        mock_model = MagicMock(return_value=mock_output)
+
+        mock_inner_tokenizer = MagicMock()
+        mock_inner_tokenizer.return_value = {
+            "input_ids": np.array([[1, 2], [3, 4]]),
+            "attention_mask": np.array([[1, 1], [1, 1]]),
+        }
+        mock_tokenizer = MagicMock()
+        mock_tokenizer._tokenizer = mock_inner_tokenizer
+
+        engine._model = mock_model
+        engine._tokenizer = mock_tokenizer
+
+        with patch("vllm_mlx.embedding.mx.clear_cache") as mock_clear_cache:
+            result = engine.embed(["hello", "world"])
+            mock_clear_cache.assert_called_once()
+
+        assert result[0] == [0.1, 0.2]
+
     def test_embed_normalises_single_string(self):
         """Test that a single string input is wrapped into a list."""
         import numpy as np

--- a/vllm_mlx/embedding.py
+++ b/vllm_mlx/embedding.py
@@ -82,7 +82,17 @@ class EmbeddingEngine:
         embeds: mx.array = output.text_embeds
 
         # Convert to Python lists for JSON serialization
-        return embeds.tolist()
+        result = embeds.tolist()
+
+        # Release the Metal buffers this pass allocated. MLX keeps freed buffers
+        # in its allocator pool, keyed by size, and `padding=True` above makes
+        # the sequence length vary from batch to batch — so nearly every request
+        # asks for sizes the pool has never seen and cannot reuse. Without this
+        # the pool only grows: measured ~70 MB retained per input text, taking a
+        # fresh process from 2.3 GB to 24 GB over 320 texts.
+        mx.clear_cache()
+
+        return result
 
     def count_tokens(self, texts: str | list[str]) -> int:
         """Approximate token count for usage reporting."""


### PR DESCRIPTION
## Problem

`/v1/embeddings` never releases the Metal buffers it allocates, so the server's memory only grows. Every LLM path calls `mx.clear_cache()` (`worker.py`, `engine_core.py`, `specprefill.py`); `embedding.py` does not.

MLX keeps freed buffers in its allocator pool, keyed by size. `EmbeddingEngine.embed()` tokenizes with `padding=True`, so the sequence length is whatever the longest text in that batch happens to be — with varied inputs almost every request asks for buffer sizes the pool has never seen and cannot reuse. Nothing ever shrinks it.

`DELETE /v1/cache` does not help: it only reaches `mlx_vlm` caches and returns `{"status":"cleared","error":"Cache clear not available (mlx_vlm not loaded)"}` on an embeddings-only server.

## Reproduction

Server started for embeddings only, with the memory flags already recommended for that setup:

```
vllm-mlx serve <small-stub-llm> \
  --embedding-model mlx-community/multilingual-e5-large-mlx \
  --lazy-load-model --auto-unload-idle-seconds 180 --cache-memory-percent 0.05
```

Then batches of 32 texts of randomly varied length (10–320 words), measuring `footprint -p <pid>`:

| after | phys_footprint |
|---|---|
| model load | 2363 MB |
| 32 texts | 4673 MB |
| 160 texts | 13 GB |
| 320 texts | 24 GB |

Roughly 70 MB retained per input text, monotonic, no plateau. None of `--lazy-load-model`, `--auto-unload-idle-seconds` or `--cache-memory-percent` affects it — the growth is not the main model and not the KV/prefix cache.

In production this reached **50 GB** `phys_footprint` on a week-old process. `footprint` attributed 49 GB of it to `IOAccelerator (graphics)` across 3442 regions, with `Reclaimable` = 0, which exhausted swap on a 64 GB machine.

## Fix

Call `mx.clear_cache()` after the embeddings are converted to Python lists — matching what every other engine path already does.

Same measurement with the patch applied:

| after | before | after fix |
|---|---|---|
| model load | 2363 MB | 1923 MB |
| 32 texts | 4673 MB | 3636 MB |
| 160 texts | 13 GB | 3214 MB |
| 320 texts | 24 GB | 3571 MB |

Flat at ~3.5 GB, of which the model itself is 1.1 GB.

### Does clearing the pool cost throughput?

The pool exists so buffers get reused, so the fair objection is that clearing it unconditionally throws away reuse. Measured on both builds, same seeded inputs:

| workload | throughput (fix / no fix) | growth over 320 texts (fix / no fix) |
|---|---|---|
| varied lengths (10–320 words) | 19.2 / 19.1 texts/s | flat ~3.5 GB / **2.3 → 24 GB** |
| uniform length (150 words) | 40.4 / 40.1 texts/s | +1.6 GB / **+3.2 GB** |

Throughput is identical in both. And the uniform case — the one where the pool *should* be reused — still grows twice as fast without the fix, so the reuse being protected is largely theoretical here.

That is what makes the unconditional call reasonable rather than a threshold on `mx.get_cache_memory()`: it costs nothing measurable on either workload, and there is no cross-request state worth keeping for embeddings, unlike generation where a KV cache spans requests.

## Environment

- macOS 15 (Darwin 25.5.0), Apple M2 Max, 64 GB
- vllm-mlx 0.4.0, mlx 0.31.2, mlx-embeddings 0.1.0
- model: `mlx-community/multilingual-e5-large-mlx`

## Note

This is adjacent to #641 (`MemoryAwarePrefixCache` retaining Metal buffers) — a different code path, but the same failure mode of Metal buffers never being handed back.
