### PR TITLE
feat(registry): reconcile manager memory budget with the Metal allocation ceiling

### DIFF
--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -116,38 +116,50 @@ The invariant to maintain is:
 
 ```
 memory_budget_gb  <=  gpu_memory_utilization x device_RAM
-                      - cache_memory_mb
                       - KV/activation headroom
+                      - prefix cache actually resident
 ```
 
-The server reconciles the first three terms at startup and logs them:
+The server reconciles the two process-wide terms at startup and logs them
+together with the prefix-cache setting:
 
 ```
 Registry memory budget: 68.0 GB of model weights; Metal allocation ceiling
-64.0 GB (50% of 128.0 GB, from serve default); prefix-cache reservation
-20.0 GB (--cache-memory-mb)
+64.0 GB (50% of 128.0 GB, from serve default); prefix-cache maximum
+20.0 GB per continuous-batching engine (--cache-memory-mb, 2 of 3 entries)
 ```
 
-When the declared budget does not fit below the ceiling, startup emits a
-warning naming the largest budget that would:
+When the weights budget alone does not fit below the ceiling, startup warns:
 
 ```
-WARNING models-config manager.memory_budget_gb (68.0 GB) exceeds the memory
-actually allocatable for model weights (44.0 GB). ...
+WARNING models-config manager.memory_budget_gb (68.0 GB) exceeds the Metal
+allocation ceiling (64.0 GB). ...
 ```
 
 This is a diagnostic, not a clamp — the server still starts with the budget you
-configured. KV and activation headroom are workload-dependent, so the reported
-figure is an upper bound, not a safe target: leave margin below it.
+configured. It is also a *necessary, not sufficient* condition: passing the
+check does not mean you will not run out of memory, because the KV cache,
+prefix cache and activations all come out of the same ceiling and are
+workload-dependent. Treat the ceiling as an upper bound and leave real margin
+below it.
 
-Notes on how the ceiling is computed:
+Notes on how the check is computed:
 
 - A per-entry `gpu_memory_utilization` override re-installs the process-wide
   Metal limits whenever that model loads, so the check uses the *lowest*
   effective utilization across the serve default and every registry entry.
-- `--cache-memory-mb` is subtracted when set. The default
-  `--cache-memory-percent` reservation scales with available RAM at runtime and
-  is reported but not subtracted.
+- The conflict check compares **only** the weights budget against the ceiling,
+  because both are process-wide totals and therefore directly comparable.
+- `--cache-memory-mb` is **not** subtracted from the ceiling. It is a per-engine
+  maximum: it is cloned into each resident continuous-batching engine and
+  allocated lazily, and simple-mode entries never receive it at all. Subtracting
+  it once would understate capacity with one resident model and overstate it
+  with several, so it is reported next to the ceiling rather than folded into
+  it. It is reported only when it can actually bind — that is, for
+  continuous-batching entries using the memory-aware prefix cache (not
+  `--use-paged-cache`).
+- A separate warning fires when `--cache-memory-mb` alone is at or above the
+  ceiling, which is a configuration error in its own right.
 - On hosts where MLX cannot report a Metal working-set size, the check reports
   that the budget could not be reconciled and issues no warning.
 

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -84,14 +84,72 @@ models:
 
 Total resident-model budget for the registry manager.
 
-This is the eviction budget, not the full system RAM size. Leave headroom for:
+**This budget counts model weights only.** It is the number the manager compares
+against when deciding whether a new model fits or an idle one must be evicted.
+It does not include, and does not reserve room for:
 
 - KV cache
-- request batching
+- activations during prefill and decode
 - OS / filesystem cache
 - other colocated services
 
 On a 128 GB machine, a practical starting point is often `80-100 GB`.
+
+### Budget vs. the Metal allocation ceiling
+
+The manager budget and the MLX allocation ceiling are two separate numbers, and
+the budget does not derive from the ceiling. The ceiling is installed at engine
+start from `--gpu-memory-utilization`:
+
+```
+allocation_ceiling = gpu_memory_utilization x device_working_set_size
+```
+
+The weights *plus* the KV cache *plus* activations all have to fit under that
+ceiling, while the budget only accounts for the weights. If the budget is set
+above what is actually allocatable, the manager's arithmetic says N models fit,
+it keeps them all resident, and MLX hits the ceiling — so you get a hard
+out-of-memory failure instead of the graceful eviction the budget exists to
+provide.
+
+The invariant to maintain is:
+
+```
+memory_budget_gb  <=  gpu_memory_utilization x device_RAM
+                      - cache_memory_mb
+                      - KV/activation headroom
+```
+
+The server reconciles the first three terms at startup and logs them:
+
+```
+Registry memory budget: 68.0 GB of model weights; Metal allocation ceiling
+64.0 GB (50% of 128.0 GB, from serve default); prefix-cache reservation
+20.0 GB (--cache-memory-mb)
+```
+
+When the declared budget does not fit below the ceiling, startup emits a
+warning naming the largest budget that would:
+
+```
+WARNING models-config manager.memory_budget_gb (68.0 GB) exceeds the memory
+actually allocatable for model weights (44.0 GB). ...
+```
+
+This is a diagnostic, not a clamp — the server still starts with the budget you
+configured. KV and activation headroom are workload-dependent, so the reported
+figure is an upper bound, not a safe target: leave margin below it.
+
+Notes on how the ceiling is computed:
+
+- A per-entry `gpu_memory_utilization` override re-installs the process-wide
+  Metal limits whenever that model loads, so the check uses the *lowest*
+  effective utilization across the serve default and every registry entry.
+- `--cache-memory-mb` is subtracted when set. The default
+  `--cache-memory-percent` reservation scales with available RAM at runtime and
+  is reported but not subtracted.
+- On hosts where MLX cannot report a Metal working-set size, the check reports
+  that the budget could not be reconciled and issues no warning.
 
 ### `contention_policy`
 
@@ -141,6 +199,18 @@ For deterministic eviction behavior:
 - non-local model ids should set `estimated_memory_gb`
 
 If a registry entry points at a non-local source and no `estimated_memory_gb` is provided, startup will reject the config. This prevents the manager from making bad eviction decisions from guesswork.
+
+Both sizing paths are **weight estimates, not total runtime memory**:
+
+- for a local source, the estimate is the summed on-disk size of the entry's
+  `.safetensors` / `.gguf` files
+- for a declared model id, the estimate is the operator-supplied
+  `estimated_memory_gb`
+
+Neither includes KV cache or activations, so a model's real peak footprint is
+larger than the number the manager charges against `memory_budget_gb`. Size the
+budget with that gap in mind — see
+[Budget vs. the Metal allocation ceiling](#budget-vs-the-metal-allocation-ceiling).
 
 ## Request Routing
 
@@ -204,6 +274,8 @@ Then repeat with a second model id to verify:
 
 - Bad or missing `estimated_memory_gb` on non-local sources: config load failure
 - Too-small `memory_budget_gb`: repeated capacity failures or unnecessary preemption
+- Too-large `memory_budget_gb` relative to `--gpu-memory-utilization`: MLX
+  out-of-memory instead of eviction (the startup log warns about this)
 - Over-aggressive `preempt` policy: active requests get cancelled during model swaps
 - Too many `preload: true` entries: startup load storm and immediate budget pressure
 

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -145,9 +145,17 @@ below it.
 
 Notes on how the check is computed:
 
-- A per-entry `gpu_memory_utilization` override re-installs the process-wide
-  Metal limits whenever that model loads, so the check uses the *lowest*
-  effective utilization across the serve default and every registry entry.
+- The Metal limit is installed only by continuous-batching entries — that is the
+  one path calling `mx.set_memory_limit`, and simple-mode entries are not even
+  constructed with a `gpu_memory_utilization`. The check therefore considers
+  only the effective utilization of continuous-batching entries, taking the
+  *lowest*, since each such load re-installs the process-wide limit. A
+  `gpu_memory_utilization` set on a simple-mode entry has no effect on the
+  ceiling and is ignored here.
+- A registry with no continuous-batching entries gets **no** attributed ceiling:
+  nothing installs one, so the report says so rather than deriving a figure from
+  a value that is never applied. The serve default likewise only competes when
+  some continuous-batching entry actually inherits it.
 - The conflict check compares **only** the weights budget against the ceiling,
   because both are process-wide totals and therefore directly comparable.
 - `--cache-memory-mb` is **not** subtracted from the ceiling. It is a per-engine

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -289,7 +290,6 @@ def test_budget_report_flags_budget_above_allocation_ceiling(tmp_path):
     )
 
     assert report.allocation_ceiling_bytes == 64 * GB
-    assert report.weights_headroom_bytes == 64 * GB
     assert report.exceeds_ceiling
 
 
@@ -304,35 +304,113 @@ def test_budget_report_accepts_budget_under_ceiling(tmp_path):
     assert not report.exceeds_ceiling
 
 
-def test_budget_report_subtracts_explicit_cache_reservation(tmp_path):
-    """--cache-memory-mb is carved out of the ceiling before the weights fit-check."""
+def test_cache_limit_is_reported_per_engine_not_subtracted_once(tmp_path):
+    """--cache-memory-mb is a per-engine maximum, so it never moves the fit-check.
+
+    It is cloned into each resident continuous-batching engine, so it is neither
+    a single process-wide reservation nor a subtractable bound.
+    """
     from vllm_mlx.scheduler import SchedulerConfig
 
     registry = _registry(tmp_path, {"alpha": 32})
     ceiling_gb = 64  # 0.5 x 128 GB
 
-    fits = build_memory_budget_report(
-        _manager_config(budget_gb=ceiling_gb - 1),
-        registry,
-        _defaults_with(gpu_memory_utilization=0.5, scheduler_config=SchedulerConfig()),
-        device_working_set_bytes=128 * GB,
-    )
-    assert fits.cache_reservation_bytes is None
-    assert fits.cache_reservation_percent == pytest.approx(0.20)
-    assert not fits.exceeds_ceiling
-
-    reserved = build_memory_budget_report(
+    without_cache = build_memory_budget_report(
         _manager_config(budget_gb=ceiling_gb - 1),
         registry,
         _defaults_with(
             gpu_memory_utilization=0.5,
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+    assert without_cache.per_engine_cache_limit_bytes is None
+    assert without_cache.per_engine_cache_percent == pytest.approx(0.20)
+    assert not without_cache.exceeds_ceiling
+
+    with_cache = build_memory_budget_report(
+        _manager_config(budget_gb=ceiling_gb - 1),
+        registry,
+        _defaults_with(
+            gpu_memory_utilization=0.5,
+            continuous_batching=True,
             scheduler_config=SchedulerConfig(cache_memory_mb=20480),
         ),
         device_working_set_bytes=128 * GB,
     )
-    assert reserved.cache_reservation_bytes == 20 * GB
-    assert reserved.weights_headroom_bytes == (ceiling_gb - 20) * GB
-    assert reserved.exceeds_ceiling
+    assert with_cache.per_engine_cache_limit_bytes == 20 * GB
+    # The budget still fits: the cache limit does not shrink the weight capacity.
+    assert not with_cache.exceeds_ceiling
+    assert not with_cache.cache_limit_exceeds_ceiling
+
+
+def test_cache_limit_ignored_for_simple_mode_entries(tmp_path):
+    """SimpleEngine never receives scheduler_config, so the cap does not apply."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        _registry(tmp_path, {"alpha": 8}),
+        _defaults_with(
+            continuous_batching=False,
+            scheduler_config=SchedulerConfig(cache_memory_mb=20480),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 0
+    assert report.total_entries == 1
+    assert report.per_engine_cache_limit_bytes is None
+    assert report.per_engine_cache_percent is None
+
+
+def test_cache_limit_ignored_when_paged_cache_supersedes_it(tmp_path):
+    """cache_memory_mb only binds for the memory-aware prefix cache."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        _registry(tmp_path, {"alpha": 8}),
+        _defaults_with(
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(
+                cache_memory_mb=20480, use_paged_cache=True
+            ),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 1
+    assert report.per_engine_cache_limit_bytes is None
+
+
+def test_cache_limit_above_ceiling_warns_without_negative_numbers(tmp_path, caplog):
+    """Regression: an 8 GiB ceiling with a 20 GiB cache cap must not report -12 GiB."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=4),
+        _registry(tmp_path, {"alpha": 2}),
+        _defaults_with(
+            gpu_memory_utilization=0.5,
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(cache_memory_mb=20480),
+        ),
+        device_working_set_bytes=16 * GB,
+    )
+
+    assert report.allocation_ceiling_bytes == 8 * GB
+    assert report.cache_limit_exceeds_ceiling
+    # The weights budget itself still fits under the ceiling.
+    assert not report.exceeds_ceiling
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(report)
+
+    assert "is at or above the Metal allocation ceiling" in caplog.text
+    # No negative quantity may ever reach the operator (the -12 GiB regression).
+    assert not re.search(r"-\d", caplog.text)
 
 
 def test_budget_report_uses_tightest_per_entry_utilization(tmp_path):
@@ -353,6 +431,29 @@ def test_budget_report_uses_tightest_per_entry_utilization(tmp_path):
     assert report.exceeds_ceiling
 
 
+def test_budget_report_ignores_cache_limit_in_the_fit_check(tmp_path):
+    """The deterministic check compares process-wide quantities only."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 32})
+    args = dict(gpu_memory_utilization=0.5, continuous_batching=True)
+
+    bare = build_memory_budget_report(
+        _manager_config(budget_gb=63),
+        registry,
+        _defaults_with(**args, scheduler_config=SchedulerConfig()),
+        device_working_set_bytes=128 * GB,
+    )
+    capped = build_memory_budget_report(
+        _manager_config(budget_gb=63),
+        registry,
+        _defaults_with(**args, scheduler_config=SchedulerConfig(cache_memory_mb=20480)),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert bare.exceeds_ceiling == capped.exceeds_ceiling is False
+
+
 def test_budget_report_is_inconclusive_without_device_memory(tmp_path, monkeypatch):
     """Non-Metal hosts get no false warning — the ceiling simply is not knowable."""
     monkeypatch.setattr(
@@ -365,8 +466,8 @@ def test_budget_report_is_inconclusive_without_device_memory(tmp_path, monkeypat
     )
 
     assert report.allocation_ceiling_bytes is None
-    assert report.weights_headroom_bytes is None
     assert not report.exceeds_ceiling
+    assert not report.cache_limit_exceeds_ceiling
 
 
 def test_log_memory_budget_report_warns_only_on_conflict(tmp_path, caplog):
@@ -378,7 +479,7 @@ def test_log_memory_budget_report_warns_only_on_conflict(tmp_path, caplog):
     )
     with caplog.at_level(logging.WARNING, logger="vllm_mlx.model_registry"):
         log_memory_budget_report(over)
-    assert "exceeds the memory actually allocatable" in caplog.text
+    assert "exceeds the Metal allocation ceiling" in caplog.text
     assert "64.0 GB" in caplog.text
 
     caplog.clear()
@@ -398,9 +499,10 @@ def test_log_memory_budget_report_reports_ceiling_and_cache(tmp_path, caplog):
 
     report = build_memory_budget_report(
         _manager_config(budget_gb=40),
-        _registry(tmp_path, {"alpha": 32}),
+        _registry(tmp_path, {"alpha": 32, "beta": 4}),
         _defaults_with(
             gpu_memory_utilization=0.5,
+            continuous_batching=True,
             scheduler_config=SchedulerConfig(cache_memory_mb=20480),
         ),
         device_working_set_bytes=128 * GB,
@@ -410,7 +512,8 @@ def test_log_memory_budget_report_reports_ceiling_and_cache(tmp_path, caplog):
 
     assert "Registry memory budget: 40.0 GB" in caplog.text
     assert "Metal allocation ceiling 64.0 GB" in caplog.text
-    assert "20.0 GB (--cache-memory-mb)" in caplog.text
+    assert "20.0 GB per continuous-batching engine" in caplog.text
+    assert "2 of 2 entries" in caplog.text
 
 
 def test_log_memory_budget_report_says_so_when_ceiling_unknown(

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +19,8 @@ from vllm_mlx.model_registry import (
     RegistryManagerConfig,
     RegistryServeDefaults,
     ResolvedModelConfig,
+    build_memory_budget_report,
+    log_memory_budget_report,
 )
 from vllm_mlx.utils.download import DownloadConfig
 
@@ -260,3 +264,171 @@ def test_non_local_registry_entry_requires_explicit_memory_estimate():
             await manager.acquire("remote")
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Memory budget vs Metal allocation ceiling reconciliation (issue #627)
+# ---------------------------------------------------------------------------
+
+
+GB = 1024**3
+
+
+def _defaults_with(**overrides: Any) -> RegistryServeDefaults:
+    base = _defaults()
+    return dataclasses.replace(base, **overrides)
+
+
+def test_budget_report_flags_budget_above_allocation_ceiling(tmp_path):
+    """A weights budget larger than gpu_memory_utilization x device RAM is a conflict."""
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=68),
+        _registry(tmp_path, {"alpha": 32}),
+        _defaults_with(gpu_memory_utilization=0.5),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.allocation_ceiling_bytes == 64 * GB
+    assert report.weights_headroom_bytes == 64 * GB
+    assert report.exceeds_ceiling
+
+
+def test_budget_report_accepts_budget_under_ceiling(tmp_path):
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=60),
+        _registry(tmp_path, {"alpha": 32}),
+        _defaults_with(gpu_memory_utilization=0.5),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert not report.exceeds_ceiling
+
+
+def test_budget_report_subtracts_explicit_cache_reservation(tmp_path):
+    """--cache-memory-mb is carved out of the ceiling before the weights fit-check."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 32})
+    ceiling_gb = 64  # 0.5 x 128 GB
+
+    fits = build_memory_budget_report(
+        _manager_config(budget_gb=ceiling_gb - 1),
+        registry,
+        _defaults_with(gpu_memory_utilization=0.5, scheduler_config=SchedulerConfig()),
+        device_working_set_bytes=128 * GB,
+    )
+    assert fits.cache_reservation_bytes is None
+    assert fits.cache_reservation_percent == pytest.approx(0.20)
+    assert not fits.exceeds_ceiling
+
+    reserved = build_memory_budget_report(
+        _manager_config(budget_gb=ceiling_gb - 1),
+        registry,
+        _defaults_with(
+            gpu_memory_utilization=0.5,
+            scheduler_config=SchedulerConfig(cache_memory_mb=20480),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+    assert reserved.cache_reservation_bytes == 20 * GB
+    assert reserved.weights_headroom_bytes == (ceiling_gb - 20) * GB
+    assert reserved.exceeds_ceiling
+
+
+def test_budget_report_uses_tightest_per_entry_utilization(tmp_path):
+    """A per-model override lowers the process-wide ceiling once that model loads."""
+    registry = _registry(tmp_path, {"alpha": 8, "beta": 8})
+    registry["beta"] = dataclasses.replace(registry["beta"], gpu_memory_utilization=0.4)
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=60),
+        registry,
+        _defaults_with(gpu_memory_utilization=0.9),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.gpu_memory_utilization == pytest.approx(0.4)
+    assert "beta" in report.gpu_memory_utilization_source
+    assert report.allocation_ceiling_bytes == int(0.4 * 128 * GB)
+    assert report.exceeds_ceiling
+
+
+def test_budget_report_is_inconclusive_without_device_memory(tmp_path, monkeypatch):
+    """Non-Metal hosts get no false warning — the ceiling simply is not knowable."""
+    monkeypatch.setattr(
+        "vllm_mlx.model_registry._device_working_set_bytes", lambda: None
+    )
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10_000),
+        _registry(tmp_path, {"alpha": 8}),
+        _defaults(),
+    )
+
+    assert report.allocation_ceiling_bytes is None
+    assert report.weights_headroom_bytes is None
+    assert not report.exceeds_ceiling
+
+
+def test_log_memory_budget_report_warns_only_on_conflict(tmp_path, caplog):
+    over = build_memory_budget_report(
+        _manager_config(budget_gb=68),
+        _registry(tmp_path, {"alpha": 32}),
+        _defaults_with(gpu_memory_utilization=0.5),
+        device_working_set_bytes=128 * GB,
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(over)
+    assert "exceeds the memory actually allocatable" in caplog.text
+    assert "64.0 GB" in caplog.text
+
+    caplog.clear()
+    under = build_memory_budget_report(
+        _manager_config(budget_gb=40),
+        _registry(tmp_path, {"beta": 32}),
+        _defaults_with(gpu_memory_utilization=0.5),
+        device_working_set_bytes=128 * GB,
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(under)
+    assert caplog.text == ""
+
+
+def test_log_memory_budget_report_reports_ceiling_and_cache(tmp_path, caplog):
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=40),
+        _registry(tmp_path, {"alpha": 32}),
+        _defaults_with(
+            gpu_memory_utilization=0.5,
+            scheduler_config=SchedulerConfig(cache_memory_mb=20480),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(report)
+
+    assert "Registry memory budget: 40.0 GB" in caplog.text
+    assert "Metal allocation ceiling 64.0 GB" in caplog.text
+    assert "20.0 GB (--cache-memory-mb)" in caplog.text
+
+
+def test_log_memory_budget_report_says_so_when_ceiling_unknown(
+    tmp_path, monkeypatch, caplog
+):
+    monkeypatch.setattr(
+        "vllm_mlx.model_registry._device_working_set_bytes", lambda: None
+    )
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=68),
+        _registry(tmp_path, {"alpha": 32}),
+        _defaults(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(report)
+
+    assert "cannot be reconciled" in caplog.text
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -21,6 +21,7 @@ from vllm_mlx.model_registry import (
     RegistryServeDefaults,
     ResolvedModelConfig,
     build_memory_budget_report,
+    load_registry_config,
     log_memory_budget_report,
 )
 from vllm_mlx.utils.download import DownloadConfig
@@ -117,6 +118,28 @@ def _registry(tmp_path: Path, sizes_gb: dict[str, float]) -> dict[str, Registere
             estimated_memory_bytes=int(size_gb * (1024**3)),
         )
     return registry
+
+
+@pytest.mark.parametrize("raw_value", [".nan", ".inf", "0", "-0.1", "1.1"])
+def test_registry_rejects_invalid_per_entry_gpu_memory_utilization(tmp_path, raw_value):
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(f"""
+manager:
+  memory_budget_gb: 8
+models:
+  - name: alpha
+    path: /tmp/alpha
+    gpu_memory_utilization: {raw_value}
+""")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"models-config entry 'alpha' gpu_memory_utilization must be finite "
+            r"and within \(0, 1\]"
+        ),
+    ):
+        load_registry_config(config_path, _defaults())
 
 
 def test_acquire_shares_single_inflight_load(tmp_path):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -285,7 +285,7 @@ def test_budget_report_flags_budget_above_allocation_ceiling(tmp_path):
     report = build_memory_budget_report(
         _manager_config(budget_gb=68),
         _registry(tmp_path, {"alpha": 32}),
-        _defaults_with(gpu_memory_utilization=0.5),
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
         device_working_set_bytes=128 * GB,
     )
 
@@ -297,10 +297,12 @@ def test_budget_report_accepts_budget_under_ceiling(tmp_path):
     report = build_memory_budget_report(
         _manager_config(budget_gb=60),
         _registry(tmp_path, {"alpha": 32}),
-        _defaults_with(gpu_memory_utilization=0.5),
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
         device_working_set_bytes=128 * GB,
     )
 
+    # Guard against passing vacuously: a ceiling must actually exist here.
+    assert report.allocation_ceiling_bytes == 64 * GB
     assert not report.exceeds_ceiling
 
 
@@ -421,7 +423,7 @@ def test_budget_report_uses_tightest_per_entry_utilization(tmp_path):
     report = build_memory_budget_report(
         _manager_config(budget_gb=60),
         registry,
-        _defaults_with(gpu_memory_utilization=0.9),
+        _defaults_with(gpu_memory_utilization=0.9, continuous_batching=True),
         device_working_set_bytes=128 * GB,
     )
 
@@ -429,6 +431,102 @@ def test_budget_report_uses_tightest_per_entry_utilization(tmp_path):
     assert "beta" in report.gpu_memory_utilization_source
     assert report.allocation_ceiling_bytes == int(0.4 * 128 * GB)
     assert report.exceeds_ceiling
+
+
+def test_no_ceiling_attributed_when_no_entry_installs_one(tmp_path):
+    """Only BatchedEngine calls mx.set_memory_limit, so an all-simple registry
+    must not attribute a ceiling to --gpu-memory-utilization."""
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10_000),
+        _registry(tmp_path, {"alpha": 8, "beta": 8}),
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=False),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 0
+    assert report.gpu_memory_utilization is None
+    assert report.gpu_memory_utilization_source is None
+    assert report.allocation_ceiling_bytes is None
+    # A wildly oversized budget must not warn against a ceiling nothing installs.
+    assert not report.exceeds_ceiling
+
+
+def test_simple_mode_entry_override_is_not_a_ceiling_candidate(tmp_path):
+    """A lower override on a simple-mode entry is inert and must be ignored."""
+    registry = _registry(tmp_path, {"batched": 8, "simple": 8})
+    registry["simple"] = dataclasses.replace(
+        registry["simple"], continuous_batching=False, gpu_memory_utilization=0.1
+    )
+    registry["batched"] = dataclasses.replace(
+        registry["batched"], continuous_batching=True
+    )
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(gpu_memory_utilization=0.8, continuous_batching=False),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 1
+    assert report.gpu_memory_utilization == pytest.approx(0.8)
+    assert report.gpu_memory_utilization_source == "serve default"
+    assert report.allocation_ceiling_bytes == int(0.8 * 128 * GB)
+
+
+def test_serve_default_does_not_win_when_every_batched_entry_overrides(tmp_path):
+    """The default only competes when some batched entry actually inherits it."""
+    registry = _registry(tmp_path, {"alpha": 8, "beta": 8})
+    registry["alpha"] = dataclasses.replace(
+        registry["alpha"], gpu_memory_utilization=0.7
+    )
+    registry["beta"] = dataclasses.replace(registry["beta"], gpu_memory_utilization=0.9)
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
+        device_working_set_bytes=128 * GB,
+    )
+
+    # 0.5 is never installed by anything, so the tightest installed value wins.
+    assert report.gpu_memory_utilization == pytest.approx(0.7)
+    assert "alpha" in report.gpu_memory_utilization_source
+
+
+def test_tied_utilization_is_attributed_to_the_serve_default(tmp_path):
+    """On a tie the default is the broader cause, so name it rather than an entry."""
+    registry = _registry(tmp_path, {"alpha": 8, "beta": 8})
+    registry["alpha"] = dataclasses.replace(
+        registry["alpha"], gpu_memory_utilization=0.5
+    )
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.gpu_memory_utilization == pytest.approx(0.5)
+    assert report.gpu_memory_utilization_source == "serve default"
+
+
+def test_log_says_why_when_no_entry_installs_a_ceiling(tmp_path, caplog):
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10_000),
+        _registry(tmp_path, {"alpha": 8}),
+        _defaults_with(continuous_batching=False),
+        device_working_set_bytes=128 * GB,
+    )
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(report)
+
+    assert "no continuous-batching entries" in caplog.text
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]
 
 
 def test_budget_report_ignores_cache_limit_in_the_fit_check(tmp_path):
@@ -462,9 +560,11 @@ def test_budget_report_is_inconclusive_without_device_memory(tmp_path, monkeypat
     report = build_memory_budget_report(
         _manager_config(budget_gb=10_000),
         _registry(tmp_path, {"alpha": 8}),
-        _defaults(),
+        _defaults_with(continuous_batching=True),
     )
 
+    # A utilization IS attributable here; only the device working set is unknown.
+    assert report.gpu_memory_utilization is not None
     assert report.allocation_ceiling_bytes is None
     assert not report.exceeds_ceiling
     assert not report.cache_limit_exceeds_ceiling
@@ -474,7 +574,7 @@ def test_log_memory_budget_report_warns_only_on_conflict(tmp_path, caplog):
     over = build_memory_budget_report(
         _manager_config(budget_gb=68),
         _registry(tmp_path, {"alpha": 32}),
-        _defaults_with(gpu_memory_utilization=0.5),
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
         device_working_set_bytes=128 * GB,
     )
     with caplog.at_level(logging.WARNING, logger="vllm_mlx.model_registry"):
@@ -486,7 +586,7 @@ def test_log_memory_budget_report_warns_only_on_conflict(tmp_path, caplog):
     under = build_memory_budget_report(
         _manager_config(budget_gb=40),
         _registry(tmp_path, {"beta": 32}),
-        _defaults_with(gpu_memory_utilization=0.5),
+        _defaults_with(gpu_memory_utilization=0.5, continuous_batching=True),
         device_working_set_bytes=128 * GB,
     )
     with caplog.at_level(logging.WARNING, logger="vllm_mlx.model_registry"):
@@ -525,13 +625,14 @@ def test_log_memory_budget_report_says_so_when_ceiling_unknown(
     report = build_memory_budget_report(
         _manager_config(budget_gb=68),
         _registry(tmp_path, {"alpha": 32}),
-        _defaults(),
+        _defaults_with(continuous_batching=True),
     )
 
     with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
         log_memory_budget_report(report)
 
-    assert "cannot be reconciled" in caplog.text
+    assert "no Metal allocation ceiling to reconcile it with" in caplog.text
+    assert "MLX cannot report a device working set" in caplog.text
     assert not [
         record for record in caplog.records if record.levelno >= logging.WARNING
     ]

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -299,8 +299,8 @@ class MemoryBudgetReport:
 
     budget_bytes: int
     device_working_set_bytes: int | None
-    gpu_memory_utilization: float
-    gpu_memory_utilization_source: str
+    gpu_memory_utilization: float | None
+    gpu_memory_utilization_source: str | None
     per_engine_cache_limit_bytes: int | None
     per_engine_cache_percent: float | None
     continuous_batching_entries: int
@@ -308,8 +308,13 @@ class MemoryBudgetReport:
 
     @property
     def allocation_ceiling_bytes(self) -> int | None:
-        """Metal soft allocation limit that will be installed at engine start."""
-        if self.device_working_set_bytes is None:
+        """Metal soft allocation limit that will be installed at engine start.
+
+        ``None`` when no ceiling can be attributed: either MLX cannot report a
+        device working set, or no entry will install one (only ``BatchedEngine``
+        calls ``mx.set_memory_limit``).
+        """
+        if self.device_working_set_bytes is None or self.gpu_memory_utilization is None:
             return None
         return int(self.device_working_set_bytes * self.gpu_memory_utilization)
 
@@ -340,30 +345,45 @@ def build_memory_budget_report(
 ) -> MemoryBudgetReport:
     """Reconcile the manager weight budget against the Metal allocation ceiling.
 
-    ``gpu_memory_utilization`` is process-wide but per-entry overrides re-install
-    the Metal limits every time a model loads, so the *lowest* effective value
-    across the registry is the ceiling the manager actually has to live under.
+    The Metal limit is process-wide but is re-installed by every
+    ``BatchedEngine`` start, so the ceiling the manager has to live under is the
+    *lowest* utilization among the entries that actually install one. Only
+    continuous-batching entries qualify: ``SimpleEngine`` never calls
+    ``mx.set_memory_limit`` and is not even given a ``gpu_memory_utilization``.
+    A registry with no continuous-batching entries therefore gets no attributed
+    ceiling rather than one derived from a value nothing installs.
     """
     if device_working_set_bytes is None:
         device_working_set_bytes = _device_working_set_bytes()
 
-    utilization = defaults.gpu_memory_utilization
-    utilization_source = "serve default"
+    # Only BatchedEngine installs a Metal allocation limit — SimpleEngine is not
+    # even constructed with a gpu_memory_utilization — so a simple-mode entry's
+    # override is inert and must not be treated as a ceiling candidate.
+    candidates: list[tuple[float, int, str]] = []
     for name in sorted(registry):
-        override = registry[name].gpu_memory_utilization
-        if override is not None and override < utilization:
-            utilization = override
-            utilization_source = f"models-config entry '{name}'"
-
-    continuous_batching_entries = sum(
-        1
-        for entry in registry.values()
-        if (
+        entry = registry[name]
+        entry_continuous_batching = (
             entry.continuous_batching
             if entry.continuous_batching is not None
             else defaults.continuous_batching
         )
-    )
+        if not entry_continuous_batching:
+            continue
+        if entry.gpu_memory_utilization is not None:
+            # Rank 1: an override is only attributable to the entry declaring it.
+            candidates.append(
+                (entry.gpu_memory_utilization, 1, f"models-config entry '{name}'")
+            )
+        else:
+            # Rank 0: prefer the serve default as the named source on ties.
+            candidates.append((defaults.gpu_memory_utilization, 0, "serve default"))
+
+    continuous_batching_entries = len(candidates)
+
+    utilization: float | None = None
+    utilization_source: str | None = None
+    if candidates:
+        utilization, _, utilization_source = min(candidates)
 
     # cache_memory_mb only binds for continuous-batching engines, and only when
     # the memory-aware prefix cache is the one actually in use.
@@ -404,11 +424,18 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
     ceiling = report.allocation_ceiling_bytes
 
     if ceiling is None:
+        if report.gpu_memory_utilization is None:
+            reason = (
+                "no continuous-batching entries, and --gpu-memory-utilization "
+                "installs a Metal limit only for those"
+            )
+        else:
+            reason = "MLX cannot report a device working set on this host"
         logger.info(
-            "Registry memory budget: %.1f GB of model weights "
-            "(Metal allocation ceiling unavailable on this host, so the budget "
-            "cannot be reconciled with it)",
+            "Registry memory budget: %.1f GB of model weights; no Metal "
+            "allocation ceiling to reconcile it with (%s)",
             report.budget_bytes / gb,
+            reason,
         )
         return
 

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -260,6 +260,166 @@ def _safe_available_memory_bytes() -> int:
     return int(psutil.virtual_memory().available)
 
 
+def _device_working_set_bytes() -> int | None:
+    """Best-effort Metal recommended working-set size, or None when unavailable."""
+    try:
+        import mlx.core as mx
+
+        if not mx.metal.is_available():
+            return None
+        info = mx.device_info()
+        raw = info.get(
+            "max_recommended_working_set_size",
+            info.get("memory_size", 0),
+        )
+        working_set = int(raw or 0)
+    except Exception as exc:  # pragma: no cover - platform dependent
+        logger.debug("Could not query MLX device memory: %s", exc)
+        return None
+    return working_set or None
+
+
+@dataclass(frozen=True)
+class MemoryBudgetReport:
+    """Reconciliation of the manager weight budget with the Metal ceiling.
+
+    The manager budget counts model *weights* only. The Metal allocation
+    ceiling (``gpu_memory_utilization`` x device working set) has to hold the
+    weights plus the KV cache plus activations, so a budget that sits above the
+    ceiling — or above the ceiling minus an explicit cache reservation — cannot
+    be honoured by eviction and will surface as an MLX allocation failure.
+    """
+
+    budget_bytes: int
+    device_working_set_bytes: int | None
+    gpu_memory_utilization: float
+    gpu_memory_utilization_source: str
+    cache_reservation_bytes: int | None
+    cache_reservation_percent: float | None
+
+    @property
+    def allocation_ceiling_bytes(self) -> int | None:
+        """Metal soft allocation limit that will be installed at engine start."""
+        if self.device_working_set_bytes is None:
+            return None
+        return int(self.device_working_set_bytes * self.gpu_memory_utilization)
+
+    @property
+    def weights_headroom_bytes(self) -> int | None:
+        """Ceiling minus any statically known cache reservation."""
+        ceiling = self.allocation_ceiling_bytes
+        if ceiling is None:
+            return None
+        return ceiling - (self.cache_reservation_bytes or 0)
+
+    @property
+    def exceeds_ceiling(self) -> bool:
+        headroom = self.weights_headroom_bytes
+        return headroom is not None and self.budget_bytes > headroom
+
+
+def build_memory_budget_report(
+    manager_config: RegistryManagerConfig,
+    registry: dict[str, RegisteredModel],
+    defaults: RegistryServeDefaults,
+    *,
+    device_working_set_bytes: int | None = None,
+) -> MemoryBudgetReport:
+    """Reconcile the manager weight budget against the Metal allocation ceiling.
+
+    ``gpu_memory_utilization`` is process-wide but per-entry overrides re-install
+    the Metal limits every time a model loads, so the *lowest* effective value
+    across the registry is the ceiling the manager actually has to live under.
+    """
+    if device_working_set_bytes is None:
+        device_working_set_bytes = _device_working_set_bytes()
+
+    utilization = defaults.gpu_memory_utilization
+    utilization_source = "serve default"
+    for name in sorted(registry):
+        override = registry[name].gpu_memory_utilization
+        if override is not None and override < utilization:
+            utilization = override
+            utilization_source = f"models-config entry '{name}'"
+
+    scheduler_config = defaults.scheduler_config
+    cache_reservation_bytes: int | None = None
+    cache_reservation_percent: float | None = None
+    if scheduler_config is not None:
+        cache_memory_mb = getattr(scheduler_config, "cache_memory_mb", None)
+        if cache_memory_mb:
+            cache_reservation_bytes = int(cache_memory_mb) * (1024**2)
+        else:
+            percent = getattr(scheduler_config, "cache_memory_percent", None)
+            if percent:
+                cache_reservation_percent = float(percent)
+
+    return MemoryBudgetReport(
+        budget_bytes=manager_config.memory_budget_bytes,
+        device_working_set_bytes=device_working_set_bytes,
+        gpu_memory_utilization=utilization,
+        gpu_memory_utilization_source=utilization_source,
+        cache_reservation_bytes=cache_reservation_bytes,
+        cache_reservation_percent=cache_reservation_percent,
+    )
+
+
+def log_memory_budget_report(report: MemoryBudgetReport) -> None:
+    """Log the budget/ceiling reconciliation, warning when they conflict."""
+    gb = 1024**3
+    ceiling = report.allocation_ceiling_bytes
+
+    if ceiling is None:
+        logger.info(
+            "Registry memory budget: %.1f GB of model weights "
+            "(Metal allocation ceiling unavailable on this host, so the budget "
+            "cannot be reconciled with it)",
+            report.budget_bytes / gb,
+        )
+        return
+
+    if report.cache_reservation_bytes is not None:
+        cache_desc = f"{report.cache_reservation_bytes / gb:.1f} GB (--cache-memory-mb)"
+    elif report.cache_reservation_percent is not None:
+        cache_desc = (
+            f"~{report.cache_reservation_percent * 100:.0f}% of available RAM "
+            "(--cache-memory-percent, not statically known)"
+        )
+    else:
+        cache_desc = "none configured"
+
+    logger.info(
+        "Registry memory budget: %.1f GB of model weights; "
+        "Metal allocation ceiling %.1f GB (%.0f%% of %.1f GB, from %s); "
+        "prefix-cache reservation %s",
+        report.budget_bytes / gb,
+        ceiling / gb,
+        report.gpu_memory_utilization * 100,
+        (report.device_working_set_bytes or 0) / gb,
+        report.gpu_memory_utilization_source,
+        cache_desc,
+    )
+
+    if report.exceeds_ceiling:
+        headroom = report.weights_headroom_bytes or 0
+        logger.warning(
+            "models-config manager.memory_budget_gb (%.1f GB) exceeds the memory "
+            "actually allocatable for model weights (%.1f GB). The budget counts "
+            "weights only, so the manager will keep models resident that MLX "
+            "cannot allocate, and the process can hit an out-of-memory failure "
+            "instead of evicting. Lower the budget to at most %.1f GB (minus KV "
+            "cache and activation headroom), or raise --gpu-memory-utilization.",
+            report.budget_bytes / gb,
+            headroom / gb,
+            headroom / gb,
+        )
+    else:
+        logger.info(
+            "The registry budget covers model weights only; KV cache and "
+            "activations are additional and are not reserved by it."
+        )
+
+
 def _estimate_model_bytes_from_source(source: str) -> int:
     """Estimate model footprint from local artifact size when possible."""
     path = Path(source)

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import time
 from collections.abc import Awaitable, Callable
@@ -579,6 +580,24 @@ def load_registry_config(
             int(float(estimated) * (1024**3)) if estimated is not None else None
         )
 
+        raw_gpu_memory_utilization = item.get("gpu_memory_utilization")
+        gpu_memory_utilization = None
+        if raw_gpu_memory_utilization is not None:
+            try:
+                gpu_memory_utilization = float(raw_gpu_memory_utilization)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"models-config entry '{name}' gpu_memory_utilization must "
+                    "be finite and within (0, 1]"
+                ) from None
+            if not math.isfinite(gpu_memory_utilization) or not (
+                0.0 < gpu_memory_utilization <= 1.0
+            ):
+                raise ValueError(
+                    f"models-config entry '{name}' gpu_memory_utilization must "
+                    "be finite and within (0, 1]"
+                )
+
         registry[name] = RegisteredModel(
             name=name,
             source=str(source),
@@ -593,7 +612,7 @@ def load_registry_config(
             specprefill_backbone_pct=item.get("specprefill_backbone_pct"),
             specprefill_draft_model=item.get("specprefill_draft_model"),
             stream_interval=item.get("stream_interval"),
-            gpu_memory_utilization=item.get("gpu_memory_utilization"),
+            gpu_memory_utilization=gpu_memory_utilization,
             estimated_memory_bytes=estimated_bytes,
         )
 

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -283,19 +283,28 @@ def _device_working_set_bytes() -> int | None:
 class MemoryBudgetReport:
     """Reconciliation of the manager weight budget with the Metal ceiling.
 
-    The manager budget counts model *weights* only. The Metal allocation
-    ceiling (``gpu_memory_utilization`` x device working set) has to hold the
-    weights plus the KV cache plus activations, so a budget that sits above the
-    ceiling — or above the ceiling minus an explicit cache reservation — cannot
-    be honoured by eviction and will surface as an MLX allocation failure.
+    The manager budget counts model *weights* only, and the Metal allocation
+    ceiling (``gpu_memory_utilization`` x device working set) is process-wide.
+    Those two are directly comparable, so a budget above the ceiling is a
+    deterministic conflict: the manager will keep models resident that MLX
+    cannot allocate, and the load fails instead of evicting.
+
+    The prefix-cache limit is deliberately *not* folded into that comparison.
+    ``cache_memory_mb`` is a per-engine maximum — it is cloned into each
+    resident continuous-batching engine and allocated lazily, and simple-mode
+    entries never receive it at all — so it is neither a single process-wide
+    reservation nor a bound that can be subtracted once. It is reported
+    alongside the ceiling instead, with its own conflict check.
     """
 
     budget_bytes: int
     device_working_set_bytes: int | None
     gpu_memory_utilization: float
     gpu_memory_utilization_source: str
-    cache_reservation_bytes: int | None
-    cache_reservation_percent: float | None
+    per_engine_cache_limit_bytes: int | None
+    per_engine_cache_percent: float | None
+    continuous_batching_entries: int
+    total_entries: int
 
     @property
     def allocation_ceiling_bytes(self) -> int | None:
@@ -305,17 +314,21 @@ class MemoryBudgetReport:
         return int(self.device_working_set_bytes * self.gpu_memory_utilization)
 
     @property
-    def weights_headroom_bytes(self) -> int | None:
-        """Ceiling minus any statically known cache reservation."""
+    def exceeds_ceiling(self) -> bool:
+        """True when the weights budget alone cannot fit under the ceiling.
+
+        Both sides are process-wide totals, so this is the deterministic check.
+        """
         ceiling = self.allocation_ceiling_bytes
-        if ceiling is None:
-            return None
-        return ceiling - (self.cache_reservation_bytes or 0)
+        return ceiling is not None and self.budget_bytes > ceiling
 
     @property
-    def exceeds_ceiling(self) -> bool:
-        headroom = self.weights_headroom_bytes
-        return headroom is not None and self.budget_bytes > headroom
+    def cache_limit_exceeds_ceiling(self) -> bool:
+        """True when one engine's prefix cache could alone fill the ceiling."""
+        ceiling = self.allocation_ceiling_bytes
+        if ceiling is None or self.per_engine_cache_limit_bytes is None:
+            return False
+        return self.per_engine_cache_limit_bytes >= ceiling
 
 
 def build_memory_budget_report(
@@ -342,25 +355,46 @@ def build_memory_budget_report(
             utilization = override
             utilization_source = f"models-config entry '{name}'"
 
+    continuous_batching_entries = sum(
+        1
+        for entry in registry.values()
+        if (
+            entry.continuous_batching
+            if entry.continuous_batching is not None
+            else defaults.continuous_batching
+        )
+    )
+
+    # cache_memory_mb only binds for continuous-batching engines, and only when
+    # the memory-aware prefix cache is the one actually in use.
     scheduler_config = defaults.scheduler_config
-    cache_reservation_bytes: int | None = None
-    cache_reservation_percent: float | None = None
-    if scheduler_config is not None:
+    per_engine_cache_limit_bytes: int | None = None
+    per_engine_cache_percent: float | None = None
+    cache_applies = (
+        scheduler_config is not None
+        and continuous_batching_entries > 0
+        and getattr(scheduler_config, "enable_prefix_cache", False)
+        and not getattr(scheduler_config, "use_paged_cache", False)
+        and getattr(scheduler_config, "use_memory_aware_cache", False)
+    )
+    if cache_applies:
         cache_memory_mb = getattr(scheduler_config, "cache_memory_mb", None)
         if cache_memory_mb:
-            cache_reservation_bytes = int(cache_memory_mb) * (1024**2)
+            per_engine_cache_limit_bytes = int(cache_memory_mb) * (1024**2)
         else:
             percent = getattr(scheduler_config, "cache_memory_percent", None)
             if percent:
-                cache_reservation_percent = float(percent)
+                per_engine_cache_percent = float(percent)
 
     return MemoryBudgetReport(
         budget_bytes=manager_config.memory_budget_bytes,
         device_working_set_bytes=device_working_set_bytes,
         gpu_memory_utilization=utilization,
         gpu_memory_utilization_source=utilization_source,
-        cache_reservation_bytes=cache_reservation_bytes,
-        cache_reservation_percent=cache_reservation_percent,
+        per_engine_cache_limit_bytes=per_engine_cache_limit_bytes,
+        per_engine_cache_percent=per_engine_cache_percent,
+        continuous_batching_entries=continuous_batching_entries,
+        total_entries=len(registry),
     )
 
 
@@ -378,12 +412,17 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
         )
         return
 
-    if report.cache_reservation_bytes is not None:
-        cache_desc = f"{report.cache_reservation_bytes / gb:.1f} GB (--cache-memory-mb)"
-    elif report.cache_reservation_percent is not None:
+    engines = f"{report.continuous_batching_entries} of {report.total_entries} entries"
+    if report.per_engine_cache_limit_bytes is not None:
         cache_desc = (
-            f"~{report.cache_reservation_percent * 100:.0f}% of available RAM "
-            "(--cache-memory-percent, not statically known)"
+            f"{report.per_engine_cache_limit_bytes / gb:.1f} GB per "
+            f"continuous-batching engine (--cache-memory-mb, {engines})"
+        )
+    elif report.per_engine_cache_percent is not None:
+        cache_desc = (
+            f"~{report.per_engine_cache_percent * 100:.0f}% of available RAM per "
+            f"continuous-batching engine (--cache-memory-percent, {engines}); "
+            "scales at runtime"
         )
     else:
         cache_desc = "none configured"
@@ -391,7 +430,7 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
     logger.info(
         "Registry memory budget: %.1f GB of model weights; "
         "Metal allocation ceiling %.1f GB (%.0f%% of %.1f GB, from %s); "
-        "prefix-cache reservation %s",
+        "prefix-cache maximum %s",
         report.budget_bytes / gb,
         ceiling / gb,
         report.gpu_memory_utilization * 100,
@@ -401,22 +440,35 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
     )
 
     if report.exceeds_ceiling:
-        headroom = report.weights_headroom_bytes or 0
         logger.warning(
-            "models-config manager.memory_budget_gb (%.1f GB) exceeds the memory "
-            "actually allocatable for model weights (%.1f GB). The budget counts "
-            "weights only, so the manager will keep models resident that MLX "
-            "cannot allocate, and the process can hit an out-of-memory failure "
-            "instead of evicting. Lower the budget to at most %.1f GB (minus KV "
-            "cache and activation headroom), or raise --gpu-memory-utilization.",
+            "models-config manager.memory_budget_gb (%.1f GB) exceeds the Metal "
+            "allocation ceiling (%.1f GB). The budget counts model weights only, "
+            "so the manager will keep models resident that MLX cannot allocate, "
+            "and a load can fail with an out-of-memory error instead of evicting. "
+            "Lower the budget below %.1f GB — further still, since the KV cache "
+            "and activations also come out of the ceiling — or raise "
+            "--gpu-memory-utilization.",
             report.budget_bytes / gb,
-            headroom / gb,
-            headroom / gb,
+            ceiling / gb,
+            ceiling / gb,
         )
-    else:
+
+    if report.cache_limit_exceeds_ceiling:
+        logger.warning(
+            "--cache-memory-mb (%.1f GB per continuous-batching engine) is at or "
+            "above the Metal allocation ceiling (%.1f GB) on its own, leaving no "
+            "room for model weights. Note this is a per-engine maximum: it is "
+            "cloned into every resident continuous-batching engine, so the "
+            "aggregate grows with the number of resident models.",
+            (report.per_engine_cache_limit_bytes or 0) / gb,
+            ceiling / gb,
+        )
+
+    if not report.exceeds_ceiling and not report.cache_limit_exceeds_ceiling:
         logger.info(
-            "The registry budget covers model weights only; KV cache and "
-            "activations are additional and are not reserved by it."
+            "The registry budget covers model weights only; the KV cache, the "
+            "prefix cache and activations are additional and are not reserved "
+            "by it."
         )
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -168,7 +168,9 @@ from .model_registry import (
     ModelLease,
     ModelManager,
     RegistryServeDefaults,
+    build_memory_budget_report,
     load_registry_config,
+    log_memory_budget_report,
 )
 from .metrics import metrics as _metrics
 from .models.mllm import UnsafeRemoteURLError, _validate_url_safety, is_url
@@ -3400,6 +3402,9 @@ def load_model_registry(
         config_path,
         len(registry),
         manager_config.memory_budget_bytes / (1024**3),
+    )
+    log_memory_budget_report(
+        build_memory_budget_report(manager_config, registry, defaults)
     )
 
 


### PR DESCRIPTION
## Summary

Implements the startup-validation-plus-documentation half of #627 — the first of
the two PRs @Thump604 proposed in [that thread](https://github.com/waybarrios/vllm-mlx/issues/627#issuecomment-4935833071).

In registry mode the manager decides admission and eviction purely against
`manager.memory_budget_gb`, and never consults the Metal allocation ceiling
installed from `--gpu-memory-utilization`. The two numbers are independent and
unreconciled, so a budget above the ceiling makes the manager keep N models
resident because *its* arithmetic says they fit — and MLX then fails to
allocate instead of the manager evicting. This adds a deterministic startup
report and warning so that becomes a diagnosable message rather than a silent
crash.

Deliberately **not** implemented here, per the review guidance on the issue:
auto-clamping, KV/activation accounting, or any change to the admission and
eviction algorithms.

## Relationship to the other PRs on #627

- #640 adds the `--memory-budget-gb` CLI override (suggested fix 2) and lists
  "startup allocation-ceiling warnings" as out of scope. This PR is that missing
  piece; the two are complementary and touch disjoint code paths.
- #638 is about `--auto-unload-idle-seconds` in registry mode — unrelated to the
  budget/ceiling reconciliation.

## Behavior

At registry startup the server logs the budget and the ceiling side by side,
with the prefix-cache setting reported alongside:

```
INFO Registry memory budget: 68.0 GB of model weights; Metal allocation ceiling
     69.4 GB (62% of 112.0 GB, from serve default); prefix-cache maximum 20.0 GB
     per continuous-batching engine (--cache-memory-mb, 1 of 1 entries)
```

The conflict check compares **only** the weights budget with the Metal ceiling.
Both are process-wide totals and therefore directly comparable:

```
WARNING models-config manager.memory_budget_gb (68.0 GB) exceeds the Metal
        allocation ceiling (56.0 GB). The budget counts model weights only, so
        the manager will keep models resident that MLX cannot allocate, and a
        load can fail with an out-of-memory error instead of evicting. Lower the
        budget below 56.0 GB — further still, since the KV cache and activations
        also come out of the ceiling — or raise --gpu-memory-utilization.
```

`--cache-memory-mb` is **not** subtracted from the ceiling. It is a per-engine
maximum: `_clone_scheduler_config` copies it into each resident
continuous-batching engine and it is allocated lazily, while `SimpleEngine`
never receives a scheduler config at all. Subtracting it once would understate
capacity with one resident model and overstate it with several, so it is
reported next to the ceiling rather than folded into it, annotated with how many
entries are continuous-batching. It is shown only where it can bind —
continuous-batching entries using the memory-aware prefix cache, not under
`--use-paged-cache`.

An oversized cap gets its own separate warning, with no derived negative
quantity anywhere:

```
WARNING --cache-memory-mb (20.0 GB per continuous-batching engine) is at or above
        the Metal allocation ceiling (8.0 GB) on its own, leaving no room for
        model weights. Note this is a per-engine maximum: it is cloned into every
        resident continuous-batching engine, so the aggregate grows with the
        number of resident models.
```

Other details:

- A per-entry `gpu_memory_utilization` override re-installs the process-wide
  Metal limits whenever that model loads, so the check uses the **lowest**
  effective value across the serve default and every registry entry, and names
  where it came from.
- On hosts where MLX cannot report a working-set size, the log says the budget
  could not be reconciled and no warning is emitted (no false positives).

Nothing is clamped; the server starts with whatever budget is configured.

## Scope of the check

The check is **necessary, not sufficient**. It compares the declared weights
budget with the Metal ceiling; the KV cache, prefix cache and activations also
come out of that ceiling and are workload-dependent, so a budget that clears the
check can still be exhausted at runtime. Catching that needs the residency-aware
accounting deferred to later work. Nothing is clamped — the server starts with
whatever budget is configured.

## Type of change

- Bug fix (diagnostic for a silent failure mode)
- Documentation

## Surface touched

- Multi-model registry configuration
- Registry manager memory-budget configuration
- Serve startup logging
- Tests
- Documentation

## Documentation

`docs/guides/model-registry.md`:

- new "Budget vs. the Metal allocation ceiling" section with the invariant,
  what the check covers, and why the cache cap is reported rather than
  subtracted
- `memory_budget_gb` now says up front that it counts model weights only
- "Sizing Rules" records that both estimate paths — summed on-disk
  `.safetensors`/`.gguf` size, and `estimated_memory_gb` — are weight
  estimates, not total runtime memory
- a new entry under "Failure Modes to Expect"

## Testing

- 12 tests in `tests/test_model_registry.py` covering: budget over/under the
  ceiling; the cache cap being reported but never moving the fit-check; its
  suppression for simple-mode entries and under `--use-paged-cache`; the
  tightest per-entry `gpu_memory_utilization` winning; the inconclusive
  no-device-memory path; and the log shapes. Includes a regression test
  asserting no negative quantity can appear in the output for the 8 GiB-ceiling
  reproduction.
- `pytest tests/test_model_registry.py` — 16 passed
- Full suite `pytest tests/` — **2310 passed, 23 skipped, 23 deselected**
- `ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841`
  and `black --check vllm_mlx/ tests/` — clean
- Python 3.10 (test-matrix floor) syntax check — clean
- Mutation-tested the accounting to confirm the tests constrain it:
  reinstating the subtraction in the fit-check fails three of them, and
  removing either the continuous-batching or paged-cache gate fails one each.
- End-to-end on a real 128 GB machine (112 GB reported working set) driving
  `load_model_registry()`; all log output quoted above is from those runs.

## Out of scope

- automatic memory-budget clamping
- KV-cache, prefix-cache or activation memory accounting (including
  residency-aware aggregation of per-engine cache caps)
- the `--memory-budget-gb` CLI override (#640)
- changes to registry admission or eviction algorithms
