### PR TITLE
fix(simple-engine): close delegated streams

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -3016,6 +3016,129 @@ class TestSimpleEngineNaturalStop:
         assert outputs[0].finish_reason == "stop"
 
 
+class TestSimpleEngineStreamClose:
+    @staticmethod
+    def _engine(generate):
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
+            engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._model = MagicMock()
+        engine._model.stream_generate.side_effect = generate
+        engine._model.tokenizer.apply_chat_template.return_value = "prompt"
+        return engine
+
+    @staticmethod
+    async def _close_and_assert_clean(engine, stream, backend_closed, loop_errors):
+        from vllm_mlx.engine.simple import _in_tracker
+
+        first = await anext(stream)
+        await stream.aclose()
+        await asyncio.sleep(0)
+
+        assert not first.finished
+        assert backend_closed()
+        assert not engine._active_requests
+        assert engine._num_running == 0
+        assert not engine._generation_lock.locked()
+        assert not _in_tracker.get()
+        assert not loop_errors
+
+    @pytest.mark.anyio
+    async def test_public_stream_generate_close_cleans_inner_state(self):
+        backend_closed = False
+
+        def generate(**kwargs):
+            nonlocal backend_closed
+            try:
+                yield SimpleNamespace(
+                    text="partial", prompt_tokens=3, finish_reason=None
+                )
+                yield SimpleNamespace(text="ignored", prompt_tokens=3)
+            finally:
+                backend_closed = True
+
+        engine = self._engine(generate)
+
+        loop_errors = []
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+        try:
+            stream = engine.stream_generate(prompt="hi", max_tokens=50)
+            await self._close_and_assert_clean(
+                engine, stream, lambda: backend_closed, loop_errors
+            )
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+    @pytest.mark.anyio
+    async def test_public_stream_chat_close_cleans_nested_generate(self):
+        backend_closed = False
+
+        def generate(**kwargs):
+            nonlocal backend_closed
+            try:
+                yield SimpleNamespace(
+                    text="partial", prompt_tokens=3, finish_reason=None
+                )
+                yield SimpleNamespace(text="ignored", prompt_tokens=3)
+            finally:
+                backend_closed = True
+
+        engine = self._engine(generate)
+        loop_errors = []
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+        try:
+            stream = engine.stream_chat(
+                messages=[{"role": "user", "content": "hi"}], max_tokens=50
+            )
+            await self._close_and_assert_clean(
+                engine, stream, lambda: backend_closed, loop_errors
+            )
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+    @pytest.mark.anyio
+    async def test_mllm_text_route_close_reaches_inner_cleanup(self):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        inner_closed = False
+
+        async def text_stream(*args, **kwargs):
+            nonlocal inner_closed
+            try:
+                yield GenerationOutput(
+                    text="partial",
+                    new_text="partial",
+                    prompt_tokens=3,
+                    completion_tokens=1,
+                    finished=False,
+                )
+                yield GenerationOutput(text="ignored")
+            finally:
+                inner_closed = True
+
+        engine = self._engine(lambda **kwargs: iter(()))
+        engine._is_mllm = True
+        engine._text_model = MagicMock()
+        engine._stream_generate_text = text_stream
+
+        stream = engine.stream_chat(
+            messages=[{"role": "user", "content": "hi"}], max_tokens=50
+        )
+        first = await anext(stream)
+        await stream.aclose()
+
+        assert not first.finished
+        assert inner_closed
+        assert not engine._active_requests
+        assert engine._num_running == 0
+
+
 class TestSimpleEngineClearRuntimeCaches:
     """Operational reset (DELETE /v1/cache) must actually release the
     multi-slot system-prompt KV cache state introduced in the LRU patch —

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -17,7 +17,7 @@ import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
+from contextlib import aclosing, asynccontextmanager
 from typing import Any
 
 # Re-entrancy guard for SimpleEngine._track_request_stream so that
@@ -1139,8 +1139,9 @@ class SimpleEngine(BaseEngine):
         consumed inside this method, so there is no value to preserve.
         """
         if _in_tracker.get():
-            async for output in source_gen:
-                yield output
+            async with aclosing(source_gen):
+                async for output in source_gen:
+                    yield output
             return
         _in_tracker.set(True)
         request_id = str(uuid.uuid4())
@@ -1165,25 +1166,29 @@ class SimpleEngine(BaseEngine):
         self._active_requests[request_id] = entry
         self._num_running += 1
         try:
-            async for output in source_gen:
-                now = time.time()
-                if hasattr(output, "prompt_tokens") and output.prompt_tokens:
-                    last_p = output.prompt_tokens
-                    entry["prompt_tokens"] = last_p
-                if hasattr(output, "completion_tokens") and output.completion_tokens:
-                    if ttft_s is None:
-                        ttft_s = now - start
-                        entry["ttft_s"] = round(ttft_s, 3)
-                        entry["phase"] = "generation"
-                    last_c = output.completion_tokens
-                    entry["completion_tokens"] = last_c
-                entry["elapsed_s"] = round(now - start, 2)
-                if max_tokens > 0:
-                    entry["progress"] = round(min(1.0, last_c / max_tokens), 3)
-                if ttft_s is not None and last_c > 0:
-                    gen_elapsed = max(1e-3, (now - start) - ttft_s)
-                    entry["tokens_per_second"] = round(last_c / gen_elapsed, 1)
-                yield output
+            async with aclosing(source_gen):
+                async for output in source_gen:
+                    now = time.time()
+                    if hasattr(output, "prompt_tokens") and output.prompt_tokens:
+                        last_p = output.prompt_tokens
+                        entry["prompt_tokens"] = last_p
+                    if (
+                        hasattr(output, "completion_tokens")
+                        and output.completion_tokens
+                    ):
+                        if ttft_s is None:
+                            ttft_s = now - start
+                            entry["ttft_s"] = round(ttft_s, 3)
+                            entry["phase"] = "generation"
+                        last_c = output.completion_tokens
+                        entry["completion_tokens"] = last_c
+                    entry["elapsed_s"] = round(now - start, 2)
+                    if max_tokens > 0:
+                        entry["progress"] = round(min(1.0, last_c / max_tokens), 3)
+                    if ttft_s is not None and last_c > 0:
+                        gen_elapsed = max(1e-3, (now - start) - ttft_s)
+                        entry["tokens_per_second"] = round(last_c / gen_elapsed, 1)
+                    yield output
         finally:
             self._active_requests.pop(request_id, None)
             self._num_running = max(0, self._num_running - 1)
@@ -1205,7 +1210,7 @@ class SimpleEngine(BaseEngine):
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Public stream-generate wrapper with request stats tracking."""
-        async for output in self._track_request_stream(
+        tracked_stream = self._track_request_stream(
             self._stream_generate_impl(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1215,8 +1220,10 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ),
             max_tokens=max_tokens,
-        ):
-            yield output
+        )
+        async with aclosing(tracked_stream):
+            async for output in tracked_stream:
+                yield output
 
     async def _stream_generate_impl(
         self,
@@ -1283,7 +1290,7 @@ class SimpleEngine(BaseEngine):
                     use_specprefill = False
 
                 if use_specprefill:
-                    async for output in self._stream_generate_specprefill(
+                    specprefill_stream = self._stream_generate_specprefill(
                         prompt,
                         tokens_list,
                         max_tokens,
@@ -1293,8 +1300,10 @@ class SimpleEngine(BaseEngine):
                         specprefill_keep_pct=specprefill_keep_pct_override,
                         specprefill_backbone_pct=specprefill_backbone_pct_override,
                         **kwargs,
-                    ):
-                        yield output
+                    )
+                    async with aclosing(specprefill_stream):
+                        async for output in specprefill_stream:
+                            yield output
                     return
 
         async with self._acquire_generation_slot(request_id):
@@ -1584,7 +1593,7 @@ class SimpleEngine(BaseEngine):
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Public stream-chat wrapper with request stats tracking."""
-        async for output in self._track_request_stream(
+        tracked_stream = self._track_request_stream(
             self._stream_chat_impl(
                 messages=messages,
                 max_tokens=max_tokens,
@@ -1596,8 +1605,10 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ),
             max_tokens=max_tokens,
-        ):
-            yield output
+        )
+        async with aclosing(tracked_stream):
+            async for output in tracked_stream:
+                yield output
 
     async def _stream_chat_impl(
         self,
@@ -1651,15 +1662,17 @@ class SimpleEngine(BaseEngine):
             logger.info("Text-only request → LLM path (MTP=%s)", has_mtp and self._mtp)
             if chat_template_kwargs:
                 kwargs["chat_template_kwargs"] = chat_template_kwargs
-            async for chunk in self._stream_generate_text(
+            text_stream = self._stream_generate_text(
                 messages,
                 max_tokens,
                 temperature,
                 top_p,
                 tools=template_tools,
                 **kwargs,
-            ):
-                yield chunk
+            )
+            async with aclosing(text_stream):
+                async for chunk in text_stream:
+                    yield chunk
             return
 
         def mllm_call_kwargs() -> dict:
@@ -2310,26 +2323,30 @@ class SimpleEngine(BaseEngine):
                 # Internal fallback to the public stream_generate. The
                 # ``_in_tracker`` context flag prevents double counting
                 # in _track_request_stream.
-                async for output in self.stream_generate(
+                fallback_stream = self.stream_generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
                     temperature=temperature,
                     top_p=top_p,
                     **kwargs,
-                ):
-                    yield output
+                )
+                async with aclosing(fallback_stream):
+                    async for output in fallback_stream:
+                        yield output
             return
 
         # Fallback: no system prefix detected -> original uncached path.
         # Re-entrancy guard in _track_request_stream keeps stats single-counted.
-        async for output in self.stream_generate(
+        fallback_stream = self.stream_generate(
             prompt=prompt,
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
             **kwargs,
-        ):
-            yield output
+        )
+        async with aclosing(fallback_stream):
+            async for output in fallback_stream:
+                yield output
 
     async def _stream_generate_specprefill(
         self,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -15,7 +15,7 @@ import threading
 import time
 import uuid
 from collections import OrderedDict, deque
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import aclosing, asynccontextmanager
 from typing import Any
@@ -1206,10 +1206,10 @@ class SimpleEngine(BaseEngine):
 
     async def _track_request_stream(
         self,
-        source_gen: AsyncIterator[GenerationOutput],
+        source_gen: AsyncGenerator[GenerationOutput, None],
         *,
         max_tokens: int = 0,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """Yield-through wrapper that records per-request live state and
         final ``prompt_tokens``/``completion_tokens`` counters.
 
@@ -1304,7 +1304,7 @@ class SimpleEngine(BaseEngine):
         top_p: float = 0.9,
         stop: list[str] | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """Public stream-generate wrapper with request stats tracking."""
         tracked_stream = self._track_request_stream(
             self._stream_generate_impl(
@@ -1329,7 +1329,7 @@ class SimpleEngine(BaseEngine):
         top_p: float = 0.9,
         stop: list[str] | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """
         Stream generation token by token.
 
@@ -1687,7 +1687,7 @@ class SimpleEngine(BaseEngine):
         images: list[str] | None = None,
         videos: list[str] | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """Public stream-chat wrapper with request stats tracking."""
         tracked_stream = self._track_request_stream(
             self._stream_chat_impl(
@@ -1716,7 +1716,7 @@ class SimpleEngine(BaseEngine):
         images: list[str] | None = None,
         videos: list[str] | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """
         Stream chat completion token by token.
 
@@ -2418,7 +2418,7 @@ class SimpleEngine(BaseEngine):
         specprefill_keep_pct: float | None = None,
         specprefill_backbone_pct: float | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """SpecPrefill path for non-MTP models (Nemotron, GPT-OSS, etc).
 
         Scores token importance with the draft model, sparse-prefills the target
@@ -2621,7 +2621,7 @@ class SimpleEngine(BaseEngine):
         top_p: float,
         tools: list | None = None,
         **kwargs,
-    ) -> AsyncIterator[GenerationOutput]:
+    ) -> AsyncGenerator[GenerationOutput, None]:
         """Text-only generation via mlx_lm TextModel.
 
         Used when text-only MLLM routing is active and the request has no media.


### PR DESCRIPTION
Closing a public SimpleEngine stream did not close the async generators it delegates to. Backend iterators and request state could remain live until finalization, which also produced `generator didn't stop after athrow()` errors.

This uses `aclosing` at each public and nested streaming delegation boundary, including the MLLM text route and SpecPrefill. Normal exhaustion is unchanged.

Tests cover direct generation, nested chat fallback, and the MLLM text route. They verify backend cleanup, request counters, generation-lock release, and tracker context reset.

Verification: 2,300 passed, 24 skipped.

Refs #682


