### PR TITLE
Restore paged-cache bulk release API

### DIFF
--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -163,6 +163,18 @@ class TestPagedCacheManager:
         # Block should be back in free queue
         assert manager.free_blocks == initial_free
 
+    def test_free_block_batch_is_callable_and_updates_free_count(self):
+        """Bulk release must not be shadowed by the free-block count property."""
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=64, max_blocks=10)
+        blocks = [manager.allocate_block(), manager.allocate_block()]
+        assert manager.free_blocks == 7
+
+        manager.free_block_batch(blocks)
+
+        assert manager.free_blocks == 9
+
     def test_reference_counting(self):
         """Test reference counting."""
         from vllm_mlx.paged_cache import PagedCacheManager

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -664,7 +664,7 @@ class PagedCacheManager:
 
             return False
 
-    def free_blocks(self, blocks: Iterable[CacheBlock]) -> None:
+    def free_block_batch(self, blocks: Iterable[CacheBlock]) -> None:
         """
         Free multiple blocks (vLLM style).
 


### PR DESCRIPTION
## What changed

- Restore a callable bulk block-release operation as `free_block_batch()`.
- Add regression coverage for releasing multiple blocks and updating the free count.

## Root cause

`PagedCacheManager.free_blocks(blocks)` was overwritten later in the same class by the integer `free_blocks` property. The method therefore did not exist at runtime.

## Validation

- `pytest -q tests/test_paged_cache.py` — 42 passed.

