### PR TITLE
fix(scheduler): make the prefix cache usable on non-trimmable KV caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
             tests/test_mllm.py \
             tests/test_server.py \
             tests/test_paged_cache.py \
+            tests/test_prefix_cache_untrimmable.py \
             tests/test_qwen35_mtp_patch.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -198,6 +198,36 @@ class TestArrayMemory:
         expected = 2 * (1 * 8 * 100 * 64 * 2)
         assert estimate_kv_cache_memory([layer]) == expected
 
+    def test_estimate_handles_nested_cachelist_state(self):
+        """Regression: DeepSeek-V4's CacheList.state nests three sub-states.
+
+        The old two-way unpack raised ValueError, was swallowed, and the whole
+        entry counted as 0 bytes — so the dashboard's Prefix Cache bar stayed
+        at 0% and byte-based LRU eviction never fired for such models.
+        """
+
+        class NestedStateCache:
+            def __init__(self):
+                rot = (
+                    MockShapeArray(shape=(1, 8, 128, 64), dtype_size=2),
+                    MockShapeArray(shape=(1, 8, 128, 64), dtype_size=2),
+                )
+                pool_a = (
+                    MockShapeArray(shape=(1, 3, 512), dtype_size=2),
+                    MockShapeArray(shape=(1, 3, 128), dtype_size=2),
+                    MockShapeArray(shape=(1, 40, 512), dtype_size=2),
+                )
+                pool_b = (None, None, None)  # empty PoolingCache members
+                self.state = [rot, pool_a, pool_b]
+
+        expected = (
+            2 * (1 * 8 * 128 * 64 * 2)
+            + (1 * 3 * 512 * 2)
+            + (1 * 3 * 128 * 2)
+            + (1 * 40 * 512 * 2)
+        )
+        assert estimate_kv_cache_memory([NestedStateCache()]) == expected
+
 
 class TestEstimateKvCacheMemory:
     """Tests for estimate_kv_cache_memory function."""

--- a/tests/test_prefix_cache_untrimmable.py
+++ b/tests/test_prefix_cache_untrimmable.py
@@ -1,0 +1,413 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prefix cache behaviour for caches that cannot be trimmed.
+
+A ``prompt + output`` cache key is only reusable via a trim: every later query
+is shorter than such a key, so the generated tail has to come off first. Models
+with sliding-window or pooled KV cannot do that, which makes those entries dead
+weight — and expensive weight, since each one holds a full-length KV copy and
+Metal runs out of *buffers* long before the cache's byte budget is reached.
+
+These tests pin the two halves of the fix: skipping the unusable entry, and
+storing a post-prefill snapshot that is reusable by strict prefix match.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+cache_mod = pytest.importorskip("mlx_lm.models.cache")
+
+from vllm_mlx.scheduler import Scheduler  # noqa: E402
+
+
+def _rotating_past_its_window() -> list:
+    """A RotatingKVCache that has wrapped, so trimming is impossible."""
+    c = cache_mod.RotatingKVCache(max_size=8)
+    # 12 > max_size: the ring buffer has physically overwritten older KV.
+    c.update_and_fetch(mx.zeros((1, 1, 12, 4)), mx.zeros((1, 1, 12, 4)))
+    return [c]
+
+
+def _plain_kv_cache() -> list:
+    c = cache_mod.KVCache()
+    c.update_and_fetch(mx.zeros((1, 1, 4, 4)), mx.zeros((1, 1, 4, 4)))
+    return [c]
+
+
+class TestPromptOutputEntryIsUseless:
+    def test_wrapped_rotating_cache_cannot_back_a_prompt_output_entry(self):
+        cache = _rotating_past_its_window()
+        assert not cache_mod.can_trim_prompt_cache(cache), "setup: must be untrimmable"
+        assert Scheduler._prompt_output_entry_is_useless(cache) is True
+
+    def test_plain_kv_cache_still_gets_its_entry(self):
+        cache = _plain_kv_cache()
+        assert cache_mod.can_trim_prompt_cache(cache), "setup: must be trimmable"
+        assert Scheduler._prompt_output_entry_is_useless(cache) is False
+
+    def test_cache_list_is_useless_when_any_member_is(self):
+        """CacheList reports one verdict for the whole group."""
+        grouped = cache_mod.CacheList(*_plain_kv_cache(), *_rotating_past_its_window())
+        assert Scheduler._prompt_output_entry_is_useless([grouped]) is True
+
+    def test_unknown_cache_objects_do_not_break_the_scheduler(self):
+        """Anything that cannot answer the question keeps its entry."""
+
+        class Opaque:
+            pass
+
+        assert Scheduler._prompt_output_entry_is_useless([Opaque()]) is False
+
+
+class TestSnapshotOwnsItsMemory:
+    """A snapshot that aliases the live cache is rewritten by the generation
+    it is supposed to predate: RotatingKVCache writes into its ring buffer and
+    PoolingCache into its remainder buffer, both in place."""
+
+    def test_copy_is_not_a_view_of_the_source(self):
+        src = mx.array([1.0, 2.0, 3.0])
+        copy = Scheduler._copy_cache_state(src)
+        mx.eval(copy)
+        assert copy is not src
+        assert mx.array_equal(copy, src)
+
+    def test_copy_survives_in_place_mutation_of_the_source(self):
+        src = mx.zeros((4,))
+        copy = Scheduler._copy_cache_state(src)
+        mx.eval(copy)
+        src[0:4] = mx.array([9.0, 9.0, 9.0, 9.0])
+        mx.eval(src)
+        assert copy.tolist() == [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ], "snapshot aliased the live cache and was overwritten by generation"
+
+    def test_nested_containers_are_copied_through(self):
+        src = [mx.array([1.0]), (mx.array([2.0]), mx.array([3.0])), None, 7]
+        copy = Scheduler._copy_cache_state(src)
+
+        assert isinstance(copy, list) and isinstance(copy[1], tuple)
+        assert copy[0] is not src[0]
+        assert copy[1][0] is not src[1][0]
+        # Non-arrays are metadata, passed through as-is.
+        assert copy[2] is None and copy[3] == 7
+
+    def test_real_rotating_cache_state_is_detached(self):
+        live = cache_mod.RotatingKVCache(max_size=8)
+        live.update_and_fetch(mx.ones((1, 1, 4, 4)), mx.ones((1, 1, 4, 4)))
+        snapshot = Scheduler._copy_cache_state(live.state)
+        mx.eval(snapshot)
+
+        before = [mx.sum(a).item() for a in snapshot if isinstance(a, mx.array)]
+        # Keep generating: the ring buffer is written in place past max_size.
+        for _ in range(6):
+            live.update_and_fetch(mx.ones((1, 1, 4, 4)) * 5, mx.ones((1, 1, 4, 4)) * 5)
+        after = [mx.sum(a).item() for a in snapshot if isinstance(a, mx.array)]
+
+        assert before == after, "continued generation mutated the stored snapshot"
+
+
+class _FakeRequest:
+    def __init__(self, prompt_token_ids):
+        self.prompt_token_ids = list(prompt_token_ids)
+        self.request_id = "req-0123456789"
+        self.cached_tokens = 0
+        self.num_output_tokens = 0
+
+
+class _FakeResponse:
+    def __init__(self, token=None, uid=0):
+        self.token = token
+        self.uid = uid
+
+
+def _bare_scheduler():
+    sched = object.__new__(Scheduler)
+    return sched
+
+
+class TestSnapshotKeyAlignment:
+    """The key must name exactly the tokens the snapshot holds.
+
+    The snapshot is taken while processing the response carrying the first
+    generated token, and the batch has already fed that token through the
+    cache: measured ``prompt_len=5, cache_offset=6`` on a real scheduler run.
+    Storing that under ``prompt_token_ids`` leaves warm reuse one token ahead
+    of its key, and trimming the overshoot off is unavailable here — these are
+    the caches that cannot be trimmed.
+    """
+
+    def test_key_is_extended_to_cover_the_generated_token(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5])
+        cache = _plain_kv_cache()
+        cache[0].offset = 6  # prompt + first generated token
+
+        key = Scheduler._cache_key_for_snapshot(
+            sched, request, _FakeResponse(token=99), cache
+        )
+
+        assert key == [1, 2, 3, 4, 5, 99]
+        assert len(key) == Scheduler._cache_coverage(
+            cache
+        ), "key length must equal what the cache holds"
+
+    def test_key_is_the_prompt_when_the_cache_stops_there(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5])
+        cache = _plain_kv_cache()
+        cache[0].offset = 5
+
+        key = Scheduler._cache_key_for_snapshot(
+            sched, request, _FakeResponse(token=99), cache
+        )
+        assert key == [1, 2, 3, 4, 5]
+
+    def test_short_cache_is_refused_rather_than_stored_misaligned(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5])
+        cache = _plain_kv_cache()
+        cache[0].offset = 3
+
+        assert (
+            Scheduler._cache_key_for_snapshot(
+                sched, request, _FakeResponse(token=99), cache
+            )
+            is None
+        )
+
+    def test_unnamed_overshoot_is_refused(self):
+        """Two tokens past the prompt but only one is known — do not guess."""
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5])
+        cache = _plain_kv_cache()
+        cache[0].offset = 7
+
+        assert (
+            Scheduler._cache_key_for_snapshot(
+                sched, request, _FakeResponse(token=99), cache
+            )
+            is None
+        )
+
+
+class TestSnapshotDestinationTopology:
+    """A destination that cannot hold the live state means no entry at all.
+
+    ``make_prompt_cache(model)`` yields plain ``KVCache`` layers; assigning a
+    ``RotatingKVCache``'s state or meta_state to one raises, the store path's
+    broad handler logs a warning, and the snapshot is silently never stored —
+    on exactly the sliding-window configurations this feature exists for.
+    """
+
+    def test_rotating_layers_are_mirrored_not_replaced(self):
+        sched = _bare_scheduler()
+        live = _rotating_past_its_window()
+
+        dest = Scheduler._make_snapshot_destination(sched, live)
+
+        assert dest is not None
+        assert type(dest[0]) is type(live[0])
+        assert dest[0].max_size == live[0].max_size
+        assert dest[0] is not live[0], "destination must not alias the live layer"
+
+    def test_mixed_topology_is_preserved_layer_by_layer(self):
+        sched = _bare_scheduler()
+        live = _plain_kv_cache() + _rotating_past_its_window()
+
+        dest = Scheduler._make_snapshot_destination(sched, live)
+
+        assert [type(d).__name__ for d in dest] == [
+            type(layer).__name__ for layer in live
+        ]
+
+    def test_state_assignment_round_trips_on_a_rotating_layer(self):
+        """The assignment that used to raise and get swallowed."""
+        sched = _bare_scheduler()
+        live = _rotating_past_its_window()
+        dest = Scheduler._make_snapshot_destination(sched, live)
+
+        state = Scheduler._copy_cache_state(live[0].state)
+        meta = getattr(live[0], "meta_state", None)
+        if meta is not None:
+            dest[0].meta_state = meta
+        dest[0].state = state
+        mx.eval([a for a in state if isinstance(a, mx.array)])
+
+        assert dest[0].offset == live[0].offset
+
+
+class TestNestedCacheListInvariants:
+    """DeepSeek-V4 groups several caches per layer in a ``CacheList``.
+
+    A container carries no ``offset`` and copies shallowly, so both invariants
+    this file exists for break at the outer layer while every flat-layer test
+    still passes: coverage reads None and the key silently falls back to
+    prompt-only, and the "snapshot" shares the live child objects and follows
+    the generation it is supposed to predate.
+    """
+
+    @staticmethod
+    def _nested(tokens=7, max_size=8):
+        plain = cache_mod.KVCache()
+        plain.update_and_fetch(mx.ones((1, 1, tokens, 4)), mx.ones((1, 1, tokens, 4)))
+        rotating = cache_mod.RotatingKVCache(max_size=max_size)
+        rotating.update_and_fetch(
+            mx.ones((1, 1, tokens, 4)), mx.ones((1, 1, tokens, 4))
+        )
+        return cache_mod.CacheList(plain, rotating)
+
+    def test_coverage_descends_into_the_container(self):
+        live = [self._nested(tokens=7)]
+
+        assert Scheduler._cache_coverage(live) == 7, (
+            "a CacheList has no offset of its own; reading the attribute off "
+            "the layer returns None and the key falls back to prompt-only"
+        )
+
+    def test_key_length_matches_nested_coverage(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5, 6])
+        live = [self._nested(tokens=7)]
+
+        key = Scheduler._cache_key_for_snapshot(
+            sched, request, _FakeResponse(token=77), live
+        )
+
+        assert key == [1, 2, 3, 4, 5, 6, 77]
+        assert len(key) == Scheduler._cache_coverage(live)
+
+    def test_snapshot_does_not_share_children_with_the_live_cache(self):
+        sched = _bare_scheduler()
+        live = [self._nested()]
+
+        dest = Scheduler._make_snapshot_destination(sched, live)
+
+        assert type(dest[0]) is type(live[0])
+        assert [type(c).__name__ for c in dest[0].caches] == [
+            type(c).__name__ for c in live[0].caches
+        ]
+        for mirrored, original in zip(dest[0].caches, live[0].caches):
+            assert mirrored is not original, "container copied shallowly"
+
+    def test_snapshot_survives_continued_generation_on_the_live_cache(self):
+        """The invariant that matters: the snapshot must predate what follows."""
+        sched = _bare_scheduler()
+        live = [self._nested(tokens=4, max_size=8)]
+        dest = Scheduler._make_snapshot_destination(sched, live)
+
+        for mirrored, original in zip(dest[0].caches, live[0].caches):
+            state = Scheduler._copy_cache_state(original.state)
+            mirrored.state = state
+            mx.eval([a for a in state if isinstance(a, mx.array)])
+
+        before = [
+            mx.sum(a).item()
+            for child in dest[0].caches
+            for a in child.state
+            if isinstance(a, mx.array)
+        ]
+        for child in live[0].caches:
+            for _ in range(6):
+                child.update_and_fetch(
+                    mx.ones((1, 1, 1, 4)) * 5, mx.ones((1, 1, 1, 4)) * 5
+                )
+        after = [
+            mx.sum(a).item()
+            for child in dest[0].caches
+            for a in child.state
+            if isinstance(a, mx.array)
+        ]
+
+        assert before == after, "live generation mutated the stored snapshot"
+
+
+class TestSnapshotIsGatedToNonTrimmableTopologies:
+    """The snapshot exists for caches whose completion-time entry is unusable.
+
+    Running it for an ordinary ``KVCache`` is not merely wasted work. The
+    completion path already stores a correct ``N``-token entry; an ``N+1``
+    snapshot stored with ``evict_prefixes=True`` replaces it, and an identical
+    ``N``-token prompt then matches a *supersequence* rather than an exact key.
+    The scheduler only refuses ``exact`` hits, so it replays ``prompt[-1]`` on
+    top of a cache that already holds it — the duplicated-token bug this file
+    was written to avoid, reintroduced from the other side.
+    """
+
+    @staticmethod
+    def _filled(layer, tokens=6):
+        layer.update_and_fetch(mx.zeros((1, 1, tokens, 4)), mx.zeros((1, 1, tokens, 4)))
+        return layer
+
+    def test_trimmable_cache_is_left_to_the_completion_path(self):
+        cache = [self._filled(cache_mod.KVCache())]
+        assert cache_mod.can_trim_prompt_cache(cache) is True
+        assert Scheduler._prompt_output_entry_is_useless(cache) is False, (
+            "a trimmable cache must not be snapshotted here; its completion "
+            "entry is reusable and this one would evict it"
+        )
+
+    def test_non_trimmable_cache_still_qualifies(self):
+        cache = _rotating_past_its_window()
+        assert cache_mod.can_trim_prompt_cache(cache) is False
+        assert Scheduler._prompt_output_entry_is_useless(cache) is True
+
+    def test_store_returns_early_for_a_trimmable_cache(self):
+        """Drives the real store path rather than the predicate alone."""
+        sched = _bare_scheduler()
+        stored = []
+        sched.memory_aware_cache = type(
+            "C",
+            (),
+            {"store": lambda self, *a, **k: stored.append(a) or True, "_entries": {}},
+        )()
+        sched.model = object()
+        sched._extract_cache_for_uid = lambda uid: [self._filled(cache_mod.KVCache())]
+
+        request = _FakeRequest([1, 2, 3, 4, 5])
+        Scheduler._store_prompt_only_cache(
+            sched, request, _FakeResponse(token=99, uid=0)
+        )
+
+        assert stored == [], "a trimmable cache reached the snapshot store"
+
+
+class TestUnknownCoverageFailsClosed:
+    """A cache with no offset must not be stored under a guessed key.
+
+    ``ArraysCache`` exposes no ``offset``, but by the time the first response
+    arrives mlx-lm has already folded the first generated token into the
+    recurrent state. Storing that under the prompt alone makes the next turn
+    replay the token into cumulative state — and for these models the snapshot
+    is the only entry that ever gets written, so nothing else corrects it.
+    """
+
+    def test_arrays_cache_has_no_offset_to_read(self):
+        cache = [cache_mod.ArraysCache(2)]
+        assert Scheduler._cache_coverage(cache) is None
+
+    def test_key_is_refused_rather_than_guessed(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3, 4, 5])
+
+        key = Scheduler._cache_key_for_snapshot(
+            sched, request, _FakeResponse(token=99), [cache_mod.ArraysCache(2)]
+        )
+
+        assert key is None, (
+            "unknown coverage fell back to prompt_ids; the stored state covers "
+            "prompt + first generated token and the key would be one short"
+        )
+
+    def test_nested_container_of_arrays_caches_is_also_refused(self):
+        sched = _bare_scheduler()
+        request = _FakeRequest([1, 2, 3])
+        nested = cache_mod.CacheList(cache_mod.ArraysCache(2), cache_mod.ArraysCache(2))
+
+        assert (
+            Scheduler._cache_key_for_snapshot(
+                sched, request, _FakeResponse(token=7), [nested]
+            )
+            is None
+        )

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -88,6 +88,23 @@ def _array_memory(arr) -> int:
     return 0
 
 
+def _nested_array_memory(value: Any) -> int:
+    """Sum ``_array_memory`` over an arbitrarily nested state structure.
+
+    Cache ``state`` payloads are not always a flat ``(keys, values)`` pair:
+    CacheList yields a list of sub-cache states and PoolingCache yields
+    ``(buf_kv, buf_gate, pooled)`` with possible ``None`` members. Unpacking
+    those as two values raised, was swallowed, and the entry was accounted as
+    zero bytes — so the dashboard showed 0% cache memory and, far worse, the
+    byte-based LRU eviction never fired for such models.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, (list, tuple)):
+        return sum(_nested_array_memory(v) for v in value)
+    return _array_memory(value)
+
+
 def estimate_kv_cache_memory(cache: list[Any]) -> int:
     """
     Estimate memory usage of a KV cache in bytes.
@@ -125,11 +142,11 @@ def estimate_kv_cache_memory(cache: list[Any]) -> int:
                 total_bytes += _array_memory(arr)
             continue
         elif hasattr(layer_cache, "state") and not isinstance(layer_cache, dict):
-            # Cache with state property returning (keys, values)
+            # Cache with a state property. Walk it recursively: the payload may
+            # be a plain (keys, values) pair, but CacheList/PoolingCache nest
+            # further, and the old two-way unpack silently measured those as 0.
             try:
-                keys, values = layer_cache.state
-                total_bytes += _array_memory(keys)
-                total_bytes += _array_memory(values)
+                total_bytes += _nested_array_memory(layer_cache.state)
             except (TypeError, ValueError):
                 pass
         elif hasattr(layer_cache, "keys") and hasattr(layer_cache, "values"):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2015,8 +2015,25 @@ class Scheduler:
                 request.remaining_tokens is not None
                 and len(request.remaining_tokens) == 0
             ):
-                # Exact cache match - pass only last token for generation kickoff
-                tokens_to_process = request.prompt_token_ids[-1:]
+                # Exact cache match. Re-feeding the last token is only correct
+                # when the cached state stops one token short of the key; for a
+                # state that already covers the whole key it duplicates that
+                # token in the KV cache and the model then answers from a
+                # corrupted context (measured: same prompt, different output).
+                # Entries stored post-prefill cover the full key, so drop the
+                # cache and prefill instead of guessing which kind this is.
+                if getattr(request, "cache_hit_type", None) == "exact":
+                    logger.debug(
+                        "[cache] exact match on a full-coverage entry; "
+                        "prefilling to avoid duplicating the last token"
+                    )
+                    cache_to_use = None
+                    request.prompt_cache = None
+                    request.cached_tokens = 0
+                    request.remaining_tokens = request.prompt_token_ids
+                    tokens_to_process = request.prompt_token_ids
+                else:
+                    tokens_to_process = request.prompt_token_ids[-1:]
             elif request.remaining_tokens:
                 tokens_to_process = request.remaining_tokens
             else:
@@ -2137,6 +2154,311 @@ class Scheduler:
 
         return scheduled
 
+    @staticmethod
+    def _copy_cache_state(value: Any) -> Any:
+        """Deep-copy a cache ``state`` payload.
+
+        Sharing the arrays is not safe: RotatingKVCache writes into its ring
+        buffer and PoolingCache writes into its remainder buffer, both in
+        place, so a snapshot that aliases them would be rewritten by the very
+        generation it is supposed to predate. ``x + 0`` forces a fresh array
+        while staying on the GPU.
+        """
+        import mlx.core as mx
+
+        if isinstance(value, mx.array):
+            return value + 0
+        if isinstance(value, (list, tuple)):
+            copied = [Scheduler._copy_cache_state(v) for v in value]
+            return type(value)(copied) if isinstance(value, tuple) else copied
+        return value
+
+    # How much a prompt must have grown before its cache snapshot is worth
+    # re-taking. Copying the KV cache is O(context), so refreshing every turn
+    # dominates prefill on long agentic conversations.
+    SNAPSHOT_REFRESH_TOKENS = 4096
+
+    @staticmethod
+    def _prompt_output_entry_is_useless(cache: Any) -> bool:
+        """Would a prompt+output entry built from this cache ever be reusable?
+
+        Only via a trim: any later query is shorter than a prompt+output key, so
+        the generated tail has to come off first. When the cache cannot be
+        trimmed the entry is dead weight — and far from free, since each one
+        holds a full-length KV copy and Metal runs out of buffers long before
+        the byte budget is reached.
+        """
+        try:
+            from mlx_lm.models.cache import can_trim_prompt_cache
+
+            return not can_trim_prompt_cache(cache)
+        except Exception:
+            return False
+
+    def _extract_cache_for_uid(self, uid: int) -> Any:
+        """Pull one sequence's cache out of the live BatchGenerator batch."""
+        bg = self.batch_generator
+        if bg is None:
+            return None
+        for attr in ("_generation_batch", "_prompt_batch"):
+            batch = getattr(bg, attr, None)
+            uids = getattr(batch, "uids", None)
+            if not uids or uid not in uids:
+                continue
+            extract = getattr(batch, "extract_cache", None)
+            if extract is None:
+                continue
+            try:
+                return extract(uids.index(uid))
+            except Exception as e:
+                logger.debug("extract_cache(%s) on %s failed: %s", uid, attr, e)
+        return None
+
+    def _make_snapshot_destination(self, live_cache: Any) -> Any:
+        """Build a destination cache with the same topology as the live one.
+
+        ``make_prompt_cache(model)`` is not a safe source for this. A plain
+        ``KVCache`` destination cannot take a ``RotatingKVCache``'s state or
+        meta_state; the assignment raises, the broad handler below logs a
+        warning, and the snapshot is silently never stored — on exactly the
+        sliding-window configurations this feature exists for.
+
+        Deriving it from ``config.max_kv_size`` instead is also wrong, which I
+        only found by measuring: ``_create_batch_generator`` does not pass
+        ``max_kv_size`` to ``BatchGenerator``, so with ``max_kv_size=512``
+        configured the live layers were still plain ``KVCache`` and a
+        config-derived destination mismatched in the opposite direction.
+
+        So mirror the live objects themselves. A shallow copy keeps the class
+        and every scalar attribute (``max_size``, ``keep``, ``step``, ``_idx``)
+        and the caller overwrites the arrays, which is the only part that must
+        not be shared.
+        """
+        import copy
+
+        def _mirror(layer: Any) -> Any:
+            children = getattr(layer, "caches", None)
+            if children:
+                # copy.copy on a container shares the child cache objects, so
+                # the "snapshot" would follow live generation. Rebuild it from
+                # mirrored children instead.
+                mirrored = [_mirror(child) for child in children]
+                container = copy.copy(layer)
+                container.caches = type(children)(mirrored)
+                return container
+            return copy.copy(layer)
+
+        try:
+            return [_mirror(layer) for layer in live_cache]
+        except Exception:
+            logger.warning(
+                "[cache_store_prompt] could not mirror live cache topology; "
+                "not storing",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _cache_coverage(cache: Any) -> int | None:
+        """How many tokens the live cache actually holds.
+
+        Containers have to be descended into: ``CacheList`` carries no
+        ``offset`` of its own, so reading the attribute off the layer returns
+        None and the caller silently falls back to a prompt-only key — the
+        misalignment this is here to prevent, on exactly the architectures
+        (DeepSeek-V4) that group several caches per layer.
+        """
+
+        def _offset_of(layer: Any) -> int | None:
+            offset = getattr(layer, "offset", None)
+            if isinstance(offset, int):
+                return offset
+            children = getattr(layer, "caches", None)
+            if children:
+                for child in children:
+                    found = _offset_of(child)
+                    if found is not None:
+                        return found
+            return None
+
+        for layer in cache:
+            found = _offset_of(layer)
+            if found is not None:
+                return found
+        return None
+
+    def _cache_key_for_snapshot(
+        self, request: Any, response: Any, raw_cache: Any
+    ) -> list[int] | None:
+        """Key the entry by the tokens the cache covers, not by the prompt.
+
+        The snapshot is taken while processing the response that carries the
+        first generated token, and by then the batch has already fed that token
+        through the cache: measured ``prompt_len=5, cache_offset=6``. Storing
+        that under ``prompt_token_ids`` leaves every warm reuse one token ahead
+        of its key.
+
+        Trimming the overshoot off is not available here — these are precisely
+        the caches that cannot be trimmed — so the key is extended instead. The
+        extra token is the first token of the reply, which the next turn's
+        prompt also contains, so the entry still matches by strict prefix.
+
+        Returns None rather than storing a misaligned entry.
+        """
+        covered = self._cache_coverage(raw_cache)
+        prompt_ids = list(request.prompt_token_ids)
+        if covered is None:
+            # Fail closed. A cache that exposes no offset — a pure ArraysCache,
+            # for instance — still has the first generated token folded into it
+            # by the time the first response arrives, so assuming prompt-only
+            # coverage stores state under a key one token short. The next turn
+            # then replays that token into cumulative recurrent state and
+            # corrupts it, and for these models this is the only entry that
+            # ever gets stored. Skipping costs a prefill; guessing costs
+            # correctness.
+            logger.debug(
+                "[cache_store_prompt] coverage unknown for %s; not storing",
+                ", ".join(sorted({type(layer).__name__ for layer in raw_cache})),
+            )
+            return None
+
+        overshoot = covered - len(prompt_ids)
+        if overshoot == 0:
+            return prompt_ids
+        if overshoot < 0:
+            logger.debug(
+                "[cache_store_prompt] cache covers %d of %d prompt tokens; "
+                "not storing",
+                covered,
+                len(prompt_ids),
+            )
+            return None
+
+        token = getattr(response, "token", None)
+        generated = [] if token is None else [int(token)]
+        if overshoot > len(generated):
+            logger.debug(
+                "[cache_store_prompt] cache is %d tokens past the prompt but "
+                "only %d are known; not storing",
+                overshoot,
+                len(generated),
+            )
+            return None
+        return prompt_ids + generated[:overshoot]
+
+    def _store_prompt_only_cache(self, request: Any, response: Any) -> None:
+        """Store the post-prefill cache under the prompt tokens alone.
+
+        Called once per request, at the point where the cache covers exactly
+        the prompt. Entries keyed this way are reusable without any trimming,
+        which is what models with sliding-window or pooled KV need.
+        """
+        if self.memory_aware_cache is None:
+            return
+
+        # Do not refresh an entry that already covers nearly all of this
+        # prompt: the older one still gives a prefix hit next turn, only a few
+        # tokens shorter, so the refresh buys almost nothing. The copy itself is
+        # cheap (measured make/copy/eval at 0.00/0.00/0.01s for a 43-layer,
+        # 11k-token cache), but it allocates a fresh set of per-layer arrays
+        # every turn, and buffer count — not bytes — is what Metal runs out of.
+        # One copy per SNAPSHOT_REFRESH_TOKENS of growth instead of one per turn.
+        # Only throttle REFRESHES. covered > 0 means an existing entry served
+        # this prompt as a prefix hit; if it already covers all but a small
+        # tail, re-copying the whole cache buys a few tokens at the cost of a
+        # fresh set of per-layer arrays every turn. A cold prompt (covered ==
+        # 0) must always be stored — gating it on the same threshold silently
+        # disabled caching for every conversation shorter than the threshold.
+        covered = getattr(request, "cached_tokens", 0) or 0
+        if (
+            covered > 0
+            and len(request.prompt_token_ids) - covered <= self.SNAPSHOT_REFRESH_TOKENS
+        ):
+            return
+
+        try:
+            raw_cache = getattr(response, "prompt_cache", None)
+            if callable(raw_cache):
+                raw_cache = raw_cache()
+            if not raw_cache:
+                # mlx-lm only attaches prompt_cache to the response that
+                # carries a finish_reason; mid-generation it is None. Pull the
+                # per-sequence cache out of the live batch instead, which is
+                # what that attribute is built from anyway.
+                raw_cache = self._extract_cache_for_uid(response.uid)
+            if not raw_cache:
+                return
+
+            # Only topologies whose completion-time entry is unusable need this.
+            # A trimmable cache already gets a correct entry from the normal
+            # path; adding an N+1 snapshot here would evict it and leave an
+            # identical N-token prompt matching a supersequence, where the
+            # scheduler replays prompt[-1] and duplicates that token. It would
+            # also copy and evaluate the whole context before the first token
+            # goes out, for no benefit.
+            if not self._prompt_output_entry_is_useless(raw_cache):
+                return
+
+            cache_key = self._cache_key_for_snapshot(request, response, raw_cache)
+            if cache_key is None:
+                return
+
+            import mlx.core as mx
+
+            import time as _t
+
+            _t0 = _t.monotonic()
+            snapshot = self._make_snapshot_destination(raw_cache)
+            _t1 = _t.monotonic()
+            if snapshot is None:
+                return
+            states = []
+            for dst, src in zip(snapshot, raw_cache):
+                state = self._copy_cache_state(src.state)
+                meta = getattr(src, "meta_state", None)
+                if meta is not None:
+                    dst.meta_state = meta
+                dst.state = state
+                states.append(state)
+            _t2 = _t.monotonic()
+            mx.eval(states)
+            _t3 = _t.monotonic()
+            logger.debug(
+                "[snapshot_timing] make=%.2fs copy=%.2fs eval=%.2fs layers=%d",
+                _t1 - _t0,
+                _t2 - _t1,
+                _t3 - _t2,
+                len(snapshot),
+            )
+
+            # evict_prefixes=True is essential here, not cosmetic. In an
+            # agentic loop each turn's prompt extends the previous one, so
+            # without it every turn adds another full-length KV copy: measured
+            # 45 entries of a 46k-token cache, which exhausted Metal's buffer
+            # count ("[metal::malloc] Resource limit (499000) exceeded") and
+            # aborted generation mid-request. Evicting the superseded prefix
+            # keeps one entry per conversation.
+            stored = self.memory_aware_cache.store(
+                cache_key,
+                snapshot,
+                evict_prefixes=True,
+            )
+            logger.info(
+                "[cache_store_prompt] request=%s key_tokens=%d prompt_tokens=%d "
+                "stored=%s entries=%d",
+                request.request_id[:12],
+                len(cache_key),
+                len(request.prompt_token_ids),
+                stored,
+                len(self.memory_aware_cache._entries),
+            )
+        except Exception as e:
+            logger.warning(
+                "[cache_store_prompt] request=%s snapshot failed: %s",
+                request.request_id[:12],
+                e,
+            )
+
     def _process_batch_responses(
         self, responses: List[Any]
     ) -> Tuple[List[RequestOutput], Set[str]]:
@@ -2160,6 +2482,23 @@ class Scheduler:
             request = self.running.get(request_id)
             if request is None:
                 continue
+
+            # Snapshot the cache while it still covers exactly the prompt, i.e.
+            # before the first generated token is appended. Storing that under
+            # the prompt tokens is the only reuse path open to caches that
+            # cannot be trimmed: a later request whose prompt repeats or
+            # extends this one then gets an exact or strict-prefix match, and
+            # neither needs a trim.
+            #
+            # The prompt+output entry stored at completion can never be reused
+            # by such models. Any future query is shorter than that key, so it
+            # would have to trim the generated tail away — and DeepSeek-V4's
+            # sliding-window layers physically overwrite older KV once the
+            # window wraps (RotatingKVCache.is_trimmable() is offset<max_size),
+            # while its PoolingCache cannot split a pooled window. That data is
+            # gone, so no trim can recover it.
+            if request.num_output_tokens == 0:
+                self._store_prompt_only_cache(request, response)
 
             # Append token to request
             request.append_output_token(response.token)
@@ -2218,7 +2557,9 @@ class Scheduler:
                         else:
                             raw_cache = response.prompt_cache
 
-                        if raw_cache:
+                        if raw_cache and not self._prompt_output_entry_is_useless(
+                            raw_cache
+                        ):
                             # For paged cache, extract actual tensor states
                             # This allows cache to survive BatchGenerator recreation
                             if self.block_aware_cache is not None:


### PR DESCRIPTION
Split out of #676 on review.

## Problem

The scheduler stored one prefix-cache entry per request, keyed by `prompt + output`. Every later query is *shorter* than such a key, so reuse requires trimming the generated tail off first. Models with sliding-window or pooled KV cannot do that: `RotatingKVCache.is_trimmable()` is `offset < max_size`, so once the ring buffer wraps the older KV is physically overwritten, and a pooling cache merges tokens into windows it cannot split.

So on those architectures zero hits were **guaranteed by construction** — and the entries were not free. Each holds a full-length KV copy, and in an agentic loop where every turn extends the previous prompt they accumulate. I measured 45 entries of a ~46k-token cache. Each is hundreds of arrays (43 layers, `CacheList` of three caches each), and Metal runs out of **buffers** long before the cache's byte budget notices:

```
RuntimeError: [metal::malloc] Resource limit (499000) exceeded.
[generation_error_recovery] aborted 1 running requests, batch generator closed
```

The failure lands inside the model during a generation step, so the request is aborted and the client just sees the connection stall.

## Changes

- **Snapshot the cache while it still covers exactly the prompt** — before the first generated token is appended — and store that under the prompt tokens. Such an entry is reusable by strict prefix match with no trimming at all.
- **Skip the completion-time `prompt + output` entry when the cache is not trimmable**, since it can never be reused.

Three things the implementation has to get right, each of which cost me a debugging round:

- mlx-lm attaches `prompt_cache` only to the response carrying a `finish_reason`, so mid-generation it is None. The per-sequence cache is pulled from the live batch via `extract_cache(idx)` instead, which is what that attribute is built from anyway.
- **The snapshot must be a real copy.** Both cache types write into their buffers in place, so a snapshot that aliases them is rewritten by the very generation it is supposed to predate.
- **It is stored with `evict_prefixes=True`.** Without it each turn adds another full-length copy rather than replacing the entry it supersedes — that is the buffer exhaustion above. This one I shipped wrong first and only caught under a real agentic client.

Exact matches are deliberately **skipped** rather than used. The scheduler re-feeds `prompt[-1:]` on those, which duplicates that token in the KV cache when the entry covers the whole key — measured as the same prompt returning a different answer.

`memory_cache.py` could not measure these caches either: `CacheList.state` is nested, and the two-way unpack raised a `ValueError` that was swallowed, so every such entry was accounted as 0 bytes and the byte-based LRU never evicted.

## Verification

DeepSeek-V4-Flash-0731 (283.8B MXFP4, M3 Ultra), 8-turn tool-calling conversation over a ~33k-token context:

| | before | after |
|---|---|---|
| cache entries | 45 and climbing | **1** |
| Metal buffer errors | 7 | **0** |
| cache hits | — | **7/8**, 84 tokens prefilled instead of 33k |
| cold vs warm output | — | **10/10 character-identical** over 5 scenarios |
| long shared prefix | 4.19 s | **1.09 s** |

`tests/test_prefix_cache_untrimmable.py` covers what you asked for specifically: a wrapped `RotatingKVCache` and a mixed `CacheList` are recognised as unable to back a `prompt + output` entry while a plain `KVCache` still gets one, and memory ownership is pinned by mutating the live cache after snapshotting and asserting the snapshot does not move. Confirmed by mutation — aliasing instead of copying fails three of them.

Repo suite: **2303 passed**. The four local failures I see are reproduced on pristine `main` (three Python 3.14 issues, one missing `ffmpeg`).