### PR TITLE
fix: select the text-model family by prefix instead of one exact string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
             tests/test_mllm_cache.py \
             tests/test_optimizations.py \
             tests/test_simple_engine.py \
+            tests/test_text_model_dispatch.py \
             tests/test_chat_template_kwargs.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \

--- a/tests/test_text_model_dispatch.py
+++ b/tests/test_text_model_dispatch.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Text-model class selection for VLM-derived TextModels.
+
+The dispatch used to match one exact ``model_type`` string and send everything
+else to the Qwen3.5 text model. That is a guess, and a wrong guess does not
+fail where it is made: it fails deep inside the chosen constructor with an
+error naming neither the model nor the class, ``build_text_model`` returns
+None, and the engine carries on with ``_text_model=None`` — a route quietly
+losing its backend.
+
+Concretely, Gemma 4 reports ``gemma4_text`` on some checkpoints and
+``gemma4_unified_text`` on others. The latter reached ``qwen3_5.TextModelArgs``,
+which leaves ``num_experts`` as None, and died on ``args.num_experts > 0``.
+"""
+
+import logging
+
+import pytest
+
+pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+
+from vllm_mlx.text_model_from_vlm import (  # noqa: E402
+    _import_text_model_classes,
+    build_text_model,
+)
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    ["gemma4_text", "gemma4_unified_text", "gemma4_unified", "gemma4"],
+)
+def test_every_gemma4_variant_gets_the_gemma4_text_model(model_type):
+    """A family must cover its variants, not one spelling of it."""
+    Model, ModelArgs = _import_text_model_classes(model_type)
+    assert Model.__module__ == "mlx_lm.models.gemma4_text", (
+        f"{model_type!r} selected {Model.__module__}.{Model.__qualname__}; "
+        "a Gemma 4 config passed to another family dies on a field it has no "
+        "opinion about"
+    )
+    assert ModelArgs.__module__ == "mlx_lm.models.gemma4_text"
+
+
+def test_gemma4_unified_text_config_actually_constructs():
+    """The regression, end to end: this config used to raise.
+
+    ``qwen3_5.TextModelArgs.from_dict`` leaves ``num_experts`` as None for a
+    Gemma 4 config, and ``qwen3_5.DecoderLayer.__init__`` compares it to 0:
+    ``TypeError: '>' not supported between instances of 'NoneType' and 'int'``.
+    """
+    text_config = {
+        "model_type": "gemma4_unified_text",
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "vocab_size": 128,
+        "rms_norm_eps": 1e-6,
+    }
+    _, ModelArgs = _import_text_model_classes(text_config["model_type"])
+    args = ModelArgs.from_dict(text_config)
+    assert getattr(args, "num_hidden_layers", None) == 2
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_5_text", "qwen3_6_text", "", "unknown"])
+def test_unmatched_types_keep_the_generic_fallback(model_type):
+    """Unknown families must not start raising — that would be a regression.
+
+    qwen3_5.TextModel handles dense and MoE natively, so it stays the default.
+    """
+    Model, ModelArgs = _import_text_model_classes(model_type)
+    assert Model.__module__ == "mlx_lm.models.qwen3_5"
+    assert Model.__qualname__ == "TextModel"
+    assert ModelArgs.__qualname__ == "TextModelArgs"
+
+
+def test_failure_names_the_model_type_and_the_chosen_class(tmp_path, caplog):
+    """The old log line was a bare TypeError from someone else's constructor.
+
+    Without the model_type and the class that was picked, the only way to find
+    out which family was guessed is to bisect the dispatch by hand.
+    """
+    (tmp_path / "config.json").write_text(
+        '{"text_config": {"model_type": "gemma4_unified_text", '
+        '"num_hidden_layers": "not-an-int"}}'
+    )
+
+    class _Vlm:
+        language_model = object()
+
+    with caplog.at_level(logging.ERROR, logger="vllm_mlx.text_model_from_vlm"):
+        assert build_text_model(_Vlm(), tmp_path) is None
+
+    assert caplog.records, "a failed build must be logged"
+    message = caplog.records[-1].getMessage()
+    assert "gemma4_unified_text" in message, message
+    assert "mlx_lm.models.gemma4_text" in message, message
+    assert caplog.records[-1].exc_info is not None, "traceback must be preserved"
+
+
+def test_missing_config_is_not_reported_as_a_build_failure(tmp_path, caplog):
+    """No config.json is a "not applicable", not an error worth a traceback."""
+
+    class _Vlm:
+        language_model = object()
+
+    with caplog.at_level(logging.ERROR, logger="vllm_mlx.text_model_from_vlm"):
+        assert build_text_model(_Vlm(), tmp_path) is None
+    assert not caplog.records

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -22,17 +22,48 @@ import mlx.utils
 logger = logging.getLogger(__name__)
 
 
+# Text-model classes keyed by config ``model_type`` *prefix*, longest first.
+# A family has to cover its variants: Gemma 4 reports ``gemma4_text`` on some
+# checkpoints and ``gemma4_unified_text`` on others, and an exact match on the
+# former silently sent the latter to the generic fallback below.
+_TEXT_MODEL_FAMILIES: tuple[tuple[str, str, tuple[str, str]], ...] = (
+    ("gemma4", "mlx_lm.models.gemma4_text", ("Model", "ModelArgs")),
+)
+
+# Fallback. qwen3_5.TextModel and TextModelArgs handle both dense and MoE
+# natively (MTPDecoderLayer auto-selects SparseMoeBlock when
+# args.num_experts > 0), which makes them a reasonable generic choice — but it
+# is a guess, and a wrong guess dies deep inside the constructor with an error
+# that names neither the model nor the class. Hence the logging either side.
+_DEFAULT_TEXT_MODEL = ("mlx_lm.models.qwen3_5", ("TextModel", "TextModelArgs"))
+
+
 def _import_text_model_classes(model_type: str):
-    if model_type == "gemma4_text":
-        from mlx_lm.models.gemma4_text import Model, ModelArgs
+    """Return ``(Model, ModelArgs)`` for a text config's ``model_type``."""
+    import importlib
 
-        return Model, ModelArgs
+    module_name, (model_attr, args_attr) = _DEFAULT_TEXT_MODEL
+    matched = False
+    for prefix, family_module, (family_model, family_args) in sorted(
+        _TEXT_MODEL_FAMILIES, key=lambda f: len(f[0]), reverse=True
+    ):
+        if model_type.startswith(prefix):
+            module_name, model_attr, args_attr = (
+                family_module,
+                family_model,
+                family_args,
+            )
+            matched = True
+            break
 
-    # qwen3_5.TextModel and TextModelArgs handle both dense and MoE natively
-    # (MTPDecoderLayer auto-selects SparseMoeBlock when args.num_experts > 0).
-    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
-
-    return TextModel, TextModelArgs
+    if not matched:
+        logger.debug(
+            "No text-model family matches model_type=%r; falling back to %s",
+            model_type,
+            module_name,
+        )
+    module = importlib.import_module(module_name)
+    return getattr(module, model_attr), getattr(module, args_attr)
 
 
 def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
@@ -52,11 +83,17 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
     if model_path is None or not (model_path / "config.json").exists():
         return None
 
+    model_type = ""
+    text_model_cls = None
     try:
         config = json.loads((model_path / "config.json").read_text())
         text_config = config.get("text_config", config)
         model_type = text_config.get("model_type") or config.get("model_type", "")
         TextModel, TextModelArgs = _import_text_model_classes(model_type)
+        text_model_cls = f"{TextModel.__module__}.{TextModel.__qualname__}"
+        logger.debug(
+            "Building TextModel for model_type=%r using %s", model_type, text_model_cls
+        )
 
         # Build args with proper __post_init__ (handles partial_rotary_factor,
         # rope_scaling, head_dim derivation)
@@ -174,7 +211,17 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         logger.error("Cannot import mlx_lm TextModel (need PR #990): %s", e)
         return None
     except Exception as e:
-        logger.error("Failed to build TextModel from vlm: %s", e)
+        # Name the model_type and the class that was picked. Without them this
+        # is a bare TypeError from inside someone else's constructor, and the
+        # engine carries on with _text_model=None — a route quietly losing its
+        # backend, which reads like a warning rather than the failure it is.
+        logger.error(
+            "Failed to build TextModel from vlm (model_type=%r, class=%s): %s",
+            model_type,
+            text_model_cls or "<not selected>",
+            e,
+            exc_info=True,
+        )
         return None
 
 


### PR DESCRIPTION
Fixes the first half of #685.

## Problem

`_import_text_model_classes` matched `model_type == "gemma4_text"` exactly and defaulted everything else to `qwen3_5.TextModel`:

```
gemma4_text            -> mlx_lm.models.gemma4_text.Model
gemma4_unified_text    -> mlx_lm.models.qwen3_5.TextModel     # <-- wrong
gemma4_unified         -> mlx_lm.models.qwen3_5.TextModel     # <-- wrong
anything-else          -> mlx_lm.models.qwen3_5.TextModel
```

Gemma 4 reports `gemma4_text` on some checkpoints and `gemma4_unified_text` on others, so the latter reached `qwen3_5.TextModelArgs`, which leaves `num_experts` as None, and construction died on `args.num_experts > 0`:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

**A wrong guess does not fail where it is made.** It fails deep inside the chosen constructor with an error naming neither the model nor the class, `build_text_model` catches it and returns None, and the engine then reports itself loaded with `_text_model=None`. The whole visible trace is:

```
ERROR:vllm_mlx.text_model_from_vlm:Failed to build TextModel from vlm: '>' not supported between instances of 'NoneType' and 'int'
```

That reads like a warning rather than a route losing its backend, which is why it sat there.

## Changes

- Families are matched **by prefix, longest first**, so one entry covers a family's variants instead of needing a line per checkpoint spelling.
- The generic fallback stays. `qwen3_5.TextModel` handles dense and MoE natively, and making unknown types raise would be a regression for every model that works through it today — but the fallback is now logged instead of silent.
- A failed build names the `model_type` **and** the class that was selected, with `exc_info=True` so the traceback survives.

## Verification

`gemma-4-12B-it` (`text_config.model_type: gemma4_unified_text`, mlx_vlm conversion, M3 Ultra):

| | before | after |
|---|---|---|
| `build_text_model` | `None` + TypeError | builds |
| `engine._text_model` | `None` | `mlx_lm.models.gemma4_text` |

Repo suite: **2305 passed** (four local failures reproduce on pristine `main` — three Python 3.14, one missing `ffmpeg`). Confirmed by mutation: restoring the exact-match dispatch fails four of the new tests, including the `gemma4_unified_text` case specifically.

## Scope: this does not fix the other half of #685, and I want to be clear about why

#685 also reports `stream_generate(prompt=...)` returning empty chunks, and in the issue I guessed that the missing chat template on the mlx_vlm fallback was to blame. **That guess was wrong and I have corrected the issue.**

`_stream_generate_impl` calls the mlx_vlm path regardless of whether a TextModel exists, so a working TextModel does not change that route. More to the point, I drove `mlx_lm` against the now-correctly-built Gemma 4 TextModel with the same raw prompt:

| backend | raw prompt output |
|---|---|
| mlx_vlm path | `'-..1.1______'` |
| mlx_lm + Gemma 4 TextModel | `'-......1.1___-______'` |
| either, with the chat template applied | `'The three primary colors are:\n\n1. **Red**'` |

Both backends agree, so this is an instruct-tuned model being handed a bare completion prompt — which is exactly what `/v1/completions` is for. Applying a chat template inside `stream_generate` would break that endpoint's semantics for every VLM, so I have deliberately left it alone.

The one thing I still cannot explain is why the engine surfaces *empty* text where a direct call on the same model instance surfaces the garbage above; the leading chunks are empty in both and the pump stops at `completion_tokens >= max_tokens`, which accounts for part of it but not the differing chunk counts. Both are wrong outputs from a wrong-shaped prompt, so I have left that noted in #685 rather than guessing at a fix.