### PR TITLE
Fix integration test opt-in

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--server-url",
         action="store",
-        default="http://localhost:8000",
+        default=None,
         help="URL of the vllm-mlx server for integration tests",
     )
     parser.addoption(
@@ -33,17 +33,25 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Skip slow tests unless --run-slow is passed."""
+    server_url = config.getoption("--server-url")
     if not config.getoption("--run-slow"):
         skip_slow = pytest.mark.skip(reason="Need --run-slow option to run")
         for item in items:
-            if "slow" in item.keywords:
+            # Supplying an integration server is an explicit opt-in to the
+            # integration suite, including tests that are also marked slow.
+            if item.get_closest_marker("slow") is not None and not (
+                server_url and item.get_closest_marker("integration") is not None
+            ):
                 item.add_marker(skip_slow)
 
     # Skip integration tests unless server URL is explicitly provided
-    skip_integration = pytest.mark.skip(reason="Integration tests require --server-url")
-    for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_integration)
+    if not server_url:
+        skip_integration = pytest.mark.skip(
+            reason="Integration tests require --server-url"
+        )
+        for item in items:
+            if item.get_closest_marker("integration") is not None:
+                item.add_marker(skip_integration)
 
 
 @pytest.fixture(scope="session")

--- a/tests/server_integration_helpers.py
+++ b/tests/server_integration_helpers.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers shared by external server integration tests."""
+
+
+def get_chat_completion_payload(requests, server_url):
+    """Build a chat payload using the model ID advertised by the server."""
+    response = requests.get(f"{server_url}/v1/models", timeout=5)
+    assert response.status_code == 200
+
+    models = response.json().get("data", [])
+    assert models
+    model_name = models[0].get("id")
+    assert model_name
+
+    return {
+        "model": model_name,
+        "messages": [{"role": "user", "content": "Say hello"}],
+        "max_tokens": 10,
+    }

--- a/tests/test_collection_policy.py
+++ b/tests/test_collection_policy.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for opt-in integration-test collection."""
+
+from tests import conftest
+
+
+class _Config:
+    def __init__(self, *, server_url=None, run_slow=False):
+        self.options = {"--server-url": server_url, "--run-slow": run_slow}
+
+    def getoption(self, name):
+        return self.options[name]
+
+
+class _Item:
+    def __init__(self, *keywords):
+        self.keywords = dict.fromkeys(keywords, True)
+        self.markers = []
+
+    def add_marker(self, marker):
+        self.markers.append(marker)
+
+    def get_closest_marker(self, name):
+        return name if name in self.keywords else None
+
+
+def test_explicit_server_url_enables_all_integration_tests():
+    items = [_Item("integration"), _Item("integration", "slow")]
+
+    conftest.pytest_collection_modifyitems(
+        _Config(server_url="http://localhost:8000"), items
+    )
+
+    assert [item.markers for item in items] == [[], []]
+
+
+def test_integration_tests_remain_skipped_without_server_url():
+    item = _Item("integration")
+
+    conftest.pytest_collection_modifyitems(_Config(), [item])
+
+    assert len(item.markers) == 1
+    assert item.markers[0].mark.name == "skip"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3736,11 +3736,9 @@ class TestServerIntegration:
         """Test /v1/chat/completions endpoint."""
         import requests
 
-        payload = {
-            "model": "default",
-            "messages": [{"role": "user", "content": "Say hello"}],
-            "max_tokens": 10,
-        }
+        from tests.server_integration_helpers import get_chat_completion_payload
+
+        payload = get_chat_completion_payload(requests, server_url)
 
         response = requests.post(
             f"{server_url}/v1/chat/completions",

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused regressions for external server integration requests."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from tests.server_integration_helpers import get_chat_completion_payload
+
+
+def test_chat_completion_uses_model_advertised_by_models_endpoint():
+    """The chat integration request must use the server's advertised model ID."""
+    models_response = SimpleNamespace(
+        status_code=200,
+        json=lambda: {"data": [{"id": "served-model"}]},
+    )
+    requests = SimpleNamespace(
+        get=Mock(return_value=models_response),
+    )
+
+    request_payload = get_chat_completion_payload(requests, "http://localhost:8000")
+
+    requests.get.assert_called_once_with("http://localhost:8000/v1/models", timeout=5)
+    assert request_payload["model"] == "served-model"


### PR DESCRIPTION
## What changed

- Treat an explicitly supplied `--server-url` as the integration-suite opt-in.
- Allow integration tests that are also marked slow to run under that opt-in.
- Query actual pytest markers instead of keyword/path membership.

## Root cause

The collection hook unconditionally attached a skip marker to every integration test. It also used `item.keywords`, which can contain parent/path keywords and caused false marker matches.

## Validation

- `pytest -q tests/test_collection_policy.py`
- `pytest -q -m integration --server-url http://localhost:8000 --setup-plan` selects and schedules all five documented tests.

