### PR TITLE
Bump mlx-vlm floor to 0.6.5 so converted Qwen3.5 weights load correctly and drop the 0.6.4 exclusion (#674)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "mlx>=0.29.0",
     "mlx-lm>=0.31.3",  # 0.31.3+ required by current mlx-vlm runtime support
-    "mlx-vlm>=0.6.2,!=0.6.4",  # 0.6.4 corrupts converted Qwen3.5 MLX weights (#632)
+    "mlx-vlm>=0.6.5",  # 0.6.5+ fixes Qwen3.5 sanitize double-run (#674)
     "transformers>=5.0.0",  # mlx-lm 0.30.5+ requires transformers 5.0 (rc3 bug fixed in stable)
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",

--- a/tests/test_dependency_floors.py
+++ b/tests/test_dependency_floors.py
@@ -32,20 +32,10 @@ def _has_minimum(requirement: str, minimum: str) -> bool:
     return _version_tuple(version) >= _version_tuple(minimum)
 
 
-def _excludes_version(requirement: str, version: str) -> bool:
-    return f"!={version}" in {part.strip() for part in requirement.split(",")}
-
-
-def test_mlx_vlm_floor_includes_step37_flash_support_and_followups():
+def test_mlx_vlm_floor_includes_loader_guard_and_step37_flash():
     dependencies = _project_dependencies()
 
-    assert _has_minimum(dependencies["mlx-vlm"], "0.6.2")
-
-
-def test_mlx_vlm_excludes_corrupt_qwen35_release():
-    dependencies = _project_dependencies()
-
-    assert _excludes_version(dependencies["mlx-vlm"], "0.6.4")
+    assert _has_minimum(dependencies["mlx-vlm"], "0.6.5")
 
 
 def test_mlx_lm_floor_matches_current_mlx_vlm_runtime_requirement():


### PR DESCRIPTION
Closes #674. Closes #632.

## Summary

Bump the mlx-vlm floor from `>=0.6.2,!=0.6.4` to `>=0.6.5` and drop the 0.6.4 exclusion, now that the upstream sanitize double-run fix from Blaizzy/mlx-vlm#1521 shipped in 0.6.5 (2026-07-16, closed 2026-07-15). PyPI has 0.6.0-0.6.8; only 0.6.4 was affected.

## Change

- pyproject.toml: `mlx-vlm>=0.6.5` with updated comment (refs #674)
- tests/test_dependency_floors.py: floor assertion 0.6.2 -> 0.6.5, renamed test to `test_mlx_vlm_floor_includes_loader_guard_and_step37_flash`, removed the `_excludes_version` helper and exclusion test (subsumed by the floor)

## Verification

- `python3 -m pytest tests/test_dependency_floors.py` -> 2 passed
- Mutation check (empirical): floor 0.6.4 makes the test fail, `>=0.6.5` passes
- ruff + black clean; `>=0.6.5` excludes 0.6.4 by PEP 440 ordering; no other mlx-vlm pins in the repo
- Reviewed by 6 code-reviewer agents (Loop 1): no findings

## Follow-up

- AGENTS.md triage note for #632 updated to reference the `>=0.6.5` floor (local only, file is gitignored)