### PR TITLE
fix(simple-engine): preserve streaming finish reasons

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2618,6 +2618,85 @@ class TestSimpleEngineConcurrency:
         assert await asyncio.to_thread(prefill_cancelled.wait, 1.0)
 
 
+class TestSimpleEngineNaturalStop:
+    @staticmethod
+    def _engine(stream_generate):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._model = MagicMock()
+        engine._model.tokenizer.encode.return_value = [1, 2, 3]
+        engine._model.stream_generate.side_effect = stream_generate
+        return engine
+
+    @pytest.mark.anyio
+    async def test_generator_exhaustion_emits_one_stop(self):
+        def generate(**kwargs):
+            yield SimpleNamespace(text="Hel", prompt_tokens=3, finish_reason=None)
+            yield SimpleNamespace(text="lo", prompt_tokens=3, finish_reason="stop")
+
+        outputs = [
+            output
+            async for output in self._engine(generate).stream_generate(
+                prompt="hi", max_tokens=50
+            )
+        ]
+
+        finished = [output for output in outputs if output.finished]
+        assert len(finished) == 1
+        assert finished[0].finish_reason == "stop"
+
+    @pytest.mark.anyio
+    async def test_token_limit_keeps_length_reason(self):
+        def generate(**kwargs):
+            yield SimpleNamespace(text="a", prompt_tokens=3, finish_reason=None)
+            yield SimpleNamespace(text="b", prompt_tokens=3, finish_reason=None)
+            yield SimpleNamespace(text="c", prompt_tokens=3, finish_reason=None)
+
+        outputs = [
+            output
+            async for output in self._engine(generate).stream_generate(
+                prompt="hi", max_tokens=3
+            )
+        ]
+
+        finished = [output for output in outputs if output.finished]
+        assert len(finished) == 1
+        assert finished[0].finish_reason == "length"
+
+    @pytest.mark.anyio
+    async def test_exception_is_not_reported_as_stop(self):
+        def generate(**kwargs):
+            yield SimpleNamespace(text="partial", prompt_tokens=3, finish_reason=None)
+            raise RuntimeError("backend failed")
+
+        engine = self._engine(generate)
+        outputs = []
+        with pytest.raises(RuntimeError, match="backend failed"):
+            async for output in engine.stream_generate(prompt="hi", max_tokens=50):
+                outputs.append(output)
+
+        assert not any(output.finished for output in outputs)
+        assert not engine._active_requests
+
+    @pytest.mark.anyio
+    async def test_empty_generator_emits_stop(self):
+        def generate(**kwargs):
+            yield from ()
+
+        outputs = [
+            output
+            async for output in self._engine(generate).stream_generate(
+                prompt="hi", max_tokens=50
+            )
+        ]
+
+        assert len(outputs) == 1
+        assert outputs[0].finished
+        assert outputs[0].finish_reason == "stop"
+
 class TestSimpleEngineClearRuntimeCaches:
     """Operational reset (DELETE /v1/cache) must actually release the
     multi-slot system-prompt KV cache state introduced in the LRU patch —

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2697,6 +2697,7 @@ class TestSimpleEngineNaturalStop:
         assert outputs[0].finished
         assert outputs[0].finish_reason == "stop"
 
+
 class TestSimpleEngineClearRuntimeCaches:
     """Operational reset (DELETE /v1/cache) must actually release the
     multi-slot system-prompt KV cache state introduced in the LRU patch —

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -974,9 +974,7 @@ class SimpleEngine(BaseEngine):
                         finish_reason = getattr(chunk, "finish_reason", None)
                         if finish_reason is None:
                             finish_reason = (
-                                "length"
-                                if completion_tokens >= max_tokens
-                                else "stop"
+                                "length" if completion_tokens >= max_tokens else "stop"
                             )
 
                     yield GenerationOutput(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -971,7 +971,13 @@ class SimpleEngine(BaseEngine):
                     )
                     finish_reason = None
                     if finished:
-                        finish_reason = getattr(chunk, "finish_reason", "stop")
+                        finish_reason = getattr(chunk, "finish_reason", None)
+                        if finish_reason is None:
+                            finish_reason = (
+                                "length"
+                                if completion_tokens >= max_tokens
+                                else "stop"
+                            )
 
                     yield GenerationOutput(
                         text=accumulated_text,
@@ -1002,7 +1008,7 @@ class SimpleEngine(BaseEngine):
                         prompt_tokens=prompt_tokens,
                         completion_tokens=completion_tokens,
                         finished=True,
-                        finish_reason=None,
+                        finish_reason="stop",
                     )
             finally:
                 self._active_requests.pop(request_id, None)


### PR DESCRIPTION
Natural generator exhaustion currently emits a final chunk with no finish reason. Strict OpenAI clients treat that as a truncated stream.

This stamps natural exhaustion as `stop`. It also fixes the engine-enforced token-limit fallback so a backend chunk with no reason is reported as `length`, while preserving explicit backend reasons.

Tests cover natural and empty exhaustion, token limits, exceptions, and request cleanup.

This adopts and extends #629 because the required regression patch could not be added to its fork-owned branch. Miguel Vilhena is credited as co-author.

Verification: 2,301 passed, 24 skipped.

Refs #628
