### PR TITLE
fix: guard non-trimmable rotating prefix caches

### DIFF
--- a/tests/test_memory_cache_mlx.py
+++ b/tests/test_memory_cache_mlx.py
@@ -282,6 +282,125 @@ class TestTrimCacheOffset:
         assert remaining == [999, 1000, 1001]
 
 
+class TestRotatingCachePartialReuse:
+    """Regression coverage for saturated rotating caches in prefix reuse (#678)."""
+
+    @staticmethod
+    def _full_cache(length):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        layer = KVCache()
+        layer.keys = mx.ones((1, 1, length, 4), dtype=mx.float32)
+        layer.values = layer.keys
+        layer.offset = length
+        return layer
+
+    @staticmethod
+    def _saturated_rotating_cache(offset=12, max_size=8):
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        layer = RotatingKVCache(max_size=max_size, keep=0)
+        layer.keys = mx.ones((1, 1, max_size, 4), dtype=mx.float32)
+        layer.values = layer.keys
+        layer.offset = offset
+        layer._idx = max_size
+        return layer
+
+    @staticmethod
+    def _prefix_cache():
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        return MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(max_memory_mb=64, max_entries=10, min_prefix_tokens=1),
+        )
+
+    def test_supersequence_skips_saturated_rotating_cache(self):
+        cache = self._prefix_cache()
+        rotating = self._saturated_rotating_cache()
+        cache.store(
+            [1, 2, 3, 4, 5, 6],
+            [self._full_cache(6), rotating],
+        )
+
+        fetched, remaining = cache.fetch([1, 2, 3, 4])
+
+        assert fetched is None
+        assert remaining == [1, 2, 3, 4]
+        assert rotating.offset == 12
+
+    def test_lcp_skips_saturated_rotating_cache(self):
+        cache = self._prefix_cache()
+        rotating = self._saturated_rotating_cache()
+        cache.store(
+            [1, 2, 3, 4, 5, 6],
+            [self._full_cache(6), rotating],
+        )
+
+        fetched, remaining = cache.fetch([1, 2, 9])
+
+        assert fetched is None
+        assert remaining == [1, 2, 9]
+        assert rotating.offset == 12
+
+    def test_exact_and_prefix_hits_do_not_require_rewind(self):
+        cache = self._prefix_cache()
+        cache.store(
+            [1, 2, 3, 4],
+            [self._full_cache(4), self._saturated_rotating_cache()],
+        )
+
+        exact, exact_remaining = cache.fetch([1, 2, 3, 4])
+        prefix, prefix_remaining = cache.fetch([1, 2, 3, 4, 5])
+
+        assert exact is not None
+        assert exact_remaining == []
+        assert prefix is not None
+        assert prefix_remaining == [5]
+
+    def test_cache_list_is_rejected_even_when_children_are_trimmable(self):
+        from mlx_lm.models.cache import CacheList
+
+        from vllm_mlx.memory_cache import _is_cache_layer_trimmable
+
+        layer = CacheList(self._full_cache(8), self._full_cache(8))
+
+        assert not _is_cache_layer_trimmable(layer)
+
+    def test_supersequence_skips_cache_list_container(self):
+        from mlx_lm.models.cache import CacheList
+
+        cache = self._prefix_cache()
+        container = CacheList(self._full_cache(6), self._full_cache(6))
+        cache.store([1, 2, 3, 4, 5, 6], [container])
+
+        fetched, remaining = cache.fetch([1, 2, 3, 4])
+
+        assert fetched is None
+        assert remaining == [1, 2, 3, 4]
+        assert all(child.offset == 6 for child in container.caches)
+
+    def test_quantized_wrapper_rejects_rotating_metadata(self):
+        from vllm_mlx.memory_cache import (
+            _QuantizedCacheWrapper,
+            _is_cache_layer_trimmable,
+        )
+
+        wrapper = _QuantizedCacheWrapper.__new__(_QuantizedCacheWrapper)
+        wrapper.keys = object()
+        wrapper.values = object()
+        wrapper.bits = 8
+        wrapper.group_size = 64
+        wrapper.orig_type = object
+        wrapper.orig_attrs = {"max_size": 8}
+
+        for offset in (4, 8):
+            wrapper.offset = offset
+            assert not _is_cache_layer_trimmable(wrapper)
+
+
 class TestDequantizeCacheSlice:
     """Tests for _dequantize_cache slicing after dequantization.
 

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -264,6 +264,33 @@ class _CacheEntry:
         )
 
 
+def _is_cache_layer_trimmable(layer_cache: Any) -> bool:
+    """Return whether a cache layer can safely be rewound for partial reuse."""
+    if isinstance(layer_cache, _QuantizedCacheWrapper):
+        if "max_size" in layer_cache.orig_attrs:
+            return False
+        return hasattr(layer_cache, "offset") and hasattr(layer_cache, "keys")
+
+    # _trim_cache_offset does not currently rewind container children.
+    if hasattr(layer_cache, "caches"):
+        return False
+
+    is_trimmable = getattr(layer_cache, "is_trimmable", None)
+    if callable(is_trimmable):
+        try:
+            return bool(is_trimmable())
+        except Exception:
+            logger.debug(
+                "Failed to check cache layer trimmability for %s",
+                type(layer_cache).__name__,
+                exc_info=True,
+            )
+            return False
+
+    # Compatibility fallback for simple KV-like cache implementations.
+    return hasattr(layer_cache, "offset") and hasattr(layer_cache, "keys")
+
+
 def _trim_cache_offset(cache: list[Any], trim_by: int) -> list[Any]:
     """Create copies of cache layers with the last ``trim_by`` positions removed.
 
@@ -792,8 +819,7 @@ class MemoryAwarePrefixCache:
             excess = n_cached - n_requested
 
             has_non_trimmable = any(
-                not (hasattr(lc, "offset") and hasattr(lc, "keys"))
-                for lc in best_super.cache
+                not _is_cache_layer_trimmable(lc) for lc in best_super.cache
             )
 
             if excess > 0 and has_non_trimmable:
@@ -886,8 +912,7 @@ class MemoryAwarePrefixCache:
             excess = len(best_lcp_entry.tokens) - best_lcp_length
 
             has_non_trimmable = any(
-                not (hasattr(lc, "offset") and hasattr(lc, "keys"))
-                for lc in best_lcp_entry.cache
+                not _is_cache_layer_trimmable(lc) for lc in best_lcp_entry.cache
             )
             logger.debug(
                 f"[cache_fetch] LCP candidate: lcp={best_lcp_length} "


### PR DESCRIPTION
A saturated `RotatingKVCache` cannot be rewound safely, but the prefix-cache LCP and supersequence paths only checked for `offset` and `keys`. That allowed partial reuse and could desync mixed cache layers.

This checks each layer's actual trimmability before partial reuse. Unsupported cache containers and rotating quantized wrappers fail closed. Exact and normal prefix hits are unchanged.

Tests cover supersequence and LCP misses, exact/prefix hits, `CacheList`, and rotating wrapper metadata.

Verification: 2,303 passed, 24 skipped.

Refs #678
