### PR TITLE
feat(mtp): support assistant drafters with MLLM batching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \
             tests/test_qwen35_mtp_patch.py \
+            tests/test_batched_engine_mllm_config.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
             tests/test_optimizations.py \

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -82,6 +82,66 @@ def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch)
     assert captured["config_kwargs"]["ssd_cache_max_gb"] == 10.0
 
 
+def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    captured = {}
+    loaded_drafter = object()
+
+    class FakeMLXMultimodalLM:
+        def __init__(self, model_name, trust_remote_code=True, **kwargs):
+            captured["model_kwargs"] = kwargs
+            self.model = object()
+            self.processor = object()
+            self._draft_model = loaded_drafter
+
+        def load(self):
+            return None
+
+    class FakeMLLMSchedulerConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class FakeMLLMScheduler:
+        def __init__(self, model, processor, config, **kwargs):
+            captured["scheduler_kwargs"] = kwargs
+
+        async def start(self):
+            return None
+
+    import vllm_mlx.engine.batched as batched_mod
+
+    fake_scheduler = types.ModuleType("vllm_mlx.mllm_scheduler")
+    fake_scheduler.MLLMScheduler = FakeMLLMScheduler
+    fake_scheduler.MLLMSchedulerConfig = FakeMLLMSchedulerConfig
+    fake_model = types.ModuleType("vllm_mlx.models.mllm")
+    fake_model.MLXMultimodalLM = FakeMLXMultimodalLM
+    monkeypatch.setitem(sys.modules, "vllm_mlx.mllm_scheduler", fake_scheduler)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.models.mllm", fake_model)
+    monkeypatch.setattr(
+        batched_mod.BatchedEngine, "_inject_mtp_mllm", lambda self: None
+    )
+
+    engine = BatchedEngine(
+        model_name="gemma4",
+        scheduler_config=_base_scheduler_config(enable_mtp=False),
+        force_mllm=True,
+        mllm_draft_model="assistant",
+        mllm_draft_kind="mtp",
+        mllm_draft_block_size=6,
+    )
+    asyncio.run(engine._start_mllm())
+
+    assert captured["model_kwargs"]["draft_model"] == "assistant"
+    assert captured["model_kwargs"]["draft_kind"] == "mtp"
+    assert captured["model_kwargs"]["draft_block_size"] == 6
+    assert captured["scheduler_kwargs"] == {
+        "draft_model": loaded_drafter,
+        "draft_kind": "mtp",
+        "draft_block_size": 6,
+    }
+
+
 def _run_start_mllm(monkeypatch, scheduler_config):
     """Run BatchedEngine._start_mllm with fakes, return captured kwargs."""
     from vllm_mlx.engine.batched import BatchedEngine

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -8,6 +8,7 @@ import asyncio
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 
 def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch):
@@ -140,6 +141,32 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
         "draft_kind": "mtp",
         "draft_block_size": 6,
     }
+
+
+def test_generate_forwards_mllm_draft_opt_in():
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    scheduler = SimpleNamespace(
+        generate=AsyncMock(
+            return_value=SimpleNamespace(
+                output_text="ok",
+                output_token_ids=[1],
+                prompt_tokens=2,
+                completion_tokens=1,
+                finish_reason="stop",
+                mtp_drafts=1,
+                mtp_accepted=1,
+            )
+        )
+    )
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._loaded = True
+    engine._is_mllm = True
+    engine._mllm_scheduler = scheduler
+
+    asyncio.run(engine.generate("hello", mllm_draft=True))
+
+    assert scheduler.generate.await_args.kwargs["mllm_draft"] is True
 
 
 def _run_start_mllm(monkeypatch, scheduler_config):

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -256,6 +257,40 @@ class TestLifecycleCli:
 
         assert captured["use_batching"] is True
         assert captured["mllm_draft_model"] == "assistant"
+
+    def test_serve_command_rejects_batched_mllm_draft_without_mtp_kind(
+        self, monkeypatch, capsys
+    ):
+        """Invalid assistant batching must fail before downloading models."""
+        import vllm_mlx.cli as cli
+        import vllm_mlx.utils.download as download
+
+        download_model = MagicMock()
+        monkeypatch.setattr(download, "ensure_model_downloaded", download_model)
+
+        args = SimpleNamespace(
+            model="gemma4",
+            models_config=None,
+            served_model_name=None,
+            enable_auto_tool_choice=False,
+            tool_call_parser=None,
+            gpu_memory_utilization=0.90,
+            max_tokens=32768,
+            max_request_tokens=32768,
+            mllm_draft_model="assistant",
+            mllm_draft_kind=None,
+            mllm_draft_block_size=6,
+            continuous_batching=True,
+            auto_unload_idle_seconds=0.0,
+            lazy_load_model=False,
+            mllm=True,
+        )
+
+        with pytest.raises(SystemExit):
+            cli.serve_command(args)
+
+        download_model.assert_not_called()
+        assert "requires --mllm-draft-kind mtp" in capsys.readouterr().out
 
     def test_serve_command_rejects_mllm_draft_without_mllm(self, capsys):
         """Drafter flags should not be silently ignored on text-only models."""

--- a/tests/test_lifecycle_cli.py
+++ b/tests/test_lifecycle_cli.py
@@ -213,6 +213,50 @@ class TestLifecycleCli:
 
         assert "--mllm-draft-block-size" in capsys.readouterr().err
 
+    def test_serve_command_allows_mllm_draft_with_continuous_batching(
+        self, monkeypatch
+    ):
+        """Assistant MTP can use the MLLM continuous-batching scheduler."""
+        import vllm_mlx.cli as cli
+
+        captured = {}
+        import uvicorn
+        import vllm_mlx.server as server
+        import vllm_mlx.utils.download as download
+
+        monkeypatch.setattr(server, "load_model", lambda *a, **k: captured.update(k))
+        monkeypatch.setattr(download, "ensure_model_downloaded", lambda *a, **k: None)
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **k: None)
+
+        args = SimpleNamespace(
+            model="gemma4",
+            models_config=None,
+            served_model_name=None,
+            enable_auto_tool_choice=False,
+            tool_call_parser=None,
+            gpu_memory_utilization=0.90,
+            max_tokens=32768,
+            max_request_tokens=32768,
+            max_kv_size=131072,
+            mllm_draft_model="assistant",
+            mllm_draft_kind="mtp",
+            mllm_draft_block_size=6,
+            continuous_batching=True,
+            auto_unload_idle_seconds=0.0,
+            lazy_load_model=False,
+            mllm=True,
+        )
+        for name, value in vars(
+            cli.build_parser().parse_args(["serve", "gemma4"])
+        ).items():
+            if not hasattr(args, name):
+                setattr(args, name, value)
+
+        cli.serve_command(args)
+
+        assert captured["use_batching"] is True
+        assert captured["mllm_draft_model"] == "assistant"
+
     def test_serve_command_rejects_mllm_draft_without_mllm(self, capsys):
         """Drafter flags should not be silently ignored on text-only models."""
         import vllm_mlx.cli as cli

--- a/tests/test_lifecycle_server.py
+++ b/tests/test_lifecycle_server.py
@@ -7,6 +7,7 @@ import asyncio
 import time
 from contextlib import suppress
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,6 +16,25 @@ async def _wait_for_resident_state(manager, model_key: str, state: str) -> None:
     """Poll until a resident reaches the expected state."""
     while manager.get_status(model_key)["state"] != state:
         await asyncio.sleep(0)
+
+
+def test_load_model_rejects_batched_mllm_draft_without_mtp_kind(monkeypatch):
+    """Programmatic startup must reject invalid batching before engine creation."""
+    import vllm_mlx.server as srv
+
+    batched_engine = MagicMock()
+    monkeypatch.setattr(srv, "BatchedEngine", batched_engine)
+
+    with pytest.raises(ValueError, match="mllm_draft_kind='mtp'"):
+        srv.load_model(
+            "gemma4",
+            use_batching=True,
+            force_mllm=True,
+            mllm_draft_model="assistant",
+            mllm_draft_kind=None,
+        )
+
+    batched_engine.assert_not_called()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2046,9 +2046,7 @@ def test_scheduler_step_error_fails_every_request_once():
     scheduler.output_queues = {
         request_id: asyncio.Queue() for request_id in scheduler.requests
     }
-    scheduler.batch_generator = SimpleNamespace(
-        process_pending_removals=MagicMock()
-    )
+    scheduler.batch_generator = SimpleNamespace(process_pending_removals=MagicMock())
 
     def abort(request_id):
         scheduler.requests.pop(request_id, None)

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -221,6 +221,7 @@ class TestMLLMBatchRequest:
         assert req.max_tokens == 256
         assert req.temperature == 0.7
         assert req.top_p == 0.9
+        assert req.mllm_draft is False
         assert req.output_tokens == []
 
 
@@ -500,6 +501,7 @@ class TestMLLMRequest:
         assert req.prompt == "Describe this image"
         assert req.images == ["image.jpg"]
         assert req.status == RequestStatus.WAITING
+        assert req.mllm_draft is False
         assert req.output_text == ""
 
 
@@ -1020,6 +1022,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             "no_active_batch": 0,
             "concurrent_batch": 0,
             "logits_processors": 0,
+            "assistant_not_requested": 0,
         }
 
         logits_processor = MagicMock()
@@ -1041,6 +1044,210 @@ class TestMLLMBatchGeneratorMTPGuards:
         stats = batch_gen.get_mtp_stats()
         assert stats["attempted"] == 0
         assert stats["bypass_counts"]["logits_processors"] == 1
+
+    def test_external_mtp_requires_every_active_request_to_opt_in(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        expected_tokens = mx.array([7, 8])
+        expected_logprobs = [mx.array([0.1, 0.9]), mx.array([0.2, 0.8])]
+        original_step = MagicMock(return_value=(expected_tokens, expected_logprobs))
+        draft_model = MagicMock()
+
+        class FakeBatchGen:
+            def __init__(self):
+                self.model = object()
+                self._step = original_step
+                self._next = MagicMock(return_value=[])
+                self.active_batch = SimpleNamespace(
+                    requests=[
+                        SimpleNamespace(mllm_draft=True),
+                        SimpleNamespace(mllm_draft=False),
+                    ]
+                )
+                self.sampler = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        language_model = MagicMock()
+        install_mtp_mllm(batch_gen, language_model, draft_model=draft_model)
+
+        assert batch_gen._allow_mid_batch_extend is False
+
+        tokens, logprobs = batch_gen._step(
+            mx.array([[1], [2]]),
+            cache=[],
+            logits_processors=None,
+            output_tokens=None,
+            samplers=None,
+        )
+
+        assert tokens.tolist() == expected_tokens.tolist()
+        assert [lp.tolist() for lp in logprobs] == [
+            lp.tolist() for lp in expected_logprobs
+        ]
+        original_step.assert_called_once()
+        language_model.assert_not_called()
+        assert batch_gen.get_mtp_stats()["attempted"] == 0
+        assert (
+            batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
+        )
+
+    def test_positive_temperature_is_stochastic_without_sampling_filters(self):
+        from vllm_mlx.mllm_batch_generator import _request_uses_stochastic_sampling
+
+        request = SimpleNamespace(temperature=0.7, top_p=1.0, top_k=0, min_p=0.0)
+
+        assert _request_uses_stochastic_sampling(request) is True
+
+    def test_external_stochastic_rejection_replays_sampled_target(self, monkeypatch):
+        import mlx_vlm.speculative.common as speculative_common
+        import mlx_vlm.speculative.mtp as speculative_mtp
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchResponse,
+            install_mtp_mllm,
+        )
+
+        monkeypatch.setattr(
+            speculative_common, "_batch_cache_left_padding", lambda cache: None
+        )
+        monkeypatch.setattr(
+            speculative_mtp,
+            "_mtp_shared_kv_from_prompt_cache",
+            lambda model, cache: {"shared": object()},
+        )
+        monkeypatch.setattr(
+            speculative_mtp,
+            "_mtp_cache_positions",
+            lambda cache, batch_size: (10, [10] * batch_size),
+        )
+        monkeypatch.setattr(
+            speculative_mtp, "_mtp_draft_position", lambda positions: positions
+        )
+        monkeypatch.setattr(
+            speculative_mtp,
+            "_mtp_draft_block_active",
+            lambda *args, **kwargs: mx.array([[2]], dtype=mx.uint32),
+        )
+
+        request = SimpleNamespace(
+            uid=7,
+            request_id="sampled-external",
+            temperature=0.7,
+            top_p=1.0,
+            top_k=1,
+            min_p=0.0,
+            mllm_draft=True,
+            output_tokens=[],
+        )
+        active_batch = SimpleNamespace(
+            uids=[7],
+            requests=[request],
+            num_tokens=[0],
+            max_tokens=[8],
+        )
+        primary_response = MLLMBatchResponse(
+            uid=7,
+            request_id=request.request_id,
+            token=1,
+            logprobs=mx.zeros(4),
+        )
+
+        class Generator:
+            def __init__(self):
+                self.model = object()
+                self.active_batch = active_batch
+                self._step = MagicMock(
+                    side_effect=AssertionError("external MTP must not bypass")
+                )
+                self._next = MagicMock(return_value=[primary_response])
+                self.sampler = MagicMock()
+                self.stop_tokens = set()
+                self._maybe_store_prefix_cache = MagicMock()
+
+        class TrimmableCache:
+            def __init__(self):
+                self.trim_calls = []
+
+            def is_trimmable(self):
+                return True
+
+            def trim(self, count):
+                self.trim_calls.append(count)
+
+        class DraftModel:
+            def __init__(self):
+                self.accept_lens = []
+                self.draft_lens = []
+
+            def reset(self, model):
+                self.model = model
+
+            def set_shared_kv(self, *args, **kwargs):
+                return None
+
+        class LanguageModel:
+            def __init__(self):
+                self.inputs = []
+
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                self.inputs.append(input_tokens.tolist())
+                seq_len = input_tokens.shape[1]
+                logits = mx.full((1, seq_len, 4), -1000.0)
+                if seq_len == 2:
+                    logits[:, 0, 3] = 0.0
+                else:
+                    logits[:, -1, 1] = 0.0
+                return logits, mx.zeros((1, seq_len, 2))
+
+        generator = Generator()
+        language_model = LanguageModel()
+        draft_model = DraftModel()
+        cache = TrimmableCache()
+        install_mtp_mllm(generator, language_model, draft_model=draft_model)
+
+        generator._step(
+            mx.array([[0]], dtype=mx.uint32),
+            cache=[cache],
+            logits_processors=None,
+            output_tokens=None,
+            samplers=[lambda logprobs: mx.array([1], dtype=mx.uint32)],
+        )
+        responses = generator._next()
+
+        assert language_model.inputs == [[[0]], [[1, 2]], [[3]]]
+        assert cache.trim_calls == [1]
+        assert [response.token for response in responses] == [1, 3]
+        assert responses[1].from_draft is False
+        assert int(mx.argmax(responses[1].logprobs).item()) == 3
+        assert draft_model.accept_lens == [0]
+        assert generator.get_mtp_stats()["rejected"] == 1
+
+    def test_uniform_draft_batches_remove_only_selected_requests(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+
+        requests = [
+            MLLMBatchRequest(uid=1, request_id="a", prompt="a", mllm_draft=True),
+            MLLMBatchRequest(uid=2, request_id="b", prompt="b", mllm_draft=False),
+            MLLMBatchRequest(uid=3, request_id="c", prompt="c", mllm_draft=True),
+        ]
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.active_batch = None
+        generator.unprocessed_requests = requests
+        generator.completion_batch_size = 2
+        generator._require_uniform_mllm_draft = True
+        generator._allow_mid_batch_extend = False
+        generator._pending_error_responses = []
+        generator._process_prompts = MagicMock(side_effect=RuntimeError("failed"))
+
+        responses = MLLMBatchGenerator._next(generator)
+
+        assert [request.request_id for request in generator.unprocessed_requests] == [
+            "b"
+        ]
+        assert [response.request_id for response in responses] == ["a", "c"]
 
     def test_sampled_mtp_uses_post_filter_distributions_and_residuals(self):
         from vllm_mlx.mllm_batch_generator import (

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1976,3 +1976,96 @@ class TestChunkedPrefillCacheHandling:
         assert orig_next_called == [
             1
         ], f"Short prompt should fall through to _orig_next, got {orig_next_called}"
+
+
+def test_external_mtp_drafts_mixed_position_rows_independently():
+    """A later request must not inherit an active row's decode position."""
+    import inspect
+
+    from vllm_mlx.mllm_batch_generator import (
+        _draft_external_mtp_active_batch,
+        install_mtp_mllm,
+    )
+
+    assert "_draft_external_mtp_active_batch(" in inspect.getsource(install_mtp_mllm)
+
+    class FakeDraftModel:
+        def __init__(self):
+            self._draft_round = 0
+            self._shared_kv = {
+                "sliding_attention": (
+                    mx.zeros((2, 1, 8, 2)),
+                    mx.zeros((2, 1, 8, 2)),
+                )
+            }
+            self.set_calls = []
+            self.draft_batch_sizes = []
+
+        def set_shared_kv(self, shared_kv, **kwargs):
+            self._shared_kv = shared_kv
+            self.set_calls.append(kwargs)
+
+        def draft_block(self, bonus_token, hidden, *args, **kwargs):
+            self.draft_batch_sizes.append(hidden.shape[0])
+            token = int(bonus_token) + 10
+            return mx.array([[token]], dtype=mx.int32)
+
+    draft_model = FakeDraftModel()
+    out = _draft_external_mtp_active_batch(
+        draft_model,
+        mx.array([1, 2], dtype=mx.int32),
+        mx.zeros((2, 1, 4)),
+        [10377, 10327],
+        lambda logits: mx.argmax(logits, axis=-1),
+    )
+
+    assert out.tolist() == [11, 12]
+    assert draft_model.draft_batch_sizes == [1, 1]
+    assert [call["kv_offset"] for call in draft_model.set_calls[:2]] == [10377, 10327]
+    assert draft_model.set_calls[-1]["kv_offset"] == 10377
+
+
+def test_scheduler_step_error_fails_every_request_once():
+    """A poisoned shared batch must not be retried behind SSE heartbeats."""
+    import inspect
+
+    from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.requests = {
+        request_id: SimpleNamespace(
+            output_tokens=[1, 2],
+            output_text="partial",
+            num_prompt_tokens=10327,
+            num_output_tokens=2,
+            mtp_drafts=10,
+            mtp_accepted=6,
+        )
+        for request_id in ("older", "joining")
+    }
+    scheduler.output_queues = {
+        request_id: asyncio.Queue() for request_id in scheduler.requests
+    }
+    scheduler.batch_generator = SimpleNamespace(
+        process_pending_removals=MagicMock()
+    )
+
+    def abort(request_id):
+        scheduler.requests.pop(request_id, None)
+        return True
+
+    scheduler.abort_request = MagicMock(side_effect=abort)
+    scheduler._fail_requests_after_step_error(ValueError("negative dimensions"))
+
+    assert scheduler.requests == {}
+    assert scheduler.abort_request.call_count == 2
+    scheduler.batch_generator.process_pending_removals.assert_called_once_with()
+    for queue in scheduler.output_queues.values():
+        output = queue.get_nowait()
+        assert output.finished is True
+        assert output.finish_reason == "error"
+        assert output.output_text == "partial"
+
+    assert "_fail_requests_after_step_error(e)" in inspect.getsource(
+        MLLMScheduler._process_loop
+    )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -113,11 +113,6 @@ def serve_command(args):
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         print("Error: --mllm-draft-block-size must be a positive integer")
         sys.exit(1)
-    if mllm_draft_model and args.continuous_batching:
-        print(
-            "Error: --mllm-draft-model is supported only without --continuous-batching"
-        )
-        sys.exit(1)
     if mllm_draft_model and (args.auto_unload_idle_seconds > 0 or args.lazy_load_model):
         print("Error: --mllm-draft-model is not supported with lifecycle residency yet")
         sys.exit(1)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -110,6 +110,12 @@ def serve_command(args):
     if mllm_draft_model and not getattr(args, "mllm", False):
         print("Error: --mllm-draft-model requires --mllm")
         sys.exit(1)
+    if mllm_draft_model and args.continuous_batching and mllm_draft_kind != "mtp":
+        print(
+            "Error: --mllm-draft-model with --continuous-batching "
+            "requires --mllm-draft-kind mtp"
+        )
+        sys.exit(1)
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         print("Error: --mllm-draft-block-size must be a positive integer")
         sys.exit(1)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -848,6 +848,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                mllm_draft=bool(kwargs.pop("mllm_draft", False)),
             )
 
             return GenerationOutput(
@@ -937,6 +938,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                mllm_draft=bool(kwargs.pop("mllm_draft", False)),
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -195,6 +195,9 @@ class BatchedEngine(BaseEngine):
         stream_interval: int = 1,
         force_mllm: bool = False,
         gpu_memory_utilization: float = 0.90,
+        mllm_draft_model: str | None = None,
+        mllm_draft_kind: str | None = None,
+        mllm_draft_block_size: int | None = None,
     ):
         """
         Initialize the batched engine.
@@ -214,6 +217,9 @@ class BatchedEngine(BaseEngine):
         self._scheduler_config = scheduler_config
         self._stream_interval = stream_interval
         self._gpu_memory_utilization = gpu_memory_utilization
+        self._mllm_draft_model = mllm_draft_model
+        self._mllm_draft_kind = mllm_draft_kind
+        self._mllm_draft_block_size = mllm_draft_block_size
         self._is_mllm = force_mllm or is_mllm_model(model_name)
 
         self._model = None
@@ -343,6 +349,9 @@ class BatchedEngine(BaseEngine):
             self._model_name,
             trust_remote_code=self._trust_remote_code,
             max_kv_size=max_kv_size,
+            draft_model=self._mllm_draft_model,
+            draft_kind=self._mllm_draft_kind,
+            draft_block_size=self._mllm_draft_block_size,
         )
         self._mllm_instance.load()
         self._model = self._mllm_instance.model
@@ -378,7 +387,11 @@ class BatchedEngine(BaseEngine):
             logger.warning(f"Failed to set Metal memory limits: {e}")
 
         # Inject MTP support if enabled
-        if self._scheduler_config and self._scheduler_config.enable_mtp:
+        if (
+            self._scheduler_config
+            and self._scheduler_config.enable_mtp
+            and self._mllm_draft_model is None
+        ):
             self._inject_mtp_mllm()
 
     async def _start_mllm(self) -> None:
@@ -462,10 +475,18 @@ class BatchedEngine(BaseEngine):
         )
 
         # Create and start MLLM scheduler
+        scheduler_kwargs = {}
+        if self._mllm_draft_model is not None:
+            scheduler_kwargs = {
+                "draft_model": getattr(self._mllm_instance, "_draft_model", None),
+                "draft_kind": self._mllm_draft_kind,
+                "draft_block_size": self._mllm_draft_block_size,
+            }
         self._mllm_scheduler = MLLMScheduler(
             model=self._model,
             processor=self._processor,
             config=mllm_config,
+            **scheduler_kwargs,
         )
         await self._mllm_scheduler.start()
 

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -77,19 +77,12 @@ def _drop_retired_processors(
 def _request_uses_stochastic_sampling(request: Any) -> bool:
     """Return whether a request needs sampler-aware speculative verification.
 
-    Greedy (temperature 0) requests are excluded regardless of top_p/top_k/
-    min_p: _sampling_logprobs() collapses to an argmax delta distribution for
-    temperature 0 and never applies those filters, so a greedy request left at
-    a non-default top_p/top_k/min_p is not actually stochastic.
+    Any positive temperature samples even when top-p, top-k, and min-p are at
+    their unrestricted defaults. Temperature zero remains greedy regardless of
+    the filter settings.
     """
     temperature = getattr(request, "temperature", 0.0)
-    if temperature in (0, 0.0):
-        return False
-    return (
-        getattr(request, "top_p", 1.0) < 1.0
-        or getattr(request, "top_k", 0) != 0
-        or getattr(request, "min_p", 0.0) != 0.0
-    )
+    return temperature not in (0, 0.0)
 
 
 def _sampling_logprobs(logits: mx.array, request: Any) -> mx.array:
@@ -212,6 +205,7 @@ class MLLMBatchRequest:
     min_p: float = 0.0
     presence_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    mllm_draft: bool = False
     # Extra logits processors (e.g. JSON schema constrained decoding).
     # Merged with built-in repetition/presence penalty processors in
     # ``_prefill_batch``.
@@ -549,6 +543,8 @@ class MLLMBatchGenerator:
         self.unprocessed_requests: List[MLLMBatchRequest] = []
         self.active_batch: Optional[MLLMBatch] = None
         self.uid_counter = 0
+        self._require_uniform_mllm_draft = False
+        self._allow_mid_batch_extend = True
 
         # Statistics
         self._stats = MLLMBatchStats()
@@ -862,6 +858,24 @@ class MLLMBatchGenerator:
         self.unprocessed_requests = [
             r for r in self.unprocessed_requests if r.uid not in uid_set
         ]
+
+    def _compatible_pending_requests(
+        self,
+        requests: List[MLLMBatchRequest],
+        limit: int,
+        reference: Optional[MLLMBatchRequest] = None,
+    ) -> List[MLLMBatchRequest]:
+        """Select requests that can safely share an assistant-drafter batch."""
+        if not requests or not getattr(self, "_require_uniform_mllm_draft", False):
+            return requests[:limit]
+
+        if reference is None and self.active_batch is not None:
+            reference = self.active_batch.requests[0]
+        if reference is None:
+            reference = requests[0]
+
+        draft_requested = reference.mllm_draft
+        return [r for r in requests if r.mllm_draft == draft_requested][:limit]
 
     def _preprocess_request(self, request: MLLMBatchRequest) -> None:
         """
@@ -1760,7 +1774,9 @@ class MLLMBatchGenerator:
         # Exception: text-only requests can be extended into an active batch
         # via the elif branch below (they skip vision encoding entirely).
         if num_active == 0:
-            requests = self.unprocessed_requests[: self.completion_batch_size]
+            requests = self._compatible_pending_requests(
+                self.unprocessed_requests, self.completion_batch_size
+            )
 
             if len(requests) == 0:
                 self.active_batch = None
@@ -1769,9 +1785,11 @@ class MLLMBatchGenerator:
             try:
                 # Save count before _process_prompts which modifies
                 # `requests` in-place via .remove() for failed items.
-                num_to_consume = len(requests)
+                requested_uids = {r.uid for r in requests}
                 new_batch = self._process_prompts(requests)
-                self.unprocessed_requests = self.unprocessed_requests[num_to_consume:]
+                self.unprocessed_requests = [
+                    r for r in self.unprocessed_requests if r.uid not in requested_uids
+                ]
                 self.active_batch = new_batch
                 prompt_processing = True
             except Exception as e:
@@ -1781,7 +1799,9 @@ class MLLMBatchGenerator:
                     exc_info=True,
                 )
                 # Remove failed requests to avoid infinite retry loop
-                self.unprocessed_requests = self.unprocessed_requests[len(requests) :]
+                self.unprocessed_requests = [
+                    r for r in self.unprocessed_requests if r.uid not in requested_uids
+                ]
                 for req in requests:
                     self._pending_error_responses.append(
                         MLLMBatchResponse(
@@ -1795,10 +1815,13 @@ class MLLMBatchGenerator:
 
         # Mid-batch extend: text-only requests can join an active batch
         # without vision encoding (no shape mismatch risk).
-        elif self.unprocessed_requests:
-            text_only = [
-                r for r in self.unprocessed_requests if not r.images and not r.videos
-            ][: self.completion_batch_size]
+        elif self.unprocessed_requests and getattr(
+            self, "_allow_mid_batch_extend", True
+        ):
+            text_only = self._compatible_pending_requests(
+                [r for r in self.unprocessed_requests if not r.images and not r.videos],
+                self.completion_batch_size,
+            )
 
             if text_only:
                 try:
@@ -2085,6 +2108,8 @@ def install_mtp_mllm(
     _draft_sampler = make_sampler(temp=0.0)
     external_drafter = draft_model is not None
     if external_drafter:
+        batch_gen._require_uniform_mllm_draft = True
+        batch_gen._allow_mid_batch_extend = False
         draft_model.reset(batch_gen.model)
 
     def _model_parts(output: Any) -> Tuple[mx.array, Optional[mx.array]]:
@@ -2124,6 +2149,7 @@ def install_mtp_mllm(
         "no_active_batch": 0,
         "concurrent_batch": 0,
         "logits_processors": 0,
+        "assistant_not_requested": 0,
     }
 
     def _get_mtp_stats() -> Dict[str, Any]:
@@ -2176,12 +2202,22 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
-        if prefill_bypass or no_active_batch_bypass or logits_processors_bypass:
+        assistant_not_requested_bypass = external_drafter and (
+            not active_requests
+            or not all(request.mllm_draft for request in active_requests)
+        )
+        if (
+            prefill_bypass
+            or no_active_batch_bypass
+            or logits_processors_bypass
+            or assistant_not_requested_bypass
+        ):
             # Keep the descriptions near the guards so operator-facing
             # telemetry stays dynamic instead of duplicating code predicates:
             # prefill=input_tokens.shape[1] > 1
             # no_active_batch=active_batch is None
             # logits_processors=request-local processors are active
+            # assistant_not_requested=not every active request opted in
             with _mtp_stats_lock:
                 if prefill_bypass:
                     _bypass_counts["prefill"] += 1
@@ -2189,6 +2225,8 @@ def install_mtp_mllm(
                     _bypass_counts["no_active_batch"] += 1
                 if logits_processors_bypass:
                     _bypass_counts["logits_processors"] += 1
+                if assistant_not_requested_bypass:
+                    _bypass_counts["assistant_not_requested"] += 1
             _skip_state_by_uid.clear()
             return _orig_step(
                 input_tokens, cache, logits_processors, output_tokens, samplers
@@ -2350,19 +2388,17 @@ def install_mtp_mllm(
                     ],
                     axis=0,
                 )
-                sampled_target = mx.concatenate(
-                    [
-                        (
-                            samplers[row]
-                            if samplers and samplers[row]
-                            else batch_gen.sampler
-                        )(verify_distribution[row : row + 1])
-                        for row in range(batch_size)
-                    ],
-                    axis=0,
-                )
+                # _sampling_logprobs already applies each request's sampler
+                # transforms. Draw directly from that distribution so
+                # temperature and top-k/top-p/min-p are not applied twice.
+                sampled_target = mx.random.categorical(verify_distribution)
                 mx.eval(sampled_target, draft_tokens)
                 all_accepted = sampled_target.tolist() == draft_list
+                if not all_accepted:
+                    sampled_target_list = sampled_target.tolist()
+                    for row, uid in enumerate(current_uids):
+                        residual_tokens_by_uid[uid] = int(sampled_target_list[row])
+                        residual_logprobs_by_uid[uid] = verify_distribution[row]
             elif uses_stochastic_sampling:
                 verify_distribution = mx.concatenate(
                     [
@@ -2402,6 +2438,9 @@ def install_mtp_mllm(
                 verify_lp = verify_logits[:, 0, :] - mx.logsumexp(
                     verify_logits[:, 0, :], axis=-1, keepdims=True
                 )
+                accepted_logprobs = (
+                    verify_distribution if uses_stochastic_sampling else verify_lp
+                )
                 for e in range(batch_size):
                     uid = current_uids[e]
                     _skip_state_by_uid[uid] = {
@@ -2410,7 +2449,8 @@ def install_mtp_mllm(
                     }
                     _deferred_drafts[uid] = {
                         "token": draft_list[e],
-                        "logprobs": verify_lp[e],
+                        "logprobs": accepted_logprobs[e],
+                        "from_draft": True,
                     }
                 with _mtp_stats_lock:
                     _mtp_stats["accepted"] += 1
@@ -2420,20 +2460,20 @@ def install_mtp_mllm(
 
             else:
                 # A batch cache cannot roll back an individual row. On a mixed
-                # concurrent rejection, replay only the primary token for every
-                # row; this preserves each target distribution and trades that
-                # step's acceleration for exact cache state. A single sampled
-                # rejection can retain its residual token and still advance.
-                sampled_single_reject = (
-                    uses_stochastic_sampling
-                    and batch_size == 1
-                    and bool(residual_tokens_by_uid)
+                # concurrent rejection, replay the same suffix for every row.
+                # External assistant verification retains the already sampled
+                # target token instead of sampling it twice. Native sampled MTP
+                # only retains a residual for a single-row rejection.
+                sampled_reject = uses_stochastic_sampling and bool(
+                    residual_tokens_by_uid
                 )
                 replay_tokens = primary_tokens
-                if sampled_single_reject:
-                    residual_token = residual_tokens_by_uid[current_uids[0]]
+                if sampled_reject:
+                    residual_tokens = mx.array(
+                        [residual_tokens_by_uid[uid] for uid in current_uids]
+                    )
                     replay_tokens = mx.concatenate(
-                        [primary_tokens[:, None], mx.array([[residual_token]])],
+                        [primary_tokens[:, None], residual_tokens[:, None]],
                         axis=1,
                     )
 
@@ -2450,11 +2490,7 @@ def install_mtp_mllm(
                     for _ci, _snap in _rnn_snapshots.items():
                         cache[_ci].state = _snap
                     rerun_out = language_model(
-                        (
-                            replay_tokens
-                            if sampled_single_reject
-                            else primary_tokens[:, None]
-                        ),
+                        (replay_tokens if sampled_reject else primary_tokens[:, None]),
                         cache=cache,
                         return_hidden=True,
                     )
@@ -2480,10 +2516,12 @@ def install_mtp_mllm(
                             and hasattr(c, "trim")
                         ):
                             c.trim(1)
-                    if sampled_single_reject:
-                        residual_token = residual_tokens_by_uid[current_uids[0]]
+                    if sampled_reject:
+                        residual_tokens = mx.array(
+                            [residual_tokens_by_uid[uid] for uid in current_uids]
+                        )
                         rerun_out = language_model(
-                            mx.array([[residual_token]]),
+                            residual_tokens[:, None],
                             cache=cache,
                             return_hidden=True,
                         )
@@ -2515,13 +2553,14 @@ def install_mtp_mllm(
                         _skip_state_by_uid.clear()
                 for row, uid in enumerate(current_uids):
                     _deferred_drafts.pop(uid, None)
-                    if sampled_single_reject:
+                    if sampled_reject:
                         # Report the logprob from the residual distribution the
                         # token was actually drawn from, not the raw unfiltered
                         # target distribution at this position.
                         _deferred_drafts[uid] = {
                             "token": residual_tokens_by_uid[uid],
                             "logprobs": residual_logprobs_by_uid[uid],
+                            "from_draft": False,
                         }
                 with _mtp_stats_lock:
                     _mtp_stats["rejected"] += 1
@@ -2604,6 +2643,7 @@ def install_mtp_mllm(
                     draft_info = prev_deferred.pop(uid)
                     draft_t = draft_info["token"]
                     draft_lp = draft_info["logprobs"]
+                    from_draft = draft_info.get("from_draft", True)
 
                     if draft_t in batch_gen.stop_tokens:
                         augmented.append(
@@ -2613,7 +2653,7 @@ def install_mtp_mllm(
                                 token=draft_t,
                                 logprobs=draft_lp,
                                 finish_reason="stop",
-                                from_draft=True,
+                                from_draft=from_draft,
                             )
                         )
                         draft_end_uids.add(uid)
@@ -2637,7 +2677,7 @@ def install_mtp_mllm(
                                 token=draft_t,
                                 logprobs=draft_lp,
                                 finish_reason=draft_finish,
-                                from_draft=True,
+                                from_draft=from_draft,
                             )
                         )
 
@@ -2860,11 +2900,22 @@ def install_chunked_prefill_mllm(
                 # IMPORTANT: Only inline requests whose prompt fits
                 # within the chunk budget — longer requests must wait
                 # for their own interleaved prefill (Phase 2).
-                if batch_gen.unprocessed_requests:
+                if batch_gen.unprocessed_requests and getattr(
+                    batch_gen, "_allow_mid_batch_extend", True
+                ):
                     _budget = batch_gen._chunked_prefill_budget
                     short_reqs = []
+                    reference = (
+                        batch_gen.active_batch.requests[0]
+                        if batch_gen.active_batch is not None
+                        else req
+                    )
                     for r in batch_gen.unprocessed_requests:
                         if r.images or r.videos:
+                            continue
+                        if not batch_gen._compatible_pending_requests(
+                            [r], 1, reference=reference
+                        ):
                             continue
                         if r.input_ids is None:
                             try:
@@ -3027,10 +3078,16 @@ def install_chunked_prefill_mllm(
         batch = batch_gen.active_batch
         num_active = len(batch) if batch else 0
 
-        if batch_gen.unprocessed_requests:
+        if batch_gen.unprocessed_requests and (
+            num_active == 0 or getattr(batch_gen, "_allow_mid_batch_extend", True)
+        ):
             # Find first text-only request eligible for interleaving
             text_only_req = None
-            for r in batch_gen.unprocessed_requests:
+            compatible_pending = batch_gen._compatible_pending_requests(
+                batch_gen.unprocessed_requests,
+                len(batch_gen.unprocessed_requests),
+            )
+            for r in compatible_pending:
                 if not r.images and not r.videos:
                     text_only_req = r
                     break

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2253,6 +2253,9 @@ def install_mtp_mllm(
                     kv_valid_len=mx.array(positions),
                     left_padding=_batch_cache_left_padding(cache),
                 )
+                # Sample-and-compare preserves the target distribution here only
+                # because the external draft is a point mass. Changing greedy=True
+                # requires a rejection-sampling verifier that accounts for q(x).
                 draft_tokens = draft_model.draft_block(
                     primary_tokens,
                     hidden_states[:, -1:, :],

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2036,6 +2036,28 @@ class MLLMBatchGenerator:
         return bool(self.unprocessed_requests or self.active_batch)
 
 
+def _draft_external_mtp_active_batch(
+    draft_model: Any,
+    primary_tokens: mx.array,
+    hidden_states: mx.array,
+    positions: List[int],
+    sampler: Callable,
+) -> mx.array:
+    """Draft one token per row without conflating mixed KV positions."""
+    from mlx_vlm.speculative.mtp import _mtp_draft_block_active
+
+    return _mtp_draft_block_active(
+        draft_model,
+        primary_tokens.tolist(),
+        hidden_states[:, -1:, :],
+        2,
+        sampler,
+        primary_tokens.dtype,
+        positions,
+        greedy_sampling=True,
+    )[:, 0]
+
+
 def install_mtp_mllm(
     batch_gen: "MLLMBatchGenerator",
     language_model: Any,
@@ -2256,15 +2278,18 @@ def install_mtp_mllm(
                 # Sample-and-compare preserves the target distribution here only
                 # because the external draft is a point mass. Changing greedy=True
                 # requires a rejection-sampling verifier that accounts for q(x).
-                draft_tokens = draft_model.draft_block(
+                # Mixed-position batches cannot share one assistant-drafter
+                # decode position. A request that joins an active batch has a
+                # shorter valid KV length than the rows already decoding; the
+                # mlx-vlm helper drafts those rows independently and restores
+                # the batched shared-KV view afterwards.
+                draft_tokens = _draft_external_mtp_active_batch(
+                    draft_model,
                     primary_tokens,
-                    hidden_states[:, -1:, :],
-                    None,
-                    2,
+                    hidden_states,
+                    positions,
                     _draft_sampler,
-                    primary_tokens.dtype,
-                    greedy=True,
-                )[:, 0]
+                )
                 draft_distribution = None
             else:
                 draft_logits = language_model.mtp_forward(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2040,6 +2040,8 @@ def install_mtp_mllm(
     batch_gen: "MLLMBatchGenerator",
     language_model: Any,
     num_draft_tokens: int = 1,
+    draft_model: Any = None,
+    draft_block_size: Optional[int] = None,
 ) -> None:
     """Install MTP (Multi-Token Prediction) on an MLLMBatchGenerator.
 
@@ -2059,6 +2061,28 @@ def install_mtp_mllm(
 
     _orig_step = batch_gen._step
     _draft_sampler = make_sampler(temp=0.0)
+    external_drafter = draft_model is not None
+    if external_drafter:
+        draft_model.reset(batch_gen.model)
+
+    def _model_parts(output: Any) -> Tuple[mx.array, Optional[mx.array]]:
+        if isinstance(output, tuple):
+            return output[0], output[1]
+        logits = getattr(output, "logits", output)
+        hidden = getattr(output, "hidden_states", None)
+        if isinstance(hidden, list):
+            hidden = hidden[-1] if hidden else None
+        return logits, hidden
+
+    def _shared_kv(cache: List[Any]) -> Dict[str, Any]:
+        from mlx_vlm.speculative.mtp import _mtp_shared_kv_from_prompt_cache
+
+        return _mtp_shared_kv_from_prompt_cache(language_model, cache)
+
+    def _cache_positions(cache: List[Any], batch_size: int) -> Tuple[int, List[int]]:
+        from mlx_vlm.speculative.mtp import _mtp_cache_positions
+
+        return _mtp_cache_positions(cache, batch_size)
 
     # Skip state belongs to a request, not a batch position. Text-only work
     # may join/leave a continuous batch between decode steps; positional state
@@ -2093,6 +2117,9 @@ def install_mtp_mllm(
             "enabled": True,
             "requested_draft_tokens": num_draft_tokens,
             "effective_draft_tokens": 1,
+            "implementation": (
+                "external_assistant" if external_drafter else "native_target_head"
+            ),
             "mode": "request_local_sampler_aware_verified",
             "attempted": attempted,
             "accepted": accepted,
@@ -2169,9 +2196,8 @@ def install_mtp_mllm(
         else:
             # Normal forward with return_hidden
             model_output = language_model(input_tokens, cache=cache, return_hidden=True)
-            if isinstance(model_output, tuple):
-                logits, hidden_states = model_output
-            else:
+            logits, hidden_states = _model_parts(model_output)
+            if hidden_states is None:
                 return _orig_step(
                     input_tokens, cache, logits_processors, output_tokens, samplers
                 )
@@ -2205,18 +2231,47 @@ def install_mtp_mllm(
         try:
             with _mtp_stats_lock:
                 _mtp_stats["attempted"] += 1
-            draft_logits = language_model.mtp_forward(
-                hidden_states[:, -1:, :],
-                primary_tokens[:, None],
-                mtp_cache=None,
-            )
-            draft_logits = draft_logits[:, -1, :]
             sampled_rows = [
                 _request_uses_stochastic_sampling(request)
                 for request in active_requests
             ]
             uses_stochastic_sampling = any(sampled_rows)
-            if uses_stochastic_sampling:
+            if external_drafter:
+                from mlx_vlm.speculative.common import _batch_cache_left_padding
+                from mlx_vlm.speculative.mtp import _mtp_draft_position
+
+                shared_kv = _shared_kv(cache)
+                if not shared_kv:
+                    raise RuntimeError(
+                        "Assistant MTP requires target shared-KV state from the batch cache"
+                    )
+                max_position, positions = _cache_positions(cache, batch_size)
+                draft_model.set_shared_kv(
+                    shared_kv,
+                    kv_offset=max_position,
+                    position=_mtp_draft_position(mx.array(positions)),
+                    kv_valid_len=mx.array(positions),
+                    left_padding=_batch_cache_left_padding(cache),
+                )
+                draft_tokens = draft_model.draft_block(
+                    primary_tokens,
+                    hidden_states[:, -1:, :],
+                    None,
+                    2,
+                    _draft_sampler,
+                    primary_tokens.dtype,
+                    greedy=True,
+                )[:, 0]
+                draft_distribution = None
+            else:
+                draft_logits = language_model.mtp_forward(
+                    hidden_states[:, -1:, :],
+                    primary_tokens[:, None],
+                    mtp_cache=None,
+                )
+                draft_logits = draft_logits[:, -1, :]
+
+            if uses_stochastic_sampling and not external_drafter:
                 draft_distribution = mx.concatenate(
                     [
                         _sampling_logprobs(draft_logits[row : row + 1], request)
@@ -2225,7 +2280,7 @@ def install_mtp_mllm(
                     axis=0,
                 )
                 draft_tokens = mx.random.categorical(draft_distribution)
-            else:
+            elif not external_drafter:
                 draft_logprobs = draft_logits - mx.logsumexp(
                     draft_logits, axis=-1, keepdims=True
                 )
@@ -2251,11 +2306,7 @@ def install_mtp_mllm(
             verify_output = language_model(
                 verify_input, cache=cache, return_hidden=True
             )
-            if isinstance(verify_output, tuple):
-                verify_logits, verify_hidden = verify_output
-            else:
-                verify_logits = verify_output
-                verify_hidden = None
+            verify_logits, verify_hidden = _model_parts(verify_output)
 
             # Verify in each request's sampler space. The old argmax equality
             # check was valid only for greedy decoding and silently bypassed
@@ -2263,7 +2314,28 @@ def install_mtp_mllm(
             draft_list = draft_tokens.tolist()
             residual_tokens_by_uid: Dict[int, int] = {}
             residual_logprobs_by_uid: Dict[int, mx.array] = {}
-            if uses_stochastic_sampling:
+            if uses_stochastic_sampling and external_drafter:
+                verify_distribution = mx.concatenate(
+                    [
+                        _sampling_logprobs(verify_logits[row : row + 1, 0, :], request)
+                        for row, request in enumerate(active_requests)
+                    ],
+                    axis=0,
+                )
+                sampled_target = mx.concatenate(
+                    [
+                        (
+                            samplers[row]
+                            if samplers and samplers[row]
+                            else batch_gen.sampler
+                        )(verify_distribution[row : row + 1])
+                        for row in range(batch_size)
+                    ],
+                    axis=0,
+                )
+                mx.eval(sampled_target, draft_tokens)
+                all_accepted = sampled_target.tolist() == draft_list
+            elif uses_stochastic_sampling:
                 verify_distribution = mx.concatenate(
                     [
                         _sampling_logprobs(verify_logits[row : row + 1, 0, :], request)
@@ -2314,6 +2386,9 @@ def install_mtp_mllm(
                     }
                 with _mtp_stats_lock:
                     _mtp_stats["accepted"] += 1
+                if external_drafter:
+                    draft_model.accept_lens.append(1)
+                    draft_model.draft_lens.append(1)
 
             else:
                 # A batch cache cannot roll back an individual row. On a mixed
@@ -2355,11 +2430,7 @@ def install_mtp_mllm(
                         cache=cache,
                         return_hidden=True,
                     )
-                    if isinstance(rerun_out, tuple):
-                        rerun_logits, rerun_hidden = rerun_out
-                    else:
-                        rerun_logits = rerun_out
-                        rerun_hidden = None
+                    rerun_logits, rerun_hidden = _model_parts(rerun_out)
                     if rerun_hidden is not None:
                         mx.async_eval(rerun_logits[:, -1, :], rerun_hidden[:, -1:, :])
                         for row, uid in enumerate(current_uids):
@@ -2388,8 +2459,8 @@ def install_mtp_mllm(
                             cache=cache,
                             return_hidden=True,
                         )
-                        if isinstance(rerun_out, tuple):
-                            rerun_logits, rerun_hidden = rerun_out
+                        if isinstance(rerun_out, tuple) or hasattr(rerun_out, "logits"):
+                            rerun_logits, rerun_hidden = _model_parts(rerun_out)
                             # language_model(...) returns (batch, seq, vocab)/
                             # (batch, seq, hidden); reduce logits to the same
                             # 2-D (batch, vocab) convention every other
@@ -2426,6 +2497,9 @@ def install_mtp_mllm(
                         }
                 with _mtp_stats_lock:
                     _mtp_stats["rejected"] += 1
+                if external_drafter:
+                    draft_model.accept_lens.append(0)
+                    draft_model.draft_lens.append(1)
 
         except Exception as e:
             logger.warning(f"[MTP-MLLM] draft/verify failed: {e}")

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -106,6 +106,7 @@ class MLLMRequest:
     videos: Optional[List[str]] = None
     audio: Optional[List[str]] = None
     sampling_params: SamplingParams = field(default_factory=SamplingParams)
+    mllm_draft: bool = False
     arrival_time: float = field(default_factory=time.time)
 
     # Batch generator UID (assigned when scheduled)
@@ -454,6 +455,7 @@ class MLLMScheduler:
             videos=videos,
             audio=audio,
             sampling_params=sampling_params,
+            mllm_draft=bool(kwargs.pop("mllm_draft", False)),
         )
 
         # Estimate prompt token count for monitoring (text tokens only;
@@ -601,6 +603,7 @@ class MLLMScheduler:
                 presence_penalty=request.sampling_params.presence_penalty,
                 repetition_penalty=request.sampling_params.repetition_penalty,
                 logits_processors=request.sampling_params.logits_processors,
+                mllm_draft=request.mllm_draft,
             )
             batch_requests.append(batch_req)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -839,6 +839,47 @@ class MLLMScheduler:
 
         return output
 
+    def _fail_requests_after_step_error(self, error: Exception) -> None:
+        """Terminate every request that may share a partially mutated batch.
+
+        A model forward can update earlier cache layers before a later layer
+        raises. Retrying that batch is unsafe and previously produced an
+        infinite exception loop while streaming clients received heartbeats.
+        """
+        request_ids = list(self.requests)
+        logger.error(
+            "Failing %d MLLM requests after an unrecoverable scheduler step: %s",
+            len(request_ids),
+            error,
+        )
+        for request_id in request_ids:
+            request = self.requests.get(request_id)
+            queue = self.output_queues.get(request_id)
+            if request is not None and queue is not None:
+                try:
+                    queue.put_nowait(
+                        RequestOutput(
+                            request_id=request_id,
+                            output_token_ids=list(request.output_tokens),
+                            output_text=request.output_text,
+                            finished=True,
+                            finish_reason="error",
+                            prompt_tokens=request.num_prompt_tokens,
+                            completion_tokens=request.num_output_tokens,
+                            mtp_drafts=request.mtp_drafts,
+                            mtp_accepted=request.mtp_accepted,
+                        )
+                    )
+                except asyncio.QueueFull:
+                    pass
+            self.abort_request(request_id)
+
+        # abort_request defers batch mutation for thread safety. This handler
+        # runs on the scheduler loop after the failed forward has unwound, so
+        # draining now is both safe and necessary before any later request.
+        if self.batch_generator is not None:
+            self.batch_generator.process_pending_removals()
+
     def get_request(self, request_id: str) -> Optional[MLLMRequest]:
         """Get a request by ID."""
         return self.requests.get(request_id)
@@ -982,6 +1023,7 @@ class MLLMScheduler:
                 raise
             except Exception as e:
                 logger.error(f"Error in MLLM process loop: {e}", exc_info=True)
+                self._fail_requests_after_step_error(e)
                 await asyncio.sleep(0.1)
 
     async def add_request_async(

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -185,6 +185,9 @@ class MLLMScheduler:
         model: Any,
         processor: Any,
         config: Optional[MLLMSchedulerConfig] = None,
+        draft_model: Any = None,
+        draft_kind: Optional[str] = None,
+        draft_block_size: Optional[int] = None,
     ):
         """
         Initialize MLLM scheduler.
@@ -197,6 +200,9 @@ class MLLMScheduler:
         self.model = model
         self.processor = processor
         self.config = config or MLLMSchedulerConfig()
+        self.draft_model = draft_model
+        self.draft_kind = draft_kind
+        self.draft_block_size = draft_block_size
 
         # Get model config
         self.model_config = getattr(model, "config", None)
@@ -366,7 +372,24 @@ class MLLMScheduler:
                 )
 
             # Install MTP if enabled and language model supports it
-            if self.config.enable_mtp:
+            draft_model = getattr(self, "draft_model", None)
+            if draft_model is not None:
+                if getattr(self, "draft_kind", None) != "mtp":
+                    raise ValueError(
+                        "Continuous-batching assistant drafters require draft_kind='mtp'"
+                    )
+                from .mllm_batch_generator import install_mtp_mllm
+
+                install_mtp_mllm(
+                    self.batch_generator,
+                    self.batch_generator.language_model,
+                    num_draft_tokens=max(
+                        1, (getattr(self, "draft_block_size", None) or 2) - 1
+                    ),
+                    draft_model=draft_model,
+                    draft_block_size=getattr(self, "draft_block_size", None),
+                )
+            elif self.config.enable_mtp:
                 lm = self.batch_generator.language_model
                 if hasattr(lm, "mtp") and lm.mtp is not None:
                     from .mllm_batch_generator import install_mtp_mllm

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3323,8 +3323,6 @@ def load_model(
         raise ValueError("MLLM draft models require force_mllm/--mllm")
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         raise ValueError("MLLM draft block size must be a positive integer")
-    if mllm_draft_model and use_batching:
-        raise ValueError("MLLM draft models are supported only by SimpleEngine")
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
         raise ValueError(
             "MLLM draft models are not supported with lifecycle residency yet"
@@ -3424,6 +3422,9 @@ def load_model(
             stream_interval=stream_interval,
             force_mllm=force_mllm,
             gpu_memory_utilization=gpu_memory_utilization,
+            mllm_draft_model=mllm_draft_model,
+            mllm_draft_kind=mllm_draft_kind,
+            mllm_draft_block_size=mllm_draft_block_size,
         )
         # BatchedEngine will be started in lifespan (uvicorn's event loop)
         # Just log for now

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3321,6 +3321,10 @@ def load_model(
         raise ValueError("Default max tokens cannot exceed max request tokens")
     if mllm_draft_model and not force_mllm:
         raise ValueError("MLLM draft models require force_mllm/--mllm")
+    if mllm_draft_model and use_batching and mllm_draft_kind != "mtp":
+        raise ValueError(
+            "Continuous-batching MLLM draft models require mllm_draft_kind='mtp'"
+        )
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         raise ValueError("MLLM draft block size must be a positive integer")
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):


### PR DESCRIPTION
## Problem

External MLLM assistant drafters are currently rejected when continuous batching is enabled, even though the batched scheduler already has request-local speculative state, verification, rollback, and cancellation handling for native MTP. This prevents Gemma 4 assistant-MTP from using the same concurrent serving path.

## Change

- pass an external MLLM drafter and its kind/block size through `BatchedEngine` into `MLLMScheduler`
- install that drafter in the existing UID-scoped MLLM speculative verifier
- bind shared target KV/positions for each request before proposing one token
- preserve request-local sampler verification, rollback, deferred-step state, cancellation cleanup, and metadata counters
- stop rejecting `--mllm-draft-model` with `--continuous-batching`

The one-token proposal size intentionally matches the effective concurrent MTP path already used by Qwen. This does not change native MTP selection and remains opt-in through the existing drafter flags.

## Verification

- full suite: `2268 passed, 24 skipped, 23 deselected`
- focused MLLM/CB/drafter suite: `90 passed, 4 deselected`
- Black, Ruff, and `git diff --check`: pass
- live Gemma 4 31B target plus matching assistant drafter at 128K KV:
  - single request: final content preserved, `finish_reason=stop`
  - two concurrent requests: both final contents preserved, both `finish_reason=stop`
  - streamed request: reasoning/final separation preserved through `[DONE]`
  - final counters: 142 drafted, 95 accepted, 47 rejected, 0 speculative errors

## Scope

This PR does not add a default drafter, change sampling, alter model templates, or claim a throughput improvement. It adds the missing batched execution path and validates correctness/engagement; performance measurement is separate.


## Compatibility boundary

`_model_parts()` preserves the existing tuple behavior and bypasses objects without `hidden_states`. It intentionally widens speculation to model outputs exposing both `.logits` and `.hidden_states`; those objects previously bypassed speculation. External assistant verification also depends on `draft_block(..., greedy=True)`: the draft is a point mass, so sample-and-compare preserves the target distribution. Changing the external draft to stochastic sampling requires a rejection-sampling verifier that accounts for the draft distribution.
