### PR TITLE
fix(reasoning): stop leaking split think tags and rescanning output

### DIFF
--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for chat template kwargs forwarding."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -435,3 +436,60 @@ async def test_stream_anthropic_skips_reasoning_parser_when_thinking_disabled():
     assert '"type": "thinking"' not in body
     assert "HEL" in body and "LO" in body
     assert '"type": "text_delta"' in body
+
+
+@pytest.mark.anyio
+async def test_stream_anthropic_flushes_partial_reasoning_marker(monkeypatch):
+    async def fake_stream_chat(messages, **kwargs):
+        yield SimpleNamespace(
+            new_text="thinking</thi",
+            prompt_tokens=3,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+        )
+
+    engine = MagicMock(stream_chat=fake_stream_chat, tokenizer=None)
+    messages = [{"role": "user", "content": "Think"}]
+    openai_request = srv.ChatCompletionRequest(
+        model="test-model",
+        messages=[srv.Message(**messages[0])],
+        max_tokens=8,
+    )
+    anthropic_request = srv.AnthropicRequest(
+        model="test-model",
+        max_tokens=8,
+        messages=messages,
+    )
+    prepared = srv.PreparedChatInvocation(
+        messages=messages,
+        chat_kwargs={},
+        response_format=None,
+        json_logits_processor=None,
+    )
+    monkeypatch.setattr(srv, "_reasoning_parser_name", "qwen3")
+    monkeypatch.setattr(srv, "_reasoning_parser", None)
+    monkeypatch.setattr(srv, "_model_name", "test-model")
+
+    body = "".join(
+        [
+            chunk
+            async for chunk in srv._stream_anthropic_messages(
+                engine, openai_request, anthropic_request, prepared
+            )
+        ]
+    )
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+    thinking = "".join(
+        event["delta"]["thinking"]
+        for event in events
+        if event["type"] == "content_block_delta"
+        and event["delta"]["type"] == "thinking_delta"
+    )
+
+    assert thinking == "thinking</thi"
+    assert body.index("thinking</thi") < body.index("message_stop")

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -1533,3 +1533,113 @@ class TestGemma4DegenerateCycling:
         # Channel tokens must not leak
         assert "<channel|>" not in full_content
         assert "<|channel>" not in full_content
+
+
+class TestSplitTagStreaming:
+    """Tags that arrive split across deltas must not leak or be lost.
+
+    A model whose tokenizer has ``</think>`` as a single token never produces
+    this, which is why it went unnoticed; one that spells the tag out in
+    ordinary tokens produces it on every reasoning turn.
+    """
+
+    @staticmethod
+    def _stream(parser, text, chunk):
+        parser.reset_state()
+        accumulated, reasoning, content = "", [], []
+        for i in range(0, len(text), chunk):
+            delta = text[i : i + chunk]
+            previous, accumulated = accumulated, accumulated + delta
+            message = parser.extract_reasoning_streaming(previous, accumulated, delta)
+            if message is not None:
+                if message.reasoning:
+                    reasoning.append(message.reasoning)
+                if message.content:
+                    content.append(message.content)
+        message = parser.finalize_stream()
+        if message is not None:
+            if message.reasoning:
+                reasoning.append(message.reasoning)
+            if message.content:
+                content.append(message.content)
+        return "".join(reasoning), "".join(content)
+
+    @pytest.fixture(params=["qwen3", "deepseek_r1"])
+    def parser(self, request):
+        return get_parser(request.param)()
+
+    @pytest.mark.parametrize("chunk", [1, 2, 3, 4, 5, 6, 7, 16])
+    def test_split_end_tag_does_not_leak(self, parser, chunk):
+        """No fragment of </think> may surface as reasoning."""
+        reasoning, content = self._stream(parser, "weighing it</think>Answer.", chunk)
+        assert reasoning.strip() == "weighing it"
+        assert content.strip() == "Answer."
+        for fragment in ("<", "/", "think", ">"):
+            assert fragment not in reasoning
+
+    @pytest.mark.parametrize("chunk", [1, 2, 3, 5])
+    def test_split_start_tag_does_not_leak(self, parser, chunk):
+        reasoning, content = self._stream(
+            parser, "<think>weighing it</think>Answer.", chunk
+        )
+        assert reasoning.strip() == "weighing it"
+        assert content.strip() == "Answer."
+        assert "<think>" not in reasoning
+        assert "<think>" not in content
+
+    @pytest.mark.parametrize(
+        "text", ["thinking<", "thinking</", "thinking</thi", "thinking</think"]
+    )
+    def test_truncated_tag_prefix_is_still_delivered(self, parser, text):
+        """Withheld text must be flushed when the stream ends without the tag."""
+        reasoning, content = self._stream(parser, text, 3)
+        assert len(reasoning) + len(content) == len(text)
+
+    @pytest.mark.parametrize("chunk", [1, 3, 7])
+    def test_nothing_is_lost(self, parser, chunk):
+        text = "weighing it</think>Answer."
+        reasoning, content = self._stream(parser, text, chunk)
+        # The tag itself is a delimiter, not content of either channel.
+        assert len(reasoning) + len(content) == len(text) - len("</think>")
+
+
+class TestStreamingCostIsFlat:
+    """Per-token cost must not grow with output length.
+
+    The parser used to search the whole accumulated text on every delta, which
+    is O(N²) over a generation — invisible on short replies, dominant on long
+    ones.
+    """
+
+    @staticmethod
+    def _elapsed_ms(parser, n_tokens):
+        import time
+
+        parser.reset_state()
+        tokens = (
+            [f"step{i} " for i in range(n_tokens)]
+            + ["</think>"]
+            + [f"word{i} " for i in range(10)]
+        )
+        accumulated = ""
+        start = time.perf_counter()
+        for delta in tokens:
+            previous, accumulated = accumulated, accumulated + delta
+            parser.extract_reasoning_streaming(previous, accumulated, delta)
+        return (time.perf_counter() - start) * 1000
+
+    @pytest.fixture(params=["qwen3", "deepseek_r1"])
+    def parser(self, request):
+        return get_parser(request.param)()
+
+    def test_scales_linearly(self, parser):
+        """20x the tokens must cost well under 20x^2 the time."""
+        small = self._elapsed_ms(parser, 250)
+        large = self._elapsed_ms(parser, 5000)
+        # Linear would be 20x. Allow generous headroom for timer noise on a
+        # loaded CI machine while still failing loudly on quadratic growth,
+        # which measured over 1000x before the fix.
+        assert large < small * 200, (
+            f"{small:.2f}ms at 250 tokens, {large:.2f}ms at 5000 — "
+            "per-token cost is growing with output length"
+        )

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -656,6 +656,41 @@ class TestResponsesEndpoint:
         assert len(engine._stream_calls) == 1
         engine.chat.assert_not_awaited()
 
+    def test_streaming_reasoning_flushes_partial_marker(self, client, monkeypatch):
+        import vllm_mlx.server as srv
+
+        engine = _mock_engine(_output("unused"))
+        engine.chat = AsyncMock(
+            side_effect=AssertionError("stream path should not call chat")
+        )
+        engine._stream_outputs = [
+            _stream_output("thinking</thi", completion_tokens=2, finish_reason="stop")
+        ]
+        srv._engine = engine
+        monkeypatch.setattr(srv, "_reasoning_parser_name", "qwen3")
+        monkeypatch.setattr(srv, "_reasoning_parser", None)
+
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json={"model": "test-model", "input": "Think", "stream": True},
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        assert resp.status_code == 200
+        events = _parse_sse_events(body)
+        reasoning = "".join(
+            payload["delta"]
+            for event_type, payload in events
+            if event_type == "response.reasoning_text.delta"
+        )
+        event_types = [event_type for event_type, _ in events]
+
+        assert reasoning == "thinking</thi"
+        assert event_types.index("response.reasoning_text.delta") < event_types.index(
+            "response.completed"
+        )
+
     def test_streaming_response_sequence_metadata_is_monotonic(self, client):
         import vllm_mlx.server as srv
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3341,6 +3341,73 @@ class TestStreamChatCompletion:
         assert not errors, f"Unexpected streaming wrapper errors: {errors}"
         assert any("data: [DONE]" in chunk for chunk in chunks)
 
+    @pytest.mark.anyio
+    async def test_reasoning_stream_flushes_partial_marker_before_finish(
+        self, monkeypatch
+    ):
+        """A final partial reasoning marker must not be dropped."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            tokenizer = None
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="thinking</thi",
+                    new_text="thinking</thi",
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=3,
+                    completion_tokens=2,
+                )
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser_name", "qwen3")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        reasoning = "".join(
+            choice["delta"].get("reasoning_content", "")
+            for payload in payloads
+            for choice in payload["choices"]
+        )
+        finish_reasons = [
+            choice["finish_reason"]
+            for payload in payloads
+            for choice in payload["choices"]
+            if choice["finish_reason"] is not None
+        ]
+
+        assert reasoning == "thinking</thi"
+        assert finish_reasons == ["stop"]
+        assert chunks[-1] == "data: [DONE]\n\n"
+
 
 class TestReasoningAndToolCallsNonStreaming:
     """Non-streaming coexistence of reasoning extraction and tool parsing."""

--- a/vllm_mlx/reasoning/deepseek_r1_parser.py
+++ b/vllm_mlx/reasoning/deepseek_r1_parser.py
@@ -7,7 +7,6 @@ The model may sometimes start outputting reasoning without the explicit
 <think> tag, so this parser is more lenient than Qwen3.
 """
 
-from .base import DeltaMessage
 from .think_parser import BaseThinkingReasoningParser
 
 
@@ -26,6 +25,11 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
 
         Input: "reasoning content</think>final answer"  # No opening tag
         Output: reasoning="reasoning content", content="final answer"
+
+    Only the complete-output path is overridden. Streaming used to be overridden
+    too, to catch an end token arriving without a start token, but the base
+    class handles that case itself now; the override only duplicated it while
+    scanning the accumulated text for the start token on every delta.
     """
 
     @property
@@ -61,50 +65,3 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
 
         # Use base class for standard case
         return super().extract_reasoning(model_output)
-
-    def extract_reasoning_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-    ) -> DeltaMessage | None:
-        """
-        Extract reasoning from streaming delta.
-
-        Handles DeepSeek-R1's pattern where <think> may be implicit.
-
-        Args:
-            previous_text: Text accumulated before this delta.
-            current_text: Text including this delta.
-            delta_text: Just the new text.
-
-        Returns:
-            DeltaMessage with reasoning/content, or None to skip.
-        """
-        # First try base class logic
-        result = super().extract_reasoning_streaming(
-            previous_text, current_text, delta_text
-        )
-
-        # Handle DeepSeek-R1 special case: no start token seen but end token appears
-        if result is not None:
-            start_in_prev = self.start_token in previous_text
-            start_in_delta = self.start_token in delta_text
-            end_in_delta = self.end_token in delta_text
-
-            # If end token in delta but we never saw start token
-            if not start_in_prev and not start_in_delta and end_in_delta:
-                # Everything before end token is reasoning
-                idx = delta_text.find(self.end_token)
-                reasoning_part = delta_text[:idx]
-                content_part = delta_text[idx + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning_part if reasoning_part else None,
-                    content=content_part if content_part else None,
-                )
-
-            # Note: DeepSeek-R1 may omit <think> but still be in reasoning mode.
-            # However, we can't reliably detect implicit reasoning without context,
-            # so we default to treating unmarked content as regular content.
-
-        return result

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -10,11 +10,11 @@ Supports three scenarios:
 2. Only closing tag (think injected in prompt): reasoning</think>content
 3. No tags: pure content
 
-Performance: The streaming parser uses a simple state machine to track the
-current phase (pre-think / thinking / content). Tag completion is detected
-against the accumulated text for correctness when `<think>` / `</think>` are
-split across delta boundaries, but phase tracking still avoids the old
-whole-output rescanning behavior.
+Performance: The streaming parser uses a state machine to track the current
+phase (pre-think / thinking / content). A tag that arrives split across delta
+boundaries is handled by withholding the fragment until it either completes or
+is ruled out, so every search stays inside the current delta and the per-token
+cost does not grow with output length.
 """
 
 import logging
@@ -24,6 +24,19 @@ from abc import abstractmethod
 from .base import DeltaMessage, ReasoningParser
 
 logger = logging.getLogger(__name__)
+
+
+def _partial_suffix_len(text: str, markers: tuple[str, ...]) -> int:
+    """Length of the trailing run of ``text`` that is still a prefix of a marker.
+
+    Returns 0 when the tail cannot grow into any of them.
+    """
+    longest = max((len(m) for m in markers), default=0)
+    for size in range(min(len(text), longest - 1), 0, -1):
+        tail = text[-size:]
+        if any(m.startswith(tail) for m in markers):
+            return size
+    return 0
 
 
 class BaseThinkingReasoningParser(ReasoningParser):
@@ -41,8 +54,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
 
         pre_think -> thinking -> content
 
-    Transitions are tracked by parser state. Accumulated text is consulted only
-    to detect when a start/end tag has completed across delta boundaries.
+    Transitions are tracked by parser state. A delta whose tail could still grow
+    into a tag is withheld rather than emitted, so a tag split across deltas is
+    never leaked into the reasoning stream and never has to be searched for in
+    the accumulated text.
     """
 
     @property
@@ -69,6 +84,8 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # Tool call promotion state.
         self._in_tool_call = False
         self._tool_call_buffer = ""
+        # Trailing text withheld because it might be the start of a tag.
+        self._pending = ""
 
     def reset_state(self):
         """Reset state machine for a new streaming request."""
@@ -77,6 +94,32 @@ class BaseThinkingReasoningParser(ReasoningParser):
         self._content_buffer = ""
         self._in_tool_call = False
         self._tool_call_buffer = ""
+        self._pending = ""
+
+    def _merge_pending(self, delta_text: str) -> str:
+        """Prepend previously withheld text to this delta.
+
+        Whatever this returns can be searched on its own: a tag's earlier
+        characters are never released, so a tag completing now is contained in
+        it. That is what keeps the scan off the accumulated text.
+        """
+        text = self._pending + delta_text
+        self._pending = ""
+        return text
+
+    def _hold(self, text: str, markers: tuple[str, ...]) -> str:
+        """Return the emittable prefix, withholding a trailing partial tag.
+
+        Applied to whatever is about to be emitted rather than to the raw delta,
+        so text that follows a tag completing in this same delta is covered too
+        — otherwise a withheld fragment would be stranded when the phase moves
+        on and would resurface out of order at the end of the stream.
+        """
+        hold = _partial_suffix_len(text, markers)
+        if not hold:
+            return text
+        self._pending = text[len(text) - hold :]
+        return text[: len(text) - hold]
 
     def extract_reasoning(
         self,
@@ -141,6 +184,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
 
         start_tok = self.start_token
         end_tok = self.end_token
+        tc_start = self._TOOL_CALL_START
 
         # ── Phase: pre_think ──────────────────────────────────────
         # Haven't seen a completed tag yet. Could be:
@@ -148,10 +192,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # - Already inside implicit reasoning (think was in prompt)
         # - No reasoning at all (pure content model)
         if self._phase == "pre_think":
-            if start_tok in current_text:
+            delta_text = self._merge_pending(delta_text)
+            idx = delta_text.find(start_tok)
+            eidx = delta_text.find(end_tok)
+
+            if idx != -1 and (eidx == -1 or idx < eidx):
                 self._phase = "thinking"
-                idx = delta_text.find(start_tok)
-                after = delta_text[idx + len(start_tok) :] if idx >= 0 else delta_text
+                after = delta_text[idx + len(start_tok) :]
 
                 if end_tok in after:
                     self._phase = "content"
@@ -160,7 +207,6 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     content = after[eidx + len(end_tok) :]
                     return self._transition_to_content(reasoning, content)
 
-                tc_start = self._TOOL_CALL_START
                 if tc_start in after:
                     tc_idx = after.find(tc_start)
                     self._in_tool_call = True
@@ -168,25 +214,26 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     before = after[:tc_idx]
                     return DeltaMessage(reasoning=before) if before else None
 
+                after = self._hold(after, (tc_start, end_tok))
                 return DeltaMessage(reasoning=after) if after else None
 
             # Implicit mode: </think> completed without an explicit <think>.
-            if end_tok in current_text:
+            if eidx != -1:
                 self._phase = "content"
-                idx = delta_text.find(end_tok)
-                if idx >= 0:
-                    reasoning = delta_text[:idx]
-                    content = delta_text[idx + len(end_tok) :]
-                else:
-                    reasoning = None
-                    content = delta_text
+                reasoning = delta_text[:eidx]
+                content = delta_text[eidx + len(end_tok) :]
                 return self._transition_to_content(reasoning, content)
 
             # No tags — default to reasoning (implicit mode assumption).
             # If the model doesn't use thinking at all, the server's
             # non-parser path handles it. This path only activates when
             # a reasoning parser is explicitly configured.
-            return DeltaMessage(reasoning=delta_text)
+            #
+            # <tool_call> is withheld alongside the tags: an explicit <think>
+            # can hand the rest of a delta straight to the thinking phase,
+            # which needs that marker intact to promote the block.
+            delta_text = self._hold(delta_text, (start_tok, end_tok, tc_start))
+            return DeltaMessage(reasoning=delta_text) if delta_text else None
 
         # ── Phase: thinking ───────────────────────────────────────
         # Inside a reasoning block, waiting for end tag.
@@ -195,33 +242,28 @@ class BaseThinkingReasoningParser(ReasoningParser):
             if self._in_tool_call:
                 return self._thinking_tool_call(previous_text, current_text, delta_text)
 
-            tc_start = self._TOOL_CALL_START
-            if tc_start in current_text and tc_start not in previous_text:
+            delta_text = self._merge_pending(delta_text)
+            tc_idx = delta_text.find(tc_start)
+            idx = delta_text.find(end_tok)
+
+            if tc_idx != -1 and (idx == -1 or tc_idx < idx):
                 self._in_tool_call = True
-                idx = delta_text.find(tc_start)
-                if idx >= 0:
-                    reasoning = delta_text[:idx]
-                    self._tool_call_buffer = delta_text[idx:]
-                else:
-                    self._tool_call_buffer = tc_start
-                    reasoning = delta_text
+                reasoning = delta_text[:tc_idx]
+                self._tool_call_buffer = delta_text[tc_idx:]
                 return DeltaMessage(reasoning=reasoning) if reasoning else None
 
-            if end_tok in current_text and end_tok not in previous_text:
+            if idx != -1:
                 self._phase = "content"
-                idx = delta_text.find(end_tok)
-                if idx >= 0:
-                    reasoning = delta_text[:idx]
-                    content = delta_text[idx + len(end_tok) :]
-                else:
-                    reasoning = delta_text
-                    content = None
+                reasoning = delta_text[:idx]
+                content = delta_text[idx + len(end_tok) :]
                 return self._transition_to_content(reasoning, content)
-            return DeltaMessage(reasoning=delta_text)
+
+            delta_text = self._hold(delta_text, (tc_start, end_tok))
+            return DeltaMessage(reasoning=delta_text) if delta_text else None
 
         # ── Phase: content ────────────────────────────────────────
         # Past the reasoning block — everything is content.
-        return self._content_delta(delta_text)
+        return self._content_delta(self._merge_pending(delta_text))
 
     def _extract_complete_reasoning(self, text: str) -> tuple[str | None, str | None]:
         """Split complete output into leading reasoning spans and final content."""
@@ -334,7 +376,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
         tc_end = self._TOOL_CALL_END
         end_tok = self.end_token
 
-        if tc_end in current_text and tc_end not in previous_text:
+        # The buffer already holds everything since the tool call opened, so a
+        # marker completing now is inside it — no need to search the whole
+        # accumulated output for it.
+        if tc_end in self._tool_call_buffer + delta_text:
             self._tool_call_buffer += delta_text
             idx = self._tool_call_buffer.find(tc_end)
             promoted = self._tool_call_buffer[: idx + len(tc_end)]
@@ -370,7 +415,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
             reasoning = remainder.strip() or None
             return DeltaMessage(content=promoted, reasoning=reasoning)
 
-        if end_tok in current_text and end_tok not in previous_text:
+        if end_tok in self._tool_call_buffer + delta_text:
             self._tool_call_buffer += delta_text
             self._in_tool_call = False
             self._phase = "content"
@@ -396,13 +441,26 @@ class BaseThinkingReasoningParser(ReasoningParser):
         return None
 
     def finalize_stream(self) -> DeltaMessage | None:
-        """Flush any buffered tool call text at end of stream."""
+        """Flush text buffered mid-stream: a tool call or a partial tag.
+
+        A generation that stops on a tag prefix — say the model's last token is
+        a bare ``<`` — would otherwise drop those characters, since they were
+        withheld pending a tag that never arrived.
+        """
         if self._in_tool_call and self._tool_call_buffer:
             promoted = self._tool_call_buffer
             self._tool_call_buffer = ""
             self._in_tool_call = False
+            self._pending = ""
             logger.warning("Promoted unclosed streaming tool_call at stream end")
             return DeltaMessage(content=promoted)
+
+        if self._pending:
+            leftover = self._pending
+            self._pending = ""
+            if self._phase == "content":
+                return DeltaMessage(content=leftover)
+            return DeltaMessage(reasoning=leftover)
         return None
 
     @classmethod

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -178,7 +178,7 @@ from .model_registry import (
 )
 from .metrics import metrics as _metrics
 from .models.mllm import UnsafeRemoteURLError, _validate_url_safety, is_url
-from .reasoning import get_parser as get_reasoning_parser
+from .reasoning import DeltaMessage, get_parser as get_reasoning_parser
 from .tool_parsers import ToolParserManager, get_parser_stop_tokens
 
 logging.basicConfig(level=logging.INFO)
@@ -1199,6 +1199,35 @@ def _streaming_json_fence_stripper(
     if response_format_type in ("json_object", "json_schema"):
         return StreamingJsonFenceStripper()
     return None
+
+
+def _extract_streaming_reasoning_delta(
+    parser,
+    previous_text: str,
+    current_text: str,
+    delta_text: str,
+    *,
+    finished: bool,
+) -> DeltaMessage | None:
+    """Parse one reasoning delta and flush buffered text on the final output."""
+    delta = parser.extract_reasoning_streaming(previous_text, current_text, delta_text)
+    if not finished:
+        return delta
+
+    finalize_stream = getattr(parser, "finalize_stream", None)
+    if finalize_stream is None:
+        return delta
+
+    final = finalize_stream()
+    if final is None:
+        return delta
+    if delta is None:
+        return final
+    return DeltaMessage(
+        role=delta.role or final.role,
+        reasoning=((delta.reasoning or "") + (final.reasoning or "")) or None,
+        content=((delta.content or "") + (final.content or "")) or None,
+    )
 
 
 # Lifecycle startup coordination — an Event lets the lifecycle loop block
@@ -2629,15 +2658,23 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
             completion_tokens = output.completion_tokens
 
         delta_text = output.new_text or ""
-        if not delta_text and not output.finished:
+        output_finished = bool(getattr(output, "finished", False))
+        use_reasoning = reasoning_parser and not _thinking_disabled(
+            request, chat_kwargs
+        )
+        if not delta_text and not (use_reasoning and output_finished):
             continue
 
         previous_text = raw_accumulated_text
         raw_accumulated_text += delta_text
 
-        if reasoning_parser:
-            delta_msg = reasoning_parser.extract_reasoning_streaming(
-                previous_text, raw_accumulated_text, delta_text
+        if use_reasoning:
+            delta_msg = _extract_streaming_reasoning_delta(
+                reasoning_parser,
+                previous_text,
+                raw_accumulated_text,
+                delta_text,
+                finished=output_finished,
             )
             if delta_msg is None:
                 continue
@@ -5893,7 +5930,8 @@ async def _stream_anthropic_messages(
         async for output in engine.stream_chat(messages=messages, **chat_kwargs):
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
-            delta_text = output.new_text
+            delta_text = output.new_text or ""
+            output_finished = bool(getattr(output, "finished", False))
 
             if hasattr(output, "prompt_tokens") and output.prompt_tokens:
                 prompt_tokens = output.prompt_tokens
@@ -5902,12 +5940,12 @@ async def _stream_anthropic_messages(
             if hasattr(output, "completion_tokens") and output.completion_tokens:
                 completion_tokens = output.completion_tokens
 
-            if not delta_text and not output.finished:
+            if not delta_text and not (use_reasoning and output_finished):
                 continue
 
             # Filter special tokens
             filtered = SPECIAL_TOKENS_PATTERN.sub("", delta_text)
-            if not filtered and not output.finished:
+            if not filtered and not (use_reasoning and output_finished):
                 continue
 
             if not use_reasoning:
@@ -5962,8 +6000,12 @@ async def _stream_anthropic_messages(
             previous_text = accumulated_text
             accumulated_text += filtered
             assert reasoning_parser is not None
-            delta_msg = reasoning_parser.extract_reasoning_streaming(
-                previous_text, accumulated_text, filtered
+            delta_msg = _extract_streaming_reasoning_delta(
+                reasoning_parser,
+                previous_text,
+                accumulated_text,
+                filtered,
+                finished=output_finished,
             )
 
             if delta_msg is None:
@@ -6258,7 +6300,8 @@ async def stream_chat_completion(
         async for output in engine.stream_chat(messages=messages, **kwargs):
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
-            delta_text = output.new_text
+            delta_text = output.new_text or ""
+            output_finished = bool(getattr(output, "finished", False))
             last_output = output
 
             # Track token counts from output (updated each chunk)
@@ -6270,11 +6313,19 @@ async def stream_chat_completion(
             # Use reasoning parser if enabled (skip when enable_thinking=False
             # is set either on the request or via the resolved chat template
             # kwargs / server default).
-            if reasoning_parser and delta_text:
+            if (
+                reasoning_parser
+                and (delta_text or output_finished)
+                and not _thinking_disabled(request, kwargs)
+            ):
                 previous_text = accumulated_text
                 accumulated_text += delta_text
-                delta_msg = reasoning_parser.extract_reasoning_streaming(
-                    previous_text, accumulated_text, delta_text
+                delta_msg = _extract_streaming_reasoning_delta(
+                    reasoning_parser,
+                    previous_text,
+                    accumulated_text,
+                    delta_text,
+                    finished=output_finished,
                 )
 
                 if delta_msg is None:


### PR DESCRIPTION
Two problems in `BaseThinkingReasoningParser`'s streaming path. Both are invisible for models whose tokenizer has the think tags as single tokens — which is why they have gone unnoticed — and both are unavoidable for models that spell the tags out in ordinary tokens.

## Split tags leaked into the reasoning stream

A tag arriving across delta boundaries was detected against the accumulated text, but by then the fragments had already gone out: `delta_text.find(end_token)` returns -1 for a partial tag, so the code fell through to treating the whole delta as reasoning. Streaming `weighing it</think>Answer.` five characters at a time produced:

```
reasoning: "weighing it</thi"
content:   "nk>Answer."
```

## Per-token cost grew with output length

While the reasoning block was open, every delta ran `start_token in current_text` and `end_token in current_text` across the whole accumulated output. That is O(N²) over a generation — despite the docstring stating the state machine avoided exactly that. Measured at 50x the tokens:

| parser | before |
|---|---|
| `deepseek_r1` | 1023x |
| `qwen3` | ~1170x |

Perfectly linear would be 50x.

## One change fixes both

A delta whose tail could still grow into a tag is withheld rather than emitted. That makes a completing tag always present in the text at hand, so there is nothing left to search the accumulated output for — the leak and the rescan disappear together.

Withholding is applied to what is about to be emitted rather than to the raw delta. Text that follows a tag completing in the same delta is then covered too; otherwise a fragment is stranded when the phase moves on and resurfaces out of order at the end of the stream. `finalize_stream()` flushes anything still withheld, so a generation that stops on a bare `<` does not drop it.

`DeepSeekR1ReasoningParser` no longer overrides the streaming method. It existed to catch an end token arriving without a start token, which the base class handles itself now; the override only duplicated that while scanning the accumulated text for the start token on every delta — which is what kept `deepseek_r1` quadratic even after the base class was fixed. Its complete-output override, the actual leniency this parser is known for, is untouched.

After: **63x** for `deepseek_r1` and **64x** for `qwen3` at 50x the tokens.

## Verification

Behaviour is unchanged on real traffic. I replayed four completions captured from a running Qwen3.6-27B server through both the old and new parsers, split on the model's own token boundaries rather than arbitrary character chunks: **identical reasoning and content in all eight parser/sample combinations**, and 1.3x faster at 1198 tokens. The gain scales with output length — at 1200 tokens the quadratic term is still small.

The new tests are checked both ways: **32 of 40 fail against the previous implementation** and all 40 pass against this one. They cover split start and end tags at every chunk size from 1 to 16, truncated tag prefixes at end of stream, and a scaling assertion that fails loudly on quadratic growth.

`tests/test_tool_call_promotion.py::test_stream_large_chunks` caught a first attempt that withheld only the think tags and not `<tool_call>`, which broke promotion when an explicit `<think>` handed the remainder of a delta to the thinking phase. That marker is withheld too now.

Full CI test list passes; the only failures in my environment are four pre-existing ones that need `mlx`, identical on a clean checkout of `main`.
