### PR TITLE
fix: pin SimpleEngine model load and generation to one thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
             tests/test_dependency_floors.py \
+            tests/test_simple_engine_thread_pinning.py \
             tests/test_harmony_parsers.py \
             tests/test_endpoint_model_policies.py \
             tests/test_truncation.py \

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3571,7 +3571,7 @@ class TestChatCompletionStreamingModeSwitching:
 
         bound_thread = {"id": None}
 
-        def fake_bind_generation_streams():
+        def fake_bind_generation_streams(*_args, **_kwargs):
             bound_thread["id"] = threading.get_ident()
 
         class FakeLLMModel:
@@ -3779,7 +3779,7 @@ class TestChatCompletionStreamingModeSwitching:
 
         bound_thread = {"id": None}
 
-        def fake_bind_generation_streams():
+        def fake_bind_generation_streams(*_args, **_kwargs):
             bound_thread["id"] = threading.get_ident()
 
         class FakeLLMModel:
@@ -3896,7 +3896,7 @@ class TestChatCompletionStreamingModeSwitching:
         bound_thread = {"id": None}
         parser_init_threads: list[int] = []
 
-        def fake_bind_generation_streams():
+        def fake_bind_generation_streams(*_args, **_kwargs):
             bound_thread["id"] = threading.get_ident()
 
         class FakeParser:

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -1508,7 +1508,10 @@ class TestSimpleEngineConcurrency:
         engine._loaded = True
         engine._text_model = MagicMock()
         engine._text_tokenizer = MagicMock()
-        engine._model = FakeMllmModel()
+        # lifecycle._prepare_engine_start runs prepare_for_start on the
+        # generation worker, so the model's owner thread is that worker rather
+        # than the event loop. Build the fake there to match.
+        engine._model = engine._generation_worker().submit(FakeMllmModel).result()
         engine._run_blocking_serialized = fail_if_called  # type: ignore[method-assign]
 
         outputs = [
@@ -1562,7 +1565,9 @@ class TestSimpleEngineConcurrency:
         )
         engine._loaded = True
         engine._text_model = MagicMock()
-        engine._model = FakeMllmModel()
+        # Same ownership rule as the media route: the model is built on the
+        # generation worker, so that is the thread stream_chat must run on.
+        engine._model = engine._generation_worker().submit(FakeMllmModel).result()
 
         outputs = [
             chunk
@@ -1784,9 +1789,14 @@ class TestSimpleEngineConcurrency:
     ):
         """MLLM text-only non-stream path must keep stream_chat on model thread.
 
-        Regression: aggregate_stream_chat -> stream_chat used _run_blocking_serialized,
-        which moved mlx_vlm stream generation to a worker thread and could raise
+        Regression: aggregate_stream_chat -> stream_chat moved mlx_vlm stream
+        generation off the thread that owns the model and could raise
         "There is no Stream(gpu, N) in current thread".
+
+        The owner is now the engine's pinned generation worker rather than the
+        caller's thread, so the model is built there — which is what ``start()``
+        does. The invariant under test is unchanged: whichever thread builds the
+        model must be the one that generates from it.
         """
         from types import SimpleNamespace
 
@@ -1808,7 +1818,10 @@ class TestSimpleEngineConcurrency:
         engine = SimpleEngine("test-model", force_mllm=True, mtp=False)
         engine._loaded = True
         engine._text_model = None
-        engine._model = FakeMllmModel()
+        loop = asyncio.get_running_loop()
+        engine._model = await loop.run_in_executor(
+            engine._generation_worker(), FakeMllmModel
+        )
 
         output = await engine.chat(
             messages=[{"role": "user", "content": "Count: one, two, three"}],
@@ -1876,13 +1889,23 @@ class TestSimpleEngineConcurrency:
 
     @pytest.mark.anyio
     async def test_requests_complete_in_order(self, mock_model):
-        """Test that concurrent requests complete (may be in any order due to lock)."""
+        """Test that concurrent requests complete (may be in any order due to lock).
+
+        Uses "wait" admission explicitly. This test is about queued requests all
+        completing, not about the admission policy — the default "fail_fast"
+        rejects the second and third outright, which
+        ``test_default_admission_rejects_second_serialized_request`` covers.
+        Before generation was pinned to its own thread, the distinction was
+        invisible here: generation blocked the event loop, so the later requests
+        could not reach admission control until the first had already finished.
+        """
         from vllm_mlx.engine.simple import SimpleEngine
 
         with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
             engine = SimpleEngine("test-model")
             engine._model = mock_model
             engine._loaded = True
+            engine._generation_lock_admission = "wait"
 
             # Launch multiple concurrent generate calls
             results = await asyncio.gather(

--- a/tests/test_simple_engine_thread_pinning.py
+++ b/tests/test_simple_engine_thread_pinning.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SimpleEngine must run model load and every generation route on one thread.
+
+MLX streams exist only in the thread that created them, and an array with
+pending primitives carries the stream those primitives were built on. So a
+model loaded on one thread cannot be driven from another: generation dies in
+``mx.eval`` with "There is no Stream(gpu, N) in current thread".
+
+These tests record the thread of each call rather than touching MLX, so they
+run anywhere. Fakes follow the convention in ``test_gemma4_mllm_patch.py``.
+"""
+
+import asyncio
+import sys
+import threading
+import time
+import types
+from typing import Any
+
+import pytest
+
+
+def _install_mlx_stubs() -> None:
+    """Stub mlx.core only when the real one is missing.
+
+    The stub must carry a real __spec__: transformers probes packages with
+    importlib.util.find_spec, which raises ValueError on a spec-less module and
+    would break every other test sharing this pytest process.
+    """
+    try:  # pragma: no cover - depends on the environment
+        import mlx.core  # noqa: F401
+
+        return
+    except Exception:
+        pass
+
+    import importlib.machinery
+
+    core = types.ModuleType("mlx.core")
+    core.__spec__ = importlib.machinery.ModuleSpec("mlx.core", loader=None)
+
+    class _Stream:
+        def __init__(self, idx: int = 0) -> None:
+            self.idx = idx
+
+    class _Array:
+        """Must be a class, not a factory function.
+
+        The engine annotates parameters as ``mx.array | None``, and PEP 604
+        unions are evaluated at definition time, so a plain function here makes
+        importing the module raise "unsupported operand type(s) for |".
+        """
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    core.Stream = _Stream
+    core.array = _Array
+    core.default_device = lambda: "gpu"
+    core.new_stream = lambda *a, **k: _Stream()
+    core.set_default_stream = lambda *a, **k: None
+    core.clear_cache = lambda: None
+    core.metal = types.SimpleNamespace(
+        get_active_memory=lambda: 0,
+        get_peak_memory=lambda: 0,
+        get_cache_memory=lambda: 0,
+    )
+    mlx = types.ModuleType("mlx")
+    mlx.__spec__ = importlib.machinery.ModuleSpec("mlx", loader=None, is_package=True)
+    mlx.__path__ = []
+    mlx.core = core
+    sys.modules.setdefault("mlx", mlx)
+    sys.modules["mlx.core"] = core
+
+
+_install_mlx_stubs()
+
+
+class _Chunk:
+    def __init__(self, text: str, finish_reason: str | None = None) -> None:
+        self.text = text
+        self.finish_reason = finish_reason
+        self.prompt_tokens = 1
+        self.finished = finish_reason is not None
+
+
+class _ThreadRecordingModel:
+    """Records the thread each MLX-touching call runs on."""
+
+    def __init__(
+        self,
+        threads: dict[str, list[str]],
+        *,
+        chunks: int = 3,
+        chunk_gate: threading.Event | None = None,
+    ) -> None:
+        self._threads = threads
+        self._chunks = chunks
+        self._chunk_gate = chunk_gate
+        self.closed = threading.Event()
+        self.tokenizer = types.SimpleNamespace(encode=lambda s: [0] * len(s.split()))
+        self.model = object()
+
+    def _record(self, key: str) -> None:
+        # Name plus ident: a fresh ThreadPoolExecutor restarts its numbering, so
+        # two different threads both answer to "simple-generate_0".
+        current = threading.current_thread()
+        self._threads.setdefault(key, []).append(f"{current.name}/{current.ident}")
+
+    def load(self) -> None:
+        self._record("load")
+
+    def stream_generate(self, **kwargs: Any):
+        # Recorded per chunk: the generator body runs where it is *pumped*,
+        # not where it is constructed, which is exactly the bug.
+        try:
+            for i in range(self._chunks):
+                if self._chunk_gate is not None:
+                    # Stands in for a slow decode: one chunk blocks the worker
+                    # until the test lets it go.
+                    self._chunk_gate.wait(timeout=10.0)
+                self._record("stream_generate")
+                yield _Chunk(f"tok{i}", "stop" if i == self._chunks - 1 else None)
+        finally:
+            self._record("close")
+            self.closed.set()
+
+    def generate(self, **kwargs: Any) -> str:
+        self._record("generate")
+        return "done"
+
+
+@pytest.fixture()
+def engine_module():
+    from vllm_mlx.engine import simple
+
+    return simple
+
+
+def _make_engine(engine_module, model=None):
+    """Build a SimpleEngine with just enough state to drive its real routes.
+
+    ``object.__new__`` keeps this off the model-loading path while still
+    exercising the engine's own code rather than a copy of it in the test.
+    """
+    from contextlib import asynccontextmanager
+
+    engine = object.__new__(engine_module.SimpleEngine)
+    engine._generation_executor = None
+    engine._generation_streams_bound = False
+    engine._pre_bind_generation_streams = None
+    engine._worker_generation_stream = None
+    engine._stopping = False
+    engine._draining_executors = []
+    engine._generation_users = 0
+    engine._generation_idle = asyncio.Event()
+    engine._generation_idle.set()
+    engine._generation_abort_hooks = {}
+    engine._active_requests = {}
+    engine._loaded = True
+    engine._is_mllm = False
+    engine._draft_model = None
+    engine._model = model
+    engine._text_model = None
+    engine._text_tokenizer = None
+    engine._system_kv_cache = {}
+    engine._system_kv_cache_stats = {
+        "hits": 0,
+        "misses": 0,
+        "stores": 0,
+        "evictions": 0,
+    }
+    engine._supports_system_kv_cache = False
+
+    @asynccontextmanager
+    async def _slot(request_id: str):
+        yield
+
+    engine._acquire_generation_slot = _slot
+    return engine
+
+
+def test_generation_worker_is_a_single_thread(engine_module):
+    """The pinned executor must hand out one thread, and always the same one."""
+    engine = _make_engine(engine_module)
+
+    worker = engine._generation_worker()
+    assert worker is engine._generation_worker(), "executor must be reused"
+
+    names = set()
+    for _ in range(5):
+        names.add(worker.submit(lambda: threading.current_thread().name).result())
+    assert len(names) == 1, f"generation spread over several threads: {names}"
+    worker.shutdown(wait=True)
+
+
+def test_load_and_generation_share_one_thread(engine_module):
+    """Regression: load on thread A + generation on thread B is the bug.
+
+    Before the fix, ``prepare_for_start`` ran on the event loop thread while
+    the non-stream route hopped to ``asyncio.to_thread``, so the two never
+    agreed and every request after a mode switch failed.
+
+    The streaming half drives ``_stream_generate_impl`` itself. Re-implementing
+    the pump in the test body would leave the engine's own pumping code — the
+    ``_next_chunk`` closure, the ``_STREAM_DONE`` protocol, the close routing —
+    untested on the no-MLX CI job, so reverting it to iterate on the loop thread
+    would still go green.
+    """
+    threads: dict[str, list[str]] = {}
+    model = _ThreadRecordingModel(threads)
+    engine = _make_engine(engine_module, model)
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        # load, as start() now does: on the generation worker
+        await loop.run_in_executor(engine._generation_worker(), model.load)
+        # non-stream route, through the engine's own serialized helper
+        await engine._run_blocking_serialized(model.generate)
+        # stream route, through the engine's own pump
+        async for _ in engine._stream_generate_impl(prompt="hi", max_tokens=8):
+            pass
+
+    asyncio.run(scenario())
+    engine._generation_executor.shutdown(wait=True)
+
+    observed = {t for calls in threads.values() for t in calls}
+    assert threads["load"], "load was never recorded"
+    assert threads["generate"], "non-stream generation was never recorded"
+    assert threads["stream_generate"], "stream generation was never recorded"
+    assert threads["close"], "generator cleanup was never recorded"
+    assert len(observed) == 1, (
+        "load and generation must share one thread, saw: "
+        f"{ {k: sorted(set(v)) for k, v in threads.items()} }"
+    )
+    assert not any(
+        t.startswith("MainThread") for t in observed
+    ), "MLX work must leave the event loop thread"
+
+
+def test_stream_done_sentinel_is_distinct(engine_module):
+    """StopIteration cannot cross a thread boundary, hence the sentinel."""
+    sentinel = engine_module._STREAM_DONE
+    assert sentinel is not None
+    assert next(iter([]), sentinel) is sentinel
+    assert next(iter([_Chunk("x")]), sentinel) is not sentinel
+
+
+def test_stop_does_not_block_the_event_loop(engine_module):
+    """stop() must stay bounded while the worker is inside a generation.
+
+    ``shutdown(wait=True)`` on the loop thread froze health checks, timers and
+    cancellation for as long as the request ran — up to ``max_tokens`` of decode
+    with the server default of 32768.
+    """
+    threads: dict[str, list[str]] = {}
+    gate = threading.Event()
+    model = _ThreadRecordingModel(threads, chunks=64, chunk_gate=gate)
+    engine = _make_engine(engine_module, model)
+
+    async def scenario() -> None:
+        stream = engine._stream_generate_impl(prompt="hi", max_tokens=64)
+
+        # One chunk through, then the worker blocks on the gate mid-generation.
+        gate.set()
+        await stream.__anext__()
+        gate.clear()
+        pump = asyncio.ensure_future(_drain(stream))
+        await asyncio.sleep(0)
+
+        ticks = 0
+
+        async def _heartbeat() -> None:
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        # asyncio.wait_for cannot catch this: a synchronous block holds the loop
+        # thread, so wait_for's own timeout callback cannot fire either and it
+        # returns successfully once the block finally clears. Measuring the
+        # loop's own progress is the only thing that sees it.
+        beat = asyncio.ensure_future(_heartbeat())
+        started = time.monotonic()
+        await engine.stop()
+        elapsed = time.monotonic() - started
+        beat.cancel()
+
+        assert elapsed < 2.0, (
+            f"stop() held on to the loop for {elapsed:.1f}s while the worker was "
+            "mid-generation"
+        )
+        assert ticks > 0, "the event loop made no progress while stop() ran"
+
+        gate.set()
+        await asyncio.wait_for(pump, timeout=5.0)
+
+    async def _drain(stream) -> list:
+        return [chunk async for chunk in stream]
+
+    engine.STOP_DRAIN_TIMEOUT_S = 0.2
+    asyncio.run(scenario())
+
+
+def test_pump_crossing_stop_ends_cleanly(engine_module):
+    """A stream that outlives stop() must not leak the executor's RuntimeError.
+
+    The pump captures the worker at entry, so a submit landing after
+    ``shutdown()`` used to raise ``cannot schedule new futures after shutdown``
+    in the middle of a client response.
+    """
+    threads: dict[str, list[str]] = {}
+    model = _ThreadRecordingModel(threads, chunks=64)
+    engine = _make_engine(engine_module, model)
+    # Nothing is pulling the stream while stop() runs, so the drain cannot
+    # resolve and has to time out. Keep that short here; the point of the test
+    # is what happens after.
+    engine.STOP_DRAIN_TIMEOUT_S = 0.2
+
+    async def scenario() -> list:
+        stream = engine._stream_generate_impl(prompt="hi", max_tokens=64)
+        first = await stream.__anext__()
+        assert first.new_text == "tok0"
+
+        await engine.stop()
+
+        return [chunk async for chunk in stream]
+
+    rest = asyncio.run(scenario())
+
+    assert rest, "the stream ended without a terminating chunk"
+    assert rest[-1].finished is True
+    assert rest[-1].finish_reason == "abort", (
+        "a stream cut short by stop() must report abort, "
+        f"saw {rest[-1].finish_reason!r}"
+    )
+    assert model.closed.is_set(), "the generator was never closed"
+    assert threads["close"] == threads["stream_generate"][:1], (
+        "cleanup must run on the thread that owns the generator, saw "
+        f"{threads['close']} vs {threads['stream_generate'][:1]}"
+    )
+
+
+def test_submit_after_stop_raises_engine_stopped(engine_module):
+    """A raw executor RuntimeError is not something callers can act on."""
+    from vllm_mlx.engine.base import EngineStopped
+
+    engine = _make_engine(engine_module)
+
+    async def scenario() -> None:
+        worker = engine._generation_worker()
+        await engine.stop()
+        with pytest.raises(EngineStopped):
+            await engine._submit_to_generation_worker(worker, lambda: "late")
+
+    asyncio.run(scenario())
+
+
+def test_submit_to_a_dead_executor_is_translated(engine_module):
+    """The executor's own RuntimeError must not reach callers verbatim.
+
+    Distinct from the check above, which never reaches ``submit`` at all: here
+    the engine still believes the worker is current, so the error comes out of
+    ``ThreadPoolExecutor`` itself as "cannot schedule new futures after
+    shutdown".
+    """
+    from vllm_mlx.engine.base import EngineStopped
+
+    engine = _make_engine(engine_module)
+
+    async def scenario() -> None:
+        worker = engine._generation_worker()
+        worker.shutdown(wait=True)
+        assert engine._generation_worker_is_live(worker), "setup: still current"
+
+        with pytest.raises(EngineStopped) as excinfo:
+            await engine._submit_to_generation_worker(worker, lambda: "late")
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+        # Unrelated RuntimeErrors from the work itself must pass through.
+        engine._generation_executor = None
+        fresh = engine._generation_worker()
+
+        def _boom():
+            raise RuntimeError("model exploded")
+
+        with pytest.raises(RuntimeError, match="model exploded"):
+            await engine._submit_to_generation_worker(fresh, _boom)
+        fresh.shutdown(wait=True)
+
+    asyncio.run(scenario())
+
+
+def test_lifecycle_prepare_runs_on_the_engine_generation_worker(engine_module):
+    """ResidencyManager must load through the engine's pinned worker.
+
+    The manager has its own start path, so an engine loaded through it would
+    otherwise land on asyncio's default pool while generation stayed pinned —
+    the same mismatch, reached by a different route.
+    """
+    from vllm_mlx.lifecycle import ResidencyManager, ResidentModel
+
+    threads: dict[str, list[str]] = {}
+    model = _ThreadRecordingModel(threads)
+    engine = _make_engine(engine_module, model)
+    engine.prepare_for_start = model.load
+
+    async def scenario() -> None:
+        manager = object.__new__(ResidencyManager)
+        manager._lock = asyncio.Lock()
+        resident = object.__new__(ResidentModel)
+        resident._prepare_task = None
+
+        await manager._prepare_engine_start(resident, engine)
+
+    asyncio.run(scenario())
+
+    # Probe the worker for its identity before retiring it.
+    worker = engine._generation_worker()
+    worker_thread = worker.submit(
+        lambda: f"{threading.current_thread().name}/{threading.get_ident()}"
+    ).result()
+    worker.shutdown(wait=True)
+
+    assert threads["load"], "prepare_for_start never ran"
+    loaded_on = threads["load"][0]
+    assert not loaded_on.startswith(
+        "MainThread"
+    ), f"model load stayed on the event loop thread: {loaded_on}"
+    assert (
+        loaded_on == worker_thread
+    ), f"model load landed on {loaded_on}, generation runs on {worker_thread}"
+
+
+def test_restart_after_stop_mid_stream_uses_a_fresh_worker(engine_module):
+    """stop() then start() must hand generation a new, exclusively-owned thread.
+
+    The detached worker may still be finishing a generation, and two threads
+    inside Metal at once is what the pinning is there to prevent — so the new
+    thread has to join the old one before it loads anything.
+    """
+    threads: dict[str, list[str]] = {}
+    gate = threading.Event()
+    slow = _ThreadRecordingModel(threads, chunks=64, chunk_gate=gate)
+    engine = _make_engine(engine_module, slow)
+
+    async def scenario() -> None:
+        stream = engine._stream_generate_impl(prompt="hi", max_tokens=64)
+        gate.set()
+        await stream.__anext__()
+        gate.clear()
+        pump = asyncio.ensure_future(_drain(stream))
+        await asyncio.sleep(0)
+
+        engine.STOP_DRAIN_TIMEOUT_S = 0.2
+        await asyncio.wait_for(engine.stop(), timeout=1.0)
+        assert engine._draining_executors, "a busy worker must be parked, not lost"
+        detached = engine._draining_executors[0]
+
+        gate.set()
+        await asyncio.wait_for(pump, timeout=5.0)
+
+        # Restart: a new worker, whose first job is to wait the old one out.
+        engine._stopping = False
+        engine._loaded = True
+        fresh = _ThreadRecordingModel(threads)
+        engine._model = fresh
+        worker = engine._generation_worker()
+        assert worker is not detached, "stop() must not hand back the dead worker"
+        assert not engine._draining_executors, "the parked worker must be claimed"
+
+        async for _ in engine._stream_generate_impl(prompt="again", max_tokens=8):
+            pass
+        engine._generation_executor.shutdown(wait=True)
+
+    async def _drain(stream) -> list:
+        return [chunk async for chunk in stream]
+
+    asyncio.run(scenario())
+
+    names = sorted(set(threads["stream_generate"]))
+    assert len(names) == 2, f"restart must not reuse the old thread, saw {names}"
+    assert not any(t.startswith("MainThread") for t in names)
+
+
+def test_new_worker_never_binds_the_retired_workers_stream(engine_module, monkeypatch):
+    """A restarted engine must allocate its own stream, not inherit the old one.
+
+    An MLX stream exists only in the thread that created it, so pointing a fresh
+    worker at the retired worker's stream puts that thread's default on a stream
+    it cannot enter, and every array it builds afterwards dies with "There is no
+    Stream(gpu, N) in current thread".
+
+    The engine is driven through its real stop/restart path; the binding helper
+    is faked so the check runs on machines without MLX, matching the rest of
+    this module.
+    """
+    owner_of: dict[int, int] = {}
+    cross_thread: list[tuple[int, int | None, int]] = []
+    issued = [0]
+
+    def fake_bind(stream=None):
+        me = threading.get_ident()
+        if stream is not None:
+            if owner_of.get(stream) != me:
+                cross_thread.append((stream, owner_of.get(stream), me))
+            return stream
+        issued[0] += 1
+        owner_of[issued[0]] = me
+        return issued[0]
+
+    monkeypatch.setattr(engine_module, "_bind_worker_generation_streams", fake_bind)
+
+    threads: dict[str, list[str]] = {}
+    engine = _make_engine(engine_module, _ThreadRecordingModel(threads))
+
+    async def scenario() -> None:
+        async for _ in engine._stream_generate_impl(prompt="hi", max_tokens=4):
+            pass
+        first_stream = engine._worker_generation_stream
+        assert first_stream is not None, "the first generation must bind a stream"
+
+        # A second route on the same worker re-points at the stream already
+        # allocated there. Allocating per request would leak one stream per
+        # request, which is how the "Stream(gpu, 32)" numbering got that high.
+        async for _ in engine._stream_generate_impl(prompt="more", max_tokens=4):
+            pass
+        assert engine._worker_generation_stream == first_stream
+        assert issued[0] == 1, f"one stream per worker, allocated {issued[0]}"
+
+        engine.STOP_DRAIN_TIMEOUT_S = 0.2
+        await asyncio.wait_for(engine.stop(), timeout=2.0)
+        assert (
+            engine._worker_generation_stream is None
+        ), "the retired worker's stream must not survive stop()"
+
+        engine._stopping = False
+        engine._loaded = True
+        engine._model = _ThreadRecordingModel(threads)
+        async for _ in engine._stream_generate_impl(prompt="again", max_tokens=4):
+            pass
+        assert engine._worker_generation_stream != first_stream, (
+            "the fresh worker must allocate its own stream, "
+            f"but reused {first_stream}"
+        )
+        engine._generation_executor.shutdown(wait=True)
+
+    asyncio.run(scenario())
+
+    assert not cross_thread, (
+        "a thread bound a stream created by another thread: "
+        f"{cross_thread} (stream, owner_ident, binder_ident)"
+    )

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -43,6 +43,19 @@ class EngineBusy(RuntimeError):
     code = "text_generation_busy"
 
 
+class EngineStopped(RuntimeError):
+    """Raised when generation work is submitted after the engine has stopped.
+
+    Engines that pin MLX work to one thread tear that thread down in ``stop()``.
+    Anything still holding a reference to it gets a defined error instead of the
+    raw ``RuntimeError("cannot schedule new futures after shutdown")`` that
+    ``ThreadPoolExecutor`` raises, so callers can tell a shutdown apart from a
+    real generation failure.
+    """
+
+    code = "engine_stopped"
+
+
 @contextmanager
 def suspend_cancellation():
     """Temporarily clear task cancellation so cleanup can finish deterministically."""
@@ -67,9 +80,18 @@ def suspend_cancellation():
             task.cancel()
 
 
-async def run_blocking_startup_work(work: Callable[[], Any]) -> None:
-    """Run blocking startup work off-loop without leaking cancellation races."""
-    task = asyncio.create_task(asyncio.to_thread(work))
+async def run_blocking_startup_work(
+    work: Callable[[], Any], executor: Any | None = None
+) -> None:
+    """Run blocking startup work off-loop without leaking cancellation races.
+
+    Pass ``executor`` to pin the work to a specific thread. MLX buffers carry
+    the stream of the thread that built them, so a model must be loaded on the
+    same thread that later generates from it; ``None`` keeps the previous
+    behaviour of using asyncio's default thread pool.
+    """
+    loop = asyncio.get_running_loop()
+    task = asyncio.ensure_future(loop.run_in_executor(executor, work))
     try:
         await asyncio.shield(task)
     except asyncio.CancelledError:

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -16,6 +16,7 @@ import time
 import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -35,19 +36,33 @@ from ..api.utils import clean_output_text, has_media_content, is_mllm_model
 from .base import (
     BaseEngine,
     EngineBusy,
+    EngineStopped,
     GenerationOutput,
     cleanup_startup_cancellation,
     run_blocking_startup_work,
 )
 from .chat_template_safety import normalize_messages_for_chat_template
-from ..mlx_streams import bind_generation_streams
+from ..mlx_streams import (
+    bind_generation_streams,
+    restore_generation_streams,
+    snapshot_generation_streams,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _bind_worker_generation_streams() -> None:
+def _bind_worker_generation_streams(stream: object | None = None) -> object:
     """Rebind mlx generation streams inside the current worker thread."""
-    bind_generation_streams()
+    return bind_generation_streams(stream=stream)
+
+
+def _join_executors(executors: list[ThreadPoolExecutor]) -> None:
+    """Wait for detached generation workers to finish, on a worker thread."""
+    for executor in executors:
+        try:
+            executor.shutdown(wait=True)
+        except Exception:  # pragma: no cover - shutdown is already idempotent
+            logger.debug("Draining a previous generation worker failed", exc_info=True)
 
 
 def _seed_logits_processors(
@@ -113,6 +128,11 @@ def _processors_retired(processors: list[Any] | None) -> bool:
     return bool(processors) and any(
         getattr(p, "is_retired", False) is True for p in processors
     )
+
+
+# Sentinel for "the generation iterator is exhausted", pulled across the
+# worker-thread boundary where StopIteration cannot travel.
+_STREAM_DONE = object()
 
 
 class _SpecPrefillCancelled(Exception):
@@ -215,6 +235,13 @@ class SimpleEngine(BaseEngine):
 
         # Lock to serialize MLX operations (prevents Metal command buffer conflicts)
         self._generation_lock = asyncio.Lock()
+        # NOTE: "fail_fast" rejects whenever the lock is held. That used to be
+        # rare for streaming requests by accident — generation ran on the event
+        # loop, so a second request could not reach this check until the first
+        # had finished. Now that generation has its own thread the loop stays
+        # responsive and genuinely concurrent requests reach it, so operators
+        # who prefer queuing to 503s want
+        # VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait.
         self._generation_lock_admission = (
             os.environ.get("VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION", "fail_fast")
             .strip()
@@ -255,6 +282,153 @@ class SimpleEngine(BaseEngine):
         # cache classes such as ``RotatingKVCache`` remain disabled because
         # their extra cursor metadata is not captured by ``.state`` alone.
         self._supports_system_kv_cache: bool = False
+
+        # Every MLX generation call runs on this one thread; see
+        # ``_generation_worker``.
+        self._generation_executor: ThreadPoolExecutor | None = None
+        self._generation_streams_bound: bool = False
+        self._pre_bind_generation_streams: dict[str, object] | None = None
+        self._worker_generation_stream: object | None = None
+        # Set by ``stop()``. In-flight pumps check it between chunks so a stop
+        # costs one token rather than one whole generation.
+        self._stopping: bool = False
+        # Workers ``stop()`` left running because MLX was still busy. The next
+        # worker thread joins them before it touches MLX itself.
+        self._draining_executors: list[ThreadPoolExecutor] = []
+        # Number of routes currently driving the generation worker, and an
+        # event that is set exactly while that number is zero. ``stop()`` waits
+        # on it briefly so generators close on the thread that owns them.
+        self._generation_users: int = 0
+        self._generation_idle: asyncio.Event = asyncio.Event()
+        self._generation_idle.set()
+        # ``on_cancel`` hooks of in-flight blocking work, so ``stop()`` can use
+        # the abort paths those routes already implement.
+        self._generation_abort_hooks: dict[str, Any] = {}
+
+    # How long ``stop()`` gives in-flight MLX work to wind down before it
+    # detaches the worker and returns. Streaming routes check the stopping flag
+    # between chunks, so they land well inside this; a monolithic
+    # ``mlx_lm.generate()`` call cannot be interrupted at all and is left to
+    # finish in the background rather than stalling the event loop.
+    STOP_DRAIN_TIMEOUT_S: float = 5.0
+
+    def _generation_worker(self) -> ThreadPoolExecutor:
+        """Return the single thread that owns every MLX generation call.
+
+        MLX streams exist only in the thread that created them, and a pending
+        array carries the stream its primitives were built on. Anything that
+        outlives one request therefore cannot be handed to a different thread:
+        the prompt cache built during load or a previous turn blows up in
+        ``mx.eval([c.state for c in prompt_cache])`` with "There is no
+        Stream(gpu, N) in current thread".
+
+        ``asyncio.to_thread`` spreads work over the default executor, so this
+        failed on every request once a cache survived a turn. Rebinding the
+        module-level generation streams cannot help — the cache already holds
+        the old stream, so the rebind changes a global nothing reads. Pinning
+        the work is the fix, and it is what BatchedEngine already does
+        (``engine_core.py``: ``ThreadPoolExecutor(max_workers=1)``).
+        """
+        if self._generation_executor is None:
+            self._generation_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="simple-generate"
+            )
+            self._generation_streams_bound = False
+            # The stream belongs to the thread that made it, so it cannot
+            # outlive the worker: a fresh one must allocate its own.
+            self._worker_generation_stream = None
+            # A previous stop() detached its worker while MLX was still busy so
+            # the event loop stayed responsive. Two threads must never be inside
+            # Metal at once, so the new thread's first job is to wait the old
+            # ones out. max_workers=1 keeps that ordered ahead of the model
+            # load, and the wait lands on the worker, never on the loop.
+            draining, self._draining_executors = self._draining_executors, []
+            if draining:
+                self._generation_executor.submit(_join_executors, draining)
+        return self._generation_executor
+
+    @asynccontextmanager
+    async def _generation_worker_in_use(self):
+        """Mark the generation worker busy for the length of one route.
+
+        ``stop()`` waits on the idle event so a route gets to close its MLX
+        generator on the thread that owns it, instead of having the executor
+        pulled out from under it.
+        """
+        self._generation_users += 1
+        self._generation_idle.clear()
+        try:
+            yield
+        finally:
+            self._generation_users -= 1
+            if self._generation_users <= 0:
+                self._generation_users = 0
+                # Hand the module-level generation streams back. They are
+                # process-global, so leaving them on the worker's stream makes
+                # every other thread's read fail, not just this engine's.
+                if self._pre_bind_generation_streams is not None:
+                    restore_generation_streams(self._pre_bind_generation_streams)
+                    self._generation_streams_bound = False
+                self._generation_idle.set()
+                self._retire_detached_workers()
+
+    def _retire_detached_workers(self) -> None:
+        """Shut down workers ``stop()`` detached, once nothing is using them.
+
+        ``stop()`` leaves a busy worker running and alive: the route still
+        holding it has an MLX generator to close, and that close belongs on the
+        thread that owns it. Ownership therefore passes to the last user, which
+        is here. The executors stay listed so the next worker thread can still
+        join them before it touches MLX itself.
+        """
+        for executor in self._draining_executors:
+            executor.shutdown(wait=False)
+
+    def _generation_worker_is_live(
+        self, worker: ThreadPoolExecutor | None, *, ignore_stopping: bool = False
+    ) -> bool:
+        """True while ``worker`` is still this engine's usable generation thread."""
+        if worker is None:
+            return False
+        if worker is self._generation_executor:
+            return ignore_stopping or not self._stopping
+        # Detached by stop() but not yet retired: still good for the cleanup its
+        # own route owes, never for new generation.
+        return ignore_stopping and worker in self._draining_executors
+
+    async def _submit_to_generation_worker(
+        self,
+        worker: ThreadPoolExecutor | None,
+        fn,
+        /,
+        *args,
+        during_shutdown: bool = False,
+    ):
+        """Run ``fn`` on the pinned thread, reporting shutdown as EngineStopped.
+
+        Routes capture the worker once and then submit per chunk, so a stop can
+        land between two submits. Without this the next submit surfaces
+        ``RuntimeError("cannot schedule new futures after shutdown")`` in the
+        middle of a client response.
+
+        ``during_shutdown`` is for the cleanup a stopping route still owes its
+        generator: the stopping flag alone must not block it, because ``stop()``
+        is waiting for exactly that work before it tears the thread down.
+        """
+        blocked_by_stop = self._stopping and not during_shutdown
+        if blocked_by_stop or not self._generation_worker_is_live(
+            worker, ignore_stopping=during_shutdown
+        ):
+            raise EngineStopped("SimpleEngine stopped while generation was in flight")
+        loop = asyncio.get_running_loop()
+        try:
+            return await loop.run_in_executor(worker, fn, *args)
+        except RuntimeError as exc:
+            if "cannot schedule new futures" in str(exc):
+                raise EngineStopped(
+                    "SimpleEngine stopped while generation was in flight"
+                ) from exc
+            raise
 
     @staticmethod
     def _clone_cache_state(value: Any) -> Any:
@@ -397,6 +571,21 @@ class SimpleEngine(BaseEngine):
             if not acquired and self._generation_waiters > 0:
                 self._generation_waiters -= 1
 
+    def _bind_generation_streams_once(self) -> None:
+        """Bind MLX generation streams on this worker, once per worker.
+
+        The snapshot is what makes the binding reversible. ``generation_stream``
+        is a module attribute, so pointing it at a worker's stream is a global
+        edit; if the worker later exits without it being put back, any other
+        thread that reads it gets a stream it cannot enter.
+        """
+        if self._pre_bind_generation_streams is None:
+            self._pre_bind_generation_streams = snapshot_generation_streams()
+        self._worker_generation_stream = _bind_worker_generation_streams(
+            self._worker_generation_stream
+        )
+        self._generation_streams_bound = True
+
     def prepare_for_start(self) -> None:
         """Load the backing model off the serving event loop."""
         if self._model is not None:
@@ -435,17 +624,20 @@ class SimpleEngine(BaseEngine):
         """Start the engine (load model if not loaded)."""
         if self._loaded:
             return
+        # A previous stop() latched this; clear it before anything asks
+        # _generation_worker_is_live, or the fresh worker looks dead on arrival.
+        self._stopping = False
         try:
             if self._model is None:
-                if self._uses_default_prepare_for_start():
-                    # MLX generation streams are thread-local. Keep model load on
-                    # the event-loop thread so default LLM stream_generate() runs
-                    # on the same thread that owns model-associated streams.
-                    self.prepare_for_start()
-                else:
-                    # Test doubles and custom overrides may block; preserve the
-                    # cancellation-safe threaded startup helper for those cases.
-                    await run_blocking_startup_work(self.prepare_for_start)
+                # MLX streams are thread-local and buffers built at load carry
+                # the stream they were built on, so load must happen on the very
+                # thread that later generates: the dedicated generation worker.
+                # This applies to an overridden prepare_for_start too — a
+                # subclass that loads on some other thread hits exactly the same
+                # failure, so there is no reason to split on which one it is.
+                await run_blocking_startup_work(
+                    self.prepare_for_start, executor=self._generation_worker()
+                )
             self._loaded = True
 
             if self._mtp and self._mtp_num_draft_tokens != 1:
@@ -595,7 +787,36 @@ class SimpleEngine(BaseEngine):
             raise
 
     async def stop(self) -> None:
-        """Stop the engine and cleanup resources."""
+        """Stop the engine and cleanup resources.
+
+        Must not block the event loop. The generation worker is handed whole
+        requests, and the server default is ``max_tokens=32768``, so waiting for
+        it here would freeze health checks, timers and cancellation for minutes.
+        Instead: signal, let in-flight routes wind down for a bounded moment,
+        then detach the worker and return.
+        """
+        self._stopping = True
+
+        executor = self._generation_executor
+        if executor is not None and self._generation_users > 0:
+            # Use the abort paths the long routes already implement, so the
+            # wait below usually resolves rather than times out.
+            for hook in list(self._generation_abort_hooks.values()):
+                try:
+                    hook()
+                except Exception:
+                    logger.debug("Generation abort hook failed", exc_info=True)
+            try:
+                await asyncio.wait_for(
+                    self._generation_idle.wait(), timeout=self.STOP_DRAIN_TIMEOUT_S
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.warning(
+                    "SimpleEngine.stop: generation worker still busy after %.1fs; "
+                    "detaching it to finish in the background",
+                    self.STOP_DRAIN_TIMEOUT_S,
+                )
+
         self._model = None
         self._text_model = None
         self._text_tokenizer = None
@@ -605,6 +826,37 @@ class SimpleEngine(BaseEngine):
         for k in self._system_kv_cache_stats:
             self._system_kv_cache_stats[k] = 0
         self._supports_system_kv_cache = False
+
+        if executor is not None:
+            # Streams and any cache built on that thread die with it.
+            self._generation_executor = None
+            self._generation_streams_bound = False
+            # The stream belongs to the thread that made it, so it cannot
+            # outlive the worker: a fresh one must allocate its own.
+            self._worker_generation_stream = None
+            # The worker is going away, so the module-level generation streams
+            # must stop naming its stream — otherwise the next thread to read
+            # them gets "There is no Stream(gpu, N) in current thread".
+            pre_bind, self._pre_bind_generation_streams = (
+                self._pre_bind_generation_streams,
+                None,
+            )
+            if self._generation_users > 0:
+                # Something is still inside MLX. Detach the executor but leave
+                # it running: the route holding it still has a generator to
+                # close, and that has to happen on this thread. The last user
+                # retires it, and the next worker joins it before loading a
+                # model of its own.
+                self._draining_executors.append(executor)
+                if pre_bind is not None:
+                    # Queue the restore behind the work still on that thread.
+                    # max_workers=1 orders it last; restoring now would hand the
+                    # draining route a stream it cannot enter mid-close.
+                    executor.submit(restore_generation_streams, pre_bind)
+            else:
+                executor.shutdown(wait=False, cancel_futures=True)
+                if pre_bind is not None:
+                    restore_generation_streams(pre_bind)
         logger.info("SimpleEngine stopped")
 
     def _should_route_text_through_text_model(
@@ -642,28 +894,45 @@ class SimpleEngine(BaseEngine):
             }
 
             def run_bound():
-                _bind_worker_generation_streams()
+                # One thread owns generation, so binding once is enough and
+                # rebinding per request would only churn streams.
+                self._bind_generation_streams_once()
                 return func(*args, **kwargs)
 
-            task = asyncio.create_task(asyncio.to_thread(run_bound))
-            try:
-                return await asyncio.shield(task)
-            except asyncio.CancelledError:
+            worker = self._generation_worker()
+
+            async def _run_on_generation_worker():
+                return await self._submit_to_generation_worker(worker, run_bound)
+
+            # create_task over a coroutine, exactly as the asyncio.to_thread
+            # version did. Wrapping the executor future directly changes how
+            # cancellation and exception retrieval behave, which breaks
+            # SpecPrefill's cancel-during-scoring path.
+            async with self._generation_worker_in_use():
                 if on_cancel is not None:
-                    try:
-                        on_cancel()
-                    except Exception:
-                        logger.debug(
-                            "Blocking worker cancellation callback failed",
-                            exc_info=True,
-                        )
+                    # stop() drives these so a shutdown uses the same abort path
+                    # a client disconnect does.
+                    self._generation_abort_hooks[request_id] = on_cancel
+                task = asyncio.create_task(_run_on_generation_worker())
                 try:
-                    await task
-                except BaseException:
-                    pass
-                raise
-            finally:
-                self._active_requests.pop(request_id, None)
+                    return await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    if on_cancel is not None:
+                        try:
+                            on_cancel()
+                        except Exception:
+                            logger.debug(
+                                "Blocking worker cancellation callback failed",
+                                exc_info=True,
+                            )
+                    try:
+                        await task
+                    except BaseException:
+                        pass
+                    raise
+                finally:
+                    self._generation_abort_hooks.pop(request_id, None)
+                    self._active_requests.pop(request_id, None)
 
     async def generate(
         self,
@@ -929,87 +1198,137 @@ class SimpleEngine(BaseEngine):
                 "elapsed_s": 0.0,
                 "started_at": started_at,
             }
-            # Non-stream chat runs in a worker thread and rebinds generation
-            # streams there. Rebind again on the current thread before
-            # stream_generate so nonstream->stream mode switches remain valid.
-            _bind_worker_generation_streams()
+            # Streaming has to run on the same thread as the non-stream route.
+            # Both share the prompt cache, and an MLX array can only be
+            # evaluated on the thread whose stream built its primitives, so
+            # pumping the generator here on the event loop thread meant every
+            # request after a non-stream turn died in generate_step with
+            # "There is no Stream(gpu, N) in current thread". Rebinding the
+            # module-level stream cannot bridge the two threads, because the
+            # cache already carries the stream it was built on.
+            worker = self._generation_worker()
+            iterator = None
+            aborted_by_stop = False
 
-            try:
-                accumulated_text = ""
-                prompt_tokens = 0
-                completion_tokens = 0
-                finished = False
+            def _next_chunk():
+                self._bind_generation_streams_once()
+                try:
+                    return next(iterator)
+                except StopIteration:
+                    return _STREAM_DONE
 
-                for chunk in self._model.stream_generate(
-                    prompt=prompt,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    top_p=top_p,
-                    stop=stop,
-                    **kwargs,
-                ):
-                    prompt_tokens = (
-                        chunk.prompt_tokens
-                        if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
-                        else prompt_tokens
+            async with self._generation_worker_in_use():
+                try:
+                    accumulated_text = ""
+                    prompt_tokens = 0
+                    completion_tokens = 0
+                    finished = False
+
+                    iterator = self._model.stream_generate(
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        stop=stop,
+                        **kwargs,
                     )
-                    completion_tokens += 1
-                    if request_id in self._active_requests:
-                        self._active_requests[request_id].update(
-                            {
-                                "prompt_tokens": prompt_tokens,
-                                "completion_tokens": completion_tokens,
-                                "elapsed_s": round(time.time() - started_at, 1),
-                            }
+
+                    while True:
+                        if not self._generation_worker_is_live(worker):
+                            # stop() ran. End the response here rather than
+                            # submitting to a dead executor, which would raise
+                            # in the middle of a client stream.
+                            aborted_by_stop = True
+                            break
+                        chunk = await self._submit_to_generation_worker(
+                            worker, _next_chunk
                         )
-                    new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                    accumulated_text += new_text
-
-                    finished = (
-                        getattr(chunk, "finished", False)
-                        or completion_tokens >= max_tokens
-                    )
-                    finish_reason = None
-                    if finished:
-                        finish_reason = getattr(chunk, "finish_reason", None)
-                        if finish_reason is None:
-                            finish_reason = (
-                                "length" if completion_tokens >= max_tokens else "stop"
+                        if chunk is _STREAM_DONE:
+                            break
+                        prompt_tokens = (
+                            chunk.prompt_tokens
+                            if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
+                            else prompt_tokens
+                        )
+                        completion_tokens += 1
+                        if request_id in self._active_requests:
+                            self._active_requests[request_id].update(
+                                {
+                                    "prompt_tokens": prompt_tokens,
+                                    "completion_tokens": completion_tokens,
+                                    "elapsed_s": round(time.time() - started_at, 1),
+                                }
                             )
+                        new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
+                        accumulated_text += new_text
 
-                    yield GenerationOutput(
-                        text=accumulated_text,
-                        new_text=new_text,
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        finished=finished,
-                        finish_reason=finish_reason,
-                    )
-
-                    if finished:
-                        break
-
-                if not finished:
-                    if prompt_tokens == 0:
-                        prompt_tokens = len(self._model.tokenizer.encode(prompt))
-                    if request_id in self._active_requests:
-                        self._active_requests[request_id].update(
-                            {
-                                "prompt_tokens": prompt_tokens,
-                                "completion_tokens": completion_tokens,
-                                "elapsed_s": round(time.time() - started_at, 1),
-                            }
+                        finished = (
+                            getattr(chunk, "finished", False)
+                            or completion_tokens >= max_tokens
                         )
-                    yield GenerationOutput(
-                        text=accumulated_text,
-                        new_text="",
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        finished=True,
-                        finish_reason="stop",
-                    )
-            finally:
-                self._active_requests.pop(request_id, None)
+                        finish_reason = None
+                        if finished:
+                            finish_reason = getattr(chunk, "finish_reason", None)
+                            if finish_reason is None:
+                                finish_reason = (
+                                    "length"
+                                    if completion_tokens >= max_tokens
+                                    else "stop"
+                                )
+
+                        yield GenerationOutput(
+                            text=accumulated_text,
+                            new_text=new_text,
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                            finished=finished,
+                            finish_reason=finish_reason,
+                        )
+
+                        if finished:
+                            break
+
+                    if not finished:
+                        if prompt_tokens == 0 and self._model is not None:
+                            prompt_tokens = len(self._model.tokenizer.encode(prompt))
+                        if request_id in self._active_requests:
+                            self._active_requests[request_id].update(
+                                {
+                                    "prompt_tokens": prompt_tokens,
+                                    "completion_tokens": completion_tokens,
+                                    "elapsed_s": round(time.time() - started_at, 1),
+                                }
+                            )
+                        yield GenerationOutput(
+                            text=accumulated_text,
+                            new_text="",
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                            finished=True,
+                            finish_reason="abort" if aborted_by_stop else "stop",
+                        )
+                finally:
+                    # Generator cleanup touches MLX, so it belongs on the worker
+                    # too — closing it here would evaluate on the loop thread.
+                    # during_shutdown lets it through while stop() is draining,
+                    # which is the whole point of that wait.
+                    if iterator is not None:
+                        try:
+                            await self._submit_to_generation_worker(
+                                worker, iterator.close, during_shutdown=True
+                            )
+                        except EngineStopped:
+                            # The worker is already gone, so no thread is left
+                            # that may evaluate these buffers; its teardown is
+                            # what releases them.
+                            logger.debug(
+                                "stream_generate close skipped: worker already down"
+                            )
+                        except Exception:
+                            logger.warning(
+                                "stream_generate close failed", exc_info=True
+                            )
+                    self._active_requests.pop(request_id, None)
 
     async def chat(
         self,
@@ -1263,34 +1582,86 @@ class SimpleEngine(BaseEngine):
                 # Stream(gpu, N) ownership mismatch.
                 local_kwargs = mllm_call_kwargs()
 
-                async with self._acquire_generation_slot(request_id):
-                    _bind_worker_generation_streams()
-                    for chunk in self._model.stream_chat(
+                # Same thread rule as the text route: the MLLM model was loaded
+                # on the generation worker, so stream_chat has to be pumped
+                # there too. Running it on the event loop thread and rebinding
+                # the module-level stream cannot work, because the model
+                # buffers already carry the stream they were built on.
+                worker = self._generation_worker()
+                iterator = None
+
+                def _next_chat_chunk():
+                    self._bind_generation_streams_once()
+                    try:
+                        return next(iterator)
+                    except StopIteration:
+                        return _STREAM_DONE
+
+                async with (
+                    self._acquire_generation_slot(request_id),
+                    self._generation_worker_in_use(),
+                ):
+                    iterator = self._model.stream_chat(
                         messages=messages,
                         max_tokens=max_tokens,
                         temperature=temperature,
                         tools=template_tools,
                         **local_kwargs,
-                    ):
-                        token_count += 1
-                        new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                        accumulated_text += new_text
+                    )
+                    try:
+                        while True:
+                            if not self._generation_worker_is_live(worker):
+                                # stop() ran; close the response out instead of
+                                # submitting to a dead executor mid-stream.
+                                yield GenerationOutput(
+                                    text=accumulated_text,
+                                    new_text="",
+                                    prompt_tokens=0,
+                                    completion_tokens=token_count,
+                                    finished=True,
+                                    finish_reason="abort",
+                                )
+                                break
+                            chunk = await self._submit_to_generation_worker(
+                                worker, _next_chat_chunk
+                            )
+                            if chunk is _STREAM_DONE:
+                                break
 
-                        finished = chunk.finish_reason is not None
+                            token_count += 1
+                            new_text = (
+                                chunk.text if hasattr(chunk, "text") else str(chunk)
+                            )
+                            accumulated_text += new_text
 
-                        yield GenerationOutput(
-                            text=accumulated_text,
-                            new_text=new_text,
-                            prompt_tokens=getattr(chunk, "prompt_tokens", 0),
-                            completion_tokens=token_count,
-                            finished=finished,
-                            finish_reason=chunk.finish_reason if finished else None,
-                            mtp_drafts=getattr(chunk, "mtp_drafts", 0),
-                            mtp_accepted=getattr(chunk, "mtp_accepted", 0),
-                        )
+                            finished = chunk.finish_reason is not None
 
-                        if finished:
-                            break
+                            yield GenerationOutput(
+                                text=accumulated_text,
+                                new_text=new_text,
+                                prompt_tokens=getattr(chunk, "prompt_tokens", 0),
+                                completion_tokens=token_count,
+                                finished=finished,
+                                finish_reason=(
+                                    chunk.finish_reason if finished else None
+                                ),
+                                mtp_drafts=getattr(chunk, "mtp_drafts", 0),
+                                mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                            )
+
+                            if finished:
+                                break
+                    finally:
+                        try:
+                            await self._submit_to_generation_worker(
+                                worker, iterator.close, during_shutdown=True
+                            )
+                        except EngineStopped:
+                            logger.debug(
+                                "stream_chat close skipped: worker already down"
+                            )
+                        except Exception:
+                            logger.warning("stream_chat close failed", exc_info=True)
                 return
 
             # mlx_vlm's native-video path is non-streaming and performs

--- a/vllm_mlx/lifecycle.py
+++ b/vllm_mlx/lifecycle.py
@@ -416,14 +416,32 @@ class ResidencyManager:
         if prepare_for_start is None:
             return
 
-        uses_default_prepare = getattr(engine, "_uses_default_prepare_for_start", None)
-        if callable(uses_default_prepare) and uses_default_prepare():
-            # Keep default engine prepare on the event-loop thread so MLX
-            # thread-local stream ownership matches subsequent streaming calls.
-            prepare_for_start()
-            return
+        # MLX buffers carry the stream of the thread that built them, so load
+        # has to land on the very thread the engine generates on. Engines that
+        # pin generation expose that thread through ``_generation_worker``.
+        generation_worker = getattr(engine, "_generation_worker", None)
+        if callable(generation_worker):
+            executor = generation_worker()
+        else:
+            uses_default_prepare = getattr(
+                engine, "_uses_default_prepare_for_start", None
+            )
+            if callable(uses_default_prepare) and uses_default_prepare():
+                # Engines without a pinned worker still depend on loading on the
+                # event-loop thread to match their stream ownership.
+                prepare_for_start()
+                return
+            executor = None
 
-        prepare_task = asyncio.create_task(asyncio.to_thread(prepare_for_start))
+        loop = asyncio.get_running_loop()
+
+        async def _prepare_off_loop():
+            return await loop.run_in_executor(executor, prepare_for_start)
+
+        # create_task over a coroutine, as the asyncio.to_thread version did:
+        # wrapping the executor future directly changes cancellation and
+        # exception-retrieval behaviour during shutdown unwinding.
+        prepare_task = asyncio.create_task(_prepare_off_loop())
         async with self._lock:
             resident._prepare_task = prepare_task
 

--- a/vllm_mlx/mlx_streams.py
+++ b/vllm_mlx/mlx_streams.py
@@ -14,20 +14,29 @@ _STREAM_REBIND_LOCK = threading.Lock()
 
 def bind_generation_streams(
     module_names: Iterable[str] = ("mlx_lm.generate", "mlx_vlm.generate"),
+    stream: object | None = None,
 ) -> object:
-    """Bind mlx-lm/mlx-vlm generation streams to the current thread.
+    """Give the calling thread a stream and point mlx-lm/mlx-vlm at it.
 
-    MLX streams are thread-local. If a model is loaded on one thread and
-    generation runs on another, module-level generation streams created during
-    import can point at a stream that does not exist in the worker thread.
+    Pass ``stream`` to re-point at a stream this thread already owns instead of
+    allocating another one; a thread that binds per request would otherwise leak
+    a new stream each time.
 
-    This intentionally creates a fresh stream for the current worker call and
-    replaces module-level generation_stream handles under a process-local lock.
-    It is an admission/ownership fix, not a batching optimization; callers
-    should invoke it at worker-entry boundaries rather than inside token loops.
+    Call this **once**, on the single thread that owns MLX work, before any
+    model is loaded on it.
+
+    It does not make state portable between threads, and must not be used to
+    try. MLX streams exist only in the thread that created them, and an array
+    with pending primitives carries the stream those primitives were built on.
+    Once a model or a prompt cache exists, rebinding this module-level handle
+    changes a global that the existing buffers do not consult, so evaluating
+    them from another thread still raises "There is no Stream(gpu, N) in
+    current thread". Load and generation must simply share one thread.
     """
     with _STREAM_REBIND_LOCK:
-        default_stream = mx.new_stream(mx.default_device())
+        default_stream = (
+            stream if stream is not None else mx.new_stream(mx.default_device())
+        )
         mx.set_default_stream(default_stream)
         for module_name in module_names:
             try:
@@ -37,3 +46,40 @@ def bind_generation_streams(
             if hasattr(module, "generation_stream"):
                 setattr(module, "generation_stream", default_stream)
         return default_stream
+
+
+def snapshot_generation_streams(
+    module_names: Iterable[str] = ("mlx_lm.generate", "mlx_vlm.generate"),
+) -> dict[str, object]:
+    """Record the module-level generation streams before a rebind.
+
+    ``generation_stream`` is a module attribute, so it is process-global even
+    though the stream it names is only usable on its creating thread. A worker
+    that binds and then exits leaves that global naming a stream no live thread
+    can enter, and the next caller gets "There is no Stream(gpu, N) in current
+    thread". Pair this with :func:`restore_generation_streams` when the binding
+    thread is retired.
+    """
+    snapshot: dict[str, object] = {}
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        if hasattr(module, "generation_stream"):
+            snapshot[module_name] = getattr(module, "generation_stream")
+    return snapshot
+
+
+def restore_generation_streams(snapshot: dict[str, object]) -> None:
+    """Put back the handles captured by :func:`snapshot_generation_streams`."""
+    if not snapshot:
+        return
+    with _STREAM_REBIND_LOCK:
+        for module_name, stream in snapshot.items():
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+            if hasattr(module, "generation_stream"):
+                setattr(module, "generation_stream", stream)


### PR DESCRIPTION
## Problem

MLX streams exist only in the thread that created them, and an array with pending primitives carries the stream those primitives were built on. A model loaded on one thread therefore cannot be driven from another — generation dies inside `mx.eval` with:

```
RuntimeError: There is no Stream(gpu, N) in current thread.
```

`SimpleEngine` spread that work across three different threads:

| route | thread |
|---|---|
| `prepare_for_start()` (model load) | event loop |
| streaming (`_stream_generate_impl`, `_stream_chat_impl`) | event loop |
| non-stream (`_run_blocking_serialized`) | `asyncio.to_thread`, any pool worker |

This held together only while all three happened to agree. As soon as a request took a different route than the one that built the prompt cache, that request and every one after it returned HTTP 500.

The three `bind_generation_streams()` calls scattered across these routes were an attempt to paper over the mismatch. They cannot work in principle: rebinding a module-level handle changes a global that the already-built buffers do not consult.

## Why pinning, and not a better rebind

I built a cache on one thread and evaluated it on another, then measured each candidate:

| approach | result |
|---|---|
| `bind_generation_streams()` per worker (current) | 3/3 fail |
| keep mlx-lm's import-time `ThreadLocalStream`, no rebinding | 3/3 fail |
| **pin load + generation to one thread** | **0/3 fail** |

The middle row is worth noting: `mx.new_thread_local_stream()` resolves per thread, but on the loading thread it resolves to a concrete stream that the pending primitives then carry, so it fails the same way. `mx.set_default_stream()` also rejects a `ThreadLocalStream` outright. There is no rebinding that fixes this — load and generation simply have to share a thread.

## Changes

- `_generation_worker()`: one `ThreadPoolExecutor(max_workers=1)` per engine, shut down in `stop()`. This mirrors what `BatchedEngine` already does in `engine_core.py`.
- Model load moved onto that worker, since the loaded buffers carry its stream.
- Both streaming routes are pumped chunk by chunk through it with `run_in_executor`, using a `_STREAM_DONE` sentinel because `StopIteration` cannot cross a thread boundary. Generator `close()` is routed there too, since cleanup touches MLX.
- Streams are bound once on that thread instead of per request.
- `bind_generation_streams()` docstring corrected — it gives the calling thread a stream; it does not make state portable between threads.

As a side effect, token generation no longer runs on the event loop thread.

## Testing

Reproduced and verified against **DeepSeek-V4-Flash-0731** (283.8B, MXFP4) on an M3 Ultra, where this failed on every single request:

- **30/30 requests pass**, 0 stream errors — multi-turn conversations on a shared prefix, single-shot, and concurrent
- **6/6 tool calls** parsed correctly, plus a `role: tool` round-trip
- **decode holds at 30.4 tok/s** (194 tokens in 6.37 s), so the per-token executor hop costs nothing measurable

Repo suite: **403 passed, 2 skipped**. The new `tests/test_simple_engine_thread_pinning.py` fails **3/3** against `main` and passes with the fix; it is added to the CI whitelist.