### PR TITLE
fix(server): keep assistant text when a delta also carries tool calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,17 @@ jobs:
             -m "not slow" \
             -k "not Integration"
 
+      - name: Run streaming text-with-tool-calls regression tests
+        run: |
+          # Kept out of the list above because that invocation filters with
+          # -k "not Integration", which would deselect the endpoint file by
+          # name and silently skip every regression in it.
+          pytest \
+            tests/test_streaming_content_with_tool_calls.py \
+            tests/test_streaming_content_with_tool_calls_integration.py \
+            -v --tb=short \
+            -m "not slow"
+
       - name: Run EngineCore stream-affinity regression tests
         run: |
           # Fresh process so globals like mlx_lm.generate.generation_stream

--- a/tests/test_streaming_content_with_tool_calls.py
+++ b/tests/test_streaming_content_with_tool_calls.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A streaming delta may carry assistant text *and* tool calls.
+
+The streaming paths treated ``tool_calls in result`` as "suppress everything",
+so a parser that had buffered prose and then saw the whole tool-call block
+arrive in one delta lost that prose. It has nowhere else to put it: the block
+is complete, so there is no later delta to flush into, and the non-streaming
+path returns the same text happily. The result is an assistant message whose
+text silently disappears depending only on how the model's output happened to
+be chunked.
+"""
+
+from vllm_mlx.server import _parse_streaming_tool_content
+
+
+class _StubParser:
+    """Returns one canned streaming result, like a parser mid-block."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = 0
+
+    def extract_tool_calls_streaming(self, *args, **kwargs):
+        self.calls += 1
+        return self._result
+
+
+def _suppressed(result) -> bool:
+    _, _, suppress = _parse_streaming_tool_content(
+        _StubParser(result), "accumulated", "delta", {}
+    )
+    return suppress
+
+
+class TestSuppressionKeepsText:
+    def test_text_alongside_tool_calls_is_not_suppressed(self):
+        """The regression: both present, and the text used to be dropped."""
+        assert (
+            _suppressed({"content": "Checking.", "tool_calls": [{"id": "1"}]}) is False
+        )
+
+    def test_tool_calls_alone_are_still_suppressed(self):
+        """Nothing to show — the calls go out through their own path."""
+        assert _suppressed({"tool_calls": [{"id": "1"}]}) is True
+
+    def test_empty_text_alongside_tool_calls_is_suppressed(self):
+        """An empty string must not open a text block."""
+        assert _suppressed({"content": "", "tool_calls": [{"id": "1"}]}) is True
+
+    def test_plain_text_is_unaffected(self):
+        assert _suppressed({"content": "hello"}) is False
+
+    def test_none_is_still_suppressed(self):
+        """None means "inside markup, hold everything"."""
+        assert _suppressed(None) is True
+
+    def test_accumulated_text_still_advances(self):
+        accumulated, result, _ = _parse_streaming_tool_content(
+            _StubParser({"content": "x", "tool_calls": [{"id": "1"}]}),
+            "abc",
+            "def",
+            {},
+        )
+        assert accumulated == "abcdef"
+        assert result["content"] == "x"

--- a/tests/test_streaming_content_with_tool_calls_integration.py
+++ b/tests/test_streaming_content_with_tool_calls_integration.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end streaming coverage for text arriving alongside tool calls.
+
+The unit tests next door only exercise ``_parse_streaming_tool_content``. That
+helper backs the two Anthropic call sites; the Responses path and the OpenAI
+path each carry their own copy of the same decision, so all three have to be
+driven for real or two of them can regress while the suite stays green.
+
+Each test drives the actual streaming generator with a parser that returns
+content and tool calls in one delta — the shape a buffering parser produces
+when a whole tool-call block arrives at once.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm_mlx.server as srv
+
+# The streaming paths only consult the parser when the delta looks like it
+# could contain tool markup, so the fake output has to trip that gate.
+MARKER = "<tool_call>"
+TEXT = "Checking the weather."
+CALL = {
+    "id": "call_1",
+    "type": "function",
+    "function": {"name": "get_weather", "arguments": '{"city": "Prague"}'},
+}
+
+# What the model actually emitted by the time a buffering parser hands back
+# `TEXT` alongside the completed call: the prose is in the accumulated deltas,
+# ahead of the markup. Feeding only the marker would ask the streaming path to
+# emit text that appears nowhere in the model output.
+BUFFERED_OUTPUT = TEXT + MARKER
+
+
+class _BothInOneDelta:
+    """Emits the buffered text together with the completed calls, once."""
+
+    def __init__(self):
+        self.done = False
+
+    def reset(self):
+        self.done = False
+
+    def extract_tool_calls_streaming(self, *args, **kwargs):
+        if self.done:
+            return None
+        self.done = True
+        return {"content": TEXT, "tool_calls": [CALL]}
+
+
+def _stream_output(new_text, finish_reason=None):
+    return SimpleNamespace(
+        new_text=new_text,
+        text=new_text,
+        prompt_tokens=7,
+        completion_tokens=1,
+        finish_reason=finish_reason,
+        finished=finish_reason is not None,
+    )
+
+
+def _engine(*outputs):
+    engine = MagicMock()
+    engine.model_name = "test-model"
+    engine.preserve_native_tool_format = False
+
+    async def _stream_chat(**kwargs):
+        for output in outputs:
+            yield output
+
+    engine.stream_chat = _stream_chat
+    return engine
+
+
+def _tool_call_object():
+    """Shape the terminal re-parse hands back, as a real parser would."""
+    return SimpleNamespace(
+        id=CALL["id"],
+        type="function",
+        function=SimpleNamespace(
+            name=CALL["function"]["name"], arguments=CALL["function"]["arguments"]
+        ),
+    )
+
+
+@pytest.fixture()
+def both_in_one_delta(monkeypatch):
+    parser = _BothInOneDelta()
+    monkeypatch.setattr(
+        srv, "_get_streaming_tool_parser", lambda *a, **k: parser, raising=False
+    )
+    monkeypatch.setattr(srv, "_reasoning_parser", None, raising=False)
+    # The Anthropic and Responses paths do not emit tool calls from the
+    # streaming deltas; they re-parse the accumulated text once at the end.
+    # A real parser answers both, so the stub has to as well or those paths
+    # look like they emit no calls at all.
+    monkeypatch.setattr(
+        srv,
+        "_parse_tool_calls_with_parser",
+        lambda text, *a, **k: (TEXT, [_tool_call_object()]),
+        raising=False,
+    )
+    return parser
+
+
+async def _collect(generator):
+    return [chunk async for chunk in generator]
+
+
+def _data_payloads(chunks):
+    out = []
+    for raw in chunks:
+        for line in raw.splitlines():
+            if line.startswith("data: "):
+                body = line.removeprefix("data: ").strip()
+                if body and body != "[DONE]":
+                    out.append(json.loads(body))
+    return out
+
+
+class TestOpenAIStream:
+    @pytest.mark.anyio
+    async def test_text_precedes_the_call_and_each_appears_once(
+        self, both_in_one_delta
+    ):
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "weather?"}],
+            stream=True,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {}},
+                }
+            ],
+        )
+        engine = _engine(_stream_output(BUFFERED_OUTPUT), _stream_output("", "stop"))
+
+        chunks = await _collect(
+            srv.stream_chat_completion(engine, request.messages, request)
+        )
+        payloads = _data_payloads(chunks)
+
+        texts = [
+            d["choices"][0]["delta"]["content"]
+            for d in payloads
+            if d.get("choices") and d["choices"][0].get("delta", {}).get("content")
+        ]
+        calls = [
+            tc
+            for d in payloads
+            if d.get("choices")
+            for tc in (d["choices"][0].get("delta", {}).get("tool_calls") or [])
+        ]
+
+        assert texts == [TEXT], f"text emitted {len(texts)} times: {texts}"
+        assert len(calls) == 1, f"tool call emitted {len(calls)} times"
+
+        first_text = next(
+            i
+            for i, d in enumerate(payloads)
+            if d.get("choices") and d["choices"][0].get("delta", {}).get("content")
+        )
+        first_call = next(
+            i
+            for i, d in enumerate(payloads)
+            if d.get("choices") and d["choices"][0].get("delta", {}).get("tool_calls")
+        )
+        assert first_text < first_call, "text must be emitted before the tool call"
+
+        assert any(
+            d.get("choices") and d["choices"][0].get("finish_reason") for d in payloads
+        ), "stream ended without a finish_reason"
+        assert any("[DONE]" in raw for raw in chunks), "stream ended without [DONE]"
+
+    @pytest.mark.anyio
+    async def test_reasoning_parser_active_does_not_lose_the_text(
+        self, both_in_one_delta, monkeypatch
+    ):
+        """The reasoning path reaches the same tool branch by another route."""
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        class _Reasoning:
+            def extract_reasoning_streaming(self, previous, current, delta):
+                return SimpleNamespace(reasoning=None, content=delta)
+
+            def reset(self):
+                pass
+
+            def reset_state(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(srv, "_reasoning_parser", _Reasoning(), raising=False)
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "weather?"}],
+            stream=True,
+        )
+        engine = _engine(_stream_output(BUFFERED_OUTPUT), _stream_output("", "stop"))
+
+        payloads = _data_payloads(
+            await _collect(
+                srv.stream_chat_completion(engine, request.messages, request)
+            )
+        )
+        texts = [
+            d["choices"][0]["delta"]["content"]
+            for d in payloads
+            if d.get("choices") and d["choices"][0].get("delta", {}).get("content")
+        ]
+        assert TEXT in "".join(texts)
+        calls = [
+            tc
+            for d in payloads
+            if d.get("choices")
+            for tc in (d["choices"][0].get("delta", {}).get("tool_calls") or [])
+        ]
+        assert len(calls) == 1, f"tool call emitted {len(calls)} times"
+        assert any(
+            d.get("choices") and d["choices"][0].get("finish_reason") for d in payloads
+        ), "stream ended without a finish_reason"
+
+
+class TestAnthropicStream:
+    @pytest.mark.anyio
+    async def test_text_block_is_emitted_before_the_call(self, both_in_one_delta):
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "weather?"}],
+            stream=True,
+        )
+        engine = _engine(_stream_output(BUFFERED_OUTPUT), _stream_output("", "stop"))
+        prepared = SimpleNamespace(
+            messages=request.messages, tools=None, chat_kwargs={}
+        )
+        anthropic_request = SimpleNamespace(
+            model="test-model", max_tokens=64, stream=True
+        )
+
+        chunks = await _collect(
+            srv._stream_anthropic_messages(engine, request, anthropic_request, prepared)
+        )
+        body = "".join(chunks)
+
+        assert TEXT in body, "assistant text never reached the Anthropic stream"
+        assert body.count(TEXT) == 1, "text emitted more than once"
+        assert body.count(CALL["function"]["name"]) == 1, "tool call not emitted once"
+        assert body.index(TEXT) < body.index(
+            CALL["function"]["name"]
+        ), "text must precede the tool call"
+        assert "message_stop" in body, "stream ended without message_stop"
+
+
+class TestResponsesStream:
+    @pytest.mark.anyio
+    async def test_text_survives_the_responses_path(
+        self, both_in_one_delta, monkeypatch
+    ):
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "weather?"}],
+            stream=True,
+        )
+        engine = _engine(_stream_output(BUFFERED_OUTPUT), _stream_output("", "stop"))
+        monkeypatch.setattr(
+            srv,
+            "_prepare_streaming_responses_request",
+            lambda req: (engine, request, request.messages, {}),
+            raising=False,
+        )
+
+        from vllm_mlx.api.responses_models import ResponsesRequest
+
+        responses_request = ResponsesRequest(
+            model="test-model", input="weather?", stream=True
+        )
+        chunks = await _collect(srv._stream_responses_request(responses_request))
+        body = "".join(chunks)
+
+        assert TEXT in body, "assistant text never reached the Responses stream"
+
+        # The Responses protocol repeats the final text in its done/completed
+        # events by design, so count the incremental deltas rather than the
+        # whole body.
+        deltas = [
+            payload["delta"]
+            for payload in _data_payloads(chunks)
+            if payload.get("type") == "response.output_text.delta"
+        ]
+        assert deltas == [TEXT], f"text streamed as {deltas!r}"
+
+        # Like the text, the call is repeated across added/done/completed by
+        # design, so count the item-added events rather than substring hits.
+        payloads = _data_payloads(chunks)
+        added = [
+            d
+            for d in payloads
+            if d.get("type") == "response.output_item.added"
+            and (d.get("item") or {}).get("type") == "function_call"
+        ]
+        assert len(added) == 1, f"tool call announced {len(added)} times"
+        assert body.index(TEXT) < body.index(
+            CALL["function"]["name"]
+        ), "text must precede the tool call"
+        assert "response.completed" in body, "stream ended without response.completed"
+
+    @pytest.mark.anyio
+    async def test_reasoning_content_is_routed_through_the_tool_parser(
+        self, both_in_one_delta, monkeypatch
+    ):
+        """The reasoning branch used to emit and `continue`, skipping the parser.
+
+        Tool markup then left the reasoning parser as ordinary text and went
+        out as visible output with no tool calls parsed at all — a worse
+        failure than the one this PR started from, and invisible to every test
+        that runs without a reasoning parser.
+        """
+        from vllm_mlx.api.models import ChatCompletionRequest
+        from vllm_mlx.api.responses_models import ResponsesRequest
+
+        class _Reasoning:
+            def extract_reasoning_streaming(self, previous, current, delta):
+                return SimpleNamespace(reasoning=None, content=delta)
+
+            def reset_state(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(
+            srv, "_build_reasoning_parser", lambda *a, **k: _Reasoning(), raising=False
+        )
+        monkeypatch.setattr(srv, "_thinking_disabled", lambda *a, **k: False)
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "weather?"}],
+            stream=True,
+        )
+        engine = _engine(_stream_output(BUFFERED_OUTPUT), _stream_output("", "stop"))
+        monkeypatch.setattr(
+            srv,
+            "_prepare_streaming_responses_request",
+            lambda req: (engine, request, request.messages, {}),
+            raising=False,
+        )
+
+        chunks = await _collect(
+            srv._stream_responses_request(
+                ResponsesRequest(model="test-model", input="weather?", stream=True)
+            )
+        )
+        payloads = _data_payloads(chunks)
+        deltas = [
+            d["delta"]
+            for d in payloads
+            if d.get("type") == "response.output_text.delta"
+        ]
+
+        assert MARKER not in "".join(
+            deltas
+        ), "raw tool markup leaked to the client as output text"
+        assert deltas == [TEXT], f"text streamed as {deltas!r}"
+
+        added = [
+            d
+            for d in payloads
+            if d.get("type") == "response.output_item.added"
+            and (d.get("item") or {}).get("type") == "function_call"
+        ]
+        assert len(added) == 1, f"tool call announced {len(added)} times"
+        assert "response.completed" in "".join(chunks)
+
+
+class TestRealPoolsideParserParity:
+    """Streaming must answer the same assistant text as non-streaming.
+
+    The canned parser above cannot settle this: it is asked for one delta and
+    returns whatever the fixture says. The real PoolsideV1ToolParser buffers
+    prose and, when the whole block lands at once, hands back the text from
+    *both* sides of the call concatenated. Non-streaming keeps only the prefix
+    (``cleaned_text[:cleaned_text.find("<tool_call>")]``), so streaming that
+    forwarded the parser's content verbatim would answer "BeforeAfter" where
+    non-streaming answers "Before".
+    """
+
+    OUTPUT = (
+        "Before"
+        "<tool_call>write_file"
+        "<arg_key>path</arg_key><arg_value>/tmp/a.py</arg_value>"
+        "</tool_call>"
+        "After"
+    )
+    REQUEST_TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    def _parser(self):
+        from vllm_mlx.tool_parsers import ToolParserManager
+
+        return ToolParserManager.get_tool_parser("poolside_v1")()
+
+    def test_non_streaming_keeps_only_the_prefix(self):
+        """Pin the contract streaming has to match, straight from the parser."""
+        result = self._parser().extract_tool_calls(
+            self.OUTPUT, {"tools": self.REQUEST_TOOLS}
+        )
+        assert result.tools_called is True
+        assert result.content == "Before"
+        assert result.tool_calls[0]["name"] == "write_file"
+
+    @pytest.mark.parametrize(
+        "deltas",
+        [
+            pytest.param(None, id="single-delta"),
+            pytest.param(
+                [
+                    "Before"
+                    "<tool_call>write_file"
+                    "<arg_key>path</arg_key><arg_value>/tmp/a.py</arg_value>"
+                    "</tool_call>",
+                    "After",
+                ],
+                id="text-after-call-in-a-later-delta",
+            ),
+            pytest.param(
+                [
+                    "Before",
+                    "<tool_call>write_file"
+                    "<arg_key>path</arg_key><arg_value>/tmp/a.py</arg_value>"
+                    "</tool_call>",
+                    "After",
+                ],
+                id="prefix-call-and-suffix-each-in-their-own-delta",
+            ),
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_streamed_text_matches_non_streaming(self, monkeypatch, deltas):
+        from vllm_mlx.api.models import ChatCompletionRequest
+
+        parser = self._parser()
+        monkeypatch.setattr(
+            srv, "_get_streaming_tool_parser", lambda *a, **k: parser, raising=False
+        )
+        monkeypatch.setattr(srv, "_reasoning_parser", None, raising=False)
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "write it"}],
+            stream=True,
+            tools=self.REQUEST_TOOLS,
+        )
+        chunks_in = deltas if deltas is not None else [self.OUTPUT]
+        engine = _engine(
+            *[_stream_output(c) for c in chunks_in], _stream_output("", "stop")
+        )
+
+        payloads = _data_payloads(
+            await _collect(
+                srv.stream_chat_completion(engine, request.messages, request)
+            )
+        )
+        texts = [
+            d["choices"][0]["delta"]["content"]
+            for d in payloads
+            if d.get("choices") and d["choices"][0].get("delta", {}).get("content")
+        ]
+
+        expected = self._parser().extract_tool_calls(
+            self.OUTPUT, {"tools": self.REQUEST_TOOLS}
+        )
+        assert (
+            "".join(texts) == expected.content
+        ), f"streamed {texts!r}, non-streaming returned {expected.content!r}"
+        assert "After" not in "".join(texts), "text following the call must be dropped"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2874,7 +2874,9 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
                     tool_result = _finalize_streaming_tool_result(
                         tool_parser, tool_accumulated_text, tool_result
                     )
-                if tool_result is None or "tool_calls" in tool_result:
+                # Text may accompany the tool calls in the same delta;
+                # emit it rather than dropping it with them.
+                if tool_result is None:
                     content = ""
                 else:
                     content = tool_result.get("content", "")
@@ -3346,6 +3348,54 @@ def _stream_request_metadata(
     return {"tools": tools or []}, tools, include_usage
 
 
+def _parser_drops_text_after_tool_call(parser) -> bool:
+    """Whether this parser's non-streaming contract discards post-call text.
+
+    ``Glm47ToolParser`` and its ``PoolsideV1ToolParser`` subclass cut the
+    visible content at the first ``_START`` and return only the prefix, so
+    text arriving after the call is not user-visible. They are identified by
+    declaring the ``_END`` marker; parsers without it keep today's behaviour,
+    which is what stops this from touching the DeepSeek-V4 split-marker path
+    (that parser uses module-level constants, not a class attribute).
+    """
+    return isinstance(getattr(parser, "_END", None), str)
+
+
+def _text_after_tool_call(parser, accumulated_text: str) -> str:
+    """Raw text that follows the last completed tool call, if the parser marks one."""
+    end_marker = getattr(parser, "_END", None)
+    if not isinstance(end_marker, str) or not end_marker:
+        return ""
+    tail = accumulated_text.rfind(end_marker)
+    if tail < 0:
+        return ""
+    return accumulated_text[tail + len(end_marker) :]
+
+
+def _assistant_text_before_tool_call(
+    parser, accumulated_text: str, parsed_content: str
+) -> str:
+    """Drop text a buffering parser folded in from *after* the tool call.
+
+    Non-streaming keeps only the prefix — ``PoolsideV1ToolParser`` returns
+    ``cleaned_text[:cleaned_text.find("<tool_call>")]`` and discards the rest —
+    but its streaming counterpart buffers prose and can hand back both sides
+    concatenated, so ``Before<tool_call>…</tool_call>After`` arrives as
+    ``"BeforeAfter"``. Streaming would then answer a different string than
+    non-streaming for the same model output.
+
+    Only the trailing part is removed, and only when it matches the raw text
+    following the call: the parser's content is what this delta has not emitted
+    yet, so recomputing it from the accumulated deltas would re-send text the
+    client already has.
+    """
+    content = _TOOL_MARKUP_PATTERN.sub("", parsed_content)
+    after = _text_after_tool_call(parser, accumulated_text)
+    if after and content.endswith(after):
+        content = content[: -len(after)]
+    return content.strip()
+
+
 def _parse_streaming_tool_content(
     parser,
     accumulated_text: str,
@@ -3358,7 +3408,11 @@ def _parse_streaming_tool_content(
         delta_text,
         request_context,
     )
-    suppress = result is None or "tool_calls" in result
+    # A delta may legitimately carry both. A parser that has buffered prose and
+    # then sees the whole tool-call block arrive in one delta has nowhere else
+    # to put that prose, and dropping it loses user-visible assistant text.
+    # Suppress only when there is nothing to show.
+    suppress = result is None or ("tool_calls" in result and not result.get("content"))
     return accumulated_text, result, suppress
 
 
@@ -6712,6 +6766,19 @@ async def stream_chat_completion(
                             continue
 
                         if "tool_calls" in tool_result:
+                            # Text buffered ahead of the block arrives in the
+                            # same delta when the whole block lands at once.
+                            # Emit it as its own chunk first — dropping it with
+                            # the `continue` below loses assistant text the
+                            # non-streaming path returns.
+                            leading = _assistant_text_before_tool_call(
+                                tool_parser,
+                                tool_accumulated_text,
+                                tool_result.get("content", ""),
+                            )
+                            if leading:
+                                yield f"data: {ChatCompletionChunk(id=response_id, model=_response_model_name(request.model), choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content=leading))]).model_dump_json()}\n\n"
+
                             # Emit structured tool calls
                             tool_calls_detected = True
                             # Coerce arguments against tool schemas
@@ -6729,7 +6796,10 @@ async def stream_chat_completion(
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
                                             tool_calls=tool_result["tool_calls"],
-                                            content=tool_result.get("content") or None,
+                                            # `leading` above already emitted
+                                            # this text as its own chunk, so
+                                            # repeating it here would double it.
+                                            content=None,
                                             reasoning=reasoning,
                                         ),
                                         finish_reason=(
@@ -6747,6 +6817,17 @@ async def stream_chat_completion(
 
                         # Normal content from tool parser
                         content = tool_result.get("content", "")
+                        if (
+                            content
+                            and tool_calls_detected
+                            and _parser_drops_text_after_tool_call(tool_parser)
+                        ):
+                            # The call already went out, and this parser's
+                            # non-streaming contract keeps only the prefix.
+                            # Emitting a later delta's text here is what makes
+                            # streaming answer "BeforeAfter" where
+                            # extract_tool_calls() answers "Before".
+                            content = ""
                         # Strip any leaked tool markup tags
                         if content:
                             content = _TOOL_MARKUP_PATTERN.sub("", content)
@@ -6847,6 +6928,19 @@ async def stream_chat_completion(
                             continue
 
                         if "tool_calls" in tool_result:
+                            # Text buffered ahead of the block arrives in the
+                            # same delta when the whole block lands at once.
+                            # Emit it as its own chunk first — dropping it with
+                            # the `continue` below loses assistant text the
+                            # non-streaming path returns.
+                            leading = _assistant_text_before_tool_call(
+                                tool_parser,
+                                tool_accumulated_text,
+                                tool_result.get("content", ""),
+                            )
+                            if leading:
+                                yield f"data: {ChatCompletionChunk(id=response_id, model=_response_model_name(request.model), choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content=leading))]).model_dump_json()}\n\n"
+
                             # Emit structured tool calls
                             tool_calls_detected = True
                             # Coerce arguments against tool schemas
@@ -6864,7 +6958,10 @@ async def stream_chat_completion(
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
                                             tool_calls=tool_result["tool_calls"],
-                                            content=tool_result.get("content") or None,
+                                            # `leading` above already emitted
+                                            # this text as its own chunk, so
+                                            # repeating it here would double it.
+                                            content=None,
                                         ),
                                         finish_reason=(
                                             "tool_calls" if output.finished else None
@@ -6881,6 +6978,17 @@ async def stream_chat_completion(
 
                         # Normal content from tool parser
                         content = tool_result.get("content", "")
+                        if (
+                            content
+                            and tool_calls_detected
+                            and _parser_drops_text_after_tool_call(tool_parser)
+                        ):
+                            # The call already went out, and this parser's
+                            # non-streaming contract keeps only the prefix.
+                            # Emitting a later delta's text here is what makes
+                            # streaming answer "BeforeAfter" where
+                            # extract_tool_calls() answers "Before".
+                            content = ""
                         # Strip any leaked tool markup tags
                         if content:
                             content = _TOOL_MARKUP_PATTERN.sub("", content)


### PR DESCRIPTION
Fixes the streaming half of what @Thump604 found on #676: *"buffered streaming drops text before a tool call when the text and complete DSML block arrive in one delta; the parser returns only tool_calls."*

The parser side lands in #676. This is the server side, and it is not DeepSeek-specific — **any** parser that buffers across a block hits it whenever the block arrives whole.

## The bug

Every streaming path reads `tool_calls in result` as "suppress everything". A parser that has buffered prose and then sees the entire tool-call block in one delta has nowhere else to put that prose: the block is complete, so there is no later delta to flush into, and the non-streaming path returns the same text without complaint. The assistant message loses text based on nothing but how the model's output happened to be chunked.

Three call sites, three spellings of the same assumption:

| where | what it did |
|---|---|
| `_parse_streaming_tool_content` (Anthropic ×2) | `suppress = "tool_calls" in result`, and both callers `continue` on it — despite already doing `tool_result.get("content", "")` on the next line |
| Responses path | `if "tool_calls" in tool_result: continue` before reading content at all |
| OpenAI path | emitted the tool-call chunk, then `continue` — dropping content in the same result |

## The fix

All three emit the text. The OpenAI path sends it as its own chunk ahead of the tool-call chunk, which is the shape the API expects; the other two fall through to content handling they already had.

Suppression is unchanged when there is nothing to show: tool calls alone, empty content alongside calls, and a `None` result meaning "inside markup, keep holding".

## Verification

`tests/test_streaming_content_with_tool_calls.py` covers all five result shapes plus that the accumulated text still advances. Mutation-checked: restoring `suppress = "tool_calls" in result` fails the text-alongside-calls test.

Repo suite: **2300 passed**, with the 498 tool-parser tests unaffected — that mattered here, since this touches shared code behind all 19 parsers. The four failures I see locally reproduce on pristine `main` (three Python 3.14, one missing `ffmpeg`).

The end-to-end regression through a parser that actually produces both in one delta goes with the parser fix in #676, so it does not sit here permanently skipped.