### PR TITLE
fix(scheduler): make --max-kv-size actually bound the KV cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \
             tests/test_scheduler_max_kv_size.py \
+            tests/test_ssd_cache.py \
             tests/test_qwen35_mtp_patch.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
             tests/test_server.py \
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \
+            tests/test_scheduler_max_kv_size.py \
             tests/test_qwen35_mtp_patch.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -29,6 +29,29 @@ from vllm_mlx.scheduler import (
 mlx_generate = importlib.import_module("mlx_lm.generate")
 
 
+class _MergeableFakeCache:
+    """Minimal per-request and batched cache for legacy prefill tests."""
+
+    def __init__(self):
+        self.state = mx.array([0])
+
+    def empty(self):
+        return True
+
+    @classmethod
+    def merge(cls, _caches):
+        return cls()
+
+    def prepare(self, **_kwargs):
+        return None
+
+    def finalize(self):
+        return None
+
+    def extract(self, _idx):
+        return self
+
+
 class TestRequest:
     """Tests for Request class."""
 
@@ -240,17 +263,6 @@ class TestSchedulerBasic:
     def test_chunked_prefill_accepts_prompt_checkpoints(self, monkeypatch):
         """Chunked prefill must match mlx-lm's 7-field prompt tuples."""
 
-        class FakeCacheEntry:
-            def empty(self):
-                return True
-
-        class FakePromptCache:
-            def __init__(self):
-                self.state = mx.array([0])
-
-            def finalize(self):
-                return None
-
         class FakeStats:
             prompt_tokens = 0
             prompt_time = 0.0
@@ -266,7 +278,7 @@ class TestSchedulerBasic:
                         7,
                         [1, 2, 3, 4, 5],
                         16,
-                        [FakeCacheEntry()],
+                        [_MergeableFakeCache()],
                         None,
                         [None],
                         2,
@@ -288,11 +300,6 @@ class TestSchedulerBasic:
             "_left_pad_prompts",
             lambda prompts, max_length=None: mx.array(prompts),
         )
-        monkeypatch.setattr(
-            mlx_generate,
-            "_make_cache",
-            lambda _model, _padding, _max_kv_size=None: [FakePromptCache()],
-        )
 
         batch_gen = FakeBatchGenerator()
         _install_chunked_prefill(batch_gen, budget=4)
@@ -306,20 +313,6 @@ class TestSchedulerBasic:
 
     def test_chunked_prefill_invokes_checkpoint_callback(self, monkeypatch):
         """prompt_checkpoint_callback must fire after finalization."""
-
-        class FakeCacheEntry:
-            def empty(self):
-                return True
-
-        class FakePromptCache:
-            def __init__(self):
-                self.state = mx.array([0])
-
-            def finalize(self):
-                return None
-
-            def extract(self, idx):
-                return self
 
         class FakeStats:
             prompt_tokens = 0
@@ -347,7 +340,7 @@ class TestSchedulerBasic:
                         7,
                         [1, 2, 3],
                         16,
-                        [FakeCacheEntry()],
+                        [_MergeableFakeCache()],
                         None,
                         [None],
                         2,
@@ -379,11 +372,6 @@ class TestSchedulerBasic:
             "_left_pad_prompts",
             lambda prompts, max_length=None: mx.array(prompts),
         )
-        monkeypatch.setattr(
-            mlx_generate,
-            "_make_cache",
-            lambda _model, _padding, _max_kv_size=None: [FakePromptCache()],
-        )
 
         batch_gen = FakeBatchGenerator()
         batch_gen.stop_tokens = {99}
@@ -404,20 +392,6 @@ class TestSchedulerBasic:
 
     def test_chunked_prefill_replays_checkpoint_tail_before_step(self, monkeypatch):
         """checkpoint tails >1 must be replayed after finalize before _step."""
-
-        class FakeCacheEntry:
-            def empty(self):
-                return True
-
-        class FakePromptCache:
-            def __init__(self):
-                self.state = mx.array([0])
-
-            def finalize(self):
-                return None
-
-            def extract(self, idx):
-                return self
 
         class FakeStats:
             prompt_tokens = 0
@@ -447,7 +421,7 @@ class TestSchedulerBasic:
                         7,
                         [1, 2, 3, 4, 5],
                         16,
-                        [FakeCacheEntry()],
+                        [_MergeableFakeCache()],
                         None,
                         [None],
                         2,
@@ -477,11 +451,6 @@ class TestSchedulerBasic:
             "_left_pad_prompts",
             lambda prompts, max_length=None: mx.array(prompts),
         )
-        monkeypatch.setattr(
-            mlx_generate,
-            "_make_cache",
-            lambda _model, _padding, _max_kv_size=None: [FakePromptCache()],
-        )
 
         batch_gen = FakeBatchGenerator()
         _install_chunked_prefill(batch_gen, budget=2)
@@ -505,20 +474,6 @@ class TestSchedulerBasic:
         self, monkeypatch
     ):
         """Chunked prefill should tolerate missing private mlx_lm.generate exports."""
-
-        class FakeCacheEntry:
-            def empty(self):
-                return True
-
-        class FakePromptCache:
-            def __init__(self):
-                self.state = mx.array([0])
-
-            def finalize(self):
-                return None
-
-            def extract(self, idx):
-                return self
 
         class FakeStats:
             prompt_tokens = 0
@@ -544,7 +499,7 @@ class TestSchedulerBasic:
                         7,
                         [1, 2, 3],
                         16,
-                        [FakeCacheEntry()],
+                        [_MergeableFakeCache()],
                         None,
                         [None],
                         2,
@@ -571,15 +526,11 @@ class TestSchedulerBasic:
 
         monkeypatch.delattr(mlx_generate, "Batch", raising=False)
         monkeypatch.delattr(mlx_generate, "_lazy_extract_cache", raising=False)
+        monkeypatch.delattr(mlx_generate, "_make_cache", raising=False)
         monkeypatch.setattr(
             mlx_generate,
             "_left_pad_prompts",
             lambda prompts, max_length=None: mx.array(prompts),
-        )
-        monkeypatch.setattr(
-            mlx_generate,
-            "_make_cache",
-            lambda _model, _padding, _max_kv_size=None: [FakePromptCache()],
         )
 
         batch_gen = FakeBatchGenerator()

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -344,6 +344,48 @@ class TestMemoryAwarePrefixCache:
         assert result is kv
         assert remaining == [4, 5, 6]
 
+    def test_fetch_retains_the_actual_supersequence_key(
+        self, small_cache, mock_kv_cache, monkeypatch
+    ):
+        stored_tokens = [1, 2, 3, 4]
+        kv = mock_kv_cache(1000)
+        small_cache.store(stored_tokens, kv)
+        monkeypatch.setattr(
+            "vllm_mlx.memory_cache._trim_cache_offset",
+            lambda cache, _trim_by: cache,
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.memory_cache._is_cache_layer_trimmable",
+            lambda _layer: True,
+        )
+
+        result, remaining = small_cache.fetch([1, 2, 3])
+
+        assert result is kv
+        assert remaining == []
+        assert small_cache._last_matched_key == tuple(stored_tokens)
+
+    def test_fetch_retains_the_actual_lcp_key(
+        self, small_cache, mock_kv_cache, monkeypatch
+    ):
+        stored_tokens = [1, 2, 3, 9]
+        kv = mock_kv_cache(1000)
+        small_cache.store(stored_tokens, kv)
+        monkeypatch.setattr(
+            "vllm_mlx.memory_cache._trim_cache_offset",
+            lambda cache, _trim_by: cache,
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.memory_cache._is_cache_layer_trimmable",
+            lambda _layer: True,
+        )
+
+        result, remaining = small_cache.fetch([1, 2, 3, 8])
+
+        assert result is kv
+        assert remaining == [8]
+        assert small_cache._last_matched_key == tuple(stored_tokens)
+
     def test_fetch_miss(self, small_cache, mock_kv_cache):
         tokens = [1, 2, 3]
         kv = mock_kv_cache(1000)
@@ -420,6 +462,31 @@ class TestMemoryAwarePrefixCache:
         assert small_cache.remove(tokens) is True
         assert len(small_cache) == 0
         assert small_cache.remove(tokens) is False  # Already removed
+
+    def test_remove_can_evict_the_same_key_from_ssd(self, small_cache, mock_kv_cache):
+        tokens = [1, 2, 3]
+        ssd_tier = MagicMock()
+        ssd_tier.remove.return_value = True
+        small_cache.set_ssd_tier(ssd_tier)
+        small_cache.store(tokens, mock_kv_cache(1000))
+
+        assert small_cache.remove(tokens, include_ssd=True) is True
+        assert tokens not in small_cache
+        ssd_tier.remove.assert_called_once_with(tuple(tokens))
+
+    def test_ssd_prefix_candidate_includes_the_actual_key(self, small_cache):
+        ssd_tier = MagicMock()
+        ssd_tier.lookup_ssd.return_value = None
+        ssd_tier.lookup_ssd_prefix.return_value = {
+            "num_tokens": 3,
+            "memory_bytes": 128,
+            "file_path": "entry",
+        }
+        small_cache.set_ssd_tier(ssd_tier)
+
+        candidate = small_cache.check_ssd([1, 2, 3, 4, 5])
+
+        assert candidate["matched_key"] == (1, 2, 3)
 
     def test_clear(self, small_cache, mock_kv_cache):
         for i in range(3):

--- a/tests/test_scheduler_max_kv_size.py
+++ b/tests/test_scheduler_max_kv_size.py
@@ -1,0 +1,625 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``--max-kv-size`` has to reach the caches that generation actually uses.
+
+It used to reach none of them. The scheduler built a bounded cache itself, then
+handed it to ``_validate_cache``, which rejects any layer whose ``keys`` are
+still None — true of every freshly created cache, bounded or not. So
+``cache_to_use`` went back to None and ``BatchGenerator``, never told about
+``max_kv_size``, built an unbounded one instead. The flag was a no-op while the
+CLI printed "Max KV size: N (RotatingKVCache)".
+"""
+
+import pytest
+
+pytest.importorskip("mlx.core")
+mx = pytest.importorskip("mlx.core")
+cache_mod = pytest.importorskip("mlx_lm.models.cache")
+
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig  # noqa: E402
+
+
+class _Layer:
+    """Stands in for a decoder layer; enough for make_prompt_cache."""
+
+
+class _Model:
+    def __init__(self, n_layers: int = 3) -> None:
+        self.layers = [_Layer() for _ in range(n_layers)]
+
+
+def _scheduler(**config_kwargs) -> Scheduler:
+    from types import SimpleNamespace
+
+    sched = object.__new__(Scheduler)
+    sched.model = _Model()
+    sched.config = SchedulerConfig(**config_kwargs)
+    # _create_batch_generator reaches for stop tokens and MTP on the way past.
+    sched.tokenizer = SimpleNamespace(eos_token_id=0, eos_token_ids={0})
+    sched._actual_tokenizer = sched.tokenizer
+    sched.memory_aware_cache = None
+    sched.block_aware_cache = None
+    sched._pending_abort_ids = set()
+    sched.uid_to_request_id = {}
+    sched.requests = {}
+    return sched
+
+
+class TestValidateCacheRejectsFreshCaches:
+    """The behaviour that made the bounded cache disappear."""
+
+    def test_a_freshly_built_cache_does_not_validate(self):
+        sched = _scheduler()
+        fresh = cache_mod.make_prompt_cache(sched.model, max_kv_size=64)
+
+        assert all(isinstance(c, cache_mod.RotatingKVCache) for c in fresh)
+        assert sched._validate_cache(fresh) is False, (
+            "an empty cache has keys=None, so validation of a *restored* entry "
+            "must not be applied to one the scheduler just created"
+        )
+
+    def test_it_is_not_specific_to_rotating_caches(self):
+        """Same verdict unbounded — the guard is about emptiness, not topology."""
+        sched = _scheduler()
+        fresh = cache_mod.make_prompt_cache(sched.model)
+
+        assert all(isinstance(c, cache_mod.KVCache) for c in fresh)
+        assert sched._validate_cache(fresh) is False
+
+
+class TestMaxKvSizeReachesTheBatchGenerator:
+    def test_configured_size_is_passed_through(self, monkeypatch):
+        captured = {}
+
+        class _FakeBatchGenerator:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "vllm_mlx.scheduler.BatchGenerator", _FakeBatchGenerator, raising=False
+        )
+        sched = _scheduler(max_kv_size=1024)
+        sched._create_batch_generator(_sampling_params())
+
+        assert captured.get("max_kv_size") == 1024, (
+            "BatchGenerator builds the cache for any sequence inserted without "
+            f"one; it was given max_kv_size={captured.get('max_kv_size')!r}"
+        )
+
+    def test_unset_stays_unbounded(self, monkeypatch):
+        captured = {}
+
+        class _FakeBatchGenerator:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "vllm_mlx.scheduler.BatchGenerator", _FakeBatchGenerator, raising=False
+        )
+        sched = _scheduler(max_kv_size=0)
+        sched._create_batch_generator(_sampling_params())
+
+        assert (
+            captured.get("max_kv_size") is None
+        ), "0 means unbounded and must not become RotatingKVCache(max_size=0)"
+
+
+class TestBoundedCacheTopology:
+    """BatchGenerator's rule is the one that survives ``make_cache`` models.
+
+    ``make_prompt_cache(model, max_kv_size=N)`` silently ignores ``max_kv_size``
+    whenever the model defines ``make_cache``, which most current
+    architectures do. Post-processing the model's own cache is the only way to
+    bound those.
+    """
+
+    def test_make_prompt_cache_ignores_the_bound_for_make_cache_models(self):
+        class _ModelWithMakeCache(_Model):
+            def make_cache(self):
+                return [cache_mod.KVCache() for _ in self.layers]
+
+        model = _ModelWithMakeCache()
+        built = cache_mod.make_prompt_cache(model, max_kv_size=64)
+
+        assert all(isinstance(c, cache_mod.KVCache) for c in built)
+        assert not any(isinstance(c, cache_mod.RotatingKVCache) for c in built), (
+            "if this ever starts honouring max_kv_size, the scheduler can stop "
+            "relying on BatchGenerator to post-process"
+        )
+
+    def test_post_processing_bounds_those_layers(self):
+        """What BatchGenerator._make_new_cache does, and why it is correct."""
+
+        class _ModelWithMakeCache(_Model):
+            def make_cache(self):
+                return [cache_mod.KVCache() for _ in self.layers]
+
+        built = cache_mod.make_prompt_cache(_ModelWithMakeCache())
+        bounded = [
+            (
+                cache_mod.RotatingKVCache(max_size=64)
+                if isinstance(c, cache_mod.KVCache)
+                else c
+            )
+            for c in built
+        ]
+        assert all(isinstance(c, cache_mod.RotatingKVCache) for c in bounded)
+        assert all(c.max_size == 64 for c in bounded)
+
+
+def _sampling_params():
+    from vllm_mlx.scheduler import SamplingParams
+
+    return SamplingParams()
+
+
+class TestBoundingDescendsIntoContainers:
+    """mlx-lm's own rule converts flat layers only.
+
+    ``BatchGenerator._make_new_cache`` rewrites ``KVCache`` layers and stops
+    there, so a ``KVCache`` nested inside a ``CacheList`` stays unbounded —
+    and the architectures that nest (DeepSeek-V4 groups three caches per layer)
+    are exactly the ones that need the bound.
+    """
+
+    def test_nested_plain_layers_are_bounded(self):
+        live = [
+            cache_mod.CacheList(
+                cache_mod.KVCache(), cache_mod.RotatingKVCache(max_size=128)
+            ),
+            cache_mod.KVCache(),
+        ]
+
+        out = Scheduler._bound_cache_layers(live, 64)
+
+        nested = out[0].caches
+        assert isinstance(nested[0], cache_mod.RotatingKVCache)
+        assert nested[0].max_size == 64, "nested KVCache was left unbounded"
+        assert isinstance(out[1], cache_mod.RotatingKVCache)
+        assert out[1].max_size == 64
+
+    def test_layers_that_bound_themselves_are_left_alone(self):
+        """A rotating layer already carries its own window; do not retune it."""
+        live = [
+            cache_mod.CacheList(
+                cache_mod.RotatingKVCache(max_size=128), cache_mod.KVCache()
+            )
+        ]
+
+        out = Scheduler._bound_cache_layers(live, 64)
+
+        assert out[0].caches[0].max_size == 128, "existing window was overwritten"
+        assert out[0].caches[1].max_size == 64
+
+    def test_non_kv_cache_types_are_preserved(self):
+        """Replacing a quantized or chunked cache would break the model."""
+        quantized = cache_mod.QuantizedKVCache()
+        chunked = cache_mod.ChunkedKVCache(chunk_size=16)
+
+        out = Scheduler._bound_cache_layers([quantized, chunked], 64)
+
+        assert out[0] is quantized
+        assert out[1] is chunked
+
+    def test_mlx_lm_rule_alone_would_miss_the_nested_case(self):
+        """Pins why the scheduler does this instead of leaving it to mlx-lm.
+
+        If BatchGenerator ever learns to recurse, this fails and the scheduler
+        can drop its own copy.
+        """
+        live = [cache_mod.CacheList(cache_mod.KVCache(), cache_mod.KVCache())]
+        mlx_lm_rule = [
+            (
+                cache_mod.RotatingKVCache(max_size=64)
+                if isinstance(layer, cache_mod.KVCache)
+                else layer
+            )
+            for layer in live
+        ]
+
+        assert isinstance(mlx_lm_rule[0], cache_mod.CacheList)
+        assert all(
+            isinstance(c, cache_mod.KVCache) for c in mlx_lm_rule[0].caches
+        ), "mlx-lm started recursing; the scheduler's own bounding is redundant"
+
+
+class TestNegativeSizesAreRejected:
+    """``self.config.max_kv_size or None`` forwarded -1 straight through.
+
+    Normalizing it per request would fix the value and create a second
+    problem: one bad startup flag logging on every scheduling pass.
+    """
+
+    @pytest.mark.parametrize("size", [-1, -1024])
+    def test_negative_is_normalized_at_config_construction(self, size):
+        config = SchedulerConfig(max_kv_size=size)
+        assert (
+            config.max_kv_size == 0
+        ), f"max_kv_size={size} would reach RotatingKVCache(max_size={size})"
+
+    def test_non_integer_is_normalized_too(self):
+        assert SchedulerConfig(max_kv_size="512").max_kv_size == 0
+
+    def test_zero_is_unbounded(self):
+        assert _scheduler(max_kv_size=0)._bounded_kv_size() is None
+
+    def test_positive_is_forwarded(self):
+        assert _scheduler(max_kv_size=4096)._bounded_kv_size() == 4096
+
+    def test_negative_never_reaches_the_batch_generator(self, monkeypatch):
+        captured = {}
+
+        class _FakeBatchGenerator:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "vllm_mlx.scheduler.BatchGenerator", _FakeBatchGenerator, raising=False
+        )
+        _scheduler(max_kv_size=-1)._create_batch_generator(_sampling_params())
+
+        assert captured.get("max_kv_size") is None
+
+    def test_bad_value_is_reported_once_not_per_request(self, caplog):
+        """A startup mistake must not scale its logging with traffic."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+            sched = _scheduler(max_kv_size=-1)
+            construction_warnings = sum(
+                "max_kv_size" in r.getMessage() for r in caplog.records
+            )
+            caplog.clear()
+
+            # Scheduling is where this used to log — once per uncached request.
+            for _ in range(5):
+                sched._bounded_kv_size()
+
+            # Count *every* warning from the scheduling path, not just ones
+            # naming max_kv_size: a hot-path warning worded differently is the
+            # same production problem, and filtering by wording let one slip
+            # past an earlier version of this test.
+            scheduling_warnings = len(caplog.records)
+
+        assert construction_warnings == 1, (
+            f"expected exactly one warning at construction, got "
+            f"{construction_warnings}"
+        )
+        assert scheduling_warnings == 0, (
+            f"{scheduling_warnings} warnings emitted from the scheduling path; "
+            "one bad startup flag would flood production logs per request"
+        )
+
+
+class TestRejectedCacheAlwaysResetsTheRequest:
+    """A rejected cache means a full prefill, whatever max_kv_size says.
+
+    The reset used to sit after the bounded-cache branch, so with
+    ``max_kv_size=0`` a request whose restored cache failed validation kept its
+    stale ``cached_tokens``/``remaining_tokens`` and the scheduler inserted only
+    the prompt's suffix — a four-token prompt prefilling one token.
+    """
+
+    @staticmethod
+    def _real_scheduler(max_kv_size):
+        from types import SimpleNamespace
+
+        return Scheduler(
+            model=_Model(),
+            tokenizer=SimpleNamespace(eos_token_id=0, eos_token_ids={0}),
+            config=SchedulerConfig(enable_prefix_cache=False, max_kv_size=max_kv_size),
+        )
+
+    @staticmethod
+    def _request(prompt_ids):
+        from vllm_mlx.request import Request
+        from vllm_mlx.scheduler import SamplingParams
+
+        request = Request(
+            request_id="req-abc",
+            prompt="prompt",
+            prompt_token_ids=list(prompt_ids),
+            sampling_params=SamplingParams(),
+        )
+        request.num_prompt_tokens = len(prompt_ids)
+        # A restored entry that _validate_cache rejects: keys are still None.
+        request.prompt_cache = [cache_mod.KVCache()]
+        request.cached_tokens = len(prompt_ids) - 1
+        request.remaining_tokens = list(prompt_ids[-1:])
+        return request
+
+    @pytest.mark.parametrize("max_kv_size", [0, 512])
+    def test_scheduler_inserts_the_whole_prompt(self, max_kv_size, monkeypatch):
+        """Drives the scheduler itself.
+
+        Replicating the branch in the test body would not have caught this: the
+        bug was *where* the reset sits, not what it does.
+        """
+        inserted = {}
+
+        class _FakeBatchGenerator:
+            def insert(self, prompts, **kwargs):
+                inserted["prompts"] = [list(p) for p in prompts]
+                return [1]
+
+        sched = self._real_scheduler(max_kv_size)
+        sched.batch_generator = _FakeBatchGenerator()
+
+        request = self._request([1, 2, 3, 4])
+        sched.requests[request.request_id] = request
+        sched.waiting.append(request)
+
+        sched._schedule_waiting()
+
+        assert request.cached_tokens == 0
+        assert request.remaining_tokens == [1, 2, 3, 4]
+
+
+class TestRestoredCacheMustMatchTheBound:
+    """A persisted entry outlives both an upgrade and a change to the flag.
+
+    ``cache_to_use = request.prompt_cache`` was validated and then kept, and
+    the bounding only ran when there was no cache at all — so a restored entry
+    bypassed the bound entirely in both directions.
+    """
+
+    @staticmethod
+    def _filled(layer, tokens=6):
+        layer.update_and_fetch(mx.zeros((1, 1, tokens, 4)), mx.zeros((1, 1, tokens, 4)))
+        return layer
+
+    @pytest.mark.parametrize(
+        "restored_factory,bound,label",
+        [
+            (lambda: cache_mod.KVCache(), 64, "unbounded entry under a bound"),
+            (
+                lambda: cache_mod.RotatingKVCache(max_size=64),
+                0,
+                "bounded entry after the flag was cleared",
+            ),
+            (
+                lambda: cache_mod.RotatingKVCache(max_size=64),
+                128,
+                "bounded entry after the window changed",
+            ),
+        ],
+    )
+    def test_mismatched_entry_is_rejected(self, restored_factory, bound, label):
+        sched = _scheduler(max_kv_size=bound)
+        # One layer per model layer; a count mismatch is its own rejection.
+        cache = [self._filled(restored_factory()) for _ in sched.model.layers]
+
+        # It is otherwise perfectly valid — populated, batch 1, right shape.
+        assert sched._validate_cache(cache) is True, "setup: entry must be valid"
+        assert sched._restored_cache_matches_kv_bound(cache) is False, label
+
+    @pytest.mark.parametrize("bound", [0, 64])
+    def test_matching_entry_is_kept(self, bound):
+        sched = _scheduler(max_kv_size=bound)
+
+        def make():
+            return (
+                cache_mod.KVCache()
+                if bound == 0
+                else cache_mod.RotatingKVCache(max_size=64)
+            )
+
+        # One layer per model layer; a count mismatch is its own rejection.
+        cache = [self._filled(make()) for _ in sched.model.layers]
+        assert sched._restored_cache_matches_kv_bound(cache) is True
+
+    def test_nested_mismatch_is_caught(self):
+        """One bad child is enough; containers are checked through."""
+        sched = _scheduler(max_kv_size=64)
+        nested = [
+            cache_mod.CacheList(
+                self._filled(cache_mod.RotatingKVCache(max_size=64)),
+                self._filled(cache_mod.KVCache()),
+            )
+            for _ in sched.model.layers
+        ]
+        assert sched._restored_cache_matches_kv_bound(nested) is False
+
+    def test_scheduler_falls_back_to_a_full_prefill(self):
+        """Drives the scheduler: a mismatched entry must not be reused as-is."""
+
+        class _FakeBatchGenerator:
+            def insert(self, prompts, **kwargs):
+                return [1]
+
+        from vllm_mlx.request import Request
+        from vllm_mlx.scheduler import SamplingParams
+
+        sched = Scheduler(
+            model=_Model(),
+            tokenizer=__import__("types").SimpleNamespace(
+                eos_token_id=0, eos_token_ids={0}
+            ),
+            config=SchedulerConfig(enable_prefix_cache=False, max_kv_size=64),
+        )
+        sched.batch_generator = _FakeBatchGenerator()
+
+        request = Request(
+            request_id="req-restored",
+            prompt="prompt",
+            prompt_token_ids=[1, 2, 3, 4],
+            sampling_params=SamplingParams(),
+        )
+        request.num_prompt_tokens = 4
+        # Valid, populated — and built without the bound now configured.
+        request.prompt_cache = [
+            self._filled(cache_mod.KVCache()) for _ in sched.model.layers
+        ]
+        request.cached_tokens = 3
+        request.remaining_tokens = [4]
+        sched.requests[request.request_id] = request
+        sched.waiting.append(request)
+
+        sched._schedule_waiting()
+
+        assert request.prompt_cache is None, "mismatched entry was kept"
+        assert request.cached_tokens == 0
+        assert request.remaining_tokens == [1, 2, 3, 4], (
+            "the request must fall back to a full prefill rather than generate "
+            "against a window it was not built for"
+        )
+
+
+class _SlidingModel(_Model):
+    """A model that creates its own rotating layers, as Gemma and Llama do."""
+
+    WINDOW = 1024
+
+    def make_cache(self):
+        return [cache_mod.RotatingKVCache(max_size=self.WINDOW) for _ in self.layers]
+
+
+class TestNativeRotatingCachesAreNotOperatorBounded:
+    """A model's own sliding window is not the operator's ``--max-kv-size``.
+
+    Measuring every ``RotatingKVCache`` against the flag rejects a perfectly
+    valid entry from a sliding-window model on every reuse — a permanent cache
+    miss on exactly the architectures that most need the cache.
+    """
+
+    def test_model_created_window_is_accepted_without_a_bound(self):
+        sched = _scheduler(max_kv_size=0)
+        sched.model = _SlidingModel()
+        native = cache_mod.make_prompt_cache(_SlidingModel())
+
+        assert all(isinstance(c, cache_mod.RotatingKVCache) for c in native)
+        assert (
+            sched._restored_cache_matches_kv_bound(native) is True
+        ), "the model's own sliding window was measured against --max-kv-size"
+
+    def test_a_different_window_is_still_rejected(self):
+        """Native does not mean "anything goes"; the window must still match."""
+        sched = _scheduler(max_kv_size=0)
+        sched.model = _SlidingModel()
+        stale = [cache_mod.RotatingKVCache(max_size=99) for _ in range(3)]
+
+        assert sched._restored_cache_matches_kv_bound(stale) is False
+
+    def test_operator_bound_still_applies_to_plain_models(self):
+        sched = _scheduler(max_kv_size=64)
+        sched.model = _Model()
+        matching = [cache_mod.RotatingKVCache(max_size=64) for _ in range(3)]
+        stale = [cache_mod.RotatingKVCache(max_size=128) for _ in range(3)]
+
+        assert sched._restored_cache_matches_kv_bound(matching) is True
+        assert sched._restored_cache_matches_kv_bound(stale) is False
+
+    def test_reference_topology_is_built_once(self):
+        sched = _scheduler(max_kv_size=0)
+        sched.model = _SlidingModel()
+
+        first = sched._reference_cache_topology()
+        second = sched._reference_cache_topology()
+
+        assert first is second, "the reference topology is rebuilt per request"
+
+
+class TestIncompatibleEntryIsEvictedFromTheSharedCache:
+    """Clearing only the request leaves the bad entry for everyone else.
+
+    Every later request with the same prefix then repeats the false hit and the
+    full prefill, and nothing removes it — the cache never heals.
+    """
+
+    def test_rejected_entry_is_removed_not_just_detached(self):
+        removed = []
+
+        class _Cache:
+            _entries = {}
+
+            def remove(self, key):
+                removed.append(list(key))
+                return True
+
+        sched = _scheduler(max_kv_size=64)
+        sched.memory_aware_cache = _Cache()
+
+        from types import SimpleNamespace
+
+        request = SimpleNamespace(
+            request_id="r",
+            prompt_token_ids=[1, 2, 3, 4, 5],
+            cached_tokens=5,
+            prompt_cache_key=[1, 2, 3, 4, 5],
+        )
+        sched._evict_incompatible_entry(request)
+
+        assert removed == [
+            [1, 2, 3, 4, 5]
+        ], f"the stale entry was not evicted from the shared cache: {removed}"
+
+    def test_scheduler_evicts_it_on_the_real_path(self):
+        """Drives _schedule_waiting so the call site itself is covered.
+
+        Calling the helper directly leaves the scheduler free to stop calling
+        it; that mutation passed an earlier version of this class.
+        """
+        removed = []
+
+        class _Cache:
+            _entries = {}
+
+            def remove(self, key):
+                removed.append(list(key))
+                return True
+
+            def fetch(self, tokens):
+                return None, list(tokens)
+
+            def store(self, *a, **k):
+                return False
+
+        class _FakeBatchGenerator:
+            def insert(self, prompts, **kwargs):
+                return [1]
+
+        from vllm_mlx.request import Request
+        from vllm_mlx.scheduler import SamplingParams
+
+        sched = Scheduler(
+            model=_Model(),
+            tokenizer=__import__("types").SimpleNamespace(
+                eos_token_id=0, eos_token_ids={0}
+            ),
+            config=SchedulerConfig(enable_prefix_cache=False, max_kv_size=64),
+        )
+        sched.batch_generator = _FakeBatchGenerator()
+        sched.memory_aware_cache = _Cache()
+
+        request = Request(
+            request_id="req-evict",
+            prompt="prompt",
+            prompt_token_ids=[1, 2, 3, 4],
+            sampling_params=SamplingParams(),
+        )
+        request.num_prompt_tokens = 4
+        # Valid and populated, but plain KVCache under a configured bound.
+        request.prompt_cache = [
+            TestRestoredCacheMustMatchTheBound._filled(cache_mod.KVCache())
+            for _ in sched.model.layers
+        ]
+        request.cached_tokens = 3
+        request.remaining_tokens = [4]
+        request.prompt_cache_key = [1, 2, 3]
+        sched.requests[request.request_id] = request
+        sched.waiting.append(request)
+
+        sched._schedule_waiting()
+
+        assert removed == [[1, 2, 3]], (
+            "the incompatible entry was detached from the request but left in "
+            f"the shared cache: remove() calls = {removed}"
+        )
+
+    def test_missing_cache_is_not_an_error(self):
+        sched = _scheduler(max_kv_size=64)
+        sched.memory_aware_cache = None
+        from types import SimpleNamespace
+
+        sched._evict_incompatible_entry(
+            SimpleNamespace(prompt_token_ids=[1], cached_tokens=0)
+        )

--- a/tests/test_scheduler_max_kv_size.py
+++ b/tests/test_scheduler_max_kv_size.py
@@ -15,7 +15,11 @@ pytest.importorskip("mlx.core")
 mx = pytest.importorskip("mlx.core")
 cache_mod = pytest.importorskip("mlx_lm.models.cache")
 
-from vllm_mlx.scheduler import Scheduler, SchedulerConfig  # noqa: E402
+from vllm_mlx.scheduler import (  # noqa: E402
+    Scheduler,
+    SchedulerConfig,
+    _install_chunked_prefill,
+)
 
 
 class _Layer:
@@ -144,6 +148,53 @@ class TestBoundedCacheTopology:
         ]
         assert all(isinstance(c, cache_mod.RotatingKVCache) for c in bounded)
         assert all(c.max_size == 64 for c in bounded)
+
+    def test_chunked_prefill_keeps_the_scheduler_supplied_bound(self):
+        """An empty bounded cache must not be rebuilt through ``make_cache``."""
+
+        class _ModelWithMakeCache(_Model):
+            def make_cache(self):
+                return [cache_mod.KVCache() for _ in self.layers]
+
+            def __call__(self, inputs, cache=None):
+                keys = mx.zeros((inputs.shape[0], 1, inputs.shape[1], 4))
+                for layer in cache:
+                    layer.update_and_fetch(keys, keys)
+                return mx.zeros((inputs.shape[0], inputs.shape[1], 8))
+
+        class _Stats:
+            prompt_tokens = 0
+            prompt_time = 0.0
+            generation_time = 0.0
+
+        class _BatchGenerator:
+            def __init__(self):
+                self.model = _ModelWithMakeCache(n_layers=1)
+                supplied = Scheduler._bound_cache_layers(self.model.make_cache(), 64)
+                self.unprocessed_prompts = [
+                    (7, [1, 2, 3, 4, 5], 16, supplied, None, [None], 2)
+                ]
+                self._stats = _Stats()
+                self._partial = None
+                self.active_batch = None
+                self.prefill_batch_size = 1
+                self.completion_batch_size = 1
+                self.max_kv_size = 64
+                self.stop_tokens = set()
+                self.prompt_progress_callback = lambda _progress: None
+                self.prompt_checkpoint_callback = None
+                self._next = lambda: []
+                self.remove = lambda _uids: None
+                self._process_prompts = lambda _prompts: None
+
+        batch_gen = _BatchGenerator()
+        _install_chunked_prefill(batch_gen, budget=2)
+
+        batch_gen._next()
+
+        live = batch_gen._partial["cache"]
+        assert isinstance(live[0], cache_mod.BatchRotatingKVCache)
+        assert live[0].max_size == 64
 
 
 def _sampling_params():
@@ -499,6 +550,16 @@ class TestNativeRotatingCachesAreNotOperatorBounded:
 
         assert sched._restored_cache_matches_kv_bound(stale) is False
 
+    def test_a_different_keep_layout_is_rejected(self):
+        sched = _scheduler(max_kv_size=0)
+        sched.model = _SlidingModel()
+        stale = [
+            cache_mod.RotatingKVCache(max_size=_SlidingModel.WINDOW, keep=4)
+            for _ in range(3)
+        ]
+
+        assert sched._restored_cache_matches_kv_bound(stale) is False
+
     def test_operator_bound_still_applies_to_plain_models(self):
         sched = _scheduler(max_kv_size=64)
         sched.model = _Model()
@@ -531,7 +592,7 @@ class TestIncompatibleEntryIsEvictedFromTheSharedCache:
         class _Cache:
             _entries = {}
 
-            def remove(self, key):
+            def remove(self, key, *, include_ssd=False):
                 removed.append(list(key))
                 return True
 
@@ -552,6 +613,45 @@ class TestIncompatibleEntryIsEvictedFromTheSharedCache:
             [1, 2, 3, 4, 5]
         ], f"the stale entry was not evicted from the shared cache: {removed}"
 
+    def test_fetch_retains_the_real_match_key_and_evicts_both_tiers(self):
+        removed = []
+
+        class _Cache:
+            _entries = {}
+            _last_match_type = "lcp"
+            _last_matched_key = (1, 2, 3, 9)
+
+            def fetch(self, _tokens):
+                return [object()], [8]
+
+            def remove(self, key, include_ssd=False):
+                removed.append((list(key), include_ssd))
+                return True
+
+        from vllm_mlx.request import Request
+        from vllm_mlx.scheduler import SamplingParams
+
+        sched = Scheduler(
+            model=_Model(),
+            tokenizer=__import__("types").SimpleNamespace(
+                eos_token_id=0, eos_token_ids={0}
+            ),
+            config=SchedulerConfig(enable_prefix_cache=False, max_kv_size=64),
+        )
+        sched.memory_aware_cache = _Cache()
+        request = Request(
+            request_id="req-real-key",
+            prompt="prompt",
+            prompt_token_ids=[1, 2, 3, 8],
+            sampling_params=SamplingParams(),
+        )
+
+        sched.add_request(request)
+        sched._evict_incompatible_entry(request)
+
+        assert request.prompt_cache_key == [1, 2, 3, 9]
+        assert removed == [([1, 2, 3, 9], True)]
+
     def test_scheduler_evicts_it_on_the_real_path(self):
         """Drives _schedule_waiting so the call site itself is covered.
 
@@ -563,7 +663,7 @@ class TestIncompatibleEntryIsEvictedFromTheSharedCache:
         class _Cache:
             _entries = {}
 
-            def remove(self, key):
+            def remove(self, key, *, include_ssd=False):
                 removed.append(list(key))
                 return True
 

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -514,6 +514,23 @@ class TestSSDCacheTierCore:
         finally:
             tier.close()
 
+    def test_remove_deletes_the_index_and_entry_directory(self, tmp_path):
+        tokens = (1, 2, 3)
+        config = SSDCacheConfig(cache_dir=str(tmp_path / "remove_test"))
+        tier = SSDCacheTier(config)
+        entry_hash = tier._entry_hash(tokens)
+        entry_dir = os.path.join(tier._data_dir, entry_hash)
+        os.makedirs(entry_dir)
+        tier._index.insert_entry(tokens, entry_hash, memory_bytes=128, num_tokens=3)
+
+        try:
+            assert tier.remove(tokens) is True
+            assert tier._index.lookup_exact(tokens) is None
+            assert not os.path.exists(entry_dir)
+            assert tier.remove(tokens) is False
+        finally:
+            tier.close()
+
     def test_close_idempotent(self, tmp_path):
         config = SSDCacheConfig(cache_dir=str(tmp_path / "close_test"))
         tier = SSDCacheTier(config)

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -729,6 +729,7 @@ class MemoryAwarePrefixCache:
 
         # Track the match type from the last fetch() call
         self._last_match_type: str | None = None
+        self._last_matched_key: tuple[int, ...] | None = None
 
         # Optional SSD cold tier (set via set_ssd_tier())
         self._ssd_tier = None
@@ -758,6 +759,7 @@ class MemoryAwarePrefixCache:
             - cache: Cached KV state if found, None otherwise
             - remaining_tokens: Tokens that still need processing
         """
+        self._last_matched_key = None
         if not tokens:
             self._stats.misses += 1
             self._last_match_type = "miss"
@@ -776,6 +778,7 @@ class MemoryAwarePrefixCache:
             self._stats.hits += 1
             self._stats.tokens_saved += len(tokens)
             self._last_match_type = "exact"
+            self._last_matched_key = tokens_key
             cache_out = (
                 _dequantize_cache(entry.cache)
                 if self._config.kv_quantize
@@ -850,6 +853,7 @@ class MemoryAwarePrefixCache:
                 self._stats.hits += 1
                 self._stats.tokens_saved += n_requested
                 self._last_match_type = "supersequence"
+                self._last_matched_key = best_super.tokens
                 trimmed_cache = (
                     _dequantize_cache(trimmed_cache)
                     if self._config.kv_quantize
@@ -861,6 +865,7 @@ class MemoryAwarePrefixCache:
                 self._stats.hits += 1
                 self._stats.tokens_saved += n_requested
                 self._last_match_type = "supersequence"
+                self._last_matched_key = best_super.tokens
                 cache_out = (
                     _dequantize_cache(best_super.cache)
                     if self._config.kv_quantize
@@ -875,6 +880,7 @@ class MemoryAwarePrefixCache:
             self._stats.tokens_saved += best_length
             remaining = tokens[best_length:]
             self._last_match_type = "prefix"
+            self._last_matched_key = best_match.tokens
             cache_out = (
                 _dequantize_cache(best_match.cache)
                 if self._config.kv_quantize
@@ -958,6 +964,7 @@ class MemoryAwarePrefixCache:
                     f"trimmed={excess} remaining={len(remaining)}"
                 )
                 self._last_match_type = "lcp"
+                self._last_matched_key = best_lcp_entry.tokens
                 trimmed_cache = (
                     _dequantize_cache(trimmed_cache)
                     if self._config.kv_quantize
@@ -1119,26 +1126,32 @@ class MemoryAwarePrefixCache:
             f"{'  (spilled to SSD)' if self._ssd_tier is not None else ''}"
         )
 
-    def remove(self, tokens: list[int]) -> bool:
+    def remove(self, tokens: list[int], *, include_ssd: bool = False) -> bool:
         """
         Remove a specific cache entry.
 
         Args:
             tokens: Token sequence to remove.
+            include_ssd: Also remove the same entry from the attached SSD tier.
 
         Returns:
             True if entry was found and removed.
         """
+        tokens_key = tuple(tokens)
+        removed = False
         with self._memory_lock:
-            tokens_key = tuple(tokens)
             entry = self._entries.pop(tokens_key, None)
             if entry is not None:
                 self._current_memory -= entry.memory_bytes
                 self._remove_from_sorted(tokens_key)
                 self._stats.entry_count = len(self._entries)
                 self._stats.current_memory_bytes = self._current_memory
-                return True
-            return False
+                removed = True
+
+        if include_ssd and self._ssd_tier is not None:
+            removed = self._ssd_tier.remove(tokens_key) or removed
+
+        return removed
 
     def clear(self) -> None:
         """Clear all cached entries."""
@@ -1232,12 +1245,14 @@ class MemoryAwarePrefixCache:
         if candidate is not None:
             candidate["match_type"] = "exact"
             candidate["matched_tokens"] = len(tokens)
+            candidate["matched_key"] = tokens_key
             return candidate
 
         prefix = self._ssd_tier.lookup_ssd_prefix(tokens_key)
         if prefix is not None:
             prefix["match_type"] = "prefix"
             prefix["matched_tokens"] = prefix["num_tokens"]
+            prefix["matched_key"] = tokens_key[: prefix["num_tokens"]]
             return prefix
 
         return None

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -114,6 +114,7 @@ class Request:
 
     # Prefix cache fields
     prompt_cache: Optional[List[Any]] = None  # Cached KV state from prefix cache
+    prompt_cache_key: Optional[List[int]] = None  # Actual shared-cache entry key
     cached_tokens: int = 0  # Number of tokens retrieved from cache
     remaining_tokens: Optional[List[int]] = None  # Tokens still needing processing
     prefix_boundary: int = 0  # Token count for shared prefix (messages[:-1])

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -139,6 +139,17 @@ class SchedulerConfig:
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
             raise ValueError("mllm_prefill_step_size must be > 0 when provided")
 
+        # Normalize once, here, rather than on every scheduling pass. A
+        # negative value is a startup mistake: warning about it per request
+        # turns one bad flag into a log flood, and it would say nothing new
+        # the second time.
+        if not isinstance(self.max_kv_size, int) or self.max_kv_size < 0:
+            logger.warning(
+                "Ignoring invalid max_kv_size=%r; treating as unbounded",
+                self.max_kv_size,
+            )
+            self.max_kv_size = 0
+
 
 @dataclass
 class SchedulerOutput:
@@ -1486,6 +1497,12 @@ class Scheduler:
             prefill_batch_size=self.config.prefill_batch_size,
             completion_batch_size=self.config.completion_batch_size,
             prefill_step_size=self.config.prefill_step_size,
+            # BatchGenerator builds caches for any sequence inserted without
+            # one, and its rule is the correct one: it post-processes the
+            # model's own cache, converting KVCache layers to RotatingKVCache.
+            # make_prompt_cache(model, max_kv_size=...) cannot do that — it
+            # ignores max_kv_size entirely for models that define make_cache.
+            max_kv_size=self._bounded_kv_size(),
         )
         # Set callback as attribute — used by _install_chunked_prefill
         # monkey-patch. Not a BatchGenerator constructor parameter.
@@ -1707,6 +1724,130 @@ class Scheduler:
             self._close_batch_generator()
             self.batch_generator = self._create_batch_generator(sampling_params)
             self._current_sampler_params = sampler_params
+
+    def _bounded_kv_size(self) -> int | None:
+        """Configured KV bound, or None when there is none to apply.
+
+        Only a positive value is a bound; ``0`` means unbounded. Negatives are
+        normalized away in ``SchedulerConfig.__post_init__``, so this stays a
+        pure accessor and never logs — it runs on every scheduling pass.
+        """
+        size = self.config.max_kv_size
+        return size if isinstance(size, int) and size > 0 else None
+
+    def _restored_cache_matches_kv_bound(self, cache: Any) -> bool:
+        """Would this restored entry be built the same way for a request now?
+
+        Prefix caches are persisted to disk, so an entry outlives both an
+        upgrade and any change to ``--max-kv-size``. Reusing one built under a
+        different bound gets it wrong in both directions: an unbounded
+        ``KVCache`` restored under ``--max-kv-size 64`` stays unbounded, and a
+        ``RotatingKVCache(max_size=64)`` restored after the flag changed keeps
+        the stale window.
+
+        The comparison is against the topology this scheduler would construct
+        for the request, not against ``max_kv_size`` alone. Models with
+        sliding-window attention (Gemma, Llama) create rotating layers with
+        *their own* window and no operator bound involved; measuring those
+        against the flag rejects a perfectly good entry on every reuse.
+
+        Re-bounding a populated cache in place is not an option — its contents
+        would have to be re-laid-out into a ring, which is the rewrite that
+        desynchronizes layers — so a mismatch is rejected and the request falls
+        back to a full prefill.
+        """
+        reference = self._reference_cache_topology()
+        if reference is None:
+            # No reference to compare against; do not reject blindly.
+            return True
+        if len(reference) != len(cache):
+            # A different layer count is incompatibility in itself.
+            return False
+
+        def _matches(restored: Any, expected: Any) -> bool:
+            restored_children = getattr(restored, "caches", None)
+            expected_children = getattr(expected, "caches", None)
+            if restored_children or expected_children:
+                if not (restored_children and expected_children):
+                    return False
+                if len(restored_children) != len(expected_children):
+                    return False
+                return all(
+                    _matches(r, e) for r, e in zip(restored_children, expected_children)
+                )
+            if type(restored) is not type(expected):
+                return False
+            restored_size = getattr(restored, "max_size", None)
+            expected_size = getattr(expected, "max_size", None)
+            return restored_size == expected_size
+
+        return all(_matches(r, e) for r, e in zip(cache, reference))
+
+    def _evict_incompatible_entry(self, request: Any) -> None:
+        """Drop a rejected entry from the shared prefix cache."""
+        cache = self.memory_aware_cache
+        if cache is None:
+            return
+        key = getattr(request, "prompt_cache_key", None) or getattr(
+            request, "cached_prefix_tokens", None
+        )
+        if key is None:
+            key = list(request.prompt_token_ids)[: getattr(request, "cached_tokens", 0)]
+        try:
+            if key and cache.remove(list(key)):
+                logger.debug(
+                    "[cache] evicted %d-token entry incompatible with the "
+                    "configured KV bound",
+                    len(key),
+                )
+        except Exception:
+            logger.debug("Evicting an incompatible cache entry failed", exc_info=True)
+
+    def _reference_cache_topology(self) -> Any:
+        """The cache this scheduler would build for a fresh request.
+
+        Cached after the first call: it depends only on the model and the
+        configured bound, and building it allocates cache objects.
+        """
+        cached = getattr(self, "_reference_topology", None)
+        if cached is not None:
+            return cached
+        try:
+            from mlx_lm.models.cache import make_prompt_cache
+
+            reference = make_prompt_cache(self.model)
+            bound = self._bounded_kv_size()
+            if bound is not None:
+                reference = self._bound_cache_layers(reference, bound)
+        except Exception:
+            logger.debug("Could not build a reference cache topology", exc_info=True)
+            return None
+        self._reference_topology = reference
+        return reference
+
+    @staticmethod
+    def _bound_cache_layers(cache: Any, max_kv_size: int) -> Any:
+        """Bound plain KV layers, descending into cache containers.
+
+        mlx-lm's own rule (``BatchGenerator._make_new_cache``) only converts
+        flat ``KVCache`` layers, so a ``KVCache`` nested inside a ``CacheList``
+        stays unbounded — and the architectures that nest are exactly the ones
+        running out of memory. Layers that are already something else keep
+        their own type: a rotating, pooling or Mamba cache carries its own
+        bounding and replacing it would break the model.
+        """
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        def _bound(layer: Any) -> Any:
+            children = getattr(layer, "caches", None)
+            if children:
+                layer.caches = type(children)([_bound(c) for c in children])
+                return layer
+            if type(layer) is KVCache:
+                return RotatingKVCache(max_size=max_kv_size)
+            return layer
+
+        return [_bound(layer) for layer in cache]
 
     def _validate_cache(self, cache: Any) -> bool:
         """
@@ -2157,25 +2298,60 @@ class Scheduler:
                 tokens_to_process = request.prompt_token_ids
             cache_to_use = request.prompt_cache  # May be None
 
-            # Create bounded cache when max_kv_size is configured and no cache exists
-            if cache_to_use is None and self.config.max_kv_size > 0:
-                from mlx_lm.models.cache import make_prompt_cache
-
-                cache_to_use = make_prompt_cache(
-                    self.model, max_kv_size=self.config.max_kv_size
+            # Validate cache before using it (restored entries only).
+            # This has to run before the bounded cache is built below, not
+            # after: it rejects any layer whose ``keys`` are still None, which
+            # is true of every freshly created cache. Running it afterwards
+            # discarded the bounded cache on every request and left
+            # --max-kv-size a no-op.
+            if cache_to_use is not None and not self._restored_cache_matches_kv_bound(
+                cache_to_use
+            ):
+                logger.debug(
+                    "Request %s: restored cache does not match the configured "
+                    "KV bound (%s); discarding it",
+                    request.request_id,
+                    self._bounded_kv_size(),
                 )
+                cache_to_use = None
+                # Evict it from the shared cache too. Clearing only the request
+                # leaves the stale entry in place, so every later request with
+                # the same prefix repeats the false hit and the full prefill,
+                # and nothing ever removes it.
+                self._evict_incompatible_entry(request)
+                request.prompt_cache = None
+                request.cached_tokens = 0
+                request.remaining_tokens = request.prompt_token_ids
+                tokens_to_process = request.prompt_token_ids
 
-            # Validate cache before using it
             if cache_to_use is not None and not self._validate_cache(cache_to_use):
                 logger.debug(
                     f"Request {request.request_id}: invalid cache detected, "
                     f"proceeding without cache"
                 )
                 cache_to_use = None
+                # The request has to fall back to a full prefill whatever
+                # happens next. Leaving this to the bounded-cache branch below
+                # meant a rejected cache with max_kv_size=0 kept stale
+                # cached_tokens/remaining_tokens, and the scheduler inserted
+                # only the prompt's suffix.
                 request.prompt_cache = None
                 request.cached_tokens = 0
                 request.remaining_tokens = request.prompt_token_ids
                 tokens_to_process = request.prompt_token_ids
+
+            # Build the bounded cache ourselves rather than leaving it to
+            # BatchGenerator. Its rule only converts flat KVCache layers, so a
+            # KVCache nested inside a CacheList stays unbounded and the flag is
+            # a no-op on those architectures (DeepSeek-V4 groups three caches
+            # per layer). BatchGenerator still gets max_kv_size as a backstop
+            # for any sequence inserted without a cache.
+            if cache_to_use is None and self._bounded_kv_size() is not None:
+                from mlx_lm.models.cache import make_prompt_cache
+
+                cache_to_use = self._bound_cache_layers(
+                    make_prompt_cache(self.model), self._bounded_kv_size()
+                )
 
             # Build per-request logits_processors from repetition_penalty and
             # any caller-supplied extras (e.g. JSON schema constrained

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -224,7 +224,6 @@ def _install_chunked_prefill(
 
     from mlx_lm.generate import (
         _left_pad_prompts,
-        _make_cache,
         _merge_caches,
         _right_pad_prompts,
     )
@@ -573,9 +572,13 @@ def _install_chunked_prefill(
 
                     if not is_cached:
                         padded = _left_pad_prompts(inputs_raw, max_length=max_length)
-                        prompt_cache = _make_cache(
-                            self.model, padding, self.max_kv_size
-                        )
+                        # Batch the per-request caches supplied by the scheduler,
+                        # even when they are empty. Rebuilding through
+                        # mlx-lm's _make_cache loses max_kv_size for models whose
+                        # make_cache() returns plain KVCache layers.
+                        prompt_cache = _merge_caches(caches)
+                        for c in prompt_cache:
+                            c.prepare(left_padding=padding)
                     else:
                         last_inputs = mx.array(
                             [p[-prompt_checkpoint:] for p in inputs_raw]
@@ -1777,9 +1780,19 @@ class Scheduler:
                 )
             if type(restored) is not type(expected):
                 return False
-            restored_size = getattr(restored, "max_size", None)
-            expected_size = getattr(expected, "max_size", None)
-            return restored_size == expected_size
+            missing = object()
+            topology_attributes = (
+                "max_size",
+                "keep",
+                "chunk_size",
+                "group_size",
+                "bits",
+            )
+            return all(
+                getattr(restored, attribute, missing)
+                == getattr(expected, attribute, missing)
+                for attribute in topology_attributes
+            )
 
         return all(_matches(r, e) for r, e in zip(cache, reference))
 
@@ -1794,7 +1807,7 @@ class Scheduler:
         if key is None:
             key = list(request.prompt_token_ids)[: getattr(request, "cached_tokens", 0)]
         try:
-            if key and cache.remove(list(key)):
+            if key and cache.remove(list(key), include_ssd=True):
                 logger.debug(
                     "[cache] evicted %d-token entry incompatible with the "
                     "configured KV bound",
@@ -2086,6 +2099,12 @@ class Scheduler:
             request.cache_hit_type = self.memory_aware_cache._last_match_type
             if cache:
                 request.prompt_cache = cache
+                matched_key = getattr(
+                    self.memory_aware_cache, "_last_matched_key", None
+                )
+                request.prompt_cache_key = (
+                    list(matched_key) if matched_key is not None else None
+                )
                 request.cached_tokens = len(request.prompt_token_ids) - len(remaining)
                 request.remaining_tokens = remaining
                 logger.info(
@@ -3516,8 +3535,13 @@ class Scheduler:
 
             # Use the SSD entry's actual token count for read and store,
             # NOT the full prompt tokens. For prefix hits these differ.
-            matched_count = candidate["matched_tokens"]
-            matched_tokens = tuple(request.prompt_token_ids[:matched_count])
+            matched_tokens = tuple(
+                candidate.get(
+                    "matched_key",
+                    request.prompt_token_ids[: candidate["matched_tokens"]],
+                )
+            )
+            matched_count = len(matched_tokens)
 
             try:
                 cache_layers = self._ssd_tier._read_entry(
@@ -3553,6 +3577,7 @@ class Scheduler:
             )
 
             request.prompt_cache = reconstructed
+            request.prompt_cache_key = list(matched_tokens)
             request.cached_tokens = matched_count
             request.remaining_tokens = request.prompt_token_ids[matched_count:]
             request.cache_hit_type = "ssd_hit"
@@ -3593,8 +3618,15 @@ class Scheduler:
                 self.memory_aware_cache.release_reserved_memory(nbytes)
 
         # Use matched token count, not full prompt, for prefix hits
-        matched_count = candidate.get("matched_tokens", len(request.prompt_token_ids))
-        matched_tokens = tuple(request.prompt_token_ids[:matched_count])
+        matched_tokens = tuple(
+            candidate.get(
+                "matched_key",
+                request.prompt_token_ids[
+                    : candidate.get("matched_tokens", len(request.prompt_token_ids))
+                ],
+            )
+        )
+        matched_count = len(matched_tokens)
 
         cache_layers = await self._ssd_tier.async_promote(
             matched_tokens, reserve_budget, release_budget
@@ -3619,6 +3651,7 @@ class Scheduler:
         )
 
         request.prompt_cache = reconstructed
+        request.prompt_cache_key = list(matched_tokens)
         request.cached_tokens = matched_count
         request.remaining_tokens = request.prompt_token_ids[matched_count:]
         request.cache_hit_type = "ssd_hit"

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -953,6 +953,30 @@ class SSDCacheTier:
             return results[0]  # Already sorted by num_tokens DESC
         return None
 
+    def remove(self, tokens: tuple[int, ...]) -> bool:
+        """Remove an entry from both the SSD index and its data directory."""
+        import shutil
+
+        meta = self._index.lookup_exact(tokens)
+        if meta is None:
+            return False
+
+        # Remove the index first so a data-file cleanup failure cannot expose
+        # the rejected entry to another promotion. Reconciliation removes any
+        # orphaned directory left behind.
+        self._index.delete_entry(tokens)
+        entry_dir = os.path.join(self._data_dir, meta["file_path"])
+        try:
+            if os.path.exists(entry_dir):
+                shutil.rmtree(entry_dir)
+        except OSError:
+            logger.warning(
+                "[ssd_cache] failed to remove entry directory %s",
+                meta["file_path"],
+                exc_info=True,
+            )
+        return True
+
     async def async_promote(
         self,
         tokens: tuple[int, ...],


### PR DESCRIPTION
`--max-kv-size` is a no-op. Every generation runs on an unbounded cache no matter what the flag says, while startup prints `Max KV size: 104856 (RotatingKVCache)`.

Found while fixing #683 — a snapshot destination derived from `SchedulerConfig.max_kv_size` mismatched the live cache, which is how I noticed the config never described it.

## Two independent breaks

Either one was enough on its own.

**1. The scheduler's bounded cache is rejected by its own validator.** It builds the cache and then hands it to `_validate_cache`, which returns False for any layer whose `keys` are still None — true of *every* freshly created cache, bounded or not. That validator exists for entries restored from the prefix cache, which have populated keys. So `cache_to_use` went straight back to None.

**2. `BatchGenerator` was never told.** It builds the cache for any sequence inserted without one, and its `max_kv_size` stayed None, so the fallback was unbounded.

Traced through a real scheduler run with `max_kv_size=512`:

```
make_prompt_cache(max_kv_size=512)  -> RotatingKVCache      # scheduler builds it
_validate_cache(RotatingKVCache)    -> False                # ...and rejects it
make_prompt_cache(max_kv_size=None) -> KVCache              # generator's fallback
BatchGenerator.max_kv_size          -> None
```

## Fix

The generator is given `max_kv_size` directly, and the scheduler no longer builds one itself. That removes a duplicated rule rather than repairing it twice — and the copy that remains is the correct one.

`make_prompt_cache(model, max_kv_size=N)` **silently ignores `max_kv_size` whenever the model defines `make_cache`**, which most current architectures do:

```python
if hasattr(model, "make_cache"):
    return model.make_cache()      # max_kv_size never consulted
```

`BatchGenerator._make_new_cache` post-processes the model's own cache instead, converting `KVCache` layers to `RotatingKVCache`, which bounds those models correctly. Keeping the scheduler's copy would have left the flag broken on exactly the architectures most likely to need it.

## Verification

Measured before and after on Qwen3-0.6B, reading the live cache out of the running batch:

| | `max_kv_size=0` | `max_kv_size=64` |
|---|---|---|
| before | `{'KVCache': None}` | `{'KVCache': None}` |
| after | `{'KVCache': None}` | `{'RotatingKVCache': 64}` |

`tests/test_scheduler_max_kv_size.py` covers the passthrough, that `0` stays unbounded rather than becoming `RotatingKVCache(max_size=0)`, that `_validate_cache` rejects fresh caches regardless of topology (the behaviour that caused this), and that `make_prompt_cache` ignores the bound for `make_cache` models — that last one is written so it fails loudly if upstream ever fixes it, since the scheduler could then stop relying on post-processing.

Mutation-checked: removing the `max_kv_size=` argument fails the passthrough test. Repo suite: **2300 passed** (four local failures reproduce on pristine `main` — three Python 3.14, one missing `ffmpeg`).

## Heads-up for anyone already passing the flag

It starts taking effect. A context longer than the configured size will now rotate — dropping the oldest KV — where it previously grew without bound. That is the flag's purpose, but it is a live behaviour change for any deployment that set it and never saw it apply. Ours are in that position: two servers running `--max-kv-size 104856` and `65536` against `--max-request-tokens 262144`, which have been silently unbounded this whole time.