### PR TITLE
fix(mllm): harden prefix cache ownership and rewind safety

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -555,3 +555,16 @@ class TestGetAvailableMemory:
             # Should return 0 when psutil not available
             # Note: This test may not work as expected due to import caching
             pass
+
+
+def test_load_rejects_v3_cache_after_rewind_semantics_change(tmp_path, caplog):
+    """Caches written before safe MLLM rewind must not survive an upgrade."""
+    import json
+
+    (tmp_path / "index.json").write_text(
+        json.dumps({"version": 3, "model_fingerprint": "", "entries": []})
+    )
+    cache = MemoryAwarePrefixCache(MagicMock(), MemoryCacheConfig(max_memory_mb=1))
+
+    assert cache.load_from_disk(str(tmp_path)) == 0
+    assert "version mismatch: disk=3 current=4" in caplog.text

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -566,5 +566,13 @@ def test_load_rejects_v3_cache_after_rewind_semantics_change(tmp_path, caplog):
     )
     cache = MemoryAwarePrefixCache(MagicMock(), MemoryCacheConfig(max_memory_mb=1))
 
-    assert cache.load_from_disk(str(tmp_path)) == 0
+    with patch.dict(
+        "sys.modules",
+        {
+            "mlx_lm": None,
+            "mlx_lm.models": None,
+            "mlx_lm.models.cache": None,
+        },
+    ):
+        assert cache.load_from_disk(str(tmp_path)) == 0
     assert "version mismatch: disk=3 current=4" in caplog.text

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -851,6 +851,72 @@ if __name__ == "__main__":
 
 
 class TestMLLMBatchGeneratorMTPGuards:
+    def test_process_prompts_rejects_unsafe_exact_rotating_hit(self, monkeypatch):
+        from mlx_lm.models.cache import CacheList, KVCache, RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FreshCache:
+            def merge(self, caches):
+                return self
+
+        full = KVCache()
+        full.update_and_fetch(mx.zeros((1, 1, 6, 2)), mx.zeros((1, 1, 6, 2)))
+        rotating = RotatingKVCache(max_size=4)
+        rotating.keys = mx.zeros((1, 1, 4, 2))
+        rotating.values = mx.zeros((1, 1, 4, 2))
+        rotating.offset = 6
+        rotating._idx = 4
+        stored = CacheList(full, rotating)
+
+        class PrefixCache:
+            def fetch(self, _):
+                return [stored], []
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_, **__: [FreshCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = PrefixCache()
+        generator._think_suffix_len = 0
+        generator.prefill_step_size = 512
+        generator.language_model = object()
+        generator.model = MagicMock()
+        generator.sampler = MagicMock()
+        generator._preprocess_request = lambda req: None
+        full_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator._run_chunked_text_prefill = full_prefill
+
+        request = MLLMBatchRequest(uid=1, request_id="unsafe-exact", prompt="x")
+        request.input_ids = mx.array([[1, 2, 3, 4, 5, 6]])
+        request.is_text_only = True
+
+        MLLMBatchGenerator._process_prompts(generator, [request])
+
+        full_prefill.assert_called_once()
+        assert full_prefill.call_args.kwargs["cache"][0].__class__ is FreshCache
+        assert [child.offset for child in stored.caches] == [6, 6]
+
     def test_process_prompts_applies_request_sampling_to_first_token(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchGenerator,
@@ -1780,9 +1846,8 @@ class TestChunkedPrefillCacheHandling:
             mx.eval(cache.keys, cache.values)
         return cache
 
-    def test_exact_hit_uses_trim_cache_offset(self, monkeypatch):
-        """Exact prefix-cache hit must use _trim_cache_offset(kv, 1),
-        NOT _copy_prefix_cache, to reduce the cache offset by 1."""
+    def test_exact_hit_uses_safe_rewind(self):
+        """An exact hit must use the type-preserving safe rewind path."""
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchRequest,
             install_chunked_prefill_mllm,
@@ -1791,21 +1856,14 @@ class TestChunkedPrefillCacheHandling:
         gen = self._make_fake_batch_gen()
 
         # Track which functions are called
-        trim_calls = []
-        copy_calls = []
+        rewind_calls = []
+        original_rewind = gen._rewind_prefix_cache
 
-        import vllm_mlx.mllm_batch_generator as bg_mod
+        def tracking_rewind(cache, n):
+            rewind_calls.append(n)
+            return original_rewind(cache, n)
 
-        orig_trim = bg_mod._trim_cache_offset
-
-        def tracking_trim(cache, n):
-            trim_calls.append(n)
-            return orig_trim(cache, n)
-
-        monkeypatch.setattr(bg_mod, "_trim_cache_offset", tracking_trim)
-
-        gen._copy_prefix_cache = lambda kv: (copy_calls.append(1), kv)[1]
-        gen._trim_rotating_caches = lambda cache: None
+        gen._rewind_prefix_cache = tracking_rewind
 
         # Fake prefix cache: exact hit → remaining_ids = [] (empty)
         fake_kv = [self._make_fake_kv_cache(offset=50)]
@@ -1837,15 +1895,52 @@ class TestChunkedPrefillCacheHandling:
 
         gen._next()
 
-        # _trim_cache_offset should have been called with trim_by=1
-        assert trim_calls == [
-            1
-        ], f"Expected _trim_cache_offset(kv, 1), got {trim_calls}"
-        # _copy_prefix_cache should NOT have been called
-        assert copy_calls == [], "Exact hit should NOT call _copy_prefix_cache"
+        assert rewind_calls == [1]
+
+    def test_saturated_rotating_exact_hit_falls_back(self, monkeypatch):
+        from mlx_lm.models.cache import CacheList, RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        full = self._make_fake_kv_cache(offset=6)
+        rotating = RotatingKVCache(max_size=4)
+        rotating.keys = mx.zeros((1, 1, 4, 4))
+        rotating.values = mx.zeros((1, 1, 4, 4))
+        rotating.offset = 6
+        rotating._idx = 4
+        stored = [CacheList(full, rotating)]
+
+        class PrefixCache:
+            def fetch(self, _):
+                return stored, []
+
+        fresh_cache = object()
+        make_cache = MagicMock(return_value=[fresh_cache])
+        monkeypatch.setattr("mlx_lm.models.cache.make_prompt_cache", make_cache)
+        gen.prefix_cache = PrefixCache()
+        gen.language_model = MagicMock()
+        original_next = MagicMock(return_value=[])
+        gen._next = original_next
+        install_chunked_prefill_mllm(gen, budget=1024)
+
+        request = MLLMBatchRequest(uid=3, request_id="unsafe-exact", prompt="x")
+        request.input_ids = mx.array([[1, 2, 3, 4, 5, 6]])
+        request.is_text_only = True
+        gen.unprocessed_requests.append(request)
+        gen._preprocess_request = lambda _: None
+
+        gen._next()
+
+        make_cache.assert_called_once()
+        original_next.assert_called_once()
+        assert [child.offset for child in stored[0].caches] == [6, 6]
 
     def test_partial_hit_uses_copy_prefix_cache(self, monkeypatch):
-        """Partial prefix-cache hit must use _copy_prefix_cache (not _trim_cache_offset)."""
+        """A partial hit clones storage and does not use exact-hit rewind."""
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchRequest,
             install_chunked_prefill_mllm,
@@ -1853,21 +1948,11 @@ class TestChunkedPrefillCacheHandling:
 
         gen = self._make_fake_batch_gen()
 
-        trim_calls = []
+        rewind_calls = []
         copy_calls = []
 
-        import vllm_mlx.mllm_batch_generator as bg_mod
-
-        orig_trim = bg_mod._trim_cache_offset
-
-        def tracking_trim(cache, n):
-            trim_calls.append(n)
-            return orig_trim(cache, n)
-
-        monkeypatch.setattr(bg_mod, "_trim_cache_offset", tracking_trim)
-
         gen._copy_prefix_cache = lambda kv: (copy_calls.append(1), kv)[1]
-        gen._trim_rotating_caches = lambda cache: None
+        gen._rewind_prefix_cache = lambda kv, n: (rewind_calls.append(n), kv)[1]
 
         # Fake prefix cache: partial hit → remaining_ids has tokens
         fake_kv = [self._make_fake_kv_cache(offset=3)]
@@ -1894,13 +1979,10 @@ class TestChunkedPrefillCacheHandling:
 
         gen._next()
 
-        # Partial hit uses _copy_prefix_cache, NOT _trim_cache_offset
         assert copy_calls == [
             1
         ], f"Expected _copy_prefix_cache called once, got {copy_calls}"
-        assert (
-            trim_calls == []
-        ), f"Partial hit should NOT call _trim_cache_offset, got {trim_calls}"
+        assert rewind_calls == []
 
     def test_abort_cleans_up_partial_prefill(self):
         """Aborting a request during chunked prefill must clean up _partial."""

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -298,15 +298,10 @@ class TestSchedulerIntegration:
 
 
 class TestTrimRotatingCaches:
-    """Regression tests for _trim_rotating_caches offset clamp."""
+    """Regression tests for restored rotating-cache validation."""
 
-    def test_offset_clamped_to_max_size(self):
-        """Restored cache with offset > max_size must be clamped.
-
-        Without clamping, RotatingKVCache._update_in_place computes
-        ``new_size = min(step, max_size - prev)`` which goes negative
-        when ``prev = offset % max_size`` exceeds max_size after trim.
-        """
+    def test_saturated_offset_is_preserved_while_buffer_is_trimmed(self):
+        """The absolute position must survive window normalization."""
         mx = pytest.importorskip("mlx.core")
         mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
         KVCache = mlx_lm_cache.KVCache
@@ -314,13 +309,13 @@ class TestTrimRotatingCaches:
 
         from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
 
-        # Simulate a RotatingKVCache with offset far beyond max_size
-        # (happens when prefix cache stores long-generation state)
+        # A large first prefill can leave an oversized buffer. The next
+        # single-token update normally reduces it to the rotating window.
         rc = RotatingKVCache(max_size=128, keep=0)
-        rc.offset = 500  # Way beyond max_size
-        rc.keys = mx.zeros((1, 4, 128, 64))  # Full buffer at max_size
-        rc.values = mx.zeros((1, 4, 128, 64))
-        rc._idx = 128
+        rc.offset = 500
+        rc.keys = mx.zeros((1, 4, 500, 64))
+        rc.values = mx.zeros((1, 4, 500, 64))
+        rc._idx = 500
 
         # Also include a regular KVCache (should be unaffected)
         kv = KVCache()
@@ -329,17 +324,18 @@ class TestTrimRotatingCaches:
         kv.values = mx.zeros((1, 4, 200, 64))
 
         cache_list = [rc, kv]
-        MLLMBatchGenerator._trim_rotating_caches(cache_list)
+        assert MLLMBatchGenerator._prepare_rotating_caches(cache_list) is True
 
-        # RotatingKVCache offset must be clamped to max_size
-        assert rc.offset <= rc.max_size
-        assert rc.offset == 128
+        assert rc.offset == 500
+        assert rc.keys.shape[2] == 128
+        assert rc.values.shape[2] == 128
+        assert rc._idx == 128
 
         # KVCache should be untouched
         assert kv.offset == 200
 
-    def test_empty_rotating_cache_offset_reset(self):
-        """RotatingKVCache with keys=None should get offset reset to 0."""
+    def test_inconsistent_undersized_buffer_is_rejected(self):
+        mx = pytest.importorskip("mlx.core")
         mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
         RotatingKVCache = mlx_lm_cache.RotatingKVCache
 
@@ -347,11 +343,12 @@ class TestTrimRotatingCaches:
 
         rc = RotatingKVCache(max_size=128, keep=0)
         rc.offset = 500
-        rc.keys = None
-        rc.values = None
+        rc.keys = mx.zeros((1, 1, 64, 4))
+        rc.values = mx.zeros((1, 1, 64, 4))
+        rc._idx = 64
 
-        MLLMBatchGenerator._trim_rotating_caches([rc])
-        assert rc.offset == 0
+        assert MLLMBatchGenerator._prepare_rotating_caches([rc]) is False
+        assert rc.offset == 500
 
 
 class TestCopyPrefixCache:
@@ -393,6 +390,130 @@ class TestCopyPrefixCache:
         assert original.offset == 50
         assert original._idx == 50
 
+    def test_copy_recurses_through_cache_list(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv = KVCache()
+        kv.update_and_fetch(mx.zeros((1, 1, 3, 4)), mx.zeros((1, 1, 3, 4)))
+        rotating = RotatingKVCache(max_size=4)
+        rotating.update_and_fetch(mx.zeros((1, 1, 3, 4)), mx.zeros((1, 1, 3, 4)))
+        original = CacheList(kv, rotating)
+
+        copied = MLLMBatchGenerator._copy_prefix_cache([original])[0]
+
+        assert copied is not original
+        assert all(a is not b for a, b in zip(copied.caches, original.caches))
+        assert copied.caches[0].keys is original.caches[0].keys
+        copied.caches[0].offset = 1
+        copied.caches[1]._idx = 1
+        assert original.caches[0].offset == 3
+        assert original.caches[1]._idx == 3
+
+    def test_copy_recurses_through_mlx_vlm_cache_list(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_vlm_cache = pytest.importorskip("mlx_vlm.models.cache")
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        child = mlx_vlm_cache.KVCache()
+        child.update_and_fetch(mx.zeros((1, 1, 3, 2)), mx.zeros((1, 1, 3, 2)))
+        original = mlx_vlm_cache.CacheList(child)
+
+        copied = MLLMBatchGenerator._copy_prefix_cache([original])[0]
+
+        assert type(copied) is mlx_vlm_cache.CacheList
+        assert copied is not original
+        assert copied.caches[0] is not child
+        copied.caches[0].offset = 1
+        assert child.offset == 3
+
+
+class TestRewindPrefixCache:
+    def test_nested_plain_cache_rewinds_without_mutating_storage(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        children = []
+        for _ in range(2):
+            cache = KVCache()
+            cache.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+            children.append(cache)
+        stored = CacheList(*children)
+
+        rewound = MLLMBatchGenerator._rewind_prefix_cache([stored], 1)[0]
+
+        assert [c.offset for c in rewound.caches] == [3, 3]
+        assert [c.offset for c in stored.caches] == [4, 4]
+        assert rewound is not stored
+
+    def test_saturated_rotating_child_fails_closed(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv = KVCache()
+        kv.update_and_fetch(mx.zeros((1, 1, 6, 2)), mx.zeros((1, 1, 6, 2)))
+        rotating = RotatingKVCache(max_size=4)
+        rotating.keys = mx.zeros((1, 1, 4, 2))
+        rotating.values = mx.zeros((1, 1, 4, 2))
+        rotating.offset = 6
+        rotating._idx = 4
+
+        assert (
+            MLLMBatchGenerator._rewind_prefix_cache([CacheList(kv, rotating)], 1)
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "cache_module", ["mlx_lm.models.cache", "mlx_vlm.models.cache"]
+    )
+    def test_chunked_cache_rewind_preserves_type_metadata(self, cache_module):
+        mx = pytest.importorskip("mlx.core")
+        cache_types = pytest.importorskip(cache_module)
+        ChunkedKVCache = cache_types.ChunkedKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        stored = ChunkedKVCache(chunk_size=8)
+        stored.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+
+        rewound = MLLMBatchGenerator._rewind_prefix_cache([stored], 1)[0]
+
+        assert type(rewound) is ChunkedKVCache
+        assert rewound.chunk_size == 8
+        assert rewound.start_position == 0
+        assert rewound.offset == 3
+        assert stored.offset == 4
+        rewound.update_and_fetch(mx.zeros((1, 1, 1, 2)), mx.zeros((1, 1, 1, 2)))
+        assert rewound.offset == 4
+
+    def test_chunked_cache_rewind_fails_when_front_was_discarded(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_vlm_cache = pytest.importorskip("mlx_vlm.models.cache")
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        stored = mlx_vlm_cache.ChunkedKVCache(chunk_size=4)
+        stored.update_and_fetch(mx.zeros((1, 1, 4, 2)), mx.zeros((1, 1, 4, 2)))
+        stored.start_position = 3
+        stored.offset = 4
+
+        assert MLLMBatchGenerator._rewind_prefix_cache([stored], 2) is None
+
 
 class TestHasEmptyRotatingCache:
     """Tests for _has_empty_rotating_cache detection."""
@@ -425,6 +546,143 @@ class TestHasEmptyRotatingCache:
         rc.keys = mx.zeros((1, 4, 50, 64))
 
         assert MLLMBatchGenerator._has_empty_rotating_cache([kv, rc]) is False
+
+    def test_detects_empty_rotating_child_in_nested_cache_list(self):
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        nested = CacheList(KVCache(), CacheList(RotatingKVCache(max_size=4)))
+        assert MLLMBatchGenerator._has_empty_rotating_cache([nested]) is True
+
+    def test_detects_empty_mlx_vlm_rotating_child(self):
+        mlx_vlm_cache = pytest.importorskip("mlx_vlm.models.cache")
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        nested = mlx_vlm_cache.CacheList(
+            mlx_vlm_cache.KVCache(), mlx_vlm_cache.RotatingKVCache(max_size=4)
+        )
+        assert MLLMBatchGenerator._has_empty_rotating_cache([nested]) is True
+
+
+class TestMLLMCompletionCacheStore:
+    @staticmethod
+    def _filled(cache, length, mx):
+        cache.update_and_fetch(mx.zeros((1, 1, length, 2)), mx.zeros((1, 1, length, 2)))
+        return cache
+
+    def test_saturated_nested_rotating_cache_is_not_stored(self):
+        from types import SimpleNamespace
+
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+        RotatingKVCache = mlx_lm_cache.RotatingKVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        full = self._filled(KVCache(), 8, mx)
+        rotating = RotatingKVCache(max_size=4)
+        rotating.keys = mx.zeros((1, 1, 4, 2))
+        rotating.values = mx.zeros((1, 1, 4, 2))
+        rotating.offset = 8
+        rotating._idx = 4
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator._think_suffix_len = 0
+        request = SimpleNamespace(
+            request_id="saturated", input_ids=mx.array([[1, 2, 3, 4]])
+        )
+        batch = SimpleNamespace(
+            requests=[request],
+            num_tokens=[4],
+            extract_cache=lambda _: [CacheList(full, rotating)],
+        )
+
+        generator._maybe_store_prefix_cache(batch, [0])
+
+        generator.prefix_cache.store.assert_not_called()
+
+    def test_saturated_flat_rotating_cache_is_not_stored(self):
+        """Exercise #689's completion rewind without the container guard."""
+        from types import SimpleNamespace
+
+        mx = pytest.importorskip("mlx.core")
+        mlx_vlm_cache = pytest.importorskip("mlx_vlm.models.cache")
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        full = self._filled(mlx_vlm_cache.KVCache(), 8, mx)
+        rotating = mlx_vlm_cache.RotatingKVCache(max_size=4)
+        rotating.keys = mx.zeros((1, 1, 4, 2))
+        rotating.values = mx.zeros((1, 1, 4, 2))
+        rotating.offset = 8
+        rotating._idx = 4
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator._think_suffix_len = 0
+        request = SimpleNamespace(request_id="flat", input_ids=mx.array([[1, 2, 3, 4]]))
+        batch = SimpleNamespace(
+            requests=[request],
+            num_tokens=[4],
+            extract_cache=lambda _: [full, rotating],
+        )
+
+        generator._maybe_store_prefix_cache(batch, [0])
+
+        generator.prefix_cache.store.assert_not_called()
+
+    def test_plain_nested_cache_is_not_stored_without_recursive_accounting(self):
+        from types import SimpleNamespace
+
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = mlx_lm_cache.CacheList
+        KVCache = mlx_lm_cache.KVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        children = [self._filled(KVCache(), 4, mx) for _ in range(2)]
+        extracted = CacheList(*children)
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator._think_suffix_len = 0
+        request = SimpleNamespace(request_id="plain", input_ids=mx.array([[1, 2, 3]]))
+        batch = SimpleNamespace(
+            requests=[request],
+            num_tokens=[1],
+            extract_cache=lambda _: [extracted],
+        )
+
+        generator._maybe_store_prefix_cache(batch, [0])
+
+        generator.prefix_cache.store.assert_not_called()
+
+    def test_zero_trim_flat_snapshot_does_not_alias_live_cache(self):
+        mx = pytest.importorskip("mlx.core")
+        mlx_lm_cache = pytest.importorskip("mlx_lm.models.cache")
+        KVCache = mlx_lm_cache.KVCache
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        live = self._filled(KVCache(), 3, mx)
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+
+        assert generator._store_prefix_snapshot(
+            [1, 2, 3], [live], 0, "interleaved", "interleaved prefill"
+        )
+
+        _, stored = generator.prefix_cache.store.call_args.args
+        assert stored[0] is not live
+        live.offset = 99
+        assert stored[0].offset == 3
 
 
 if __name__ == "__main__":

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -638,7 +638,7 @@ class TestMLLMCompletionCacheStore:
 
         generator.prefix_cache.store.assert_not_called()
 
-    def test_plain_nested_cache_is_not_stored_without_recursive_accounting(self):
+    def test_plain_nested_cache_is_stored_with_recursive_accounting(self):
         from types import SimpleNamespace
 
         mx = pytest.importorskip("mlx.core")
@@ -647,6 +647,7 @@ class TestMLLMCompletionCacheStore:
         KVCache = mlx_lm_cache.KVCache
 
         from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+        from vllm_mlx.memory_cache import estimate_kv_cache_memory
 
         children = [self._filled(KVCache(), 4, mx) for _ in range(2)]
         extracted = CacheList(*children)
@@ -662,7 +663,10 @@ class TestMLLMCompletionCacheStore:
 
         generator._maybe_store_prefix_cache(batch, [0])
 
-        generator.prefix_cache.store.assert_not_called()
+        generator.prefix_cache.store.assert_called_once()
+        _, stored = generator.prefix_cache.store.call_args.args
+        assert estimate_kv_cache_memory(stored) > 0
+        assert [child.offset for child in stored[0].caches] == [3, 3]
 
     def test_zero_trim_flat_snapshot_does_not_alias_live_cache(self):
         mx = pytest.importorskip("mlx.core")

--- a/tests/test_specprefill_rotating_cache.py
+++ b/tests/test_specprefill_rotating_cache.py
@@ -84,14 +84,8 @@ def test_sparse_prefill_expands_tail_when_prompt_exceeds_window():
     assert flattened == [0, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
-def test_trim_rotating_caches_clamps_offset():
-    """Regression: offset > max_size after prefix restore must be clamped.
-
-    RotatingKVCache._update_in_place computes
-    ``new_size = min(step, max_size - prev)`` where prev = offset.
-    If offset > max_size the result is negative → crash.
-    _trim_rotating_caches must clamp offset after trimming buffers.
-    """
+def test_prepare_rotating_caches_preserves_absolute_offset():
+    """Window normalization must not reset the sequence position."""
     from mlx_lm.models.cache import RotatingKVCache
 
     from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
@@ -104,9 +98,9 @@ def test_trim_rotating_caches_clamps_offset():
     cache.offset = 8
     cache._idx = 8
 
-    MLLMBatchGenerator._trim_rotating_caches([cache])
+    assert MLLMBatchGenerator._prepare_rotating_caches([cache]) is True
 
     assert cache.keys.shape[2] == max_size
     assert cache.values.shape[2] == max_size
     assert cache._idx == max_size
-    assert cache.offset <= max_size
+    assert cache.offset == 8

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -41,7 +41,7 @@ _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 _MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
 # Bump this when the cache on-disk format or KV semantics change.
 # Loading a cache with a different version is rejected automatically.
-_CACHE_PERSIST_VERSION = 3
+_CACHE_PERSIST_VERSION = 4
 
 
 def _get_available_memory() -> int:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1355,12 +1355,6 @@ class MemoryAwarePrefixCache:
 
         t0 = _time.monotonic()
 
-        try:
-            from mlx_lm.models.cache import load_prompt_cache
-        except ImportError:
-            logger.warning("[cache_persist] mlx_lm not available, cannot load")
-            return 0
-
         with open(index_path) as f:
             index = json.load(f)
 
@@ -1370,6 +1364,12 @@ class MemoryAwarePrefixCache:
                 f"[cache_persist] version mismatch: disk={version} "
                 f"current={_CACHE_PERSIST_VERSION}, discarding stale cache"
             )
+            return 0
+
+        try:
+            from mlx_lm.models.cache import load_prompt_cache
+        except ImportError:
+            logger.warning("[cache_persist] mlx_lm not available, cannot load")
             return 0
 
         disk_fp = index.get("model_fingerprint", "")

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -22,12 +22,12 @@ import os
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 
-from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig, _trim_cache_offset
+from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 from .multimodal_processor import MultimodalProcessor
 from .vision_embedding_cache import VisionEmbeddingCache
 
@@ -1017,87 +1017,185 @@ class MLLMBatchGenerator:
         )
 
     @staticmethod
-    def _copy_prefix_cache(cache_list):
-        """Create shallow copies of cache objects to prevent mutation of stored prefix cache.
-
-        MLX arrays are immutable and safe to share, but cache objects have mutable
-        Python attributes (offset, _idx) that get modified by update_and_fetch().
-        Without copying, the stored prefix cache entry is corrupted after each use.
-        """
-        from mlx_lm.models.cache import KVCache, RotatingKVCache
-
-        copies = []
-        for c in cache_list:
-            if isinstance(c, RotatingKVCache):
-                new_c = RotatingKVCache(c.max_size, c.keep)
-                new_c.step = c.step
-                new_c.keys = c.keys
-                new_c.values = c.values
-                new_c.offset = c.offset
-                new_c._idx = c._idx
-                copies.append(new_c)
-            elif isinstance(c, KVCache):
-                new_c = KVCache()
-                new_c.step = c.step
-                new_c.keys = c.keys
-                new_c.values = c.values
-                new_c.offset = c.offset
-                copies.append(new_c)
-            else:
-                copies.append(c)
-        return copies
+    def _copy_cache_state(value):
+        """Copy mutable state containers while sharing immutable MLX arrays."""
+        if isinstance(value, list):
+            return [MLLMBatchGenerator._copy_cache_state(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(MLLMBatchGenerator._copy_cache_state(v) for v in value)
+        if isinstance(value, dict):
+            return {
+                k: MLLMBatchGenerator._copy_cache_state(v) for k, v in value.items()
+            }
+        return value
 
     @staticmethod
-    def _has_empty_rotating_cache(cache_list):
+    def _cache_class_families():
+        """Return cache classes shared by the mlx-lm and mlx-vlm families."""
+        from mlx_lm.models import cache as mlx_lm_cache
+        from mlx_vlm.models import cache as mlx_vlm_cache
+
+        return (
+            (mlx_lm_cache.CacheList, mlx_vlm_cache.CacheList),
+            (mlx_lm_cache.KVCache, mlx_vlm_cache.KVCache),
+            (mlx_lm_cache.RotatingKVCache, mlx_vlm_cache.RotatingKVCache),
+        )
+
+    @classmethod
+    def _copy_cache_layer(cls, cache):
+        """Clone one cache wrapper without copying its immutable MLX arrays."""
+        cache_lists, kv_caches, rotating_caches = cls._cache_class_families()
+
+        if isinstance(cache, cache_lists):
+            return type(cache)(*(cls._copy_cache_layer(c) for c in cache.caches))
+        if type(cache) in rotating_caches:
+            copied = type(cache)(cache.max_size, cache.keep)
+            copied.step = cache.step
+            copied.keys = cache.keys
+            copied.values = cache.values
+            copied.offset = cache.offset
+            copied._idx = cache._idx
+            return copied
+        if type(cache) in kv_caches:
+            copied = type(cache)()
+            copied.step = cache.step
+            copied.keys = cache.keys
+            copied.values = cache.values
+            copied.offset = cache.offset
+            return copied
+
+        from_state = getattr(type(cache), "from_state", None)
+        if not callable(from_state):
+            raise TypeError(f"Unsupported prefix cache layer: {type(cache).__name__}")
+        state = cls._copy_cache_state(cache.state)
+        meta_state = cls._copy_cache_state(cache.meta_state)
+        copied = from_state(state, meta_state)
+        if "step" in getattr(cache, "__dict__", {}):
+            copied.step = cache.step
+        return copied
+
+    @classmethod
+    def _copy_prefix_cache(cls, cache_list):
+        """Clone cache wrappers recursively so reuse cannot mutate storage."""
+        try:
+            return [cls._copy_cache_layer(c) for c in cache_list]
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.warning("Prefix cache copy rejected: %s", exc)
+            return None
+
+    @classmethod
+    def _cache_leaves(cls, cache_list) -> Iterator[Any]:
+        """Yield cache leaves from a possibly nested CacheList topology."""
+        cache_lists, _, _ = cls._cache_class_families()
+
+        for cache in cache_list:
+            if isinstance(cache, cache_lists):
+                yield from cls._cache_leaves(cache.caches)
+            else:
+                yield cache
+
+    @classmethod
+    def _cache_storage_is_accounted(cls, cache_list) -> bool:
+        """Return whether MemoryAwarePrefixCache can account this topology.
+
+        Its current estimator treats each top-level layer state as one KV pair
+        and does not recurse through CacheList. Until shared recursive
+        accounting lands, storing a nested container would bypass the byte cap.
+        Reads remain supported so existing entries can be handled safely.
+        """
+        cache_lists, _, _ = cls._cache_class_families()
+        return not any(isinstance(cache, cache_lists) for cache in cache_list)
+
+    @classmethod
+    def _has_empty_rotating_cache(cls, cache_list):
         """Check if any RotatingKVCache layer has no data (keys=None).
 
         This happens when prefix cache stores a long response where all
         sliding-window entries were trimmed (entries_to_keep=0).
         Using such a cache produces garbage — fall through to full prefill.
         """
-        from mlx_lm.models.cache import RotatingKVCache
+        _, _, rotating_caches = cls._cache_class_families()
 
-        for c in cache_list:
-            if isinstance(c, RotatingKVCache) and c.keys is None:
+        for c in cls._cache_leaves(cache_list):
+            if isinstance(c, rotating_caches) and c.keys is None:
                 return True
         return False
 
-    @staticmethod
-    def _trim_rotating_caches(cache_list):
-        """Trim RotatingKVCache buffers restored from prefix cache.
+    @classmethod
+    def _prepare_rotating_caches(cls, cache_list) -> bool:
+        """Normalize oversized rotating buffers without changing positions.
 
-        Prefix cache stores the full KV state (offset may exceed max_size for
-        sliding-window layers).  RotatingKVCache._update_in_place computes
-        ``new_size = min(step, max_size - prev)`` which goes negative when
-        ``prev > max_size``, crashing with "Negative dimensions not allowed".
-
-        Trimming the buffer to max_size and clamping offset/idx prevents this.
+        A saturated cache legitimately has ``offset > max_size``: offset is the
+        absolute sequence position and must not be clamped to the window size.
+        Oversized prefill buffers are reduced to the configured window while
+        preserving that offset. Inconsistent undersized buffers fail closed.
         """
-        from mlx_lm.models.cache import RotatingKVCache
+        _, _, rotating_caches = cls._cache_class_families()
 
-        for layer_cache in cache_list:
-            if not isinstance(layer_cache, RotatingKVCache):
+        for layer_cache in cls._cache_leaves(cache_list):
+            # Buffered subclasses deliberately retain rollback slack beyond the
+            # attention window; only normalize the two plain implementations.
+            if type(layer_cache) not in rotating_caches:
                 continue
             if layer_cache.keys is None:
-                layer_cache.offset = 0
-                continue
+                if layer_cache.offset == 0:
+                    continue
+                return False
             buf_len = layer_cache.keys.shape[2]
             if buf_len > layer_cache.max_size:
                 trim_size = buf_len - layer_cache.max_size
                 layer_cache.keys = layer_cache._trim(trim_size, layer_cache.keys)
                 layer_cache.values = layer_cache._trim(trim_size, layer_cache.values)
                 layer_cache._idx = layer_cache.max_size
-            layer_cache.offset = min(layer_cache.offset, layer_cache.max_size)
-            # Defensive: ensure size() <= keys.shape[2] to prevent merge crash.
-            # Prefix cache trimming can create offset > keys.shape[2] when
-            # a supersequence/LCP trim crosses the max_size boundary.
             buf_len = layer_cache.keys.shape[2]
-            if min(layer_cache.offset, layer_cache.max_size) > buf_len:
+            required = min(layer_cache.offset, layer_cache.max_size)
+            if required > buf_len:
                 logger.warning(
-                    f"RotatingKVCache offset ({layer_cache.offset}) > "
-                    f"buffer ({buf_len}), capping to buffer size"
+                    "Prefix cache has inconsistent RotatingKVCache state: "
+                    "offset=%s max_size=%s buffer=%s",
+                    layer_cache.offset,
+                    layer_cache.max_size,
+                    buf_len,
                 )
-                layer_cache.offset = buf_len
+                return False
+        return True
+
+    @classmethod
+    def _can_rewind_prefix_cache(cls, cache_list, trim_by: int) -> bool:
+        """Return whether every cache leaf retains the positions to rewind."""
+        if trim_by <= 0:
+            return True
+        for cache in cls._cache_leaves(cache_list):
+            keys = getattr(cache, "keys", None)
+            offset = getattr(cache, "offset", None)
+            if keys is None or offset is None or offset < trim_by:
+                return False
+            if isinstance(keys, (list, tuple)):
+                return False
+            is_trimmable = getattr(cache, "is_trimmable", None)
+            if not callable(is_trimmable) or not is_trimmable():
+                return False
+        return True
+
+    @classmethod
+    def _rewind_prefix_cache(cls, cache_list, trim_by: int):
+        """Clone and safely rewind every leaf, or return None to fail closed."""
+        if not cls._can_rewind_prefix_cache(cache_list, trim_by):
+            return None
+        copied = cls._copy_prefix_cache(cache_list)
+        if copied is None or trim_by <= 0:
+            return copied
+
+        # Use each cache implementation's own trim contract after cloning.
+        # This preserves type-specific metadata such as ChunkedKVCache's
+        # chunk_size/start_position instead of reconstructing a generic KV
+        # wrapper. Verify the full rewind so a partially retained window cannot
+        # be stored under a longer token key.
+        for cache in cls._cache_leaves(copied):
+            trim = getattr(cache, "trim", None)
+            if not callable(trim) or trim(trim_by) != trim_by:
+                return None
+        return copied
 
     def _run_chunked_text_prefill(
         self, request: MLLMBatchRequest, cache: List[Any]
@@ -1434,11 +1532,34 @@ class MLLMBatchGenerator:
                     cached_kv = None
                     remaining_ids = None
 
+                prepared_cache = None
+                if cached_kv is not None and remaining_ids:
+                    prepared_cache = self._copy_prefix_cache(cached_kv)
+                    if prepared_cache is None or not self._prepare_rotating_caches(
+                        prepared_cache
+                    ):
+                        logger.warning(
+                            "Prefix cache hit for %s has unsupported or inconsistent "
+                            "cache state — falling through to full prefill",
+                            req.request_id,
+                        )
+                        cached_kv = None
+                        remaining_ids = None
+                        prepared_cache = None
+                elif cached_kv is not None and not remaining_ids:
+                    prepared_cache = self._rewind_prefix_cache(cached_kv, 1)
+                    if prepared_cache is None:
+                        logger.debug(
+                            "Prefix cache exact hit for %s cannot be rewound "
+                            "safely — falling through to full prefill",
+                            req.request_id,
+                        )
+                        cached_kv = None
+
                 if cached_kv is not None and remaining_ids:
                     # Prefix/LCP match — run language model on remaining tokens.
-                    # Copy cache to prevent mutation of stored prefix cache entry.
-                    request_cache = self._copy_prefix_cache(cached_kv)
-                    self._trim_rotating_caches(request_cache)
+                    # The prepared cache is an isolated recursive copy.
+                    request_cache = prepared_cache
                     remaining = mx.array(remaining_ids)[None, :]
                     cached_count = len(input_ids_list) - len(remaining_ids)
                     total_tokens = len(input_ids_list)
@@ -1514,9 +1635,8 @@ class MLLMBatchGenerator:
                     # but we still need logits for the last position.
                     # Trim by 1 so re-running the last token produces correct
                     # logits for the next-token prediction.
-                    # _trim_cache_offset creates new cache objects (safe for
-                    # stored entry).
-                    request_cache = _trim_cache_offset(cached_kv, 1)
+                    # The prepared cache is a safe recursive one-token rewind.
+                    request_cache = prepared_cache
                     last_token = req.input_ids[:, -1:]
                     total_tokens = len(input_ids_list)
                     self._prefill_progress[req.request_id] = (
@@ -1604,7 +1724,8 @@ class MLLMBatchGenerator:
         from mlx_lm.models.cache import RotatingKVCache
 
         for rc in per_request_caches:
-            self._trim_rotating_caches(rc)
+            if not self._prepare_rotating_caches(rc):
+                raise RuntimeError("Cannot merge inconsistent rotating cache state")
             for layer_cache in rc:
                 if isinstance(layer_cache, RotatingKVCache):
                     if layer_cache.keys is not None:
@@ -1977,6 +2098,38 @@ class MLLMBatchGenerator:
         self._stats.peak_memory = mx.get_peak_memory() / 1e9
         return self._stats
 
+    def _store_prefix_snapshot(
+        self,
+        cache_key: List[int],
+        cache: List[Any],
+        trim_by: int,
+        request_id: str,
+        source: str,
+    ) -> bool:
+        """Store an isolated, key-aligned cache snapshot when rewind is safe."""
+        if self.prefix_cache is None:
+            return False
+        if not self._cache_storage_is_accounted(cache):
+            logger.debug(
+                "Skipping %s prefix cache store for %s: nested cache "
+                "memory is not recursively accounted",
+                source,
+                request_id,
+            )
+            return False
+        snapshot = self._rewind_prefix_cache(cache, trim_by)
+        if snapshot is None:
+            logger.debug(
+                "Skipping %s prefix cache store for %s: cache cannot be "
+                "rewound safely by %s token(s)",
+                source,
+                request_id,
+                trim_by,
+            )
+            return False
+        self.prefix_cache.store(cache_key, snapshot)
+        return True
+
     def _maybe_store_prefix_cache(
         self, batch: MLLMBatch, end_indices: List[int]
     ) -> None:
@@ -1999,9 +2152,14 @@ class MLLMBatchGenerator:
                     output_count = batch.num_tokens[i]
                     S = self._think_suffix_len
                     total_trim = output_count + S
-                    prompt_cache = _trim_cache_offset(extracted, total_trim)
                     cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
-                    self.prefix_cache.store(cache_key, prompt_cache)
+                    self._store_prefix_snapshot(
+                        cache_key,
+                        extracted,
+                        total_trim,
+                        req.request_id,
+                        "completion",
+                    )
                 except Exception as e:
                     logger.warning(
                         f"Failed to store prefix cache for {req.request_id}: {type(e).__name__}: {e}"
@@ -2861,7 +3019,10 @@ def install_chunked_prefill_mllm(
                     from mlx_lm.models.cache import RotatingKVCache
 
                     request_cache = partial["cache"]
-                    batch_gen._trim_rotating_caches(request_cache)
+                    if not batch_gen._prepare_rotating_caches(request_cache):
+                        raise RuntimeError(
+                            "Cannot merge inconsistent rotating cache state"
+                        )
                     for layer_cache in request_cache:
                         if isinstance(layer_cache, RotatingKVCache):
                             if layer_cache.keys is not None:
@@ -2904,8 +3065,13 @@ def install_chunked_prefill_mllm(
                         # trim by S only (matching canonical path's
                         # output_count + S invariant).
                         trim_amount = S
-                        store_cache = _trim_cache_offset(partial["cache"], trim_amount)
-                        batch_gen.prefix_cache.store(cache_key, store_cache)
+                        batch_gen._store_prefix_snapshot(
+                            cache_key,
+                            partial["cache"],
+                            trim_amount,
+                            req.request_id,
+                            "interleaved prefill",
+                        )
                     except Exception as e:
                         logger.warning(
                             f"Failed to store prefix cache after chunked "
@@ -2979,17 +3145,31 @@ def install_chunked_prefill_mllm(
                         cached_kv = None
                         remaining_ids = None
 
+                prepared_cache = None
+                if cached_kv is not None and remaining_ids:
+                    prepared_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    if (
+                        prepared_cache is None
+                        or not batch_gen._prepare_rotating_caches(prepared_cache)
+                    ):
+                        cached_kv = None
+                        remaining_ids = None
+                        prepared_cache = None
+                elif cached_kv is not None and not remaining_ids:
+                    prepared_cache = batch_gen._rewind_prefix_cache(cached_kv, 1)
+                    if prepared_cache is None:
+                        cached_kv = None
+
                 if cached_kv is not None and remaining_ids:
                     # Prefix cache hit
-                    request_cache = batch_gen._copy_prefix_cache(cached_kv)
-                    batch_gen._trim_rotating_caches(request_cache)
+                    request_cache = prepared_cache
                     remaining = mx.array(remaining_ids)[None, :]
                     cached_count = total_tokens - len(remaining_ids)
                     remaining_count = len(remaining_ids)
                 elif cached_kv is not None and not remaining_ids:
                     # Exact hit — trim cache by 1 so replaying the last token
                     # produces correct logits (same as _process_prompts path).
-                    request_cache = _trim_cache_offset(cached_kv, 1)
+                    request_cache = prepared_cache
                     remaining = input_ids[:, -1:]
                     cached_count = total_tokens - 1
                     remaining_count = 1

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1095,18 +1095,6 @@ class MLLMBatchGenerator:
                 yield cache
 
     @classmethod
-    def _cache_storage_is_accounted(cls, cache_list) -> bool:
-        """Return whether MemoryAwarePrefixCache can account this topology.
-
-        Its current estimator treats each top-level layer state as one KV pair
-        and does not recurse through CacheList. Until shared recursive
-        accounting lands, storing a nested container would bypass the byte cap.
-        Reads remain supported so existing entries can be handled safely.
-        """
-        cache_lists, _, _ = cls._cache_class_families()
-        return not any(isinstance(cache, cache_lists) for cache in cache_list)
-
-    @classmethod
     def _has_empty_rotating_cache(cls, cache_list):
         """Check if any RotatingKVCache layer has no data (keys=None).
 
@@ -2108,14 +2096,6 @@ class MLLMBatchGenerator:
     ) -> bool:
         """Store an isolated, key-aligned cache snapshot when rewind is safe."""
         if self.prefix_cache is None:
-            return False
-        if not self._cache_storage_is_accounted(cache):
-            logger.debug(
-                "Skipping %s prefix cache store for %s: nested cache "
-                "memory is not recursively accounted",
-                source,
-                request_id,
-            )
             return False
         snapshot = self._rewind_prefix_cache(cache, trim_by)
         if snapshot is None:


### PR DESCRIPTION
## Summary

MLLM completion caching could rewind saturated sliding-window state after the prompt tokens had already been overwritten, then store that cache under the prompt key. Exact and prefix hits could later reuse desynchronized KV state. Nested `CacheList` wrappers were also copied by reference, so live generation could mutate stored entries.

This change makes cache reuse type-aware, isolated, and fail-closed:

- recursively clones both `mlx_lm` and `mlx_vlm` cache families while sharing immutable MLX tensors;
- preserves type-specific state for `ChunkedKVCache` and rotating caches;
- uses each cache implementation's native trim contract and requires the full rewind;
- rejects saturated or inconsistent rotating state instead of storing or reusing it;
- applies the same policy to canonical and interleaved exact, partial, and completion-store paths;
- preserves absolute rotating offsets while normalizing oversized plain rotating buffers;
- rejects nested `CacheList` writes until `MemoryAwarePrefixCache` can account their memory recursively, while retaining safe reads;
- bumps persisted cache semantics to v4 so pre-fix v3 snapshots are discarded after upgrade.

The hot path copies Python cache wrappers only. MLX arrays remain shared, so this does not duplicate KV tensor storage.

## Validation

- Full suite: 2313 passed, 24 skipped, 23 deselected
- Focused cache/MLLM suite: 156 passed, 4 deselected
- Combined with #680 exact head: 162 passed, 4 deselected
- Black, Ruff, and `git diff --check`: clean
- Independent review: approved with no remaining P0/P1/P2 findings

## Merge gates

- Depends on #680. Merge #680 first, then rebase and rerun the combined cache suite at the final head.
- Nested cache storage remains intentionally disabled until recursive byte accounting is implemented in the shared memory cache.

Refs #689
