### PR TITLE
Fail invalid multimodal inputs atomically

### DIFF
--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -42,6 +42,21 @@ def test_create_chat_function_uses_default_served_model_name(monkeypatch):
     assert captured["json"]["model"] == "default"
 
 
+def test_chat_function_does_not_print_prompt_or_file_details(monkeypatch, capsys):
+    monkeypatch.setattr(
+        gradio_app.requests, "post", lambda *args, **kwargs: DummyResponse("ok")
+    )
+    chat_fn = gradio_app.create_chat_function(
+        server_url="http://localhost:8000",
+        max_tokens=16,
+        temperature=0.0,
+    )
+
+    assert chat_fn({"text": "private prompt", "files": []}, history=[]) == "ok"
+    captured = capsys.readouterr()
+    assert "private prompt" not in captured.out
+
+
 def test_create_chat_function_uses_configured_served_model_name(monkeypatch):
     captured = {}
 

--- a/tests/test_mllm.py
+++ b/tests/test_mllm.py
@@ -120,6 +120,56 @@ class TestMLLMHelperFunctions:
         assert not is_base64_image("https://example.com/image.jpg")
         assert not is_base64_image("/path/to/image.jpg")
 
+    def test_remote_media_log_does_not_expose_signed_url(self, monkeypatch, caplog):
+        import logging
+        import requests
+
+        from vllm_mlx.models import mllm
+
+        signed_url = "https://example.com/media.png?token=super-secret"
+
+        def fail_request(*args, **kwargs):
+            raise requests.Timeout("offline")
+
+        monkeypatch.setattr(mllm, "_request_with_safe_redirects", fail_request)
+        with caplog.at_level(logging.INFO), pytest.raises(requests.Timeout):
+            mllm._download_media(signed_url, "image", {"png": ".png"}, ".png", 1, 1024)
+
+        assert "super-secret" not in caplog.text
+        assert signed_url not in caplog.text
+
+
+class TestMLLMMediaAndHelperFunctions:
+    def test_invalid_image_fails_request_instead_of_becoming_text_only(
+        self, monkeypatch
+    ):
+        from vllm_mlx.models import mllm
+
+        model = mllm.MLXMultimodalLM.__new__(mllm.MLXMultimodalLM)
+        monkeypatch.setattr(
+            mllm,
+            "process_image_input",
+            lambda image: (_ for _ in ()).throw(ValueError("invalid image")),
+        )
+
+        with pytest.raises(ValueError, match="invalid image"):
+            model._prepare_images(["bad-image"])
+
+    def test_invalid_audio_fails_request_instead_of_becoming_text_only(
+        self, monkeypatch
+    ):
+        from vllm_mlx.models import mllm
+
+        model = mllm.MLXMultimodalLM.__new__(mllm.MLXMultimodalLM)
+        monkeypatch.setattr(
+            mllm,
+            "process_audio_input",
+            lambda audio: (_ for _ in ()).throw(ValueError("invalid audio")),
+        )
+
+        with pytest.raises(ValueError, match="invalid audio"):
+            model._prepare_audio(["bad-audio"])
+
     def test_is_base64_video(self):
         """Test base64 video detection."""
         from vllm_mlx.models.mllm import is_base64_video

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -535,6 +535,19 @@ class TestMultimodalProcessorBatch:
         result = processor.batch_pixel_values([None, None])
         assert result is None
 
+    def test_process_rejects_invalid_image_atomically(self, monkeypatch):
+        from vllm_mlx import multimodal_processor
+
+        processor = multimodal_processor.MultimodalProcessor(MagicMock(), MagicMock())
+        monkeypatch.setattr(
+            multimodal_processor,
+            "process_image_input",
+            lambda image: (_ for _ in ()).throw(ValueError("invalid image")),
+        )
+
+        with pytest.raises(ValueError, match="invalid image"):
+            processor.process("Describe", images=["bad-image"])
+
     def test_batch_pixel_values_single(self):
         """Test batching single pixel value."""
         from vllm_mlx.multimodal_processor import MultimodalProcessor
@@ -1741,6 +1754,29 @@ class TestPreprocessIdempotent:
 
         # Should NOT return early — will try to import prepare_inputs
         with pytest.raises(Exception):
+            gen._preprocess_request(req)
+
+    def test_invalid_media_fails_batched_preprocessing(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+        from vllm_mlx.models import mllm
+
+        req = MLLMBatchRequest(
+            uid=0,
+            prompt="Describe",
+            request_id="bad-media",
+            images=["bad-image"],
+        )
+        gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        monkeypatch.setattr(
+            mllm,
+            "process_image_input",
+            lambda image: (_ for _ in ()).throw(ValueError("invalid image")),
+        )
+
+        with pytest.raises(ValueError, match="invalid image"):
             gen._preprocess_request(req)
 
 

--- a/vllm_mlx/benchmark.py
+++ b/vllm_mlx/benchmark.py
@@ -1060,7 +1060,7 @@ def download_video(url: str, timeout: int = 120) -> str:
     """Download video from URL and return local path."""
     headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"}
 
-    print(f"  Downloading video from: {url[:60]}...")
+    print("  Downloading remote video...")
     response = requests.get(url, timeout=timeout, headers=headers, stream=True)
     response.raise_for_status()
 

--- a/vllm_mlx/gradio_app.py
+++ b/vllm_mlx/gradio_app.py
@@ -146,14 +146,6 @@ def create_chat_function(
         text = message.get("text", "") if isinstance(message, dict) else message
         files = message.get("files", []) if isinstance(message, dict) else []
 
-        # Debug output
-        import sys
-
-        print(f"[Chat] Text: {text!r}", flush=True)
-        print(f"[Chat] Files: {files}", flush=True)
-        print(f"[Chat] History length: {len(history)}", flush=True)
-        sys.stdout.flush()
-
         # Build messages list for API
         messages = []
 
@@ -221,15 +213,6 @@ def create_chat_function(
                     )
             if media_items:
                 media_cache[current_idx] = media_items
-                print(
-                    f"[Chat] Cached {len(media_items)} media items for message {current_idx}",
-                    flush=True,
-                )
-
-        # Debug
-        print(f"[Chat] Sending {len(messages)} messages to server")
-        if isinstance(current_content, list):
-            print(f"[Chat] Content types: {[c.get('type') for c in current_content]}")
 
         # Send request to server
         try:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -902,11 +902,7 @@ class MLLMBatchGenerator:
             from .models.mllm import process_image_input
 
             for img in request.images:
-                try:
-                    path = process_image_input(img)
-                    all_images.append(path)
-                except Exception as e:
-                    logger.warning(f"Failed to process image: {e}")
+                all_images.append(process_image_input(img))
 
         if request.videos:
             from .models.mllm import (
@@ -918,27 +914,20 @@ class MLLMBatchGenerator:
             )
 
             for video in request.videos:
-                try:
-                    video_path = process_video_input(video)
-                    frames = extract_video_frames_smart(
-                        video_path,
-                        fps=DEFAULT_FPS,
-                        max_frames=MAX_FRAMES,
-                    )
-                    frame_paths = save_frames_to_temp(frames)
-                    all_images.extend(frame_paths)
-                except Exception as e:
-                    logger.warning(f"Failed to process video: {e}")
+                video_path = process_video_input(video)
+                frames = extract_video_frames_smart(
+                    video_path,
+                    fps=DEFAULT_FPS,
+                    max_frames=MAX_FRAMES,
+                )
+                frame_paths = save_frames_to_temp(frames)
+                all_images.extend(frame_paths)
 
         if request.audio:
             from .models.mllm import process_audio_input
 
             for audio in request.audio:
-                try:
-                    path = process_audio_input(audio)
-                    all_audio.append(path)
-                except Exception as e:
-                    logger.warning(f"Failed to process audio: {e}")
+                all_audio.append(process_audio_input(audio))
 
         # Check pixel cache first
         cached_pixels = None

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -680,7 +680,9 @@ def _download_media(
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
     }
 
-    logger.info(f"Downloading {media_type} from: {url}")
+    # URLs may contain credentials or signed query parameters. Keep request
+    # targets out of normal logs while retaining useful operation context.
+    logger.info("Downloading remote %s", media_type)
 
     try:
         head_response = _request_with_safe_redirects(
@@ -1404,25 +1406,11 @@ class MLXMultimodalLM:
 
     def _prepare_images(self, images: list) -> list[str]:
         """Process remote/base64 image inputs into local temp file paths."""
-        processed = []
-        for img in images:
-            try:
-                path = process_image_input(img)
-                processed.append(path)
-            except Exception as e:
-                logger.warning(f"Failed to process image: {e}")
-        return processed
+        return [process_image_input(image) for image in images]
 
     def _prepare_audio(self, audio_inputs: list) -> list[str]:
         """Process audio inputs and return local file paths."""
-        processed = []
-        for audio_input in audio_inputs:
-            try:
-                path = process_audio_input(audio_input)
-                processed.append(path)
-            except Exception as e:
-                logger.warning(f"Failed to process audio: {e}")
-        return processed
+        return [process_audio_input(audio_input) for audio_input in audio_inputs]
 
     def _prepare_video(
         self,

--- a/vllm_mlx/multimodal_processor.py
+++ b/vllm_mlx/multimodal_processor.py
@@ -124,27 +124,20 @@ class MultimodalProcessor:
         all_images = []
         if images:
             for img in images:
-                try:
-                    path = process_image_input(img)
-                    all_images.append(path)
-                except Exception as e:
-                    logger.warning(f"Failed to process image: {e}")
+                all_images.append(process_image_input(img))
 
         # Extract frames from videos
         if videos:
             for video in videos:
-                try:
-                    video_path = process_video_input(video)
-                    frames = extract_video_frames_smart(
-                        video_path,
-                        fps=video_fps,
-                        max_frames=video_max_frames,
-                    )
-                    frame_paths = save_frames_to_temp(frames)
-                    all_images.extend(frame_paths)
-                    logger.debug(f"Extracted {len(frame_paths)} frames from video")
-                except Exception as e:
-                    logger.warning(f"Failed to process video: {e}")
+                video_path = process_video_input(video)
+                frames = extract_video_frames_smart(
+                    video_path,
+                    fps=video_fps,
+                    max_frames=video_max_frames,
+                )
+                frame_paths = save_frames_to_temp(frames)
+                all_images.extend(frame_paths)
+                logger.debug(f"Extracted {len(frame_paths)} frames from video")
 
         # Determine add_special_tokens based on model type
         if self.config and self.config.model_type in ["gemma3", "gemma3n"]:


### PR DESCRIPTION
## What changed

- Make multimodal preprocessing request-atomic across the direct `MLXMultimodalLM`, shared `MultimodalProcessor`, and continuous-batching paths.
- If any requested image, audio, or video item cannot be resolved, decoded, or prepared, preprocessing raises instead of silently dropping that item and continuing with a partial media set.
- Preserve per-request isolation in continuous batching. `_preprocess_request` is already wrapped by request-level error handling at all three batch-preprocessing call sites. A failed request is removed from the batch and receives an error result; other requests continue. One bad attachment therefore cannot fail or poison the shared batch.
- Remove unconditional Gradio prompt/file debug output.
- Stop logging remote media URLs, including signed query parameters, at normal INFO level.

## Root cause

Media items were previously processed inside broad per-item exception handlers that logged the failure and continued. That could leave a request with only some of its requested attachments, or with no usable media, while inference proceeded without telling the caller that the input had changed.

This change makes preprocessing all-or-error for the affected request. “Atomic” here means that generation does not start with an incomplete media set; it does not promise a particular HTTP status code.

## Batch isolation

The batched scheduler retains its existing per-request protection around `_preprocess_request`:

- failed requests are collected and removed before the batch is formed;
- each failed request receives a request-level error result;
- unrelated requests in the same batch remain eligible to continue.

The change removes the inner per-item catches so an invalid attachment cannot be converted into a plausible answer to a different, silently modified request.

## Observed deployment behavior

On the current batched `--mllm` deployment, corrupt-media probes did not produce a successful partial-media answer. The observed wire results were:

```text
one corrupt image             -> HTTP 200, content=null, finish_reason="error"
one valid + one corrupt image -> HTTP 200, content="",   finish_reason="error"
```

This PR moves media validation ahead of model work, but it does not itself change the existing HTTP status mapping to `4xx`. In particular, it does not claim that every invalid-media request will return a `4xx` response.

The direct and Gradio entry points still need independent end-to-end verification of exception-to-response serialization and any remaining partial-media behavior. The batched observation above does not certify those paths or imply that every route returns the same status and payload.

## Validation

- `pytest -q tests/test_gradio_app.py tests/test_mllm.py tests/test_mllm_continuous_batching.py`
  - `86 passed, 10 deselected`
- Coverage includes invalid image, audio, shared-processor, and batched-preprocessing failures.
- Coverage verifies that Gradio no longer prints private prompt/file details.
- Coverage verifies that signed remote media URLs are absent from normal logs.
- CI: lint, type-check, Python test matrix, Apple Silicon tests, and aggregate tests pass.

## Explicit non-claims

- This PR does not promise a universal `4xx` response for invalid media.
- This PR does not claim that direct or Gradio paths have the same wire-level behavior as the batched deployment.
- This PR does not claim that every route normalizes invalid-media failures to one identical status or payload.
- Valid media requests retain their existing processing behavior.
