### PR TITLE
Add request-local SpecPrefill with native Qwen MTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,vision,harmony]"
+          # This PR consumes the public typed native-MTP lifecycle introduced
+          # by mlx-lm PR #1724. Pin its immutable reviewed head until that API
+          # is available in a released mlx-lm wheel.
+          pip install --no-deps --force-reinstall \
+            "mlx-lm @ git+https://github.com/ml-explore/mlx-lm.git@a9e671b33ce8dd687859c0dc3c34de12b6c96f18"
 
       - name: Verify Apple Silicon
         run: |

--- a/tests/test_batched_engine_specprefill.py
+++ b/tests/test_batched_engine_specprefill.py
@@ -485,9 +485,7 @@ def test_failed_start_cleans_prepared_runtime_and_retry_prepares_again(monkeypat
     def prepare(_model, _processor):
         attempt = len(prepare_calls) + 1
         prepare_calls.append(attempt)
-        return _bundle(
-            lambda: cleanup_calls.append(attempt), _model, _processor
-        )
+        return _bundle(lambda: cleanup_calls.append(attempt), _model, _processor)
 
     engine = _engine(
         SchedulerConfig(specprefill_enabled=True, specprefill_prepare=prepare)
@@ -790,9 +788,7 @@ def test_server_enable_switch_copies_scheduler_launch_config(monkeypatch):
 def test_batched_stats_promote_exact_specprefill_status():
     engine = _engine(SchedulerConfig())
     exact = {"enabled": False, "advertisable": False, "diagnostic": True}
-    engine._mllm_scheduler = SimpleNamespace(
-        get_stats=lambda: {"specprefill": exact}
-    )
+    engine._mllm_scheduler = SimpleNamespace(get_stats=lambda: {"specprefill": exact})
 
     stats = engine.get_stats()
 
@@ -1031,7 +1027,8 @@ def test_explicit_media_bit_survives_empty_extraction_arrays():
 
 
 def test_real_runtime_builder_eagerly_installs_and_builds_request_sessions(
-    monkeypatch, tmp_path,
+    monkeypatch,
+    tmp_path,
 ):
     from contextlib import contextmanager
 
@@ -1196,9 +1193,7 @@ def test_real_runtime_builder_eagerly_installs_and_builds_request_sessions(
     prepared.cleanup()
     assert events[-1] == "loader_cleanup"
     with pytest.raises(runtime.SpecPrefillRuntimePreparationError, match="closed"):
-        prepared.session_factory(
-            SimpleNamespace(request_id="later"), (1,), config
-        )
+        prepared.session_factory(SimpleNamespace(request_id="later"), (1,), config)
 
 
 def test_real_runtime_builder_cleanup_is_fail_atomic_on_hook_failure(
@@ -1296,9 +1291,7 @@ def test_scorer_artifact_manifest_rejects_symlinks(tmp_path, symlink_kind):
     else:
         artifact = tmp_path / "artifact"
         artifact.mkdir()
-        (artifact / "weights.safetensors").symlink_to(
-            real / "weights.safetensors"
-        )
+        (artifact / "weights.safetensors").symlink_to(real / "weights.safetensors")
 
     with pytest.raises(
         runtime.SpecPrefillRuntimePreparationError,
@@ -1397,7 +1390,11 @@ def test_real_runtime_builder_eager_cache_probe_fails_and_cleans(
         language_model=SimpleNamespace(layers=[SimpleNamespace(is_linear=False)])
     )
 
-    expected = RuntimeError if cache_failure == "raise" else runtime.SpecPrefillRuntimePreparationError
+    expected = (
+        RuntimeError
+        if cache_failure == "raise"
+        else runtime.SpecPrefillRuntimePreparationError
+    )
     with pytest.raises(expected):
         prepare(target, object())
 
@@ -1450,7 +1447,8 @@ def test_real_runtime_builder_rejects_qwen_vlm_adapter(monkeypatch, tmp_path):
 
 
 def test_runtime_builder_requires_certification_and_marks_diagnostic_nonadvertisable(
-    monkeypatch, tmp_path,
+    monkeypatch,
+    tmp_path,
 ):
     from dataclasses import replace
 

--- a/tests/test_batched_engine_specprefill.py
+++ b/tests/test_batched_engine_specprefill.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from types import SimpleNamespace
 
 import pytest
@@ -31,14 +32,20 @@ def _hash(letter: str) -> str:
     return letter * 64
 
 
-def _certified_registry():
+def _certified_registry(
+    *,
+    target_hash=None,
+    tokenizer_hash=None,
+    scorer_hash=None,
+    adapter_id="qwen35_text_hybrid",
+):
     key = SpecPrefillProfileKey(
         target_artifact_id="qwen-target",
-        target_artifact_hash=_hash("a"),
-        tokenizer_artifact_hash=_hash("b"),
+        target_artifact_hash=target_hash or _hash("a"),
+        tokenizer_artifact_hash=tokenizer_hash or _hash("b"),
         scorer_artifact_id="qwen-scorer",
-        scorer_artifact_hash=_hash("c"),
-        adapter_id="qwen-adapter",
+        scorer_artifact_hash=scorer_hash or _hash("c"),
+        adapter_id=adapter_id,
         engine=SpecPrefillEngine.CONTINUOUS_BATCHING,
         cell=SpecPrefillCell.SPARSE_ONLY,
     )
@@ -90,6 +97,12 @@ def _certified_registry():
         evidence,
     )
     return SpecPrefillProfileRegistry((profile,)), key
+
+
+def _scorer_artifact(tmp_path, contents=b"synthetic scorer weights"):
+    path = tmp_path / "scorer.safetensors"
+    path.write_bytes(contents)
+    return str(path), hashlib.sha256(contents).hexdigest()
 
 
 def _bundle(cleanup, target_model, processor):
@@ -170,6 +183,8 @@ def test_prepared_launch_wires_exact_scheduler_dependencies(monkeypatch):
     assert wired.specprefill_session_factory is bundle.session_factory
     assert wired.specprefill_cache_capability is bundle.cache_capability
     assert wired.specprefill_target_forward_context is bundle.target_forward_context
+    assert wired.specprefill_advertisable is True
+    assert wired.specprefill_diagnostic is False
     assert cleanup_calls == []
 
     asyncio.run(engine.stop())
@@ -454,8 +469,9 @@ def test_enabled_launch_fails_closed_without_admitted_preparation(config):
     assert engine._prepared_specprefill_runtime is None
 
 
-def test_server_enable_switch_copies_scheduler_launch_config():
+def test_server_enable_switch_copies_scheduler_launch_config(monkeypatch):
     from vllm_mlx.server import _configure_batched_specprefill
+    import vllm_mlx.specprefill_runtime as runtime
 
     prepare = lambda *_args: None
     original = SchedulerConfig(
@@ -470,6 +486,112 @@ def test_server_enable_switch_copies_scheduler_launch_config():
 
     with pytest.raises(ValueError, match="unavailable"):
         _configure_batched_specprefill(SchedulerConfig(), enabled=True)
+
+    builder_calls = []
+    built_prepare = lambda *_args: None
+    monkeypatch.setattr(
+        runtime,
+        "build_qwen_cb_specprefill_prepare",
+        lambda **kwargs: builder_calls.append(kwargs) or built_prepare,
+    )
+    internal = SchedulerConfig(
+        specprefill_runtime_builder_inputs={"internal": "inputs"}
+    )
+    built = _configure_batched_specprefill(internal, enabled=True)
+
+    assert builder_calls == [{"internal": "inputs"}]
+    assert built.specprefill_prepare is built_prepare
+    assert internal.specprefill_prepare is None
+
+
+def test_batched_stats_promote_exact_specprefill_status():
+    engine = _engine(SchedulerConfig())
+    exact = {"enabled": False, "advertisable": False, "diagnostic": True}
+    engine._mllm_scheduler = SimpleNamespace(
+        get_stats=lambda: {"specprefill": exact}
+    )
+
+    stats = engine.get_stats()
+
+    assert stats["specprefill"] is exact
+
+
+def test_public_status_and_model_discovery_separate_diagnostic_and_production(
+    monkeypatch,
+):
+    import vllm_mlx.server as server
+
+    class Engine:
+        def __init__(self, specprefill):
+            self.specprefill = specprefill
+
+        def get_stats(self):
+            return {
+                "running": True,
+                "specprefill": self.specprefill,
+                "requests": [],
+            }
+
+    monkeypatch.setattr(server, "_model_manager", None)
+    monkeypatch.setattr(server, "_model_name", "qwen")
+    monkeypatch.setattr(server, "_residency_manager", None)
+    monkeypatch.setattr(server, "_default_model_key", None)
+    monkeypatch.setattr(server, "_embedding_engine", None)
+    monkeypatch.setattr(server, "_rerank_engine", None)
+    diagnostic = {"enabled": False, "advertisable": False, "diagnostic": True}
+    monkeypatch.setattr(server, "_engine", Engine(diagnostic))
+
+    status_payload = asyncio.run(server.status())
+    diagnostic_models = asyncio.run(server.list_models())
+
+    assert status_payload["specprefill"] == diagnostic
+    assert diagnostic_models.data[0].capabilities == []
+
+    production = {"enabled": True, "advertisable": True, "diagnostic": False}
+    monkeypatch.setattr(server, "_engine", Engine(production))
+    production_models = asyncio.run(server.list_models())
+
+    assert production_models.data[0].capabilities == ["specprefill"]
+
+    class ThrowingEngine:
+        def get_stats(self):
+            raise RuntimeError("stats unavailable")
+
+    monkeypatch.setattr(server, "_engine", ThrowingEngine())
+    unavailable_models = asyncio.run(server.list_models())
+    assert unavailable_models.data[0].capabilities == []
+
+
+def test_registry_status_keeps_diagnostic_state_out_of_model_discovery(monkeypatch):
+    import vllm_mlx.server as server
+
+    diagnostic = {
+        "state": "diagnostic",
+        "enabled": False,
+        "advertisable": False,
+        "diagnostic": True,
+    }
+
+    class Manager:
+        memory_budget_bytes = 1024**3
+
+        def list_models(self):
+            return [
+                {
+                    "id": "diagnostic-qwen",
+                    "capabilities": [],
+                    "specprefill": diagnostic,
+                }
+            ]
+
+    monkeypatch.setattr(server, "_model_manager", Manager())
+    monkeypatch.setattr(server, "_model_name", None)
+
+    status_payload = asyncio.run(server.status())
+    models_payload = asyncio.run(server.list_models())
+
+    assert status_payload["model_manager"]["models"][0]["specprefill"] == diagnostic
+    assert models_payload.data[0].capabilities == []
 
 
 def test_request_controls_and_terminal_metadata_cross_batched_engine():
@@ -623,3 +745,501 @@ def test_explicit_media_bit_survives_empty_extraction_arrays():
     )
 
     assert engine._mllm_scheduler.seen["specprefill_has_media"] is True
+
+
+def test_real_runtime_builder_eagerly_installs_and_builds_request_sessions(
+    monkeypatch, tmp_path,
+):
+    from contextlib import contextmanager
+
+    import vllm_mlx.specprefill_runtime as runtime
+    from vllm_mlx.cooperative_specprefill import CooperativeSpecPrefillConfig
+    from vllm_mlx.specprefill_cache import (
+        SparseCacheIdentity,
+        SparseCacheState,
+        SparsePolicyTuning,
+    )
+    from vllm_mlx.specprefill_positions import QWEN35_TEXT_HYBRID_TARGET
+    from vllm_mlx.specprefill_scorer_session import ScorerSessionPhase
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    registry, key = _certified_registry(scorer_hash=scorer_hash)
+    profile = registry.profiles[0]
+    events = []
+    scorer_model = object()
+    target_text = SimpleNamespace(layers=[SimpleNamespace(is_linear=False)])
+    target_outer = SimpleNamespace(language_model=target_text)
+    processor = object()
+
+    class FakeScorerSession:
+        phase = ScorerSessionPhase.PREFILL
+
+        def cancel(self):
+            events.append("scorer_cancel")
+
+    class FakeHooks:
+        @contextmanager
+        def session_for_plan(self, plan):
+            events.append(("decode_plan", plan.logical_positions))
+            yield
+
+    class FakeTargetSession:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def step(self):
+            raise AssertionError("not stepped in builder test")
+
+        def cancel(self):
+            events.append("target_cancel")
+
+    monkeypatch.setattr(
+        runtime.SpecPrefillScorer,
+        "for_model",
+        lambda model: events.append(("install_scorer", model)) or object(),
+    )
+    monkeypatch.setattr(
+        runtime.TargetPositionHooks,
+        "for_model",
+        lambda model, adapter: (
+            events.append(("install_hooks", model, adapter)) or FakeHooks()
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "resolve_target_position_adapter",
+        lambda _model: QWEN35_TEXT_HYBRID_TARGET,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "SpecPrefillScorerSession",
+        lambda *_a, **_k: FakeScorerSession(),
+    )
+    monkeypatch.setattr(runtime, "SparseTargetPrefillSession", FakeTargetSession)
+    caches = []
+
+    def cache_factory(model):
+        from mlx_lm.models.cache import KVCache
+
+        cache = [KVCache()]
+        caches.append((model, cache))
+        return cache
+
+    def loader(path, expected_hash):
+        events.append(("load", path, expected_hash))
+        return runtime.LoadedSpecPrefillScorer(
+            scorer_model,
+            lambda: events.append("loader_cleanup"),
+        )
+
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=key.scorer_artifact_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=512,
+        target_identity_attestor=lambda target, actual_processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                actual_processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=loader,
+        target_cache_factory=cache_factory,
+    )
+    prepared = prepare(target_outer, processor)
+
+    assert events[:3] == [
+        ("load", scorer_path, key.scorer_artifact_hash),
+        ("install_scorer", scorer_model),
+        ("install_hooks", target_text, QWEN35_TEXT_HYBRID_TARGET),
+    ]
+    tuning = SparsePolicyTuning(0.5, 0.1, 1, 1, 32)
+    config = CooperativeSpecPrefillConfig(
+        target_id=f"{key.target_artifact_id}@sha256:{key.target_artifact_hash}",
+        tokenizer_id=f"tokenizer@sha256:{key.tokenizer_artifact_hash}",
+        scorer_id=f"{key.scorer_artifact_id}@sha256:{key.scorer_artifact_hash}",
+        tuning=tuning,
+    )
+    admission = prepared.session_factory(
+        SimpleNamespace(request_id="request"),
+        (1, 2, 3),
+        config,
+    )
+    identity = SparseCacheIdentity.from_tokens(
+        target_id=config.target_id,
+        tokenizer_id=config.tokenizer_id,
+        scorer_id=config.scorer_id,
+        selector_version="hybrid-v1",
+        tuning=tuning,
+        tokens=(1, 2, 3),
+        selection_fingerprint="a" * 64,
+    )
+    state = SparseCacheState.from_selection(identity, ((0, 2),), (3,))
+    target_session = admission.session._target_session_factory((1, 3), state)
+    assert isinstance(target_session, FakeTargetSession)
+    assert len(caches) == 2
+    assert caches[0][0] is target_text
+    assert tuple(caches[1][1]) == target_session.args[2]
+    second_target_session = admission.session._target_session_factory((1, 3), state)
+    assert isinstance(second_target_session, FakeTargetSession)
+    assert len(caches) == 3
+    assert caches[1][1] is not caches[2][1]
+    assert target_session.args[2] is not second_target_session.args[2]
+    forward = SimpleNamespace(
+        phase=runtime.MLLMTargetForwardPhase.DECODE,
+        sparse_row_states=state.rows,
+    )
+    with prepared.target_forward_context(forward):
+        events.append("decode")
+    assert events[-2:] == [("decode_plan", ((3,),)), "decode"]
+    with pytest.raises(
+        runtime.SpecPrefillRuntimePreparationError,
+        match="sparse and dense rows",
+    ):
+        prepared.target_forward_context(
+            SimpleNamespace(
+                phase=runtime.MLLMTargetForwardPhase.DECODE,
+                sparse_row_states=(state.rows[0], None),
+            )
+        )
+
+    prepared.cleanup()
+    assert events[-1] == "loader_cleanup"
+    with pytest.raises(runtime.SpecPrefillRuntimePreparationError, match="closed"):
+        prepared.session_factory(
+            SimpleNamespace(request_id="later"), (1,), config
+        )
+
+
+def test_real_runtime_builder_cleanup_is_fail_atomic_on_hook_failure(
+    monkeypatch, tmp_path
+):
+    import vllm_mlx.specprefill_runtime as runtime
+    from vllm_mlx.specprefill_positions import QWEN35_TEXT_HYBRID_TARGET
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    registry, key = _certified_registry(scorer_hash=scorer_hash)
+    profile = registry.profiles[0]
+    cleanup_calls = []
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime,
+        "resolve_target_position_adapter",
+        lambda _model: QWEN35_TEXT_HYBRID_TARGET,
+    )
+    monkeypatch.setattr(
+        runtime.TargetPositionHooks,
+        "for_model",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("hook install failed")),
+    )
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=key.scorer_artifact_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=512,
+        target_identity_attestor=lambda target, processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: cleanup_calls.append("cleanup")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="hook install failed"):
+        prepare(SimpleNamespace(language_model=object()), object())
+
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_real_runtime_builder_rejects_wrong_scorer_bytes_before_loading(tmp_path):
+    import vllm_mlx.specprefill_runtime as runtime
+
+    scorer_path, _actual_hash = _scorer_artifact(tmp_path, b"wrong bytes")
+    registry, key = _certified_registry()
+    profile = registry.profiles[0]
+    load_calls = []
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=key.scorer_artifact_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=512,
+        target_identity_attestor=lambda target, processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: load_calls.append("load"),
+    )
+
+    with pytest.raises(ValueError, match="artifact bytes"):
+        prepare(object(), object())
+
+    assert load_calls == []
+
+
+@pytest.mark.parametrize("symlink_kind", ["directory", "shard"])
+def test_scorer_artifact_manifest_rejects_symlinks(tmp_path, symlink_kind):
+    import vllm_mlx.specprefill_runtime as runtime
+
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "weights.safetensors").write_bytes(b"weights")
+    if symlink_kind == "directory":
+        artifact = tmp_path / "artifact-link"
+        artifact.symlink_to(real, target_is_directory=True)
+    else:
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "weights.safetensors").symlink_to(
+            real / "weights.safetensors"
+        )
+
+    with pytest.raises(
+        runtime.SpecPrefillRuntimePreparationError,
+        match="symlink",
+    ):
+        runtime.sha256_artifact_path(artifact)
+
+
+@pytest.mark.parametrize("wrong_object", ["target", "processor"])
+def test_real_runtime_builder_rejects_unbound_target_attestation(
+    tmp_path, wrong_object
+):
+    import vllm_mlx.specprefill_runtime as runtime
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    registry, key = _certified_registry(scorer_hash=scorer_hash)
+    profile = registry.profiles[0]
+
+    def attest(target, processor):
+        return runtime.TargetProcessorAttestation(
+            object() if wrong_object == "target" else target,
+            object() if wrong_object == "processor" else processor,
+            key.target_artifact_hash,
+            key.tokenizer_artifact_hash,
+        )
+
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=1,
+        target_identity_attestor=attest,
+        scorer_loader=lambda *_args: pytest.fail("loader must not run"),
+    )
+
+    with pytest.raises(ValueError, match="loaded objects"):
+        prepare(object(), object())
+
+
+@pytest.mark.parametrize("cache_failure", ["raise", "rotating"])
+def test_real_runtime_builder_eager_cache_probe_fails_and_cleans(
+    monkeypatch, tmp_path, cache_failure
+):
+    import vllm_mlx.specprefill_runtime as runtime
+    from mlx_lm.models.cache import RotatingKVCache
+    from vllm_mlx.specprefill_positions import QWEN35_TEXT_HYBRID_TARGET
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    registry, key = _certified_registry(scorer_hash=scorer_hash)
+    profile = registry.profiles[0]
+    cleanup_calls = []
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime,
+        "resolve_target_position_adapter",
+        lambda _model: QWEN35_TEXT_HYBRID_TARGET,
+    )
+    monkeypatch.setattr(
+        runtime.TargetPositionHooks,
+        "for_model",
+        lambda *_args: SimpleNamespace(),
+    )
+
+    def cache_factory(_model):
+        if cache_failure == "raise":
+            raise RuntimeError("cache allocation failed")
+        return [RotatingKVCache(max_size=32)]
+
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=1,
+        target_identity_attestor=lambda target, processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: cleanup_calls.append("cleanup")
+        ),
+        target_cache_factory=cache_factory,
+    )
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(layers=[SimpleNamespace(is_linear=False)])
+    )
+
+    expected = RuntimeError if cache_failure == "raise" else runtime.SpecPrefillRuntimePreparationError
+    with pytest.raises(expected):
+        prepare(target, object())
+
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_real_runtime_builder_rejects_qwen_vlm_adapter(monkeypatch, tmp_path):
+    import vllm_mlx.specprefill_runtime as runtime
+    from vllm_mlx.specprefill_positions import QWEN35_VLM_HYBRID_TARGET
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    registry, key = _certified_registry(
+        scorer_hash=scorer_hash,
+        adapter_id=QWEN35_VLM_HYBRID_TARGET.adapter_id,
+    )
+    profile = registry.profiles[0]
+    cleanup_calls = []
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime,
+        "resolve_target_position_adapter",
+        lambda _model: QWEN35_VLM_HYBRID_TARGET,
+    )
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=profile.calibration.tuning,
+        estimated_residency_bytes=1,
+        target_identity_attestor=lambda target, processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: cleanup_calls.append("cleanup")
+        ),
+    )
+
+    with pytest.raises(runtime.SpecPrefillRuntimePreparationError, match="text"):
+        prepare(object(), object())
+
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_runtime_builder_requires_certification_and_marks_diagnostic_nonadvertisable(
+    monkeypatch, tmp_path,
+):
+    from dataclasses import replace
+
+    import vllm_mlx.specprefill_runtime as runtime
+    from mlx_lm.models.cache import KVCache
+    from vllm_mlx.specprefill_positions import QWEN35_TEXT_HYBRID_TARGET
+    from vllm_mlx.specprefill_profiles import (
+        SpecPrefillProfileRegistry,
+        SpecPrefillProfileTier,
+    )
+
+    scorer_path, scorer_hash = _scorer_artifact(tmp_path)
+    certified_registry, key = _certified_registry(scorer_hash=scorer_hash)
+    production = certified_registry.profiles[0]
+    uncertified = replace(production, qualification_evidence=None)
+    with pytest.raises(ValueError, match="certified evidence"):
+        runtime.build_qwen_cb_specprefill_prepare(
+            scorer_artifact_path=scorer_path,
+            scorer_artifact_hash=key.scorer_artifact_hash,
+            target_artifact_hash=key.target_artifact_hash,
+            tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+            profile_registry=SpecPrefillProfileRegistry((uncertified,)),
+            profile_key=key,
+            calibrated_tuning=production.calibration.tuning,
+            estimated_residency_bytes=1,
+            target_identity_attestor=lambda *_args: None,
+        )
+
+    diagnostic_profile = replace(
+        production,
+        tier=SpecPrefillProfileTier.DIAGNOSTIC,
+        qualification_evidence=None,
+    )
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime,
+        "resolve_target_position_adapter",
+        lambda _model: QWEN35_TEXT_HYBRID_TARGET,
+    )
+    monkeypatch.setattr(
+        runtime.TargetPositionHooks,
+        "for_model",
+        lambda *_args: SimpleNamespace(session_for_plan=lambda _plan: None),
+    )
+    prepare = runtime.build_qwen_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=key.scorer_artifact_hash,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        profile_registry=SpecPrefillProfileRegistry((diagnostic_profile,)),
+        profile_key=key,
+        calibrated_tuning=production.calibration.tuning,
+        estimated_residency_bytes=1,
+        target_identity_attestor=lambda target, processor: (
+            runtime.TargetProcessorAttestation(
+                target,
+                processor,
+                key.target_artifact_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        diagnostic=True,
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: None
+        ),
+        target_cache_factory=lambda _model: [KVCache()],
+    )
+    target = SimpleNamespace(
+        language_model=SimpleNamespace(layers=[SimpleNamespace(is_linear=False)])
+    )
+    processor = object()
+    prepared = prepare(target, processor)
+
+    assert prepared.diagnostic is True
+    assert prepared.advertisable is False

--- a/tests/test_batched_engine_specprefill.py
+++ b/tests/test_batched_engine_specprefill.py
@@ -1,0 +1,625 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic BatchedEngine SpecPrefill launch and transport contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.engine.batched import (
+    BatchedEngine,
+    PreparedMLLMSpecPrefillRuntime,
+)
+from vllm_mlx.mllm_scheduler import MLLMSpecPrefillCacheCapability
+from vllm_mlx.scheduler import SchedulerConfig
+from vllm_mlx.specprefill_profiles import (
+    SpecPrefillCalibration,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfile,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillProfileTier,
+    SpecPrefillQualificationEvidence,
+    SpecPrefillTuning,
+)
+
+
+def _hash(letter: str) -> str:
+    return letter * 64
+
+
+def _certified_registry():
+    key = SpecPrefillProfileKey(
+        target_artifact_id="qwen-target",
+        target_artifact_hash=_hash("a"),
+        tokenizer_artifact_hash=_hash("b"),
+        scorer_artifact_id="qwen-scorer",
+        scorer_artifact_hash=_hash("c"),
+        adapter_id="qwen-adapter",
+        engine=SpecPrefillEngine.CONTINUOUS_BATCHING,
+        cell=SpecPrefillCell.SPARSE_ONLY,
+    )
+    calibration = SpecPrefillCalibration(
+        selector_version="hybrid-v1",
+        tuning=SpecPrefillTuning(0.5, 0.1, 1, 1, 32),
+        crossover_tokens=8,
+        max_context_tokens=128,
+        residency_limit_bytes=1024,
+        min_ttft_improvement_pct=10.0,
+        max_total_latency_regression_pct=5.0,
+        max_decode_throughput_regression_pct=5.0,
+        required_context_tokens=(8, 16, 32, 64, 128),
+        required_concurrency_levels=(1, 2, 4, 8),
+        max_p95_inter_token_latency_regression_pct=5.0,
+        min_prefill_heavy_throughput_improvement_pct=10.0,
+    )
+    evidence = SpecPrefillQualificationEvidence(
+        report_id="run/specprefill/cb.json",
+        report_sha256=_hash("d"),
+        key=key,
+        selector_version="hybrid-v1",
+        tested_context_tokens=(8, 16, 32, 64, 128),
+        tested_concurrency_levels=(1, 2, 4, 8),
+        deterministic_baseline_successes=1,
+        preserved_baseline_successes=1,
+        fabricated_or_source_corruption_count=0,
+        quality_noninferiority_ci_lower_points=-1.0,
+        median_ttft_improvement_pct=20.0,
+        median_total_latency_regression_pct=1.0,
+        decode_throughput_regression_pct=1.0,
+        oom_count=0,
+        swap_escalation_count=0,
+        unbounded_retry_count=0,
+        peak_resident_bytes=512,
+        admission_safety_reserve_pct=10.0,
+        cb_p95_inter_token_latency_regression_pct=1.0,
+        cb_aggregate_throughput_regression_pct=0.0,
+        cb_prefill_heavy_throughput_improvement_pct=20.0,
+        mtp_evidence_id=None,
+        mtp_evidence_sha256=None,
+        mtp_drafts=0,
+        mtp_accepted=0,
+    )
+    profile = SpecPrefillProfile(
+        key,
+        SpecPrefillProfileTier.PRODUCTION,
+        calibration,
+        evidence,
+    )
+    return SpecPrefillProfileRegistry((profile,)), key
+
+
+def _bundle(cleanup, target_model, processor):
+    registry, key = _certified_registry()
+    return PreparedMLLMSpecPrefillRuntime(
+        profile_registry=registry,
+        profile_key=key,
+        estimated_residency_bytes=512,
+        session_factory=lambda **_kwargs: None,
+        cache_capability=MLLMSpecPrefillCacheCapability(
+            adapter_id=key.adapter_id,
+            layout="qwen3_5_nonrotating_hybrid",
+        ),
+        target_forward_context=lambda _forward: None,
+        target_model=target_model,
+        processor=processor,
+        target_artifact_hash=key.target_artifact_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        scorer_artifact_hash=key.scorer_artifact_hash,
+        cleanup=cleanup,
+    )
+
+
+class _Scheduler:
+    instances = []
+    fail_starts = 0
+
+    def __init__(self, model, processor, config):
+        self.model = model
+        self.processor = processor
+        self.config = config
+        self.stopped = False
+        self.__class__.instances.append(self)
+
+    async def start(self):
+        if self.__class__.fail_starts:
+            self.__class__.fail_starts -= 1
+            raise RuntimeError("scheduler start failed")
+
+    async def stop(self):
+        self.stopped = True
+
+
+def _engine(config):
+    engine = BatchedEngine("test", scheduler_config=config, force_mllm=True)
+    engine._model = object()
+    engine._processor = object()
+    return engine
+
+
+def test_prepared_launch_wires_exact_scheduler_dependencies(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    _Scheduler.instances = []
+    _Scheduler.fail_starts = 0
+    prepare_calls = []
+    cleanup_calls = []
+    engine = _engine(SchedulerConfig())
+    bundle = _bundle(
+        lambda: cleanup_calls.append("cleanup"), engine._model, engine._processor
+    )
+    config = SchedulerConfig(
+        specprefill_enabled=True,
+        specprefill_prepare=lambda model, processor: (
+            prepare_calls.append((model, processor)) or bundle
+        ),
+    )
+    engine._scheduler_config = config
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", _Scheduler)
+
+    asyncio.run(engine._start_mllm())
+
+    assert prepare_calls == [(engine._model, engine._processor)]
+    wired = _Scheduler.instances[0].config
+    assert wired.specprefill_enabled is True
+    assert wired.specprefill_profile_registry is bundle.profile_registry
+    assert wired.specprefill_profile_key is bundle.profile_key
+    assert wired.specprefill_session_factory is bundle.session_factory
+    assert wired.specprefill_cache_capability is bundle.cache_capability
+    assert wired.specprefill_target_forward_context is bundle.target_forward_context
+    assert cleanup_calls == []
+
+    asyncio.run(engine.stop())
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_failed_start_cleans_prepared_runtime_and_retry_prepares_again(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    _Scheduler.instances = []
+    _Scheduler.fail_starts = 1
+    prepare_calls = []
+    cleanup_calls = []
+
+    def prepare(_model, _processor):
+        attempt = len(prepare_calls) + 1
+        prepare_calls.append(attempt)
+        return _bundle(
+            lambda: cleanup_calls.append(attempt), _model, _processor
+        )
+
+    engine = _engine(
+        SchedulerConfig(specprefill_enabled=True, specprefill_prepare=prepare)
+    )
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", _Scheduler)
+
+    with pytest.raises(RuntimeError, match="scheduler start failed"):
+        asyncio.run(engine._start_mllm())
+    assert engine._mllm_scheduler is None
+    assert engine._prepared_specprefill_runtime is None
+    assert cleanup_calls == [1]
+
+    asyncio.run(engine._start_mllm())
+    assert prepare_calls == [1, 2]
+    assert engine._prepared_specprefill_runtime is not None
+    assert cleanup_calls == [1]
+
+
+def test_prepare_failure_or_incomplete_bundle_never_constructs_scheduler(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    _Scheduler.instances = []
+    cleaned = []
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", _Scheduler)
+    raising = _engine(
+        SchedulerConfig(
+            specprefill_enabled=True,
+            specprefill_prepare=lambda *_args: (_ for _ in ()).throw(
+                RuntimeError("scorer prepare failed")
+            ),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="scorer prepare failed"):
+        asyncio.run(raising._start_mllm())
+    assert _Scheduler.instances == []
+    assert raising._prepared_specprefill_runtime is None
+
+    incomplete = _engine(
+        SchedulerConfig(
+            specprefill_enabled=True,
+            specprefill_prepare=lambda *_args: SimpleNamespace(
+                cleanup=lambda: cleaned.append("incomplete")
+            ),
+        )
+    )
+    with pytest.raises(TypeError, match="PreparedMLLMSpecPrefillRuntime"):
+        asyncio.run(incomplete._start_mllm())
+    assert cleaned == ["incomplete"]
+    assert _Scheduler.instances == []
+    assert incomplete._prepared_specprefill_runtime is None
+
+
+def test_prepared_bundle_rejects_gemma_or_rotating_adapter():
+    registry, key = _certified_registry()
+
+    with pytest.raises(ValueError, match="not admitted"):
+        PreparedMLLMSpecPrefillRuntime(
+            profile_registry=registry,
+            profile_key=key,
+            estimated_residency_bytes=512,
+            session_factory=lambda **_kwargs: None,
+            cache_capability=MLLMSpecPrefillCacheCapability(
+                adapter_id=key.adapter_id,
+                layout="gemma4_dense",
+            ),
+            target_forward_context=lambda _forward: None,
+            target_model=object(),
+            processor=object(),
+            target_artifact_hash=key.target_artifact_hash,
+            tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+            scorer_artifact_hash=key.scorer_artifact_hash,
+            cleanup=lambda: None,
+        )
+
+
+def test_prepared_bundle_rejects_model_processor_or_hash_mismatch(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    _Scheduler.instances = []
+    cleaned = []
+    engine = _engine(SchedulerConfig())
+    mismatched = _bundle(lambda: cleaned.append("identity"), object(), object())
+    engine._scheduler_config = SchedulerConfig(
+        specprefill_enabled=True,
+        specprefill_prepare=lambda *_args: mismatched,
+    )
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", _Scheduler)
+
+    with pytest.raises(ValueError, match="target model identity mismatch"):
+        asyncio.run(engine._start_mllm())
+    assert cleaned == ["identity"]
+    assert _Scheduler.instances == []
+
+    registry, key = _certified_registry()
+    with pytest.raises(ValueError, match="artifact hashes"):
+        PreparedMLLMSpecPrefillRuntime(
+            profile_registry=registry,
+            profile_key=key,
+            estimated_residency_bytes=512,
+            session_factory=lambda **_kwargs: None,
+            cache_capability=MLLMSpecPrefillCacheCapability(
+                adapter_id=key.adapter_id,
+                layout="qwen3_5_nonrotating_hybrid",
+            ),
+            target_forward_context=lambda _forward: None,
+            target_model=object(),
+            processor=object(),
+            target_artifact_hash=_hash("e"),
+            tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+            scorer_artifact_hash=key.scorer_artifact_hash,
+            cleanup=lambda: None,
+        )
+
+
+def test_startup_preserves_original_when_both_cleanups_fail_and_retries(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    state = {
+        "start_fails": True,
+        "scheduler_cleanup_fails": True,
+        "prepared_cleanup_fails": True,
+    }
+    events = []
+    prepare_calls = 0
+
+    class Scheduler(_Scheduler):
+        async def start(self):
+            if state["start_fails"]:
+                raise RuntimeError("original startup failure")
+
+        async def stop(self):
+            events.append(("stop", self))
+            if state["scheduler_cleanup_fails"]:
+                raise asyncio.CancelledError("scheduler cleanup cancelled")
+            self.stopped = True
+
+    engine = _engine(SchedulerConfig())
+
+    def cleanup():
+        events.append(("cleanup", engine._prepared_specprefill_runtime))
+        if state["prepared_cleanup_fails"]:
+            raise RuntimeError("prepared cleanup failed")
+
+    def prepare(model, processor):
+        nonlocal prepare_calls
+        prepare_calls += 1
+        events.append(("prepare", prepare_calls))
+        return _bundle(cleanup, model, processor)
+
+    engine._scheduler_config = SchedulerConfig(
+        specprefill_enabled=True,
+        specprefill_prepare=prepare,
+    )
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", Scheduler)
+
+    with pytest.raises(RuntimeError, match="original startup failure"):
+        asyncio.run(engine._start_mllm())
+    old_scheduler = engine._mllm_scheduler
+    old_prepared = engine._prepared_specprefill_runtime
+    assert old_scheduler is not None
+    assert old_prepared is not None
+    assert prepare_calls == 1
+    assert events == [
+        ("prepare", 1),
+        ("stop", old_scheduler),
+        ("cleanup", old_prepared),
+    ]
+
+    with pytest.raises(RuntimeError, match="cleanup remains incomplete"):
+        asyncio.run(engine._start_mllm())
+    assert engine._mllm_scheduler is old_scheduler
+    assert engine._prepared_specprefill_runtime is old_prepared
+    assert prepare_calls == 1
+    assert events[-2:] == [("stop", old_scheduler), ("cleanup", old_prepared)]
+
+    state["scheduler_cleanup_fails"] = False
+    state["prepared_cleanup_fails"] = False
+    state["start_fails"] = False
+    asyncio.run(engine._start_mllm())
+    assert engine._mllm_scheduler is not None
+    assert engine._prepared_specprefill_runtime is not None
+    assert engine._mllm_scheduler is not old_scheduler
+    assert engine._prepared_specprefill_runtime is not old_prepared
+    assert prepare_calls == 2
+    assert events[-3:] == [
+        ("stop", old_scheduler),
+        ("cleanup", old_prepared),
+        ("prepare", 2),
+    ]
+
+
+def test_mismatch_cleanup_failure_retains_candidate_until_retry(monkeypatch):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    _Scheduler.instances = []
+    events = []
+    cleanup_fails = True
+    prepare_calls = 0
+    engine = _engine(SchedulerConfig())
+
+    def invalid_cleanup():
+        events.append("invalid_cleanup")
+        if cleanup_fails:
+            raise RuntimeError("invalid cleanup failed")
+
+    invalid = _bundle(invalid_cleanup, object(), object())
+
+    def prepare(model, processor):
+        nonlocal prepare_calls
+        prepare_calls += 1
+        events.append(f"prepare_{prepare_calls}")
+        if prepare_calls == 1:
+            return invalid
+        return _bundle(lambda: None, model, processor)
+
+    engine._scheduler_config = SchedulerConfig(
+        specprefill_enabled=True,
+        specprefill_prepare=prepare,
+    )
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", _Scheduler)
+
+    with pytest.raises(ValueError, match="target model identity mismatch"):
+        asyncio.run(engine._start_mllm())
+    assert engine._prepared_specprefill_runtime is invalid
+    assert prepare_calls == 1
+    assert events == ["prepare_1", "invalid_cleanup"]
+
+    cleanup_fails = False
+    asyncio.run(engine._start_mllm())
+
+    assert events[:3] == ["prepare_1", "invalid_cleanup", "invalid_cleanup"]
+    assert events[3] == "prepare_2"
+    assert prepare_calls == 2
+    assert engine._prepared_specprefill_runtime is not invalid
+    assert len(_Scheduler.instances) == 1
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        SchedulerConfig(specprefill_enabled=True),
+        SchedulerConfig(
+            specprefill_enabled=True,
+            enable_mtp=True,
+            specprefill_prepare=lambda *_args: None,
+        ),
+        SchedulerConfig(
+            specprefill_enabled=True,
+            max_kv_size=64,
+            specprefill_prepare=lambda *_args: None,
+        ),
+    ],
+)
+def test_enabled_launch_fails_closed_without_admitted_preparation(config):
+    engine = _engine(config)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(engine._start_mllm())
+
+    assert engine._mllm_scheduler is None
+    assert engine._prepared_specprefill_runtime is None
+
+
+def test_server_enable_switch_copies_scheduler_launch_config():
+    from vllm_mlx.server import _configure_batched_specprefill
+
+    prepare = lambda *_args: None
+    original = SchedulerConfig(
+        specprefill_enabled=False,
+        specprefill_prepare=prepare,
+    )
+    configured = _configure_batched_specprefill(original, enabled=True)
+
+    assert configured is not original
+    assert original.specprefill_enabled is False
+    assert configured.specprefill_enabled is True
+
+    with pytest.raises(ValueError, match="unavailable"):
+        _configure_batched_specprefill(SchedulerConfig(), enabled=True)
+
+
+def test_request_controls_and_terminal_metadata_cross_batched_engine():
+    terminal = SimpleNamespace(
+        output_text="ok",
+        output_token_ids=[7],
+        prompt_tokens=10,
+        completion_tokens=1,
+        finish_reason="stop",
+        mtp_drafts=4,
+        mtp_accepted=3,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="sparse",
+        specprefill_coverage="selective",
+        specprefill_engaged=True,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_fallback_reason=None,
+        specprefill_total_tokens=10,
+        specprefill_selected_tokens=5,
+        specprefill_scorer_ms=1.0,
+        specprefill_target_prefill_ms=2.0,
+    )
+
+    class Scheduler:
+        seen = None
+
+        async def generate(self, **kwargs):
+            self.seen = kwargs
+            return terminal
+
+    engine = _engine(SchedulerConfig())
+    engine._loaded = True
+    engine._mllm_scheduler = Scheduler()
+    output = asyncio.run(
+        engine.generate(
+            "prompt",
+            specprefill_policy="auto",
+            specprefill_coverage="selective",
+            specprefill_control_token_indices=[4, 1],
+        )
+    )
+
+    assert engine._mllm_scheduler.seen["specprefill_policy"] == "auto"
+    assert engine._mllm_scheduler.seen["specprefill_coverage"] == "selective"
+    assert engine._mllm_scheduler.seen["specprefill_control_token_indices"] == (4, 1)
+    assert "specprefill_keep_pct" not in engine._mllm_scheduler.seen
+    assert output.mtp_drafts == 4
+    assert output.mtp_accepted == 3
+    assert output.specprefill_selected_tokens == 5
+    assert output.specprefill_target_prefill_ms == 2.0
+
+    with pytest.raises(ValueError, match="does not accept"):
+        asyncio.run(
+            engine.generate(
+                "prompt",
+                specprefill_policy="auto",
+                specprefill_keep_pct=0.9,
+            )
+        )
+
+    with pytest.raises(ValueError, match="conflicts with specprefill_policy"):
+        asyncio.run(
+            engine.generate(
+                "prompt",
+                specprefill=False,
+                specprefill_policy="sparse",
+            )
+        )
+
+
+def test_streaming_terminal_preserves_complete_independent_metadata():
+    terminal = SimpleNamespace(
+        output_text="ok",
+        new_text="ok",
+        prompt_tokens=10,
+        completion_tokens=1,
+        finished=True,
+        finish_reason="stop",
+        mtp_drafts=2,
+        mtp_accepted=1,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="dense",
+        specprefill_coverage="exhaustive",
+        specprefill_engaged=False,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_fallback_reason="coverage_not_selective",
+        specprefill_total_tokens=10,
+        specprefill_selected_tokens=0,
+        specprefill_scorer_ms=0.0,
+        specprefill_target_prefill_ms=0.0,
+    )
+
+    class Scheduler:
+        seen = None
+
+        async def add_request_async(self, **kwargs):
+            self.seen = kwargs
+            return "request"
+
+        async def stream_outputs(self, _request_id):
+            yield terminal
+
+    async def collect(engine):
+        return [
+            item
+            async for item in engine.stream_generate(
+                "prompt",
+                specprefill_policy="auto",
+                specprefill_coverage="exhaustive",
+                specprefill_control_token_indices=[3],
+            )
+        ]
+
+    engine = _engine(SchedulerConfig())
+    engine._loaded = True
+    engine._mllm_scheduler = Scheduler()
+    output = asyncio.run(collect(engine))[0]
+
+    assert engine._mllm_scheduler.seen["specprefill_control_token_indices"] == (3,)
+    assert output.finished is True
+    assert (output.mtp_drafts, output.mtp_accepted) == (2, 1)
+    assert output.specprefill_effective_policy == "dense"
+    assert output.specprefill_fallback_reason == "coverage_not_selective"
+
+
+def test_explicit_media_bit_survives_empty_extraction_arrays():
+    class Scheduler:
+        seen = None
+
+        async def generate(self, **kwargs):
+            self.seen = kwargs
+            return SimpleNamespace(
+                output_text="",
+                output_token_ids=[],
+                prompt_tokens=1,
+                completion_tokens=0,
+                finish_reason="stop",
+            )
+
+    engine = _engine(SchedulerConfig())
+    engine._loaded = True
+    engine._mllm_scheduler = Scheduler()
+    asyncio.run(
+        engine.generate(
+            "prompt",
+            images=[],
+            specprefill_policy="auto",
+            specprefill_coverage="selective",
+            specprefill_has_media=True,
+        )
+    )
+
+    assert engine._mllm_scheduler.seen["specprefill_has_media"] is True

--- a/tests/test_batched_engine_specprefill.py
+++ b/tests/test_batched_engine_specprefill.py
@@ -105,7 +105,7 @@ def _scorer_artifact(tmp_path, contents=b"synthetic scorer weights"):
     return str(path), hashlib.sha256(contents).hexdigest()
 
 
-def _bundle(cleanup, target_model, processor):
+def _bundle(cleanup, target_model, processor, *, native_mtp_session_factory=None):
     registry, key = _certified_registry()
     return PreparedMLLMSpecPrefillRuntime(
         profile_registry=registry,
@@ -123,6 +123,7 @@ def _bundle(cleanup, target_model, processor):
         tokenizer_artifact_hash=key.tokenizer_artifact_hash,
         scorer_artifact_hash=key.scorer_artifact_hash,
         cleanup=cleanup,
+        native_mtp_session_factory=native_mtp_session_factory,
     )
 
 
@@ -189,6 +190,288 @@ def test_prepared_launch_wires_exact_scheduler_dependencies(monkeypatch):
 
     asyncio.run(engine.stop())
     assert cleanup_calls == ["cleanup"]
+
+
+def test_standard_text_native_mtp_specprefill_prepares_and_wires_public_config():
+    """Combined text startup owns one prepared bundle through SchedulerConfig."""
+    model = SimpleNamespace(mtp_capability=SimpleNamespace(supported=True, reason=None))
+    tokenizer = object()
+    cleaned = []
+    factory = lambda *_args: None
+    bundle = _bundle(
+        lambda: cleaned.append("cleanup"),
+        model,
+        tokenizer,
+        native_mtp_session_factory=factory,
+    )
+    config = SchedulerConfig(
+        enable_mtp=True,
+        enable_prefix_cache=False,
+        specprefill_enabled=True,
+        specprefill_prepare=lambda actual_model, actual_tokenizer: (
+            bundle
+            if (actual_model, actual_tokenizer) == (model, tokenizer)
+            else pytest.fail("prepare received an unexpected startup identity")
+        ),
+    )
+    engine = BatchedEngine("test", scheduler_config=config)
+    engine._model = model
+    engine._tokenizer = tokenizer
+
+    assert engine._prepare_llm_native_mtp_specprefill_runtime() is bundle
+    assert config.native_mtp_specprefill_runtime is bundle
+    assert engine.native_mtp_server_state().incompatibility is None
+    assert cleaned == []
+
+    asyncio.run(engine.stop())
+    assert cleaned == ["cleanup"]
+    assert config.native_mtp_specprefill_runtime is None
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (
+            SchedulerConfig(
+                enable_mtp=True,
+                enable_prefix_cache=True,
+                specprefill_enabled=True,
+                specprefill_prepare=lambda *_args: None,
+            ),
+            "native_mtp_prefix_reuse_unsupported",
+        ),
+        (
+            SchedulerConfig(
+                enable_mtp=True,
+                enable_prefix_cache=False,
+                chunked_prefill_tokens=1,
+                specprefill_enabled=True,
+                specprefill_prepare=lambda *_args: None,
+            ),
+            "native_mtp_chunked_prefill_unsupported",
+        ),
+    ],
+)
+def test_standard_text_combined_startup_fails_before_prepare_for_incompatible_cb_knobs(
+    config, message
+):
+    engine = BatchedEngine("test", scheduler_config=config)
+    engine._model = object()
+    engine._tokenizer = object()
+
+    with pytest.raises(RuntimeError, match=message):
+        engine._prepare_llm_native_mtp_specprefill_runtime()
+    assert config.native_mtp_specprefill_runtime is None
+
+
+def test_standard_text_combined_startup_rejects_bundle_without_sparse_factory():
+    model, tokenizer = object(), object()
+    cleaned = []
+    bundle = _bundle(lambda: cleaned.append("cleanup"), model, tokenizer)
+    config = SchedulerConfig(
+        enable_mtp=True,
+        enable_prefix_cache=False,
+        specprefill_enabled=True,
+        specprefill_prepare=lambda *_args: bundle,
+    )
+    engine = BatchedEngine("test", scheduler_config=config)
+    engine._model = model
+    engine._tokenizer = tokenizer
+
+    with pytest.raises(ValueError, match="native MTP session factory missing"):
+        engine._prepare_llm_native_mtp_specprefill_runtime()
+    assert cleaned == ["cleanup"]
+    assert config.native_mtp_specprefill_runtime is None
+
+
+def test_standard_text_specprefill_only_remains_fail_closed_for_native_mtp_state():
+    config = SchedulerConfig(specprefill_enabled=True, enable_prefix_cache=False)
+    engine = BatchedEngine("test", scheduler_config=config)
+    engine._model = SimpleNamespace(mtp_capability=SimpleNamespace(supported=True))
+
+    assert (
+        engine.native_mtp_server_state().incompatibility
+        == "native_mtp_specprefill_composition_unsupported"
+    )
+
+
+def test_standard_text_combined_preflight_rejects_before_model_or_core_startup():
+    events = []
+    config = SchedulerConfig(
+        enable_mtp=True,
+        enable_prefix_cache=True,
+        specprefill_enabled=True,
+        specprefill_prepare=lambda *_args: events.append("prepare"),
+    )
+    engine = BatchedEngine("test", scheduler_config=config)
+    engine.prepare_for_start = lambda: events.append("model")
+
+    with pytest.raises(RuntimeError, match="native_mtp_prefix_reuse_unsupported"):
+        asyncio.run(engine.start())
+    assert events == []
+    assert engine._engine is None
+
+
+def test_standard_text_start_failure_closes_core_before_prepared_runtime(monkeypatch):
+    import vllm_mlx.engine_core as core_module
+
+    events = []
+    model, tokenizer = object(), object()
+    bundle = _bundle(
+        lambda: events.append("prepared_cleanup"),
+        model,
+        tokenizer,
+        native_mtp_session_factory=lambda *_args: None,
+    )
+    engine = BatchedEngine("test", scheduler_config=SchedulerConfig())
+    engine._model = model
+    engine._tokenizer = tokenizer
+    monkeypatch.setattr(
+        engine,
+        "_prepare_llm_native_mtp_specprefill_runtime",
+        lambda: bundle,
+    )
+
+    class _SchedulerCore:
+        async def start(self):
+            raise RuntimeError("core start failed")
+
+        def close(self):
+            events.append("core_close")
+
+    class _Core:
+        def __init__(self, **_kwargs):
+            self.engine = _SchedulerCore()
+
+        async def stop(self):
+            events.append("core_stop")
+
+    monkeypatch.setattr(core_module, "AsyncEngineCore", _Core)
+
+    with pytest.raises(RuntimeError, match="core start failed"):
+        asyncio.run(engine._start_llm())
+    assert events == ["core_stop", "core_close", "prepared_cleanup"]
+    assert engine._engine is None
+    assert engine._prepared_specprefill_runtime is None
+
+
+def test_standard_text_stop_closes_core_before_prepared_runtime():
+    events = []
+    engine = BatchedEngine("test", scheduler_config=SchedulerConfig())
+    engine._engine = SimpleNamespace(
+        stop=lambda: _async_event(events, "core_stop"),
+        engine=SimpleNamespace(close=lambda: events.append("core_close")),
+    )
+    engine._prepared_specprefill_runtime = SimpleNamespace(
+        cleanup=lambda: events.append("prepared_cleanup")
+    )
+
+    asyncio.run(engine.stop())
+
+    assert events == ["core_stop", "core_close", "prepared_cleanup"]
+
+
+def test_standard_text_stop_defers_prepared_cleanup_until_core_retry_succeeds():
+    events = []
+    attempts = 0
+
+    async def _stop_core():
+        nonlocal attempts
+        attempts += 1
+        events.append(f"core_stop_{attempts}")
+        if attempts == 1:
+            raise RuntimeError("core stop failed")
+
+    engine = BatchedEngine("test", scheduler_config=SchedulerConfig())
+    engine._engine = SimpleNamespace(
+        stop=_stop_core,
+        engine=SimpleNamespace(close=lambda: events.append("core_close")),
+    )
+    engine._prepared_specprefill_runtime = SimpleNamespace(
+        cleanup=lambda: events.append("prepared_cleanup")
+    )
+
+    with pytest.raises(RuntimeError, match="core stop failed"):
+        asyncio.run(engine.stop())
+    assert events == ["core_stop_1", "core_close"]
+    assert engine._engine is not None
+    assert engine._prepared_specprefill_runtime is not None
+
+    asyncio.run(engine.stop())
+    assert events == [
+        "core_stop_1",
+        "core_close",
+        "core_stop_2",
+        "core_close",
+        "prepared_cleanup",
+    ]
+    assert engine._engine is None
+    assert engine._prepared_specprefill_runtime is None
+
+
+def test_standard_text_retry_start_waits_for_prior_core_before_runtime_or_replacement(
+    monkeypatch,
+):
+    import vllm_mlx.engine_core as core_module
+
+    events = []
+    prior_stop_attempts = 0
+    replacement_constructions = []
+
+    async def _stop_prior_core():
+        nonlocal prior_stop_attempts
+        prior_stop_attempts += 1
+        events.append(f"prior_stop_{prior_stop_attempts}")
+        if prior_stop_attempts == 1:
+            raise RuntimeError("prior core still live")
+
+    class _ReplacementScheduler:
+        async def start(self):
+            events.append("replacement_start")
+
+        def close(self):
+            events.append("replacement_close")
+
+    class _ReplacementCore:
+        def __init__(self, **_kwargs):
+            replacement_constructions.append("constructed")
+            self.engine = _ReplacementScheduler()
+
+        async def stop(self):
+            events.append("replacement_stop")
+
+    engine = BatchedEngine("test", scheduler_config=SchedulerConfig())
+    engine._model = object()
+    engine._tokenizer = object()
+    engine._engine = SimpleNamespace(
+        stop=_stop_prior_core,
+        engine=SimpleNamespace(close=lambda: events.append("prior_close")),
+    )
+    engine._prepared_specprefill_runtime = SimpleNamespace(
+        cleanup=lambda: events.append("prepared_cleanup")
+    )
+    monkeypatch.setattr(core_module, "AsyncEngineCore", _ReplacementCore)
+
+    with pytest.raises(RuntimeError, match="startup cleanup remains incomplete"):
+        asyncio.run(engine._start_llm())
+    assert events == ["prior_stop_1", "prior_close"]
+    assert replacement_constructions == []
+    assert engine._prepared_specprefill_runtime is not None
+
+    asyncio.run(engine._start_llm())
+    assert events == [
+        "prior_stop_1",
+        "prior_close",
+        "prior_stop_2",
+        "prior_close",
+        "prepared_cleanup",
+        "replacement_start",
+    ]
+    assert replacement_constructions == ["constructed"]
+
+
+async def _async_event(events, event):
+    events.append(event)
 
 
 def test_failed_start_cleans_prepared_runtime_and_retry_prepares_again(monkeypatch):

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -768,6 +768,8 @@ class TestSchedulerBasic:
 
         monkeypatch.setattr("vllm_mlx.scheduler.BatchGenerator", FakeBatchGenerator)
         mock_model.mtp = object()
+        mock_model.mtp_capability = None
+        mock_model.language_model.mtp_capability = None
         scheduler = Scheduler(
             model=mock_model,
             tokenizer=mock_tokenizer,

--- a/tests/test_cb_native_mtp_adapter.py
+++ b/tests/test_cb_native_mtp_adapter.py
@@ -429,8 +429,15 @@ def _bare_scheduler(*requests):
     scheduler._native_zero_token_ids = set()
     scheduler._native_cancelled_ids = set()
     scheduler._native_admission_errors = {}
+    scheduler._native_mtp_specprefill_bridges = {}
+    scheduler._native_mtp_specprefill_queue = deque()
     scheduler._pending_abort_ids = set()
-    scheduler.config = SimpleNamespace(max_num_seqs=8, prefill_step_size=4)
+    scheduler.config = SimpleNamespace(
+        max_num_seqs=8,
+        prefill_step_size=4,
+        native_mtp_specprefill_runtime=None,
+        specprefill_enabled=False,
+    )
     scheduler.model = _Model()
     scheduler.total_prompt_tokens = 0
     scheduler.total_completion_tokens = 0
@@ -822,6 +829,242 @@ def test_scheduler_native_admission_failure_is_one_terminal_error_per_row_and_qu
         (output.request_id, output.finish_reason) for output in second_step.outputs
     ] == [(next_zero.request_id, "length")]
     assert len(calls) == 1
+
+
+def test_scheduler_claims_combined_sparse_cohort_only_after_every_bridge_ready(
+    monkeypatch,
+):
+    """The adapter receives attested bootstraps, never a partial cohort."""
+    import vllm_mlx.native_mtp_cb_adapter as adapter_mod
+    import vllm_mlx.native_mtp_specprefill_bridge as bridge_mod
+
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    key = SimpleNamespace(
+        target_artifact_id="target",
+        target_artifact_hash="a" * 64,
+        tokenizer_artifact_hash="b" * 64,
+        scorer_artifact_id="scorer",
+        scorer_artifact_hash="c" * 64,
+    )
+    tuning = SimpleNamespace(
+        keep_pct=0.5,
+        backbone_pct=0.0,
+        halo_chunks=0,
+        anchor_chunks=1,
+        chunk_size=2,
+    )
+    scheduler.config = SimpleNamespace(
+        max_num_seqs=8,
+        prefill_step_size=4,
+        specprefill_enabled=True,
+        native_mtp_specprefill_runtime=SimpleNamespace(
+            profile_key=key,
+            profile_registry=SimpleNamespace(
+                resolve=lambda *_args, **_kwargs: SimpleNamespace(
+                    eligible=True, tuning=tuning
+                )
+            ),
+            estimated_residency_bytes=1,
+        ),
+    )
+
+    states = SimpleNamespace(
+        BOOTSTRAP_READY=SimpleNamespace(value="bootstrap_ready"),
+    )
+
+    class _Bridge:
+        def __init__(self, _prepared, request, _config):
+            self.request_id = request.request_id
+            self.state = SimpleNamespace(value="waiting")
+            self.bootstrap = object()
+            self.adopted = 0
+            self.cancelled = False
+
+        def step(self):
+            self.state = states.BOOTSTRAP_READY
+            return SimpleNamespace(state=self.state, fallback_reason=None)
+
+        def mark_adopted(self):
+            self.adopted += 1
+            self.state = SimpleNamespace(value="adopted")
+
+        def cancel(self):
+            self.cancelled = True
+
+    calls = []
+    monkeypatch.setattr(bridge_mod, "NativeMTPSpecPrefillBridge", _Bridge)
+    monkeypatch.setattr(
+        bridge_mod,
+        "NativeMTPSpecPrefillBridgeState",
+        states,
+    )
+    monkeypatch.setattr(
+        adapter_mod.NativeMTPContinuousBatchAdapter,
+        "create",
+        classmethod(lambda _cls, *_args, **kwargs: calls.append(kwargs) or object()),
+    )
+
+    assert scheduler._schedule_waiting() == [first, second]
+    assert calls == []
+    scheduler._schedule_waiting()
+    assert calls == []
+    scheduler._schedule_waiting()
+    assert len(calls) == 1
+    assert len(calls[0]["sparse_bootstraps"]) == 2
+    assert all(not bridge.adopted for bridge in scheduler._native_mtp_specprefill_bridges.values())
+
+
+def test_scheduler_cancels_unclaimed_combined_bridge_before_adapter_start():
+    from vllm_mlx.request import RequestStatus
+    request = _real_request(1)
+    scheduler = _bare_scheduler(request)
+    bridge = SimpleNamespace(cancelled=False)
+    bridge.cancel = lambda: setattr(bridge, "cancelled", True)
+    scheduler._native_mtp_specprefill_bridges[request.request_id] = bridge
+    scheduler._native_mtp_specprefill_queue.append(request.request_id)
+    request.status = RequestStatus.RUNNING
+    scheduler.running[request.request_id] = request
+
+    assert scheduler._do_abort_request(request.request_id)
+    assert bridge.cancelled is True
+    assert request.request_id not in scheduler._native_mtp_specprefill_bridges
+    assert not scheduler._native_mtp_specprefill_queue
+
+
+def test_combined_bridge_construction_failure_cancels_prior_and_errors_cohort_once(
+    monkeypatch,
+):
+    import vllm_mlx.native_mtp_specprefill_bridge as bridge_mod
+
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    scheduler.config.specprefill_enabled = True
+    scheduler.config.native_mtp_specprefill_runtime = object()
+    bridge_config = object()
+    monkeypatch.setattr(
+        scheduler, "_native_mtp_specprefill_config", lambda _r: bridge_config
+    )
+    built = []
+
+    class _Bridge:
+        def __init__(self, _prepared, request, _config):
+            if request is second:
+                raise RuntimeError("later_bridge_failed")
+            self.cancelled = False
+            built.append(self)
+
+        def cancel(self):
+            self.cancelled = True
+
+    monkeypatch.setattr(bridge_mod, "NativeMTPSpecPrefillBridge", _Bridge)
+    assert scheduler._start_native_mtp_specprefill_bridges() == [first, second]
+    assert built[0].cancelled is True
+    assert scheduler._native_mtp_specprefill_bridges == {}
+    assert scheduler._native_admission_errors == {
+        first.request_id: "later_bridge_failed",
+        second.request_id: "later_bridge_failed",
+    }
+
+
+def test_combined_bridge_failure_cancels_and_errors_every_cohort_member_no_subset_adapter(
+    monkeypatch,
+):
+    import vllm_mlx.native_mtp_cb_adapter as adapter_mod
+
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    scheduler.waiting.clear()
+    cancelled = []
+
+    class _Bridge:
+        def __init__(self, *, fails=False):
+            self.state = SimpleNamespace(value="prefilling")
+            self.fails = fails
+
+        def step(self):
+            if self.fails:
+                raise RuntimeError("bridge_quantum_failed")
+            return SimpleNamespace(state=self.state, fallback_reason=None)
+
+        def cancel(self):
+            cancelled.append(self)
+
+    scheduler.running = {first.request_id: first, second.request_id: second}
+    scheduler._native_mtp_specprefill_bridges = {
+        first.request_id: _Bridge(fails=True),
+        second.request_id: _Bridge(),
+    }
+    scheduler._native_mtp_specprefill_queue.extend((first.request_id, second.request_id))
+    scheduler._native_mtp_specprefill_cohort_ids = (first.request_id, second.request_id)
+    monkeypatch.setattr(
+        adapter_mod.NativeMTPContinuousBatchAdapter,
+        "create",
+        classmethod(lambda *_args, **_kwargs: pytest.fail("subset adapter forbidden")),
+    )
+
+    scheduler._advance_native_mtp_specprefill_bridge()
+    assert len(cancelled) == 2
+    assert scheduler._native_mtp_specprefill_bridges == {}
+    assert scheduler._native_admission_errors == {
+        first.request_id: "bridge_quantum_failed",
+        second.request_id: "bridge_quantum_failed",
+    }
+
+
+def test_combined_claim_callback_records_exact_ready_cohort_without_fallible_adoption(
+    monkeypatch,
+):
+    import vllm_mlx.native_mtp_cb_adapter as adapter_mod
+    import vllm_mlx.native_mtp_specprefill_bridge as bridge_mod
+
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    scheduler.waiting.clear()
+    ready = SimpleNamespace(BOOTSTRAP_READY=object())
+    records = []
+
+    class _Bridge:
+        state = ready.BOOTSTRAP_READY
+
+        def __init__(self, token):
+            self.bootstrap = token
+
+        def record_public_claim(self):
+            records.append(self.bootstrap)
+            self.bootstrap = None
+            self.state = SimpleNamespace(value="adopted")
+
+        def cancel(self):
+            pytest.fail("claimed bridge must not be cancelled")
+
+    first_bridge, second_bridge = _Bridge("one"), _Bridge("two")
+    scheduler.running = {first.request_id: first, second.request_id: second}
+    scheduler._native_mtp_specprefill_bridges = {
+        first.request_id: first_bridge,
+        second.request_id: second_bridge,
+    }
+    scheduler._native_mtp_specprefill_cohort_ids = (first.request_id, second.request_id)
+    captured = {}
+    monkeypatch.setattr(bridge_mod, "NativeMTPSpecPrefillBridgeState", ready)
+    monkeypatch.setattr(
+        adapter_mod.NativeMTPContinuousBatchAdapter,
+        "create",
+        classmethod(
+            lambda _cls, _model, requests, **kwargs: (
+                captured.update(requests=tuple(requests), **kwargs) or object()
+            )
+        ),
+    )
+
+    assert scheduler._start_ready_native_mtp_specprefill_cohort() is True
+    assert tuple(item.request_id for item in captured["requests"]) == (
+        first.request_id,
+        second.request_id,
+    )
+    assert captured["sparse_bootstraps"] == ["one", "two"]
+    captured["sparse_adopted"]()
+    assert records == ["one", "two"]
 
 
 def test_scheduler_zero_budget_head_finishes_same_step_before_adapter_and_keeps_next_row(

--- a/tests/test_cb_native_mtp_adapter.py
+++ b/tests/test_cb_native_mtp_adapter.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import asyncio
 from collections import deque
+from contextlib import contextmanager
 import importlib
 import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
+import mlx.core as mx
 import pytest
 
 
@@ -144,6 +146,13 @@ class _Generator:
         )
         return emissions, _Initial(tuple(row.uid for row in self.admission.rows))
 
+    def start_sparse(self):
+        emissions = tuple(
+            _Emission(row.uid, row.uid + 1, object(), False)
+            for row in self.admission.rows
+        )
+        return emissions, _Initial(tuple(row.uid for row in self.admission.rows))
+
 
 class _RejectGenerator(_Generator):
     def prefill(self, *, prefill_step_size):
@@ -205,6 +214,11 @@ class _Admission:
         cls.calls.append((model, tuple(rows), tuple(request_caches), kwargs))
         return SimpleNamespace(rows=tuple(rows))
 
+    @classmethod
+    def create_from_sparse_bootstraps(cls, model, rows, bootstraps):
+        cls.calls.append((model, tuple(rows), tuple(bootstraps), "sparse"))
+        return SimpleNamespace(rows=tuple(rows))
+
 
 def _lifecycle(*, reject=False):
     return SimpleNamespace(
@@ -234,10 +248,128 @@ class _Model:
         return cache
 
 
+class _SparseBootstrap:
+    def __init__(self, model, request):
+        self.selected_logical_positions = (0, 2)
+        self.selected_token_ids = (request.prompt_token_ids[0], request.prompt_token_ids[2])
+        self.immediate_successor_token_ids = (request.prompt_token_ids[1],)
+        self.target_cache = [object()]
+        self.next_logical_position = len(request.prompt_token_ids)
+        self.receipts = (
+            SimpleNamespace(
+                model_id=id(model),
+                cache_container_id=id(self.target_cache),
+                cache_entry_ids=tuple(id(item) for item in self.target_cache),
+            ),
+        )
+
+
 class _FreshCacheFailureModel(_Model):
     def make_mtp_request_cache(self, *, prompt_cache=None):
         assert prompt_cache is None
         raise RuntimeError("fresh_cache_failed")
+
+
+class _PinnedSparseModel:
+    """Real cache-writing target/MTP double for pinned sparse admission."""
+
+    mtp_capability = SimpleNamespace(supported=True, reason="")
+    vocab_size = 11
+
+    def __init__(self, *, moe=False):
+        from mlx_lm.models.cache import KVCache
+
+        self._cache_type = KVCache
+        self.layers = [type("_Attention", (), {"is_linear": False})()]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+        self.moe = moe
+        self.target_calls = 0
+        self.mtp_calls = 0
+        self._forward = None
+
+    def make_cache(self):
+        return [self._cache_type()]
+
+    def make_mtp_cache(self):
+        return [self._cache_type()]
+
+    @contextmanager
+    def generation_forward_context(self, forward):
+        prior, self._forward = self._forward, forward
+        try:
+            yield
+        finally:
+            self._forward = prior
+
+    def _ack(self):
+        if self._forward is not None:
+            self._forward.logical_position_ack.acknowledge(
+                self._forward.logical_positions
+            )
+
+    def _logits(self, inputs):
+        delta = mx.where(inputs % 2 == 0, 1, self.vocab_size - 1) if self.moe else 1
+        ids = (inputs.astype(mx.int32) + delta) % self.vocab_size
+        logits = mx.full((*inputs.shape, self.vocab_size), -20.0)
+        for row in range(inputs.shape[0]):
+            for column in range(inputs.shape[1]):
+                logits[row, column, ids[row, column]] = 20.0
+        return logits
+
+    def __call__(self, inputs, *, cache, return_hidden=False):
+        self.target_calls += 1
+        self._ack()
+        values = mx.broadcast_to(
+            inputs.astype(mx.float32)[:, None, :, None],
+            (inputs.shape[0], 1, inputs.shape[1], 8),
+        )
+        cache[0].update_and_fetch(values, values)
+        hidden = mx.stack((inputs.astype(mx.float32), inputs.astype(mx.float32)), axis=-1)
+        logits = self._logits(inputs)
+        return (logits, hidden) if return_hidden else logits
+
+    def mtp_forward(self, hidden, next_tokens, cache):
+        self.mtp_calls += 1
+        self._ack()
+        values = mx.broadcast_to(
+            next_tokens.astype(mx.float32)[:, None, :, None],
+            (next_tokens.shape[0], 1, next_tokens.shape[1], 8),
+        )
+        cache[0].update_and_fetch(values, values)
+        return self._logits(next_tokens)
+
+
+def _pinned_bootstrap(model, prompt, positions):
+    from mlx_lm.generate import (
+        GenerationForwardPhase,
+        NativeMTPSparseBootstrap,
+        attested_target_forward,
+    )
+
+    cache = model.make_cache()
+    selected = tuple(prompt[position] for position in positions)
+    successors = tuple(prompt[position + 1] for position in positions[:-1])
+    receipts = []
+    for index, token in enumerate(selected):
+        successor = () if index == len(selected) - 1 else (successors[index],)
+        (_, _), receipt = attested_target_forward(
+            model,
+            (token,),
+            cache,
+            phase=GenerationForwardPhase.PREFILL,
+            logical_positions=(positions[index],),
+            immediate_successor_token_ids=successor,
+            model_forward_context=model.generation_forward_context,
+        )
+        receipts.append(receipt)
+    return NativeMTPSparseBootstrap(
+        receipts=tuple(receipts),
+        selected_logical_positions=tuple(positions),
+        selected_token_ids=selected,
+        immediate_successor_token_ids=successors,
+        target_cache=cache,
+        next_logical_position=len(prompt),
+    )
 
 
 def _request(uid, *, seed=None):
@@ -364,6 +496,166 @@ def test_uniform_reject_exposes_target_logprobs_and_finish_reason():
         (1, False, "length")
     ]
     assert emissions[0].logprobs is not None
+
+
+def test_sparse_bootstraps_are_atomically_adopted_and_start_from_sparse_head():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _Model()
+    requests = [_request(1), _request(2)]
+    bootstraps = tuple(_SparseBootstrap(model, request) for request in requests)
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        model,
+        requests,
+        lifecycle=_lifecycle(),
+        sparse_bootstraps=bootstraps,
+    )
+    emissions = adapter.step()
+    assert [item.uid for item in emissions] == [1, 2]
+    assert model.created == []
+    _, rows, received, kind = _Admission.calls[-1]
+    assert kind == "sparse"
+    assert [(row.uid, row.prompt) for row in rows] == [(1, (1, 1)), (2, (1, 2))]
+    assert received == bootstraps
+
+
+def test_sparse_adopted_callback_runs_only_after_public_admission():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _Model()
+    request = _request(1)
+    called = []
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        model,
+        [request],
+        lifecycle=_lifecycle(),
+        sparse_bootstraps=(_SparseBootstrap(model, request),),
+        sparse_adopted=lambda: called.append("claimed"),
+    )
+    assert called == []
+    adapter.step()
+    assert called == ["claimed"]
+
+
+def test_sparse_bootstrap_count_mismatch_fails_before_fresh_cache_creation():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _Model()
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_count_mismatch"):
+        NativeMTPContinuousBatchAdapter.create(
+            model,
+            [_request(1), _request(2)],
+            lifecycle=_lifecycle(),
+            sparse_bootstraps=(_SparseBootstrap(model, _request(1)),),
+        )
+    assert model.created == []
+
+
+def test_sparse_bootstrap_cannot_be_reordered_or_reused_before_admission():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _Model()
+    first, second = _request(1), _request(2)
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_request_tokens_mismatch"):
+        NativeMTPContinuousBatchAdapter.create(
+            model,
+            [first, second],
+            lifecycle=_lifecycle(),
+            sparse_bootstraps=(_SparseBootstrap(model, second), _SparseBootstrap(model, first)),
+        )
+    bootstrap = _SparseBootstrap(model, first)
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_reused"):
+        NativeMTPContinuousBatchAdapter.create(
+            model,
+            [first, second],
+            lifecycle=_lifecycle(),
+            sparse_bootstraps=(bootstrap, bootstrap),
+        )
+
+
+@pytest.mark.parametrize("moe", [False, True])
+def test_pinned_sparse_admission_uses_selected_prompt_without_target_replay(moe):
+    """Exercise real receipt authority through the adapter's public path."""
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _PinnedSparseModel(moe=moe)
+    request = _request(7, seed=3)
+    request.prompt_token_ids = [0, 1, 2, 3, 4]
+    bootstrap = _pinned_bootstrap(model, request.prompt_token_ids, (0, 2, 4))
+    target_calls = model.target_calls
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        model, [request], sparse_bootstraps=(bootstrap,)
+    )
+    emissions = adapter.step()
+    assert [item.uid for item in emissions] == [7]
+    assert model.target_calls == target_calls
+    assert model.mtp_calls > 0
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        from mlx_lm.generate import NativeMTPAdmission, NativeMTPRowSpec
+
+        NativeMTPAdmission.create_from_sparse_bootstraps(
+            model, (NativeMTPRowSpec(8, (0, 2, 4), 2),), (bootstrap,)
+        )
+
+
+def test_pinned_bootstrap_forgery_is_rejected_before_claim_and_original_survives():
+    from mlx_lm.generate import NativeMTPAdmission, NativeMTPRowSpec
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _PinnedSparseModel()
+    request = _request(1)
+    request.prompt_token_ids = [0, 1, 2, 3, 4]
+    bootstrap = _pinned_bootstrap(model, request.prompt_token_ids, (0, 2, 4))
+    forged = replace(bootstrap, target_cache=[object()])
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_receipt_provenance_mismatch"):
+        NativeMTPContinuousBatchAdapter.create(
+            model, [request], sparse_bootstraps=(forged,)
+        )
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model, (NativeMTPRowSpec(1, (0, 2, 4), 2),), (bootstrap,)
+    )
+    assert admission.rows[0].prompt == (0, 2, 4)
+
+
+def test_pinned_bootstrap_close_abandons_authority_before_downstream_claim():
+    from mlx_lm.generate import NativeMTPAdmission, NativeMTPRowSpec
+
+    model = _PinnedSparseModel()
+    bootstrap = _pinned_bootstrap(model, (0, 1, 2, 3, 4), (0, 2, 4))
+    bootstrap.close()
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        NativeMTPAdmission.create_from_sparse_bootstraps(
+            model, (NativeMTPRowSpec(1, (0, 2, 4), 2),), (bootstrap,)
+        )
+
+
+def test_partial_sparse_admission_failure_consumes_every_bootstrap_authority():
+    from mlx_lm.generate import NativeMTPAdmission, NativeMTPRowSpec
+
+    model = _PinnedSparseModel()
+    first = _pinned_bootstrap(model, (0, 1, 2, 3, 4), (0, 2, 4))
+    second = _pinned_bootstrap(model, (5, 6, 7, 8, 9), (0, 2, 4))
+    # The second bootstrap presents a receipt owned by the first target cache;
+    # the first claim has already been made when this one fails validation.
+    malformed = replace(second, receipts=(first.receipts[0],))
+    with pytest.raises(RuntimeError):
+        NativeMTPAdmission.create_from_sparse_bootstraps(
+            model,
+            (
+                NativeMTPRowSpec(1, (0, 2, 4), 2),
+                NativeMTPRowSpec(2, (5, 7, 9), 2),
+            ),
+            (first, malformed),
+        )
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+        NativeMTPAdmission.create_from_sparse_bootstraps(
+            model, (NativeMTPRowSpec(3, first.selected_token_ids, 2),), (first,)
+        )
+    # The untouched original second authority was never passed or reserved.
+    admission = NativeMTPAdmission.create_from_sparse_bootstraps(
+        model, (NativeMTPRowSpec(4, second.selected_token_ids, 2),), (second,)
+    )
+    assert admission.rows[0].uid == 4
 
 
 def test_b_gt_1_mixed_resolution_filters_terminal_and_tracks_uid_local_telemetry():

--- a/tests/test_cb_native_mtp_adapter.py
+++ b/tests/test_cb_native_mtp_adapter.py
@@ -1,0 +1,678 @@
+"""MLX-free contracts for standard-text native-MTP CB dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import asyncio
+from collections import deque
+import importlib
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@dataclass(frozen=True)
+class _Emission:
+    uid: int
+    token: int
+    logprobs: object
+    from_draft: bool
+    finish_reason: str | None = None
+
+
+class _Epoch:
+    def __init__(self, active_uids):
+        self.active_uids = tuple(active_uids)
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _Initial(_Epoch):
+    def resume(self):
+        return _Ready(self.active_uids)
+
+
+class _RejectInitial(_Epoch):
+    def resume(self):
+        return _RejectReady(self.active_uids)
+
+
+class _Ready(_Epoch):
+    def decide(self):
+        return _Decision(self.active_uids)
+
+
+class _RejectReady(_Epoch):
+    def decide(self):
+        return _RejectDecision(self.active_uids)
+
+
+class _Decision(_Epoch):
+    def __init__(self, active_uids):
+        super().__init__(active_uids)
+        self.accepted_uids = (active_uids[0],)
+        self.rejected_uids = tuple(active_uids[1:])
+
+    def accept(self):
+        return (
+            tuple(
+                _Emission(uid, uid + 10, object(), True, "length")
+                for uid in self.active_uids
+            ),
+            _Accepted(self.active_uids),
+        )
+
+    def reject(self):
+        return (
+            tuple(
+                _Emission(uid, uid + 10, object(), False, "length")
+                for uid in self.active_uids
+            ),
+            _Rejected(self.active_uids),
+        )
+
+    def resolve(self):
+        return (
+            tuple(
+                _Emission(uid, uid + 10, object(), uid in self.accepted_uids)
+                for uid in self.active_uids
+            ),
+            _Mixed(self.accepted_uids, self.rejected_uids),
+        )
+
+
+class _RejectDecision(_Decision):
+    def __init__(self, active_uids):
+        _Epoch.__init__(self, active_uids)
+        self.accepted_uids = ()
+        self.rejected_uids = tuple(active_uids)
+
+
+class _Accepted(_Epoch):
+    def bonus(self):
+        return (
+            tuple(
+                _Emission(uid, uid + 20, object(), False) for uid in self.active_uids
+            ),
+            _Bonus(self.active_uids),
+        )
+
+
+class _Bonus(_Epoch):
+    def catch_up(self):
+        return _Ready(self.active_uids)
+
+
+class _Rejected(_Epoch):
+    def redraft(self):
+        return _Ready(self.active_uids)
+
+
+class _Mixed(_Epoch):
+    def __init__(self, accepted, rejected):
+        super().__init__(accepted + rejected)
+        self.accepted, self.rejected = accepted, rejected
+
+    def resume_after_resolution(self):
+        return (
+            tuple(
+                _Emission(uid, uid + 20, object(), False, "length")
+                for uid in self.accepted
+            ),
+            _MixedBonus(self.rejected),
+        )
+
+
+class _MixedBonus(_Epoch):
+    def resume_after_bonus(self):
+        return _Ready(self.active_uids)
+
+
+class _Generator:
+    def __init__(self, admission):
+        self.admission = admission
+
+    def prefill(self, *, prefill_step_size):
+        assert prefill_step_size == 4
+        emissions = tuple(
+            _Emission(row.uid, row.uid + 1, object(), False)
+            for row in self.admission.rows
+        )
+        return emissions, _Initial(tuple(row.uid for row in self.admission.rows))
+
+
+class _RejectGenerator(_Generator):
+    def prefill(self, *, prefill_step_size):
+        assert prefill_step_size == 4
+        emissions = tuple(
+            _Emission(row.uid, row.uid + 1, object(), False)
+            for row in self.admission.rows
+        )
+        return emissions, _RejectInitial(tuple(row.uid for row in self.admission.rows))
+
+
+@dataclass(frozen=True)
+class _Row:
+    uid: int
+    prompt: tuple[int, ...]
+    max_tokens: int
+    seed: int | None
+    eos_token_ids: frozenset[int]
+    sampling_config: object
+
+
+class _Admission:
+    calls = []
+
+    @classmethod
+    def create(cls, model, rows, request_caches, **kwargs):
+        cls.calls.append((model, tuple(rows), tuple(request_caches), kwargs))
+        return SimpleNamespace(rows=tuple(rows))
+
+
+def _lifecycle(*, reject=False):
+    return SimpleNamespace(
+        NativeMTPRowSpec=_Row,
+        NativeMTPAdmission=_Admission,
+        NativeMTPBatchGenerator=_RejectGenerator if reject else _Generator,
+        NativeMTPSamplingConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+
+class _Model:
+    mtp_capability = SimpleNamespace(supported=True, reason="")
+
+    def __init__(self):
+        self.created = []
+
+    def make_mtp_request_cache(self, *, prompt_cache=None):
+        assert prompt_cache is None
+        cache = object()
+        self.created.append(cache)
+        return cache
+
+
+class _FreshCacheFailureModel(_Model):
+    def make_mtp_request_cache(self, *, prompt_cache=None):
+        assert prompt_cache is None
+        raise RuntimeError("fresh_cache_failed")
+
+
+def _request(uid, *, seed=None):
+    return SimpleNamespace(
+        request_id=f"r{uid}",
+        batch_uid=uid,
+        prompt_token_ids=[1, 2, uid],
+        sampling_params=SimpleNamespace(
+            max_tokens=8,
+            stop_token_ids=[],
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+        ),
+        native_mtp_eos_token_ids={99},
+        native_mtp_config=SimpleNamespace(
+            sampling=SimpleNamespace(
+                temperature=0.7, top_p=0.9, top_k=7, min_p=0.1, seed=seed
+            )
+        ),
+    )
+
+
+def _real_request(uid, *, max_tokens=8):
+    from vllm_mlx.request import Request, SamplingParams
+
+    request = Request(
+        request_id=f"real-{uid}",
+        prompt=[1, 2, uid],
+        sampling_params=SamplingParams(max_tokens=max_tokens),
+    )
+    request.prompt_token_ids = [1, 2, uid]
+    request.num_prompt_tokens = 3
+    request.native_mtp_config = _request(uid).native_mtp_config
+    return request
+
+
+def _bare_scheduler(*requests):
+    import vllm_mlx.scheduler as scheduler_mod
+
+    scheduler = object.__new__(scheduler_mod.Scheduler)
+    scheduler.waiting = deque(requests)
+    scheduler.running = {}
+    scheduler.requests = {request.request_id: request for request in requests}
+    scheduler.finished_req_ids = set()
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler.native_mtp_adapter = None
+    scheduler.batch_generator = None
+    scheduler._current_sampler_params = None
+    scheduler.prefix_cache = None
+    scheduler.memory_aware_cache = None
+    scheduler.paged_cache_manager = None
+    scheduler.block_aware_cache = None
+    scheduler._ssd_tier = None
+    scheduler._detokenizer_pool = {}
+    scheduler._next_native_mtp_uid = 7
+    scheduler._native_zero_token_ids = set()
+    scheduler._native_cancelled_ids = set()
+    scheduler._native_admission_errors = {}
+    scheduler._pending_abort_ids = set()
+    scheduler.config = SimpleNamespace(max_num_seqs=8, prefill_step_size=4)
+    scheduler.model = _Model()
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.num_requests_processed = 0
+    scheduler._step_count = 0
+    scheduler._clear_cache_interval = 999
+    scheduler._memory_log_interval = 999
+    return scheduler
+
+
+def _install_minimal_step_cleanup(monkeypatch, scheduler):
+    def _cleanup(ids):
+        for request_id in ids:
+            uid = scheduler.request_id_to_uid.pop(request_id, None)
+            if uid is not None:
+                scheduler.uid_to_request_id.pop(uid, None)
+            scheduler.running.pop(request_id, None)
+
+    monkeypatch.setattr(scheduler, "_cleanup_finished", _cleanup)
+
+
+def test_b1_uses_uniform_public_emission_result_and_fresh_request_cache():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    model = _Model()
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        model, [_request(1, seed=17)], lifecycle=_lifecycle(), prefill_step_size=4
+    )
+    assert model.created == []  # cancellation before prefill owns no cache bytes
+    assert [item.uid for item in adapter.step()] == [1]
+    adapter.step()
+    adapter.step()
+    emissions = adapter.step()
+    assert [(item.uid, item.from_draft, item.finish_reason) for item in emissions] == [
+        (1, True, "length")
+    ]
+    assert emissions[0].logprobs is not None
+    _, rows, caches, kwargs = _Admission.calls[-1]
+    assert rows[0].seed == 17
+    assert caches == tuple(model.created)
+    assert kwargs == {
+        "prefix_cache": None,
+        "media": None,
+        "external_draft": None,
+        "sparse_bootstrap": None,
+        "logits_processors": None,
+        "kv_bits": None,
+        "max_kv_size": None,
+    }
+
+
+def test_uniform_reject_exposes_target_logprobs_and_finish_reason():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        _Model(), [_request(1)], lifecycle=_lifecycle(reject=True), prefill_step_size=4
+    )
+    adapter.step()
+    adapter.step()
+    adapter.step()
+    emissions = adapter.step()
+    assert [(item.uid, item.from_draft, item.finish_reason) for item in emissions] == [
+        (1, False, "length")
+    ]
+    assert emissions[0].logprobs is not None
+
+
+def test_b_gt_1_mixed_resolution_filters_terminal_and_tracks_uid_local_telemetry():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        _Model(),
+        [_request(1, seed=3), _request(2, seed=5)],
+        lifecycle=_lifecycle(),
+        prefill_step_size=4,
+    )
+    adapter.step()
+    adapter.step()
+    adapter.step()
+    decision_emissions = adapter.step()
+    assert [(item.uid, item.from_draft) for item in decision_emissions] == [
+        (1, True),
+        (2, False),
+    ]
+    assert all(item.logprobs is not None for item in decision_emissions)
+    assert [(item.uid, item.finish_reason) for item in adapter.step()] == [
+        (1, "length")
+    ]
+    adapter.step()
+    assert adapter.active_uids == (2,)
+    assert adapter.telemetry_for(1) == {
+        "target_tokens": 5,
+        "draft_tokens": 1,
+        "accepted_tokens": 1,
+    }
+    assert adapter.telemetry_for(2) == {
+        "target_tokens": 4,
+        "draft_tokens": 2,
+        "accepted_tokens": 0,
+    }
+
+
+def test_cancellation_before_and_after_initial_emission_is_public_and_cohort_scoped():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    before = NativeMTPContinuousBatchAdapter.create(
+        _Model(), [_request(1)], lifecycle=_lifecycle()
+    )
+    assert before.cancel() == (1,)
+    assert before.closed
+    after = NativeMTPContinuousBatchAdapter.create(
+        _Model(), [_request(1)], lifecycle=_lifecycle(), prefill_step_size=4
+    )
+    after.step()
+    assert after.cancel() == (1,)
+    assert after.closed
+
+
+def test_fresh_cache_failure_is_deferred_until_prefill_and_remains_cancellable():
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        _FreshCacheFailureModel(),
+        [_request(1)],
+        lifecycle=_lifecycle(),
+        prefill_step_size=4,
+    )
+    with pytest.raises(RuntimeError, match="^fresh_cache_failed$"):
+        adapter.step()
+    assert adapter.cancel() == (1,)
+    assert adapter.closed
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "reason"),
+    [
+        ("prefix_reused", True, "native_mtp_prefix_reuse_unsupported"),
+        ("chunked_prefill", True, "native_mtp_chunked_prefill_unsupported"),
+        ("quantized_kv", True, "native_mtp_quantized_cache_unsupported"),
+        ("has_media", True, "native_mtp_media_unsupported"),
+        ("external_draft", True, "native_mtp_external_draft_unsupported"),
+        ("logits_processors", [object()], "native_mtp_logits_processors_unsupported"),
+    ],
+)
+def test_adapter_fails_closed_for_every_unadmitted_composition(name, value, reason):
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    request = _request(1)
+    setattr(request, name, value)
+    with pytest.raises(RuntimeError, match=f"^{reason}$"):
+        NativeMTPContinuousBatchAdapter.create(
+            _Model(), [request], lifecycle=_lifecycle()
+        )
+
+
+def test_adapter_uses_no_private_lifecycle_or_legacy_batch_generator_surface():
+    source = (
+        Path(__file__).parents[1] / "vllm_mlx" / "native_mtp_cb_adapter.py"
+    ).read_text()
+    assert "_install_mtp" not in source
+    assert "._draft" not in source
+    assert "._replacement" not in source
+    assert "._verify" not in source
+    assert "from mlx_lm.generate import BatchGenerator" not in source
+    assert "_install_mtp(" not in source
+
+
+def test_pinned_public_lifecycle_import_surface_exposes_uniform_emissions():
+    module = importlib.import_module("mlx_lm.generate")
+    assert inspect.ismodule(module)
+    assert hasattr(module, "NativeMTPRowSpec")
+    assert hasattr(module, "NativeMTPAdmission")
+    assert hasattr(module, "NativeMTPBatchGenerator")
+    assert "Tuple" in str(
+        inspect.signature(module.NativeMTPDecisionEpoch.accept).return_annotation
+    )
+    assert "Tuple" in str(
+        inspect.signature(module.NativeMTPDecisionEpoch.reject).return_annotation
+    )
+
+
+def test_scheduler_native_admission_failure_is_one_terminal_error_per_row_and_queue_advances(
+    monkeypatch,
+):
+    import vllm_mlx.native_mtp_cb_adapter as adapter_mod
+
+    first, second, next_zero = (
+        _real_request(1),
+        _real_request(2),
+        _real_request(3, max_tokens=0),
+    )
+    first.batch_uid, second.batch_uid = 41, 42
+    scheduler = _bare_scheduler(first, second, next_zero)
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+    calls = []
+
+    monkeypatch.setattr(
+        adapter_mod.NativeMTPContinuousBatchAdapter,
+        "create",
+        classmethod(
+            lambda cls, *args, **kwargs: (
+                calls.append((args, kwargs)),
+                (_ for _ in ()).throw(RuntimeError("create_failed")),
+            )[1]
+        ),
+    )
+    first_step = scheduler.step()
+    assert [
+        (output.request_id, output.finish_reason, output.native_mtp_error_reason)
+        for output in first_step.outputs
+    ] == [
+        (first.request_id, "error", "create_failed"),
+        (second.request_id, "error", "create_failed"),
+    ]
+    assert tuple(scheduler.waiting) == (next_zero,)
+    assert (first.batch_uid, second.batch_uid, scheduler._next_native_mtp_uid) == (
+        41,
+        42,
+        7,
+    )
+    assert (
+        scheduler.running
+        == scheduler.request_id_to_uid
+        == scheduler.uid_to_request_id
+        == {}
+    )
+    second_step = scheduler.step()
+    assert [
+        (output.request_id, output.finish_reason) for output in second_step.outputs
+    ] == [(next_zero.request_id, "length")]
+    assert len(calls) == 1
+
+
+def test_scheduler_zero_budget_head_finishes_same_step_before_adapter_and_keeps_next_row(
+    monkeypatch,
+):
+    import vllm_mlx.native_mtp_cb_adapter as adapter_mod
+
+    zero, following = _real_request(1, max_tokens=0), _real_request(2)
+    scheduler = _bare_scheduler(zero, following)
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+    monkeypatch.setattr(
+        adapter_mod.NativeMTPContinuousBatchAdapter,
+        "create",
+        classmethod(lambda cls, *args, **kwargs: pytest.fail("adapter must not start")),
+    )
+    output = scheduler.step()
+    assert [
+        (item.request_id, item.finish_reason, item.completion_tokens)
+        for item in output.outputs
+    ] == [(zero.request_id, "length", 0)]
+    assert tuple(scheduler.waiting) == (following,)
+    assert scheduler._next_native_mtp_uid == 7
+
+
+def test_native_emission_logprobs_survive_scheduler_collector_and_batched_conversion(
+    monkeypatch,
+):
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.output_collector import RequestOutputCollector
+    from vllm_mlx.request import RequestOutput
+
+    request = _real_request(1)
+    scheduler = _bare_scheduler(request)
+    scheduler.running[request.request_id] = request
+    scheduler.uid_to_request_id[1] = request.request_id
+    scheduler.native_mtp_adapter = SimpleNamespace(
+        telemetry_for=lambda uid: {"draft_tokens": 1, "accepted_tokens": 1}
+    )
+    logprobs = object()
+    detok = SimpleNamespace(
+        add_token=lambda token: None, last_segment="x", finalize=lambda: None, text="x"
+    )
+    monkeypatch.setattr(scheduler, "_get_detokenizer", lambda request_id: detok)
+    monkeypatch.setattr(scheduler, "_cleanup_detokenizer", lambda request_id: None)
+    outputs, _ = scheduler._process_native_mtp_emissions(
+        [SimpleNamespace(uid=1, token=5, logprobs=logprobs, finish_reason=None)]
+    )
+    collector = RequestOutputCollector()
+    collector.put(outputs[0])
+    assert collector.get_nowait().logprobs is logprobs
+
+    class _Engine:
+        async def generate(self, **kwargs):
+            return RequestOutput(
+                request_id="engine-request",
+                output_text="ok",
+                logprobs=logprobs,
+                native_mtp_error_reason="native_error",
+            )
+
+    engine = object.__new__(BatchedEngine)
+    engine._loaded = True
+    engine._is_mllm = False
+    engine._engine = _Engine()
+    native = asyncio.run(engine.generate("prompt", _native_mtp_request_config=object()))
+    ordinary = asyncio.run(engine.generate("prompt"))
+    assert native.logprobs is logprobs
+    assert native.mtp_bypass_reason == "native_error"
+    assert ordinary.logprobs is None
+    assert ordinary.mtp_bypass_reason is None
+
+
+def test_scheduler_native_abort_is_cohort_scoped_and_cleans_all_terminal_mappings(
+    monkeypatch,
+):
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    scheduler.running = {first.request_id: first, second.request_id: second}
+    scheduler.request_id_to_uid = {first.request_id: 1, second.request_id: 2}
+    scheduler.uid_to_request_id = {1: first.request_id, 2: second.request_id}
+    cancelled = []
+    scheduler.native_mtp_adapter = SimpleNamespace(
+        cancel=lambda: cancelled.append(True)
+    )
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+    assert scheduler._do_abort_request(first.request_id)
+    output = scheduler.step()
+    assert cancelled == [True]
+    assert {
+        (item.request_id, item.finish_reason, item.native_mtp_error_reason)
+        for item in output.outputs
+    } == {
+        (first.request_id, "abort", None),
+        (second.request_id, "abort", None),
+    }
+    assert (
+        scheduler.running
+        == scheduler.request_id_to_uid
+        == scheduler.uid_to_request_id
+        == {}
+    )
+
+
+def test_two_pending_native_cohort_aborts_cancel_once_and_drain_exactly_once(
+    monkeypatch,
+):
+    first, second = _real_request(1), _real_request(2)
+    scheduler = _bare_scheduler(first, second)
+    scheduler.waiting.clear()
+    scheduler.running = {first.request_id: first, second.request_id: second}
+    scheduler.request_id_to_uid = {first.request_id: 1, second.request_id: 2}
+    scheduler.uid_to_request_id = {1: first.request_id, 2: second.request_id}
+    scheduler._pending_abort_ids = {first.request_id, second.request_id}
+    cancelled = []
+    scheduler.native_mtp_adapter = SimpleNamespace(
+        cancel=lambda: cancelled.append(True)
+    )
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+
+    first_step = scheduler.step()
+    assert cancelled == [True]
+    assert {
+        (item.request_id, item.finish_reason, item.native_mtp_error_reason)
+        for item in first_step.outputs
+    } == {
+        (first.request_id, "abort", None),
+        (second.request_id, "abort", None),
+    }
+    assert len(first_step.outputs) == 2
+    assert (
+        scheduler.running
+        == scheduler.request_id_to_uid
+        == scheduler.uid_to_request_id
+        == {}
+    )
+
+    second_step = scheduler.step()
+    assert second_step.outputs == []
+    assert cancelled == [True]
+
+
+def test_scheduler_native_prefill_failure_is_one_terminal_error_without_retry_hang(
+    monkeypatch,
+):
+    request = _real_request(1)
+    scheduler = _bare_scheduler(request)
+    scheduler.waiting.clear()
+    scheduler.running = {request.request_id: request}
+    scheduler.request_id_to_uid = {request.request_id: 1}
+    scheduler.uid_to_request_id = {1: request.request_id}
+    scheduler.native_mtp_adapter = SimpleNamespace(
+        step=lambda: (_ for _ in ()).throw(RuntimeError("fresh_cache_failed")),
+        cancel=lambda: None,
+    )
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+    first = scheduler.step()
+    assert [
+        (item.request_id, item.finish_reason, item.native_mtp_error_reason)
+        for item in first.outputs
+    ] == [(request.request_id, "error", "fresh_cache_failed")]
+    assert scheduler.native_mtp_adapter is None
+    assert (
+        scheduler.running
+        == scheduler.request_id_to_uid
+        == scheduler.uid_to_request_id
+        == {}
+    )
+    second = scheduler.step()
+    assert second.outputs == []
+
+
+def test_inactive_scheduler_keeps_ordinary_constructor_and_insert_call_shapes():
+    source = (Path(__file__).parents[1] / "vllm_mlx" / "scheduler.py").read_text()
+    assert "BatchGenerator(\n            model=self.model," in source
+    assert (
+        "self.batch_generator.insert(\n                    [tokens_to_process],"
+        in source
+    )
+    assert (
+        "native_mtp_config"
+        not in source.split("def _create_batch_generator", 1)[1].split(
+            "def _make_prompt_cache_save_callback", 1
+        )[0]
+    )

--- a/tests/test_cb_native_mtp_adapter.py
+++ b/tests/test_cb_native_mtp_adapter.py
@@ -155,6 +155,38 @@ class _RejectGenerator(_Generator):
         return emissions, _RejectInitial(tuple(row.uid for row in self.admission.rows))
 
 
+class _PoisonedInitial(_Epoch):
+    """A consumed public epoch whose model call has already closed its owner."""
+
+    def __init__(self, active_uids, generator):
+        super().__init__(active_uids)
+        self._generator = generator
+
+    def resume(self):
+        self._generator.closed = True
+        self._generator.cohort.poisoned = True
+        raise RuntimeError("forced_mtp_failure")
+
+    def cancel(self):
+        raise AssertionError("stale poisoned epoch must not be cancelled")
+
+
+class _PoisoningGenerator(_Generator):
+    def __init__(self, admission):
+        super().__init__(admission)
+        self.closed = False
+        self.cohort = SimpleNamespace(poisoned=False)
+
+    def prefill(self, *, prefill_step_size):
+        emissions = tuple(
+            _Emission(row.uid, row.uid + 1, object(), False)
+            for row in self.admission.rows
+        )
+        return emissions, _PoisonedInitial(
+            tuple(row.uid for row in self.admission.rows), self
+        )
+
+
 @dataclass(frozen=True)
 class _Row:
     uid: int
@@ -181,6 +213,12 @@ def _lifecycle(*, reject=False):
         NativeMTPBatchGenerator=_RejectGenerator if reject else _Generator,
         NativeMTPSamplingConfig=lambda **kwargs: SimpleNamespace(**kwargs),
     )
+
+
+def _poisoning_lifecycle():
+    lifecycle = _lifecycle()
+    lifecycle.NativeMTPBatchGenerator = _PoisoningGenerator
+    return lifecycle
 
 
 class _Model:
@@ -661,6 +699,61 @@ def test_scheduler_native_prefill_failure_is_one_terminal_error_without_retry_ha
     )
     second = scheduler.step()
     assert second.outputs == []
+
+
+def test_scheduler_preserves_primary_mtp_failure_when_public_epoch_is_already_poisoned(
+    monkeypatch,
+):
+    """Terminal cleanup must not call a consumed public epoch a second time."""
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+    request = _real_request(1)
+    request.batch_uid = 1
+    scheduler = _bare_scheduler(request)
+    scheduler.waiting.clear()
+    scheduler.running = {request.request_id: request}
+    scheduler.request_id_to_uid = {request.request_id: request.batch_uid}
+    scheduler.uid_to_request_id = {request.batch_uid: request.request_id}
+    _install_minimal_step_cleanup(monkeypatch, scheduler)
+    detokenizer = SimpleNamespace(
+        last_segment="x",
+        text="x",
+        add_token=lambda _token_id: None,
+        finalize=lambda: None,
+    )
+    monkeypatch.setattr(scheduler, "_get_detokenizer", lambda _request_id: detokenizer)
+    adapter = NativeMTPContinuousBatchAdapter.create(
+        scheduler.model,
+        [request],
+        lifecycle=_poisoning_lifecycle(),
+        prefill_step_size=4,
+    )
+    scheduler.native_mtp_adapter = adapter
+
+    first = scheduler.step()
+    assert first.outputs[0].finish_reason is None
+    generator = adapter._generator
+    assert generator.closed is False
+    assert generator.cohort.poisoned is False
+
+    error = scheduler.step()
+    assert [
+        (item.request_id, item.finish_reason, item.native_mtp_error_reason)
+        for item in error.outputs
+    ] == [(request.request_id, "error", "forced_mtp_failure")]
+    assert adapter.closed is True
+    assert generator.closed is True
+    assert generator.cohort.poisoned is True
+    assert scheduler.native_mtp_adapter is None
+    assert (
+        scheduler.running
+        == scheduler.request_id_to_uid
+        == scheduler.uid_to_request_id
+        == {}
+    )
+
+    retry = scheduler.step()
+    assert retry.outputs == []
 
 
 def test_inactive_scheduler_keeps_ordinary_constructor_and_insert_call_shapes():

--- a/tests/test_cb_native_mtp_adapter.py
+++ b/tests/test_cb_native_mtp_adapter.py
@@ -251,7 +251,10 @@ class _Model:
 class _SparseBootstrap:
     def __init__(self, model, request):
         self.selected_logical_positions = (0, 2)
-        self.selected_token_ids = (request.prompt_token_ids[0], request.prompt_token_ids[2])
+        self.selected_token_ids = (
+            request.prompt_token_ids[0],
+            request.prompt_token_ids[2],
+        )
         self.immediate_successor_token_ids = (request.prompt_token_ids[1],)
         self.target_cache = [object()]
         self.next_logical_position = len(request.prompt_token_ids)
@@ -324,7 +327,9 @@ class _PinnedSparseModel:
             (inputs.shape[0], 1, inputs.shape[1], 8),
         )
         cache[0].update_and_fetch(values, values)
-        hidden = mx.stack((inputs.astype(mx.float32), inputs.astype(mx.float32)), axis=-1)
+        hidden = mx.stack(
+            (inputs.astype(mx.float32), inputs.astype(mx.float32)), axis=-1
+        )
         logits = self._logits(inputs)
         return (logits, hidden) if return_hidden else logits
 
@@ -548,7 +553,9 @@ def test_sparse_bootstrap_count_mismatch_fails_before_fresh_cache_creation():
     from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
 
     model = _Model()
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_count_mismatch"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_count_mismatch"
+    ):
         NativeMTPContinuousBatchAdapter.create(
             model,
             [_request(1), _request(2)],
@@ -568,7 +575,10 @@ def test_sparse_bootstrap_cannot_be_reordered_or_reused_before_admission():
             model,
             [first, second],
             lifecycle=_lifecycle(),
-            sparse_bootstraps=(_SparseBootstrap(model, second), _SparseBootstrap(model, first)),
+            sparse_bootstraps=(
+                _SparseBootstrap(model, second),
+                _SparseBootstrap(model, first),
+            ),
         )
     bootstrap = _SparseBootstrap(model, first)
     with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_reused"):
@@ -597,7 +607,9 @@ def test_pinned_sparse_admission_uses_selected_prompt_without_target_replay(moe)
     assert [item.uid for item in emissions] == [7]
     assert model.target_calls == target_calls
     assert model.mtp_calls > 0
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         from mlx_lm.generate import NativeMTPAdmission, NativeMTPRowSpec
 
         NativeMTPAdmission.create_from_sparse_bootstraps(
@@ -614,7 +626,9 @@ def test_pinned_bootstrap_forgery_is_rejected_before_claim_and_original_survives
     request.prompt_token_ids = [0, 1, 2, 3, 4]
     bootstrap = _pinned_bootstrap(model, request.prompt_token_ids, (0, 2, 4))
     forged = replace(bootstrap, target_cache=[object()])
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_receipt_provenance_mismatch"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_receipt_provenance_mismatch"
+    ):
         NativeMTPContinuousBatchAdapter.create(
             model, [request], sparse_bootstraps=(forged,)
         )
@@ -630,7 +644,9 @@ def test_pinned_bootstrap_close_abandons_authority_before_downstream_claim():
     model = _PinnedSparseModel()
     bootstrap = _pinned_bootstrap(model, (0, 1, 2, 3, 4), (0, 2, 4))
     bootstrap.close()
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         NativeMTPAdmission.create_from_sparse_bootstraps(
             model, (NativeMTPRowSpec(1, (0, 2, 4), 2),), (bootstrap,)
         )
@@ -654,7 +670,9 @@ def test_partial_sparse_admission_failure_consumes_every_bootstrap_authority():
             ),
             (first, malformed),
         )
-    with pytest.raises(RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"):
+    with pytest.raises(
+        RuntimeError, match="native_mtp_sparse_bootstrap_already_claimed"
+    ):
         NativeMTPAdmission.create_from_sparse_bootstraps(
             model, (NativeMTPRowSpec(3, first.selected_token_ids, 2),), (first,)
         )
@@ -912,11 +930,15 @@ def test_scheduler_claims_combined_sparse_cohort_only_after_every_bridge_ready(
     scheduler._schedule_waiting()
     assert len(calls) == 1
     assert len(calls[0]["sparse_bootstraps"]) == 2
-    assert all(not bridge.adopted for bridge in scheduler._native_mtp_specprefill_bridges.values())
+    assert all(
+        not bridge.adopted
+        for bridge in scheduler._native_mtp_specprefill_bridges.values()
+    )
 
 
 def test_scheduler_cancels_unclaimed_combined_bridge_before_adapter_start():
     from vllm_mlx.request import RequestStatus
+
     request = _real_request(1)
     scheduler = _bare_scheduler(request)
     bridge = SimpleNamespace(cancelled=False)
@@ -995,7 +1017,9 @@ def test_combined_bridge_failure_cancels_and_errors_every_cohort_member_no_subse
         first.request_id: _Bridge(fails=True),
         second.request_id: _Bridge(),
     }
-    scheduler._native_mtp_specprefill_queue.extend((first.request_id, second.request_id))
+    scheduler._native_mtp_specprefill_queue.extend(
+        (first.request_id, second.request_id)
+    )
     scheduler._native_mtp_specprefill_cohort_ids = (first.request_id, second.request_id)
     monkeypatch.setattr(
         adapter_mod.NativeMTPContinuousBatchAdapter,

--- a/tests/test_cb_native_mtp_gate.py
+++ b/tests/test_cb_native_mtp_gate.py
@@ -1,0 +1,361 @@
+"""Continuous-batching native-Qwen MTP capability gates."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def _model(
+    model_type: str,
+    *,
+    capability: object | None = None,
+    mtp: object | None = None,
+) -> SimpleNamespace:
+    model = SimpleNamespace(config=SimpleNamespace(model_type=model_type), mtp=mtp)
+    if capability is not None:
+        model.mtp_capability = capability
+    return model
+
+
+@pytest.mark.parametrize(
+    ("model_type", "capability", "expected"),
+    [
+        (
+            "qwen3_5",
+            SimpleNamespace(supported=True, reason=None),
+            "native_mtp_continuous_batching_unsupported",
+        ),
+        (
+            "qwen3_6_moe",
+            SimpleNamespace(
+                supported=False,
+                reason="native_mtp_weights_not_loaded",
+            ),
+            "native_mtp_weights_not_loaded",
+        ),
+        (
+            "qwen3_5_moe",
+            SimpleNamespace(supported=False, reason=None),
+            "native_mtp_unsupported",
+        ),
+        ("qwen3_6", None, "native_mtp_capability_missing"),
+    ],
+)
+def test_native_qwen_cb_gate_has_stable_fail_closed_reasons(
+    model_type, capability, expected
+):
+    from vllm_mlx.scheduler import _continuous_batching_mtp_capability
+
+    with pytest.raises(RuntimeError, match=f"^{expected}$"):
+        _continuous_batching_mtp_capability(
+            _model(model_type, capability=capability),
+            enabled=True,
+        )
+
+
+def test_native_qwen_cb_gate_rejects_malformed_capability():
+    from vllm_mlx.scheduler import _continuous_batching_mtp_capability
+
+    capability = SimpleNamespace(supported="yes", reason=None)
+    with pytest.raises(RuntimeError, match="^native_mtp_capability_invalid$"):
+        _continuous_batching_mtp_capability(
+            _model("qwen3_5", capability=capability),
+            enabled=True,
+        )
+
+
+def test_qwen3_next_without_native_capability_retains_legacy_gate_result():
+    from vllm_mlx.scheduler import _continuous_batching_mtp_capability
+
+    model = _model("qwen3_next", mtp=object())
+    assert _continuous_batching_mtp_capability(model, enabled=True) is None
+
+
+def test_standard_scheduler_never_installs_native_qwen_mtp(monkeypatch):
+    import vllm_mlx.scheduler as scheduler_mod
+
+    model = _model(
+        "qwen3_5",
+        capability=SimpleNamespace(supported=True, reason=None),
+        mtp=object(),
+    )
+    installed = []
+    constructed = []
+    hooked = []
+
+    class FakeBatchGenerator:
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(scheduler_mod, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "_install_mtp",
+        lambda *args, **kwargs: installed.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        scheduler_mod,
+        "_install_chunked_prefill",
+        lambda *args, **kwargs: hooked.append((args, kwargs)),
+    )
+    scheduler = scheduler_mod.Scheduler(
+        model,
+        SimpleNamespace(),
+        scheduler_mod.SchedulerConfig(
+            enable_prefix_cache=False,
+            enable_mtp=True,
+            chunked_prefill_tokens=32,
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="^native_mtp_continuous_batching_unsupported$",
+    ):
+        scheduler._create_batch_generator(scheduler_mod.SamplingParams())
+    assert constructed == []
+    assert hooked == []
+    assert installed == []
+    assert scheduler.batch_generator is None
+
+
+def test_standard_scheduler_preserves_qwen3_next_legacy_install(monkeypatch):
+    import vllm_mlx.scheduler as scheduler_mod
+
+    model = _model("qwen3_next", mtp=object())
+    installed = []
+
+    class FakeBatchGenerator:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(scheduler_mod, "BatchGenerator", FakeBatchGenerator)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "_install_mtp",
+        lambda *args, **kwargs: installed.append((args, kwargs)),
+    )
+    config = scheduler_mod.SchedulerConfig(
+        enable_prefix_cache=False,
+        enable_mtp=True,
+        mtp_num_draft_tokens=2,
+        mtp_optimistic=True,
+    )
+    scheduler = scheduler_mod.Scheduler(model, SimpleNamespace(), config)
+
+    batch_generator = scheduler._create_batch_generator(scheduler_mod.SamplingParams())
+
+    assert isinstance(batch_generator, FakeBatchGenerator)
+    assert len(installed) == 1
+    install_kwargs = installed[0][1]
+    stats_state = install_kwargs.pop("stats_state")
+    assert stats_state is scheduler._mtp_stats_state
+    assert install_kwargs == {
+        "model": model,
+        "num_draft_tokens": 2,
+        "optimistic": True,
+    }
+    assert stats_state.counters == {
+        "attempted": 0,
+        "accepted": 0,
+        "rejected": 0,
+        "errors": 0,
+    }
+    assert stats_state.bypass_counts == {
+        "prefill": 0,
+        "no_active_batch": 0,
+        "cache_mismatch": 0,
+    }
+
+
+def test_preloaded_mllm_startup_fails_before_injection_or_scheduler(monkeypatch):
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    model = _model(
+        "qwen3_5",
+        capability=SimpleNamespace(supported=True, reason=None),
+        mtp=object(),
+    )
+    engine = BatchedEngine(
+        model_name="fixture-qwen3.5",
+        scheduler_config=SchedulerConfig(enable_mtp=True),
+        force_mllm=True,
+    )
+    engine._model = model
+    engine._processor = object()
+    injected = []
+    monkeypatch.setattr(
+        engine,
+        "_inject_mtp_mllm",
+        lambda: injected.append(True),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="^native_mtp_continuous_batching_unsupported$",
+    ):
+        asyncio.run(engine._start_mllm())
+    assert injected == []
+    assert engine._mllm_scheduler is None
+
+
+def test_preloaded_mllm_startup_propagates_unsupported_capability_reason():
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    model = _model(
+        "qwen3_6",
+        capability=SimpleNamespace(
+            supported=False,
+            reason="native_mtp_aux_head_missing",
+        ),
+    )
+    engine = BatchedEngine(
+        model_name="fixture-qwen3.6",
+        scheduler_config=SchedulerConfig(enable_mtp=True),
+        force_mllm=True,
+    )
+    engine._model = model
+    engine._processor = object()
+
+    with pytest.raises(RuntimeError, match="^native_mtp_aux_head_missing$"):
+        asyncio.run(engine._start_mllm())
+    assert engine._mllm_scheduler is None
+
+
+def test_lazy_mllm_native_gate_does_not_publish_loaded_ownership(monkeypatch):
+    import vllm_mlx.models.mllm as model_mod
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    instances = []
+
+    class FakeMLXMultimodalLM:
+        def __init__(self, *args, **kwargs):
+            self.model = _model(
+                "qwen3_5",
+                capability=SimpleNamespace(supported=True, reason=None),
+                mtp=object(),
+            )
+            self.processor = object()
+            instances.append(self)
+
+        def load(self):
+            return None
+
+    monkeypatch.setattr(model_mod, "MLXMultimodalLM", FakeMLXMultimodalLM)
+    engine = BatchedEngine(
+        model_name="fixture-qwen3.5",
+        scheduler_config=SchedulerConfig(enable_mtp=True),
+        force_mllm=True,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="^native_mtp_continuous_batching_unsupported$",
+    ):
+        asyncio.run(engine.start())
+
+    assert len(instances) == 1
+    assert engine._mllm_instance is None
+    assert engine._model is None
+    assert engine._processor is None
+    assert engine._mllm_scheduler is None
+    assert engine._loaded is False
+
+
+def _bare_mllm_scheduler(monkeypatch, language_model):
+    import mlx_lm.sample_utils as sample_utils
+    import vllm_mlx.mllm_scheduler as scheduler_mod
+
+    constructed = []
+
+    class FakeBatchGenerator:
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+            self.language_model = language_model
+            self.prefix_cache = None
+
+    monkeypatch.setattr(sample_utils, "make_sampler", lambda **kwargs: object())
+    monkeypatch.setattr(scheduler_mod, "MLLMBatchGenerator", FakeBatchGenerator)
+    scheduler = object.__new__(scheduler_mod.MLLMScheduler)
+    scheduler.batch_generator = None
+    scheduler.model = SimpleNamespace(language_model=language_model)
+    scheduler.processor = object()
+    scheduler.mm_processor = object()
+    scheduler.stop_tokens = set()
+    scheduler.config = scheduler_mod.MLLMSchedulerConfig(
+        enable_prefix_cache=False,
+        enable_mtp=True,
+    )
+    return scheduler, scheduler_mod, constructed
+
+
+def test_mllm_scheduler_never_installs_native_qwen_mtp(monkeypatch):
+    import vllm_mlx.mllm_batch_generator as batch_generator_mod
+
+    language_model = _model(
+        "qwen3_5",
+        capability=SimpleNamespace(supported=True, reason=None),
+        mtp=object(),
+    )
+    scheduler, _, constructed = _bare_mllm_scheduler(monkeypatch, language_model)
+    installed = []
+    hooked = []
+    ssd_started = []
+    scheduler.config.chunked_prefill_tokens = 32
+    scheduler.config.ssd_cache_dir = "/not-used"
+    monkeypatch.setattr(
+        batch_generator_mod,
+        "install_mtp_mllm",
+        lambda *args, **kwargs: installed.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        batch_generator_mod,
+        "install_chunked_prefill_mllm",
+        lambda *args, **kwargs: hooked.append((args, kwargs)),
+    )
+
+    class UnexpectedSSDTier:
+        def __init__(self, *args, **kwargs):
+            ssd_started.append("constructed")
+
+    import vllm_mlx.ssd_cache as ssd_cache_mod
+
+    monkeypatch.setattr(ssd_cache_mod, "SSDCacheTier", UnexpectedSSDTier)
+
+    with pytest.raises(
+        RuntimeError,
+        match="^native_mtp_continuous_batching_unsupported$",
+    ):
+        scheduler._ensure_batch_generator()
+    assert constructed == []
+    assert hooked == []
+    assert ssd_started == []
+    assert installed == []
+    assert scheduler.batch_generator is None
+
+
+def test_mllm_scheduler_preserves_qwen3_next_legacy_install(monkeypatch):
+    import vllm_mlx.mllm_batch_generator as batch_generator_mod
+
+    language_model = _model("qwen3_next", mtp=object())
+    scheduler, _, _ = _bare_mllm_scheduler(monkeypatch, language_model)
+    installed = []
+    monkeypatch.setattr(
+        batch_generator_mod,
+        "install_mtp_mllm",
+        lambda *args, **kwargs: installed.append((args, kwargs)),
+    )
+
+    scheduler._ensure_batch_generator()
+
+    assert len(installed) == 1
+    assert installed[0][0][0] is scheduler.batch_generator
+    assert installed[0][0][1] is language_model
+    assert installed[0][1] == {"num_draft_tokens": 1}

--- a/tests/test_cb_native_mtp_gate.py
+++ b/tests/test_cb_native_mtp_gate.py
@@ -26,7 +26,7 @@ def _model(
         (
             "qwen3_5",
             SimpleNamespace(supported=True, reason=None),
-            "native_mtp_continuous_batching_unsupported",
+            None,
         ),
         (
             "qwen3_6_moe",
@@ -49,11 +49,12 @@ def test_native_qwen_cb_gate_has_stable_fail_closed_reasons(
 ):
     from vllm_mlx.scheduler import _continuous_batching_mtp_capability
 
-    with pytest.raises(RuntimeError, match=f"^{expected}$"):
-        _continuous_batching_mtp_capability(
-            _model(model_type, capability=capability),
-            enabled=True,
-        )
+    model = _model(model_type, capability=capability)
+    if expected is None:
+        assert _continuous_batching_mtp_capability(model, enabled=True) is capability
+    else:
+        with pytest.raises(RuntimeError, match=f"^{expected}$"):
+            _continuous_batching_mtp_capability(model, enabled=True)
 
 
 def test_native_qwen_cb_gate_rejects_malformed_capability():
@@ -74,7 +75,9 @@ def test_qwen3_next_without_native_capability_retains_legacy_gate_result():
     assert _continuous_batching_mtp_capability(model, enabled=True) is None
 
 
-def test_standard_scheduler_never_installs_native_qwen_mtp(monkeypatch):
+def test_standard_scheduler_selects_native_admission_without_legacy_install(
+    monkeypatch,
+):
     import vllm_mlx.scheduler as scheduler_mod
 
     model = _model(
@@ -108,16 +111,13 @@ def test_standard_scheduler_never_installs_native_qwen_mtp(monkeypatch):
         scheduler_mod.SchedulerConfig(
             enable_prefix_cache=False,
             enable_mtp=True,
-            chunked_prefill_tokens=32,
+            chunked_prefill_tokens=0,
         ),
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="^native_mtp_continuous_batching_unsupported$",
-    ):
-        scheduler._create_batch_generator(scheduler_mod.SamplingParams())
-    assert constructed == []
+    batch_generator = scheduler._create_batch_generator(scheduler_mod.SamplingParams())
+    assert isinstance(batch_generator, FakeBatchGenerator)
+    assert len(constructed) == 1
     assert hooked == []
     assert installed == []
     assert scheduler.batch_generator is None
@@ -174,6 +174,7 @@ def test_standard_scheduler_preserves_qwen3_next_legacy_install(monkeypatch):
 
 def test_preloaded_mllm_startup_fails_before_injection_or_scheduler(monkeypatch):
     from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
     from vllm_mlx.scheduler import SchedulerConfig
 
     model = _model(
@@ -194,17 +195,21 @@ def test_preloaded_mllm_startup_fails_before_injection_or_scheduler(monkeypatch)
         "_inject_mtp_mllm",
         lambda: injected.append(True),
     )
+    adapter_creates = []
+    monkeypatch.setattr(
+        NativeMTPContinuousBatchAdapter,
+        "create",
+        lambda *args, **kwargs: adapter_creates.append((args, kwargs)),
+    )
 
-    with pytest.raises(
-        RuntimeError,
-        match="^native_mtp_continuous_batching_unsupported$",
-    ):
+    with pytest.raises(RuntimeError, match="^native_mtp_mllm_unsupported$"):
         asyncio.run(engine._start_mllm())
     assert injected == []
+    assert adapter_creates == []
     assert engine._mllm_scheduler is None
 
 
-def test_preloaded_mllm_startup_propagates_unsupported_capability_reason():
+def test_preloaded_mllm_startup_hard_closes_any_native_capability():
     from vllm_mlx.engine.batched import BatchedEngine
     from vllm_mlx.scheduler import SchedulerConfig
 
@@ -223,7 +228,7 @@ def test_preloaded_mllm_startup_propagates_unsupported_capability_reason():
     engine._model = model
     engine._processor = object()
 
-    with pytest.raises(RuntimeError, match="^native_mtp_aux_head_missing$"):
+    with pytest.raises(RuntimeError, match="^native_mtp_mllm_unsupported$"):
         asyncio.run(engine._start_mllm())
     assert engine._mllm_scheduler is None
 
@@ -231,6 +236,7 @@ def test_preloaded_mllm_startup_propagates_unsupported_capability_reason():
 def test_lazy_mllm_native_gate_does_not_publish_loaded_ownership(monkeypatch):
     import vllm_mlx.models.mllm as model_mod
     from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
     from vllm_mlx.scheduler import SchedulerConfig
 
     instances = []
@@ -249,16 +255,19 @@ def test_lazy_mllm_native_gate_does_not_publish_loaded_ownership(monkeypatch):
             return None
 
     monkeypatch.setattr(model_mod, "MLXMultimodalLM", FakeMLXMultimodalLM)
+    adapter_creates = []
+    monkeypatch.setattr(
+        NativeMTPContinuousBatchAdapter,
+        "create",
+        lambda *args, **kwargs: adapter_creates.append((args, kwargs)),
+    )
     engine = BatchedEngine(
         model_name="fixture-qwen3.5",
         scheduler_config=SchedulerConfig(enable_mtp=True),
         force_mllm=True,
     )
 
-    with pytest.raises(
-        RuntimeError,
-        match="^native_mtp_continuous_batching_unsupported$",
-    ):
+    with pytest.raises(RuntimeError, match="^native_mtp_mllm_unsupported$"):
         asyncio.run(engine.start())
 
     assert len(instances) == 1
@@ -267,6 +276,7 @@ def test_lazy_mllm_native_gate_does_not_publish_loaded_ownership(monkeypatch):
     assert engine._processor is None
     assert engine._mllm_scheduler is None
     assert engine._loaded is False
+    assert adapter_creates == []
 
 
 def _bare_mllm_scheduler(monkeypatch, language_model):
@@ -298,6 +308,7 @@ def _bare_mllm_scheduler(monkeypatch, language_model):
 
 def test_mllm_scheduler_never_installs_native_qwen_mtp(monkeypatch):
     import vllm_mlx.mllm_batch_generator as batch_generator_mod
+    from vllm_mlx.native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
 
     language_model = _model(
         "qwen3_5",
@@ -320,6 +331,12 @@ def test_mllm_scheduler_never_installs_native_qwen_mtp(monkeypatch):
         "install_chunked_prefill_mllm",
         lambda *args, **kwargs: hooked.append((args, kwargs)),
     )
+    adapter_creates = []
+    monkeypatch.setattr(
+        NativeMTPContinuousBatchAdapter,
+        "create",
+        lambda *args, **kwargs: adapter_creates.append((args, kwargs)),
+    )
 
     class UnexpectedSSDTier:
         def __init__(self, *args, **kwargs):
@@ -329,15 +346,13 @@ def test_mllm_scheduler_never_installs_native_qwen_mtp(monkeypatch):
 
     monkeypatch.setattr(ssd_cache_mod, "SSDCacheTier", UnexpectedSSDTier)
 
-    with pytest.raises(
-        RuntimeError,
-        match="^native_mtp_continuous_batching_unsupported$",
-    ):
+    with pytest.raises(RuntimeError, match="^native_mtp_mllm_unsupported$"):
         scheduler._ensure_batch_generator()
     assert constructed == []
     assert hooked == []
     assert ssd_started == []
     assert installed == []
+    assert adapter_creates == []
     assert scheduler.batch_generator is None
 
 

--- a/tests/test_cooperative_specprefill.py
+++ b/tests/test_cooperative_specprefill.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local cooperative SpecPrefill orchestration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.cooperative_specprefill import (
+    CooperativeSpecPrefillCleanupError,
+    CooperativeSpecPrefillConfig,
+    CooperativeSpecPrefillError,
+    CooperativeSpecPrefillOutcome,
+    CooperativeSpecPrefillPhase,
+    CooperativeSpecPrefillSession,
+)
+from vllm_mlx.specprefill import SpecPrefillScorerLaneBusy, build_selection_plan
+from vllm_mlx.specprefill_cache import SparseCacheState, SparsePolicyTuning
+from vllm_mlx.specprefill_scorer_session import (
+    ScorerSessionPhase,
+    ScorerSessionProgress,
+)
+from vllm_mlx.specprefill_selection import RotatingTailRequirement
+from vllm_mlx.specprefill_target_executor import (
+    SparseTargetPrefillLaneBusy,
+    SparseTargetPrefillProgress,
+    SparseTargetPrefillResult,
+    SparseTargetPrefillTelemetry,
+)
+
+_TOKENS = (10, 11, 12, 13, 14, 15, 16, 17)
+_IMPORTANCE = mx.array([0.0, 0.1, 0.2, 0.3, 0.9, 0.8, 0.4, 0.5])
+_TUNING = SparsePolicyTuning(
+    keep_pct=0.25,
+    backbone_pct=0.0,
+    halo_chunks=0,
+    anchor_chunks=0,
+    chunk_size=2,
+)
+_CONFIG = CooperativeSpecPrefillConfig(
+    target_id="target@sha256:target",
+    tokenizer_id="tokenizer@sha256:tokenizer",
+    scorer_id="scorer@sha256:scorer",
+    tuning=_TUNING,
+)
+
+
+class _FakeScorerSession:
+    def __init__(
+        self,
+        *,
+        importance=_IMPORTANCE,
+        fail_at: int | None = None,
+        cleanup_raises: bool = False,
+    ):
+        self.phase = ScorerSessionPhase.PREFILL
+        self.importance = importance
+        self.fail_at = fail_at
+        self.calls = 0
+        self.cancelled = False
+        self.cleanup_raises = cleanup_raises
+        self.active = False
+
+    def step(self):
+        self.calls += 1
+        if self.fail_at == self.calls:
+            raise RuntimeError("scorer failed")
+        self.active = True
+        try:
+            schedule = (
+                ScorerSessionProgress(ScorerSessionPhase.PREFILL, 4, 0, 0, False),
+                ScorerSessionProgress(ScorerSessionPhase.LOOKAHEAD, 8, 0, 0, False),
+                ScorerSessionProgress(ScorerSessionPhase.IMPORTANCE, 8, 1, 0, False),
+                ScorerSessionProgress(ScorerSessionPhase.IMPORTANCE, 8, 1, 1, False),
+                ScorerSessionProgress(ScorerSessionPhase.COMPLETE, 8, 1, 1, True),
+            )
+            progress = schedule[self.calls - 1]
+            self.phase = progress.phase
+            return progress
+        finally:
+            self.active = False
+
+    def cancel(self):
+        self.cancelled = True
+        if self.cleanup_raises:
+            raise RuntimeError("scorer cleanup failed")
+
+
+class _BusyOnceScorer(_FakeScorerSession):
+    def __init__(self):
+        super().__init__()
+        self._busy_returned = False
+
+    def step(self):
+        if not self._busy_returned:
+            self._busy_returned = True
+            raise SpecPrefillScorerLaneBusy("busy")
+        return super().step()
+
+
+@dataclass
+class _FakeTargetSession:
+    state: SparseCacheState
+    fail_at: int | None = None
+    busy_once: bool = False
+    cleanup_raises: bool = False
+
+    def __post_init__(self):
+        self.calls = 0
+        self.cancelled = False
+        self.active = False
+        self._busy_returned = False
+        self.result = SparseTargetPrefillResult(
+            logits=mx.array([[[1.0, 0.0]]]),
+            cache_state=self.state.clone(),
+            telemetry=SparseTargetPrefillTelemetry(
+                selected_tokens=self.state.rows[0].physical_valid_length,
+                target_prefill_ms=1.0,
+                chunk_count=2,
+                physical_cache_starts=((0,), (1,)),
+            ),
+        )
+
+    def step(self):
+        if self.busy_once and not self._busy_returned:
+            self._busy_returned = True
+            raise SparseTargetPrefillLaneBusy("busy")
+        self.calls += 1
+        if self.fail_at == self.calls:
+            raise RuntimeError("target failed")
+        self.active = True
+        try:
+            return SparseTargetPrefillProgress(
+                selected_tokens_processed=min(self.calls, 2),
+                chunk_count=self.calls,
+                complete=self.calls == 2,
+            )
+        finally:
+            self.active = False
+
+    def cancel(self):
+        self.cancelled = True
+        if self.cleanup_raises:
+            raise RuntimeError("target cleanup failed")
+
+
+class _TargetFactory:
+    def __init__(self, *, setup_raises=False, **target_options):
+        self.calls = []
+        self.setup_raises = setup_raises
+        self.target_options = target_options
+        self.session = None
+
+    def __call__(self, selected_tokens, sparse_state):
+        self.calls.append((selected_tokens, sparse_state))
+        if self.setup_raises:
+            raise RuntimeError("target setup failed")
+        self.session = _FakeTargetSession(sparse_state, **self.target_options)
+        return self.session
+
+
+def _cooperative(
+    *,
+    scorer=None,
+    factory=None,
+    tokens=_TOKENS,
+    config=_CONFIG,
+    selection_builder=build_selection_plan,
+):
+    scorer = scorer or _FakeScorerSession()
+    factory = factory or _TargetFactory()
+    session = CooperativeSpecPrefillSession(
+        "request-1",
+        tokens,
+        scorer,
+        factory,
+        config,
+        selection_builder=selection_builder,
+    )
+    return session, scorer, factory
+
+
+def _run_until_ready(session):
+    progress = []
+    while not session.ready_for_adoption:
+        progress.append(session.step())
+    return progress
+
+
+def test_exact_phase_trace_commits_only_one_model_quantum_per_step():
+    session, scorer, factory = _cooperative()
+
+    progress = _run_until_ready(session)
+
+    assert [item.attempted_phase for item in progress] == [
+        CooperativeSpecPrefillPhase.SCORE_PREFILL,
+        CooperativeSpecPrefillPhase.SCORE_PREFILL,
+        CooperativeSpecPrefillPhase.LOOKAHEAD,
+        CooperativeSpecPrefillPhase.IMPORTANCE,
+        CooperativeSpecPrefillPhase.IMPORTANCE,
+        CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL,
+        CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL,
+    ]
+    assert all(item.quantum_committed for item in progress)
+    assert scorer.calls == 5
+    assert factory.session.calls == 2
+    assert len(progress) == scorer.calls + factory.session.calls
+    assert all(not scorer.active for _ in progress)
+    assert not factory.session.active
+    assert session.phase is CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL
+    assert session.outcome is CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+    assert session.telemetry.scorer_quanta == 5
+    assert session.telemetry.target_quanta == 2
+    assert session.telemetry.importance_layers == 1
+    assert session.telemetry.target_chunks == 2
+    assert session.telemetry.target_prefill_ms == pytest.approx(1.0)
+
+
+def test_selection_and_exact_identity_are_deterministic_and_request_owned():
+    first, _, first_factory = _cooperative()
+    second, _, second_factory = _cooperative()
+
+    _run_until_ready(first)
+    _run_until_ready(second)
+
+    assert first.selection_plan == second.selection_plan
+    assert first.identity == second.identity
+    assert first.identity.selection_fingerprint == first.selection_plan.fingerprint
+    assert first.identity.full_token_hash == second.identity.full_token_hash
+    assert first.sparse_state is first_factory.calls[0][1]
+    assert second.sparse_state is second_factory.calls[0][1]
+    expected_tokens = tuple(
+        _TOKENS[index] for index in first.selection_plan.selected_indices
+    )
+    assert first_factory.calls[0][0] == expected_tokens
+    assert first.sparse_state.logical_positions == (
+        first.selection_plan.selected_indices,
+    )
+    assert first.sparse_state.next_logical_positions == (len(_TOKENS),)
+
+
+def test_different_full_prompt_cannot_share_exact_identity():
+    first, _, _ = _cooperative()
+    changed, _, _ = _cooperative(tokens=(*_TOKENS[:-1], 99))
+
+    _run_until_ready(first)
+    _run_until_ready(changed)
+
+    assert first.selection_plan == changed.selection_plan
+    assert (
+        first.identity.selection_fingerprint == changed.identity.selection_fingerprint
+    )
+    assert first.identity.full_token_hash != changed.identity.full_token_hash
+    assert first.identity != changed.identity
+
+
+def test_control_anchors_and_rotating_tail_reach_selection_and_identity():
+    requirement = RotatingTailRequirement(2)
+    config = CooperativeSpecPrefillConfig(
+        target_id=_CONFIG.target_id,
+        tokenizer_id=_CONFIG.tokenizer_id,
+        scorer_id=_CONFIG.scorer_id,
+        tuning=_TUNING,
+        control_token_indices=(5, 0, 5),
+        rotating_tail_requirement=requirement,
+    )
+    observed = {}
+
+    def recording_builder(importance, **kwargs):
+        observed.update(kwargs)
+        return build_selection_plan(importance, **kwargs)
+
+    session, _, _ = _cooperative(config=config, selection_builder=recording_builder)
+    _run_until_ready(session)
+
+    assert config.control_token_indices == (0, 5)
+    assert observed["control_token_indices"] == (0, 5)
+    assert observed["rotating_tail_requirement"] is requirement
+    assert session.selection_plan.control_anchor_indices == (0, 5)
+    assert session.selection_plan.rotating_tail_requirement is requirement
+    assert session.selection_plan.rotating_tail_chunks == (3,)
+    assert {0, 2, 3}.issubset(session.selection_plan.selected_chunks)
+    assert session.identity.selection_fingerprint == session.selection_plan.fingerprint
+
+
+def test_selector_cannot_drop_mandatory_request_semantics():
+    config = CooperativeSpecPrefillConfig(
+        target_id=_CONFIG.target_id,
+        tokenizer_id=_CONFIG.tokenizer_id,
+        scorer_id=_CONFIG.scorer_id,
+        tuning=_TUNING,
+        control_token_indices=(0,),
+        rotating_tail_requirement=RotatingTailRequirement(2),
+    )
+
+    def dropping_builder(importance, **kwargs):
+        kwargs.pop("control_token_indices")
+        kwargs.pop("rotating_tail_requirement")
+        return build_selection_plan(importance, **kwargs)
+
+    session, _, factory = _cooperative(
+        config=config, selection_builder=dropping_builder
+    )
+
+    while session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+        session.step()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.FALLBACK
+    assert session.fallback_reason == "selection_failed"
+    assert factory.calls == []
+
+
+def test_config_validates_tuning_controls_tail_and_prompt_bounds():
+    with pytest.raises(TypeError, match="CooperativeSpecPrefillConfig"):
+        _cooperative(config=object())
+    with pytest.raises(TypeError, match="SparsePolicyTuning"):
+        CooperativeSpecPrefillConfig(
+            _CONFIG.target_id, _CONFIG.tokenizer_id, _CONFIG.scorer_id, object()
+        )
+    with pytest.raises(ValueError, match="non-negative integer"):
+        CooperativeSpecPrefillConfig(
+            _CONFIG.target_id,
+            _CONFIG.tokenizer_id,
+            _CONFIG.scorer_id,
+            _TUNING,
+            control_token_indices=(True,),
+        )
+    with pytest.raises(TypeError, match="RotatingTailRequirement"):
+        CooperativeSpecPrefillConfig(
+            _CONFIG.target_id,
+            _CONFIG.tokenizer_id,
+            _CONFIG.scorer_id,
+            _TUNING,
+            rotating_tail_requirement=object(),
+        )
+    config = CooperativeSpecPrefillConfig(
+        _CONFIG.target_id,
+        _CONFIG.tokenizer_id,
+        _CONFIG.scorer_id,
+        _TUNING,
+        control_token_indices=(len(_TOKENS),),
+    )
+    with pytest.raises(ValueError, match="within the request prompt"):
+        _cooperative(config=config)
+
+
+def test_lane_busy_is_retryable_and_does_not_commit_a_quantum():
+    scorer = _BusyOnceScorer()
+    factory = _TargetFactory(busy_once=True)
+    session, _, _ = _cooperative(scorer=scorer, factory=factory)
+
+    scorer_busy = session.step()
+    assert scorer_busy.busy
+    assert not scorer_busy.quantum_committed
+    assert session.phase is CooperativeSpecPrefillPhase.SCORE_PREFILL
+    assert session.outcome is CooperativeSpecPrefillOutcome.ACTIVE
+
+    while session.phase is not CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL:
+        session.step()
+    target_busy = session.step()
+    assert target_busy.busy
+    assert not target_busy.quantum_committed
+    assert session.outcome is CooperativeSpecPrefillOutcome.ACTIVE
+    assert session.telemetry.busy_retries == 2
+
+    _run_until_ready(session)
+    assert session.outcome is CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+
+
+@pytest.mark.parametrize(
+    ("scorer", "factory", "reason"),
+    (
+        (_FakeScorerSession(fail_at=1), _TargetFactory(), "scorer_failed"),
+        (_FakeScorerSession(), _TargetFactory(fail_at=1), "target_prefill_failed"),
+    ),
+)
+def test_execution_failure_becomes_pre_adoption_fallback(scorer, factory, reason):
+    session, _, _ = _cooperative(scorer=scorer, factory=factory)
+
+    while session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+        session.step()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.FALLBACK
+    assert session.fallback_reason == reason
+    assert session.failure.error_type == "RuntimeError"
+    assert scorer.cancelled
+    if factory.session is not None:
+        assert factory.session.cancelled
+    with pytest.raises(CooperativeSpecPrefillError, match="not publishable"):
+        _ = session.prepared_result
+
+
+def test_target_setup_failure_is_distinct_and_preserves_immutable_identity():
+    factory = _TargetFactory(setup_raises=True)
+    session, scorer, _ = _cooperative(factory=factory)
+
+    while session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+        session.step()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.FALLBACK
+    assert session.fallback_reason == "target_setup_failed"
+    assert session.selection_plan is not None
+    assert session.identity is not None
+    assert session.sparse_state is not None
+    assert scorer.cancelled
+    assert session._target_session is None
+    assert session._target_session_factory is None
+
+
+@pytest.mark.parametrize(
+    ("malformed_target", "expected_outcome", "expected_reason"),
+    (
+        (
+            None,
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            "target_setup_failed",
+        ),
+        (
+            SimpleNamespace(cancel=lambda: None, result=object()),
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            "target_setup_failed",
+        ),
+        (
+            SimpleNamespace(step=lambda: None, result=object()),
+            CooperativeSpecPrefillOutcome.FAILED,
+            "resource_cleanup_failed",
+        ),
+        (
+            SimpleNamespace(step=lambda: None, cancel=lambda: None),
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            "target_setup_failed",
+        ),
+    ),
+)
+def test_malformed_target_factory_result_becomes_target_setup_fallback(
+    malformed_target, expected_outcome, expected_reason
+):
+    factory = lambda _tokens, _state: malformed_target
+    session, scorer, _ = _cooperative(factory=factory)
+
+    while session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+        session.step()
+
+    assert session.outcome is expected_outcome
+    assert session.fallback_reason == expected_reason
+    if expected_outcome is CooperativeSpecPrefillOutcome.FAILED:
+        assert isinstance(session.failure, CooperativeSpecPrefillCleanupError)
+    else:
+        assert session.failure.error_type == "CooperativeSpecPrefillError"
+    assert scorer.cancelled
+    assert session._target_session is None
+    assert session._target_session_factory is None
+
+
+def test_invalid_importance_falls_back_before_target_construction():
+    scorer = _FakeScorerSession(importance=mx.array([0.0, float("nan")] * 4))
+    session, _, factory = _cooperative(scorer=scorer)
+
+    while session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+        session.step()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.FALLBACK
+    assert session.fallback_reason == "selection_failed"
+    assert factory.calls == []
+    assert scorer.cancelled
+
+
+def test_cancel_hides_prepared_result_and_never_enters_decode():
+    session, scorer, factory = _cooperative()
+    _run_until_ready(session)
+    assert session.prepared_result is factory.session.result
+
+    session.cancel()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.CANCELLED
+    assert session.phase is CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL
+    assert scorer.cancelled
+    assert factory.session.cancelled
+    assert session._target_session is None
+    assert session._target_session_factory is None
+    assert session._prepared_result is None
+    with pytest.raises(CooperativeSpecPrefillError, match="not publishable"):
+        _ = session.prepared_result
+    with pytest.raises(CooperativeSpecPrefillError, match="adoption requires"):
+        session.mark_adopted()
+
+
+@pytest.mark.parametrize("resource", ("scorer", "target"))
+def test_cleanup_failure_is_terminal_failed_and_drops_target_references(resource):
+    scorer = _FakeScorerSession(cleanup_raises=resource == "scorer")
+    factory = _TargetFactory(cleanup_raises=resource == "target")
+    session, _, _ = _cooperative(scorer=scorer, factory=factory)
+
+    if resource == "target":
+        _run_until_ready(session)
+    session.cancel()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.FAILED
+    assert session.fallback_reason == "resource_cleanup_failed"
+    assert isinstance(session.failure, CooperativeSpecPrefillCleanupError)
+    assert session.failure.cleanup_failures
+    assert session._scorer_session is None
+    assert session._target_session is None
+    assert session._target_session_factory is None
+    assert session._prepared_result is None
+    with pytest.raises(CooperativeSpecPrefillError, match="cannot step"):
+        session.step()
+
+
+def test_decode_transition_requires_explicit_successful_adoption():
+    session, _, factory = _cooperative()
+    with pytest.raises(CooperativeSpecPrefillError, match="adoption requires"):
+        session.mark_adopted()
+
+    _run_until_ready(session)
+    result = session.mark_adopted()
+
+    assert result is factory.session.result
+    assert session.phase is CooperativeSpecPrefillPhase.DECODE
+    assert session.outcome is CooperativeSpecPrefillOutcome.DECODE
+    with pytest.raises(CooperativeSpecPrefillError, match="cannot step"):
+        session.step()
+    with pytest.raises(CooperativeSpecPrefillError, match="unsafe after"):
+        session.fallback("adoption_failed")
+    with pytest.raises(CooperativeSpecPrefillError, match="unavailable after"):
+        session.cancel()

--- a/tests/test_cooperative_specprefill.py
+++ b/tests/test_cooperative_specprefill.py
@@ -114,6 +114,7 @@ class _FakeTargetSession:
         self.cancelled = False
         self.active = False
         self._busy_returned = False
+        self.cache = [object()]
         self.result = SparseTargetPrefillResult(
             logits=mx.array([[[1.0, 0.0]]]),
             cache_state=self.state.clone(),
@@ -146,6 +147,12 @@ class _FakeTargetSession:
         self.cancelled = True
         if self.cleanup_raises:
             raise RuntimeError("target cleanup failed")
+
+    @property
+    def adoption_cache(self):
+        if self.calls < 2:
+            raise RuntimeError("cache not ready")
+        return self.cache
 
 
 class _TargetFactory:
@@ -513,10 +520,13 @@ def test_cleanup_failure_is_terminal_failed_and_drops_target_references(resource
 
 def test_decode_transition_requires_explicit_successful_adoption():
     session, _, factory = _cooperative()
+    with pytest.raises(CooperativeSpecPrefillError, match="not publishable"):
+        _ = session.prepared_cache
     with pytest.raises(CooperativeSpecPrefillError, match="adoption requires"):
         session.mark_adopted()
 
     _run_until_ready(session)
+    assert session.prepared_cache is factory.session.cache
     result = session.mark_adopted()
 
     assert result is factory.session.result

--- a/tests/test_cooperative_specprefill.py
+++ b/tests/test_cooperative_specprefill.py
@@ -38,7 +38,7 @@ _TUNING = SparsePolicyTuning(
     keep_pct=0.25,
     backbone_pct=0.0,
     halo_chunks=0,
-    anchor_chunks=0,
+    anchor_chunks=1,
     chunk_size=2,
 )
 _CONFIG = CooperativeSpecPrefillConfig(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -78,6 +78,34 @@ def test_model_stream_generate_passes_num_draft_tokens():
     assert captured_kwargs["num_draft_tokens"] == 4
 
 
+def test_model_stream_generate_passes_request_local_forward_context():
+    """Sparse decode forwards its request-local position context to mlx-lm."""
+    from vllm_mlx.models.llm import MLXLanguageModel
+
+    model = MLXLanguageModel("test-model")
+    model._loaded = True
+    model.model = object()
+    tokenizer = MagicMock()
+    tokenizer.encode.return_value = [1, 2, 3]
+    model.tokenizer = tokenizer
+    forward_context = object()
+    captured_kwargs = {}
+
+    def fake_stream_generate(_model, _tokenizer, **kwargs):
+        captured_kwargs.update(kwargs)
+        yield SimpleNamespace(text="Hello")
+
+    with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
+        chunks = list(
+            model.stream_generate(
+                "Hello", max_tokens=8, model_forward_context=forward_context
+            )
+        )
+
+    assert chunks[-1].text == "Hello"
+    assert captured_kwargs["model_forward_context"] is forward_context
+
+
 @pytest.mark.slow
 def test_model_load(small_model_name):
     """Test loading a model (slow test, downloads model)."""

--- a/tests/test_mllm_batch_generator_gemma_sparse.py
+++ b/tests/test_mllm_batch_generator_gemma_sparse.py
@@ -42,7 +42,6 @@ from vllm_mlx.specprefill_gemma_cache import (
 )
 from vllm_mlx.specprefill_runtime import TargetProcessorAttestation
 
-
 _PROMPT = (10, 11, 12, 13)
 _TUNING = SparsePolicyTuning(0.5, 0.0, 0, 1, 2)
 
@@ -131,9 +130,7 @@ def _scalar_cache(*, physical=2):
         values = mx.arange(physical, dtype=mx.float32).reshape(1, 1, physical, 1)
         entry.update_and_fetch(values, values + 100)
         cache.append(entry)
-    mx.eval(
-        *(tensor for entry in cache for tensor in (entry.keys, entry.values))
-    )
+    mx.eval(*(tensor for entry in cache for tensor in (entry.keys, entry.values)))
     return cache
 
 
@@ -345,8 +342,7 @@ def test_gemma_extend_wrapper_restores_both_operands_on_failure():
     destination = _batch(1, "destination")
     source = _batch(2, "source")
     destination_before = tuple(
-        batch_cache_cursor(entry, logical_positions=(4,))
-        for entry in destination.cache
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in destination.cache
     )
     source_before = tuple(
         batch_cache_cursor(entry, logical_positions=(4,)) for entry in source.cache
@@ -361,13 +357,19 @@ def test_gemma_extend_wrapper_restores_both_operands_on_failure():
     with pytest.raises(RuntimeError, match="extend failed"):
         destination.extend(source)
 
-    assert tuple(
-        batch_cache_cursor(entry, logical_positions=(4,))
-        for entry in destination.cache
-    ) == destination_before
-    assert tuple(
-        batch_cache_cursor(entry, logical_positions=(4,)) for entry in source.cache
-    ) == source_before
+    assert (
+        tuple(
+            batch_cache_cursor(entry, logical_positions=(4,))
+            for entry in destination.cache
+        )
+        == destination_before
+    )
+    assert (
+        tuple(
+            batch_cache_cursor(entry, logical_positions=(4,)) for entry in source.cache
+        )
+        == source_before
+    )
     assert destination.uids == [1]
     assert source.uids == [2]
 
@@ -401,9 +403,11 @@ def test_gemma_active_adoption_cancellation_restores_extended_cache(cancel_at):
 
     generator._sampling_for_request = lambda _request: (
         [cancel_processor] if cancel_at == "processor" else None,
-        cancel_sampler
-        if cancel_at == "sampler"
-        else (lambda logprobs: mx.argmax(logprobs, axis=-1)),
+        (
+            cancel_sampler
+            if cancel_at == "sampler"
+            else (lambda logprobs: mx.argmax(logprobs, axis=-1))
+        ),
     )
 
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_mllm_batch_generator_gemma_sparse.py
+++ b/tests/test_mllm_batch_generator_gemma_sparse.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real-cache tests for the opt-in Gemma sparse CB transaction foundation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from mlx_vlm.models.cache import KVCache, RotatingKVCache
+
+from vllm_mlx.mllm_batch_generator import (
+    GemmaSparseBatchConfig,
+    GemmaPreparedTargetAttestation,
+    MLLMBatch,
+    MLLMBatchGenerator,
+    MLLMBatchRequest,
+    SparseAdoptionError,
+    SparseBatchCompatibilityError,
+    SparseBatchError,
+    install_mtp_mllm,
+    prepare_gemma_sparse_target,
+)
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheRowState,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from vllm_mlx.specprefill_gemma_cache import (
+    FULL,
+    GEMMA4_E2B,
+    GemmaCacheError,
+    GemmaCacheTopologyError,
+    batch_cache_cursor,
+)
+from vllm_mlx.specprefill_runtime import TargetProcessorAttestation
+
+
+_PROMPT = (10, 11, 12, 13)
+_TUNING = SparsePolicyTuning(0.5, 0.0, 0, 1, 2)
+
+
+class _LiveGemmaTopology:
+    def __init__(self, *, layer_types=None, previous_kvs=None):
+        self.config = SimpleNamespace(
+            layer_types=list(layer_types or GEMMA4_E2B.layer_types)
+        )
+        self.model = SimpleNamespace(
+            previous_kvs=list(previous_kvs or GEMMA4_E2B.previous_kvs)
+        )
+
+
+_TARGET_MODEL = _LiveGemmaTopology()
+_PROCESSOR = object()
+_TARGET_ARTIFACT_PATH = str(Path(__file__).resolve())
+_TARGET_HASH = hashlib.sha256(Path(_TARGET_ARTIFACT_PATH).read_bytes()).hexdigest()
+_TARGET_ID = f"{GEMMA4_E2B.artifact_id}@sha256:{_TARGET_HASH}"
+
+
+def _identity(*, target_id=_TARGET_ID):
+    return SparseCacheIdentity.from_tokens(
+        target_id=target_id,
+        tokenizer_id="tokenizer",
+        scorer_id="scorer",
+        selector_version="test-v1",
+        tuning=_TUNING,
+        tokens=_PROMPT,
+        selection_fingerprint="d" * 64,
+    )
+
+
+def _row(*, target_id=_TARGET_ID, physical=2, logical=4):
+    positions = tuple(range(max(0, physical - 1))) + (logical - 1,)
+    return SparseCacheRowState(
+        identity=_identity(target_id=target_id),
+        logical_positions=positions,
+        physical_valid_length=physical,
+        next_logical_position=logical,
+        prefill_physical_length=physical,
+    )
+
+
+def _prepared_attestation(
+    *,
+    target_model=_TARGET_MODEL,
+    processor=_PROCESSOR,
+    attested_target_model=None,
+    attested_processor=None,
+    target_hash=_TARGET_HASH,
+    artifact=GEMMA4_E2B,
+):
+    trusted_identity = TargetProcessorAttestation(
+        target_model=(
+            target_model if attested_target_model is None else attested_target_model
+        ),
+        processor=processor if attested_processor is None else attested_processor,
+        target_artifact_hash=target_hash,
+        tokenizer_artifact_hash="b" * 64,
+    )
+    return prepare_gemma_sparse_target(
+        target_model=target_model,
+        processor=processor,
+        target_artifact_path=_TARGET_ARTIFACT_PATH,
+        artifact=artifact,
+        target_identity_attestation=trusted_identity,
+    )
+
+
+def _config(*, target_id=_TARGET_ID, target_model=_TARGET_MODEL):
+    return GemmaSparseBatchConfig(
+        _prepared_attestation(target_model=target_model),
+        _identity(target_id=target_id).execution_config,
+    )
+
+
+def _scalar_cache(*, physical=2):
+    cache = []
+    for layer_type in GEMMA4_E2B.layer_types[: GEMMA4_E2B.owner_count]:
+        entry = (
+            KVCache()
+            if layer_type == FULL
+            else RotatingKVCache(GEMMA4_E2B.sliding_window, keep=0)
+        )
+        values = mx.arange(physical, dtype=mx.float32).reshape(1, 1, physical, 1)
+        entry.update_and_fetch(values, values + 100)
+        cache.append(entry)
+    mx.eval(
+        *(tensor for entry in cache for tensor in (entry.keys, entry.values))
+    )
+    return cache
+
+
+def _batch_cache(*, physical=2):
+    return [entry.merge([entry]) for entry in _scalar_cache(physical=physical)]
+
+
+def _request(uid, request_id):
+    return MLLMBatchRequest(
+        uid=uid,
+        request_id=request_id,
+        prompt="prompt",
+        max_tokens=4,
+        temperature=0.0,
+        input_ids=mx.array(_PROMPT),
+        is_text_only=True,
+    )
+
+
+def _batch(uid, request_id, *, row=None, cache=None, config=None):
+    row = row or _row()
+    return MLLMBatch(
+        uids=[uid],
+        request_ids=[request_id],
+        y=mx.array([7]),
+        logprobs=[mx.zeros(8)],
+        max_tokens=[4],
+        num_tokens=[0],
+        cache=cache or _batch_cache(physical=row.physical_valid_length),
+        requests=[_request(uid, request_id)],
+        sparse_row_states=(row,),
+        gemma_sparse_config=config or _config(),
+    )
+
+
+class _OneTokenModel(_LiveGemmaTopology):
+    def __init__(self, *, failure=None):
+        super().__init__()
+        self.failure = failure
+        self.calls = 0
+
+    def __call__(self, tokens, *, cache):
+        self.calls += 1
+        rows = tokens.shape[0]
+        values = mx.ones((rows, 1, 1, 1))
+        for entry in cache:
+            entry.update_and_fetch(values, values)
+        if self.failure is not None:
+            raise self.failure
+        logits = mx.zeros((rows, 1, 8))
+        logits[:, :, 3] = 9.0
+        return logits
+
+
+def _generator_for(batch, model):
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.active_batch = batch
+    generator.model = model
+    generator.language_model = model
+    generator.processor = _PROCESSOR
+    generator.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    generator._target_forward_context = lambda _forward: nullcontext()
+    generator._sparse_checkpoint_scalar_reads = 0
+    generator._sparse_checkpoint_host_scalar_reads = 0
+    return generator
+
+
+def test_prepared_adoption_uses_real_gemma_batch_cache_and_emits_nothing():
+    config = _config()
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator._target_forward_context = lambda _forward: nullcontext()
+    generator._expected_sparse_execution_config = config.execution_config
+    generator._expected_gemma_sparse_config = config
+    generator.model = _TARGET_MODEL
+    generator.language_model = _TARGET_MODEL
+    generator.processor = _PROCESSOR
+    generator._mtp_installed = False
+    generator._aborted_request_ids = set()
+    generator.active_batch = None
+    generator.unprocessed_requests = []
+    generator.uid_counter = 1
+    generator.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    request = _request(-1, "adopt")
+    sparse_state = SparseCacheState((_row(),))
+
+    uid = generator.adopt_prefilled_sparse_row(
+        request,
+        _scalar_cache(),
+        mx.array([[[0.0, 0.0, 0.0, 8.0]]]),
+        sparse_state,
+    )
+
+    assert uid == 1
+    assert generator.active_batch is not None
+    assert generator.active_batch.gemma_sparse_config is config
+    assert generator.active_batch.y.tolist() == [3]
+    assert request.output_tokens == []
+    assert generator.unprocessed_requests == []
+
+
+def test_gemma_decode_context_commits_exactly_one_logical_and_physical_token():
+    contexts = []
+    model = _OneTokenModel()
+    batch = _batch(1, "decode", config=_config(target_model=model))
+    generator = _generator_for(batch, model)
+    generator._target_forward_context = (
+        lambda forward: contexts.append(forward.sparse_row_states) or nullcontext()
+    )
+
+    sampled, _ = generator._step(batch.y, batch.cache)
+
+    assert sampled.tolist() == [3]
+    assert model.calls == 1
+    assert contexts == [(_row(),)]
+    assert batch.sparse_row_states[0].next_logical_position == 5
+    assert batch.sparse_row_states[0].physical_valid_length == 3
+    for entry in batch.cache:
+        cursor = batch_cache_cursor(entry, logical_positions=(5,))
+        assert cursor.total_writes == (3,)
+
+
+def test_gemma_vlm_decode_binds_outer_text_and_processor_identities():
+    text_model = _OneTokenModel()
+    outer_model = SimpleNamespace(language_model=text_model)
+    config = _config(target_model=outer_model)
+    batch = _batch(1, "vlm-decode", config=config)
+    generator = _generator_for(batch, text_model)
+    generator.model = outer_model
+
+    sampled, _ = generator._step(batch.y, batch.cache)
+
+    assert sampled.tolist() == [3]
+    assert text_model.calls == 1
+    assert batch.sparse_row_states[0].physical_valid_length == 3
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("forward failed"), asyncio.CancelledError()],
+)
+def test_gemma_decode_error_or_cancellation_rolls_back_real_cache(failure):
+    model = _OneTokenModel(failure=failure)
+    batch = _batch(1, "rollback", config=_config(target_model=model))
+    before = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in batch.cache
+    )
+    generator = _generator_for(batch, model)
+
+    with pytest.raises(type(failure)):
+        generator._step(batch.y, batch.cache)
+
+    after = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in batch.cache
+    )
+    assert after == before
+    assert batch.sparse_row_states == (_row(),)
+    assert all("update_and_fetch" not in entry.__dict__ for entry in batch.cache)
+
+
+def test_gemma_filter_and_extend_are_atomic_and_restore_source():
+    destination = _batch(1, "first")
+    source = _batch(2, "second")
+    source_refs = tuple(
+        (entry.keys, entry.values, entry.offset, entry.left_padding)
+        for entry in source.cache
+    )
+
+    destination.extend(source)
+
+    assert destination.uids == [1, 2]
+    assert destination.sparse_row_states == (_row(), _row())
+    for entry, refs in zip(source.cache, source_refs, strict=True):
+        assert entry.keys is refs[0]
+        assert entry.values is refs[1]
+        assert entry.offset is refs[2]
+        assert entry.left_padding is refs[3]
+    destination.filter([1])
+    assert destination.uids == [2]
+    assert destination.request_ids == ["second"]
+    for entry in destination.cache:
+        assert batch_cache_cursor(entry, logical_positions=(4,)).total_writes == (2,)
+
+
+def test_gemma_filter_wrapper_restores_cache_and_rows_on_failure():
+    batch = _batch(1, "first")
+    batch.extend(_batch(2, "second"))
+    before = tuple(
+        batch_cache_cursor(entry, logical_positions=(4, 4)) for entry in batch.cache
+    )
+    original_filter = batch.cache[1].filter
+
+    def failing_filter(indices):
+        original_filter(indices)
+        raise RuntimeError("filter failed")
+
+    batch.cache[1].filter = failing_filter
+    with pytest.raises(RuntimeError, match="filter failed"):
+        batch.filter([0])
+
+    after = tuple(
+        batch_cache_cursor(entry, logical_positions=(4, 4)) for entry in batch.cache
+    )
+    assert after == before
+    assert batch.uids == [1, 2]
+    assert batch.sparse_row_states == (_row(), _row())
+
+
+def test_gemma_extend_wrapper_restores_both_operands_on_failure():
+    destination = _batch(1, "destination")
+    source = _batch(2, "source")
+    destination_before = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,))
+        for entry in destination.cache
+    )
+    source_before = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in source.cache
+    )
+    original_extend = destination.cache[1].extend
+
+    def failing_extend(other):
+        original_extend(other)
+        raise RuntimeError("extend failed")
+
+    destination.cache[1].extend = failing_extend
+    with pytest.raises(RuntimeError, match="extend failed"):
+        destination.extend(source)
+
+    assert tuple(
+        batch_cache_cursor(entry, logical_positions=(4,))
+        for entry in destination.cache
+    ) == destination_before
+    assert tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in source.cache
+    ) == source_before
+    assert destination.uids == [1]
+    assert source.uids == [2]
+
+
+@pytest.mark.parametrize("cancel_at", ["processor", "sampler"])
+def test_gemma_active_adoption_cancellation_restores_extended_cache(cancel_at):
+    config = _config()
+    active = _batch(1, "active", config=config)
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.active_batch = active
+    generator.model = _TARGET_MODEL
+    generator.language_model = _TARGET_MODEL
+    generator.processor = _PROCESSOR
+    generator._target_forward_context = lambda _forward: nullcontext()
+    generator._expected_sparse_execution_config = config.execution_config
+    generator._expected_gemma_sparse_config = config
+    generator._mtp_installed = False
+    generator._aborted_request_ids = set()
+    generator.unprocessed_requests = []
+    generator.uid_counter = 2
+    generator._pending_error_responses = []
+    before = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in active.cache
+    )
+
+    def cancel_processor(_tokens, _logits):
+        raise asyncio.CancelledError()
+
+    def cancel_sampler(_logprobs):
+        raise asyncio.CancelledError()
+
+    generator._sampling_for_request = lambda _request: (
+        [cancel_processor] if cancel_at == "processor" else None,
+        cancel_sampler
+        if cancel_at == "sampler"
+        else (lambda logprobs: mx.argmax(logprobs, axis=-1)),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        generator.adopt_prefilled_sparse_row(
+            _request(2, "candidate"),
+            _scalar_cache(),
+            mx.zeros((1, 1, 8)),
+            SparseCacheState((_row(),)),
+        )
+
+    after = tuple(
+        batch_cache_cursor(entry, logical_positions=(4,)) for entry in active.cache
+    )
+    assert after == before
+    assert generator.active_batch is active
+    assert active.uids == [1]
+    assert active.sparse_row_states == (_row(),)
+
+
+def test_install_mtp_after_gemma_adoption_bypasses_drafts():
+    model = _OneTokenModel()
+    config = _config(target_model=model)
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.active_batch = None
+    generator.model = model
+    generator.language_model = model
+    generator.processor = _PROCESSOR
+    generator._target_forward_context = lambda _forward: nullcontext()
+    generator._expected_sparse_execution_config = config.execution_config
+    generator._expected_gemma_sparse_config = config
+    generator._mtp_installed = False
+    generator._aborted_request_ids = set()
+    generator.unprocessed_requests = []
+    generator.uid_counter = 1
+    generator.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    generator._sparse_checkpoint_scalar_reads = 0
+    generator._sparse_checkpoint_host_scalar_reads = 0
+    generator.adopt_prefilled_sparse_row(
+        _request(-1, "mtp-after"),
+        _scalar_cache(),
+        mx.zeros((1, 1, 8)),
+        SparseCacheState((_row(),)),
+    )
+
+    install_mtp_mllm(generator, model)
+    generator._step(generator.active_batch.y[:, None], generator.active_batch.cache)
+
+    assert model.calls == 1
+    stats = generator.get_mtp_stats()
+    assert stats["attempted"] == 0
+    assert stats["bypass_counts"]["sparse_rows"] == 1
+
+
+def test_gemma_cross_namespace_alias_profile_and_prefix_paths_fail_closed():
+    from mlx_lm.models.cache import KVCache as LmKVCache
+
+    config = _config()
+    wrong_namespace = [LmKVCache() for _ in range(GEMMA4_E2B.owner_count)]
+    with pytest.raises(GemmaCacheTopologyError, match="backend"):
+        config.validate_cache(wrong_namespace)
+
+    with pytest.raises(SparseBatchCompatibilityError, match="profile"):
+        _batch(1, "profile", row=_row(target_id="other"), config=config)
+
+    batch = _batch(1, "prefix")
+    with pytest.raises(SparseBatchError, match="prefix cache"):
+        batch.extract_cache(0)
+
+    aliased = _batch(2, "alias", cache=batch.cache)
+    before = tuple(entry.offset for entry in batch.cache)
+    with pytest.raises(GemmaCacheError, match="overlap"):
+        batch.extend(aliased)
+    assert all(
+        entry.offset is offset
+        for entry, offset in zip(batch.cache, before, strict=True)
+    )
+
+
+def test_gemma_uniform_cache_row_mismatch_rejected_at_construction_and_decode():
+    with pytest.raises(SparseBatchCompatibilityError, match="row occupancy"):
+        _batch(1, "construct-mismatch", row=_row(physical=1), cache=_batch_cache())
+
+    model = _OneTokenModel()
+    batch = _batch(1, "decode-mismatch", config=_config(target_model=model))
+    for entry in batch.cache:
+        entry.offset = mx.array([1])
+    generator = _generator_for(batch, model)
+
+    with pytest.raises(SparseBatchCompatibilityError, match="row occupancy"):
+        generator._step(batch.y, batch.cache)
+
+    assert model.calls == 0
+
+
+def test_gemma_prepared_attestation_rejects_forgery_and_wrong_live_identity():
+    with pytest.raises(SparseBatchCompatibilityError, match="target_id"):
+        _config(target_id="wrong-target")
+
+    with pytest.raises(TypeError, match="prepared runtime"):
+        GemmaPreparedTargetAttestation(
+            target_model=_TARGET_MODEL,
+            text_model=_TARGET_MODEL,
+            processor=_PROCESSOR,
+            target_artifact_hash=_TARGET_HASH,
+            artifact=GEMMA4_E2B,
+            layer_types=GEMMA4_E2B.layer_types,
+            previous_kvs=GEMMA4_E2B.previous_kvs,
+            _token=object(),
+        )
+
+    with pytest.raises(SparseBatchCompatibilityError, match="artifact bytes"):
+        _prepared_attestation(target_hash="a" * 64)
+
+    with pytest.raises(SparseBatchCompatibilityError, match="loaded target/processor"):
+        _prepared_attestation(attested_target_model=object())
+
+    wrong_topology = _LiveGemmaTopology(layer_types=("wrong",))
+    with pytest.raises(SparseBatchCompatibilityError, match="layer topology"):
+        _prepared_attestation(target_model=wrong_topology)
+
+    config = _config()
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.active_batch = None
+    generator.model = object()
+    generator.language_model = object()
+    generator.processor = _PROCESSOR
+    generator._expected_sparse_execution_config = config.execution_config
+    with pytest.raises(SparseBatchCompatibilityError, match="generator-owned"):
+        generator.set_expected_gemma_sparse_config(config)
+
+
+def test_gemma_heterogeneous_writes_and_mtp_fail_closed():
+    cache = _batch_cache()
+    for entry in cache:
+        entry.offset = mx.array([2, 3])
+        entry.left_padding = mx.array([0, 0])
+        entry.keys = mx.concatenate([entry.keys, entry.keys], axis=0)
+        entry.values = mx.concatenate([entry.values, entry.values], axis=0)
+    with pytest.raises(GemmaCacheError, match="heterogeneous writes"):
+        MLLMBatch(
+            uids=[1, 2],
+            request_ids=["one", "two"],
+            y=mx.array([7, 7]),
+            logprobs=[mx.zeros(8), mx.zeros(8)],
+            max_tokens=[4, 4],
+            num_tokens=[0, 0],
+            cache=cache,
+            requests=[_request(1, "one"), _request(2, "two")],
+            sparse_row_states=(_row(), _row()),
+            gemma_sparse_config=_config(),
+        )
+
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.active_batch = None
+    generator._target_forward_context = lambda _forward: nullcontext()
+    generator._expected_sparse_execution_config = _config().execution_config
+    generator._expected_gemma_sparse_config = _config()
+    generator.model = _TARGET_MODEL
+    generator.language_model = _TARGET_MODEL
+    generator.processor = _PROCESSOR
+    generator._mtp_installed = True
+    generator._aborted_request_ids = set()
+    generator.unprocessed_requests = []
+    generator.uid_counter = 1
+    with pytest.raises(SparseAdoptionError, match="MTP"):
+        generator.adopt_prefilled_sparse_row(
+            _request(-1, "mtp"),
+            _scalar_cache(),
+            mx.zeros((1, 1, 8)),
+            SparseCacheState((_row(),)),
+        )

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -924,7 +924,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert batch.y.tolist() == [3]
         assert batch.samplers == [request_sampler]
         assert batch.logits_processors == [[processor]]
-        assert processor.calls == [[]]
+        assert processor.calls == [[42]]
         assert request_sampler.call_count == 1
         fallback_sampler.assert_not_called()
         assert sampler_calls == [{"temp": 0.3, "top_p": 0.8, "top_k": 0, "min_p": 0.0}]
@@ -1020,6 +1020,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             "no_active_batch": 0,
             "concurrent_batch": 0,
             "logits_processors": 0,
+            "sparse_rows": 0,
         }
 
         logits_processor = MagicMock()
@@ -1469,6 +1470,7 @@ class TestMLLMBatchGeneratorMTPGuards:
                 self.active_batch = MagicMock()
                 self.active_batch.__len__.return_value = 1
                 self.active_batch.uids = [7]
+                self.active_batch.has_sparse_rows = False
                 request = MagicMock(
                     request_id="req-7",
                     temperature=0.0,
@@ -1476,6 +1478,7 @@ class TestMLLMBatchGeneratorMTPGuards:
                     top_k=0,
                     min_p=0.0,
                     output_tokens=[],
+                    specprefill=False,
                 )
                 self.active_batch.requests = [request]
                 self.active_batch.num_tokens = [0]

--- a/tests/test_mllm_mtp_routing.py
+++ b/tests/test_mllm_mtp_routing.py
@@ -228,6 +228,10 @@ def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs():
     class _Tokenizer:
         clean_up_tokenization_spaces = False
 
+        def encode(self, _text, *, add_special_tokens=False):
+            assert add_special_tokens is False
+            return [1, 2, 3]
+
         def decode(self, tokens):
             return "".join(str(token) for token in tokens)
 

--- a/tests/test_mllm_scheduler_specprefill.py
+++ b/tests/test_mllm_scheduler_specprefill.py
@@ -257,6 +257,8 @@ def _scheduler(
     enabled=True,
     mtp=False,
     cache_layout="qwen3_5_nonrotating_hybrid",
+    diagnostic=False,
+    advertisable=True,
 ):
     events = factory.events
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
@@ -274,6 +276,8 @@ def _scheduler(
             adapter_id=_PROFILE_KEY.adapter_id,
             layout=cache_layout,
         ),
+        specprefill_diagnostic=diagnostic,
+        specprefill_advertisable=advertisable,
     )
     scheduler.batch_generator = _BatchGenerator(events)
     scheduler.waiting = deque()
@@ -506,6 +510,38 @@ def test_dense_or_unavailable_policy_never_enters_cooperative_queue():
     assert factory.sessions == {}
     assert len(scheduler.batch_generator.inserted) == 1
     assert scheduler._specprefill_queue == deque()
+
+
+def test_diagnostic_forcing_is_distinct_and_auto_is_not_advertised():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory, diagnostic=True, advertisable=False)
+    scheduler.add_request(
+        "prompt",
+        request_id="diagnostic-auto",
+        specprefill_policy=SpecPrefillPolicy.AUTO,
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+    scheduler.add_request(
+        "prompt",
+        request_id="diagnostic-force",
+        specprefill_policy=SpecPrefillPolicy.SPARSE,
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+
+    scheduler._schedule_waiting()
+
+    auto = scheduler.running["diagnostic-auto"]
+    assert auto.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert auto.specprefill_fallback_reason == "admission_denied"
+    assert "diagnostic-auto" not in factory.sessions
+    assert "diagnostic-force" in factory.sessions
+    scheduler.batch_generator = None
+    status = scheduler.get_stats()["specprefill"]
+    assert status == {
+        "enabled": False,
+        "advertisable": False,
+        "diagnostic": True,
+    }
 
 
 def test_media_request_uses_separate_dense_fallback_path():

--- a/tests/test_mllm_scheduler_specprefill.py
+++ b/tests/test_mllm_scheduler_specprefill.py
@@ -523,6 +523,26 @@ def test_media_request_uses_separate_dense_fallback_path():
     request = scheduler.running["media"]
     assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
     assert request.specprefill_fallback_reason == "media_request"
+
+
+def test_explicit_media_bit_forces_dense_when_extraction_is_empty():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    scheduler.add_request(
+        "prompt",
+        request_id="empty-media",
+        images=[],
+        specprefill_policy=SpecPrefillPolicy.AUTO,
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+        specprefill_has_media=True,
+    )
+
+    scheduler.step()
+
+    request = scheduler.running["empty-media"]
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "media_request"
+    assert factory.sessions == {}
     assert factory.sessions == {}
 
 

--- a/tests/test_mllm_scheduler_specprefill.py
+++ b/tests/test_mllm_scheduler_specprefill.py
@@ -410,7 +410,9 @@ def test_adoption_replay_obeys_typed_sampling_boundary(
     assert bool(scheduler.batch_generator.inserted) is dense_replay
     if dense_replay:
         assert output.outputs == []
-        assert scheduler.running["boundary"].specprefill_fallback_reason == expected_reason
+        assert (
+            scheduler.running["boundary"].specprefill_fallback_reason == expected_reason
+        )
     else:
         assert output.outputs[0].finished is True
         assert output.outputs[0].specprefill_fallback_reason == expected_reason
@@ -633,9 +635,7 @@ def test_mtp_composition_fails_closed_to_dense():
     assert factory.sessions == {}
 
 
-@pytest.mark.parametrize(
-    "layout", ("gemma4_dense", "gemma4_a4b", "mixed_rotating")
-)
+@pytest.mark.parametrize("layout", ("gemma4_dense", "gemma4_a4b", "mixed_rotating"))
 def test_unqualified_adapter_cache_layouts_fail_closed_to_dense(layout):
     factory = _AdmissionFactory()
     scheduler = _scheduler(factory, cache_layout=layout)

--- a/tests/test_mllm_scheduler_specprefill.py
+++ b/tests/test_mllm_scheduler_specprefill.py
@@ -1,0 +1,672 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic scheduler contracts for cooperative MLLM SpecPrefill."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.cooperative_specprefill import (
+    CooperativeSpecPrefillOutcome,
+    CooperativeSpecPrefillSession,
+)
+from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, SparseAdoptionError
+from vllm_mlx.mllm_scheduler import (
+    MLLMScheduler,
+    MLLMSchedulerConfig,
+    MLLMSpecPrefillAdmission,
+    MLLMSpecPrefillCacheCapability,
+)
+from vllm_mlx.specprefill import (
+    SpecPrefillCoverage,
+    SpecPrefillPolicy,
+    SpecPrefillScorerLaneBusy,
+)
+from vllm_mlx.specprefill_profiles import (
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillTuning,
+)
+from vllm_mlx.specprefill_scorer_session import (
+    ScorerSessionPhase,
+    ScorerSessionProgress,
+)
+from vllm_mlx.specprefill_target_executor import (
+    SparseTargetPrefillProgress,
+    SparseTargetPrefillResult,
+    SparseTargetPrefillTelemetry,
+)
+
+_TOKENS = (10, 11, 12, 13, 14, 15, 16, 17)
+_IMPORTANCE = mx.array([0.0, 0.1, 0.2, 0.3, 0.9, 0.8, 0.4, 0.5])
+_PROFILE_KEY = SpecPrefillProfileKey(
+    target_artifact_id="target",
+    target_artifact_hash="a" * 64,
+    tokenizer_artifact_hash="b" * 64,
+    scorer_artifact_id="scorer",
+    scorer_artifact_hash="c" * 64,
+    adapter_id="synthetic-adapter",
+    engine=SpecPrefillEngine.CONTINUOUS_BATCHING,
+    cell=SpecPrefillCell.SPARSE_ONLY,
+)
+_PROFILE_TUNING = SpecPrefillTuning(0.25, 0.0, 0, 1, 2)
+
+
+class _Tokenizer:
+    eos_token_id = 99
+    name_or_path = None
+    clean_up_tokenization_spaces = False
+
+    def encode(self, _prompt, *, add_special_tokens=False):
+        assert add_special_tokens is False
+        return list(_TOKENS)
+
+    def decode(self, tokens):
+        return "".join(str(token) for token in tokens)
+
+
+class _ProfileRegistry(SpecPrefillProfileRegistry):
+    def resolve(self, *_args, **_kwargs):
+        return SimpleNamespace(
+            eligible=True,
+            tuning=_PROFILE_TUNING,
+            fallback_reason=None,
+        )
+
+
+class _ScorerSession:
+    def __init__(
+        self,
+        *,
+        busy_once=False,
+        fail=False,
+        cleanup_raises=False,
+        events=None,
+        name="",
+    ):
+        self.phase = ScorerSessionPhase.PREFILL
+        self.importance = _IMPORTANCE
+        self.busy_once = busy_once
+        self.fail = fail
+        self.cleanup_raises = cleanup_raises
+        self.events = events if events is not None else []
+        self.name = name
+        self.calls = 0
+        self.cancelled = False
+
+    def step(self):
+        self.events.append(f"score:{self.name}")
+        if self.busy_once:
+            self.busy_once = False
+            raise SpecPrefillScorerLaneBusy("busy")
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("scorer failed")
+        self.phase = ScorerSessionPhase.COMPLETE
+        return ScorerSessionProgress(
+            ScorerSessionPhase.COMPLETE,
+            len(_TOKENS),
+            1,
+            1,
+            True,
+        )
+
+    def cancel(self):
+        self.cancelled = True
+        if self.cleanup_raises:
+            raise RuntimeError("cleanup failed")
+
+
+@dataclass
+class _TargetSession:
+    state: object
+
+    def __post_init__(self):
+        self.calls = 0
+        self.cancelled = False
+        self.cache = [object()]
+        self.cache_reads = 0
+        self.replace_on_second_read = False
+        self.fail_cache_read = False
+        self.result = SparseTargetPrefillResult(
+            logits=mx.array([[[0.0, 8.0]]]),
+            cache_state=self.state.clone(),
+            telemetry=SparseTargetPrefillTelemetry(
+                selected_tokens=self.state.rows[0].physical_valid_length,
+                target_prefill_ms=1.0,
+                chunk_count=1,
+                physical_cache_starts=((0,),),
+            ),
+        )
+
+    def step(self):
+        self.calls += 1
+        return SparseTargetPrefillProgress(
+            selected_tokens_processed=self.state.rows[0].physical_valid_length,
+            chunk_count=1,
+            complete=True,
+        )
+
+    def cancel(self):
+        self.cancelled = True
+
+    @property
+    def adoption_cache(self):
+        if self.calls < 1:
+            raise RuntimeError("cache not ready")
+        if self.fail_cache_read:
+            raise RuntimeError("cache seam failed")
+        self.cache_reads += 1
+        if self.replace_on_second_read and self.cache_reads == 2:
+            self.cache[0] = object()
+        return self.cache
+
+
+class _AdmissionFactory:
+    def __init__(self, scorer_by_request=None, events=None):
+        self.scorer_by_request = scorer_by_request or {}
+        self.events = events if events is not None else []
+        self.sessions = {}
+
+    def __call__(self, request, tokens, config):
+        scorer = self.scorer_by_request.get(request.request_id)
+        if scorer is None:
+            scorer = _ScorerSession(events=self.events, name=request.request_id)
+
+        def target_factory(_selected_tokens, sparse_state):
+            return _TargetSession(sparse_state)
+
+        session = CooperativeSpecPrefillSession(
+            request.request_id,
+            tokens,
+            scorer,
+            target_factory,
+            config,
+        )
+        self.sessions[request.request_id] = session
+        return MLLMSpecPrefillAdmission(session)
+
+
+class _BatchGenerator:
+    def __init__(self, events):
+        self.events = events
+        self.active_batch = None
+        self.inserted = []
+        self.next_uid = 100
+        self.expected_config = None
+        self.adoptions = []
+        self.adoption_error = None
+        self.responses = []
+        self.on_adopt = None
+        self.scheduled_removals = []
+        self.pending_removals = []
+        self.active_rows = {}
+        self.active_cache_rows = {}
+
+    def process_pending_removals(self):
+        for uid in self.pending_removals:
+            self.active_rows.pop(uid, None)
+            self.active_cache_rows.pop(uid, None)
+        self.pending_removals.clear()
+
+    def insert(self, requests):
+        self.inserted.extend(requests)
+        result = list(range(self.next_uid, self.next_uid + len(requests)))
+        self.next_uid += len(requests)
+        return result
+
+    def next(self):
+        self.events.append("decode")
+        responses, self.responses = self.responses, []
+        return responses
+
+    def set_expected_sparse_execution_config(self, config):
+        self.expected_config = config
+        self._expected_sparse_execution_config = config
+
+    def adopt_prefilled_sparse_row(self, request, cache, logits, sparse_state):
+        self.adoptions.append((request, cache, logits, sparse_state))
+        if self.adoption_error is not None:
+            raise self.adoption_error
+        if self.on_adopt is not None:
+            self.on_adopt()
+        uid = self.next_uid
+        self.next_uid += 1
+        self.active_rows[uid] = request
+        self.active_cache_rows[uid] = cache
+        return uid
+
+    def abort_prefill(self, _request_id):
+        pass
+
+    def schedule_removal(self, _uids):
+        self.scheduled_removals.extend(_uids)
+        self.pending_removals.extend(_uids)
+
+
+def _scheduler(
+    factory,
+    *,
+    enabled=True,
+    mtp=False,
+    cache_layout="qwen3_5_nonrotating_hybrid",
+):
+    events = factory.events
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.model = object()
+    scheduler.processor = _Tokenizer()
+    scheduler.config = MLLMSchedulerConfig(
+        enable_mtp=mtp,
+        specprefill_enabled=enabled,
+        specprefill_profile_registry=_ProfileRegistry(),
+        specprefill_profile_key=_PROFILE_KEY,
+        specprefill_estimated_residency_bytes=1,
+        specprefill_session_factory=factory,
+        specprefill_target_forward_context=lambda _forward: None,
+        specprefill_cache_capability=MLLMSpecPrefillCacheCapability(
+            adapter_id=_PROFILE_KEY.adapter_id,
+            layout=cache_layout,
+        ),
+    )
+    scheduler.batch_generator = _BatchGenerator(events)
+    scheduler.waiting = deque()
+    scheduler.running = {}
+    scheduler.requests = {}
+    scheduler.finished_req_ids = set()
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler._specprefill_queue = deque()
+    scheduler._specprefill_admissions = {}
+    scheduler._specprefill_batch_requests = {}
+    scheduler._specprefill_cancel_pending = set()
+    scheduler._specprefill_cancel_lock = __import__("threading").RLock()
+    scheduler._detokenizer_pool = {}
+    scheduler.output_queues = {}
+    scheduler._step_count = 0
+    scheduler._clear_cache_interval = 10_000
+    scheduler.num_requests_processed = 0
+    scheduler.total_prompt_tokens = 0
+    scheduler.total_completion_tokens = 0
+    scheduler.stop_tokens = {99}
+    return scheduler
+
+
+def _add_selective(scheduler, request_id):
+    return scheduler.add_request(
+        "prompt",
+        request_id=request_id,
+        specprefill_policy=SpecPrefillPolicy.AUTO,
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+
+
+def test_active_decode_runs_before_one_round_robin_busy_quantum():
+    events = []
+    first = _ScorerSession(busy_once=True, events=events, name="first")
+    second = _ScorerSession(events=events, name="second")
+    factory = _AdmissionFactory({"first": first, "second": second}, events)
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "first")
+    _add_selective(scheduler, "second")
+
+    first_output = scheduler.step()
+
+    assert events == ["decode", "score:first"]
+    assert first_output.specprefill_progress["first"].busy is True
+    assert first_output.specprefill_progress["first"].quantum_committed is False
+    assert list(scheduler._specprefill_queue) == ["second", "first"]
+    assert scheduler.batch_generator.inserted == []
+
+    scheduler.step()
+    assert events[-2:] == ["decode", "score:second"]
+    assert first.calls == 0
+    assert second.calls == 1
+
+
+def test_preoutput_failure_requeues_dense_without_emitting_output():
+    events = []
+    scorer = _ScorerSession(fail=True, events=events, name="failed")
+    factory = _AdmissionFactory({"failed": scorer}, events)
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "failed")
+
+    output = scheduler.step()
+
+    request = scheduler.running["failed"]
+    assert output.outputs == []
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "scorer_failed"
+    assert len(scheduler.batch_generator.inserted) == 1
+    assert "failed" not in scheduler._specprefill_admissions
+
+
+def test_ready_session_adopts_only_after_bounded_target_quantum():
+    events = []
+    factory = _AdmissionFactory(events=events)
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "ready")
+
+    first = scheduler.step()
+    assert first.specprefill_progress["ready"].scorer_quanta == 1
+    assert scheduler.batch_generator.adoptions == []
+
+    second = scheduler.step()
+
+    session = factory.sessions["ready"]
+    assert second.specprefill_progress["ready"].target_quanta == 1
+    assert session.outcome is CooperativeSpecPrefillOutcome.DECODE
+    assert len(scheduler.batch_generator.adoptions) == 1
+    assert scheduler.request_id_to_uid["ready"] == 100
+    assert "ready" not in scheduler._specprefill_admissions
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_reason", "dense_replay"),
+    [
+        (
+            SparseAdoptionError("pre", sampling_consumed=False),
+            "adoption_failed",
+            True,
+        ),
+        (
+            SparseAdoptionError("post", sampling_consumed=True),
+            "adoption_failed_after_sampling",
+            False,
+        ),
+        (
+            SparseAdoptionError(
+                "rollback",
+                sampling_consumed=False,
+                rollback_succeeded=False,
+            ),
+            "adoption_rollback_failed",
+            False,
+        ),
+        (RuntimeError("unknown"), "adoption_failed_unknown_boundary", False),
+    ],
+)
+def test_adoption_replay_obeys_typed_sampling_boundary(
+    failure, expected_reason, dense_replay
+):
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "boundary")
+    scheduler.step()
+    scheduler.batch_generator.adoption_error = failure
+
+    output = scheduler.step()
+
+    assert bool(scheduler.batch_generator.inserted) is dense_replay
+    if dense_replay:
+        assert output.outputs == []
+        assert scheduler.running["boundary"].specprefill_fallback_reason == expected_reason
+    else:
+        assert output.outputs[0].finished is True
+        assert output.outputs[0].specprefill_fallback_reason == expected_reason
+        assert "boundary" not in scheduler.running
+
+
+def test_cleanup_failure_is_terminal_and_never_enqueues_dense():
+    scorer = _ScorerSession(fail=True, cleanup_raises=True, name="cleanup")
+    factory = _AdmissionFactory({"cleanup": scorer})
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "cleanup")
+
+    output = scheduler.step()
+
+    assert scheduler.batch_generator.inserted == []
+    assert output.outputs[0].finished is True
+    assert output.outputs[0].specprefill_fallback_reason == "resource_cleanup_failed"
+    assert "cleanup" not in scheduler.running
+
+
+def test_scheduler_step_removes_every_row_failed_by_poisoned_batch():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory, enabled=False)
+    _add_selective(scheduler, "poisoned-1")
+    _add_selective(scheduler, "poisoned-2")
+    scheduler.step()
+    owned = dict(scheduler.request_id_to_uid)
+    scheduler.batch_generator.responses = [
+        MLLMBatchResponse(
+            uid=uid,
+            request_id=request_id,
+            token=0,
+            logprobs=mx.zeros(1),
+            finish_reason="error",
+        )
+        for request_id, uid in owned.items()
+    ]
+
+    output = scheduler.step()
+
+    assert output.finished_request_ids == {"poisoned-1", "poisoned-2"}
+    assert {item.request_id for item in output.outputs} == output.finished_request_ids
+    assert all(item.finish_reason == "error" for item in output.outputs)
+    assert scheduler.running == {}
+    assert scheduler.requests == {}
+    assert scheduler.request_id_to_uid == {}
+    assert scheduler.uid_to_request_id == {}
+
+
+def test_terminal_output_preserves_complete_specprefill_metadata_and_mtp_independence():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "metadata")
+    scheduler.step()
+    scheduler.step()
+    uid = scheduler.request_id_to_uid["metadata"]
+    scheduler.running["metadata"].mtp_drafts = 3
+    scheduler.running["metadata"].mtp_accepted = 2
+    scheduler.batch_generator.responses = [
+        MLLMBatchResponse(
+            uid=uid,
+            request_id="metadata",
+            token=1,
+            logprobs=mx.zeros(2),
+            finish_reason="length",
+        )
+    ]
+
+    output = scheduler.step().outputs[0]
+
+    assert output.specprefill_requested_policy == "auto"
+    assert output.specprefill_effective_policy == "sparse"
+    assert output.specprefill_coverage == "selective"
+    assert output.specprefill_fallback_reason is None
+    assert output.specprefill_selector_version is not None
+    assert output.specprefill_total_tokens == len(_TOKENS)
+    assert output.specprefill_selected_tokens > 0
+    assert output.specprefill_scorer_ms >= 0.0
+    assert output.specprefill_target_prefill_ms == 1.0
+    assert (output.mtp_drafts, output.mtp_accepted) == (3, 2)
+
+
+def test_dense_or_unavailable_policy_never_enters_cooperative_queue():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory, enabled=False)
+    scheduler.add_request(
+        "prompt",
+        request_id="dense",
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+
+    scheduler.step()
+
+    request = scheduler.running["dense"]
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "admission_denied"
+    assert factory.sessions == {}
+    assert len(scheduler.batch_generator.inserted) == 1
+    assert scheduler._specprefill_queue == deque()
+
+
+def test_media_request_uses_separate_dense_fallback_path():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    scheduler.add_request(
+        "prompt",
+        images=["image.png"],
+        request_id="media",
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+
+    scheduler.step()
+
+    request = scheduler.running["media"]
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "media_request"
+    assert factory.sessions == {}
+
+
+def test_ready_sparse_waits_behind_incompatible_dense_active_batch():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "waiter")
+    scheduler.step()
+    scheduler.batch_generator.active_batch = SimpleNamespace(
+        has_sparse_rows=False,
+        sparse_execution_config=None,
+    )
+
+    scheduler.step()
+
+    assert scheduler.batch_generator.adoptions == []
+    assert list(scheduler._specprefill_queue) == ["waiter"]
+    assert scheduler.running["waiter"].output_tokens == []
+
+
+def test_cancellation_is_terminal_and_never_requeues_dense():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "cancelled")
+    scheduler._schedule_waiting()
+    session = factory.sessions["cancelled"]
+
+    assert scheduler.abort_request("cancelled") is True
+    assert session.outcome is CooperativeSpecPrefillOutcome.ACTIVE
+    assert "cancelled" in scheduler._specprefill_admissions
+    assert scheduler.has_requests() is True
+
+    scheduler.step()
+
+    assert session.outcome is CooperativeSpecPrefillOutcome.CANCELLED
+    assert "cancelled" not in scheduler.running
+    assert "cancelled" not in scheduler.requests
+    assert scheduler.batch_generator.inserted == []
+    assert scheduler._specprefill_queue == deque()
+
+
+def test_mtp_composition_fails_closed_to_dense():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory, mtp=True)
+    _add_selective(scheduler, "mtp")
+
+    scheduler.step()
+
+    request = scheduler.running["mtp"]
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "mtp_composition_unavailable"
+    assert factory.sessions == {}
+
+
+@pytest.mark.parametrize(
+    "layout", ("gemma4_dense", "gemma4_a4b", "mixed_rotating")
+)
+def test_unqualified_adapter_cache_layouts_fail_closed_to_dense(layout):
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory, cache_layout=layout)
+    _add_selective(scheduler, layout)
+
+    scheduler.step()
+
+    request = scheduler.running[layout]
+    assert request.specprefill_effective_policy is SpecPrefillPolicy.DENSE
+    assert request.specprefill_fallback_reason == "cache_capability_unsupported"
+    assert factory.sessions == {}
+
+
+def test_cache_object_identity_change_is_terminal_before_adoption():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "identity")
+    scheduler.step()
+    target = factory.sessions["identity"]._target_session
+    target.replace_on_second_read = True
+
+    output = scheduler.step()
+
+    assert scheduler.batch_generator.adoptions == []
+    assert scheduler.batch_generator.inserted == []
+    assert output.outputs[0].specprefill_fallback_reason == (
+        "adoption_failed_unknown_boundary"
+    )
+    assert "identity" not in scheduler.running
+
+
+def test_abort_during_generator_adoption_removes_published_orphan_row():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "coordinated-abort")
+    scheduler.step()
+    scheduler.batch_generator.on_adopt = lambda: scheduler.abort_request(
+        "coordinated-abort"
+    )
+
+    output = scheduler.step()
+
+    assert output.outputs == []
+    assert scheduler.batch_generator.scheduled_removals == [100]
+    assert scheduler.batch_generator.pending_removals == []
+    assert scheduler.batch_generator.active_rows == {}
+    assert scheduler.batch_generator.active_cache_rows == {}
+    assert "coordinated-abort" not in scheduler.running
+    assert "coordinated-abort" not in scheduler._specprefill_admissions
+    assert 100 not in scheduler.uid_to_request_id
+
+
+def test_mark_adopted_failure_removes_published_row_before_terminal_failure():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "mark-failure")
+    scheduler.step()
+    session = factory.sessions["mark-failure"]
+
+    def fail_mark():
+        raise RuntimeError("mark failed")
+
+    session.mark_adopted = fail_mark
+    output = scheduler.step()
+
+    assert scheduler.batch_generator.scheduled_removals == [100]
+    assert scheduler.batch_generator.pending_removals == []
+    assert scheduler.batch_generator.active_rows == {}
+    assert scheduler.batch_generator.active_cache_rows == {}
+    assert output.outputs[0].specprefill_fallback_reason == (
+        "adoption_transition_failed"
+    )
+    assert "mark-failure" not in scheduler.running
+    assert 100 not in scheduler.uid_to_request_id
+
+
+def test_authoritative_cache_property_failure_is_unknown_boundary_terminal():
+    factory = _AdmissionFactory()
+    scheduler = _scheduler(factory)
+    _add_selective(scheduler, "cache-seam")
+    scheduler.step()
+    target = factory.sessions["cache-seam"]._target_session
+    target.fail_cache_read = True
+    output = scheduler.step()
+
+    assert scheduler.batch_generator.adoptions == []
+    assert scheduler.batch_generator.inserted == []
+    assert output.outputs[0].specprefill_fallback_reason == (
+        "adoption_failed_unknown_boundary"
+    )

--- a/tests/test_mllm_specprefill_decode.py
+++ b/tests/test_mllm_specprefill_decode.py
@@ -10,6 +10,7 @@ import pytest
 mx = pytest.importorskip("mlx.core")
 from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
 
+import vllm_mlx.mllm_batch_generator as mllm_batch_generator
 from vllm_mlx.mllm_batch_generator import (
     MLLMBatch,
     MLLMBatchGenerator,
@@ -18,6 +19,7 @@ from vllm_mlx.mllm_batch_generator import (
     MLLMTargetForwardPhase,
     SparseBatchCompatibilityError,
     SparseBatchError,
+    SparseAdoptionError,
     _SupportedSparseCacheCheckpoint,
     _apply_first_token_processors,
     _decode_processor_contexts,
@@ -392,13 +394,114 @@ def test_adoption_extend_failure_restores_active_batch_atomically():
     original_offsets = generator.active_batch.cache[0].offset.tolist()
     request = _request(request_id="sparse-extension")
 
-    with pytest.raises(RuntimeError, match="extend failed"):
+    with pytest.raises(SparseAdoptionError, match="extend failed") as failure:
         _adopt(generator, request=request)
+
+    assert failure.value.sampling_consumed is False
+    assert failure.value.rollback_succeeded is True
+    assert failure.value.replay_safe is True
+    assert isinstance(failure.value.__cause__, RuntimeError)
 
     assert generator.active_batch.uids == original_uids
     assert generator.active_batch.cache[0].offset.tolist() == original_offsets
     assert len(generator.active_batch.sparse_row_states) == 1
     assert request.uid == -1
+
+
+def test_pre_sampling_restore_failure_poison_active_sparse_batch(monkeypatch):
+    generator, _ = _generator()
+    _adopt(generator)
+    active = generator.active_batch
+    request = _request(request_id="pre-rollback-failure")
+    processor_calls = []
+    request.logits_processors = [
+        lambda tokens, logits: processor_calls.append(tokens.tolist()) or logits
+    ]
+
+    def fail_extend(_other):
+        raise RuntimeError("extend failed")
+
+    def fail_restore(_checkpoint):
+        raise RuntimeError("restore failed")
+
+    active.cache[0].extend = fail_extend
+    monkeypatch.setattr(_SupportedSparseCacheCheckpoint, "restore", fail_restore)
+
+    with pytest.raises(SparseAdoptionError, match="rollback failed") as failure:
+        _adopt(generator, request=request)
+
+    assert failure.value.sampling_consumed is False
+    assert failure.value.rollback_succeeded is False
+    assert failure.value.replay_safe is False
+    with pytest.raises(AttributeError):
+        failure.value._rollback_succeeded = True
+    assert processor_calls == []
+    assert generator.active_batch is None
+    assert [(item.uid, item.request_id, item.finish_reason) for item in generator._pending_error_responses] == [
+        (0, "request-1", "error")
+    ]
+    assert request.uid == -1
+
+
+def test_post_sampling_restore_failure_poison_active_sparse_batch(monkeypatch):
+    generator, _ = _generator()
+    _adopt(generator)
+    request = _request(request_id="post-rollback-failure")
+    request.logits_processors = [
+        lambda _tokens, _logits: (_ for _ in ()).throw(
+            RuntimeError("sampling failed")
+        )
+    ]
+
+    def fail_restore(_checkpoint):
+        raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(_SupportedSparseCacheCheckpoint, "restore", fail_restore)
+
+    with pytest.raises(SparseAdoptionError, match="rollback failed") as failure:
+        _adopt(generator, request=request)
+
+    assert failure.value.sampling_consumed is True
+    assert failure.value.rollback_succeeded is False
+    assert failure.value.replay_safe is False
+    assert generator.active_batch is None
+    assert [(item.uid, item.request_id, item.finish_reason) for item in generator._pending_error_responses] == [
+        (0, "request-1", "error")
+    ]
+    assert request.uid == -1
+
+
+def test_public_next_drains_every_poisoned_row_with_no_remaining_work(monkeypatch):
+    generator, _ = _generator()
+    _adopt(generator)
+    _adopt(generator, request=_request(request_id="request-2"))
+    request = _request(request_id="rollback-candidate")
+
+    def fail_extend(_other):
+        raise RuntimeError("extend failed")
+
+    def fail_restore(_checkpoint):
+        raise RuntimeError("restore failed")
+
+    generator.active_batch.cache[0].extend = fail_extend
+    monkeypatch.setattr(_SupportedSparseCacheCheckpoint, "restore", fail_restore)
+    with pytest.raises(SparseAdoptionError):
+        _adopt(generator, request=request)
+
+    assert generator.active_batch is None
+    assert generator.unprocessed_requests == []
+    previous_stream = MLLMBatchGenerator._stream
+    MLLMBatchGenerator._stream = mx.new_stream(mx.default_device())
+    try:
+        responses = generator.next()
+    finally:
+        MLLMBatchGenerator._stream = previous_stream
+
+    assert [(item.uid, item.request_id, item.finish_reason) for item in responses] == [
+        (0, "request-1", "error"),
+        (1, "request-2", "error"),
+    ]
+    assert generator._pending_error_responses == []
 
 
 def test_extend_failure_does_not_consume_stochastic_sampling_and_retry_is_exact():
@@ -425,9 +528,10 @@ def test_extend_failure_does_not_consume_stochastic_sampling_and_retry_is_exact(
         raise RuntimeError("extend failed before sampling")
 
     generator.active_batch.cache[0].extend = failing_extend
-    with pytest.raises(RuntimeError, match="before sampling"):
+    with pytest.raises(SparseAdoptionError, match="before sampling") as failure:
         _adopt(generator, request=request)
 
+    assert failure.value.sampling_consumed is False
     assert sampling_factory_calls == 0
     assert processor_calls == []
     assert generator.active_batch.uids == [0]
@@ -442,6 +546,78 @@ def test_extend_failure_does_not_consume_stochastic_sampling_and_retry_is_exact(
     assert generator.active_batch.uids == [0, 1]
 
 
+def test_deferred_cache_realization_failure_rolls_back_before_sampling(monkeypatch):
+    generator, _ = _generator()
+    _adopt(generator)
+    batch = generator.active_batch
+    original_offsets = batch.cache[0].offset.tolist()
+    original_uids = list(batch.uids)
+    processor_calls = []
+    request = _request(request_id="lazy-cache-failure")
+    request.logits_processors = [
+        lambda tokens, logits: processor_calls.append(tokens.tolist()) or logits
+    ]
+    original_eval = mllm_batch_generator._eval_sparse_adoption_cache
+    eval_calls = 0
+
+    def fail_active_extension(cache):
+        nonlocal eval_calls
+        eval_calls += 1
+        if eval_calls == 2:
+            raise RuntimeError("deferred cache OOM")
+        original_eval(cache)
+
+    monkeypatch.setattr(
+        mllm_batch_generator, "_eval_sparse_adoption_cache", fail_active_extension
+    )
+
+    with pytest.raises(SparseAdoptionError, match="deferred cache OOM") as failure:
+        _adopt(generator, request=request)
+
+    assert failure.value.sampling_consumed is False
+    assert processor_calls == []
+    assert batch.uids == original_uids
+    assert batch.cache[0].offset.tolist() == original_offsets
+    assert request.uid == -1
+
+
+def test_deferred_publication_realization_failure_rolls_back_after_sampling(
+    monkeypatch,
+):
+    generator, _ = _generator()
+    _adopt(generator)
+    batch = generator.active_batch
+    original_offsets = batch.cache[0].offset.tolist()
+    original_uids = list(batch.uids)
+    processor_calls = []
+    request = _request(request_id="lazy-publication-failure")
+    request.logits_processors = [
+        lambda tokens, logits: processor_calls.append(tokens.tolist()) or logits
+    ]
+
+    def fail_publication(*_values):
+        raise RuntimeError("deferred publication OOM")
+
+    monkeypatch.setattr(
+        mllm_batch_generator,
+        "_eval_sparse_adoption_publication",
+        fail_publication,
+    )
+
+    with pytest.raises(
+        SparseAdoptionError, match="deferred publication OOM"
+    ) as failure:
+        _adopt(generator, request=request)
+
+    assert failure.value.sampling_consumed is True
+    assert failure.value.rollback_succeeded is True
+    assert failure.value.replay_safe is False
+    assert processor_calls == [list(_TOKENS)]
+    assert batch.uids == original_uids
+    assert batch.cache[0].offset.tolist() == original_offsets
+    assert request.uid == -1
+
+
 def test_sampling_failure_rolls_back_preextended_cache_without_publication():
     generator, _ = _generator()
     _adopt(generator)
@@ -453,9 +629,12 @@ def test_sampling_failure_rolls_back_preextended_cache_without_publication():
     original_offsets = batch.cache[0].offset.tolist()
     original_uids = list(batch.uids)
 
-    with pytest.raises(RuntimeError, match="sample failed"):
+    with pytest.raises(SparseAdoptionError, match="sample failed") as failure:
         _adopt(generator, request=request)
 
+    assert failure.value.sampling_consumed is True
+    with pytest.raises(AttributeError):
+        failure.value.sampling_consumed = False
     assert batch.cache[0].offset.tolist() == original_offsets
     assert batch.uids == original_uids
     assert request.uid == -1
@@ -469,12 +648,15 @@ def test_incompatible_sparse_adoption_splits_before_mutating_active_batch():
     original_states = generator.active_batch.sparse_row_states
     incompatible_request = _request(request_id="request-2")
 
-    with pytest.raises(SparseBatchCompatibilityError):
+    with pytest.raises(SparseAdoptionError) as failure:
         _adopt(
             generator,
             request=incompatible_request,
             state=_state(scorer_id="other-scorer@sha256:other"),
         )
+
+    assert failure.value.sampling_consumed is False
+    assert isinstance(failure.value.__cause__, SparseBatchCompatibilityError)
 
     assert generator.active_batch.uids == original_uids
     assert generator.active_batch.cache[0].offset.tolist() == original_offsets

--- a/tests/test_mllm_specprefill_decode.py
+++ b/tests/test_mllm_specprefill_decode.py
@@ -437,9 +437,10 @@ def test_pre_sampling_restore_failure_poison_active_sparse_batch(monkeypatch):
         failure.value._rollback_succeeded = True
     assert processor_calls == []
     assert generator.active_batch is None
-    assert [(item.uid, item.request_id, item.finish_reason) for item in generator._pending_error_responses] == [
-        (0, "request-1", "error")
-    ]
+    assert [
+        (item.uid, item.request_id, item.finish_reason)
+        for item in generator._pending_error_responses
+    ] == [(0, "request-1", "error")]
     assert request.uid == -1
 
 
@@ -448,9 +449,7 @@ def test_post_sampling_restore_failure_poison_active_sparse_batch(monkeypatch):
     _adopt(generator)
     request = _request(request_id="post-rollback-failure")
     request.logits_processors = [
-        lambda _tokens, _logits: (_ for _ in ()).throw(
-            RuntimeError("sampling failed")
-        )
+        lambda _tokens, _logits: (_ for _ in ()).throw(RuntimeError("sampling failed"))
     ]
 
     def fail_restore(_checkpoint):
@@ -465,9 +464,10 @@ def test_post_sampling_restore_failure_poison_active_sparse_batch(monkeypatch):
     assert failure.value.rollback_succeeded is False
     assert failure.value.replay_safe is False
     assert generator.active_batch is None
-    assert [(item.uid, item.request_id, item.finish_reason) for item in generator._pending_error_responses] == [
-        (0, "request-1", "error")
-    ]
+    assert [
+        (item.uid, item.request_id, item.finish_reason)
+        for item in generator._pending_error_responses
+    ] == [(0, "request-1", "error")]
     assert request.uid == -1
 
 

--- a/tests/test_mllm_specprefill_decode.py
+++ b/tests/test_mllm_specprefill_decode.py
@@ -1,0 +1,688 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic prepared-sparse-row and request-local decode contracts."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
+
+from vllm_mlx.mllm_batch_generator import (
+    MLLMBatch,
+    MLLMBatchGenerator,
+    MLLMBatchRequest,
+    MLLMBatchStats,
+    MLLMTargetForwardPhase,
+    SparseBatchCompatibilityError,
+    SparseBatchError,
+    _SupportedSparseCacheCheckpoint,
+    _apply_first_token_processors,
+    _decode_processor_contexts,
+    install_mtp_mllm,
+)
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+
+_TOKENS = (10, 11, 12, 13, 14, 15)
+_SELECTED = (0, 1, 4, 5)
+_TUNING = SparsePolicyTuning(0.5, 0.0, 0, 1, 2)
+
+
+class _PreparedCache(KVCache):
+    def __init__(self, offset):
+        super().__init__()
+        self.offset = offset
+        self.keys = mx.zeros((1, 1, offset, 1))
+        self.values = mx.zeros((1, 1, offset, 1))
+        self.quantize_calls = 0
+        self.ssd_calls = 0
+
+    def quantize(self, *_args, **_kwargs):
+        self.quantize_calls += 1
+        raise AssertionError("sparse adoption must not quantize")
+
+    def write_ssd(self, *_args, **_kwargs):
+        self.ssd_calls += 1
+        raise AssertionError("sparse adoption must not use SSD")
+
+
+def _batch_cache(offsets):
+    caches = [_PreparedCache(offset) for offset in offsets]
+    return BatchKVCache.merge(caches)
+
+
+def test_sparse_checkpoint_rejects_misaligned_arrays_cache_rows():
+    recurrent = ArraysCache(2)
+    recurrent.cache[0] = mx.zeros((2, 1))
+    with pytest.raises(SparseBatchCompatibilityError, match="ArraysCache metadata"):
+        _SupportedSparseCacheCheckpoint.capture(
+            [_batch_cache((_state().rows[0].physical_valid_length,)), recurrent],
+            _state().rows,
+        )
+
+
+class _ContextRecorder:
+    def __init__(self, *, fail_enter=False):
+        self.active = False
+        self.calls = []
+        self.fail_enter = fail_enter
+
+    @contextmanager
+    def __call__(self, forward):
+        assert forward.phase is MLLMTargetForwardPhase.DECODE
+        before = tuple(tuple(entry.offset.tolist()) for entry in forward.cache)
+        if self.fail_enter:
+            raise RuntimeError("context failed")
+        self.active = True
+        self.calls.append((forward, before))
+        try:
+            # Merely entering logical-position context cannot rewrite physical
+            # occupancy. The model call below is the only offset advancer.
+            assert (
+                tuple(tuple(entry.offset.tolist()) for entry in forward.cache) == before
+            )
+            yield
+        finally:
+            self.active = False
+
+
+class _LanguageModel:
+    def __init__(self, context, *, fail_after_cache=False, physical_advance=1):
+        self.context = context
+        self.fail_after_cache = fail_after_cache
+        self.physical_advance = physical_advance
+        self.calls = 0
+        self.mtp_calls = 0
+
+    def __call__(self, input_tokens, *, cache, return_hidden=False):
+        assert self.context.active
+        self.calls += 1
+        count = self.physical_advance
+        for entry in cache:
+            entry.offset = entry.offset + count
+            entry._idx += count
+            extension = mx.zeros((entry.keys.shape[0], 1, count, 1))
+            entry.keys = mx.concatenate((entry.keys, extension), axis=2)
+            entry.values = mx.concatenate((entry.values, extension), axis=2)
+        if self.fail_after_cache:
+            raise RuntimeError("target decode failed")
+        batch, length = input_tokens.shape
+        logits = mx.zeros((batch, length, 4))
+        logits[:, :, 1] = 5.0
+        if return_hidden:
+            return logits, mx.ones((batch, length, 2))
+        return logits
+
+    def mtp_forward(self, *_args, **_kwargs):
+        self.mtp_calls += 1
+        raise AssertionError("sparse rows must bypass MTP")
+
+
+class _PrefixCacheSpy:
+    def __init__(self):
+        self.fetch_calls = 0
+        self.store_calls = 0
+
+    def fetch(self, *_args, **_kwargs):
+        self.fetch_calls += 1
+        raise AssertionError("sparse rows must not use ordinary prefix lookup")
+
+    def store(self, *_args, **_kwargs):
+        self.store_calls += 1
+        raise AssertionError("sparse rows must not use ordinary prefix storage")
+
+
+def _identity(*, scorer_id="scorer@sha256:scorer"):
+    return SparseCacheIdentity.from_tokens(
+        target_id="target@sha256:target",
+        tokenizer_id="tokenizer@sha256:tokenizer",
+        scorer_id=scorer_id,
+        selector_version="hybrid-chunk-v2",
+        tuning=_TUNING,
+        tokens=_TOKENS,
+        selection_fingerprint="a" * 64,
+    )
+
+
+def _state(*, scorer_id="scorer@sha256:scorer"):
+    return SparseCacheState.from_selection(
+        _identity(scorer_id=scorer_id), (_SELECTED,), (len(_TOKENS),)
+    )
+
+
+def _request(uid=-1, request_id="request-1", *, max_tokens=2):
+    return MLLMBatchRequest(
+        uid=uid,
+        request_id=request_id,
+        prompt="prompt",
+        max_tokens=max_tokens,
+        temperature=0.0,
+        top_p=1.0,
+        input_ids=mx.array([_TOKENS]),
+        is_text_only=True,
+    )
+
+
+def _generator(*, fail_after_cache=False, fail_context=False, physical_advance=1):
+    context = _ContextRecorder(fail_enter=fail_context)
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.language_model = _LanguageModel(
+        context,
+        fail_after_cache=fail_after_cache,
+        physical_advance=physical_advance,
+    )
+    generator.model = generator.language_model
+    generator.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    generator._target_forward_context = context
+    generator._expected_sparse_execution_config = _identity().execution_config
+    generator._sparse_checkpoint_scalar_reads = 0
+    generator._sparse_checkpoint_host_scalar_reads = 0
+    generator.active_batch = None
+    generator.unprocessed_requests = []
+    generator.uid_counter = 0
+    generator._aborted_request_ids = set()
+    generator._pending_removal_uids = set()
+    generator._pending_removal_lock = __import__("threading").Lock()
+    generator._pending_error_responses = []
+    generator._prefill_progress = {}
+    generator._stats = MLLMBatchStats()
+    generator.completion_batch_size = 8
+    generator.stop_tokens = set()
+    generator.prefix_cache = _PrefixCacheSpy()
+    generator._think_suffix_len = 0
+    return generator, context
+
+
+def _adopt(generator, request=None, state=None, cache=None, logits=None):
+    request = request or _request()
+    state = state or _state()
+    cache = cache or [_PreparedCache(len(_SELECTED))]
+    logits = logits if logits is not None else mx.array([[[0.0, 1.0, 8.0, 0.0]]])
+    uid = generator.adopt_prefilled_sparse_row(request, cache, logits, state)
+    return uid, request, cache
+
+
+def _dense_batch(uid=80):
+    request = _request(uid=uid, request_id=f"dense-{uid}")
+    return MLLMBatch(
+        uids=[uid],
+        request_ids=[request.request_id],
+        y=mx.array([1]),
+        logprobs=[mx.zeros(4)],
+        max_tokens=[3],
+        num_tokens=[0],
+        cache=[_batch_cache([len(_TOKENS)])],
+        requests=[request],
+    )
+
+
+def test_adoption_is_atomic_and_emits_only_after_wrapped_decode():
+    generator, context = _generator()
+    uid, request, _ = _adopt(generator)
+
+    assert uid == request.uid == 0
+    assert request.output_tokens == []
+    assert generator._pending_error_responses == []
+    assert generator.language_model.calls == 0
+    assert generator.active_batch.sparse_row_states[0].next_logical_position == 6
+
+    responses = generator._next()
+
+    assert [response.token for response in responses] == [2]
+    assert request.output_tokens == [2]
+    assert len(context.calls) == 1
+    assert context.calls[0][0].sparse_row_states[0].next_logical_position == 6
+    assert not context.active
+    assert generator.active_batch.sparse_row_states[0].next_logical_position == 7
+    assert generator.active_batch.cache[0].offset.tolist() == [5]
+    assert generator._sparse_checkpoint_scalar_reads == 5
+    assert generator._sparse_checkpoint_host_scalar_reads == 1
+
+    second_responses = generator._next()
+    assert [response.token for response in second_responses] == [1]
+    assert request.output_tokens == [2, 1]
+    assert request.output_tokens.count(2) == 1
+
+
+def test_prepared_first_token_processors_receive_exact_full_prompt_context():
+    generator, _ = _generator()
+    observed = []
+
+    def processor(tokens, logits):
+        observed.append(tuple(tokens.tolist()))
+        forced = mx.full(logits.shape, -100.0)
+        forced[:, 3] = 100.0
+        return forced
+
+    request = _request()
+    request.logits_processors = [processor]
+
+    _adopt(generator, request=request)
+
+    assert observed == [_TOKENS]
+    assert generator.active_batch.y.tolist() == [3]
+    assert request.output_tokens == []
+
+
+def test_dense_and_chunked_processor_helpers_use_full_prompt_and_current_y():
+    observed = []
+
+    def processor(tokens, logits):
+        observed.append(tuple(tokens.tolist()))
+        return logits
+
+    logits = mx.zeros((1, 4))
+    _apply_first_token_processors(logits, mx.array([_TOKENS]), [processor])
+    request = _request()
+    request.output_tokens[:] = [20, 21]
+
+    assert observed == [_TOKENS]
+    assert _decode_processor_contexts([request], [22]) == [[20, 21, 22]]
+
+
+def test_mixed_sparse_dense_extend_fails_closed_before_cache_mutation():
+    dense = _dense_batch()
+    sparse_request = _request(uid=81, request_id="sparse-81")
+    sparse_row = _state().rows[0]
+    sparse = MLLMBatch(
+        uids=[81],
+        request_ids=[sparse_request.request_id],
+        y=mx.array([2]),
+        logprobs=[mx.zeros(4)],
+        max_tokens=[3],
+        num_tokens=[0],
+        cache=[_batch_cache([len(_SELECTED)])],
+        requests=[sparse_request],
+        sparse_row_states=(sparse_row,),
+    )
+
+    with pytest.raises(SparseBatchCompatibilityError, match="cannot share"):
+        dense.extend(sparse)
+
+    assert dense.uids == [80]
+    assert dense.sparse_row_states == (None,)
+    assert dense.cache[0].offset.tolist() == [len(_TOKENS)]
+
+
+@pytest.mark.parametrize(
+    "row_states",
+    [
+        lambda row: (row, None),
+        lambda row: (row, row.append_decode(1)),
+    ],
+)
+def test_direct_terminal_batch_constructor_rejects_invalid_sparse_rows(row_states):
+    row = _state().rows[0]
+    requests = [
+        _request(uid=91, request_id="row-1", max_tokens=1),
+        _request(uid=92, request_id="row-2", max_tokens=1),
+    ]
+
+    with pytest.raises(SparseBatchCompatibilityError):
+        MLLMBatch(
+            uids=[91, 92],
+            request_ids=[request.request_id for request in requests],
+            y=mx.array([2, 2]),
+            logprobs=[mx.zeros(4), mx.zeros(4)],
+            max_tokens=[1, 1],
+            num_tokens=[0, 0],
+            cache=[_batch_cache([len(_SELECTED), len(_SELECTED)])],
+            requests=requests,
+            sparse_row_states=row_states(row),
+        )
+
+
+@pytest.mark.parametrize("y", [mx.array([[2]]), mx.array([2, 2])])
+def test_batch_constructor_rejects_non_vector_or_misaligned_y(y):
+    request = _request(uid=93, request_id="shape-row")
+
+    with pytest.raises(ValueError, match="row-aligned token vector"):
+        MLLMBatch(
+            uids=[93],
+            request_ids=[request.request_id],
+            y=y,
+            logprobs=[mx.zeros(4)],
+            max_tokens=[1],
+            num_tokens=[0],
+            cache=[_batch_cache([len(_SELECTED)])],
+            requests=[request],
+        )
+
+
+def test_sparse_filter_failure_restores_cache_and_all_row_metadata():
+    generator, _ = _generator()
+    _adopt(generator)
+    batch = generator.active_batch
+    original_filter = batch.cache[0].filter
+
+    def failing_filter(keep_idx):
+        original_filter(keep_idx)
+        raise RuntimeError("filter failed")
+
+    batch.cache[0].filter = failing_filter
+    original_uids = list(batch.uids)
+    original_offsets = batch.cache[0].offset.tolist()
+    original_states = batch.sparse_row_states
+
+    with pytest.raises(RuntimeError, match="filter failed"):
+        batch.filter([0])
+
+    assert batch.uids == original_uids
+    assert batch.cache[0].offset.tolist() == original_offsets
+    assert batch.sparse_row_states == original_states
+
+
+def test_adoption_extend_failure_restores_active_batch_atomically():
+    generator, _ = _generator()
+    _adopt(generator)
+    original_extend = generator.active_batch.cache[0].extend
+
+    def failing_extend(other):
+        original_extend(other)
+        raise RuntimeError("extend failed")
+
+    generator.active_batch.cache[0].extend = failing_extend
+    original_uids = list(generator.active_batch.uids)
+    original_offsets = generator.active_batch.cache[0].offset.tolist()
+    request = _request(request_id="sparse-extension")
+
+    with pytest.raises(RuntimeError, match="extend failed"):
+        _adopt(generator, request=request)
+
+    assert generator.active_batch.uids == original_uids
+    assert generator.active_batch.cache[0].offset.tolist() == original_offsets
+    assert len(generator.active_batch.sparse_row_states) == 1
+    assert request.uid == -1
+
+
+def test_extend_failure_does_not_consume_stochastic_sampling_and_retry_is_exact():
+    generator, _ = _generator()
+    _adopt(generator)
+    request = _request(request_id="stochastic-retry")
+    request.temperature = 1.0
+    processor_calls = []
+    request.logits_processors = [
+        lambda tokens, logits: processor_calls.append(tuple(tokens.tolist())) or logits
+    ]
+    sampling_factory_calls = 0
+    original_sampling_factory = generator._sampling_for_request
+
+    def tracked_sampling_factory(candidate):
+        nonlocal sampling_factory_calls
+        sampling_factory_calls += 1
+        return original_sampling_factory(candidate)
+
+    generator._sampling_for_request = tracked_sampling_factory
+    original_extend = generator.active_batch.cache[0].extend
+
+    def failing_extend(_other):
+        raise RuntimeError("extend failed before sampling")
+
+    generator.active_batch.cache[0].extend = failing_extend
+    with pytest.raises(RuntimeError, match="before sampling"):
+        _adopt(generator, request=request)
+
+    assert sampling_factory_calls == 0
+    assert processor_calls == []
+    assert generator.active_batch.uids == [0]
+    assert request.uid == -1
+
+    generator.active_batch.cache[0].extend = original_extend
+    uid, _, _ = _adopt(generator, request=request)
+
+    assert uid == 1
+    assert sampling_factory_calls == 1
+    assert processor_calls == [_TOKENS]
+    assert generator.active_batch.uids == [0, 1]
+
+
+def test_sampling_failure_rolls_back_preextended_cache_without_publication():
+    generator, _ = _generator()
+    _adopt(generator)
+    request = _request(request_id="sampling-failure")
+    request.logits_processors = [
+        lambda _tokens, _logits: (_ for _ in ()).throw(RuntimeError("sample failed"))
+    ]
+    batch = generator.active_batch
+    original_offsets = batch.cache[0].offset.tolist()
+    original_uids = list(batch.uids)
+
+    with pytest.raises(RuntimeError, match="sample failed"):
+        _adopt(generator, request=request)
+
+    assert batch.cache[0].offset.tolist() == original_offsets
+    assert batch.uids == original_uids
+    assert request.uid == -1
+
+
+def test_incompatible_sparse_adoption_splits_before_mutating_active_batch():
+    generator, _ = _generator()
+    _adopt(generator)
+    original_uids = list(generator.active_batch.uids)
+    original_offsets = generator.active_batch.cache[0].offset.tolist()
+    original_states = generator.active_batch.sparse_row_states
+    incompatible_request = _request(request_id="request-2")
+
+    with pytest.raises(SparseBatchCompatibilityError):
+        _adopt(
+            generator,
+            request=incompatible_request,
+            state=_state(scorer_id="other-scorer@sha256:other"),
+        )
+
+    assert generator.active_batch.uids == original_uids
+    assert generator.active_batch.cache[0].offset.tolist() == original_offsets
+    assert generator.active_batch.sparse_row_states == original_states
+    assert incompatible_request.uid == -1
+
+
+def test_decode_error_restores_physical_cache_and_logical_state_without_output():
+    generator, context = _generator(fail_after_cache=True)
+    _adopt(generator)
+    batch = generator.active_batch
+    original_y = batch.y.tolist()
+    original_state = batch.sparse_row_states
+
+    with pytest.raises(RuntimeError, match="target decode failed"):
+        generator._next()
+
+    assert batch.cache[0].offset.tolist() == [len(_SELECTED)]
+    assert batch.sparse_row_states == original_state
+    assert batch.y.tolist() == original_y
+    assert batch.requests[0].output_tokens == []
+    assert not context.active
+
+
+def test_context_error_is_fail_closed_before_cache_or_logical_advance():
+    generator, _ = _generator(fail_context=True)
+    _adopt(generator)
+    batch = generator.active_batch
+    original_state = batch.sparse_row_states
+
+    with pytest.raises(RuntimeError, match="context failed"):
+        generator._next()
+
+    assert batch.cache[0].offset.tolist() == [len(_SELECTED)]
+    assert batch.sparse_row_states == original_state
+    assert batch.requests[0].output_tokens == []
+
+
+@pytest.mark.parametrize("physical_advance", [0, 2])
+def test_wrong_physical_advance_rolls_back_before_logical_commit(physical_advance):
+    generator, _ = _generator(physical_advance=physical_advance)
+    _adopt(generator)
+    batch = generator.active_batch
+    original_state = batch.sparse_row_states
+    original_keys = batch.cache[0].keys
+
+    with pytest.raises(SparseBatchError, match="advance exactly one"):
+        generator._next()
+
+    assert batch.cache[0].offset.tolist() == [len(_SELECTED)]
+    assert batch.cache[0].keys is original_keys
+    assert batch.sparse_row_states == original_state
+    assert batch.requests[0].output_tokens == []
+
+
+def test_sparse_step_rejects_input_row_mismatch_before_target_context():
+    generator, context = _generator()
+    _adopt(generator)
+    batch = generator.active_batch
+
+    with pytest.raises(SparseBatchCompatibilityError, match="input row count"):
+        generator._step(mx.array([[2], [2]]), batch.cache)
+
+    assert generator.language_model.calls == 0
+    assert context.calls == []
+    assert batch.cache[0].offset.tolist() == [len(_SELECTED)]
+
+
+def test_sparse_checkpoint_rejects_cache_metadata_row_mismatch():
+    generator, context = _generator()
+    request = _request(uid=94, request_id="cache-shape")
+    row = _state().rows[0]
+    generator.active_batch = MLLMBatch(
+        uids=[94],
+        request_ids=[request.request_id],
+        y=mx.array([2]),
+        logprobs=[mx.zeros(4)],
+        max_tokens=[2],
+        num_tokens=[0],
+        cache=[_batch_cache([len(_SELECTED), len(_SELECTED)])],
+        requests=[request],
+        sparse_row_states=(row,),
+    )
+
+    with pytest.raises(SparseBatchCompatibilityError, match="metadata"):
+        generator._step(mx.array([[2]]), generator.active_batch.cache)
+
+    assert generator.language_model.calls == 0
+    assert context.calls == []
+
+
+def test_every_ordinary_dense_target_call_uses_same_bounded_context_seam():
+    generator, context = _generator()
+    generator.active_batch = _dense_batch()
+    batch = generator.active_batch
+
+    generator._step(batch.y[:, None], batch.cache)
+
+    assert len(context.calls) == 1
+    assert context.calls[0][0].sparse_row_states == (None,)
+    assert batch.cache[0].offset.tolist() == [len(_TOKENS) + 1]
+    assert batch.sparse_row_states == (None,)
+    assert not context.active
+
+
+def test_sparse_finish_bypasses_prefix_lcp_and_transformed_cache_paths():
+    generator, _ = _generator()
+    request = _request(max_tokens=1)
+    _, _, prepared_cache = _adopt(generator, request=request)
+
+    responses = generator._next()
+
+    assert len(responses) == 1
+    assert responses[0].finish_reason == "length"
+    assert responses[0].prompt_cache is None
+    assert generator.prefix_cache.fetch_calls == 0
+    assert generator.prefix_cache.store_calls == 0
+    assert prepared_cache[0].quantize_calls == 0
+    assert prepared_cache[0].ssd_calls == 0
+    assert generator.language_model.calls == 0
+
+
+def test_sparse_eos_first_token_emits_without_target_lookahead():
+    generator, _ = _generator()
+    generator.stop_tokens = {2}
+    _, request, _ = _adopt(generator)
+    row_state = generator.active_batch.sparse_row_states[0]
+
+    responses = generator._next()
+
+    assert [(response.token, response.finish_reason) for response in responses] == [
+        (2, "stop")
+    ]
+    assert request.output_tokens == [2]
+    assert generator.language_model.calls == 0
+    assert row_state.next_logical_position == len(_TOKENS)
+
+
+def test_sparse_nonpositive_max_tokens_rejected_before_sampling_or_cache_merge():
+    generator, _ = _generator()
+    request = _request(max_tokens=0)
+    observed = []
+    request.logits_processors = [
+        lambda tokens, logits: observed.append(tokens) or logits
+    ]
+
+    with pytest.raises(SparseBatchError, match="greater than zero"):
+        _adopt(generator, request=request)
+
+    assert observed == []
+    assert generator.active_batch is None
+
+
+def test_dense_text_arrival_remains_queued_while_sparse_lane_is_active():
+    generator, _ = _generator()
+    _adopt(generator)
+    dense_request = _request(uid=70, request_id="queued-dense", max_tokens=3)
+    generator.unprocessed_requests.append(dense_request)
+
+    def forbidden_prefill(_requests):
+        raise AssertionError("dense request must remain queued behind sparse lane")
+
+    generator._process_prompts = forbidden_prefill
+    responses = generator._next()
+
+    assert [response.token for response in responses] == [2]
+    assert generator.unprocessed_requests == [dense_request]
+    assert dense_request.output_tokens == []
+    assert generator.active_batch.has_sparse_rows
+
+
+def test_exact_identity_mismatch_rejects_without_queue_or_prefix_side_effects():
+    generator, _ = _generator()
+    request = _request()
+    request.input_ids = mx.array([[10, 11, 12, 13, 14, 99]])
+
+    with pytest.raises(SparseBatchError, match="identity does not match"):
+        _adopt(generator, request=request)
+
+    assert generator.active_batch is None
+    assert generator.unprocessed_requests == []
+    assert generator.prefix_cache.fetch_calls == 0
+    assert generator.prefix_cache.store_calls == 0
+    assert request.uid == -1
+
+
+def test_cancellation_removes_sparse_row_before_any_output():
+    generator, _ = _generator()
+    uid, request, _ = _adopt(generator)
+
+    generator.remove([uid])
+
+    assert generator.active_batch is None
+    assert request.output_tokens == []
+    assert generator.language_model.calls == 0
+
+
+def test_native_mtp_bypasses_sparse_rows_before_any_draft_or_verify_call():
+    generator, _ = _generator()
+    _adopt(generator)
+    install_mtp_mllm(generator, generator.language_model)
+    batch = generator.active_batch
+
+    batch.y, batch.logprobs = generator._step(
+        batch.y[:, None], batch.cache, batch.logits_processors, None, batch.samplers
+    )
+
+    assert generator.language_model.mtp_calls == 0
+    assert generator.language_model.calls == 1
+    assert batch.sparse_row_states[0].next_logical_position == len(_TOKENS) + 1
+    assert generator.get_mtp_stats()["bypass_counts"]["sparse_rows"] == 1

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -7,6 +7,7 @@ import asyncio
 import dataclasses
 import logging
 import re
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,7 @@ from vllm_mlx.model_registry import (
     load_registry_config,
     log_memory_budget_report,
 )
+from vllm_mlx.scheduler import SchedulerConfig
 from vllm_mlx.utils.download import DownloadConfig
 
 
@@ -140,6 +142,38 @@ models:
         ),
     ):
         load_registry_config(config_path, _defaults())
+
+
+def test_registry_cb_specprefill_requires_and_propagates_explicit_builder(tmp_path):
+    registry = _registry(tmp_path, {"alpha": 1})
+    enabled_defaults = replace(
+        _defaults(),
+        continuous_batching=True,
+        force_mllm=True,
+        specprefill_enabled=True,
+    )
+    manager = ModelManager(
+        _manager_config(budget_gb=2),
+        registry,
+        enabled_defaults,
+    )
+    entry = registry["alpha"]
+
+    with pytest.raises(ValueError, match="specprefill_prepare"):
+        manager._resolve_model_config(entry, entry.source)
+
+    prepared_config = SchedulerConfig(specprefill_prepare=lambda *_args: None)
+    manager = ModelManager(
+        _manager_config(budget_gb=2),
+        registry,
+        replace(enabled_defaults, scheduler_config=prepared_config),
+    )
+    resolved = manager._resolve_model_config(entry, entry.source)
+
+    assert resolved.specprefill_enabled is True
+    assert resolved.scheduler_config is not prepared_config
+    assert resolved.scheduler_config.specprefill_enabled is True
+    assert callable(resolved.scheduler_config.specprefill_prepare)
 
 
 def test_acquire_shares_single_inflight_load(tmp_path):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -24,6 +24,7 @@ from vllm_mlx.model_registry import (
     build_memory_budget_report,
     load_registry_config,
     log_memory_budget_report,
+    _loaded_model_specprefill_status,
 )
 from vllm_mlx.scheduler import SchedulerConfig
 from vllm_mlx.utils.download import DownloadConfig
@@ -174,6 +175,45 @@ def test_registry_cb_specprefill_requires_and_propagates_explicit_builder(tmp_pa
     assert resolved.scheduler_config is not prepared_config
     assert resolved.scheduler_config.specprefill_enabled is True
     assert callable(resolved.scheduler_config.specprefill_prepare)
+
+
+@pytest.mark.parametrize(
+    ("stats", "expected_state"),
+    [
+        (
+            {
+                "specprefill": {
+                    "enabled": False,
+                    "advertisable": False,
+                    "diagnostic": True,
+                }
+            },
+            "diagnostic",
+        ),
+        (
+            {
+                "specprefill": {
+                    "enabled": False,
+                    "advertisable": False,
+                    "diagnostic": False,
+                }
+            },
+            "disabled",
+        ),
+        ({}, "unavailable"),
+    ],
+)
+def test_registry_specprefill_status_distinguishes_diagnostic_and_unavailable(
+    stats, expected_state
+):
+    class Engine:
+        def get_stats(self):
+            return stats
+
+    loaded = type("Loaded", (), {"engine": Engine()})()
+
+    assert _loaded_model_specprefill_status(loaded)["state"] == expected_state
+    assert _loaded_model_specprefill_status(None)["state"] == "unloaded"
 
 
 def test_acquire_shares_single_inflight_load(tmp_path):

--- a/tests/test_native_mtp_batch.py
+++ b/tests/test_native_mtp_batch.py
@@ -1,0 +1,440 @@
+"""Synthetic real-cache coverage for native-Qwen CB transactions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
+
+from vllm_mlx.native_mtp_batch import (
+    NativeMTPBatch,
+    NativeMTPBatchError,
+    NativeMTPBatchPosition,
+    NativeMTPBatchRow,
+)
+from vllm_mlx.native_mtp_request import NativeMTPRequestConfig, NativeMTPSampling
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool = True
+    reason: str = "supported"
+    num_layers: int = 1
+
+
+class _Model:
+    def __init__(self, *, capability=None, linear_layers=1, attention_layers=1):
+        self._capability = capability or _Capability()
+        self.layers = [
+            *[type("_Linear", (), {"is_linear": True})() for _ in range(linear_layers)],
+            *[
+                type("_Attention", (), {"is_linear": False})()
+                for _ in range(attention_layers)
+            ],
+        ]
+        self.mtp = type("_MTP", (), {"layers": [object()]})()
+        self.model = type("_Core", (), {"pipeline_size": 1})()
+
+    @property
+    def mtp_capability(self):
+        return self._capability
+
+
+class _FreshCapabilityModel(_Model):
+    @property
+    def mtp_capability(self):
+        value = self._capability
+        return _Capability(value.supported, value.reason, value.num_layers)
+
+
+def _sampling(seed):
+    return NativeMTPRequestConfig(
+        sampling=NativeMTPSampling(
+            temperature=0.7,
+            top_p=0.9,
+            top_k=20,
+            min_p=0.0,
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+            seed=seed,
+        ),
+        num_draft_tokens=2,
+    )
+
+
+def _advance_kv(cache, count, *, batch_size=1, value=1.0):
+    keys = mx.full((batch_size, 1, count, 8), value, dtype=mx.float32)
+    cache.update_and_fetch(keys, keys + 10)
+
+
+def _row(model, uid, *, position=0, seed=None):
+    recurrent = ArraysCache(2)
+    recurrent[0] = mx.array([[float(uid), 1.0]])
+    recurrent[1] = mx.array([[float(uid), 2.0]])
+    attention = KVCache()
+    head = KVCache()
+    if position:
+        _advance_kv(attention, position, value=float(uid + 1))
+        _advance_kv(head, position, value=float(uid + 2))
+    return NativeMTPBatchRow(
+        uid=uid,
+        target_model=model,
+        capability=model.mtp_capability,
+        backbone_cache=[recurrent, attention],
+        mtp_cache=[head],
+        position=NativeMTPBatchPosition(position, position, position),
+        request_config=_sampling(uid if seed is None else seed),
+    )
+
+
+def _advance_batch(batch, count=1, *, recurrent_delta=1.0):
+    batch_size = len(batch.uids)
+    for entry in (*batch.backbone_cache, *batch.mtp_cache):
+        if type(entry) is BatchKVCache:
+            _advance_kv(entry, count, batch_size=batch_size)
+        elif type(entry) is ArraysCache:
+            entry.cache = [
+                value + recurrent_delta if value is not None else None
+                for value in entry.cache
+            ]
+
+
+def _positions(batch, delta):
+    return {
+        uid: NativeMTPBatchPosition(
+            position.logical_cursor + delta,
+            position.backbone_tokens + delta,
+            position.mtp_tokens + delta,
+        )
+        for uid, position in batch.positions
+    }
+
+
+def test_full_verified_batch_commit_advances_all_rows_atomically():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 11, position=2), _row(model, 22, position=2)])
+    assert all(
+        type(entry) in {BatchKVCache, ArraysCache}
+        for entry in (*batch.backbone_cache, *batch.mtp_cache)
+    )
+
+    batch.checkpoint()
+    _advance_batch(batch, 2, recurrent_delta=2)
+    sealed = _positions(batch, 2)
+    batch.seal_verified(sealed)
+    batch.commit(sealed)
+
+    assert dict(batch.positions) == sealed
+    assert batch.checkpoint_active is False
+    assert batch.backbone_cache[1]._idx == 4
+    assert batch.mtp_cache[0]._idx == 4
+
+
+def test_partial_recurrent_rejection_rolls_back_partitions_replays_and_rejoins():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1), _row(model, 2)])
+    initial = [value + mx.zeros(value.shape) for value in batch.backbone_cache[0].cache]
+
+    batch.checkpoint()
+    _advance_batch(batch, 3, recurrent_delta=30)
+    verified = _positions(batch, 3)
+    batch.seal_verified(verified)
+    targets = {
+        1: NativeMTPBatchPosition(0, 0, 0),
+        2: NativeMTPBatchPosition(2, 2, 2),
+    }
+    plan = batch.reject_partial(targets)
+
+    assert plan.groups == ((1,), (2,))
+    assert batch.backbone_cache[1]._idx == 0
+    assert batch.mtp_cache[0]._idx == 0
+    assert all(
+        mx.array_equal(actual, expected).item()
+        for actual, expected in zip(batch.backbone_cache[0].cache, initial)
+    )
+
+    partitions = batch.partition_replay_groups()
+    assert len(partitions) == 2
+    for partition in partitions:
+        target = targets[partition.uids[0]]
+        while dict(partition.positions)[partition.uids[0]] != target:
+            _advance_batch(partition, 1, recurrent_delta=1)
+            partition.replay_retained(_positions(partition, 1))
+        assert partition.replay_targets == ()
+
+    joined = NativeMTPBatch.join(partitions)
+    assert joined.uids == (1, 2)
+    assert dict(joined.positions) == targets
+    assert joined.backbone_cache[1].offset.tolist() == [0, 2]
+    assert joined.mtp_cache[0].offset.tolist() == [0, 2]
+    recurrent = joined.backbone_cache[0].cache[0]
+    assert recurrent[:, 1].tolist() == [1.0, 3.0]
+
+
+def test_all_zero_partial_rejection_can_rejoin_without_replay():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1), _row(model, 2)])
+    batch.checkpoint()
+    _advance_batch(batch, 2, recurrent_delta=9)
+    batch.seal_verified(_positions(batch, 2))
+    targets = {uid: NativeMTPBatchPosition(0, 0, 0) for uid in batch.uids}
+
+    plan = batch.reject_partial(targets)
+
+    assert plan.groups == ((1, 2),)
+    assert batch.replay_targets == ()
+    partitions = batch.partition_replay_groups()
+    assert partitions == (batch,)
+    joined = NativeMTPBatch.join(partitions)
+    assert joined.uids == (1, 2)
+    assert dict(joined.positions) == targets
+
+
+def test_partial_commit_is_forbidden_even_if_attention_was_trimmed():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1)])
+    batch.checkpoint()
+    _advance_batch(batch, 2, recurrent_delta=2)
+    batch.seal_verified(_positions(batch, 2))
+    batch.backbone_cache[1].trim(1)
+    batch.mtp_cache[0].trim(1)
+
+    with pytest.raises(
+        NativeMTPBatchError,
+        match="native_mtp_batch_partial_commit_requires_replay",
+    ):
+        batch.commit({1: NativeMTPBatchPosition(1, 1, 1)})
+
+    batch.reject_partial({1: NativeMTPBatchPosition(1, 1, 1)})
+    assert batch.backbone_cache[1]._idx == 0
+    assert batch.mtp_cache[0]._idx == 0
+
+
+def test_filter_and_compatible_join_preserve_positions_and_rng_ownership():
+    model = _Model()
+    batch = NativeMTPBatch(
+        [
+            _row(model, 1, position=1),
+            _row(model, 2, position=2),
+            _row(model, 3, position=3),
+        ]
+    )
+    batch.filter((3, 1))
+    assert batch.uids == (3, 1)
+    assert batch.backbone_cache[1].offset.tolist() == [3, 1]
+    assert batch.mtp_cache[0].offset.tolist() == [3, 1]
+
+    other = NativeMTPBatch([_row(model, 4, position=2)])
+    joined = NativeMTPBatch.join((batch, other))
+    assert joined.uids == (3, 1, 4)
+    assert joined.backbone_cache[1].offset.tolist() == [3, 1, 2]
+    assert batch.closed and other.closed
+    assert batch.backbone_cache == [] and other.mtp_cache == []
+
+
+def test_filter_failure_restores_every_cache_and_uid(monkeypatch):
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1, position=1), _row(model, 2, position=1)])
+    original_filter = BatchKVCache.filter
+    calls = 0
+
+    def fail_second_attention(entry, indices):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("synthetic filter failure")
+        return original_filter(entry, indices)
+
+    monkeypatch.setattr(BatchKVCache, "filter", fail_second_attention)
+    with pytest.raises(RuntimeError, match="synthetic filter failure"):
+        batch.filter((2,))
+
+    assert batch.uids == (1, 2)
+    assert batch.backbone_cache[0].batch_size == 2
+    assert batch.backbone_cache[1].offset.tolist() == [1, 1]
+    assert batch.mtp_cache[0].offset.tolist() == [1, 1]
+
+
+def test_cancellation_rolls_back_active_transaction_then_removes_only_uid():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1, position=1), _row(model, 2, position=1)])
+    initial = batch.backbone_cache[0].cache[0] + mx.zeros(
+        batch.backbone_cache[0].cache[0].shape
+    )
+    batch.checkpoint()
+    _advance_batch(batch, 2, recurrent_delta=8)
+
+    batch.finish(1, "cancelled")
+
+    assert batch.uids == (2,)
+    assert batch.backbone_cache[1].offset.tolist() == [1]
+    assert batch.mtp_cache[0].offset.tolist() == [1]
+    assert mx.array_equal(batch.backbone_cache[0].cache[0], initial[1:2]).item()
+    batch.finish(2, "eos")
+    assert batch.closed
+    assert batch.backbone_cache == [] and batch.mtp_cache == []
+
+
+def test_rollback_failure_poison_closes_batch():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1)])
+    batch.checkpoint()
+    _advance_batch(batch, 1)
+    batch.backbone_cache[1] = BatchKVCache([0])
+
+    with pytest.raises(NativeMTPBatchError, match="native_mtp_batch_rollback_failed"):
+        batch.rollback()
+    assert batch.poisoned and batch.closed
+    assert batch.uids == ()
+    assert batch.backbone_cache == [] and batch.mtp_cache == []
+    assert batch.checkpoint_active is False
+    assert batch.replay_targets == ()
+    assert batch.target_model is None
+    assert batch.capability is None
+
+
+def test_target_capability_topology_and_aliasing_fail_closed():
+    model = _Model()
+    other = _Model(capability=model.mtp_capability)
+    row = _row(model, 1)
+    with pytest.raises(NativeMTPBatchError, match="target_identity_mismatch"):
+        NativeMTPBatch([row, _row(other, 2)])
+
+    forged = _row(model, 3)
+    object.__setattr__(forged, "capability", _Capability(num_layers=2))
+    with pytest.raises(NativeMTPBatchError, match="capability_identity_mismatch"):
+        NativeMTPBatch([forged])
+
+    wrong = _row(model, 4)
+    wrong.backbone_cache.reverse()
+    with pytest.raises(TypeError, match="backbone_cache_type_mismatch"):
+        NativeMTPBatch([wrong])
+
+    aliased = _row(model, 5)
+    aliased.mtp_cache[0] = aliased.backbone_cache[1]
+    with pytest.raises(ValueError, match="cache_entries_must_be_unique"):
+        NativeMTPBatch([aliased])
+
+
+def test_fresh_qwen_capability_snapshots_bind_by_value_and_recheck_current_state():
+    model = _FreshCapabilityModel()
+    first = model.mtp_capability
+    second = model.mtp_capability
+    assert first == second and first is not second
+
+    batch = NativeMTPBatch([_row(model, 1)])
+    batch.checkpoint()
+    batch.rollback()
+    model._capability = _Capability(False, "native_mtp_weights_not_loaded", 1)
+    with pytest.raises(NativeMTPBatchError, match="native_mtp_capability_changed"):
+        batch.next_rng_key(1)
+
+
+@pytest.mark.parametrize("pipeline_owner", ("target", "backbone"))
+def test_direct_and_nested_pipeline_parallelism_fail_closed(pipeline_owner):
+    model = _Model()
+    if pipeline_owner == "target":
+        model.pipeline_size = 2
+    else:
+        model.model.pipeline_size = 2
+    with pytest.raises(
+        NativeMTPBatchError,
+        match="native_mtp_pipeline_parallelism_unsupported",
+    ):
+        NativeMTPBatch([_row(model, 1)])
+
+
+def test_truly_empty_recurrent_cache_admits_canonical_zero_padding_for_exact_rows():
+    model = _Model()
+    rows = [_row(model, uid) for uid in (1, 2, 3)]
+    for row in rows:
+        row.backbone_cache[0] = ArraysCache(2)
+
+    batch = NativeMTPBatch(rows)
+
+    recurrent = batch.backbone_cache[0]
+    assert recurrent.empty()
+    assert recurrent.batch_size == 3
+    assert recurrent.left_padding.tolist() == [0, 0, 0]
+    batch.checkpoint()
+    batch.rollback()
+    assert recurrent.left_padding.tolist() == [0, 0, 0]
+
+
+def test_alignment_uses_one_host_scalar_read_per_transaction_boundary():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1), _row(model, 2)])
+    assert (batch.alignment_checks, batch.alignment_host_syncs) == (1, 1)
+
+    batch.checkpoint()
+    assert (batch.alignment_checks, batch.alignment_host_syncs) == (2, 2)
+    _advance_batch(batch, 1)
+    sealed = _positions(batch, 1)
+    batch.seal_verified(sealed)
+    assert (batch.alignment_checks, batch.alignment_host_syncs) == (3, 3)
+    batch.commit(sealed)
+    assert (batch.alignment_checks, batch.alignment_host_syncs) == (3, 3)
+    assert batch.alignment_check_ms >= 0
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("prefix_reused", "native_mtp_prefix_reuse_unsupported"),
+        ("has_media", "native_mtp_media_unsupported"),
+        ("specprefill_selected", "native_mtp_specprefill_composition_unsupported"),
+        ("external_assistant_selected", "native_mtp_external_assistant_conflict"),
+    ],
+)
+def test_unqualified_compositions_fail_before_batch_cache_creation(field, reason):
+    model = _Model()
+    values = {
+        "uid": 1,
+        "target_model": model,
+        "capability": model.mtp_capability,
+        "backbone_cache": [ArraysCache(2), KVCache()],
+        "mtp_cache": [KVCache()],
+        "position": NativeMTPBatchPosition(0, 0, 0),
+        "request_config": _sampling(1),
+        field: True,
+    }
+    with pytest.raises(NativeMTPBatchError, match=f"^{reason}$"):
+        NativeMTPBatchRow(**values)
+
+
+def test_request_rng_streams_do_not_cross_between_uids_or_after_filter_join():
+    model = _Model()
+    batch = NativeMTPBatch([_row(model, 1, seed=77), _row(model, 2, seed=77)])
+    first_one = batch.next_rng_key(1)
+    second_one = batch.next_rng_key(1)
+    first_two = batch.next_rng_key(2)
+    mx.eval(first_one, second_one, first_two)
+    assert mx.array_equal(first_one, first_two).item()
+    assert not mx.array_equal(first_one, second_one).item()
+
+    batch.filter((2,))
+    other = NativeMTPBatch([_row(model, 3, seed=77)])
+    joined = NativeMTPBatch.join((batch, other))
+    second_two = joined.next_rng_key(2)
+    first_three = joined.next_rng_key(3)
+    mx.eval(second_two, first_three)
+    assert mx.array_equal(second_one, second_two).item()
+    assert mx.array_equal(first_one, first_three).item()
+
+
+def test_join_rejects_cross_model_and_active_checkpoint_without_consuming_sources():
+    first = NativeMTPBatch([_row(_Model(), 1)])
+    second = NativeMTPBatch([_row(_Model(), 2)])
+    with pytest.raises(NativeMTPBatchError, match="native_mtp_batch_join_incompatible"):
+        NativeMTPBatch.join((first, second))
+    assert not first.closed and not second.closed
+
+    model = _Model()
+    left = NativeMTPBatch([_row(model, 3)])
+    right = NativeMTPBatch([_row(model, 4)])
+    left.checkpoint()
+    with pytest.raises(NativeMTPBatchError, match="native_mtp_batch_checkpoint_active"):
+        NativeMTPBatch.join((left, right))
+    assert not left.closed and not right.closed

--- a/tests/test_native_mtp_request_contract.py
+++ b/tests/test_native_mtp_request_contract.py
@@ -72,7 +72,15 @@ def _install_fake_upstream_mtp(monkeypatch, calls):
                 "kwargs": kwargs,
             }
         )
-        yield SimpleNamespace(text="x", token=1, finish_reason="stop")
+        yield SimpleNamespace(
+            text="x",
+            token=1,
+            logprobs="target-logprobs",
+            mtp_drafts=3,
+            mtp_accepted=2,
+            mtp_bypass_reason=None,
+            finish_reason="stop",
+        )
 
     monkeypatch.setattr(mlx_lm, "stream_generate", fake_stream_generate)
     monkeypatch.setattr(
@@ -445,6 +453,7 @@ def test_pure_llm_selected_forwards_exact_native_mtp_kwargs(monkeypatch):
         0.7, 0.9, 20, 0.05, 11
     )
     assert "num_draft_tokens" not in calls[0]["kwargs"]
+    assert "sampler" not in calls[0]["kwargs"]
 
 
 def test_pure_llm_default_off_and_false_do_not_forward_native_kwargs(monkeypatch):
@@ -457,6 +466,7 @@ def test_pure_llm_default_off_and_false_do_not_forward_native_kwargs(monkeypatch
 
     assert [call["mtp"] for call in calls] == [unset, unset]
     assert [call["mtp_sampling_config"] for call in calls] == [unset, unset]
+    assert all("sampler" in call["kwargs"] for call in calls)
 
 
 @pytest.mark.anyio
@@ -500,9 +510,153 @@ async def test_mllm_text_selected_forwards_exact_native_mtp_kwargs(monkeypatch):
     ]
 
     assert outputs[-1].text == "x"
+    assert outputs[-1].logprobs == "target-logprobs"
+    assert (outputs[-1].mtp_drafts, outputs[-1].mtp_accepted) == (3, 2)
     assert calls[0]["mtp"] is True
     assert isinstance(calls[0]["mtp_sampling_config"], _FakeUpstreamSampling)
     assert "num_draft_tokens" not in calls[0]["kwargs"]
+    assert "sampler" not in calls[0]["kwargs"]
+
+
+def test_pure_llm_copies_native_target_logprobs_and_cumulative_telemetry(
+    monkeypatch,
+):
+    import mlx_lm
+
+    closed = []
+    target_logprobs = object()
+
+    def fake_stream_generate(
+        model,
+        tokenizer,
+        prompt,
+        *,
+        mtp=False,
+        mtp_sampling_config=None,
+        **kwargs,
+    ):
+        del model, tokenizer, prompt, mtp, mtp_sampling_config, kwargs
+        try:
+            yield SimpleNamespace(
+                text="x",
+                token=3,
+                logprobs=target_logprobs,
+                mtp_drafts=2,
+                mtp_accepted=1,
+                mtp_bypass_reason=None,
+                finish_reason="length",
+            )
+        finally:
+            closed.append(True)
+
+    monkeypatch.setattr(mlx_lm, "stream_generate", fake_stream_generate)
+    config = NativeMTPRequestConfig(_sampling(seed=11), num_draft_tokens=1)
+
+    outputs = list(
+        _fake_language_model().stream_generate(
+            "hi", max_tokens=1, native_mtp_request=config
+        )
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].logprobs is target_logprobs
+    assert (outputs[0].mtp_drafts, outputs[0].mtp_accepted) == (2, 1)
+    assert outputs[0].finish_reason == "length"
+    assert closed == [True]
+
+
+def test_pure_llm_early_stop_deterministically_closes_upstream(monkeypatch):
+    import mlx_lm
+
+    closed = []
+
+    def fake_stream_generate(
+        model,
+        tokenizer,
+        prompt,
+        *,
+        mtp=False,
+        mtp_sampling_config=None,
+        **kwargs,
+    ):
+        del model, tokenizer, prompt, mtp, mtp_sampling_config, kwargs
+        try:
+            yield SimpleNamespace(text="STOP", token=3, finish_reason=None)
+            yield SimpleNamespace(text="unreachable", token=4, finish_reason=None)
+        finally:
+            closed.append(True)
+
+    monkeypatch.setattr(mlx_lm, "stream_generate", fake_stream_generate)
+    config = NativeMTPRequestConfig(_sampling(seed=11), num_draft_tokens=1)
+
+    outputs = list(
+        _fake_language_model().stream_generate(
+            "hi",
+            max_tokens=8,
+            stop=["STOP"],
+            native_mtp_request=config,
+        )
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].finish_reason == "stop"
+    assert closed == [True]
+
+
+def test_pure_llm_iteration_error_is_not_masked_by_close_error(monkeypatch):
+    import mlx_lm
+
+    class FailingStream:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise RuntimeError("primary iteration failure")
+
+        def close(self):
+            raise ValueError("secondary close failure")
+
+    def fake_stream_generate(
+        model,
+        tokenizer,
+        prompt,
+        *,
+        mtp=False,
+        mtp_sampling_config=None,
+        **kwargs,
+    ):
+        del model, tokenizer, prompt, mtp, mtp_sampling_config, kwargs
+        return FailingStream()
+
+    monkeypatch.setattr(mlx_lm, "stream_generate", fake_stream_generate)
+    config = NativeMTPRequestConfig(_sampling(seed=11), num_draft_tokens=1)
+
+    with pytest.raises(RuntimeError, match="primary iteration failure"):
+        list(
+            _fake_language_model().stream_generate(
+                "hi", max_tokens=2, native_mtp_request=config
+            )
+        )
+
+
+@pytest.mark.anyio
+async def test_tracker_primary_error_survives_aclose_error_and_cleans_state():
+    class FailingAsyncStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise RuntimeError("primary async iteration failure")
+
+        async def aclose(self):
+            raise ValueError("secondary async close failure")
+
+    engine = SimpleEngine("synthetic")
+    with pytest.raises(RuntimeError, match="primary async iteration failure"):
+        async for _ in engine._track_request_stream(FailingAsyncStream()):
+            pass
+    assert engine._active_requests == {}
+    assert engine._num_running == 0
 
 
 @pytest.mark.anyio

--- a/tests/test_native_mtp_request_contract.py
+++ b/tests/test_native_mtp_request_contract.py
@@ -394,10 +394,7 @@ def test_configured_native_default_keeps_intent_when_head_is_missing():
     request = CompletionRequest(model="m", prompt="hi")
     kwargs = _kwargs()
     _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
-    assert (
-        kwargs["_native_mtp_bypass_reason"]
-        == "native_mtp_model_capability_missing"
-    )
+    assert kwargs["_native_mtp_bypass_reason"] == "native_mtp_model_capability_missing"
     assert kwargs["_native_mtp_disabled"] is True
 
 
@@ -477,9 +474,7 @@ async def test_mllm_text_selected_forwards_exact_native_mtp_kwargs(monkeypatch):
 
     sample_utils = importlib.import_module("mlx_lm.sample_utils")
     monkeypatch.setattr(sample_utils, "make_sampler", lambda **kwargs: object())
-    monkeypatch.setattr(
-        sample_utils, "make_logits_processors", lambda **kwargs: []
-    )
+    monkeypatch.setattr(sample_utils, "make_logits_processors", lambda **kwargs: [])
     tokenizer = SimpleNamespace(
         apply_chat_template=lambda messages, **kwargs: "rendered",
         bos_token=None,
@@ -682,7 +677,9 @@ async def test_completion_preflight_rejection_finishes_metrics(monkeypatch):
     monkeypatch.setattr(server._metrics, "track_inference", lambda *a, **k: tracker)
     monkeypatch.setattr(server, "_acquire_default_engine_for_request", acquire)
     monkeypatch.setattr(server, "_release_engine_for_request", release)
-    monkeypatch.setattr(server, "_validate_cb_specprefill_request_tuning", lambda *a: None)
+    monkeypatch.setattr(
+        server, "_validate_cb_specprefill_request_tuning", lambda *a: None
+    )
 
     request = CompletionRequest(model="m", prompt="hi", stream=True, mtp=True)
     with pytest.raises(HTTPException) as exc:
@@ -707,7 +704,9 @@ async def test_chat_preparation_rejection_finishes_metrics(monkeypatch):
     monkeypatch.setattr(server._metrics, "track_inference", lambda *a, **k: tracker)
     monkeypatch.setattr(server, "_acquire_default_engine_for_request", acquire)
     monkeypatch.setattr(server, "_release_engine_for_request", release)
-    monkeypatch.setattr(server, "_validate_cb_specprefill_request_tuning", lambda *a: None)
+    monkeypatch.setattr(
+        server, "_validate_cb_specprefill_request_tuning", lambda *a: None
+    )
     monkeypatch.setattr(
         server,
         "_prepare_chat_completion_invocation",

--- a/tests/test_native_mtp_request_contract.py
+++ b/tests/test_native_mtp_request_contract.py
@@ -1,0 +1,569 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import ChatCompletionRequest, CompletionRequest
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.engine.simple import SimpleEngine, _consume_native_mtp_request
+from vllm_mlx.models.llm import MLXLanguageModel
+from vllm_mlx.native_mtp_request import (
+    NativeMTPRequestConfig,
+    NativeMTPRequestError,
+    NativeMTPSampling,
+    NativeMTPServerState,
+    native_mtp_consumer_supported,
+    resolve_native_mtp_request,
+)
+from vllm_mlx.server import (
+    _attach_native_mtp_request_kwargs,
+    _generation_metadata,
+    _preflight_streaming_completion_native_mtp,
+)
+
+
+def _sampling(seed=None):
+    return NativeMTPSampling(
+        temperature=0.7,
+        top_p=0.9,
+        top_k=20,
+        min_p=0.05,
+        presence_penalty=0.1,
+        repetition_penalty=1.1,
+        seed=seed,
+    )
+
+
+@dataclass(frozen=True)
+class _FakeUpstreamSampling:
+    temperature: float
+    top_p: float
+    top_k: int
+    min_p: float
+    seed: int | None
+
+
+def _install_fake_upstream_mtp(monkeypatch, calls):
+    import importlib
+
+    import mlx_lm
+
+    generate_module = importlib.import_module("mlx_lm.generate")
+
+    unset = object()
+
+    def fake_stream_generate(
+        model,
+        tokenizer,
+        prompt,
+        max_tokens=256,
+        draft_model=None,
+        mtp=unset,
+        mtp_sampling_config=unset,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "mtp": mtp,
+                "mtp_sampling_config": mtp_sampling_config,
+                "kwargs": kwargs,
+            }
+        )
+        yield SimpleNamespace(text="x", token=1, finish_reason="stop")
+
+    monkeypatch.setattr(mlx_lm, "stream_generate", fake_stream_generate)
+    monkeypatch.setattr(
+        generate_module,
+        "NativeMTPSamplingConfig",
+        _FakeUpstreamSampling,
+        raising=False,
+    )
+    return fake_stream_generate, unset
+
+
+def _kwargs(**overrides):
+    values = {
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 20,
+        "min_p": 0.05,
+        "presence_penalty": 0.1,
+        "repetition_penalty": 1.1,
+    }
+    values.update(overrides)
+    return values
+
+
+class _Engine:
+    def __init__(self, state):
+        self.state = state
+
+    def native_mtp_server_state(self, *, has_media=False):
+        if has_media:
+            return NativeMTPServerState(
+                server_default=self.state.server_default,
+                capable=self.state.capable,
+                incompatibility="native_mtp_media_unsupported",
+            )
+        return self.state
+
+
+@pytest.mark.parametrize("request_type", [ChatCompletionRequest, CompletionRequest])
+@pytest.mark.parametrize("value", [1, 0, "true", "false"])
+def test_public_mtp_is_strict_boolean(request_type, value):
+    body = {"model": "m", "mtp": value}
+    body["messages" if request_type is ChatCompletionRequest else "prompt"] = (
+        [{"role": "user", "content": "hi"}]
+        if request_type is ChatCompletionRequest
+        else "hi"
+    )
+    with pytest.raises(ValidationError):
+        request_type(**body)
+
+
+@pytest.mark.parametrize("request_type", [ChatCompletionRequest, CompletionRequest])
+@pytest.mark.parametrize("seed", [True, "7", -1, 0x100000000])
+def test_public_seed_is_bounded_strict_int(request_type, seed):
+    body = {"model": "m", "mtp": True, "seed": seed}
+    body["messages" if request_type is ChatCompletionRequest else "prompt"] = (
+        [{"role": "user", "content": "hi"}]
+        if request_type is ChatCompletionRequest
+        else "hi"
+    )
+    with pytest.raises(ValidationError):
+        request_type(**body)
+
+
+def test_seed_conflicts_with_explicit_mtp_opt_out():
+    with pytest.raises(ValidationError, match="seed conflicts with mtp=false"):
+        CompletionRequest(model="m", prompt="hi", mtp=False, seed=7)
+
+
+def test_native_and_external_mtp_intents_conflict():
+    with pytest.raises(ValidationError, match="conflicts with mllm_draft"):
+        ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            mtp=True,
+            mllm_draft=True,
+        )
+
+
+def test_resolver_explicit_true_never_silently_downgrades():
+    with pytest.raises(NativeMTPRequestError) as exc:
+        resolve_native_mtp_request(
+            requested=True,
+            sampling=_sampling(),
+            server_default=False,
+            capable=False,
+            num_draft_tokens=1,
+        )
+    assert exc.value.reason == "native_mtp_unsupported"
+
+
+def test_server_attaches_exact_immutable_sampling_only_when_selected():
+    engine = _Engine(
+        NativeMTPServerState(
+            server_default=False,
+            capable=True,
+            num_draft_tokens=3,
+        )
+    )
+    request = CompletionRequest(model="m", prompt="hi", mtp=True, seed=17)
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(engine, request, kwargs)
+
+    config = kwargs.pop("_native_mtp_request_config")
+    assert config == NativeMTPRequestConfig(_sampling(seed=17), num_draft_tokens=3)
+    assert kwargs == _kwargs()
+    with pytest.raises(Exception):
+        config.num_draft_tokens = 9
+
+
+def test_seed_uses_request_effective_native_default():
+    state = NativeMTPServerState(server_default=True, capable=True)
+    request = CompletionRequest(model="m", prompt="hi", seed=23)
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    assert kwargs["_native_mtp_request_config"].sampling.seed == 23
+
+
+def test_seed_fails_when_native_default_is_not_effective():
+    state = NativeMTPServerState(server_default=False, capable=True)
+    request = CompletionRequest(model="m", prompt="hi", seed=23)
+    with pytest.raises(HTTPException) as exc:
+        _attach_native_mtp_request_kwargs(_Engine(state), request, _kwargs())
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "native_mtp_seed_requires_effective_mtp"
+
+
+def test_default_off_and_explicit_false_do_not_change_backend_kwargs():
+    state = NativeMTPServerState(server_default=False, capable=True)
+    for requested in (None, False):
+        request = CompletionRequest(model="m", prompt="hi", mtp=requested)
+        kwargs = _kwargs()
+        _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+        assert kwargs == _kwargs()
+
+
+def test_external_or_incapable_default_does_not_publish_native_bypass():
+    state = NativeMTPServerState(server_default=False, capable=False)
+    request = ChatCompletionRequest(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        mllm_draft=True,
+    )
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    assert kwargs == _kwargs()
+
+
+def test_explicit_false_disables_only_an_active_native_default():
+    state = NativeMTPServerState(server_default=True, capable=True)
+    request = CompletionRequest(model="m", prompt="hi", mtp=False)
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    assert kwargs.pop("_native_mtp_disabled") is True
+    assert kwargs == _kwargs()
+
+
+@pytest.mark.parametrize(
+    "incompatibility",
+    [
+        "native_mtp_max_kv_unsupported",
+        "native_mtp_prefix_cache_unsupported",
+        "native_mtp_media_unsupported",
+    ],
+)
+def test_explicit_incompatibility_fails_before_engine_invocation(incompatibility):
+    state = NativeMTPServerState(
+        server_default=True,
+        capable=True,
+        incompatibility=incompatibility,
+    )
+    request = CompletionRequest(model="m", prompt="hi", mtp=True)
+    with pytest.raises(HTTPException) as exc:
+        _attach_native_mtp_request_kwargs(_Engine(state), request, _kwargs())
+    assert exc.value.status_code == 422
+    assert exc.value.detail == incompatibility
+
+
+def test_streaming_completion_preflights_before_sse_generator_starts():
+    state = NativeMTPServerState(
+        server_default=True,
+        capable=True,
+        incompatibility="native_mtp_max_kv_unsupported",
+    )
+    request = CompletionRequest(model="m", prompt="hi", stream=True, mtp=True)
+    with pytest.raises(HTTPException) as exc:
+        _preflight_streaming_completion_native_mtp(
+            _Engine(state),
+            request,
+            repetition_penalty=None,
+        )
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "native_mtp_max_kv_unsupported"
+
+
+def test_any_constructed_processor_fails_explicit_native_mtp_closed():
+    state = NativeMTPServerState(server_default=True, capable=True)
+    request = CompletionRequest(model="m", prompt="hi", mtp=True)
+    with pytest.raises(HTTPException) as exc:
+        _attach_native_mtp_request_kwargs(
+            _Engine(state),
+            request,
+            _kwargs(logits_processors=[object()]),
+        )
+    assert exc.value.detail == "native_mtp_logits_processors_unsupported"
+
+
+def test_mllm_hidden_penalty_processors_fail_before_engine_invocation():
+    state = NativeMTPServerState(
+        server_default=True,
+        capable=True,
+        supports_penalty_processors=False,
+    )
+    request = CompletionRequest(model="m", prompt="hi", mtp=True)
+    with pytest.raises(HTTPException) as exc:
+        _attach_native_mtp_request_kwargs(
+            _Engine(state),
+            request,
+            _kwargs(repetition_penalty=1.2),
+        )
+    assert exc.value.detail == "native_mtp_penalty_processors_unsupported"
+
+
+def test_default_native_mtp_bypass_is_stable_and_terminally_visible():
+    state = NativeMTPServerState(server_default=True, capable=True)
+    request = CompletionRequest(model="m", prompt="hi")
+    kwargs = _kwargs(logits_processors=[object()])
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    reason = kwargs.pop("_native_mtp_bypass_reason")
+    assert reason == "native_mtp_logits_processors_unsupported"
+    assert kwargs.pop("_native_mtp_disabled") is True
+
+    metadata = _generation_metadata(
+        None,
+        GenerationOutput(text="ok", mtp_bypass_reason=reason),
+    )
+    assert metadata is not None
+    assert metadata.mtp_bypass_reason == reason
+
+
+def test_default_native_mtp_yields_to_external_draft_without_leaking_controls():
+    state = NativeMTPServerState(server_default=True, capable=True)
+    request = ChatCompletionRequest(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        mllm_draft=True,
+    )
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    assert kwargs["_native_mtp_disabled"] is True
+    assert kwargs["_native_mtp_bypass_reason"] == "native_mtp_external_draft_selected"
+
+    controls = {
+        name: kwargs.pop(name)
+        for name in tuple(kwargs)
+        if name.startswith("_native_mtp_")
+    }
+    assert _consume_native_mtp_request(controls, server_default=True) == (
+        None,
+        True,
+        False,
+        "native_mtp_external_draft_selected",
+    )
+    assert controls == {}
+    assert kwargs == _kwargs()
+
+
+def test_ordinary_output_does_not_create_generation_metadata():
+    assert _generation_metadata(None, GenerationOutput(text="ok")) is None
+
+
+def test_simple_capability_rejects_max_kv_and_resident_prefix_state(monkeypatch):
+    engine = object.__new__(SimpleEngine)
+    engine._mtp = True
+    engine._mtp_num_draft_tokens = 2
+    engine._is_mllm = False
+    engine._model = SimpleNamespace(
+        model=SimpleNamespace(
+            mtp_capability=SimpleNamespace(supported=True, reason="supported")
+        )
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.engine.simple.resolve_native_mtp_consumer", lambda: object()
+    )
+    engine._max_kv_size = 128
+    engine._system_kv_cache = {}
+    assert (
+        engine.native_mtp_server_state().incompatibility
+        == "native_mtp_max_kv_unsupported"
+    )
+    engine._max_kv_size = 0
+    engine._system_kv_cache = {"prefix": object()}
+    assert (
+        engine.native_mtp_server_state().incompatibility
+        == "native_mtp_prefix_cache_unsupported"
+    )
+
+
+def test_configured_native_default_keeps_intent_when_head_is_missing():
+    engine = object.__new__(SimpleEngine)
+    engine._mtp = True
+    engine._mtp_num_draft_tokens = 1
+    engine._is_mllm = False
+    engine._model = SimpleNamespace(model=SimpleNamespace())
+    engine._max_kv_size = 0
+    engine._system_kv_cache = {}
+    state = engine.native_mtp_server_state()
+    assert state.server_default is True
+    assert state.capable is False
+
+    request = CompletionRequest(model="m", prompt="hi")
+    kwargs = _kwargs()
+    _attach_native_mtp_request_kwargs(_Engine(state), request, kwargs)
+    assert (
+        kwargs["_native_mtp_bypass_reason"]
+        == "native_mtp_model_capability_missing"
+    )
+    assert kwargs["_native_mtp_disabled"] is True
+
+
+def test_private_controls_are_consumed_and_never_reach_backends():
+    config = NativeMTPRequestConfig(_sampling(), num_draft_tokens=4)
+    kwargs = {"_native_mtp_request_config": config, "ordinary": 1}
+    assert _consume_native_mtp_request(kwargs, server_default=False) == (
+        config,
+        False,
+        True,
+        None,
+    )
+    assert kwargs == {"ordinary": 1}
+
+
+def test_consumer_requires_explicit_current_mlx_lm_parameters():
+    def legacy(model, tokenizer, prompt, **kwargs):
+        del model, tokenizer, prompt, kwargs
+
+    def current(model, tokenizer, prompt, mtp=False, mtp_sampling_config=None):
+        del model, tokenizer, prompt, mtp, mtp_sampling_config
+
+    assert native_mtp_consumer_supported(legacy) is False
+    assert native_mtp_consumer_supported(current) is True
+
+
+def _fake_language_model():
+    model = object.__new__(MLXLanguageModel)
+    model._loaded = True
+    model.model = object()
+    model.tokenizer = SimpleNamespace(encode=lambda prompt: [1, 2])
+    model._mtp = False
+    model._mtp_num_draft_tokens = 4
+    model._create_sampler = lambda *args: object()
+    model._create_logits_processors = lambda *args: []
+    return model
+
+
+def test_pure_llm_selected_forwards_exact_native_mtp_kwargs(monkeypatch):
+    calls = []
+    _, unset = _install_fake_upstream_mtp(monkeypatch, calls)
+    config = NativeMTPRequestConfig(_sampling(seed=11), num_draft_tokens=4)
+
+    list(
+        _fake_language_model().stream_generate(
+            "hi", max_tokens=1, native_mtp_request=config
+        )
+    )
+
+    assert calls[0]["mtp"] is True
+    assert calls[0]["mtp"] is not unset
+    assert calls[0]["mtp_sampling_config"] == _FakeUpstreamSampling(
+        0.7, 0.9, 20, 0.05, 11
+    )
+    assert "num_draft_tokens" not in calls[0]["kwargs"]
+
+
+def test_pure_llm_default_off_and_false_do_not_forward_native_kwargs(monkeypatch):
+    calls = []
+    _, unset = _install_fake_upstream_mtp(monkeypatch, calls)
+    model = _fake_language_model()
+
+    list(model.stream_generate("hi", max_tokens=1))
+    list(model.stream_generate("hi", max_tokens=1, native_mtp_disabled=True))
+
+    assert [call["mtp"] for call in calls] == [unset, unset]
+    assert [call["mtp_sampling_config"] for call in calls] == [unset, unset]
+
+
+@pytest.mark.anyio
+async def test_mllm_text_selected_forwards_exact_native_mtp_kwargs(monkeypatch):
+    calls = []
+    _install_fake_upstream_mtp(monkeypatch, calls)
+    import importlib
+
+    sample_utils = importlib.import_module("mlx_lm.sample_utils")
+    monkeypatch.setattr(sample_utils, "make_sampler", lambda **kwargs: object())
+    monkeypatch.setattr(
+        sample_utils, "make_logits_processors", lambda **kwargs: []
+    )
+    tokenizer = SimpleNamespace(
+        apply_chat_template=lambda messages, **kwargs: "rendered",
+        bos_token=None,
+        eos_token_id=99,
+        eos_token_ids={99},
+    )
+    engine = SimpleEngine("test-model", force_mllm=True, mtp=True)
+    engine._loaded = True
+    engine._text_model = SimpleNamespace(
+        mtp_capability=SimpleNamespace(supported=True, reason="supported")
+    )
+    engine._text_tokenizer = tokenizer
+    config = NativeMTPRequestConfig(
+        NativeMTPSampling(0.7, 0.9, 20, 0.05, 0.0, 1.0, None),
+        num_draft_tokens=4,
+    )
+
+    outputs = [
+        output
+        async for output in engine._stream_generate_text(
+            [{"role": "user", "content": "hi"}],
+            max_tokens=1,
+            temperature=0.7,
+            top_p=0.9,
+            combined_mtp=True,
+            _native_mtp_request_config=config,
+        )
+    ]
+
+    assert outputs[-1].text == "x"
+    assert calls[0]["mtp"] is True
+    assert isinstance(calls[0]["mtp_sampling_config"], _FakeUpstreamSampling)
+    assert "num_draft_tokens" not in calls[0]["kwargs"]
+
+
+@pytest.mark.anyio
+async def test_completion_preflight_rejection_finishes_metrics(monkeypatch):
+    import vllm_mlx.server as server
+
+    tracker = MagicMock()
+    engine = _Engine(
+        NativeMTPServerState(
+            server_default=True,
+            capable=True,
+            incompatibility="native_mtp_consumer_contract_missing",
+        )
+    )
+
+    async def acquire(*args, **kwargs):
+        return engine
+
+    async def release(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(server, "_validate_model_name", lambda model: None)
+    monkeypatch.setattr(server._metrics, "track_inference", lambda *a, **k: tracker)
+    monkeypatch.setattr(server, "_acquire_default_engine_for_request", acquire)
+    monkeypatch.setattr(server, "_release_engine_for_request", release)
+    monkeypatch.setattr(server, "_validate_cb_specprefill_request_tuning", lambda *a: None)
+
+    request = CompletionRequest(model="m", prompt="hi", stream=True, mtp=True)
+    with pytest.raises(HTTPException) as exc:
+        await server.create_completion(request, raw_request=None)
+    assert exc.value.status_code == 422
+    tracker.finish.assert_called_once_with(result="client_error")
+
+
+@pytest.mark.anyio
+async def test_chat_preparation_rejection_finishes_metrics(monkeypatch):
+    import vllm_mlx.server as server
+
+    tracker = MagicMock()
+
+    async def acquire(*args, **kwargs):
+        return object()
+
+    async def release(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(server, "_validate_model_name", lambda model: None)
+    monkeypatch.setattr(server._metrics, "track_inference", lambda *a, **k: tracker)
+    monkeypatch.setattr(server, "_acquire_default_engine_for_request", acquire)
+    monkeypatch.setattr(server, "_release_engine_for_request", release)
+    monkeypatch.setattr(server, "_validate_cb_specprefill_request_tuning", lambda *a: None)
+    monkeypatch.setattr(
+        server,
+        "_prepare_chat_completion_invocation",
+        MagicMock(side_effect=HTTPException(status_code=422, detail="native rejected")),
+    )
+
+    request = ChatCompletionRequest(
+        model="m", messages=[{"role": "user", "content": "hi"}], mtp=True
+    )
+    with pytest.raises(HTTPException) as exc:
+        await server.create_chat_completion(request, raw_request=None)
+    assert exc.value.status_code == 422
+    tracker.finish.assert_called_once_with(result="client_error")

--- a/tests/test_native_mtp_specprefill_bridge.py
+++ b/tests/test_native_mtp_specprefill_bridge.py
@@ -97,7 +97,9 @@ def test_build_failure_cancels_unadopted_session(monkeypatch):
 
 
 def test_mark_adopt_failure_abandons_bootstrap_and_session(monkeypatch):
-    bridge, session = _bridge(monkeypatch, session=_Session(ready_after=1, fail_adoption=True))
+    bridge, session = _bridge(
+        monkeypatch, session=_Session(ready_after=1, fail_adoption=True)
+    )
     bridge.step()
     with pytest.raises(RuntimeError, match="adoption_failed"):
         bridge.mark_adopted()

--- a/tests/test_native_mtp_specprefill_bridge.py
+++ b/tests/test_native_mtp_specprefill_bridge.py
@@ -1,0 +1,114 @@
+"""Focused executable contracts for the standard-text sparse bridge.
+
+These tests substitute only the public bootstrap constructor; the bridge uses
+the real cooperative outcome enum and drives the same ready/adoption boundary
+as the runtime owner.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.cooperative_specprefill import CooperativeSpecPrefillOutcome
+from vllm_mlx.native_mtp_specprefill_bridge import (
+    NativeMTPSpecPrefillBridge,
+    NativeMTPSpecPrefillBridgeState,
+)
+
+
+class _Bootstrap:
+    made = []
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.closed = False
+        type(self).made.append(self)
+
+    def close(self):
+        self.closed = True
+
+
+class _Session:
+    def __init__(self, *, ready_after=2, fail_adoption=False):
+        self.ready_after = ready_after
+        self.fail_adoption = fail_adoption
+        self.steps = 0
+        self.cancelled = False
+        self.outcome = CooperativeSpecPrefillOutcome.ACTIVE
+        self.fallback_reason = None
+        self.selection_plan = SimpleNamespace(selected_indices=(0, 2, 4))
+        self.prepared_result = SimpleNamespace(forward_receipts=(object(), object()))
+        self.prepared_cache = [object()]
+
+    def step(self):
+        self.steps += 1
+        if self.steps >= self.ready_after:
+            self.outcome = CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+        return SimpleNamespace(busy=False)
+
+    def mark_adopted(self):
+        if self.fail_adoption:
+            raise RuntimeError("adoption_failed")
+        self.outcome = CooperativeSpecPrefillOutcome.DECODE
+
+    def cancel(self):
+        self.cancelled = True
+        self.outcome = CooperativeSpecPrefillOutcome.CANCELLED
+
+
+def _bridge(monkeypatch, *, session=None):
+    generate = importlib.import_module("mlx_lm.generate")
+
+    monkeypatch.setattr(generate, "NativeMTPSparseBootstrap", _Bootstrap)
+    session = session or _Session()
+    request = SimpleNamespace(request_id="r", prompt_token_ids=[4, 5, 6, 7, 8])
+    prepared = SimpleNamespace(
+        native_mtp_session_factory=lambda request, tokens, config: session
+    )
+    return NativeMTPSpecPrefillBridge(prepared, request, object()), session
+
+
+def test_multi_quantum_bridge_preserves_original_successors_and_cache(monkeypatch):
+    bridge, session = _bridge(monkeypatch)
+    assert bridge.step().state is NativeMTPSpecPrefillBridgeState.PREFILLING
+    assert bridge.step().state is NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY
+    bootstrap = bridge.bootstrap
+    assert bootstrap.selected_token_ids == (4, 6, 8)
+    assert bootstrap.immediate_successor_token_ids == (5, 7)
+    assert bootstrap.target_cache is session.prepared_cache
+    assert bootstrap.receipts is session.prepared_result.forward_receipts
+    assert bridge.mark_adopted() is bootstrap
+    bridge.cancel()
+    assert bootstrap.closed
+    assert not session.cancelled
+
+
+def test_build_failure_cancels_unadopted_session(monkeypatch):
+    bridge, session = _bridge(monkeypatch)
+    session.prepared_result = SimpleNamespace(forward_receipts=())
+    bridge.step()
+    with pytest.raises(RuntimeError, match="native_mtp_sparse_receipts_missing"):
+        bridge.step()
+    assert session.cancelled
+    assert bridge.state is NativeMTPSpecPrefillBridgeState.TERMINAL
+
+
+def test_mark_adopt_failure_abandons_bootstrap_and_session(monkeypatch):
+    bridge, session = _bridge(monkeypatch, session=_Session(ready_after=1, fail_adoption=True))
+    bridge.step()
+    with pytest.raises(RuntimeError, match="adoption_failed"):
+        bridge.mark_adopted()
+    # The caller still owns the ready bootstrap when adoption is declined.
+    bridge.cancel()
+    assert _Bootstrap.made[-1].closed
+    assert session.cancelled
+
+
+def test_cancel_before_adoption_cancels_cooperative_owner(monkeypatch):
+    bridge, session = _bridge(monkeypatch)
+    bridge.cancel()
+    assert session.cancelled
+    assert bridge.state is NativeMTPSpecPrefillBridgeState.TERMINAL

--- a/tests/test_qwen_native_mtp_loader.py
+++ b/tests/test_qwen_native_mtp_loader.py
@@ -1,0 +1,586 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic contract tests for native Qwen3.5/3.6 loader integration."""
+
+from __future__ import annotations
+
+import json
+import importlib
+import sys
+import struct
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+import vllm_mlx.text_model_from_vlm as extraction
+import vllm_mlx.utils.tokenizer as tokenizer_utils
+
+
+@dataclass(frozen=True)
+class _Capability:
+    supported: bool
+    reason: str
+    num_layers: int
+
+
+class _FakeTextModel:
+    def __init__(self, num_layers: int):
+        self.num_layers = num_layers
+        self._loaded = False
+        self.training = True
+
+    @property
+    def mtp_capability(self):
+        if not self.num_layers:
+            return _Capability(False, "native_mtp_head_not_configured", 0)
+        if not self._loaded:
+            return _Capability(
+                False, "native_mtp_weights_not_loaded", self.num_layers
+            )
+        return _Capability(True, "supported", self.num_layers)
+
+    def train(self, mode=True):
+        self.training = mode
+        return self
+
+    def __call__(self, tokens):
+        return ("ordinary-forward", tokens)
+
+
+class _FakeQwenWrapper:
+    instances = []
+    sanitize_error = None
+
+    def __init__(self, args):
+        self.args = args
+        self.language_model = _FakeTextModel(args["mtp_num_hidden_layers"])
+        self.sanitize_calls = []
+        self.load_calls = []
+        self.events = []
+        self.__class__.instances.append(self)
+
+    def sanitize(self, weights):
+        self.events.append("sanitize")
+        self.sanitize_calls.append(weights)
+        if self.__class__.sanitize_error is not None:
+            raise self.__class__.sanitize_error
+        sanitized = {}
+        for key, value in weights.items():
+            if key.startswith("model.language_model.mtp."):
+                key = key.replace(
+                    "model.language_model.", "language_model.", 1
+                )
+            sanitized[key] = value
+        self._handshake = tuple(
+            sorted((key, id(value)) for key, value in sanitized.items())
+        )
+        return sanitized
+
+    def load_weights(self, weights, strict=True):
+        self.events.append("load")
+        assert isinstance(weights, list)
+        assert strict is True
+        assert tuple(sorted((key, id(value)) for key, value in weights)) == (
+            self._handshake
+        )
+        self.load_calls.append((weights, strict))
+        self.language_model._loaded = bool(self.language_model.num_layers)
+
+
+class _FakeQwenArgs:
+    seen = []
+
+    @classmethod
+    def from_dict(cls, config):
+        cls.seen.append(config)
+        text_config = config["text_config"]
+        return {
+            "model_type": text_config["model_type"],
+            "mtp_num_hidden_layers": text_config.get("mtp_num_hidden_layers", 0),
+            "num_experts": text_config.get("num_experts", 0),
+        }
+
+
+class _FakeVLMLanguageModel:
+    def __init__(self, weights):
+        self._weights = weights
+
+    def parameters(self):
+        return self._weights
+
+
+def _write_config(tmp_path, *, model_type, mtp_layers, num_experts=0, **extra):
+    model_path = tmp_path / model_type
+    model_path.mkdir()
+    text_config = {
+        "model_type": model_type,
+        "mtp_num_hidden_layers": mtp_layers,
+        "num_experts": num_experts,
+        **extra,
+    }
+    config = {"model_type": "qwen3_5", "text_config": text_config}
+    (model_path / "config.json").write_text(json.dumps(config))
+    return model_path, config
+
+
+@pytest.fixture
+def fake_qwen_loader(monkeypatch):
+    _FakeQwenWrapper.instances.clear()
+    _FakeQwenWrapper.sanitize_error = None
+    _FakeQwenArgs.seen.clear()
+    monkeypatch.setattr(
+        extraction,
+        "_import_qwen_model_classes",
+        lambda _model_type: (_FakeQwenWrapper, _FakeQwenArgs),
+    )
+    monkeypatch.setattr(
+        extraction, "_qwen_checkpoint_requires_norm_shift", lambda _path: False
+    )
+    monkeypatch.setattr(
+        extraction.mlx.utils,
+        "tree_flatten",
+        lambda weights: list(weights.items()),
+    )
+    monkeypatch.setattr(extraction, "_realize_model_arrays", lambda _model: None)
+    monkeypatch.setattr(extraction.nn, "quantize", lambda *args, **kwargs: None)
+
+
+@pytest.mark.parametrize(
+    ("model_type", "num_experts"),
+    (("qwen3_5_text", 0), ("qwen3_5_moe_text", 128)),
+)
+def test_qwen_vlm_extraction_uses_outer_one_shot_handshake(
+    tmp_path, monkeypatch, fake_qwen_loader, model_type, num_experts
+):
+    model_path, config = _write_config(
+        tmp_path,
+        model_type=model_type,
+        mtp_layers=1,
+        num_experts=num_experts,
+    )
+    backbone = object()
+    head = object()
+    mtp = object()
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel(
+            {"model.embed_tokens.weight": backbone, "lm_head.weight": head}
+        )
+    )
+    monkeypatch.setattr(
+        extraction,
+        "_load_mtp_weights",
+        lambda _path: {"model.language_model.mtp.layers.0.weight": mtp},
+    )
+
+    text_model = extraction.build_text_model(vlm, model_path)
+
+    wrapper = _FakeQwenWrapper.instances[-1]
+    assert _FakeQwenArgs.seen == [config]
+    assert text_model is wrapper.language_model
+    assert text_model.mtp_capability.supported is True
+    assert text_model.training is False
+    assert len(wrapper.sanitize_calls) == 2
+    assert len(wrapper.load_calls) == 1
+    assert wrapper.events == ["sanitize", "sanitize", "load"]
+    loaded = dict(wrapper.load_calls[0][0])
+    assert loaded["language_model.model.embed_tokens.weight"] is backbone
+    assert loaded["language_model.lm_head.weight"] is head
+    assert loaded["language_model.mtp.layers.0.weight"] is mtp
+    assert text_model([1, 2]) == ("ordinary-forward", [1, 2])
+
+
+def test_qwen_configured_mtp_missing_subtree_fails_closed(
+    tmp_path, monkeypatch, fake_qwen_loader
+):
+    model_path, _ = _write_config(
+        tmp_path, model_type="qwen3_5_text", mtp_layers=1
+    )
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel({"model.weight": object()})
+    )
+    monkeypatch.setattr(extraction, "_load_mtp_weights", lambda _path: {})
+
+    assert extraction.build_text_model(vlm, model_path) is None
+    assert _FakeQwenWrapper.instances[-1].load_calls == []
+
+
+@pytest.mark.parametrize(
+    "error",
+    (
+        ValueError("missing language_model.mtp.layers.0.weight"),
+        ValueError("unexpected language_model.mtp.layers.1.weight"),
+        ValueError("incomplete quantized triplet language_model.mtp.fc"),
+    ),
+)
+def test_qwen_malformed_mtp_sanitize_never_partially_loads(
+    tmp_path, monkeypatch, fake_qwen_loader, error
+):
+    model_path, _ = _write_config(
+        tmp_path, model_type="qwen3_5_moe_text", mtp_layers=1, num_experts=64
+    )
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel({"model.weight": object()})
+    )
+    monkeypatch.setattr(
+        extraction,
+        "_load_mtp_weights",
+        lambda _path: {"language_model.mtp.weight": object()},
+    )
+    _FakeQwenWrapper.sanitize_error = error
+
+    assert extraction.build_text_model(vlm, model_path) is None
+    assert _FakeQwenWrapper.instances[-1].load_calls == []
+
+
+def test_qwen_base_checkpoint_remains_ordinary_without_injected_head(
+    tmp_path, monkeypatch, fake_qwen_loader
+):
+    model_path, _ = _write_config(
+        tmp_path, model_type="qwen3_5_text", mtp_layers=0
+    )
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel({"model.weight": object()})
+    )
+    monkeypatch.setattr(extraction, "_load_mtp_weights", lambda _path: {})
+
+    text_model = extraction.build_text_model(vlm, model_path)
+
+    assert text_model.mtp_capability == _Capability(
+        False, "native_mtp_head_not_configured", 0
+    )
+    assert not hasattr(text_model, "mtp")
+    assert text_model([7]) == ("ordinary-forward", [7])
+    assert len(_FakeQwenWrapper.instances[-1].load_calls) == 1
+
+
+def test_qwen_quantization_precedes_single_strict_load(
+    tmp_path, monkeypatch, fake_qwen_loader
+):
+    model_path, _ = _write_config(
+        tmp_path,
+        model_type="qwen3_5_text",
+        mtp_layers=1,
+        quantization={"group_size": 64, "bits": 4},
+    )
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel({"model.weight": object()})
+    )
+    monkeypatch.setattr(
+        extraction,
+        "_load_mtp_weights",
+        lambda _path: {
+            "language_model.mtp.fc.weight": object(),
+            "language_model.mtp.fc.scales": object(),
+            "language_model.mtp.fc.biases": object(),
+        },
+    )
+
+    def fake_quantize(model, **kwargs):
+        model.events.append("quantize")
+        quantizable = SimpleNamespace(to_quantized=lambda: None)
+        assert kwargs["group_size"] == 64
+        assert kwargs["bits"] == 4
+        assert kwargs["class_predicate"](
+            "language_model.mtp.fc", quantizable
+        ) is True
+
+    monkeypatch.setattr(extraction.nn, "quantize", fake_quantize)
+
+    assert extraction.build_text_model(vlm, model_path) is not None
+    wrapper = _FakeQwenWrapper.instances[-1]
+    assert wrapper.events == ["sanitize", "sanitize", "quantize", "load"]
+    assert len(wrapper.load_calls) == 1
+
+
+def test_qwen_quantization_failure_never_strict_loads(
+    tmp_path, monkeypatch, fake_qwen_loader
+):
+    model_path, _ = _write_config(
+        tmp_path,
+        model_type="qwen3_5_text",
+        mtp_layers=1,
+        quantization={"group_size": 64, "bits": 4},
+    )
+    vlm = SimpleNamespace(
+        language_model=_FakeVLMLanguageModel({"model.weight": object()})
+    )
+    monkeypatch.setattr(
+        extraction,
+        "_load_mtp_weights",
+        lambda _path: {"language_model.mtp.weight": object()},
+    )
+    monkeypatch.setattr(
+        extraction.nn,
+        "quantize",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad quant tree")),
+    )
+
+    assert extraction.build_text_model(vlm, model_path) is None
+    assert _FakeQwenWrapper.instances[-1].load_calls == []
+
+
+def test_indexed_mtp_loader_preserves_exact_keys(tmp_path, monkeypatch):
+    index = {
+        "weight_map": {
+            "model.language_model.mtp.layers.0.weight": "model-mtp.safetensors",
+            "language_model.model.embed_tokens.weight": "model-base.safetensors",
+        }
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+    (tmp_path / "model-mtp.safetensors").touch()
+    value = object()
+    monkeypatch.setattr(
+        extraction.mx,
+        "load",
+        lambda _path: {"model.language_model.mtp.layers.0.weight": value},
+    )
+
+    weights = extraction._load_mtp_weights(tmp_path)
+
+    assert weights == {"model.language_model.mtp.layers.0.weight": value}
+
+
+def test_indexed_mtp_loader_rejects_missing_shard_entry(tmp_path, monkeypatch):
+    key = "language_model.mtp.layers.0.weight"
+    index = {"weight_map": {key: "model-mtp.safetensors"}}
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+    (tmp_path / "model-mtp.safetensors").touch()
+    monkeypatch.setattr(extraction.mx, "load", lambda _path: {})
+
+    with pytest.raises(ValueError, match="index entry missing"):
+        extraction._load_mtp_weights(tmp_path)
+
+
+def _write_header_only_safetensors(path, entries):
+    header = json.dumps(entries, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(header)) + header)
+
+
+def test_qwen_checkpoint_sanitation_convention_comes_from_raw_headers(tmp_path):
+    raw_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
+    index = {"weight_map": {raw_key: "model-1.safetensors"}}
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+    _write_header_only_safetensors(
+        tmp_path / "model-1.safetensors",
+        {raw_key: {"dtype": "F32", "shape": [16, 1, 3], "data_offsets": [0, 0]}},
+    )
+
+    assert extraction._qwen_checkpoint_requires_norm_shift(tmp_path) is True
+
+
+def test_qwen_checkpoint_rejects_mixed_conv_conventions(tmp_path):
+    raw = "model.language_model.layers.0.linear_attn.conv1d.weight"
+    native = "model.language_model.layers.1.linear_attn.conv1d.weight"
+    index = {
+        "weight_map": {raw: "model-1.safetensors", native: "model-2.safetensors"}
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+    _write_header_only_safetensors(
+        tmp_path / "model-1.safetensors",
+        {raw: {"dtype": "F32", "shape": [16, 1, 3], "data_offsets": [0, 0]}},
+    )
+    _write_header_only_safetensors(
+        tmp_path / "model-2.safetensors",
+        {native: {"dtype": "F32", "shape": [16, 3, 1], "data_offsets": [0, 0]}},
+    )
+
+    with pytest.raises(ValueError, match="Mixed native Qwen conv1d"):
+        extraction._qwen_checkpoint_requires_norm_shift(tmp_path)
+
+
+def test_legacy_injection_is_explicitly_qwen3_next_only(monkeypatch):
+    calls = []
+    module = types.ModuleType("vllm_mlx.patches.qwen3_next_mtp")
+    module.inject_mtp_support = lambda *args: calls.append(args)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    tokenizer_utils._try_inject_mtp(
+        object(), "/model", {"model_type": "qwen3_5", "num_nextn_predict_layers": 1}
+    )
+    tokenizer_utils._try_inject_mtp(
+        object(), "/model", {"model_type": "other", "num_nextn_predict_layers": 1}
+    )
+    tokenizer_utils._try_inject_mtp(
+        object(),
+        "/model",
+        {"model_type": "qwen3_next", "num_nextn_predict_layers": 1},
+    )
+
+    assert len(calls) == 1
+
+
+def test_legacy_post_load_injection_is_explicitly_qwen3_next_only(
+    tmp_path, monkeypatch
+):
+    calls = []
+    module = types.ModuleType("vllm_mlx.patches.qwen3_next_mtp")
+    module.inject_mtp_support = lambda *args: calls.append(args)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(tokenizer_utils, "_try_inject_mtp", lambda *args: calls.append(args))
+    monkeypatch.setattr("mlx_lm.utils._download", lambda _name: tmp_path)
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen3_5", "mtp_num_hidden_layers": 1})
+    )
+    tokenizer_utils._try_inject_mtp_post_load(object(), "qwen")
+    assert calls == []
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen3_next", "num_nextn_predict_layers": 1})
+    )
+    (tmp_path / "model-mtp.safetensors").touch()
+    tokenizer_utils._try_inject_mtp_post_load(object(), "qwen-next")
+    assert len(calls) == 1
+
+
+_HIDDEN = 32
+_HEAD_DIM = 8
+
+
+def _real_config(*, moe: bool) -> dict:
+    text = {
+        "model_type": "qwen3_5_moe" if moe else "qwen3_5",
+        "hidden_size": _HIDDEN,
+        "intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "vocab_size": 64,
+        "linear_num_value_heads": 2,
+        "linear_num_key_heads": 2,
+        "linear_key_head_dim": 8,
+        "linear_value_head_dim": 8,
+        "linear_conv_kernel_dim": 3,
+        "full_attention_interval": 2,
+        "tie_word_embeddings": False,
+        "rms_norm_eps": 1e-5,
+        "head_dim": _HEAD_DIM,
+        "rope_theta": 1000.0,
+        "partial_rotary_factor": 0.5,
+        "max_position_embeddings": 128,
+        "mtp_num_hidden_layers": 1,
+    }
+    if moe:
+        text.update(
+            {
+                "num_experts": 2,
+                "num_experts_per_tok": 1,
+                "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": 64,
+                "moe_intermediate_size": 32,
+            }
+        )
+    return {"model_type": text["model_type"], "text_config": text}
+
+
+_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+    ".pre_fc_norm_hidden.weight",
+    ".pre_fc_norm_embedding.weight",
+    "mtp.norm.weight",
+)
+
+
+def _raw_checkpoint_from_model(model) -> dict[str, mx.array]:
+    """Reverse the official raw-conv/RMSNorm transforms for a tiny model."""
+
+    raw = {}
+    for key, value in tree_flatten(model.parameters()):
+        if "conv1d.weight" in key:
+            assert value.shape[-1] == 1
+            value = value.moveaxis(1, 2)
+        if value.ndim == 1 and any(key.endswith(sfx) for sfx in _NORM_SUFFIXES):
+            value = value - 1.0
+        raw[key] = value
+    return raw
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_extracted_mtp_matches_official_full_raw_sanitize_and_load(moe):
+    """Numerically prove mixed-state extraction equals canonical sanitation."""
+
+    module = importlib.import_module(
+        "mlx_lm.models.qwen3_5_moe" if moe else "mlx_lm.models.qwen3_5"
+    )
+    config = _real_config(moe=moe)
+    args = module.ModelArgs.from_dict(config)
+    source = module.Model(args)
+    if not hasattr(type(source.language_model), "mtp_capability"):
+        pytest.skip("requires mlx-lm native Qwen MTP capability branch")
+    source.set_dtype(mx.float32)
+    mx.eval(source.parameters())
+    raw = _raw_checkpoint_from_model(source)
+    assert any(
+        "conv1d.weight" in key and value.shape[-1] != 1
+        for key, value in raw.items()
+    )
+
+    reference = module.Model(args)
+    canonical = reference.sanitize(dict(raw))
+    reference.load_weights(list(canonical.items()), strict=True)
+    assert reference.language_model.mtp_capability.supported is True
+
+    extracted = module.Model(args)
+    raw_mtp = {key: value for key, value in raw.items() if ".mtp." in key}
+    live_backbone = {
+        key: value for key, value in canonical.items() if ".mtp." not in key
+    }
+    normalized_mtp = extraction._sanitize_raw_qwen_mtp(
+        extracted, raw_mtp, shift_norm_weights=True
+    )
+    final = extracted.sanitize({**live_backbone, **normalized_mtp})
+    extracted.load_weights(list(final.items()), strict=True)
+    assert extracted.language_model.mtp_capability.supported is True
+
+    assert set(final) == set(canonical)
+    for key in canonical:
+        assert mx.allclose(final[key], canonical[key], rtol=0, atol=0).item()
+    reference_params = dict(tree_flatten(reference.parameters()))
+    extracted_params = dict(tree_flatten(extracted.parameters()))
+    assert set(extracted_params) == set(reference_params)
+    for key in reference_params:
+        assert mx.allclose(
+            extracted_params[key], reference_params[key], rtol=0, atol=0
+        ).item()
+
+    mtp_norm = "language_model.mtp.norm.weight"
+    assert mx.allclose(canonical[mtp_norm], raw[mtp_norm] + 1.0).item()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    (
+        ("missing", "missing"),
+        ("unexpected", "unexpected"),
+        ("partial_quantized", "incomplete quantized triplet"),
+    ),
+)
+def test_official_qwen_sanitizer_rejects_malformed_mtp(mutation, match):
+    module = importlib.import_module("mlx_lm.models.qwen3_5")
+    if not hasattr(module.TextModel, "mtp_capability"):
+        pytest.skip("requires mlx-lm native Qwen MTP capability branch")
+    config = _real_config(moe=False)
+    wrapper = module.Model(module.ModelArgs.from_dict(config))
+    wrapper.set_dtype(mx.float32)
+    mx.eval(wrapper.parameters())
+    raw = _raw_checkpoint_from_model(wrapper)
+    raw_mtp = {key: value for key, value in raw.items() if ".mtp." in key}
+    if mutation == "missing":
+        raw_mtp.pop("language_model.mtp.norm.weight")
+    elif mutation == "unexpected":
+        raw_mtp["language_model.mtp.unexpected.weight"] = mx.zeros((1,))
+    else:
+        raw_mtp["language_model.mtp.fc.scales"] = mx.zeros((1,))
+
+    with pytest.raises(ValueError, match=match):
+        extraction._sanitize_raw_qwen_mtp(
+            wrapper, raw_mtp, shift_norm_weights=True
+        )
+    assert wrapper.language_model.mtp_capability.supported is False

--- a/tests/test_qwen_native_mtp_loader.py
+++ b/tests/test_qwen_native_mtp_loader.py
@@ -37,9 +37,7 @@ class _FakeTextModel:
         if not self.num_layers:
             return _Capability(False, "native_mtp_head_not_configured", 0)
         if not self._loaded:
-            return _Capability(
-                False, "native_mtp_weights_not_loaded", self.num_layers
-            )
+            return _Capability(False, "native_mtp_weights_not_loaded", self.num_layers)
         return _Capability(True, "supported", self.num_layers)
 
     def train(self, mode=True):
@@ -70,9 +68,7 @@ class _FakeQwenWrapper:
         sanitized = {}
         for key, value in weights.items():
             if key.startswith("model.language_model.mtp."):
-                key = key.replace(
-                    "model.language_model.", "language_model.", 1
-                )
+                key = key.replace("model.language_model.", "language_model.", 1)
             sanitized[key] = value
         self._handshake = tuple(
             sorted((key, id(value)) for key, value in sanitized.items())
@@ -195,9 +191,7 @@ def test_qwen_vlm_extraction_uses_outer_one_shot_handshake(
 def test_qwen_configured_mtp_missing_subtree_fails_closed(
     tmp_path, monkeypatch, fake_qwen_loader
 ):
-    model_path, _ = _write_config(
-        tmp_path, model_type="qwen3_5_text", mtp_layers=1
-    )
+    model_path, _ = _write_config(tmp_path, model_type="qwen3_5_text", mtp_layers=1)
     vlm = SimpleNamespace(
         language_model=_FakeVLMLanguageModel({"model.weight": object()})
     )
@@ -238,9 +232,7 @@ def test_qwen_malformed_mtp_sanitize_never_partially_loads(
 def test_qwen_base_checkpoint_remains_ordinary_without_injected_head(
     tmp_path, monkeypatch, fake_qwen_loader
 ):
-    model_path, _ = _write_config(
-        tmp_path, model_type="qwen3_5_text", mtp_layers=0
-    )
+    model_path, _ = _write_config(tmp_path, model_type="qwen3_5_text", mtp_layers=0)
     vlm = SimpleNamespace(
         language_model=_FakeVLMLanguageModel({"model.weight": object()})
     )
@@ -283,9 +275,7 @@ def test_qwen_quantization_precedes_single_strict_load(
         quantizable = SimpleNamespace(to_quantized=lambda: None)
         assert kwargs["group_size"] == 64
         assert kwargs["bits"] == 4
-        assert kwargs["class_predicate"](
-            "language_model.mtp.fc", quantizable
-        ) is True
+        assert kwargs["class_predicate"]("language_model.mtp.fc", quantizable) is True
 
     monkeypatch.setattr(extraction.nn, "quantize", fake_quantize)
 
@@ -374,9 +364,7 @@ def test_qwen_checkpoint_sanitation_convention_comes_from_raw_headers(tmp_path):
 def test_qwen_checkpoint_rejects_mixed_conv_conventions(tmp_path):
     raw = "model.language_model.layers.0.linear_attn.conv1d.weight"
     native = "model.language_model.layers.1.linear_attn.conv1d.weight"
-    index = {
-        "weight_map": {raw: "model-1.safetensors", native: "model-2.safetensors"}
-    }
+    index = {"weight_map": {raw: "model-1.safetensors", native: "model-2.safetensors"}}
     (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
     _write_header_only_safetensors(
         tmp_path / "model-1.safetensors",
@@ -419,7 +407,9 @@ def test_legacy_post_load_injection_is_explicitly_qwen3_next_only(
     module = types.ModuleType("vllm_mlx.patches.qwen3_next_mtp")
     module.inject_mtp_support = lambda *args: calls.append(args)
     monkeypatch.setitem(sys.modules, module.__name__, module)
-    monkeypatch.setattr(tokenizer_utils, "_try_inject_mtp", lambda *args: calls.append(args))
+    monkeypatch.setattr(
+        tokenizer_utils, "_try_inject_mtp", lambda *args: calls.append(args)
+    )
     monkeypatch.setattr("mlx_lm.utils._download", lambda _name: tmp_path)
 
     (tmp_path / "config.json").write_text(
@@ -518,8 +508,7 @@ def test_extracted_mtp_matches_official_full_raw_sanitize_and_load(moe):
     mx.eval(source.parameters())
     raw = _raw_checkpoint_from_model(source)
     assert any(
-        "conv1d.weight" in key and value.shape[-1] != 1
-        for key, value in raw.items()
+        "conv1d.weight" in key and value.shape[-1] != 1 for key, value in raw.items()
     )
 
     reference = module.Model(args)
@@ -580,7 +569,5 @@ def test_official_qwen_sanitizer_rejects_malformed_mtp(mutation, match):
         raw_mtp["language_model.mtp.fc.scales"] = mx.zeros((1,))
 
     with pytest.raises(ValueError, match=match):
-        extraction._sanitize_raw_qwen_mtp(
-            wrapper, raw_mtp, shift_norm_weights=True
-        )
+        extraction._sanitize_raw_qwen_mtp(wrapper, raw_mtp, shift_norm_weights=True)
     assert wrapper.language_model.mtp_capability.supported is False

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -9,7 +9,24 @@ from unittest.mock import MagicMock, patch
 import mlx.core as mx
 import pytest
 
+from vllm_mlx.native_mtp_request import NativeMTPRequestConfig, NativeMTPSampling
+
 pytestmark = pytest.mark.anyio
+
+
+def _native_mtp_request(*, temperature=0.7, top_p=0.9):
+    return NativeMTPRequestConfig(
+        NativeMTPSampling(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=0,
+            min_p=0.0,
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+            seed=17,
+        ),
+        num_draft_tokens=4,
+    )
 
 
 class _SparseTestDetokenizer:
@@ -2045,9 +2062,21 @@ class TestSimpleEngineConcurrency:
 
             return _sample
 
-        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
+        def fake_stream_generate(
+            model,
+            tokenizer,
+            prompt,
+            *,
+            mtp=False,
+            mtp_sampling_config=None,
+            **kwargs,
+        ):
             captured["prompt"] = prompt
-            captured["kwargs"] = kwargs
+            captured["kwargs"] = {
+                "mtp": mtp,
+                "mtp_sampling_config": mtp_sampling_config,
+                **kwargs,
+            }
             yield SimpleNamespace(token=18, text="B", finish_reason="stop")
 
         tokenizer = MagicMock()
@@ -2088,7 +2117,7 @@ class TestSimpleEngineConcurrency:
                 "mlx_lm.sample_utils.make_logits_processors",
                 return_value=[],
             ),
-            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("mlx_lm.stream_generate", new=fake_stream_generate),
             patch("vllm_mlx.specprefill.score_tokens") as score_tokens,
             patch.object(engine, "_prepare_sparse_target_prefill") as prepare_sparse,
         ):
@@ -2102,6 +2131,9 @@ class TestSimpleEngineConcurrency:
                     specprefill_policy="sparse",
                     specprefill_backbone_pct=0.25,
                     combined_mtp=True,
+                    _native_mtp_request_config=_native_mtp_request(
+                        temperature=0.6, top_p=0.95
+                    ),
                 )
             ]
 
@@ -2113,8 +2145,10 @@ class TestSimpleEngineConcurrency:
             "min_p": 0.0,
         }
         assert captured["prompt"] == "<|im_start|>user\nhello"
-        assert "mtp" not in captured["kwargs"]
-        assert captured["kwargs"]["num_draft_tokens"] == 4
+        assert captured["kwargs"]["mtp"] is True
+        assert "mtp_sampling_config" in captured["kwargs"]
+        assert "num_draft_tokens" not in captured["kwargs"]
+        assert "sampler" not in captured["kwargs"]
         assert captured["kwargs"]["max_tokens"] == 4
         assert outputs[-1].specprefill_effective_policy == "dense"
         assert (
@@ -2352,8 +2386,18 @@ class TestSimpleEngineConcurrency:
 
         captured_kwargs = {}
 
-        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
-            captured_kwargs.update(kwargs)
+        def fake_stream_generate(
+            model,
+            tokenizer,
+            prompt,
+            *,
+            mtp=False,
+            mtp_sampling_config=None,
+            **kwargs,
+        ):
+            captured_kwargs.update(
+                mtp=mtp, mtp_sampling_config=mtp_sampling_config, **kwargs
+            )
             yield SimpleNamespace(text="Hello", finish_reason="stop")
 
         tokenizer = MagicMock()
@@ -2372,7 +2416,7 @@ class TestSimpleEngineConcurrency:
         engine._text_model.mtp = MagicMock()
         engine._text_tokenizer = tokenizer
 
-        with patch("mlx_lm.stream_generate", side_effect=fake_stream_generate):
+        with patch("mlx_lm.stream_generate", new=fake_stream_generate):
             outputs = [
                 chunk
                 async for chunk in engine._stream_generate_text(
@@ -2381,12 +2425,15 @@ class TestSimpleEngineConcurrency:
                     temperature=0.7,
                     top_p=0.9,
                     combined_mtp=True,
+                    _native_mtp_request_config=_native_mtp_request(),
                 )
             ]
 
         assert outputs[-1].text == "Hello"
-        assert "mtp" not in captured_kwargs
-        assert captured_kwargs["num_draft_tokens"] == 4
+        assert captured_kwargs["mtp"] is True
+        assert "mtp_sampling_config" in captured_kwargs
+        assert "num_draft_tokens" not in captured_kwargs
+        assert "sampler" not in captured_kwargs
 
     @pytest.mark.anyio
     async def test_stream_generate_text_reenables_mtp_after_retired_processor_when_enabled(
@@ -2407,9 +2454,23 @@ class TestSimpleEngineConcurrency:
                 return logits
 
         processor = RetiringProcessor()
+        unset = object()
 
-        def fake_stream_generate(model, tokenizer, prompt, **kwargs):
-            calls.append({"prompt": prompt, **kwargs})
+        def fake_stream_generate(
+            model,
+            tokenizer,
+            prompt,
+            *,
+            mtp=unset,
+            mtp_sampling_config=unset,
+            **kwargs,
+        ):
+            call = {"prompt": prompt, **kwargs}
+            if mtp is not unset:
+                call["mtp"] = mtp
+            if mtp_sampling_config is not unset:
+                call["mtp_sampling_config"] = mtp_sampling_config
+            calls.append(call)
             if len(calls) == 1:
                 processor.is_retired = True
                 yield SimpleNamespace(token=11, text="Hello", finish_reason=None)
@@ -2439,7 +2500,7 @@ class TestSimpleEngineConcurrency:
                 "os.environ",
                 {"VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME": "1"},
             ),
-            patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
+            patch("mlx_lm.stream_generate", new=fake_stream_generate),
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
             patch("mlx_lm.models.cache.trim_prompt_cache"),
         ):
@@ -2451,6 +2512,7 @@ class TestSimpleEngineConcurrency:
                     temperature=0.7,
                     top_p=0.9,
                     logits_processors=[processor],
+                    _native_mtp_request_config=_native_mtp_request(),
                 )
             ]
 
@@ -2458,8 +2520,10 @@ class TestSimpleEngineConcurrency:
         assert len(calls) == 2
         assert "mtp" not in calls[0]
         assert calls[0]["logits_processors"][0] is processor
-        assert "mtp" not in calls[1]
-        assert calls[1]["num_draft_tokens"] == 4
+        assert calls[1]["mtp"] is True
+        assert "mtp_sampling_config" in calls[1]
+        assert "num_draft_tokens" not in calls[1]
+        assert "sampler" not in calls[1]
         assert "prompt_cache" in calls[1]
         assert "logits_processors" not in calls[1]
 

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2152,7 +2152,8 @@ class TestSimpleEngineConcurrency:
         assert captured["kwargs"]["max_tokens"] == 4
         assert outputs[-1].specprefill_effective_policy == "dense"
         assert (
-            outputs[-1].specprefill_fallback_reason == "mtp_composition_not_implemented"
+            outputs[-1].specprefill_fallback_reason
+            == "sparse_forward_context_unavailable"
         )
         score_tokens.assert_not_called()
         prepare_sparse.assert_not_called()
@@ -2792,6 +2793,8 @@ class TestSimpleEngineConcurrency:
             assert len(outputs) == 1
             assert outputs[0].finished
             assert outputs[0].completion_tokens == 0
+            assert outputs[0].new_text == ""
+            assert outputs[0].finish_reason == "stop"
 
     @pytest.mark.anyio
     async def test_direct_specprefill_streams_before_worker_completion_and_forwards_sampling(
@@ -2893,6 +2896,89 @@ class TestSimpleEngineConcurrency:
         assert captured["continuation"]["min_p"] == 0.2
         assert captured["continuation"]["presence_penalty"] == 0.0
         assert captured["continuation"]["repetition_penalty"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_direct_sparse_clean_exhaustion_keeps_telemetry_in_stop_epilogue(self):
+        """Sparse producer exhaustion appends one telemetry-preserving stop frame."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        def continuation(**_kwargs):
+            yield SimpleNamespace(
+                token=18,
+                text="ignored",
+                finished=False,
+                finish_reason=None,
+                mtp_drafts=7,
+                mtp_accepted=5,
+                mtp_bypass_reason="backend-bypass",
+            )
+
+        engine = SimpleEngine(
+            "test-model",
+            specprefill_enabled=True,
+            specprefill_diagnostic_mode=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._model = MagicMock()
+        engine._model.model = MagicMock()
+        engine._model.tokenizer = SimpleNamespace(eos_token_id=99)
+        engine._model.stream_generate.side_effect = continuation
+        forward_context = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "mlx_lm.sample_utils.make_sampler",
+                return_value=lambda _logits: mx.array(17, dtype=mx.uint32),
+            ),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch(
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
+            ),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_specprefill(
+                    "prompt", [1, 2, 3], max_tokens=4, temperature=0.0, top_p=1.0
+                )
+            ]
+
+        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+            ("A", False, None),
+            ("B", False, None),
+            ("", True, "stop"),
+        ]
+        terminal = outputs[-1]
+        assert (terminal.text, terminal.completion_tokens) == ("AB", 2)
+        for field in (
+            "specprefill_requested_policy",
+            "specprefill_effective_policy",
+            "specprefill_coverage",
+            "specprefill_engaged",
+            "specprefill_selected_tokens",
+            "specprefill_scorer_ms",
+            "specprefill_target_prefill_ms",
+            "mtp_drafts",
+            "mtp_accepted",
+            "mtp_bypass_reason",
+        ):
+            assert getattr(terminal, field) == getattr(outputs[-2], field)
 
     @pytest.mark.anyio
     async def test_direct_specprefill_falls_back_only_before_seed(self):
@@ -3022,6 +3108,178 @@ class TestSimpleEngineConcurrency:
             assert len(outputs) == 1
             assert outputs[0].finished
             assert outputs[0].completion_tokens == 0
+
+    @pytest.mark.anyio
+    async def test_text_sparse_clean_exhaustion_emits_one_empty_stop_terminal(self):
+        """A sparse text producer ending below the cap gets one stop epilogue."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        def continuation(*_args, **_kwargs):
+            yield SimpleNamespace(
+                token=18,
+                text="ignored",
+                finish_reason=None,
+                mtp_drafts=7,
+                mtp_accepted=5,
+                mtp_bypass_reason="backend-bypass",
+            )
+
+        async def inline_serialized(func, *args, **kwargs):
+            kwargs.pop("on_cancel", None)
+            return func(*args, **kwargs)
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            specprefill_enabled=True,
+            specprefill_diagnostic_mode=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "prompt"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 99
+        tokenizer.encode.return_value = [1, 2, 3]
+        engine._text_tokenizer = tokenizer
+        engine._run_blocking_serialized = inline_serialized  # type: ignore[method-assign]
+        forward_context = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "mlx_lm.sample_utils.make_sampler",
+                return_value=lambda _logits: mx.array(17, dtype=mx.uint32),
+            ),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("mlx_lm.stream_generate", side_effect=continuation),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch(
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
+            ),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=4,
+                    temperature=0.0,
+                    top_p=1.0,
+                    specprefill=True,
+                )
+            ]
+
+        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+            ("A", False, None),
+            ("B", False, None),
+            ("", True, "stop"),
+        ]
+        terminal = outputs[-1]
+        assert (terminal.text, terminal.completion_tokens) == ("AB", 2)
+        for field in (
+            "specprefill_requested_policy",
+            "specprefill_effective_policy",
+            "specprefill_coverage",
+            "specprefill_engaged",
+            "specprefill_selected_tokens",
+            "specprefill_scorer_ms",
+            "specprefill_target_prefill_ms",
+            "mtp_drafts",
+            "mtp_accepted",
+            "mtp_bypass_reason",
+        ):
+            assert getattr(terminal, field) == getattr(outputs[-2], field)
+
+    @pytest.mark.anyio
+    async def test_text_sparse_exact_cap_marks_last_token_length_without_epilogue(self):
+        """Sparse text must expose an unreasoned exact cap on its last token."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        def continuation(*_args, **_kwargs):
+            yield SimpleNamespace(token=18, text="ignored", finish_reason=None)
+
+        async def inline_serialized(func, *args, **kwargs):
+            kwargs.pop("on_cancel", None)
+            return func(*args, **kwargs)
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "prompt"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 99
+        tokenizer.encode.return_value = [1, 2, 3]
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            specprefill_enabled=True,
+            specprefill_diagnostic_mode=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        engine._text_tokenizer = tokenizer
+        engine._run_blocking_serialized = inline_serialized  # type: ignore[method-assign]
+        forward_context = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "mlx_lm.sample_utils.make_sampler",
+                return_value=lambda _logits: mx.array(17, dtype=mx.uint32),
+            ),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("mlx_lm.stream_generate", side_effect=continuation),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch(
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
+            ),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
+        ):
+            outputs = [
+                chunk
+                async for chunk in engine._stream_generate_text(
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=2,
+                    temperature=0.0,
+                    top_p=1.0,
+                    specprefill=True,
+                )
+            ]
+
+        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+            ("A", False, None),
+            ("B", True, "length"),
+        ]
 
     @pytest.mark.anyio
     async def test_specprefill_threads_same_cancel_check_to_helpers(self):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2045,6 +2045,7 @@ class TestSimpleEngineConcurrency:
             mtp_num_draft_tokens=4,
             specprefill_enabled=True,
             specprefill_threshold=1,
+            specprefill_diagnostic_mode=True,
         )
         engine._loaded = True
         engine._text_model = text_model
@@ -2084,6 +2085,7 @@ class TestSimpleEngineConcurrency:
                     max_tokens=4,
                     temperature=0.6,
                     top_p=0.95,
+                    specprefill_policy="sparse",
                     specprefill_backbone_pct=0.25,
                 )
             ]
@@ -2478,6 +2480,7 @@ class TestSimpleEngineConcurrency:
             mtp=True,
             mtp_num_draft_tokens=4,
             specprefill_enabled=True,
+            specprefill_diagnostic_mode=True,
         )
         engine._loaded = True
         engine._draft_model = MagicMock()

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -12,6 +12,26 @@ import pytest
 pytestmark = pytest.mark.anyio
 
 
+class _SparseTestDetokenizer:
+    def __init__(self):
+        self.segment = ""
+
+    def reset(self):
+        self.segment = ""
+
+    def add_token(self, token):
+        self.segment = {17: "A", 18: "B"}.get(token, "")
+
+    def finalize(self):
+        return None
+
+    @property
+    def last_segment(self):
+        segment = self.segment
+        self.segment = ""
+        return segment
+
+
 class TestSimpleEngineConcurrency:
     """Test SimpleEngine lock behavior with concurrent requests."""
 
@@ -1462,10 +1482,18 @@ class TestSimpleEngineConcurrency:
         text_model.mtp = None
         tokenizer = MagicMock()
         tokenizer.convert_tokens_to_ids.return_value = 42
+        tokenizer.get_vocab.return_value = {}
+        tokenizer.chat_template = None
+        detokenizer = MagicMock()
+        detokenizer.last_segment = ""
 
         mock_mllm = MagicMock()
         mock_mllm.model = MagicMock()
-        mock_mllm.get_tokenizer.return_value = tokenizer
+        mock_mllm.processor = SimpleNamespace(
+            tokenizer=tokenizer,
+            detokenizer=detokenizer,
+            eos_token_ids=(42,),
+        )
 
         with (
             patch(
@@ -1481,7 +1509,8 @@ class TestSimpleEngineConcurrency:
             await engine.start()
 
         assert engine._text_model is text_model
-        assert engine._text_tokenizer is tokenizer
+        assert engine._text_tokenizer._tokenizer is tokenizer
+        assert engine._text_tokenizer.eos_token_ids == {42}
 
     @pytest.mark.anyio
     async def test_mllm_media_stream_stays_on_owner_thread_with_text_route(self):
@@ -2000,8 +2029,8 @@ class TestSimpleEngineConcurrency:
         assert seen["tokens"] == [10, 11, 12, 13]
 
     @pytest.mark.anyio
-    async def test_specprefill_success_preserves_mtp_path(self):
-        """Successful sparse prefill should continue through the normal MTP path."""
+    async def test_specprefill_intent_with_effective_mtp_falls_back_dense(self):
+        """Unqualified SpecPrefill+MTP must retain the independently safe MTP path."""
         from types import SimpleNamespace
 
         from vllm_mlx.engine.simple import SimpleEngine
@@ -2017,13 +2046,9 @@ class TestSimpleEngineConcurrency:
             return _sample
 
         def fake_stream_generate(model, tokenizer, prompt, **kwargs):
-            captured["prompt"] = prompt.tolist()
+            captured["prompt"] = prompt
             captured["kwargs"] = kwargs
-            yield SimpleNamespace(text="B", finish_reason="stop")
-
-        def fake_select_chunks(_importance, **kwargs):
-            captured["select_chunks_kwargs"] = kwargs
-            return mx.array([0, 1, 2], dtype=mx.int32)
+            yield SimpleNamespace(token=18, text="B", finish_reason="stop")
 
         tokenizer = MagicMock()
         tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
@@ -2064,19 +2089,8 @@ class TestSimpleEngineConcurrency:
                 return_value=[],
             ),
             patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
-            patch(
-                "vllm_mlx.specprefill.score_tokens",
-                return_value=mx.array([1.0, 0.9, 0.8], dtype=mx.float32),
-            ),
-            patch(
-                "vllm_mlx.specprefill.select_chunks",
-                side_effect=fake_select_chunks,
-            ),
-            patch(
-                "vllm_mlx.specprefill.sparse_prefill",
-                return_value=mx.zeros((1, 3, 32), dtype=mx.float32),
-            ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch("vllm_mlx.specprefill.score_tokens") as score_tokens,
+            patch.object(engine, "_prepare_sparse_target_prefill") as prepare_sparse,
         ):
             outputs = [
                 chunk
@@ -2087,23 +2101,27 @@ class TestSimpleEngineConcurrency:
                     top_p=0.95,
                     specprefill_policy="sparse",
                     specprefill_backbone_pct=0.25,
+                    combined_mtp=True,
                 )
             ]
 
-        assert [chunk.new_text for chunk in outputs] == ["A", "B"]
+        assert [chunk.new_text for chunk in outputs] == ["B"]
         assert captured["sampler_kwargs"] == {
             "temp": 0.6,
             "top_p": 0.95,
             "top_k": 0,
             "min_p": 0.0,
         }
-        assert captured["prompt"] == [17]
+        assert captured["prompt"] == "<|im_start|>user\nhello"
         assert "mtp" not in captured["kwargs"]
         assert captured["kwargs"]["num_draft_tokens"] == 4
-        assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
-        assert captured["kwargs"]["max_tokens"] == 3
-        assert captured["kwargs"]["logits_processors"] is None
-        assert captured["select_chunks_kwargs"]["backbone_pct"] == 0.25
+        assert captured["kwargs"]["max_tokens"] == 4
+        assert outputs[-1].specprefill_effective_policy == "dense"
+        assert (
+            outputs[-1].specprefill_fallback_reason == "mtp_composition_not_implemented"
+        )
+        score_tokens.assert_not_called()
+        prepare_sparse.assert_not_called()
 
     @pytest.mark.anyio
     async def test_stream_generate_text_forwards_logits_processors_and_sampler_args(
@@ -2362,6 +2380,7 @@ class TestSimpleEngineConcurrency:
                     max_tokens=16,
                     temperature=0.7,
                     top_p=0.9,
+                    combined_mtp=True,
                 )
             ]
 
@@ -2445,7 +2464,7 @@ class TestSimpleEngineConcurrency:
         assert "logits_processors" not in calls[1]
 
     @pytest.mark.anyio
-    async def test_stream_generate_text_specprefill_reenables_mtp_after_retirement(
+    async def test_specprefill_with_active_retiring_processor_falls_dense_without_mtp(
         self,
     ):
         """SpecPrefill retirement-to-MTP continuation is explicit opt-in."""
@@ -2501,15 +2520,8 @@ class TestSimpleEngineConcurrency:
             ),
             patch("mlx_lm.stream_generate", side_effect=fake_stream_generate),
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
-            patch(
-                "vllm_mlx.specprefill.score_tokens", return_value=mx.array([0.1, 0.2])
-            ),
-            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0, 1])),
-            patch(
-                "vllm_mlx.specprefill.sparse_prefill",
-                return_value=mx.zeros((1, 1, 32)),
-            ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch("vllm_mlx.specprefill.score_tokens") as score_tokens,
+            patch.object(engine, "_prepare_sparse_target_prefill") as prepare_sparse,
             patch(
                 "vllm_mlx.engine.simple._sample_with_processors",
                 side_effect=fake_sample,
@@ -2527,12 +2539,15 @@ class TestSimpleEngineConcurrency:
                 )
             ]
 
-        assert outputs[-1].text == "Hello world"
+        assert outputs[-1].text == " world"
+        assert outputs[-1].specprefill_effective_policy == "dense"
         assert len(calls) == 1
         assert "mtp" not in calls[0]
-        assert calls[0]["num_draft_tokens"] == 4
+        assert "num_draft_tokens" not in calls[0]
         assert "prompt_cache" in calls[0]
-        assert "logits_processors" not in calls[0]
+        assert calls[0]["logits_processors"][0] is processor
+        score_tokens.assert_not_called()
+        prepare_sparse.assert_not_called()
 
     @pytest.mark.anyio
     async def test_text_specprefill_does_not_restart_dense_after_seed_failure(self):
@@ -2563,6 +2578,10 @@ class TestSimpleEngineConcurrency:
         engine._text_model = MagicMock()
         engine._text_model.mtp = None
         engine._text_tokenizer = tokenizer
+        forward_context = MagicMock()
+        forward_context.finish = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
 
         with (
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
@@ -2573,12 +2592,25 @@ class TestSimpleEngineConcurrency:
             patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
             patch("mlx_lm.stream_generate", side_effect=failing_continuation),
             patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
-            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
             patch(
-                "vllm_mlx.specprefill.sparse_prefill",
-                return_value=mx.zeros((1, 1, 8)),
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=SimpleNamespace(
+                    add_token=lambda _token: None,
+                    finalize=lambda: None,
+                    last_segment="A",
+                ),
             ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
         ):
             stream = engine._stream_generate_text(
                 messages=[{"role": "user", "content": "hello"}],
@@ -2593,6 +2625,7 @@ class TestSimpleEngineConcurrency:
                 await anext(stream)
 
         assert calls == ["continuation"]
+        forward_context.finish.assert_called_once()
 
     @pytest.mark.anyio
     async def test_cancellation_does_not_release_lock_before_worker_finishes(
@@ -2726,7 +2759,9 @@ class TestSimpleEngineConcurrency:
             continuation_started.set()
             release_continuation.wait(timeout=1)
             worker_finished.set()
-            yield SimpleNamespace(text="B", finish_reason="stop")
+            yield SimpleNamespace(
+                token=18, text="ignored", finished=True, finish_reason="stop"
+            )
 
         engine = SimpleEngine("test-model")
         engine._loaded = True
@@ -2737,18 +2772,31 @@ class TestSimpleEngineConcurrency:
             decode=lambda ids: "A", eos_token_id=99
         )
         engine._model.stream_generate.side_effect = continuation
+        forward_context = MagicMock()
+        forward_context.finish = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
 
         with (
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
             patch("mlx_lm.sample_utils.make_sampler", side_effect=sampler_factory),
             patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
             patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
-            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
             patch(
-                "vllm_mlx.specprefill.sparse_prefill",
-                return_value=mx.zeros((1, 1, 8)),
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
             ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
         ):
             stream = engine._stream_generate_specprefill(
                 "prompt",
@@ -2797,13 +2845,20 @@ class TestSimpleEngineConcurrency:
             [SimpleNamespace(text="dense", finish_reason="stop")]
         )
 
+        scorer = MagicMock(side_effect=RuntimeError("before seed"))
         with (
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch("vllm_mlx.specprefill.score_tokens", scorer),
             patch(
-                "vllm_mlx.specprefill.score_tokens",
-                side_effect=RuntimeError("before seed"),
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
             ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
         ):
             outputs = [
                 output
@@ -2814,6 +2869,7 @@ class TestSimpleEngineConcurrency:
 
         assert [output.new_text for output in outputs] == ["dense"]
         assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+        scorer.assert_called_once()
         assert engine._model.stream_generate.call_count == 1
 
     @pytest.mark.anyio
@@ -2830,6 +2886,10 @@ class TestSimpleEngineConcurrency:
             decode=lambda _ids: "A", eos_token_id=99
         )
         engine._model.stream_generate.side_effect = RuntimeError("after seed")
+        forward_context = MagicMock()
+        forward_context.finish = MagicMock()
+        sparse_result = SimpleNamespace(logits=mx.zeros((1, 1, 8)))
+        sparse_plan = SimpleNamespace(selected_indices=(0,))
 
         with (
             patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
@@ -2839,12 +2899,21 @@ class TestSimpleEngineConcurrency:
             ),
             patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
             patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
-            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
             patch(
-                "vllm_mlx.specprefill.sparse_prefill",
-                return_value=mx.zeros((1, 1, 8)),
+                "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                return_value=_SparseTestDetokenizer(),
             ),
-            patch("vllm_mlx.specprefill.cleanup_rope"),
+            patch.object(engine, "_supports_sparse_continuation", return_value=True),
+            patch.object(
+                engine,
+                "_admit_sparse_target",
+                return_value=(SimpleNamespace(adapter_id="qwen_dense"), MagicMock()),
+            ),
+            patch.object(
+                engine,
+                "_prepare_sparse_target_prefill",
+                return_value=(sparse_result, forward_context, sparse_plan),
+            ),
         ):
             stream = engine._stream_generate_specprefill(
                 "prompt", [1], max_tokens=2, temperature=0.0, top_p=1.0
@@ -2855,6 +2924,7 @@ class TestSimpleEngineConcurrency:
                 await anext(stream)
 
         assert engine._model.stream_generate.call_count == 1
+        forward_context.finish.assert_called_once()
 
     @pytest.mark.anyio
     async def test_text_mtp_path_does_not_prelock_serialized_runner(self):
@@ -2900,13 +2970,17 @@ class TestSimpleEngineConcurrency:
             captured["score"] = cancel_check
             return mx.array([0.5], dtype=mx.float32)
 
+        forward_context = MagicMock()
+        forward_context.finish = MagicMock()
+
         def fake_sparse_prefill(*args, cancel_check=None, **kwargs):
             captured["prefill"] = cancel_check
-            return mx.zeros((1, 1, 8), dtype=mx.float32)
-
-        def fake_select_chunks(_importance, **kwargs):
-            captured["select_chunks_kwargs"] = kwargs
-            return mx.array([0], dtype=mx.int32)
+            captured["prepare_kwargs"] = kwargs
+            return (
+                SimpleNamespace(logits=mx.zeros((1, 1, 8), dtype=mx.float32)),
+                forward_context,
+                SimpleNamespace(selected_indices=(0,)),
+            )
 
         with patch("vllm_mlx.engine.simple.is_mllm_model", return_value=False):
             engine = SimpleEngine("test-model")
@@ -2916,32 +2990,43 @@ class TestSimpleEngineConcurrency:
             engine._model.model = MagicMock()
             engine._model.tokenizer = MagicMock()
             engine._model.tokenizer.decode = MagicMock(return_value="A")
-            engine._model.tokenizer.eos_token_id = 0
+            engine._model.tokenizer.eos_token_id = 99
 
             outputs = []
             with (
                 patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
                 patch(
                     "mlx_lm.sample_utils.make_sampler",
-                    return_value=lambda logits: mx.array([0], dtype=mx.int32),
+                    return_value=lambda logits: mx.array([17], dtype=mx.int32),
                 ),
                 patch(
                     "vllm_mlx.specprefill.score_tokens", side_effect=fake_score_tokens
                 ),
                 patch(
-                    "vllm_mlx.specprefill.select_chunks",
-                    side_effect=fake_select_chunks,
+                    "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                    return_value=_SparseTestDetokenizer(),
                 ),
-                patch(
-                    "vllm_mlx.specprefill.sparse_prefill",
+                patch.object(
+                    engine, "_supports_sparse_continuation", return_value=True
+                ),
+                patch.object(
+                    engine,
+                    "_admit_sparse_target",
+                    return_value=(
+                        SimpleNamespace(adapter_id="qwen_dense"),
+                        MagicMock(),
+                    ),
+                ),
+                patch.object(
+                    engine,
+                    "_prepare_sparse_target_prefill",
                     side_effect=fake_sparse_prefill,
                 ),
-                patch("vllm_mlx.specprefill.cleanup_rope"),
             ):
                 async for chunk in engine._stream_generate_specprefill(
                     prompt="hello",
                     tokens=[1, 2, 3, 4],
-                    max_tokens=4,
+                    max_tokens=1,
                     temperature=0.7,
                     top_p=0.9,
                     specprefill_backbone_pct=0.25,
@@ -2951,7 +3036,7 @@ class TestSimpleEngineConcurrency:
         assert outputs == ["A"]
         assert callable(captured["score"])
         assert captured["score"] is captured["prefill"]
-        assert captured["select_chunks_kwargs"]["backbone_pct"] == 0.25
+        assert captured["prepare_kwargs"]["backbone_pct"] == 0.25
 
     @pytest.mark.anyio
     async def test_cancelling_specprefill_request_stops_during_scoring(self):
@@ -2999,7 +3084,21 @@ class TestSimpleEngineConcurrency:
                     "vllm_mlx.specprefill.score_tokens",
                     side_effect=fake_score_tokens,
                 ),
-                patch("vllm_mlx.specprefill.cleanup_rope"),
+                patch(
+                    "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                    return_value=_SparseTestDetokenizer(),
+                ),
+                patch.object(
+                    engine, "_supports_sparse_continuation", return_value=True
+                ),
+                patch.object(
+                    engine,
+                    "_admit_sparse_target",
+                    return_value=(
+                        SimpleNamespace(adapter_id="qwen_dense"),
+                        MagicMock(),
+                    ),
+                ),
             ):
                 task = asyncio.create_task(consume())
                 assert await asyncio.to_thread(score_started.wait, 1.0)
@@ -3057,14 +3156,25 @@ class TestSimpleEngineConcurrency:
                     return_value=mx.array([0.5], dtype=mx.float32),
                 ),
                 patch(
-                    "vllm_mlx.specprefill.select_chunks",
-                    return_value=mx.array([0], dtype=mx.int32),
+                    "vllm_mlx.engine.simple._new_sparse_detokenizer",
+                    return_value=_SparseTestDetokenizer(),
                 ),
-                patch(
-                    "vllm_mlx.specprefill.sparse_prefill",
+                patch.object(
+                    engine, "_supports_sparse_continuation", return_value=True
+                ),
+                patch.object(
+                    engine,
+                    "_admit_sparse_target",
+                    return_value=(
+                        SimpleNamespace(adapter_id="qwen_dense"),
+                        MagicMock(),
+                    ),
+                ),
+                patch.object(
+                    engine,
+                    "_prepare_sparse_target_prefill",
                     side_effect=fake_sparse_prefill,
                 ),
-                patch("vllm_mlx.specprefill.cleanup_rope"),
             ):
                 task = asyncio.create_task(consume())
                 assert await asyncio.to_thread(prefill_started.wait, 1.0)

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2098,7 +2098,8 @@ class TestSimpleEngineConcurrency:
             "min_p": 0.0,
         }
         assert captured["prompt"] == [17]
-        assert captured["kwargs"]["mtp"] is True
+        assert "mtp" not in captured["kwargs"]
+        assert captured["kwargs"]["num_draft_tokens"] == 4
         assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
         assert captured["kwargs"]["max_tokens"] == 3
         assert captured["kwargs"]["logits_processors"] is None
@@ -2534,6 +2535,66 @@ class TestSimpleEngineConcurrency:
         assert "logits_processors" not in calls[0]
 
     @pytest.mark.anyio
+    async def test_text_specprefill_does_not_restart_dense_after_seed_failure(self):
+        """A text-route sparse seed commits the response before continuation."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        calls = []
+
+        def failing_continuation(*_args, **_kwargs):
+            calls.append("continuation")
+            raise RuntimeError("after text seed")
+
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<|im_start|>user\nhello"
+        tokenizer.bos_token = None
+        tokenizer.eos_token_id = 99
+        tokenizer.encode.return_value = [1, 2, 3]
+        tokenizer.decode.return_value = "A"
+
+        engine = SimpleEngine(
+            "test-model",
+            force_mllm=True,
+            specprefill_enabled=True,
+            specprefill_diagnostic_mode=True,
+        )
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._text_model = MagicMock()
+        engine._text_model.mtp = None
+        engine._text_tokenizer = tokenizer
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "mlx_lm.sample_utils.make_sampler",
+                return_value=lambda _logits: mx.array(17, dtype=mx.uint32),
+            ),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("mlx_lm.stream_generate", side_effect=failing_continuation),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
+            patch(
+                "vllm_mlx.specprefill.sparse_prefill",
+                return_value=mx.zeros((1, 1, 8)),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+        ):
+            stream = engine._stream_generate_text(
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=2,
+                temperature=0.0,
+                top_p=1.0,
+                specprefill=True,
+            )
+            first = await anext(stream)
+            assert first.new_text == "A"
+            with pytest.raises(RuntimeError, match="after text seed"):
+                await anext(stream)
+
+        assert calls == ["continuation"]
+
+    @pytest.mark.anyio
     async def test_cancellation_does_not_release_lock_before_worker_finishes(
         self, mock_llm_model
     ):
@@ -2634,6 +2695,166 @@ class TestSimpleEngineConcurrency:
             assert len(outputs) == 1
             assert outputs[0].finished
             assert outputs[0].completion_tokens == 0
+
+    @pytest.mark.anyio
+    async def test_direct_specprefill_streams_before_worker_completion_and_forwards_sampling(
+        self,
+    ):
+        """The sparse seed is observable before a blocked continuation ends."""
+        from threading import Event
+
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        continuation_started = Event()
+        release_continuation = Event()
+        worker_finished = Event()
+        captured = {}
+
+        def sampler_factory(**kwargs):
+            captured["sampler"] = kwargs
+            return lambda _logits: mx.array(17, dtype=mx.uint32)
+
+        def processor(tokens, logits):
+            captured.setdefault("processor_tokens", []).append(tokens.tolist())
+            return logits
+
+        def continuation(**kwargs):
+            captured["continuation"] = kwargs
+            kwargs["logits_processors"][0](
+                mx.array([17], dtype=mx.uint32), mx.zeros((1, 8), dtype=mx.float32)
+            )
+            continuation_started.set()
+            release_continuation.wait(timeout=1)
+            worker_finished.set()
+            yield SimpleNamespace(text="B", finish_reason="stop")
+
+        engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._model = MagicMock()
+        engine._model.model = MagicMock()
+        engine._model.tokenizer = SimpleNamespace(
+            decode=lambda ids: "A", eos_token_id=99
+        )
+        engine._model.stream_generate.side_effect = continuation
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch("mlx_lm.sample_utils.make_sampler", side_effect=sampler_factory),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
+            patch(
+                "vllm_mlx.specprefill.sparse_prefill",
+                return_value=mx.zeros((1, 1, 8)),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+        ):
+            stream = engine._stream_generate_specprefill(
+                "prompt",
+                [1, 2, 3],
+                max_tokens=2,
+                temperature=0.6,
+                top_p=0.9,
+                top_k=23,
+                min_p=0.2,
+                presence_penalty=0.4,
+                repetition_penalty=1.2,
+                logits_processors=[processor],
+            )
+            first = await anext(stream)
+            assert first.new_text == "A"
+            assert await asyncio.to_thread(continuation_started.wait, 1)
+            assert not worker_finished.is_set()
+            release_continuation.set()
+            rest = [output async for output in stream]
+
+        assert [output.new_text for output in rest] == ["B"]
+        assert captured["sampler"] == {
+            "temp": 0.6,
+            "top_p": 0.9,
+            "top_k": 23,
+            "min_p": 0.2,
+        }
+        assert captured["processor_tokens"] == [[1, 2, 3], [1, 2, 3, 17]]
+        assert captured["continuation"]["top_k"] == 23
+        assert captured["continuation"]["min_p"] == 0.2
+        assert captured["continuation"]["presence_penalty"] == 0.0
+        assert captured["continuation"]["repetition_penalty"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_direct_specprefill_falls_back_only_before_seed(self):
+        """Pre-seed sparse failures safely restart dense exactly once."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._model = MagicMock()
+        engine._model.model = MagicMock()
+        engine._model.tokenizer = SimpleNamespace(eos_token_id=99)
+        engine._model.stream_generate.return_value = iter(
+            [SimpleNamespace(text="dense", finish_reason="stop")]
+        )
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "vllm_mlx.specprefill.score_tokens",
+                side_effect=RuntimeError("before seed"),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+        ):
+            outputs = [
+                output
+                async for output in engine._stream_generate_specprefill(
+                    "prompt", [1], max_tokens=2, temperature=0.0, top_p=1.0
+                )
+            ]
+
+        assert [output.new_text for output in outputs] == ["dense"]
+        assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+        assert engine._model.stream_generate.call_count == 1
+
+    @pytest.mark.anyio
+    async def test_direct_specprefill_never_restarts_dense_after_sparse_output(self):
+        """Seed and continuation failures propagate without duplicate dense text."""
+        from vllm_mlx.engine.simple import SimpleEngine
+
+        engine = SimpleEngine("test-model")
+        engine._loaded = True
+        engine._draft_model = MagicMock()
+        engine._model = MagicMock()
+        engine._model.model = MagicMock()
+        engine._model.tokenizer = SimpleNamespace(
+            decode=lambda _ids: "A", eos_token_id=99
+        )
+        engine._model.stream_generate.side_effect = RuntimeError("after seed")
+
+        with (
+            patch("mlx_lm.models.cache.make_prompt_cache", return_value=[]),
+            patch(
+                "mlx_lm.sample_utils.make_sampler",
+                return_value=lambda _logits: mx.array(17, dtype=mx.uint32),
+            ),
+            patch("mlx_lm.sample_utils.make_logits_processors", return_value=[]),
+            patch("vllm_mlx.specprefill.score_tokens", return_value=mx.array([1.0])),
+            patch("vllm_mlx.specprefill.select_chunks", return_value=mx.array([0])),
+            patch(
+                "vllm_mlx.specprefill.sparse_prefill",
+                return_value=mx.zeros((1, 1, 8)),
+            ),
+            patch("vllm_mlx.specprefill.cleanup_rope"),
+        ):
+            stream = engine._stream_generate_specprefill(
+                "prompt", [1], max_tokens=2, temperature=0.0, top_p=1.0
+            )
+            first = await anext(stream)
+            assert first.new_text == "A"
+            with pytest.raises(RuntimeError, match="after seed"):
+                await anext(stream)
+
+        assert engine._model.stream_generate.call_count == 1
 
     @pytest.mark.anyio
     async def test_text_mtp_path_does_not_prelock_serialized_runner(self):

--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2898,7 +2898,9 @@ class TestSimpleEngineConcurrency:
         assert captured["continuation"]["repetition_penalty"] == 1.0
 
     @pytest.mark.anyio
-    async def test_direct_sparse_clean_exhaustion_keeps_telemetry_in_stop_epilogue(self):
+    async def test_direct_sparse_clean_exhaustion_keeps_telemetry_in_stop_epilogue(
+        self,
+    ):
         """Sparse producer exhaustion appends one telemetry-preserving stop frame."""
         from vllm_mlx.engine.simple import SimpleEngine
 
@@ -2959,7 +2961,9 @@ class TestSimpleEngineConcurrency:
                 )
             ]
 
-        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+        assert [
+            (chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs
+        ] == [
             ("A", False, None),
             ("B", False, None),
             ("", True, "stop"),
@@ -3185,7 +3189,9 @@ class TestSimpleEngineConcurrency:
                 )
             ]
 
-        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+        assert [
+            (chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs
+        ] == [
             ("A", False, None),
             ("B", False, None),
             ("", True, "stop"),
@@ -3276,7 +3282,9 @@ class TestSimpleEngineConcurrency:
                 )
             ]
 
-        assert [(chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs] == [
+        assert [
+            (chunk.new_text, chunk.finished, chunk.finish_reason) for chunk in outputs
+        ] == [
             ("A", False, None),
             ("B", True, "length"),
         ]

--- a/tests/test_simple_engine_sparse_migration.py
+++ b/tests/test_simple_engine_sparse_migration.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic successful SimpleEngine sparse-only lifecycle tests."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+import time
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.engine import simple as simple_module
+from vllm_mlx.engine.simple import (
+    SimpleEngine,
+    _SpecPrefillCancelled,
+    _build_text_tokenizer,
+    _detokenize_sparse_token,
+)
+from vllm_mlx.specprefill_positions import GEMMA4_DENSE_TARGET, QWEN_DENSE_TARGET
+
+
+class _Detokenizer:
+    def reset(self):
+        self._segment = ""
+
+    def add_token(self, token):
+        self._segment += {5: "A", 6: "B"}.get(token, f"<{token}>")
+
+    def finalize(self):
+        return None
+
+    @property
+    def last_segment(self):
+        segment = self._segment
+        self._segment = ""
+        return segment
+
+
+class _Tokenizer:
+    bos_token = None
+    eos_token_id = 9
+    eos_token_ids = (9, 10)
+    all_special_ids = (9, 10)
+
+    @property
+    def detokenizer(self):
+        return _Detokenizer()
+
+
+class _RawTokenizer:
+    bos_token = None
+    eos_token = "<eos>"
+    eos_token_id = 9
+    chat_template = None
+
+    def get_vocab(self):
+        return {}
+
+    def encode(self, *_args, **_kwargs):
+        return [1, 2, 3, 4]
+
+    def apply_chat_template(self, *_args, **_kwargs):
+        return "rendered prompt"
+
+
+def _text_tokenizer():
+    return _build_text_tokenizer(
+        SimpleNamespace(
+            tokenizer=_RawTokenizer(),
+            detokenizer=_Detokenizer(),
+            eos_token_ids=(9, 10),
+        )
+    )
+
+
+def test_terminal_sparse_token_finalizes_buffered_segment_for_both_routes():
+    class BufferedDetokenizer:
+        def __init__(self):
+            self.pending = ""
+            self.visible = ""
+
+        def add_token(self, token):
+            self.pending = {5: "A"}[token]
+
+        def finalize(self):
+            self.visible += self.pending
+            self.pending = ""
+
+        @property
+        def last_segment(self):
+            segment = self.visible
+            self.visible = ""
+            return segment
+
+    text, is_eos = _detokenize_sparse_token(
+        BufferedDetokenizer(), 5, frozenset((9,)), terminal=True
+    )
+    assert text == "A"
+    assert is_eos is False
+
+
+class _ForwardContext:
+    def __init__(self, model, cache):
+        self.model = model
+        self.cache = cache
+        self.calls = []
+        self.finish_count = 0
+
+    def __call__(self, forward):
+        self.calls.append((forward.phase, forward.model, forward.cache))
+        return nullcontext()
+
+    def finish(self):
+        self.finish_count += 1
+
+
+def _engine(monkeypatch, *, continuation_tokens=(6,), seed_token=5):
+    engine = SimpleEngine("synthetic", specprefill_diagnostic_mode=True)
+    engine._draft_model = object()
+    tokenizer = _Tokenizer()
+    target_model = SimpleNamespace()
+    cache = [SimpleNamespace(offset=0)]
+    context = _ForwardContext(target_model, cache)
+    continuation_calls = []
+
+    def stream_generate(
+        *, prompt, prompt_cache, model_forward_context, max_tokens, **_kwargs
+    ):
+        continuation_calls.append(
+            (prompt, prompt_cache, model_forward_context, max_tokens)
+        )
+        for index, token in enumerate(continuation_tokens):
+            with model_forward_context(
+                SimpleNamespace(
+                    phase="decode",
+                    model=target_model,
+                    cache=prompt_cache,
+                )
+            ):
+                pass
+            yield SimpleNamespace(
+                token=token,
+                text="wrong-detokenizer-segment",
+                finished=index == len(continuation_tokens) - 1,
+                finish_reason=(
+                    "length" if index == len(continuation_tokens) - 1 else None
+                ),
+            )
+
+    engine._model = SimpleNamespace(
+        model=target_model,
+        tokenizer=tokenizer,
+        stream_generate=stream_generate,
+    )
+    engine._supports_sparse_continuation = lambda _continuation: True
+    profile_key = SimpleNamespace(adapter_id="qwen_dense")
+    engine._admit_sparse_target = lambda _model: (profile_key, QWEN_DENSE_TARGET)
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.make_prompt_cache", lambda *_args, **_kwargs: cache
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.specprefill.score_tokens",
+        lambda *_args, **_kwargs: mx.ones((4,)),
+    )
+    monkeypatch.setattr(
+        simple_module,
+        "_sample_with_processors",
+        lambda *_args, **_kwargs: (mx.array(seed_token), mx.array([0.0])),
+    )
+    plan = SimpleNamespace(selected_indices=(0, 3))
+    result = SimpleNamespace(
+        logits=mx.zeros((1, 1, 16)),
+        telemetry=SimpleNamespace(selected_tokens=2, target_prefill_ms=1.0),
+    )
+    prepare_calls = []
+
+    def prepare(**kwargs):
+        prepare_calls.append(kwargs)
+        return result, context, plan
+
+    engine._prepare_sparse_target_prefill = prepare
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="sparse",
+        coverage="selective",
+        has_media=False,
+        total_tokens=4,
+    )
+    return engine, telemetry, cache, context, continuation_calls, prepare_calls
+
+
+@pytest.mark.anyio
+async def test_sparse_seed_and_continuation_share_cache_context_and_detokenizer(
+    monkeypatch,
+):
+    engine, telemetry, cache, context, continuation_calls, prepare_calls = _engine(
+        monkeypatch
+    )
+
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt",
+            [1, 2, 3, 4],
+            max_tokens=2,
+            temperature=0.0,
+            top_p=1.0,
+            telemetry=telemetry,
+        )
+    ]
+
+    assert [output.new_text for output in outputs] == ["A", "B"]
+    assert outputs[-1].text == "AB"
+    assert continuation_calls[0][1] is cache
+    assert continuation_calls[0][2] is context
+    assert context.calls == [("decode", engine._model.model, cache)]
+    assert context.finish_count == 1
+    assert prepare_calls[0]["profile_key"].adapter_id == "qwen_dense"
+    assert prepare_calls[0]["adapter"] is QWEN_DENSE_TARGET
+    with pytest.raises(_SpecPrefillCancelled):
+        prepare_calls[0]["cancel_check"]()
+
+
+@pytest.mark.anyio
+async def test_sparse_max_one_skips_continuation_and_finishes_context(monkeypatch):
+    engine, telemetry, _cache, context, continuation_calls, _prepare_calls = _engine(
+        monkeypatch
+    )
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt", [1, 2, 3, 4], 1, 0.0, 1.0, telemetry=telemetry
+        )
+    ]
+    assert outputs[-1].text == "A"
+    assert outputs[-1].finish_reason == "length"
+    assert continuation_calls == []
+    assert context.finish_count == 1
+
+
+@pytest.mark.anyio
+async def test_sparse_seed_eos_is_suppressed_and_never_continues(monkeypatch):
+    engine, telemetry, _cache, context, continuation_calls, _prepare_calls = _engine(
+        monkeypatch, seed_token=10
+    )
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt", [1, 2, 3, 4], 4, 0.0, 1.0, telemetry=telemetry
+        )
+    ]
+    assert outputs[-1].text == ""
+    assert outputs[-1].finish_reason == "stop"
+    assert continuation_calls == []
+    assert context.finish_count == 1
+
+
+@pytest.mark.anyio
+async def test_sparse_sampling_failure_is_terminal_and_finishes_context(monkeypatch):
+    engine, telemetry, _cache, context, continuation_calls, _prepare_calls = _engine(
+        monkeypatch
+    )
+    monkeypatch.setattr(
+        simple_module,
+        "_sample_with_processors",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("sample failed")),
+    )
+    with pytest.raises(RuntimeError, match="sample failed"):
+        _ = [
+            output
+            async for output in engine._stream_generate_specprefill(
+                "prompt", [1, 2, 3, 4], 2, 0.0, 1.0, telemetry=telemetry
+            )
+        ]
+    assert continuation_calls == []
+    assert context.finish_count == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("failure_phase", ["scorer", "target_prefill"])
+async def test_pre_sample_sparse_failures_discard_state_and_restart_dense(
+    monkeypatch, failure_phase
+):
+    engine, telemetry, _cache, _context, _continuation, _prepare = _engine(monkeypatch)
+    dense_calls = []
+
+    def dense_stream(**kwargs):
+        dense_calls.append(kwargs)
+        yield SimpleNamespace(text="dense", finish_reason="stop")
+
+    engine._model.stream_generate = dense_stream
+    if failure_phase == "scorer":
+        monkeypatch.setattr(
+            "vllm_mlx.specprefill.score_tokens",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("scorer failed")
+            ),
+        )
+    else:
+        engine._prepare_sparse_target_prefill = lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("target prefill failed")
+        )
+
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt", [1, 2, 3, 4], 2, 0.0, 1.0, telemetry=telemetry
+        )
+    ]
+
+    assert [output.new_text for output in outputs] == ["dense"]
+    assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+    assert len(dense_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_logits_processor_failure_after_prefill_is_terminal_without_dense_replay(
+    monkeypatch,
+):
+    engine, telemetry, _cache, context, _continuation, _prepare = _engine(monkeypatch)
+    dense_calls = []
+    original_stream = engine._model.stream_generate
+
+    def counting_stream(**kwargs):
+        dense_calls.append(kwargs)
+        return original_stream(**kwargs)
+
+    engine._model.stream_generate = counting_stream
+
+    def failing_processor(_tokens, _logits):
+        raise RuntimeError("processor failed")
+
+    def sample_with_processors(tokens, logits, _sampler, processors):
+        processors[0](tokens, logits)
+        raise AssertionError("processor unexpectedly returned")
+
+    monkeypatch.setattr(
+        simple_module, "_sample_with_processors", sample_with_processors
+    )
+
+    with pytest.raises(RuntimeError, match="processor failed"):
+        _ = [
+            output
+            async for output in engine._stream_generate_specprefill(
+                "prompt",
+                [1, 2, 3, 4],
+                2,
+                0.0,
+                1.0,
+                telemetry=telemetry,
+                logits_processors=[failing_processor],
+            )
+        ]
+
+    assert dense_calls == []
+    assert context.finish_count == 1
+
+
+@pytest.mark.anyio
+async def test_sparse_stop_sequence_signals_worker_cancellation(monkeypatch):
+    engine, telemetry, _cache, context, _calls, prepare_calls = _engine(monkeypatch)
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt",
+            [1, 2, 3, 4],
+            4,
+            0.0,
+            1.0,
+            stop=["B"],
+            telemetry=telemetry,
+        )
+    ]
+    assert outputs[-1].finish_reason == "stop"
+    with pytest.raises(_SpecPrefillCancelled):
+        prepare_calls[0]["cancel_check"]()
+    assert context.finish_count == 1
+
+
+@pytest.mark.anyio
+async def test_terminal_stop_normalizes_late_worker_cancellation(monkeypatch):
+    engine, telemetry, cache, context, _calls, prepare_calls = _engine(monkeypatch)
+
+    def longer_stream(*, prompt_cache, model_forward_context, **_kwargs):
+        yield SimpleNamespace(
+            token=6, text="ignored", finished=False, finish_reason=None
+        )
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            try:
+                prepare_calls[0]["cancel_check"]()
+            except _SpecPrefillCancelled:
+                break
+            time.sleep(0.001)
+        yield SimpleNamespace(
+            token=7, text="ignored", finished=False, finish_reason=None
+        )
+
+    engine._model.stream_generate = longer_stream
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt",
+            [1, 2, 3, 4],
+            4,
+            0.0,
+            1.0,
+            stop=["B"],
+            telemetry=telemetry,
+        )
+    ]
+    assert outputs[-1].text == "AB"
+    assert outputs[-1].finish_reason == "stop"
+    assert context.finish_count == 1
+    assert cache
+
+
+@pytest.mark.anyio
+async def test_mllm_text_sparse_route_uses_mlx_lm_wrapper_and_shared_lifecycle(
+    monkeypatch,
+):
+    engine = SimpleEngine(
+        "synthetic-gemma4", force_mllm=True, specprefill_diagnostic_mode=True
+    )
+    engine._draft_model = object()
+    engine._supports_system_kv_cache = False
+    tokenizer = _text_tokenizer()
+    target_model = SimpleNamespace(mtp=None)
+    cache = [SimpleNamespace(offset=0)]
+    context = _ForwardContext(target_model, cache)
+    engine._text_model = target_model
+    engine._text_tokenizer = tokenizer
+    engine._supports_sparse_continuation = lambda _continuation: True
+    profile_key = SimpleNamespace(adapter_id="gemma4_dense")
+    engine._admit_sparse_target = lambda _model: (profile_key, GEMMA4_DENSE_TARGET)
+    plan = SimpleNamespace(selected_indices=(0, 3))
+    result = SimpleNamespace(
+        logits=mx.zeros((1, 1, 16)),
+        telemetry=SimpleNamespace(selected_tokens=2, target_prefill_ms=1.0),
+    )
+    engine._prepare_sparse_target_prefill = lambda **_kwargs: (
+        result,
+        context,
+        plan,
+    )
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.make_prompt_cache", lambda *_args, **_kwargs: cache
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.specprefill.score_tokens",
+        lambda *_args, **_kwargs: mx.ones((4,)),
+    )
+    monkeypatch.setattr(
+        simple_module,
+        "_sample_with_processors",
+        lambda *_args, **_kwargs: (mx.array(5), mx.array([0.0])),
+    )
+    continuation = []
+
+    def stream_generate(model, received_tokenizer, prompt, **kwargs):
+        continuation.append((model, received_tokenizer, prompt, kwargs))
+        with kwargs["model_forward_context"](
+            SimpleNamespace(phase="decode", model=model, cache=kwargs["prompt_cache"])
+        ):
+            pass
+        yield SimpleNamespace(token=6, text="wrong", finish_reason="length")
+
+    monkeypatch.setattr("mlx_lm.stream_generate", stream_generate)
+
+    outputs = [
+        output
+        async for output in engine._stream_generate_text(
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=2,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_coverage="selective",
+        )
+    ]
+
+    assert outputs[-1].text == "AB"
+    assert continuation[0][1] is tokenizer
+    assert continuation[0][3]["prompt_cache"] is cache
+    assert context.calls == [("decode", target_model, cache)]
+    assert context.finish_count == 1
+    assert tokenizer.eos_token_ids == {9, 10}
+
+    max_one = [
+        output
+        async for output in engine._stream_generate_text(
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=1,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_coverage="selective",
+        )
+    ]
+    assert max_one[-1].text == "A"
+    assert max_one[-1].finish_reason == "length"
+    assert len(continuation) == 1
+
+    monkeypatch.setattr(
+        simple_module,
+        "_sample_with_processors",
+        lambda *_args, **_kwargs: (mx.array(9), mx.array([0.0])),
+    )
+    max_one_eos = [
+        output
+        async for output in engine._stream_generate_text(
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=1,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_coverage="selective",
+        )
+    ]
+    assert max_one_eos[-1].text == ""
+    assert max_one_eos[-1].finish_reason == "stop"
+    assert len(continuation) == 1
+    assert context.finish_count == 3

--- a/tests/test_simple_engine_specprefill_policy.py
+++ b/tests/test_simple_engine_specprefill_policy.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Mocked SimpleEngine policy and telemetry contracts for SpecPrefill."""
 
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -8,14 +9,145 @@ import pytest
 pytest.importorskip("mlx.core")
 
 from vllm_mlx.engine.base import GenerationOutput
-from vllm_mlx.engine.simple import SimpleEngine
+from vllm_mlx.engine.simple import SimpleEngine, _request_can_compose_mtp
+from vllm_mlx.specprefill_profiles import (
+    SpecPrefillCalibration,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfile,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillProfileTier,
+    SpecPrefillQualificationEvidence,
+    SpecPrefillTuning,
+)
 
 
-def _engine(*, diagnostic: bool = False) -> SimpleEngine:
+def _hash(letter: str) -> str:
+    return letter * 64
+
+
+def _profile_key(*, cell: SpecPrefillCell) -> SpecPrefillProfileKey:
+    return SpecPrefillProfileKey(
+        target_artifact_id="test-model@bf16",
+        target_artifact_hash=_hash("a"),
+        tokenizer_artifact_hash=_hash("b"),
+        scorer_artifact_id="test-scorer@bf16",
+        scorer_artifact_hash=_hash("c"),
+        adapter_id="test-dense-adapter",
+        engine=SpecPrefillEngine.SIMPLE,
+        cell=cell,
+    )
+
+
+def _calibration(
+    *, selector_version: str, tuning: SpecPrefillTuning
+) -> SpecPrefillCalibration:
+    return SpecPrefillCalibration(
+        selector_version=selector_version,
+        tuning=tuning,
+        crossover_tokens=4,
+        max_context_tokens=131072,
+        residency_limit_bytes=80 * 1024**3,
+        min_ttft_improvement_pct=20.0,
+        max_total_latency_regression_pct=5.0,
+        max_decode_throughput_regression_pct=5.0,
+        required_context_tokens=(8192, 16384, 32768, 65536, 98304, 130048),
+        required_concurrency_levels=(1,),
+        max_p95_inter_token_latency_regression_pct=5.0,
+        min_prefill_heavy_throughput_improvement_pct=10.0,
+    )
+
+
+def _profile(
+    *,
+    cell: SpecPrefillCell,
+    diagnostic: bool = False,
+    selector_version: str,
+    tuning: SpecPrefillTuning,
+) -> SpecPrefillProfile:
+    key = _profile_key(cell=cell)
+    calibration = _calibration(selector_version=selector_version, tuning=tuning)
+    if diagnostic:
+        return SpecPrefillProfile(
+            key=key,
+            tier=SpecPrefillProfileTier.DIAGNOSTIC,
+            calibration=calibration,
+        )
+    return SpecPrefillProfile(
+        key=key,
+        tier=SpecPrefillProfileTier.PRODUCTION,
+        calibration=calibration,
+        qualification_evidence=SpecPrefillQualificationEvidence(
+            report_id="run/specprefill/simple-policy/summary.json",
+            report_sha256=_hash("d"),
+            key=key,
+            selector_version=selector_version,
+            tested_context_tokens=(8192, 16384, 32768, 65536, 98304, 130048),
+            tested_concurrency_levels=(1,),
+            deterministic_baseline_successes=4,
+            preserved_baseline_successes=4,
+            fabricated_or_source_corruption_count=0,
+            quality_noninferiority_ci_lower_points=-1.0,
+            median_ttft_improvement_pct=25.0,
+            median_total_latency_regression_pct=2.0,
+            decode_throughput_regression_pct=2.0,
+            oom_count=0,
+            swap_escalation_count=0,
+            unbounded_retry_count=0,
+            peak_resident_bytes=70 * 1024**3,
+            admission_safety_reserve_pct=10.0,
+            cb_p95_inter_token_latency_regression_pct=None,
+            cb_aggregate_throughput_regression_pct=None,
+            cb_prefill_heavy_throughput_improvement_pct=None,
+            mtp_evidence_id=(
+                "run/specprefill/simple-combined-mtp.json"
+                if cell is SpecPrefillCell.COMBINED_MTP
+                else None
+            ),
+            mtp_evidence_sha256=(
+                _hash("e") if cell is SpecPrefillCell.COMBINED_MTP else None
+            ),
+            mtp_drafts=(10 if cell is SpecPrefillCell.COMBINED_MTP else 0),
+            mtp_accepted=(8 if cell is SpecPrefillCell.COMBINED_MTP else 0),
+        ),
+    )
+
+
+def _engine(
+    *,
+    diagnostic: bool = False,
+    mtp: bool = False,
+    registered: bool = False,
+    estimated_residency: bool = True,
+) -> SimpleEngine:
+    sparse_profile = _profile(
+        cell=SpecPrefillCell.SPARSE_ONLY,
+        diagnostic=diagnostic,
+        selector_version="test-sparse-selector-v1",
+        tuning=SpecPrefillTuning(0.55, 0.1, 1, 1, 32),
+    )
+    combined_profile = _profile(
+        cell=SpecPrefillCell.COMBINED_MTP,
+        diagnostic=diagnostic,
+        selector_version="test-combined-selector-v1",
+        tuning=SpecPrefillTuning(0.65, 0.2, 2, 3, 64),
+    )
     engine = SimpleEngine(
         "test-model",
+        mtp=mtp,
         specprefill_threshold=4,
         specprefill_diagnostic_mode=diagnostic,
+        specprefill_profile_registry=(
+            SpecPrefillProfileRegistry((sparse_profile, combined_profile))
+            if registered
+            else None
+        ),
+        specprefill_sparse_profile_key=(sparse_profile.key if registered else None),
+        specprefill_combined_profile_key=(combined_profile.key if registered else None),
+        specprefill_estimated_residency_bytes=(
+            70 * 1024**3 if registered and estimated_residency else None
+        ),
     )
     engine._draft_model = object()
     return engine
@@ -53,7 +185,7 @@ def test_production_default_and_legacy_intent_are_dense_without_selective_covera
     )
     assert legacy_enabled.decision.requested_policy.value == "sparse"
     assert legacy_enabled.decision.effective_policy.value == "dense"
-    assert legacy_enabled.decision.fallback_reason == "sparse_forcing_diagnostic_only"
+    assert legacy_enabled.decision.fallback_reason == "profile_not_registered"
 
 
 def test_auto_selective_engages_only_with_value_admission_and_media_is_dense():
@@ -66,8 +198,24 @@ def test_auto_selective_engages_only_with_value_admission_and_media_is_dense():
         has_media=False,
         total_tokens=8,
     )
+    assert eligible.decision.effective_policy.value == "dense"
+    assert eligible.decision.fallback_reason == "profile_not_registered"
+
+    registered = _engine(registered=True)
+    eligible = registered._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
     assert eligible.decision.effective_policy.value == "sparse"
     assert eligible.as_output_kwargs()["specprefill_engaged"] is True
+    assert (
+        eligible.as_output_kwargs()["specprefill_selector_version"]
+        == "test-sparse-selector-v1"
+    )
+    assert eligible.profile_tuning == SpecPrefillTuning(0.55, 0.1, 1, 1, 32)
     assert eligible.selected_tokens is None
 
     media = engine._resolve_specprefill_telemetry(
@@ -106,6 +254,18 @@ def test_explicit_sparse_and_selector_overrides_are_diagnostic_only():
         ).decision.effective_policy.value
         == "sparse"
     )
+    # Preserve diagnostic legacy forcing. Production maps the same legacy
+    # intent through an evidence-backed selective auto profile instead.
+    assert (
+        diagnostic._resolve_specprefill_telemetry(
+            legacy=True,
+            policy=None,
+            coverage="unknown",
+            has_media=False,
+            total_tokens=8,
+        ).decision.effective_policy.value
+        == "sparse"
+    )
 
     controls = {"specprefill_keep_pct": 0.2, "specprefill_backbone_pct": 0.1}
     parsed = diagnostic._specprefill_controls(controls)
@@ -114,8 +274,110 @@ def test_explicit_sparse_and_selector_overrides_are_diagnostic_only():
     assert controls == {}
 
 
+def test_diagnostic_auto_requires_an_exact_diagnostic_profile():
+    unregistered = _engine(diagnostic=True)
+    denied = unregistered._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert denied.decision.fallback_reason == "profile_not_registered"
+
+    registered = _engine(diagnostic=True, registered=True)
+    eligible = registered._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert eligible.decision.effective_policy.value == "sparse"
+    assert eligible.profile_tuning == SpecPrefillTuning(0.55, 0.1, 1, 1, 32)
+
+
+def test_profile_cell_is_selected_from_the_actual_request_mtp_route():
+    engine = _engine(mtp=True, registered=True)
+
+    sparse_only = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+        combined_mtp=False,
+    )
+    combined = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+        combined_mtp=True,
+    )
+
+    assert sparse_only.profile_selector_version == "test-sparse-selector-v1"
+    assert sparse_only.profile_tuning == SpecPrefillTuning(0.55, 0.1, 1, 1, 32)
+    assert combined.profile_selector_version == "test-combined-selector-v1"
+    assert combined.profile_tuning == SpecPrefillTuning(0.65, 0.2, 2, 3, 64)
+
+
+def test_retiring_processor_selects_combined_cell_but_permanent_processor_does_not(
+    monkeypatch,
+):
+    class RetiringProcessor:
+        is_retired = False
+
+    class PermanentProcessor:
+        pass
+
+    monkeypatch.setenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME", "1")
+    assert _request_can_compose_mtp(True, [RetiringProcessor()]) is True
+    assert _request_can_compose_mtp(True, [PermanentProcessor()]) is False
+
+    engine = _engine(mtp=True, registered=True)
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+        combined_mtp=_request_can_compose_mtp(True, [RetiringProcessor()]),
+    )
+    assert telemetry.profile_selector_version == "test-combined-selector-v1"
+
+
+def test_profile_keys_must_match_the_simple_engine_cell():
+    sparse_key = _profile_key(cell=SpecPrefillCell.SPARSE_ONLY)
+    combined_key = _profile_key(cell=SpecPrefillCell.COMBINED_MTP)
+
+    with pytest.raises(ValueError, match="sparse_only"):
+        SimpleEngine("test-model", specprefill_sparse_profile_key=combined_key)
+    with pytest.raises(ValueError, match="SimpleEngine"):
+        SimpleEngine(
+            "test-model",
+            specprefill_sparse_profile_key=replace(
+                sparse_key, engine=SpecPrefillEngine.CONTINUOUS_BATCHING
+            ),
+        )
+
+
+def test_registered_profile_requires_an_estimated_residency_value():
+    engine = _engine(registered=True, estimated_residency=False)
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert telemetry.decision.effective_policy.value == "dense"
+    assert telemetry.decision.fallback_reason == "profile_residency_not_estimated"
+
+
 def test_long_context_has_no_hidden_ceiling_and_production_overrides_fail():
-    uncapped = _engine()
+    uncapped = _engine(registered=True)
     long_context = uncapped._resolve_specprefill_telemetry(
         legacy=None,
         policy="auto",
@@ -144,6 +406,87 @@ def test_long_context_has_no_hidden_ceiling_and_production_overrides_fail():
         uncapped._specprefill_controls(
             {"specprefill_keep_pct": 0.2, "specprefill_has_media": False}
         )
+
+
+@pytest.mark.anyio
+async def test_production_profile_forwards_every_calibrated_selector_control(
+    monkeypatch,
+):
+    engine = _engine(registered=True)
+    engine._loaded = True
+    engine._model = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            bos_token=None,
+            encode=lambda *_args, **_kwargs: list(range(8)),
+        )
+    )
+    received: dict[str, object] = {}
+
+    async def fake_sparse_stream(*_args, **kwargs):
+        received.update(
+            {
+                name: kwargs[name]
+                for name in (
+                    "specprefill_keep_pct",
+                    "specprefill_backbone_pct",
+                    "specprefill_chunk_size",
+                    "specprefill_halo_chunks",
+                    "specprefill_anchor_chunks",
+                )
+            }
+        )
+        yield GenerationOutput(text="ok")
+
+    monkeypatch.setattr(engine, "_stream_generate_specprefill", fake_sparse_stream)
+    outputs = [
+        output
+        async for output in engine._stream_generate_impl(
+            "prompt",
+            max_tokens=1,
+            specprefill_policy="auto",
+            specprefill_coverage="selective",
+        )
+    ]
+
+    assert outputs[-1].text == "ok"
+    assert received == {
+        "specprefill_keep_pct": 0.55,
+        "specprefill_backbone_pct": 0.1,
+        "specprefill_chunk_size": 32,
+        "specprefill_halo_chunks": 1,
+        "specprefill_anchor_chunks": 1,
+    }
+
+
+@pytest.mark.anyio
+async def test_direct_native_mtp_route_uses_the_combined_profile_cell(monkeypatch):
+    engine = _engine(mtp=True, registered=True)
+    engine._loaded = True
+    engine._model = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            bos_token=None,
+            encode=lambda *_args, **_kwargs: list(range(8)),
+        )
+    )
+    received: dict[str, object] = {}
+
+    async def fake_sparse_stream(*_args, **kwargs):
+        received["selector_version"] = kwargs["telemetry"].profile_selector_version
+        yield GenerationOutput(text="ok")
+
+    monkeypatch.setattr(engine, "_stream_generate_specprefill", fake_sparse_stream)
+    outputs = [
+        output
+        async for output in engine._stream_generate_impl(
+            "prompt",
+            max_tokens=1,
+            specprefill_policy="auto",
+            specprefill_coverage="selective",
+        )
+    ]
+
+    assert outputs[-1].text == "ok"
+    assert received == {"selector_version": "test-combined-selector-v1"}
 
 
 @pytest.mark.anyio
@@ -220,13 +563,14 @@ def test_sparse_fallback_retains_completed_phase_timing():
 
 @pytest.mark.anyio
 async def test_combined_mtp_and_specprefill_metadata_are_independent():
-    engine = _engine()
+    engine = _engine(mtp=True, registered=True)
     telemetry = engine._resolve_specprefill_telemetry(
         legacy=None,
         policy="auto",
         coverage="selective",
         has_media=False,
         total_tokens=8,
+        combined_mtp=True,
     )
     telemetry.selected_tokens = 4
     telemetry.scorer_ms = 3.5
@@ -243,6 +587,6 @@ async def test_combined_mtp_and_specprefill_metadata_are_independent():
     assert output.mtp_accepted == 5
     assert output.specprefill_effective_policy == "sparse"
     assert output.specprefill_engaged is True
-    assert output.specprefill_selector_version == "hybrid-chunk-v1"
+    assert output.specprefill_selector_version == "test-combined-selector-v1"
     assert output.specprefill_total_tokens == 8
     assert output.specprefill_selected_tokens == 4

--- a/tests/test_simple_engine_specprefill_policy.py
+++ b/tests/test_simple_engine_specprefill_policy.py
@@ -461,7 +461,7 @@ async def test_production_profile_forwards_every_calibrated_selector_control(
 
 
 @pytest.mark.anyio
-async def test_direct_native_mtp_routes_dense_until_composition_is_qualified(
+async def test_direct_legacy_native_mtp_requires_request_contract_for_composition(
     monkeypatch,
 ):
     engine = _engine(mtp=True, registered=True)
@@ -495,12 +495,31 @@ async def test_direct_native_mtp_routes_dense_until_composition_is_qualified(
     assert outputs[-1].text == "dense"
     assert received == {}
     assert outputs[-1].specprefill_effective_policy == "dense"
-    assert outputs[-1].specprefill_fallback_reason == "mtp_composition_not_implemented"
+    assert (
+        outputs[-1].specprefill_fallback_reason == "native_mtp_request_contract_missing"
+    )
 
 
 def test_sparse_eos_accepts_tokenizer_multi_id_contract():
     tokenizer = SimpleNamespace(eos_token_id=1, eos_token_ids=(1, 7))
     assert SimpleEngine._eos_token_ids(tokenizer) == frozenset((1, 7))
+
+
+def test_composed_sparse_rejects_configured_rotating_cache_before_model_admission(
+    monkeypatch,
+):
+    engine = _engine(registered=True)
+    engine._max_kv_size = 128
+    profile_lookup = []
+    monkeypatch.setattr(
+        engine,
+        "_active_specprefill_profile_key",
+        lambda combined_mtp: profile_lookup.append(combined_mtp),
+    )
+
+    with pytest.raises(ValueError, match="nonrotating"):
+        engine._admit_sparse_target(object(), combined_mtp=True)
+    assert profile_lookup == []
 
 
 def test_sparse_cache_identity_rejects_selector_version_drift():
@@ -529,6 +548,47 @@ def test_sparse_cache_identity_rejects_selector_version_drift():
             profile_key=engine._active_specprefill_profile_key(False),
             adapter=QWEN_DENSE_TARGET,
         )
+
+
+def test_sparse_plan_missing_actual_final_prompt_token_fails_before_target_mutation(
+    monkeypatch,
+):
+    engine = _engine(registered=True)
+    plan = SimpleNamespace(
+        selected_indices=(0, 2),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.engine.simple.build_selection_plan",
+        lambda *_args, **_kwargs: plan,
+    )
+    target_calls = []
+    target = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen3"),
+        __call__=lambda *_args, **_kwargs: target_calls.append(True),
+    )
+    telemetry = SimpleNamespace(
+        profile_selector_version=None,
+        selected_tokens=None,
+        target_prefill_ms=None,
+    )
+
+    with pytest.raises(ValueError, match="final prompt tokens"):
+        engine._prepare_sparse_target_prefill(
+            target_model=target,
+            tokenizer=SimpleNamespace(all_special_ids=()),
+            tokens=list(range(8)),
+            importance=mx.ones((8,)),
+            cache=[],
+            telemetry=telemetry,
+            keep_pct=0.25,
+            backbone_pct=0.0,
+            chunk_size=1,
+            halo_chunks=0,
+            anchor_chunks=1,
+            profile_key=engine._active_specprefill_profile_key(False),
+            adapter=QWEN_DENSE_TARGET,
+        )
+    assert target_calls == []
 
 
 @pytest.mark.anyio

--- a/tests/test_simple_engine_specprefill_policy.py
+++ b/tests/test_simple_engine_specprefill_policy.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 pytest.importorskip("mlx.core")
+import mlx.core as mx
 
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.engine.simple import SimpleEngine, _request_can_compose_mtp
@@ -21,6 +22,7 @@ from vllm_mlx.specprefill_profiles import (
     SpecPrefillQualificationEvidence,
     SpecPrefillTuning,
 )
+from vllm_mlx.specprefill_positions import QWEN_DENSE_TARGET
 
 
 def _hash(letter: str) -> str:
@@ -34,7 +36,7 @@ def _profile_key(*, cell: SpecPrefillCell) -> SpecPrefillProfileKey:
         tokenizer_artifact_hash=_hash("b"),
         scorer_artifact_id="test-scorer@bf16",
         scorer_artifact_hash=_hash("c"),
-        adapter_id="test-dense-adapter",
+        adapter_id="qwen_dense",
         engine=SpecPrefillEngine.SIMPLE,
         cell=cell,
     )
@@ -459,14 +461,19 @@ async def test_production_profile_forwards_every_calibrated_selector_control(
 
 
 @pytest.mark.anyio
-async def test_direct_native_mtp_route_uses_the_combined_profile_cell(monkeypatch):
+async def test_direct_native_mtp_routes_dense_until_composition_is_qualified(
+    monkeypatch,
+):
     engine = _engine(mtp=True, registered=True)
     engine._loaded = True
     engine._model = SimpleNamespace(
         tokenizer=SimpleNamespace(
             bos_token=None,
             encode=lambda *_args, **_kwargs: list(range(8)),
-        )
+        ),
+        stream_generate=lambda **_kwargs: iter(
+            [SimpleNamespace(text="dense", finish_reason="stop")]
+        ),
     )
     received: dict[str, object] = {}
 
@@ -485,12 +492,80 @@ async def test_direct_native_mtp_route_uses_the_combined_profile_cell(monkeypatc
         )
     ]
 
-    assert outputs[-1].text == "ok"
-    assert received == {"selector_version": "test-combined-selector-v1"}
+    assert outputs[-1].text == "dense"
+    assert received == {}
+    assert outputs[-1].specprefill_effective_policy == "dense"
+    assert outputs[-1].specprefill_fallback_reason == "mtp_composition_not_implemented"
+
+
+def test_sparse_eos_accepts_tokenizer_multi_id_contract():
+    tokenizer = SimpleNamespace(eos_token_id=1, eos_token_ids=(1, 7))
+    assert SimpleEngine._eos_token_ids(tokenizer) == frozenset((1, 7))
+
+
+def test_sparse_cache_identity_rejects_selector_version_drift():
+    engine = _engine(registered=True)
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    target = SimpleNamespace(config=SimpleNamespace(model_type="qwen3"))
+    with pytest.raises(ValueError, match="selector version"):
+        engine._prepare_sparse_target_prefill(
+            target_model=target,
+            tokenizer=SimpleNamespace(all_special_ids=()),
+            tokens=list(range(8)),
+            importance=mx.ones((8,)),
+            cache=[],
+            telemetry=telemetry,
+            keep_pct=0.55,
+            backbone_pct=0.1,
+            chunk_size=32,
+            halo_chunks=1,
+            anchor_chunks=1,
+            profile_key=engine._active_specprefill_profile_key(False),
+            adapter=QWEN_DENSE_TARGET,
+        )
 
 
 @pytest.mark.anyio
-async def test_sparse_failure_restarts_dense_and_reports_fallback(monkeypatch):
+async def test_zero_max_tokens_never_enters_sparse_seed_path(monkeypatch):
+    engine = _engine(diagnostic=True)
+    engine._loaded = True
+    engine._model = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            bos_token=None,
+            encode=lambda *_args, **_kwargs: list(range(8)),
+        ),
+        stream_generate=lambda **_kwargs: iter(()),
+    )
+    entered_sparse = False
+
+    async def fake_sparse_stream(*_args, **_kwargs):
+        nonlocal entered_sparse
+        entered_sparse = True
+        yield GenerationOutput(text="unexpected")
+
+    monkeypatch.setattr(engine, "_stream_generate_specprefill", fake_sparse_stream)
+    outputs = [
+        output
+        async for output in engine._stream_generate_impl(
+            "prompt",
+            max_tokens=0,
+            specprefill_policy="sparse",
+            specprefill_coverage="selective",
+        )
+    ]
+    assert entered_sparse is False
+    assert outputs[-1].specprefill_effective_policy == "dense"
+    assert outputs[-1].specprefill_fallback_reason == "sparse_no_completion_requested"
+
+
+@pytest.mark.anyio
+async def test_target_prefill_failure_before_sampling_restarts_dense(monkeypatch):
     engine = _engine(diagnostic=True)
     engine._loaded = True
     engine._model = SimpleNamespace(
@@ -513,12 +588,16 @@ async def test_sparse_failure_restarts_dense_and_reports_fallback(monkeypatch):
 
     monkeypatch.setattr("mlx_lm.models.cache.make_prompt_cache", lambda *_a, **_k: [])
     monkeypatch.setattr("vllm_mlx.specprefill.score_tokens", lambda *_a, **_k: object())
+    monkeypatch.setattr(engine, "_supports_sparse_continuation", lambda *_a: True)
     monkeypatch.setattr(
-        "vllm_mlx.specprefill.select_chunks",
-        lambda *_a, **_k: SimpleNamespace(shape=(4,)),
+        engine,
+        "_admit_sparse_target",
+        lambda *_a: (SimpleNamespace(adapter_id="qwen_dense"), QWEN_DENSE_TARGET),
     )
-    monkeypatch.setattr("vllm_mlx.specprefill.sparse_prefill", fail_sparse_prefill)
-    monkeypatch.setattr("vllm_mlx.specprefill.cleanup_rope", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "vllm_mlx.engine.simple._new_sparse_detokenizer", lambda *_a: object()
+    )
+    monkeypatch.setattr(engine, "_prepare_sparse_target_prefill", fail_sparse_prefill)
     outputs = [
         output
         async for output in engine._stream_generate_specprefill(
@@ -531,15 +610,10 @@ async def test_sparse_failure_restarts_dense_and_reports_fallback(monkeypatch):
         )
     ]
 
-    assert outputs[-1].text == "dense"
-    assert outputs[-1].specprefill_requested_policy == "sparse"
-    assert outputs[-1].specprefill_effective_policy == "dense"
-    assert outputs[-1].specprefill_engaged is False
-    assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
-    assert outputs[-1].specprefill_total_tokens == 8
-    assert outputs[-1].specprefill_selected_tokens == 8
-    assert outputs[-1].specprefill_scorer_ms is not None
-    assert outputs[-1].specprefill_target_prefill_ms is None
+    assert telemetry.scorer_ms is not None
+    assert outputs[-1].new_text == "dense"
+    assert telemetry.decision.effective_policy.value == "dense"
+    assert telemetry.decision.fallback_reason == "sparse_execution_failed"
 
 
 def test_sparse_fallback_retains_completed_phase_timing():

--- a/tests/test_simple_engine_specprefill_policy.py
+++ b/tests/test_simple_engine_specprefill_policy.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mocked SimpleEngine policy and telemetry contracts for SpecPrefill."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.engine.simple import SimpleEngine
+
+
+def _engine(*, diagnostic: bool = False) -> SimpleEngine:
+    engine = SimpleEngine(
+        "test-model",
+        specprefill_threshold=4,
+        specprefill_diagnostic_mode=diagnostic,
+    )
+    engine._draft_model = object()
+    return engine
+
+
+def test_production_default_and_legacy_intent_are_dense_without_selective_coverage():
+    engine = _engine()
+
+    omitted = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy=None,
+        coverage=None,
+        has_media=False,
+        total_tokens=8,
+    )
+    assert omitted.decision.effective_policy.value == "dense"
+    assert omitted.decision.fallback_reason == "coverage_not_selective"
+
+    legacy_disabled = engine._resolve_specprefill_telemetry(
+        legacy=False,
+        policy=None,
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert legacy_disabled.decision.requested_policy.value == "dense"
+    assert legacy_disabled.decision.effective_policy.value == "dense"
+
+    legacy_enabled = engine._resolve_specprefill_telemetry(
+        legacy=True,
+        policy=None,
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert legacy_enabled.decision.requested_policy.value == "sparse"
+    assert legacy_enabled.decision.effective_policy.value == "dense"
+    assert legacy_enabled.decision.fallback_reason == "sparse_forcing_diagnostic_only"
+
+
+def test_auto_selective_engages_only_with_value_admission_and_media_is_dense():
+    engine = _engine()
+
+    eligible = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    assert eligible.decision.effective_policy.value == "sparse"
+    assert eligible.as_output_kwargs()["specprefill_engaged"] is True
+    assert eligible.selected_tokens is None
+
+    media = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=True,
+        total_tokens=8,
+    )
+    assert media.decision.effective_policy.value == "dense"
+    assert media.decision.fallback_reason == "media_request"
+    assert media.selected_tokens == 8
+
+
+def test_explicit_sparse_and_selector_overrides_are_diagnostic_only():
+    production = _engine()
+    diagnostic = _engine(diagnostic=True)
+
+    assert (
+        production._resolve_specprefill_telemetry(
+            legacy=None,
+            policy="sparse",
+            coverage="selective",
+            has_media=False,
+            total_tokens=8,
+        ).decision.fallback_reason
+        == "sparse_forcing_diagnostic_only"
+    )
+    assert (
+        diagnostic._resolve_specprefill_telemetry(
+            legacy=None,
+            policy="sparse",
+            coverage="exhaustive",
+            has_media=False,
+            total_tokens=8,
+        ).decision.effective_policy.value
+        == "sparse"
+    )
+
+    controls = {"specprefill_keep_pct": 0.2, "specprefill_backbone_pct": 0.1}
+    parsed = diagnostic._specprefill_controls(controls)
+    assert parsed["keep_pct"] == 0.2
+    assert parsed["backbone_pct"] == 0.1
+    assert controls == {}
+
+
+def test_long_context_has_no_hidden_ceiling_and_production_overrides_fail():
+    uncapped = _engine()
+    long_context = uncapped._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=127 * 1024,
+    )
+    assert long_context.decision.effective_policy.value == "sparse"
+
+    capped = SimpleEngine(
+        "test-model",
+        specprefill_threshold=4,
+        specprefill_max_tokens=16,
+    )
+    capped._draft_model = object()
+    denied = capped._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=17,
+    )
+    assert denied.decision.fallback_reason == "admission_denied"
+
+    with pytest.raises(ValueError, match="diagnostic-only"):
+        uncapped._specprefill_controls(
+            {"specprefill_keep_pct": 0.2, "specprefill_has_media": False}
+        )
+
+
+@pytest.mark.anyio
+async def test_sparse_failure_restarts_dense_and_reports_fallback(monkeypatch):
+    engine = _engine(diagnostic=True)
+    engine._loaded = True
+    engine._model = SimpleNamespace(
+        model=object(),
+        tokenizer=SimpleNamespace(eos_token_id=0),
+        stream_generate=lambda **_kwargs: iter(
+            [SimpleNamespace(text="dense", finish_reason="stop")]
+        ),
+    )
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="sparse",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+
+    def fail_sparse_prefill(*_args, **_kwargs):
+        raise RuntimeError("target sparse prefill failed")
+
+    monkeypatch.setattr("mlx_lm.models.cache.make_prompt_cache", lambda *_a, **_k: [])
+    monkeypatch.setattr("vllm_mlx.specprefill.score_tokens", lambda *_a, **_k: object())
+    monkeypatch.setattr(
+        "vllm_mlx.specprefill.select_chunks",
+        lambda *_a, **_k: SimpleNamespace(shape=(4,)),
+    )
+    monkeypatch.setattr("vllm_mlx.specprefill.sparse_prefill", fail_sparse_prefill)
+    monkeypatch.setattr("vllm_mlx.specprefill.cleanup_rope", lambda *_a, **_k: None)
+    outputs = [
+        output
+        async for output in engine._stream_generate_specprefill(
+            "prompt",
+            list(range(8)),
+            max_tokens=1,
+            temperature=0.0,
+            top_p=1.0,
+            telemetry=telemetry,
+        )
+    ]
+
+    assert outputs[-1].text == "dense"
+    assert outputs[-1].specprefill_requested_policy == "sparse"
+    assert outputs[-1].specprefill_effective_policy == "dense"
+    assert outputs[-1].specprefill_engaged is False
+    assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+    assert outputs[-1].specprefill_total_tokens == 8
+    assert outputs[-1].specprefill_selected_tokens == 8
+    assert outputs[-1].specprefill_scorer_ms is not None
+    assert outputs[-1].specprefill_target_prefill_ms is None
+
+
+def test_sparse_fallback_retains_completed_phase_timing():
+    engine = _engine(diagnostic=True)
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="sparse",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    telemetry.scorer_ms = 12.5
+    telemetry.target_prefill_ms = 30.0
+    telemetry.fallback("sparse_execution_failed")
+
+    metadata = telemetry.as_output_kwargs()
+    assert metadata["specprefill_effective_policy"] == "dense"
+    assert metadata["specprefill_scorer_ms"] == 12.5
+    assert metadata["specprefill_target_prefill_ms"] == 30.0
+
+
+@pytest.mark.anyio
+async def test_combined_mtp_and_specprefill_metadata_are_independent():
+    engine = _engine()
+    telemetry = engine._resolve_specprefill_telemetry(
+        legacy=None,
+        policy="auto",
+        coverage="selective",
+        has_media=False,
+        total_tokens=8,
+    )
+    telemetry.selected_tokens = 4
+    telemetry.scorer_ms = 3.5
+    telemetry.target_prefill_ms = 8.0
+
+    output = GenerationOutput(
+        text="ok",
+        mtp_drafts=6,
+        mtp_accepted=5,
+        **telemetry.as_output_kwargs(),
+    )
+
+    assert output.mtp_drafts == 6
+    assert output.mtp_accepted == 5
+    assert output.specprefill_effective_policy == "sparse"
+    assert output.specprefill_engaged is True
+    assert output.specprefill_selector_version == "hybrid-chunk-v1"
+    assert output.specprefill_total_tokens == 8
+    assert output.specprefill_selected_tokens == 4

--- a/tests/test_simple_native_mtp_behavior.py
+++ b/tests/test_simple_native_mtp_behavior.py
@@ -12,6 +12,8 @@ import importlib
 import os
 import asyncio
 import threading
+from functools import wraps
+from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
@@ -21,7 +23,12 @@ from vllm_mlx.engine.simple import SimpleEngine
 from vllm_mlx.mlx_streams import bind_generation_streams
 from vllm_mlx.models.llm import MLXLanguageModel
 from vllm_mlx.native_mtp_request import NativeMTPRequestConfig, NativeMTPSampling
-
+from vllm_mlx.specprefill_positions import resolve_target_position_adapter
+from vllm_mlx.specprefill_selection import (
+    SelectionPlan,
+    SelectionPolicy,
+    SelectionProvenance,
+)
 
 _HIDDEN = 64
 _HEAD_DIM = 16
@@ -97,25 +104,28 @@ class _TinyTokenizer:
     eos_token_id = 999
     chat_template = "synthetic"
 
+    def __init__(self, tokens=(0, 1)):
+        self.tokens = list(tokens)
+
     def get_vocab(self):
         return {}
 
     def encode(self, text, add_special_tokens=True):
         del text, add_special_tokens
-        return [0, 1]
+        return list(self.tokens)
 
     def decode(self, tokens):
         return "".join(chr(ord("a") + int(token) % 26) for token in tokens)
 
     def apply_chat_template(self, messages, *, tokenize=True, **kwargs):
         del messages, kwargs
-        return [0, 1] if tokenize else "synthetic prompt"
+        return list(self.tokens) if tokenize else "synthetic prompt"
 
 
-def _tokenizer(*, eos_token_ids=(999,)):
+def _tokenizer(*, eos_token_ids=(999,), tokens=(0, 1)):
     from mlx_lm.tokenizer_utils import TokenizerWrapper
 
-    return TokenizerWrapper(_TinyTokenizer(), eos_token_ids=eos_token_ids)
+    return TokenizerWrapper(_TinyTokenizer(tokens=tokens), eos_token_ids=eos_token_ids)
 
 
 def _request(*, temperature=0.0, seed=None):
@@ -142,8 +152,11 @@ def _language_model(model, tokenizer=None):
 
 
 def _track_requests(monkeypatch, model):
+    from mlx_lm.models.cache import NativeMTPRequestCache
+
     requests = []
     original = model.make_mtp_request_cache
+    original_adopt = NativeMTPRequestCache.adopt_sparse_target.__func__
 
     def tracked(*, prompt_cache=None):
         request = original(prompt_cache=prompt_cache)
@@ -151,6 +164,18 @@ def _track_requests(monkeypatch, model):
         return request
 
     monkeypatch.setattr(model, "make_mtp_request_cache", tracked)
+
+    def tracked_adopt(cls, actual_model, **kwargs):
+        request = original_adopt(cls, actual_model, **kwargs)
+        if actual_model is model:
+            requests.append(request)
+        return request
+
+    monkeypatch.setattr(
+        NativeMTPRequestCache,
+        "adopt_sparse_target",
+        classmethod(tracked_adopt),
+    )
     return requests
 
 
@@ -177,6 +202,259 @@ def _assert_target_logprobs(outputs):
         assert mx.argmax(output.logprobs).item() == output.token
 
 
+def _sparse_profile(adapter):
+    return SimpleNamespace(
+        adapter_id=adapter.adapter_id,
+        target_artifact_id="synthetic-qwen",
+        target_artifact_hash="a" * 64,
+        tokenizer_artifact_hash="b" * 64,
+        scorer_artifact_id="synthetic-scorer",
+        scorer_artifact_hash="c" * 64,
+    )
+
+
+def _selection_plan(prompt_length, selected_indices):
+    policy = SelectionPolicy(
+        keep_pct=len(selected_indices) / prompt_length,
+        backbone_pct=0.0,
+        halo_chunks=0,
+        anchor_chunks=1,
+        chunk_size=1,
+    )
+    return SelectionPlan(
+        prompt_length=prompt_length,
+        policy=policy,
+        selected_chunks=selected_indices,
+        selected_indices=selected_indices,
+        provenance=SelectionProvenance(
+            anchor_chunks=(0, prompt_length - 1),
+        ),
+    )
+
+
+def _prepare_native_sparse(monkeypatch, model, tokens, selected_indices):
+    from mlx_lm.models.cache import make_prompt_cache
+
+    engine = object.__new__(SimpleEngine)
+    engine._prefill_step_size = 2
+    engine._max_kv_size = None
+    plan = _selection_plan(len(tokens), selected_indices)
+    monkeypatch.setattr(
+        "vllm_mlx.engine.simple.build_selection_plan",
+        lambda *_args, **_kwargs: plan,
+    )
+    adapter = resolve_target_position_adapter(model)
+    telemetry = SimpleNamespace(
+        profile_selector_version=plan.selector_version,
+        selected_tokens=None,
+        target_prefill_ms=None,
+    )
+    cache = make_prompt_cache(model)
+    result, forward_context, actual_plan, bootstrap = (
+        engine._prepare_sparse_target_prefill(
+            target_model=model,
+            tokenizer=SimpleNamespace(
+                all_special_ids=(),
+                bos_token_id=None,
+                eos_token_id=None,
+                pad_token_id=None,
+            ),
+            tokens=list(tokens),
+            importance=mx.ones((len(tokens),)),
+            cache=cache,
+            telemetry=telemetry,
+            keep_pct=plan.policy.keep_pct,
+            backbone_pct=0.0,
+            chunk_size=1,
+            halo_chunks=0,
+            anchor_chunks=1,
+            profile_key=_sparse_profile(adapter),
+            adapter=adapter,
+            combined_mtp=True,
+        )
+    )
+    assert actual_plan is plan
+    return result, forward_context, bootstrap
+
+
+def _position_correct_sequential_oracle(
+    monkeypatch, model, tokens, selected_indices, *, max_tokens
+):
+    from mlx_lm.generate import GenerationForward, GenerationForwardPhase
+
+    result, forward_context, bootstrap = _prepare_native_sparse(
+        monkeypatch, model, tokens, selected_indices
+    )
+    assert bootstrap.try_abandon_unclaimed() is True
+    generated = [mx.argmax(result.logits[:, -1, :], axis=-1).item()]
+
+    class Ack:
+        def acknowledge(self, positions):
+            self.positions = positions
+
+    try:
+        while len(generated) < max_tokens:
+            position = len(tokens) + len(generated) - 1
+            input_tokens = mx.array([[generated[-1]]], dtype=mx.uint32)
+            ack = Ack()
+            forward = GenerationForward(
+                model=model,
+                input_tokens=input_tokens,
+                cache=bootstrap.target_cache,
+                phase=GenerationForwardPhase.DECODE,
+                logical_positions=(position,),
+                logical_position_ack=ack,
+            )
+            with forward_context(forward):
+                logits = model(input_tokens, cache=bootstrap.target_cache)
+                mx.eval(logits, [entry.state for entry in bootstrap.target_cache])
+            assert ack.positions == (position,)
+            generated.append(mx.argmax(logits[:, -1, :], axis=-1).item())
+    finally:
+        forward_context.finish()
+    return generated
+
+
+def _force_mtp_drafts(monkeypatch, model, oracle, *, selected_count, accept):
+    original = model.mtp_forward
+    next_oracle_index = 1
+
+    def controlled(hidden_states, next_token_ids, mtp_cache):
+        nonlocal next_oracle_index
+        logits = original(hidden_states, next_token_ids, mtp_cache)
+        # Sparse bootstrap first fills the N-1 prompt pairs. Only subsequent
+        # calls are speculative drafts whose token choice affects acceptance.
+        if mtp_cache[0].offset <= selected_count - 1:
+            return logits
+        oracle_id = oracle[min(next_oracle_index, len(oracle) - 1)]
+        draft_id = oracle_id if accept else (oracle_id + 1) % logits.shape[-1]
+        controlled_logits = mx.full(logits.shape, -100.0, dtype=logits.dtype)
+        controlled_logits[..., draft_id] = 100.0
+        next_oracle_index += 2 if accept else 1
+        return controlled_logits
+
+    monkeypatch.setattr(model, "mtp_forward", controlled)
+
+
+def _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected):
+    plan = _selection_plan(len(tokens), selected)
+    adapter = resolve_target_position_adapter(model)
+    profile = _sparse_profile(adapter)
+    monkeypatch.setattr(
+        "vllm_mlx.engine.simple.build_selection_plan",
+        lambda *_args, **_kwargs: plan,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.specprefill.score_tokens",
+        lambda *_args, **_kwargs: mx.ones((len(tokens),)),
+    )
+    monkeypatch.setattr(
+        engine,
+        "_admit_sparse_target",
+        lambda actual_model, *, combined_mtp=False: (
+            profile,
+            resolve_target_position_adapter(actual_model),
+        ),
+    )
+    engine._draft_model = object()
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_real_qwen_keep_one_sparse_native_mtp_matches_dense_public_stream(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+    tokens = (0, 1, 2, 3, 4, 5)
+    dense = list(
+        wrapper.stream_generate(
+            list(tokens), max_tokens=4, native_mtp_request=_request()
+        )
+    )
+
+    _, forward_context, bootstrap = _prepare_native_sparse(
+        monkeypatch, model, tokens, tuple(range(len(tokens)))
+    )
+    sparse = list(
+        wrapper.stream_generate(
+            None,
+            max_tokens=4,
+            native_mtp_request=_request(),
+            sparse_bootstrap=bootstrap,
+            model_forward_context=forward_context,
+        )
+    )
+
+    assert _tokens(sparse) == _tokens(dense)
+    assert sparse[-1].prompt_tokens == len(tokens)
+    assert sparse[-1].mtp_drafts > 0
+    request = requests[-1]
+    assert request.state.backbone_tokens >= len(tokens)
+    assert request.state.mtp_tokens >= len(tokens) - 1
+    assert request.state.next_logical_position >= len(tokens)
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_real_qwen_noncontiguous_receipts_use_original_immediate_successors(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    result, forward_context, bootstrap = _prepare_native_sparse(
+        monkeypatch, model, tokens, selected
+    )
+
+    assert bootstrap.selected_logical_positions == selected
+    assert bootstrap.selected_token_ids == tuple(tokens[index] for index in selected)
+    assert bootstrap.immediate_successor_token_ids == (11, 17, 23)
+    assert tuple(
+        successor
+        for receipt in bootstrap.receipts
+        for successor in receipt.immediate_successor_token_ids
+    ) == (11, 17, 23)
+    assert all(receipt.logits is None for receipt in bootstrap.receipts[:-1])
+    assert bootstrap.receipts[-1].logits is not None
+    assert result.telemetry.selected_tokens == len(selected)
+    assert result.telemetry.physical_cache_starts == ((0,), (2,))
+    assert bootstrap.try_abandon_unclaimed() is True
+    forward_context.finish()
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_sparse_native_mtp_first_output_has_exact_physical_counts_and_cursor(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+    tokens = (2, 3, 5, 7, 11, 13)
+    selected = (0, 2, 4, 5)
+    _, forward_context, bootstrap = _prepare_native_sparse(
+        monkeypatch, model, tokens, selected
+    )
+    generation = wrapper.stream_generate(
+        None,
+        max_tokens=4,
+        native_mtp_request=_request(),
+        sparse_bootstrap=bootstrap,
+        model_forward_context=forward_context,
+    )
+
+    first = next(generation)
+    request = requests[-1]
+    assert first.prompt_tokens == len(tokens)
+    assert request.state.backbone_tokens == len(selected)
+    assert request.state.mtp_tokens == len(selected) - 1
+    assert request.state.next_logical_position == len(tokens) + 1
+    generation.close()
+    assert bootstrap.try_abandon_unclaimed() is False
+    forward_context.finish()
+    _assert_requests_closed(requests)
+
+
 @pytest.mark.parametrize("moe", (False, True))
 def test_real_native_qwen_mlx_language_model_greedy_parity_and_telemetry(
     monkeypatch, moe
@@ -187,9 +465,7 @@ def test_real_native_qwen_mlx_language_model_greedy_parity_and_telemetry(
 
     dense = list(wrapper.stream_generate([0, 1], max_tokens=4, temperature=0.0))
     native = list(
-        wrapper.stream_generate(
-            [0, 1], max_tokens=4, native_mtp_request=_request()
-        )
+        wrapper.stream_generate([0, 1], max_tokens=4, native_mtp_request=_request())
     )
 
     assert _tokens(native) == _tokens(dense)
@@ -225,9 +501,7 @@ def test_real_native_qwen_seeded_stochastic_stream_is_request_repeatable(
 
 
 @pytest.mark.parametrize("moe", (False, True))
-def test_real_native_qwen_max1_eos_stop_and_iterator_close_cleanup(
-    monkeypatch, moe
-):
+def test_real_native_qwen_max1_eos_stop_and_iterator_close_cleanup(monkeypatch, moe):
     model = _native_model(moe=moe)
     requests = _track_requests(monkeypatch, model)
     wrapper = _language_model(model)
@@ -314,6 +588,294 @@ async def test_real_native_qwen_simple_pure_llm_stream_and_cancel_cleanup(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("accept", (False, True), ids=("reject_replay", "accept"))
+async def test_public_simple_llm_noncontiguous_sparse_native_mtp_matches_oracle(
+    monkeypatch, accept
+):
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    model = _native_model(moe=False)
+    oracle = _position_correct_sequential_oracle(
+        monkeypatch, model, tokens, selected, max_tokens=4
+    )
+    _force_mtp_drafts(
+        monkeypatch,
+        model,
+        oracle,
+        selected_count=len(selected),
+        accept=accept,
+    )
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model, _tokenizer(tokens=tokens))
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._model = wrapper
+    engine._loaded = True
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+
+    outputs = [
+        output
+        async for output in engine.stream_generate(
+            "synthetic prompt",
+            max_tokens=4,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_keep_pct=len(selected) / len(tokens),
+            specprefill_backbone_pct=0.0,
+            _native_mtp_request_config=_request(),
+        )
+    ]
+    output_ids = [mx.argmax(output.logprobs).item() for output in outputs]
+
+    assert output_ids == oracle[: len(output_ids)]
+    assert outputs[-1].specprefill_effective_policy == "sparse"
+    assert outputs[-1].specprefill_selected_tokens == len(selected)
+    assert outputs[-1].prompt_tokens == len(tokens)
+    assert outputs[-1].mtp_drafts > 0
+    assert (outputs[-1].mtp_accepted > 0) is accept
+    assert all(output.logprobs is not None for output in outputs)
+    assert all(mx.all(mx.isfinite(output.logprobs)).item() for output in outputs)
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.anyio
+async def test_public_simple_preclaim_failure_abandons_and_dense_falls_back(
+    monkeypatch,
+):
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    model = _native_model(moe=False)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model, _tokenizer(tokens=tokens))
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._model = wrapper
+    engine._loaded = True
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+    bootstraps = []
+    original_prepare = engine._prepare_sparse_target_prefill
+
+    def capture_prepare(**kwargs):
+        prepared = original_prepare(**kwargs)
+        bootstraps.append(prepared[-1])
+        return prepared
+
+    monkeypatch.setattr(engine, "_prepare_sparse_target_prefill", capture_prepare)
+    original_stream = wrapper.stream_generate
+
+    @wraps(original_stream)
+    def fail_sparse_before_claim(**kwargs):
+        if kwargs.get("sparse_bootstrap") is not None:
+
+            def failed():
+                raise ValueError("invalid sparse processor config")
+                yield  # pragma: no cover
+
+            return failed()
+        return original_stream(**kwargs)
+
+    monkeypatch.setattr(wrapper, "stream_generate", fail_sparse_before_claim)
+    outputs = [
+        output
+        async for output in engine.stream_generate(
+            "synthetic prompt",
+            max_tokens=3,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_keep_pct=len(selected) / len(tokens),
+            specprefill_backbone_pct=0.0,
+            _native_mtp_request_config=_request(),
+        )
+    ]
+
+    assert outputs[-1].specprefill_effective_policy == "dense"
+    assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+    assert bootstraps[0].try_abandon_unclaimed() is False
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.anyio
+async def test_public_simple_postclaim_failure_is_terminal_without_dense_replay(
+    monkeypatch,
+):
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    model = _native_model(moe=False)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model, _tokenizer(tokens=tokens))
+    dense_prompts = []
+    original_stream = wrapper.stream_generate
+
+    @wraps(original_stream)
+    def count_dense(**kwargs):
+        if kwargs.get("sparse_bootstrap") is None:
+            dense_prompts.append(kwargs.get("prompt"))
+        return original_stream(**kwargs)
+
+    monkeypatch.setattr(wrapper, "stream_generate", count_dense)
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._model = wrapper
+    engine._loaded = True
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+
+    def fail_after_adoption(*_args, **_kwargs):
+        raise RuntimeError("postclaim MTP failure")
+
+    monkeypatch.setattr(model, "mtp_forward", fail_after_adoption)
+    with pytest.raises(RuntimeError, match="postclaim MTP failure"):
+        _ = [
+            output
+            async for output in engine.stream_generate(
+                "synthetic prompt",
+                max_tokens=3,
+                temperature=0.0,
+                top_p=1.0,
+                specprefill_policy="sparse",
+                specprefill_keep_pct=len(selected) / len(tokens),
+                specprefill_backbone_pct=0.0,
+                _native_mtp_request_config=_request(),
+            )
+        ]
+
+    assert dense_prompts == []
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.anyio
+async def test_public_simple_cancel_before_first_resume_abandons_authority(
+    monkeypatch,
+):
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    model = _native_model(moe=False)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model, _tokenizer(tokens=tokens))
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._model = wrapper
+    engine._loaded = True
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+    original_prepare = engine._prepare_sparse_target_prefill
+    prepared_event = threading.Event()
+    release_worker = threading.Event()
+    bootstraps = []
+
+    def held_prepare(**kwargs):
+        prepared = original_prepare(**kwargs)
+        bootstraps.append(prepared[-1])
+        prepared_event.set()
+        release_worker.wait(timeout=5)
+        return prepared
+
+    monkeypatch.setattr(engine, "_prepare_sparse_target_prefill", held_prepare)
+    stream = engine.stream_generate(
+        "synthetic prompt",
+        max_tokens=3,
+        temperature=0.0,
+        top_p=1.0,
+        specprefill_policy="sparse",
+        specprefill_keep_pct=len(selected) / len(tokens),
+        specprefill_backbone_pct=0.0,
+        _native_mtp_request_config=_request(),
+    )
+    next_task = asyncio.create_task(anext(stream))
+    assert await asyncio.to_thread(prepared_event.wait, 5)
+    next_task.cancel()
+    # Let cancellation traverse public stream -> tracker -> sparse child. The
+    # child sets its cooperative worker-cancel event and then waits for this
+    # held worker, proving release cannot race ahead into bootstrap adoption.
+    await asyncio.sleep(0)
+    assert not next_task.done()
+    release_worker.set()
+    with pytest.raises(asyncio.CancelledError):
+        await next_task
+    await stream.aclose()
+
+    assert bootstraps[0].try_abandon_unclaimed() is False
+    assert requests == []
+    assert engine._active_requests == {}
+
+
+@pytest.mark.anyio
+async def test_public_simple_generator_exit_after_sparse_sample_closes_request(
+    monkeypatch,
+):
+    tokens = (7, 11, 13, 17, 19, 23)
+    selected = (0, 2, 4, 5)
+    model = _native_model(moe=False)
+    requests = _track_requests(monkeypatch, model)
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._model = _language_model(model, _tokenizer(tokens=tokens))
+    engine._loaded = True
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+    original_stream = engine._model.stream_generate
+    release_worker = threading.Event()
+
+    @wraps(original_stream)
+    def held_stream(**kwargs):
+        inner = original_stream(**kwargs)
+        try:
+            yield next(inner)
+            release_worker.wait(timeout=5)
+            yield from inner
+        finally:
+            inner.close()
+
+    monkeypatch.setattr(engine._model, "stream_generate", held_stream)
+    stream = engine.stream_generate(
+        "synthetic prompt",
+        max_tokens=8,
+        temperature=0.0,
+        top_p=1.0,
+        specprefill_policy="sparse",
+        specprefill_keep_pct=len(selected) / len(tokens),
+        specprefill_backbone_pct=0.0,
+        _native_mtp_request_config=_request(),
+    )
+
+    first = await anext(stream)
+    assert first.specprefill_effective_policy == "sparse"
+    assert requests[-1].closed is False
+    close_task = asyncio.create_task(stream.aclose())
+    await asyncio.sleep(0)
+    release_worker.set()
+    await close_task
+
+    _assert_requests_closed(requests)
+    assert engine._active_requests == {}
+    assert engine._num_running == 0
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("moe", (False, True))
 async def test_real_native_qwen_vlm_derived_simple_text_route(monkeypatch, moe):
     import mlx_lm
@@ -393,3 +955,63 @@ async def test_real_native_qwen_vlm_derived_simple_text_route(monkeypatch, moe):
     _assert_requests_closed(requests)
     assert engine._active_requests == {}
     assert engine._num_running == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("accept", (False, True), ids=("reject_replay", "accept"))
+async def test_public_vlm_text_noncontiguous_sparse_native_mtp_matches_oracle(
+    monkeypatch, accept
+):
+    tokens = (5, 7, 11, 13, 17, 19)
+    selected = (0, 2, 4, 5)
+    wrapper_model = _native_model(moe=False)
+    model = wrapper_model.language_model
+    oracle = _position_correct_sequential_oracle(
+        monkeypatch, model, tokens, selected, max_tokens=4
+    )
+    _force_mtp_drafts(
+        monkeypatch,
+        model,
+        oracle,
+        selected_count=len(selected),
+        accept=accept,
+    )
+    requests = _track_requests(monkeypatch, model)
+    engine = SimpleEngine(
+        "synthetic-qwen",
+        force_mllm=True,
+        mtp=True,
+        specprefill_enabled=True,
+        specprefill_threshold=1,
+        specprefill_diagnostic_mode=True,
+    )
+    engine._loaded = True
+    engine._text_model = model
+    engine._text_tokenizer = _tokenizer(tokens=tokens)
+    engine._supports_system_kv_cache = False
+    _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
+
+    outputs = [
+        output
+        async for output in engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            max_tokens=4,
+            temperature=0.0,
+            top_p=1.0,
+            specprefill_policy="sparse",
+            specprefill_keep_pct=len(selected) / len(tokens),
+            specprefill_backbone_pct=0.0,
+            _native_mtp_request_config=_request(),
+        )
+    ]
+    output_ids = [mx.argmax(output.logprobs).item() for output in outputs]
+
+    assert output_ids == oracle[: len(output_ids)]
+    assert outputs[-1].specprefill_effective_policy == "sparse"
+    assert outputs[-1].specprefill_selected_tokens == len(selected)
+    assert outputs[-1].prompt_tokens == len(tokens)
+    assert outputs[-1].mtp_drafts > 0
+    assert (outputs[-1].mtp_accepted > 0) is accept
+    assert all(output.logprobs is not None for output in outputs)
+    assert all(mx.all(mx.isfinite(output.logprobs)).item() for output in outputs)
+    _assert_requests_closed(requests)

--- a/tests/test_simple_native_mtp_behavior.py
+++ b/tests/test_simple_native_mtp_behavior.py
@@ -1,0 +1,395 @@
+"""Behavioral certification for Simple B=1 native Qwen MTP integration.
+
+These tests deliberately use the tiny real dense and MoE Qwen modules from
+the clean mlx-lm native-MTP branch.  They exercise model-owned transactional
+caches through vllm-mlx's two supported Simple text wrappers without loading a
+checkpoint or starting a service.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import asyncio
+import threading
+
+import mlx.core as mx
+import pytest
+from mlx.utils import tree_flatten
+
+from vllm_mlx.engine.simple import SimpleEngine
+from vllm_mlx.mlx_streams import bind_generation_streams
+from vllm_mlx.models.llm import MLXLanguageModel
+from vllm_mlx.native_mtp_request import NativeMTPRequestConfig, NativeMTPSampling
+
+
+_HIDDEN = 64
+_HEAD_DIM = 16
+
+
+def _config(*, moe: bool) -> dict:
+    text = {
+        "model_type": "qwen3_5_moe" if moe else "qwen3_5",
+        "hidden_size": _HIDDEN,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "vocab_size": 64,
+        "linear_num_value_heads": 2,
+        "linear_num_key_heads": 2,
+        # The production Metal recurrent kernel consumes one 32-wide SIMD
+        # lane per key head.  Smaller synthetic widths force n_per_t=0 and do
+        # not represent the eval-mode route used by SimpleEngine.
+        "linear_key_head_dim": 32,
+        "linear_value_head_dim": 32,
+        "linear_conv_kernel_dim": 3,
+        "full_attention_interval": 2,
+        "tie_word_embeddings": False,
+        "rms_norm_eps": 1e-5,
+        "head_dim": _HEAD_DIM,
+        "rope_theta": 1000.0,
+        "partial_rotary_factor": 0.5,
+        "max_position_embeddings": 128,
+        "mtp_num_hidden_layers": 1,
+    }
+    if moe:
+        text.update(
+            {
+                "num_experts": 2,
+                "num_experts_per_tok": 1,
+                "decoder_sparse_step": 1,
+                "shared_expert_intermediate_size": 128,
+                "moe_intermediate_size": 64,
+            }
+        )
+    return {"model_type": text["model_type"], "text_config": text}
+
+
+def _native_model(*, moe: bool):
+    # mlx-lm's module-level generation stream is thread-local.  Bind it on the
+    # same thread that constructs, realizes, and later executes this fixture.
+    bind_generation_streams(("mlx_lm.generate",))
+    module = importlib.import_module(
+        "mlx_lm.models.qwen3_5_moe" if moe else "mlx_lm.models.qwen3_5"
+    )
+    model = module.Model(module.ModelArgs.from_dict(_config(moe=moe)))
+    if not hasattr(type(model.language_model), "mtp_capability"):
+        if os.environ.get("VLLM_MLX_REQUIRE_NATIVE_MTP_TESTS") == "1":
+            pytest.fail("designated native-MTP suite requires clean mlx-lm API")
+        pytest.skip("requires mlx-lm native Qwen MTP capability branch")
+    model.set_dtype(mx.float32)
+    mx.eval(model.parameters())
+
+    # Exercise the same exact one-shot sanitize/load handshake as a real
+    # checkpoint, using this tiny module's concrete arrays as the checkpoint.
+    weights = dict(tree_flatten(model.parameters()))
+    sanitized = model.sanitize(dict(weights))
+    model.load_weights(list(sanitized.items()), strict=True)
+    model.train(False)
+    mx.eval(model.parameters())
+    assert model.mtp_capability.supported is True
+    return model
+
+
+class _TinyTokenizer:
+    bos_token = None
+    eos_token_id = 999
+    chat_template = "synthetic"
+
+    def get_vocab(self):
+        return {}
+
+    def encode(self, text, add_special_tokens=True):
+        del text, add_special_tokens
+        return [0, 1]
+
+    def decode(self, tokens):
+        return "".join(chr(ord("a") + int(token) % 26) for token in tokens)
+
+    def apply_chat_template(self, messages, *, tokenize=True, **kwargs):
+        del messages, kwargs
+        return [0, 1] if tokenize else "synthetic prompt"
+
+
+def _tokenizer(*, eos_token_ids=(999,)):
+    from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+    return TokenizerWrapper(_TinyTokenizer(), eos_token_ids=eos_token_ids)
+
+
+def _request(*, temperature=0.0, seed=None):
+    return NativeMTPRequestConfig(
+        NativeMTPSampling(
+            temperature=temperature,
+            top_p=0.9 if temperature else 1.0,
+            top_k=8 if temperature else 0,
+            min_p=0.01 if temperature else 0.0,
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+            seed=seed,
+        ),
+        num_draft_tokens=1,
+    )
+
+
+def _language_model(model, tokenizer=None):
+    wrapper = MLXLanguageModel("synthetic-qwen")
+    wrapper.model = model
+    wrapper.tokenizer = tokenizer or _tokenizer()
+    wrapper._loaded = True
+    return wrapper
+
+
+def _track_requests(monkeypatch, model):
+    requests = []
+    original = model.make_mtp_request_cache
+
+    def tracked(*, prompt_cache=None):
+        request = original(prompt_cache=prompt_cache)
+        requests.append(request)
+        return request
+
+    monkeypatch.setattr(model, "make_mtp_request_cache", tracked)
+    return requests
+
+
+def _assert_requests_closed(requests):
+    assert requests
+    for request in requests:
+        assert request.closed is True
+        assert request.checkpoint_active is False
+        assert request.replay_required is None
+
+
+def _tokens(outputs):
+    return [output.token for output in outputs]
+
+
+def _assert_target_logprobs(outputs):
+    assert outputs
+    for output in outputs:
+        assert output.logprobs is not None
+        assert mx.all(mx.isfinite(output.logprobs)).item()
+        assert mx.allclose(
+            mx.sum(mx.exp(output.logprobs)), mx.array(1.0), atol=1e-5
+        ).item()
+        assert mx.argmax(output.logprobs).item() == output.token
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_real_native_qwen_mlx_language_model_greedy_parity_and_telemetry(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+
+    dense = list(wrapper.stream_generate([0, 1], max_tokens=4, temperature=0.0))
+    native = list(
+        wrapper.stream_generate(
+            [0, 1], max_tokens=4, native_mtp_request=_request()
+        )
+    )
+
+    assert _tokens(native) == _tokens(dense)
+    _assert_target_logprobs(native)
+    assert native[-1].mtp_drafts > 0
+    assert 0 <= native[-1].mtp_accepted <= native[-1].mtp_drafts
+    assert native[-1].mtp_bypass_reason is None
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_real_native_qwen_seeded_stochastic_stream_is_request_repeatable(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+    request = _request(temperature=0.7, seed=17)
+
+    first = list(
+        wrapper.stream_generate([0, 1], max_tokens=5, native_mtp_request=request)
+    )
+    second = list(
+        wrapper.stream_generate([0, 1], max_tokens=5, native_mtp_request=request)
+    )
+
+    assert _tokens(first) == _tokens(second)
+    assert (first[-1].mtp_drafts, first[-1].mtp_accepted) == (
+        second[-1].mtp_drafts,
+        second[-1].mtp_accepted,
+    )
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.parametrize("moe", (False, True))
+def test_real_native_qwen_max1_eos_stop_and_iterator_close_cleanup(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+
+    max1 = list(
+        wrapper.stream_generate([0, 1], max_tokens=1, native_mtp_request=_request())
+    )
+    assert len(max1) == 1
+    assert max1[-1].finish_reason == "length"
+    assert (max1[-1].mtp_drafts, max1[-1].mtp_accepted) == (0, 0)
+
+    first_token = max1[0].token
+    wrapper.tokenizer = _tokenizer(eos_token_ids=(first_token,))
+    eos = list(
+        wrapper.stream_generate([0, 1], max_tokens=4, native_mtp_request=_request())
+    )
+    assert len(eos) == 1
+    assert eos[-1].finish_reason == "stop"
+
+    wrapper.tokenizer = _tokenizer()
+    stop = list(
+        wrapper.stream_generate(
+            [0, 1],
+            max_tokens=8,
+            stop=[max1[0].text],
+            native_mtp_request=_request(),
+        )
+    )
+    assert len(stop) == 1
+    assert stop[-1].finish_reason == "stop"
+
+    iterator = wrapper.stream_generate(
+        [0, 1], max_tokens=8, native_mtp_request=_request()
+    )
+    next(iterator)
+    assert requests[-1].closed is False
+    iterator.close()
+    assert requests[-1].closed is True
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("moe", (False, True))
+async def test_real_native_qwen_simple_pure_llm_stream_and_cancel_cleanup(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe)
+    requests = _track_requests(monkeypatch, model)
+    wrapper = _language_model(model)
+    engine = SimpleEngine("synthetic-qwen", mtp=True)
+    engine._model = wrapper
+    engine._loaded = True
+
+    outputs = [
+        output
+        async for output in engine.stream_generate(
+            "synthetic prompt",
+            max_tokens=4,
+            temperature=0.0,
+            top_p=1.0,
+            _native_mtp_request_config=_request(),
+        )
+    ]
+    assert outputs[-1].finished is True
+    assert outputs[-1].mtp_drafts > 0
+    assert 0 <= outputs[-1].mtp_accepted <= outputs[-1].mtp_drafts
+    assert outputs[-1].logprobs is not None
+    assert requests[-1].closed is True
+
+    stream = engine.stream_generate(
+        "synthetic prompt",
+        max_tokens=8,
+        temperature=0.0,
+        top_p=1.0,
+        _native_mtp_request_config=_request(),
+    )
+    await anext(stream)
+    assert requests[-1].closed is False
+    assert engine._active_requests
+    await stream.aclose()
+    _assert_requests_closed(requests)
+    assert engine._active_requests == {}
+    assert engine._num_running == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("moe", (False, True))
+async def test_real_native_qwen_vlm_derived_simple_text_route(monkeypatch, moe):
+    import mlx_lm
+
+    wrapper_model = _native_model(moe=moe)
+    text_model = wrapper_model.language_model
+    requests = _track_requests(monkeypatch, text_model)
+    engine = SimpleEngine("synthetic-qwen", force_mllm=True, mtp=True)
+    engine._loaded = True
+    engine._text_model = text_model
+    engine._text_tokenizer = _tokenizer()
+    engine._supports_system_kv_cache = False
+
+    outputs = [
+        output
+        async for output in engine.stream_chat(
+            [{"role": "user", "content": "hi"}],
+            max_tokens=4,
+            temperature=0.0,
+            top_p=1.0,
+            _native_mtp_request_config=_request(),
+        )
+    ]
+
+    assert outputs[-1].finished is True
+    assert outputs[-1].mtp_drafts > 0
+    assert 0 <= outputs[-1].mtp_accepted <= outputs[-1].mtp_drafts
+    assert outputs[-1].mtp_bypass_reason is None
+    assert outputs[-1].logprobs is not None
+    _assert_requests_closed(requests)
+
+    # Hold the worker after its first real native response. Public GeneratorExit
+    # must propagate through stream_chat -> tracker -> text route and close the
+    # request before either active-request entry is released.
+    original_stream_generate = mlx_lm.stream_generate
+    release_worker = threading.Event()
+
+    def held_stream(
+        model,
+        tokenizer,
+        prompt,
+        *,
+        mtp=False,
+        mtp_sampling_config=None,
+        **kwargs,
+    ):
+        inner = original_stream_generate(
+            model,
+            tokenizer,
+            prompt,
+            mtp=mtp,
+            mtp_sampling_config=mtp_sampling_config,
+            **kwargs,
+        )
+        try:
+            yield next(inner)
+            release_worker.wait(timeout=5)
+            yield from inner
+        finally:
+            inner.close()
+
+    monkeypatch.setattr(mlx_lm, "stream_generate", held_stream)
+    stream = engine.stream_chat(
+        [{"role": "user", "content": "hi"}],
+        max_tokens=8,
+        temperature=0.0,
+        top_p=1.0,
+        _native_mtp_request_config=_request(),
+    )
+    await anext(stream)
+    assert requests[-1].closed is False
+    assert engine._active_requests
+    close_task = asyncio.create_task(stream.aclose())
+    await asyncio.sleep(0)
+    release_worker.set()
+    await close_task
+    _assert_requests_closed(requests)
+    assert engine._active_requests == {}
+    assert engine._num_running == 0

--- a/tests/test_simple_native_mtp_behavior.py
+++ b/tests/test_simple_native_mtp_behavior.py
@@ -280,7 +280,11 @@ def _prepare_native_sparse(monkeypatch, model, tokens, selected_indices):
 def _position_correct_sequential_oracle(
     monkeypatch, model, tokens, selected_indices, *, max_tokens
 ):
-    from mlx_lm.generate import GenerationForward, GenerationForwardPhase
+    from mlx_lm.generate import (
+        GenerationForward,
+        GenerationForwardPhase,
+        GenerationForwardPositionAck,
+    )
 
     result, forward_context, bootstrap = _prepare_native_sparse(
         monkeypatch, model, tokens, selected_indices
@@ -288,15 +292,16 @@ def _position_correct_sequential_oracle(
     assert bootstrap.try_abandon_unclaimed() is True
     generated = [mx.argmax(result.logits[:, -1, :], axis=-1).item()]
 
-    class Ack:
-        def acknowledge(self, positions):
-            self.positions = positions
-
     try:
         while len(generated) < max_tokens:
             position = len(tokens) + len(generated) - 1
             input_tokens = mx.array([[generated[-1]]], dtype=mx.uint32)
-            ack = Ack()
+            ack = GenerationForwardPositionAck(
+                (position,),
+                model=model,
+                cache=bootstrap.target_cache,
+                phase=GenerationForwardPhase.DECODE,
+            )
             forward = GenerationForward(
                 model=model,
                 input_tokens=input_tokens,
@@ -306,9 +311,13 @@ def _position_correct_sequential_oracle(
                 logical_position_ack=ack,
             )
             with forward_context(forward):
-                logits = model(input_tokens, cache=bootstrap.target_cache)
-                mx.eval(logits, [entry.state for entry in bootstrap.target_cache])
-            assert ack.positions == (position,)
+                ack._activate()
+                try:
+                    logits = model(input_tokens, cache=bootstrap.target_cache)
+                    ack._require_acknowledged()
+                    mx.eval(logits, [entry.state for entry in bootstrap.target_cache])
+                finally:
+                    ack._finish()
             generated.append(mx.argmax(logits[:, -1, :], axis=-1).item())
     finally:
         forward_context.finish()
@@ -664,11 +673,20 @@ async def test_public_simple_preclaim_failure_abandons_and_dense_falls_back(
     engine._loaded = True
     _configure_public_sparse_engine(monkeypatch, engine, model, tokens, selected)
     bootstraps = []
+    transfers = []
     original_prepare = engine._prepare_sparse_target_prefill
 
     def capture_prepare(**kwargs):
         prepared = original_prepare(**kwargs)
         bootstraps.append(prepared[-1])
+        forward_context = prepared[-3]
+        original_transfer = forward_context.transfer_to_native_mtp
+
+        def track_transfer():
+            transfers.append("before_native_iteration")
+            return original_transfer()
+
+        monkeypatch.setattr(forward_context, "transfer_to_native_mtp", track_transfer)
         return prepared
 
     monkeypatch.setattr(engine, "_prepare_sparse_target_prefill", capture_prepare)
@@ -677,6 +695,7 @@ async def test_public_simple_preclaim_failure_abandons_and_dense_falls_back(
     @wraps(original_stream)
     def fail_sparse_before_claim(**kwargs):
         if kwargs.get("sparse_bootstrap") is not None:
+            assert transfers == ["before_native_iteration"]
 
             def failed():
                 raise ValueError("invalid sparse processor config")
@@ -702,6 +721,7 @@ async def test_public_simple_preclaim_failure_abandons_and_dense_falls_back(
 
     assert outputs[-1].specprefill_effective_policy == "dense"
     assert outputs[-1].specprefill_fallback_reason == "sparse_execution_failed"
+    assert transfers == ["before_native_iteration"]
     assert bootstraps[0].try_abandon_unclaimed() is False
     _assert_requests_closed(requests)
 

--- a/tests/test_simple_native_mtp_behavior.py
+++ b/tests/test_simple_native_mtp_behavior.py
@@ -1015,3 +1015,299 @@ async def test_public_vlm_text_noncontiguous_sparse_native_mtp_matches_oracle(
     assert all(output.logprobs is not None for output in outputs)
     assert all(mx.all(mx.isfinite(output.logprobs)).item() for output in outputs)
     _assert_requests_closed(requests)
+
+
+# These are intentionally scheduler-level tests rather than direct adapter tests.
+# The adapter-only contract is covered in test_cb_native_mtp_adapter.py; this
+# slice proves that standard-text CB neither bypasses its public lifecycle nor
+# loses output accounting when it drives actual Qwen caches.
+def _cb_scheduler(model, tokenizer):
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    return Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(
+            enable_mtp=True,
+            enable_prefix_cache=False,
+            max_num_seqs=4,
+            prefill_step_size=2,
+        ),
+    )
+
+
+def _cb_request(request_id, prompt, *, max_tokens=2, seed=17):
+    from vllm_mlx.request import Request, SamplingParams
+
+    request = Request(
+        request_id=request_id,
+        prompt=list(prompt),
+        sampling_params=SamplingParams(max_tokens=max_tokens, temperature=0.0),
+    )
+    request.native_mtp_config = _request(seed=seed)
+    return request
+
+
+def _run_scheduler_to_terminal(scheduler):
+    outputs = []
+    # Every native-MTP epoch is one scheduler step.  A small fixed guard makes
+    # a broken public lifecycle visible instead of masking it with an endless
+    # test loop.
+    for _ in range(32):
+        result = scheduler.step()
+        outputs.extend(result.outputs)
+        if not scheduler.has_requests():
+            return outputs
+    raise AssertionError("native MTP scheduler did not reach a terminal state")
+
+
+def _live_native_cohort(scheduler):
+    """Return the adapter's sole live owner after source-cache consumption."""
+    adapter = scheduler.native_mtp_adapter
+    assert adapter is not None
+    generator = adapter._generator
+    assert generator is not None
+    cohort = generator._cohort
+    assert adapter.closed is False
+    assert generator.closed is False
+    assert cohort.poisoned is False
+    assert cohort._checkpoint is None
+    return adapter, generator, cohort
+
+
+def _direct_native_b1_oracle(model, prompt, *, max_tokens, seed):
+    """Collect the two observable boundaries from upstream's public API."""
+    from mlx_lm.generate import (
+        NativeMTPAdmission,
+        NativeMTPBatchGenerator,
+        NativeMTPRowSpec,
+        NativeMTPSamplingConfig,
+    )
+
+    row = NativeMTPRowSpec(
+        uid=1,
+        prompt=tuple(prompt),
+        max_tokens=max_tokens,
+        seed=seed,
+        eos_token_ids=frozenset(),
+        sampling_config=NativeMTPSamplingConfig(temperature=0.0),
+    )
+    cache = model.make_mtp_request_cache(prompt_cache=None)
+    generator = NativeMTPBatchGenerator(
+        NativeMTPAdmission.create(model, (row,), (cache,))
+    )
+    initial, epoch = generator.prefill(prefill_step_size=2)
+    ready = epoch.resume()
+    decision = ready.decide()
+    if decision.accepted_uids:
+        emitted, terminal_epoch = decision.accept()
+    else:
+        emitted, terminal_epoch = decision.reject()
+    # max_tokens=2 means this epoch cannot own a surviving row.  Still consume
+    # its public cancellation to prove that the direct oracle leaves no cache.
+    terminal_epoch.cancel()
+    return tuple(initial) + tuple(emitted), cache
+
+
+def _force_cb_second_token(monkeypatch, model, wanted_by_batch_row, *, prompt_tokens):
+    """Force the first post-head MTP draft without changing target logits."""
+    original = model.mtp_forward
+
+    def controlled(hidden_states, next_token_ids, mtp_cache):
+        logits = original(hidden_states, next_token_ids, mtp_cache)
+        # Prompt-pair MTP prefill can have any width.  The first width-one MTP
+        # call after it is the public Initial -> Ready draft boundary.  The
+        # cohort may split and join its cache owner while pre-filling, so use
+        # the actual MTP cursor rather than Python object identity or calls.
+        width = int(next_token_ids.shape[1])
+        offset = mtp_cache[0].offset
+        cursor = int(mx.min(offset).item()) if isinstance(offset, mx.array) else offset
+        if width != 1 or cursor < prompt_tokens:
+            return logits
+        values = [wanted_by_batch_row[index] for index in range(logits.shape[0])]
+        forced = mx.full(logits.shape, -100.0, dtype=logits.dtype)
+        for index, token in enumerate(values):
+            forced[index, -1, token] = 100.0
+        return forced
+
+    monkeypatch.setattr(model, "mtp_forward", controlled)
+
+
+@pytest.mark.parametrize("moe", (False, True), ids=("dense", "recurrent_kv_moe"))
+@pytest.mark.parametrize("accept", (False, True), ids=("all_reject", "all_accept"))
+def test_actual_qwen_standard_cb_b1_forced_decision_matches_public_oracle(
+    monkeypatch, moe, accept
+):
+    model = _native_model(moe=moe).language_model
+    requests = _track_requests(monkeypatch, model)
+    prompt = (3, 5, 7, 11)
+    wrapper = _language_model(model, _tokenizer(tokens=prompt))
+    dense = _tokens(
+        list(wrapper.stream_generate(list(prompt), max_tokens=2, temperature=0.0))
+    )
+    wanted = (
+        dense[1]
+        if accept
+        else (dense[1] + 1) % _config(moe=moe)["text_config"]["vocab_size"]
+    )
+    _force_cb_second_token(monkeypatch, model, (wanted,), prompt_tokens=len(prompt))
+
+    oracle, oracle_cache = _direct_native_b1_oracle(
+        model, prompt, max_tokens=2, seed=17
+    )
+    scheduler = _cb_scheduler(model, _tokenizer(tokens=prompt))
+    request = _cb_request("b1", prompt, max_tokens=2, seed=17)
+    scheduler.add_request(request)
+    outputs = _run_scheduler_to_terminal(scheduler)
+
+    assert [token for output in outputs for token in output.new_token_ids] == [
+        item.token for item in oracle
+    ]
+    assert [output.logprobs is not None for output in outputs] == [True, True]
+    assert outputs[-1].finish_reason == "length"
+    assert outputs[-1].completion_tokens == 2
+    assert (outputs[-1].mtp_drafts, outputs[-1].mtp_accepted) == (1, int(accept))
+    assert scheduler.total_prompt_tokens == len(prompt)
+    assert scheduler.total_completion_tokens == 2
+    assert scheduler.num_requests_processed == 1
+    assert oracle_cache.closed is True
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.parametrize("moe", (False, True), ids=("dense", "recurrent_kv_moe"))
+def test_actual_qwen_standard_cb_batched_mixed_decision_is_uid_local(monkeypatch, moe):
+    model = _native_model(moe=moe).language_model
+    requests = _track_requests(monkeypatch, model)
+    prompts = ((2, 3, 5, 7), (11, 13, 17, 19))
+    wrapper = _language_model(model)
+    dense = [
+        _tokens(
+            list(wrapper.stream_generate(list(prompt), max_tokens=2, temperature=0.0))
+        )
+        for prompt in prompts
+    ]
+    vocab = _config(moe=moe)["text_config"]["vocab_size"]
+    wanted = (dense[0][1], (dense[1][1] + 1) % vocab)
+    # Build independent B=1 public-lifecycle oracles under exactly the same
+    # forced decision.  This is the regression guard for UID-local state: a
+    # batched mixed cohort must not borrow its neighbour's outcome or cache.
+    expected = {}
+    oracle_caches = []
+    for uid, (prompt, token) in enumerate(zip(prompts, wanted), start=1):
+        with monkeypatch.context() as direct_patch:
+            _force_cb_second_token(
+                direct_patch, model, (token,), prompt_tokens=len(prompt)
+            )
+            expected[uid], cache = _direct_native_b1_oracle(
+                model, prompt, max_tokens=2, seed=(19, 23)[uid - 1]
+            )
+            oracle_caches.append(cache)
+    _force_cb_second_token(
+        monkeypatch,
+        model,
+        wanted,
+        prompt_tokens=len(prompts[0]),
+    )
+
+    scheduler = _cb_scheduler(model, _tokenizer())
+    first = _cb_request("accepted", prompts[0], max_tokens=2, seed=19)
+    second = _cb_request("rejected", prompts[1], max_tokens=2, seed=23)
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+    outputs = _run_scheduler_to_terminal(scheduler)
+    by_request = {}
+    for output in outputs:
+        by_request.setdefault(output.request_id, []).extend(output.new_token_ids)
+
+    assert set(by_request) == {"accepted", "rejected"}
+    assert all(len(tokens) == 2 for tokens in by_request.values())
+    assert by_request["accepted"] == [item.token for item in expected[1]]
+    assert by_request["rejected"] == [item.token for item in expected[2]]
+    assert all(output.logprobs is not None for output in outputs)
+    final = {output.request_id: output for output in outputs if output.finished}
+    assert {key: value.finish_reason for key, value in final.items()} == {
+        "accepted": "length",
+        "rejected": "length",
+    }
+    assert final["accepted"].mtp_accepted == 1
+    assert final["rejected"].mtp_accepted == 0
+    assert final["accepted"].mtp_drafts == final["rejected"].mtp_drafts == 1
+    assert scheduler.total_prompt_tokens == sum(map(len, prompts))
+    assert scheduler.total_completion_tokens == 4
+    assert scheduler.num_requests_processed == 2
+    assert all(cache.closed is True for cache in oracle_caches)
+    _assert_requests_closed(requests)
+
+
+@pytest.mark.parametrize("moe", (False, True), ids=("dense", "recurrent_kv_moe"))
+def test_actual_qwen_standard_cb_cancellation_and_error_close_request_caches(
+    monkeypatch, moe
+):
+    model = _native_model(moe=moe).language_model
+    prompt = (3, 5, 7, 11)
+
+    # A queued cancellation must not create a fresh native request cache.
+    before = _track_requests(monkeypatch, model)
+    scheduler = _cb_scheduler(model, _tokenizer())
+    queued = _cb_request("queued", prompt)
+    scheduler.add_request(queued)
+    scheduler.abort_request("queued")
+    queued_abort = scheduler.step()
+    assert queued_abort.outputs == []
+    assert queued_abort.finished_request_ids == set()
+    assert scheduler.has_requests() is False
+    assert before == []
+
+    # Once initial prefill owns the cache, cancellation is cohort-scoped and
+    # produces one abort output while closing the request-local owner.
+    after = _track_requests(monkeypatch, model)
+    scheduler = _cb_scheduler(model, _tokenizer())
+    active = _cb_request("active", prompt)
+    scheduler.add_request(active)
+    first = scheduler.step()
+    assert first.outputs
+    # Admission transfers B=1 source ownership into a merged cohort, closing
+    # the source wrappers before the first public emission is returned.
+    _assert_requests_closed(after)
+    adapter, generator, cohort = _live_native_cohort(scheduler)
+    scheduler.abort_request("active")
+    cancelled = scheduler.step()
+    assert [
+        (item.request_id, item.finished, item.finish_reason, item.completion_tokens)
+        for item in cancelled.outputs
+    ] == [("active", True, "abort", 1)]
+    assert cancelled.finished_request_ids == {"active"}
+    assert scheduler.has_requests() is False
+    assert scheduler.running == {}
+    assert scheduler.request_id_to_uid == scheduler.uid_to_request_id == {}
+    assert adapter.closed is True
+    assert generator.closed is True
+    assert cohort.poisoned is True
+    assert cohort._checkpoint is None
+
+    # A lifecycle error after initial prefill must turn into a terminal error,
+    # not an ordinary BatchGenerator fallback or a leaked cache owner.
+    failed = _track_requests(monkeypatch, model)
+    scheduler = _cb_scheduler(model, _tokenizer())
+    request = _cb_request("failed", prompt)
+    scheduler.add_request(request)
+    scheduler.step()
+    _assert_requests_closed(failed)
+    adapter, generator, cohort = _live_native_cohort(scheduler)
+    monkeypatch.setattr(
+        model,
+        "mtp_forward",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("forced_mtp_failure")
+        ),
+    )
+    error = scheduler.step()
+    assert [
+        (item.request_id, item.finish_reason, item.native_mtp_error_reason)
+        for item in error.outputs
+    ] == [("failed", "error", "forced_mtp_failure")]
+    assert scheduler.batch_generator is None
+    assert adapter.closed is True
+    assert generator.closed is True
+    assert cohort.poisoned is True
+    assert cohort._checkpoint is None

--- a/tests/test_specprefill_cache_state.py
+++ b/tests/test_specprefill_cache_state.py
@@ -52,6 +52,17 @@ def _state(*, rows: int = 2) -> SparseCacheState:
     )
 
 
+def test_sparse_cache_tuning_requires_boundary_anchors():
+    with pytest.raises(SparseCacheStateError, match="anchor_chunks must be positive"):
+        SparsePolicyTuning(
+            keep_pct=0.7,
+            backbone_pct=0.1,
+            halo_chunks=1,
+            anchor_chunks=0,
+            chunk_size=32,
+        )
+
+
 def test_identity_includes_artifacts_policy_full_prompt_and_selection():
     base = _identity()
     assert base.full_token_hash == SparseCacheIdentity.hash_tokens((10, 11, 12, 13))

--- a/tests/test_specprefill_cache_state.py
+++ b/tests/test_specprefill_cache_state.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python invariants for request-local SpecPrefill cache state."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from vllm_mlx.specprefill_cache import (
+    ExactSparseCacheStore,
+    SparseCacheIdentity,
+    SparseCacheRowState,
+    SparseCacheState,
+    SparseCacheStateError,
+    SparseCacheTransformUnsupported,
+    SparsePolicyTuning,
+)
+
+
+def _identity(
+    tokens: tuple[int, ...] = (10, 11, 12, 13),
+    *,
+    selection_fingerprint: str = "a" * 64,
+) -> SparseCacheIdentity:
+    return SparseCacheIdentity.from_tokens(
+        target_id="gemma-4-31b-bf16@sha256:target",
+        tokenizer_id="gemma-tokenizer@sha256:tokenizer",
+        scorer_id="gemma-4-e2b@sha256:scorer",
+        selector_version="hybrid-chunk-v1",
+        tuning=SparsePolicyTuning(
+            keep_pct=0.7,
+            backbone_pct=0.1,
+            halo_chunks=1,
+            anchor_chunks=1,
+            chunk_size=32,
+        ),
+        tokens=tokens,
+        selection_fingerprint=selection_fingerprint,
+    )
+
+
+def _state(*, rows: int = 2) -> SparseCacheState:
+    identities = (
+        _identity(selection_fingerprint="a" * 64),
+        _identity(selection_fingerprint="b" * 64),
+    )[:rows]
+    return SparseCacheState.from_selection(
+        identities,
+        selected_logical_positions=((0, 2, 3), (0, 1, 3))[:rows],
+        next_logical_positions=(4, 4)[:rows],
+    )
+
+
+def test_identity_includes_artifacts_policy_full_prompt_and_selection():
+    base = _identity()
+    assert base.full_token_hash == SparseCacheIdentity.hash_tokens((10, 11, 12, 13))
+    assert base != _identity(tokens=(10, 11, 12, 14))
+    assert base != _identity(selection_fingerprint="b" * 64)
+    assert base != SparseCacheIdentity.from_tokens(
+        target_id="gemma-4-31b-bf16@sha256:target",
+        tokenizer_id="gemma-tokenizer@sha256:tokenizer",
+        scorer_id="other-scorer@sha256:scorer",
+        selector_version="hybrid-chunk-v1",
+        tuning=base.tuning,
+        tokens=(10, 11, 12, 13),
+        selection_fingerprint="a" * 64,
+    )
+
+
+def test_state_tracks_per_row_logical_positions_separately_from_physical_lengths():
+    state = _state()
+    assert state.physical_valid_lengths == (3, 3)
+    assert state.logical_positions == ((0, 2, 3), (0, 1, 3))
+    assert state.next_logical_positions == (4, 4)
+
+    advanced = state.append_decode((2, 1))
+    assert advanced.physical_valid_lengths == (5, 4)
+    assert advanced.logical_positions == ((0, 2, 3, 4, 5), (0, 1, 3, 4))
+    assert advanced.next_logical_positions == (6, 5)
+    assert state.physical_valid_lengths == (3, 3)
+
+
+def test_filter_clone_and_extend_are_immutable_and_atomic():
+    state = _state()
+    clone = state.clone()
+    assert clone == state
+    assert clone is not state
+
+    filtered = state.filter((1,))
+    assert filtered.logical_positions == ((0, 1, 3),)
+    assert state.row_count == 2
+
+    extended = filtered.extend(filtered)
+    assert extended.row_count == 2
+    assert extended.logical_positions == ((0, 1, 3), (0, 1, 3))
+
+    with pytest.raises(SparseCacheStateError, match="unique"):
+        state.filter((0, 0))
+    with pytest.raises(SparseCacheStateError, match="outside"):
+        state.filter((2,))
+    incompatible = SparseCacheIdentity.from_tokens(
+        target_id="other-target@sha256:target",
+        tokenizer_id="gemma-tokenizer@sha256:tokenizer",
+        scorer_id="gemma-4-e2b@sha256:scorer",
+        selector_version="hybrid-chunk-v1",
+        tuning=_identity().tuning,
+        tokens=(1, 2, 3),
+        selection_fingerprint="a" * 64,
+    )
+    with pytest.raises(SparseCacheStateError, match="execution config"):
+        state.extend(SparseCacheState.from_selection(incompatible, ((0, 1),), (2,)))
+    incompatible_row = SparseCacheState.from_selection(
+        incompatible, ((0, 1),), (2,)
+    ).rows[0]
+    with pytest.raises(SparseCacheStateError, match="execution config"):
+        SparseCacheState(rows=(state.rows[0], incompatible_row))
+    assert state.row_count == 2
+
+
+def test_compatible_mixed_prompt_rows_extend_and_filter_without_identity_loss():
+    left = SparseCacheState.from_selection(
+        _identity(tokens=(10, 11, 12, 13), selection_fingerprint="a" * 64),
+        ((0, 2, 3),),
+        (4,),
+    )
+    right = SparseCacheState.from_selection(
+        _identity(tokens=(20, 21, 22, 23, 24, 25), selection_fingerprint="b" * 64),
+        ((0, 1, 4, 5),),
+        (6,),
+    )
+    batch = left.extend(right)
+    assert batch.row_count == 2
+    assert batch.identities == (left.rows[0].identity, right.rows[0].identity)
+    assert batch.physical_valid_lengths == (3, 4)
+
+    filtered = batch.filter((1,))
+    assert filtered.identities == (right.rows[0].identity,)
+    assert filtered.logical_positions == ((0, 1, 4, 5),)
+
+
+def test_rollback_requires_contiguous_decode_suffix_and_is_atomic():
+    advanced = _state().append_decode((2, 1))
+    restored = advanced.rollback((2, 1))
+    assert restored == _state()
+    with pytest.raises(SparseCacheStateError, match="one value per row"):
+        advanced.rollback((1,))
+    assert advanced.physical_valid_lengths == (5, 4)
+
+    with pytest.raises(SparseCacheStateError, match="contiguous decode suffix"):
+        SparseCacheRowState(
+            identity=_identity(),
+            logical_positions=(0, 2, 3),
+            physical_valid_length=3,
+            next_logical_position=5,
+            prefill_physical_length=2,
+        )
+
+    sparse_only = _state(rows=1)
+    with pytest.raises(SparseCacheStateError, match="prefill boundary"):
+        sparse_only.rollback(1)
+    assert sparse_only.logical_positions == ((0, 2, 3),)
+
+    corrupt = SparseCacheState(
+        rows=(
+            SparseCacheRowState(
+                identity=_identity(),
+                logical_positions=(0, 2, 3),
+                physical_valid_length=3,
+                next_logical_position=4,
+                prefill_physical_length=3,
+            ),
+        ),
+    )
+    assert corrupt.rollback(0) == corrupt
+
+
+def test_trim_requires_explicit_cursor_when_sparse_suffix_makes_it_ambiguous():
+    sparse_only = _state(rows=1)
+    with pytest.raises(SparseCacheStateError, match="prefill boundary"):
+        sparse_only.trim(1)
+
+    decoded = sparse_only.append_decode(2)
+    trimmed = decoded.trim(1)
+    assert trimmed.logical_positions == ((0, 2, 3, 4),)
+    assert trimmed.physical_valid_lengths == (4,)
+    assert trimmed.next_logical_positions == (5,)
+
+
+def test_state_rejects_partial_or_mismatched_row_metadata():
+    with pytest.raises(SparseCacheStateError, match="does not match"):
+        SparseCacheRowState(
+            identity=_identity(),
+            logical_positions=(0, 1),
+            physical_valid_length=1,
+            next_logical_position=2,
+            prefill_physical_length=1,
+        )
+    with pytest.raises(SparseCacheStateError, match="one value per row"):
+        SparseCacheState.from_selection(_identity(), ((0, 1),), (2, 3))
+    with pytest.raises(SparseCacheStateError, match="strictly increasing"):
+        SparseCacheState.from_selection(_identity(), ((0, 2, 2),), (3,))
+
+
+def test_exact_store_rejects_lcp_supersequence_and_different_selection_hits():
+    store: ExactSparseCacheStore[str] = ExactSparseCacheStore()
+    state = _state(rows=1)
+    store.store(state, "opaque-cache-payload", clone_payload=lambda payload: payload)
+    hit = store.lookup(state.rows[0].identity)
+    assert hit is not None
+    assert hit.payload == "opaque-cache-payload"
+    assert hit.state == state
+    assert hit.state is not state
+    assert store.lookup(_identity(tokens=(10, 11, 12))) is None
+    assert store.lookup(_identity(tokens=(10, 11, 12, 13, 14))) is None
+    assert store.lookup(_identity(selection_fingerprint="b" * 64)) is None
+    with pytest.raises(SparseCacheStateError, match="exactly one request row"):
+        store.store(_state(rows=2), "must-not-be-shared", clone_payload=lambda p: p)
+
+    mutable_store: ExactSparseCacheStore[list[str]] = ExactSparseCacheStore()
+    mutable_store.store(state, ["request-local"], clone_payload=list)
+    first_hit = mutable_store.lookup(state.rows[0].identity)
+    assert first_hit is not None
+    first_hit.payload.append("mutated")
+    second_hit = mutable_store.lookup(state.rows[0].identity)
+    assert second_hit is not None
+    assert second_hit.payload == ["request-local"]
+
+
+def test_exact_store_clones_payload_outside_its_lock():
+    store: ExactSparseCacheStore[list[str]] = ExactSparseCacheStore()
+    state = _state(rows=1)
+    clone_completed = threading.Event()
+
+    def clone_payload(payload: list[str]) -> list[str]:
+        worker = threading.Thread(
+            target=lambda: (
+                store.discard(state.rows[0].identity),
+                clone_completed.set(),
+            )
+        )
+        worker.start()
+        try:
+            assert clone_completed.wait(
+                timeout=1
+            ), "payload clone ran while store lock was held"
+        finally:
+            worker.join(timeout=1)
+        return list(payload)
+
+    store.store(state, ["payload"], clone_payload=clone_payload)
+    assert store.lookup(state.rows[0].identity) is not None
+
+
+def test_quantized_and_ssd_transforms_fail_closed_until_atomic_serializers_exist():
+    state = _state(rows=1)
+    for method in (state.for_quantized_storage, state.for_ssd_storage):
+        with pytest.raises(SparseCacheTransformUnsupported, match="not supported"):
+            method()

--- a/tests/test_specprefill_gemma_cache.py
+++ b/tests/test_specprefill_gemma_cache.py
@@ -17,6 +17,7 @@ from vllm_mlx.specprefill_gemma_cache import (
     GEMMA4_E2B,
     GemmaArtifactSpec,
     GemmaCacheCheckpoint,
+    GemmaCacheBackend,
     GemmaCacheError,
     GemmaCacheTopologyError,
     GemmaCacheTransactionError,
@@ -127,16 +128,28 @@ def _append(cache, values, *, rows=1):
     return result
 
 
-def _artifact_cache(spec, *, batch=False):
+def _artifact_cache(spec, *, batch=False, backend=GemmaCacheBackend.MLX_VLM):
     entries = []
     for layer_type in spec.layer_types[: spec.owner_count]:
         if layer_type == "full_attention":
-            entries.append(BatchKVCache([0]) if batch else KVCache())
+            entries.append(
+                BatchKVCache([0])
+                if batch
+                else (
+                    MlxLmKVCache()
+                    if backend is GemmaCacheBackend.MLX_LM
+                    else KVCache()
+                )
+            )
         else:
             entries.append(
                 BatchRotatingKVCache(spec.sliding_window, [0])
                 if batch
-                else RotatingKVCache(spec.sliding_window, keep=0)
+                else (
+                    MlxLmRotatingKVCache(spec.sliding_window, keep=0)
+                    if backend is GemmaCacheBackend.MLX_LM
+                    else RotatingKVCache(spec.sliding_window, keep=0)
+                )
             )
     return entries
 
@@ -158,18 +171,33 @@ def test_certified_artifact_topologies_are_exact(config):
     assert len(config["config_sha256"]) == 64
 
 
-def test_mlx_lm_cache_classes_are_rejected_even_when_shape_compatible():
-    cache = _artifact_cache(GEMMA4_E2B)
-    cache[0] = MlxLmRotatingKVCache(512, keep=0)
-    with pytest.raises(GemmaCacheTopologyError, match="rotating KV cache"):
+def test_explicit_backends_accept_exact_types_and_reject_crossed_pairs():
+    lm_cache = _artifact_cache(GEMMA4_E2B, backend=GemmaCacheBackend.MLX_LM)
+    validate_gemma_cache_topology(
+        GEMMA4_E2B,
+        layer_types=GEMMA4_E2B.layer_types,
+        previous_kvs=GEMMA4_E2B.previous_kvs,
+        cache=lm_cache,
+        backend=GemmaCacheBackend.MLX_LM,
+    )
+    with pytest.raises(GemmaCacheTopologyError, match="does not match"):
         validate_gemma_cache_topology(
             GEMMA4_E2B,
             layer_types=GEMMA4_E2B.layer_types,
             previous_kvs=GEMMA4_E2B.previous_kvs,
-            cache=cache,
+            cache=lm_cache,
+            backend=GemmaCacheBackend.MLX_VLM,
         )
-    with pytest.raises(GemmaCacheError, match="unsupported scalar"):
-        scalar_cache_cursor(MlxLmKVCache(), logical_position=0)
+    crossed = list(lm_cache)
+    crossed[0] = RotatingKVCache(512, keep=0)
+    with pytest.raises(GemmaCacheError, match="cross"):
+        validate_gemma_cache_topology(
+            GEMMA4_E2B,
+            layer_types=GEMMA4_E2B.layer_types,
+            previous_kvs=GEMMA4_E2B.previous_kvs,
+            cache=crossed,
+            backend=GemmaCacheBackend.MLX_LM,
+        )
 
 
 def test_e2b_followers_use_last_owner_of_matching_type():

--- a/tests/test_specprefill_gemma_cache.py
+++ b/tests/test_specprefill_gemma_cache.py
@@ -34,7 +34,6 @@ from vllm_mlx.specprefill_gemma_cache import (
     validate_homogeneous_batch_lane,
 )
 
-
 # Minimal snapshots of the installed config.json text_config sections.  The
 # hashes identify the complete source configs without making tests depend on a
 # workstation path.  No model weights are represented or loaded here.
@@ -45,8 +44,7 @@ _CONFIG_SNAPSHOTS = (
         "num_hidden_layers": 35,
         "num_kv_shared_layers": 20,
         "sliding_window": 512,
-        "layer_types": tuple(
-            """
+        "layer_types": tuple("""
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
@@ -54,8 +52,7 @@ _CONFIG_SNAPSHOTS = (
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention full_attention
-            """.split()
-        ),
+            """.split()),
     },
     {
         "artifact_id": "gemma4-31b",
@@ -63,8 +60,7 @@ _CONFIG_SNAPSHOTS = (
         "num_hidden_layers": 60,
         "num_kv_shared_layers": 0,
         "sliding_window": 1024,
-        "layer_types": tuple(
-            """
+        "layer_types": tuple("""
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
@@ -75,8 +71,7 @@ _CONFIG_SNAPSHOTS = (
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
-            """.split()
-        ),
+            """.split()),
     },
     {
         "artifact_id": "gemma4-26b-a4b",
@@ -84,15 +79,13 @@ _CONFIG_SNAPSHOTS = (
         "num_hidden_layers": 30,
         "num_kv_shared_layers": 0,
         "sliding_window": 1024,
-        "layer_types": tuple(
-            """
+        "layer_types": tuple("""
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
             sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
-            """.split()
-        ),
+            """.split()),
     },
 )
 
@@ -136,9 +129,7 @@ def _artifact_cache(spec, *, batch=False, backend=GemmaCacheBackend.MLX_VLM):
                 BatchKVCache([0])
                 if batch
                 else (
-                    MlxLmKVCache()
-                    if backend is GemmaCacheBackend.MLX_LM
-                    else KVCache()
+                    MlxLmKVCache() if backend is GemmaCacheBackend.MLX_LM else KVCache()
                 )
             )
         else:
@@ -519,9 +510,7 @@ def test_atomic_filter_keeps_selected_rows_and_rolls_back_mid_failure(monkeypatc
     rotating = BatchRotatingKVCache(4, [0, 0])
     _append(full, [1], rows=2)
     _append(rotating, [1], rows=2)
-    selected = atomic_batch_filter(
-        [full, rotating], [1], logical_positions=[4, 4]
-    )
+    selected = atomic_batch_filter([full, rotating], [1], logical_positions=[4, 4])
     assert selected == (4,)
     assert full.keys.shape[0] == rotating.keys.shape[0] == 1
 

--- a/tests/test_specprefill_gemma_cache.py
+++ b/tests/test_specprefill_gemma_cache.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import KVCache as MlxLmKVCache
+from mlx_lm.models.cache import RotatingKVCache as MlxLmRotatingKVCache
+from mlx_vlm.models.cache import (
+    BatchKVCache,
+    BatchRotatingKVCache,
+    KVCache,
+    RotatingKVCache,
+)
+
+import vllm_mlx.specprefill_gemma_cache as gemma_cache
+
+from vllm_mlx.specprefill_gemma_cache import (
+    GEMMA4_E2B,
+    GemmaArtifactSpec,
+    GemmaCacheCheckpoint,
+    GemmaCacheError,
+    GemmaCacheTopologyError,
+    GemmaCacheTransactionError,
+    GemmaOneTokenTransaction,
+    atomic_batch_extend,
+    atomic_batch_filter,
+    batch_cache_cursor,
+    normalize_batch_rotating,
+    normalize_scalar_rotating,
+    run_atomic_one_token,
+    scalar_cache_cursor,
+    validate_gemma_cache_topology,
+    validate_aligned_scalar_cache,
+    validate_homogeneous_batch_lane,
+)
+
+
+# Minimal snapshots of the installed config.json text_config sections.  The
+# hashes identify the complete source configs without making tests depend on a
+# workstation path.  No model weights are represented or loaded here.
+_CONFIG_SNAPSHOTS = (
+    {
+        "artifact_id": "gemma4-e2b",
+        "config_sha256": "1b28f3d2c3100f6c594754b81107428bd7b822a7f48272ca681dae9d2ec38330",
+        "num_hidden_layers": 35,
+        "num_kv_shared_layers": 20,
+        "sliding_window": 512,
+        "layer_types": tuple(
+            """
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            """.split()
+        ),
+    },
+    {
+        "artifact_id": "gemma4-31b",
+        "config_sha256": "c58b3d20b54d0ed7e5650c2d6c7d13f0f7bdbc190a0fe428b18bfb2a8d182eb4",
+        "num_hidden_layers": 60,
+        "num_kv_shared_layers": 0,
+        "sliding_window": 1024,
+        "layer_types": tuple(
+            """
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            """.split()
+        ),
+    },
+    {
+        "artifact_id": "gemma4-26b-a4b",
+        "config_sha256": "431b1c1364c7f043612717de5de557069d23d8ee06a532b887224251043ec495",
+        "num_hidden_layers": 30,
+        "num_kv_shared_layers": 0,
+        "sliding_window": 1024,
+        "layer_types": tuple(
+            """
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            sliding_attention sliding_attention sliding_attention sliding_attention sliding_attention full_attention
+            """.split()
+        ),
+    },
+)
+
+
+def _spec_from_snapshot(config):
+    layer_types = tuple(config["layer_types"])
+    owner_count = config["num_hidden_layers"] - config["num_kv_shared_layers"]
+    previous = list(range(len(layer_types)))
+    latest = {}
+    for layer, layer_type in enumerate(layer_types):
+        if layer < owner_count:
+            latest[layer_type] = layer
+        else:
+            previous[layer] = latest[layer_type]
+    return GemmaArtifactSpec(
+        artifact_id=config["artifact_id"],
+        layer_types=layer_types,
+        previous_kvs=tuple(previous),
+        owner_count=owner_count,
+        sliding_window=config["sliding_window"],
+    )
+
+
+def _token(values, *, rows=1):
+    data = mx.array(list(values), dtype=mx.float32).reshape(1, 1, -1, 1)
+    return mx.broadcast_to(data, (rows, 1, data.shape[2], 1))
+
+
+def _append(cache, values, *, rows=1):
+    token = _token(values, rows=rows)
+    result = cache.update_and_fetch(token, token + 100)
+    mx.eval(*result)
+    return result
+
+
+def _artifact_cache(spec, *, batch=False):
+    entries = []
+    for layer_type in spec.layer_types[: spec.owner_count]:
+        if layer_type == "full_attention":
+            entries.append(BatchKVCache([0]) if batch else KVCache())
+        else:
+            entries.append(
+                BatchRotatingKVCache(spec.sliding_window, [0])
+                if batch
+                else RotatingKVCache(spec.sliding_window, keep=0)
+            )
+    return entries
+
+
+@pytest.mark.parametrize(
+    "config", _CONFIG_SNAPSHOTS, ids=lambda config: config["artifact_id"]
+)
+def test_certified_artifact_topologies_are_exact(config):
+    spec = _spec_from_snapshot(config)
+    topology = validate_gemma_cache_topology(
+        spec,
+        layer_types=spec.layer_types,
+        previous_kvs=spec.previous_kvs,
+        cache=_artifact_cache(spec),
+    )
+    assert len(topology.layer_to_slot) == config["num_hidden_layers"]
+    assert topology.owner_layers == tuple(range(spec.owner_count))
+    assert topology.sliding_window == config["sliding_window"]
+    assert len(config["config_sha256"]) == 64
+
+
+def test_mlx_lm_cache_classes_are_rejected_even_when_shape_compatible():
+    cache = _artifact_cache(GEMMA4_E2B)
+    cache[0] = MlxLmRotatingKVCache(512, keep=0)
+    with pytest.raises(GemmaCacheTopologyError, match="rotating KV cache"):
+        validate_gemma_cache_topology(
+            GEMMA4_E2B,
+            layer_types=GEMMA4_E2B.layer_types,
+            previous_kvs=GEMMA4_E2B.previous_kvs,
+            cache=cache,
+        )
+    with pytest.raises(GemmaCacheError, match="unsupported scalar"):
+        scalar_cache_cursor(MlxLmKVCache(), logical_position=0)
+
+
+def test_e2b_followers_use_last_owner_of_matching_type():
+    assert GEMMA4_E2B.previous_kvs[:15] == tuple(range(15))
+    assert set(GEMMA4_E2B.previous_kvs[15:]) == {13, 14}
+    for layer, owner in enumerate(GEMMA4_E2B.previous_kvs):
+        assert GEMMA4_E2B.layer_types[layer] == GEMMA4_E2B.layer_types[owner]
+
+
+@pytest.mark.parametrize("corruption", ["type", "owner", "window", "count"])
+def test_topology_validation_fails_closed(corruption):
+    spec = GEMMA4_E2B
+    layer_types = list(spec.layer_types)
+    previous = list(spec.previous_kvs)
+    cache = _artifact_cache(spec)
+    if corruption == "type":
+        cache[0] = KVCache()
+    elif corruption == "owner":
+        previous[16] = 14
+    elif corruption == "window":
+        cache[0].max_size = 1024
+    else:
+        cache.pop()
+    with pytest.raises(GemmaCacheTopologyError):
+        validate_gemma_cache_topology(
+            spec, layer_types=layer_types, previous_kvs=previous, cache=cache
+        )
+
+
+def test_scalar_cursors_separate_total_resident_circular_and_logical():
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, range(6))
+    normalize_scalar_rotating(cache)
+    cursor = scalar_cache_cursor(cache, logical_position=19)
+    assert cursor.total_writes == 6
+    assert cursor.resident_tokens == 4
+    assert cursor.circular_index == 4
+    assert cursor.logical_position == 19
+
+
+@pytest.mark.parametrize("length", [3, 4, 5])
+def test_rotating_boundaries_and_next_decode_preserve_total_offset(length):
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, range(length))
+    normalize_scalar_rotating(cache)
+    before = cache.offset
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[20])
+    _append(cache, [99])
+    transaction.commit(logical_positions=[21])
+    assert cache.offset == before + 1
+    assert cache.keys.shape[2] == min(before + 1, 4)
+    assert cache._idx <= 4
+
+
+@pytest.mark.parametrize("initial", [1, 4])
+def test_decode_commit_keeps_cache_allocation_and_never_copies_full_window(
+    initial, monkeypatch
+):
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, range(initial))
+    normalize_scalar_rotating(cache)
+    keys = cache.keys
+    copied_lengths = []
+    original = mx.contiguous
+
+    def track(array, *args, **kwargs):
+        copied_lengths.append(array.shape[2])
+        return original(array, *args, **kwargs)
+
+    monkeypatch.setattr(gemma_cache.mx, "contiguous", track)
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[initial])
+    _append(cache, [9])
+    transaction.commit(logical_positions=[initial + 1])
+    assert cache.keys is keys
+    assert 4 not in copied_lengths
+    assert copied_lengths in ([], [1, 1])
+
+
+def test_multi_token_concat_normalizes_to_latest_window_without_clamping_writes():
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, [0, 1, 2])
+    _append(cache, [3, 4, 5])
+    assert cache.keys.shape[2] == 6
+    normalize_scalar_rotating(cache)
+    assert cache.offset == 6
+    assert cache._idx == 4
+    assert cache.keys.reshape(-1).tolist() == [2, 3, 4, 5]
+
+
+def test_batch_multi_token_concat_normalizes_without_clamping_any_cursor():
+    cache = BatchRotatingKVCache(4, [0, 0])
+    _append(cache, [0, 1, 2], rows=2)
+    _append(cache, [3, 4, 5], rows=2)
+    offsets = cache.offset
+    normalize_batch_rotating(cache)
+    cursor = batch_cache_cursor(cache, logical_positions=[10, 10])
+    assert cursor.total_writes == (6, 6)
+    assert cursor.physical_write_cursor == 6
+    assert cursor.resident_tokens == 4
+    assert cursor.circular_index == 4
+    assert cache.offset is offsets
+    assert cache.left_padding.tolist() == [-2, -2]
+    assert cache.keys[0].reshape(-1).tolist() == [2, 3, 4, 5]
+
+
+def test_checkpoint_restores_every_scalar_and_batch_field_by_reference():
+    scalar = RotatingKVCache(4, keep=0)
+    _append(scalar, [1, 2, 3, 4])
+    batch = BatchRotatingKVCache(4, [0, 0])
+    _append(batch, [1], rows=2)
+    scalar_keys, batch_keys = scalar.keys, batch.keys
+    scalar_snapshot = (scalar.offset, scalar._idx, scalar.max_size, scalar.keep)
+    batch_snapshot = (
+        batch.offset,
+        batch.left_padding,
+        batch._idx,
+        batch._offset,
+        batch.rotated,
+        batch._lengths,
+        batch.max_size,
+    )
+    checkpoint = GemmaCacheCheckpoint([scalar, batch])
+    scalar.keys = mx.zeros_like(scalar.keys)
+    scalar.offset, scalar._idx, scalar.max_size, scalar.keep = 2, 1, 8, 1
+    batch.keys = mx.zeros_like(batch.keys)
+    batch.offset = mx.array([7, 8])
+    batch.left_padding = mx.array([2, 3])
+    batch._idx, batch._offset, batch.rotated = 0, 9, True
+    batch._lengths, batch.max_size = mx.array([1, 1]), 8
+    checkpoint.restore()
+    assert scalar.keys is scalar_keys
+    assert (scalar.offset, scalar._idx, scalar.max_size, scalar.keep) == scalar_snapshot
+    assert batch.keys is batch_keys
+    assert batch.offset is batch_snapshot[0]
+    assert batch.left_padding is batch_snapshot[1]
+    assert (
+        batch._idx,
+        batch._offset,
+        batch.rotated,
+        batch._lengths,
+        batch.max_size,
+    ) == batch_snapshot[2:]
+
+
+def test_saturated_one_token_failure_restores_overwritten_slot_and_metadata():
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, [0, 1, 2, 3])
+    normalize_scalar_rotating(cache)
+    before = cache.keys.tolist()
+
+    def forward():
+        _append(cache, [99])
+        return mx.array([1])
+
+    with pytest.raises(RuntimeError, match="cancelled"):
+        run_atomic_one_token(
+            [cache],
+            logical_positions=[4],
+            forward=forward,
+            evaluate=lambda _: (_ for _ in ()).throw(RuntimeError("cancelled")),
+        )
+    mx.eval(cache.keys)
+    assert cache.offset == 4
+    assert cache._idx == 4
+    assert cache.keys.tolist() == before
+
+
+def test_committed_transaction_discards_journal_and_cannot_be_recommitted():
+    cache = KVCache()
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[0])
+    _append(cache, [7])
+    transaction.commit(logical_positions=[1])
+    accepted_keys, accepted_value = cache.keys, cache.keys[..., 0, :].tolist()
+    transaction.rollback()
+    assert cache.keys is accepted_keys
+    assert cache.offset == 1
+    assert cache.keys[..., 0, :].tolist() == accepted_value
+    with pytest.raises(GemmaCacheTransactionError, match="already committed"):
+        transaction.commit(logical_positions=[1])
+    assert cache.offset == 1
+    assert cache.keys[..., 0, :].tolist() == accepted_value
+
+
+def test_one_token_guard_rejects_second_update_before_mutation_and_rolls_back():
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, [0, 1, 2, 3])
+    normalize_scalar_rotating(cache)
+    keys, before = cache.keys, cache.keys.tolist()
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[4])
+    _append(cache, [1])
+    with pytest.raises(GemmaCacheTransactionError, match="more than once"):
+        _append(cache, [2])
+    transaction.rollback()
+    assert cache.keys is keys
+    assert cache.keys.tolist() == before
+    assert cache.offset == cache._idx == 4
+
+
+def test_one_token_guard_rejects_multi_token_update_before_mutation():
+    cache = KVCache()
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[8])
+    with pytest.raises(GemmaCacheTransactionError, match="multi-token"):
+        _append(cache, [1, 2])
+    transaction.rollback()
+    assert cache.offset == 0
+    assert cache.keys is None
+
+
+def test_scalar_and_batch_owner_alignment_is_exact():
+    full, rotating = KVCache(), RotatingKVCache(4, keep=0)
+    _append(full, [1])
+    with pytest.raises(GemmaCacheError, match="physical writes"):
+        validate_aligned_scalar_cache([full, rotating], logical_position=1)
+
+    batch_full = BatchKVCache([0, 0])
+    batch_rotating = BatchRotatingKVCache(4, [0, 0])
+    _append(batch_full, [1], rows=2)
+    with pytest.raises(GemmaCacheError, match="physical writes"):
+        validate_homogeneous_batch_lane(
+            [batch_full, batch_rotating], logical_positions=[1, 1]
+        )
+
+
+def test_batch_cursor_and_lane_reject_heterogeneous_physical_or_logical_rows():
+    batch = BatchKVCache([0, 1])
+    _append(batch, [1], rows=2)
+    cursor = batch_cache_cursor(batch, logical_positions=[5, 5])
+    assert cursor.total_writes == (1, 0)
+    with pytest.raises(GemmaCacheError, match="heterogeneous writes"):
+        validate_homogeneous_batch_lane([batch], logical_positions=[5, 5])
+    equal = BatchKVCache([0, 0])
+    with pytest.raises(GemmaCacheError, match="equal logical"):
+        validate_homogeneous_batch_lane([equal], logical_positions=[5, 6])
+
+
+def test_batch_one_token_commit_tracks_lifetime_writes_across_wrap():
+    left = RotatingKVCache(4, keep=0)
+    right = RotatingKVCache(4, keep=0)
+    _append(left, range(5))
+    _append(right, range(5))
+    normalize_scalar_rotating(left)
+    normalize_scalar_rotating(right)
+    batch = BatchRotatingKVCache.merge([left, right])
+    transaction = GemmaOneTokenTransaction([batch], logical_positions=[9, 9])
+    _append(batch, [10], rows=2)
+    transaction.commit(logical_positions=[10, 10])
+    cursor = batch_cache_cursor(batch, logical_positions=[10, 10])
+    assert cursor.total_writes == (6, 6)
+    assert cursor.circular_index == 1
+    assert cursor.rotated is True
+
+
+def test_batch_rotation_state_canonicalizes_after_a_complete_wrap():
+    rows = [RotatingKVCache(4, keep=0), RotatingKVCache(4, keep=0)]
+    for row in rows:
+        _append(row, range(4))
+        normalize_scalar_rotating(row)
+    batch = BatchRotatingKVCache.merge(rows)
+    assert (batch._idx, batch.rotated) == (4, False)
+    logical = 4
+    for expected_index in (1, 2, 3):
+        transaction = GemmaOneTokenTransaction(
+            [batch], logical_positions=[logical, logical]
+        )
+        _append(batch, [logical], rows=2)
+        logical += 1
+        transaction.commit(logical_positions=[logical, logical])
+        assert (batch._idx, batch.rotated) == (expected_index, True)
+    transaction = GemmaOneTokenTransaction(
+        [batch], logical_positions=[logical, logical]
+    )
+    _append(batch, [logical], rows=2)
+    logical += 1
+    transaction.commit(logical_positions=[logical, logical])
+    assert (batch._idx, batch.rotated) == (4, False)
+
+
+@pytest.mark.parametrize(
+    ("offset", "index", "rotated", "message"),
+    [
+        (3, 3, True, "unsaturated"),
+        (4, 4, True, "normalized saturated"),
+        (5, 1, False, "wrapped"),
+    ],
+)
+def test_batch_rotation_state_machine_rejects_malformed_states(
+    offset, index, rotated, message
+):
+    cache = BatchRotatingKVCache(4, [0])
+    cache.keys = mx.zeros((1, 1, 4, 1))
+    cache.values = mx.zeros((1, 1, 4, 1))
+    cache.offset = mx.array([offset])
+    cache._offset = offset
+    cache._idx = index
+    cache.rotated = rotated
+    with pytest.raises(GemmaCacheError, match=message):
+        batch_cache_cursor(cache, logical_positions=[offset])
+
+
+def test_batch_lane_requires_equal_rotation_state_across_owners():
+    def cache(index, rotated):
+        entry = BatchRotatingKVCache(4, [0])
+        entry.keys = mx.zeros((1, 1, 4, 1))
+        entry.values = mx.zeros((1, 1, 4, 1))
+        entry.offset = mx.array([5])
+        entry._offset = 5
+        entry._idx = index
+        entry.rotated = rotated
+        return entry
+
+    with pytest.raises(GemmaCacheError, match="resident state"):
+        validate_homogeneous_batch_lane(
+            [cache(4, False), cache(1, True)], logical_positions=[5]
+        )
+
+
+def test_atomic_filter_keeps_selected_rows_and_rolls_back_mid_failure(monkeypatch):
+    full = BatchKVCache([0, 0])
+    rotating = BatchRotatingKVCache(4, [0, 0])
+    _append(full, [1], rows=2)
+    _append(rotating, [1], rows=2)
+    selected = atomic_batch_filter(
+        [full, rotating], [1], logical_positions=[4, 4]
+    )
+    assert selected == (4,)
+    assert full.keys.shape[0] == rotating.keys.shape[0] == 1
+
+    full = BatchKVCache([0, 0])
+    rotating = BatchRotatingKVCache(4, [0, 0])
+    _append(full, [1], rows=2)
+    _append(rotating, [1], rows=2)
+    full_keys = full.keys
+    monkeypatch.setattr(
+        BatchRotatingKVCache,
+        "filter",
+        lambda self, indices: (_ for _ in ()).throw(RuntimeError("mid-filter")),
+    )
+    with pytest.raises(RuntimeError, match="mid-filter"):
+        atomic_batch_filter([full, rotating], [0], logical_positions=[4, 4])
+    assert full.keys is full_keys
+    assert full.keys.shape[0] == 2
+
+
+def test_atomic_filter_rejects_duplicate_owners_before_mutation():
+    cache = BatchKVCache([0, 0])
+    _append(cache, [1], rows=2)
+    keys, offset = cache.keys, cache.offset
+    with pytest.raises(GemmaCacheError, match="duplicate owners"):
+        atomic_batch_filter([cache, cache], [0], logical_positions=[1, 1])
+    assert cache.keys is keys
+    assert cache.offset is offset
+
+
+def test_atomic_extend_restores_source_on_success_and_both_on_failure(monkeypatch):
+    destination = [BatchRotatingKVCache(4, [0])]
+    source = [BatchRotatingKVCache(4, [0])]
+    _append(destination[0], [1], rows=1)
+    _append(source[0], [2], rows=1)
+    source_keys, source_idx = source[0].keys, source[0]._idx
+    atomic_batch_extend(destination, source)
+    assert destination[0].keys.shape[0] == 2
+    assert source[0].keys is source_keys
+    assert source[0]._idx == source_idx
+
+    destination = [BatchKVCache([0]), BatchRotatingKVCache(4, [0])]
+    source = [BatchKVCache([0]), BatchRotatingKVCache(4, [0])]
+    for entry in destination + source:
+        _append(entry, [1], rows=1)
+    destination_refs = tuple(entry.keys for entry in destination)
+    source_refs = tuple(entry.keys for entry in source)
+    monkeypatch.setattr(
+        BatchRotatingKVCache,
+        "extend",
+        lambda self, other: (_ for _ in ()).throw(RuntimeError("mid-extend")),
+    )
+    with pytest.raises(RuntimeError, match="mid-extend"):
+        atomic_batch_extend(destination, source)
+    assert tuple(entry.keys for entry in destination) == destination_refs
+    assert tuple(entry.keys for entry in source) == source_refs
+
+
+@pytest.mark.parametrize("duplicate_side", ["destination", "source", "overlap"])
+def test_atomic_extend_rejects_aliasing_before_mutation(duplicate_side):
+    left = BatchKVCache([0])
+    right = BatchKVCache([0])
+    if duplicate_side == "destination":
+        destination, source = [left, left], [right, BatchKVCache([0])]
+    elif duplicate_side == "source":
+        destination, source = [left, BatchKVCache([0])], [right, right]
+    else:
+        destination, source = [left], [left]
+    with pytest.raises(GemmaCacheError, match="duplicate|overlap"):
+        atomic_batch_extend(destination, source)
+
+
+@pytest.mark.parametrize("operation", ["normalize", "filter", "extend"])
+def test_deferred_cache_failure_restores_all_references(operation, monkeypatch):
+    monkeypatch.setattr(
+        gemma_cache,
+        "_evaluate_cache",
+        lambda cache: (_ for _ in ()).throw(RuntimeError("deferred")),
+    )
+    if operation == "normalize":
+        cache = RotatingKVCache(4, keep=0)
+        _append(cache, [1, 2, 3, 4, 5])
+        keys, offset, index = cache.keys, cache.offset, cache._idx
+        with pytest.raises(RuntimeError, match="deferred"):
+            normalize_scalar_rotating(cache)
+        assert cache.keys is keys
+        assert (cache.offset, cache._idx) == (offset, index)
+    elif operation == "filter":
+        cache = BatchKVCache([0, 0])
+        _append(cache, [1], rows=2)
+        keys, offset = cache.keys, cache.offset
+        with pytest.raises(RuntimeError, match="deferred"):
+            atomic_batch_filter([cache], [0], logical_positions=[1, 1])
+        assert cache.keys is keys
+        assert cache.offset is offset
+    else:
+        destination, source = [BatchKVCache([0])], [BatchKVCache([0])]
+        _append(destination[0], [1])
+        _append(source[0], [2])
+        destination_keys, source_keys = destination[0].keys, source[0].keys
+        with pytest.raises(RuntimeError, match="deferred"):
+            atomic_batch_extend(destination, source)
+        assert destination[0].keys is destination_keys
+        assert source[0].keys is source_keys
+
+
+def test_eos_or_cancel_rollback_is_idempotent():
+    cache = RotatingKVCache(4, keep=0)
+    _append(cache, [0, 1, 2, 3])
+    normalize_scalar_rotating(cache)
+    transaction = GemmaOneTokenTransaction([cache], logical_positions=[4])
+    _append(cache, [5])
+    transaction.rollback()
+    transaction.rollback()
+    assert cache.offset == 4
+    assert cache._idx == 4
+
+
+def test_malformed_saturated_prefix_is_rejected_before_negative_dimension_path():
+    def malformed():
+        cache = RotatingKVCache(4, keep=0)
+        cache.keys = mx.zeros((1, 1, 3, 1))
+        cache.values = mx.zeros((1, 1, 3, 1))
+        cache.offset = 6
+        cache._idx = 3
+        return cache
+
+    # mlx-lm's next one-token growth would calculate max_size - offset == -2.
+    with pytest.raises(ValueError, match="Negative dimensions"):
+        _append(malformed(), [7])
+    with pytest.raises(GemmaCacheError, match="short resident buffer"):
+        GemmaOneTokenTransaction([malformed()], logical_positions=[6])
+
+
+def test_batch_malformed_prefix_and_window_mismatch_fail_closed():
+    malformed = BatchRotatingKVCache(4, [0])
+    malformed.keys = mx.zeros((1, 1, 3, 1))
+    malformed.values = mx.zeros((1, 1, 3, 1))
+    malformed.offset = mx.array([6])
+    malformed._offset = 6
+    malformed._idx = 3
+    with pytest.raises(GemmaCacheError, match="short buffer"):
+        GemmaOneTokenTransaction([malformed], logical_positions=[6])
+
+    with pytest.raises(GemmaCacheError, match="windows differ"):
+        atomic_batch_extend(
+            [BatchRotatingKVCache(4, [0])],
+            [BatchRotatingKVCache(8, [0])],
+        )

--- a/tests/test_specprefill_gemma_executor.py
+++ b/tests/test_specprefill_gemma_executor.py
@@ -40,7 +40,6 @@ from vllm_mlx.specprefill_target_hooks import (
     TargetPositionSession,
 )
 
-
 _CASES = (
     (GEMMA4_E2B, GEMMA4_DENSE_TARGET, False),
     (GEMMA4_31B, GEMMA4_DENSE_TARGET, False),
@@ -235,9 +234,7 @@ def test_real_proportional_rope_hook_matches_independent_native_offsets(backend)
     )
     rope = attention.rope
     positions = (0, 3, 7)
-    x = mx.random.normal((1, 2, len(positions), attention.head_dim)).astype(
-        mx.bfloat16
-    )
+    x = mx.random.normal((1, 2, len(positions), attention.head_dim)).astype(mx.bfloat16)
     expected = mx.concatenate(
         [
             rope(x[:, :, index : index + 1], offset=logical)

--- a/tests/test_specprefill_gemma_executor.py
+++ b/tests/test_specprefill_gemma_executor.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Architecture-faithful scalar Gemma target integration tests."""
+
+from __future__ import annotations
+
+import pytest
+from mlx.utils import tree_map
+
+mx = pytest.importorskip("mlx.core")
+
+import vllm_mlx.specprefill_target_executor as target_executor
+from mlx_lm.models.gemma4_text import Model as LmGemmaModel
+from mlx_lm.models.gemma4_text import ModelArgs as LmGemmaArgs
+from mlx_vlm.models.base import LanguageModelOutput
+from mlx_vlm.models.gemma4.config import TextConfig as VlmGemmaArgs
+from mlx_vlm.models.gemma4.language import LanguageModel as VlmGemmaModel
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from vllm_mlx.specprefill_gemma_cache import (
+    GEMMA4_26B_A4B,
+    GEMMA4_31B,
+    GEMMA4_E2B,
+    GemmaCacheBackend,
+)
+from vllm_mlx.specprefill_positions import (
+    GEMMA4_A4B_TARGET,
+    GEMMA4_DENSE_TARGET,
+    PositionPhase,
+)
+from vllm_mlx.specprefill_target_executor import (
+    SparseTargetPrefillError,
+    SparseTargetPrefillSession,
+    execute_sparse_target_prefill,
+)
+from vllm_mlx.specprefill_target_hooks import (
+    TargetPositionHooks,
+    TargetPositionSession,
+)
+
+
+_CASES = (
+    (GEMMA4_E2B, GEMMA4_DENSE_TARGET, False),
+    (GEMMA4_31B, GEMMA4_DENSE_TARGET, False),
+    (GEMMA4_26B_A4B, GEMMA4_A4B_TARGET, True),
+)
+
+
+def _args(spec, backend, a4b):
+    cls = LmGemmaArgs if backend is GemmaCacheBackend.MLX_LM else VlmGemmaArgs
+    return cls(
+        hidden_size=8,
+        num_hidden_layers=spec.layer_count,
+        intermediate_size=16,
+        num_attention_heads=2,
+        head_dim=4,
+        global_head_dim=8,
+        global_partial_rotary_factor=0.25,
+        vocab_size=32,
+        vocab_size_per_layer_input=32,
+        num_key_value_heads=1,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=spec.layer_count - spec.owner_count,
+        hidden_size_per_layer_input=0,
+        sliding_window=spec.sliding_window,
+        layer_types=list(spec.layer_types),
+        final_logit_softcapping=None,
+        use_double_wide_mlp=False,
+        enable_moe_block=a4b,
+        num_experts=2 if a4b else None,
+        top_k_experts=1 if a4b else None,
+        moe_intermediate_size=4 if a4b else None,
+        attention_k_eq_v=spec is not GEMMA4_E2B,
+        rope_parameters={
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {
+                "partial_rotary_factor": 1.0,
+                "rope_theta": 10000.0,
+                "rope_type": "default",
+            },
+        },
+    )
+
+
+def _model(spec, backend, a4b=False):
+    model = (
+        LmGemmaModel(_args(spec, backend, a4b))
+        if backend is GemmaCacheBackend.MLX_LM
+        else VlmGemmaModel(_args(spec, backend, a4b))
+    )
+    model.update(tree_map(lambda value: value.astype(mx.bfloat16), model.parameters()))
+    return model
+
+
+def _logits(output):
+    return output.logits if type(output) is LanguageModelOutput else output
+
+
+def _state(positions):
+    full_length = max(positions) + 1
+    identity = SparseCacheIdentity.from_tokens(
+        target_id="gemma@sha256:target",
+        tokenizer_id="tokenizer@sha256:tokenizer",
+        scorer_id="scorer@sha256:scorer",
+        selector_version="hybrid-v1",
+        tuning=SparsePolicyTuning(1.0, 0.0, 1, 1, 64),
+        tokens=tuple(range(full_length)),
+        selection_fingerprint="a" * 64,
+    )
+    return SparseCacheState.from_selection(
+        identity, (tuple(positions),), (full_length,)
+    )
+
+
+def _dense(model, tokens, cache, step_size):
+    logits = None
+    for start in range(0, tokens.shape[1], step_size):
+        logits = _logits(model(tokens[:, start : start + step_size], cache=cache))
+        target_executor._eval_forward(logits, cache)
+    return logits
+
+
+def _active_kv(cache):
+    active = []
+    for entry in cache:
+        length = min(entry.offset, getattr(entry, "max_size", entry.offset))
+        active.append(
+            (
+                entry.keys[..., :length, :],
+                entry.values[..., :length, :],
+            )
+        )
+    return active
+
+
+def _assert_close(actual, expected):
+    mx.eval(actual, expected)
+    assert mx.allclose(actual, expected, rtol=1e-2, atol=1e-2).item()
+
+
+@pytest.mark.parametrize("backend", tuple(GemmaCacheBackend))
+@pytest.mark.parametrize(("spec", "adapter", "a4b"), _CASES)
+def test_keep_one_actual_layout_matches_bf16_logits_and_active_kv(
+    spec, adapter, a4b, backend
+):
+    model = _model(spec, backend, a4b)
+    # q_norm and proportional partial RoPE are real architecture modules here.
+    full = next(
+        layer.self_attn
+        for layer in model.layers
+        if layer.self_attn.layer_type == "full_attention"
+    )
+    assert full.q_norm is not None
+    mx.eval(full.rope._freqs)
+    assert mx.isinf(full.rope._freqs).any().item()
+    assert (~mx.isinf(full.rope._freqs)).sum().item() == 1
+
+    tokens = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+    dense_cache = model.make_cache()
+    dense_logits = _dense(model, tokens, dense_cache, 3)
+    sparse_cache = model.make_cache()
+    result = execute_sparse_target_prefill(
+        model,
+        tokens,
+        sparse_cache,
+        _state((0, 1, 2, 3)),
+        adapter,
+        step_size=3,
+    )
+    assert result.logits.dtype == mx.bfloat16
+    _assert_close(result.logits, dense_logits)
+    for sparse_pair, dense_pair in zip(
+        _active_kv(sparse_cache), _active_kv(dense_cache), strict=True
+    ):
+        for sparse_value, dense_value in zip(sparse_pair, dense_pair, strict=True):
+            _assert_close(sparse_value, dense_value)
+
+
+@pytest.mark.parametrize("backend", tuple(GemmaCacheBackend))
+def test_real_proportional_rope_noncontiguous_quantum_matches_one_token_oracle(
+    backend,
+):
+    model = _model(GEMMA4_E2B, backend)
+    adapter = GEMMA4_DENSE_TARGET
+    positions = (0, 3, 4)
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+
+    oracle_cache = model.make_cache()
+    hooks = TargetPositionHooks.for_model(model, adapter)
+    oracle_logits = None
+    for physical, logical in enumerate(positions):
+        session = TargetPositionSession(
+            logical_positions=((logical,),),
+            physical_starts=(physical,),
+            phase=PositionPhase.SPARSE_PREFILL,
+        )
+        with hooks.session(session):
+            oracle_logits = _logits(
+                model(tokens[:, physical : physical + 1], cache=oracle_cache)
+            )
+            target_executor._eval_forward(oracle_logits, oracle_cache)
+
+    sparse_cache = model.make_cache()
+    result = execute_sparse_target_prefill(
+        model,
+        tokens,
+        sparse_cache,
+        _state(positions),
+        adapter,
+        step_size=2,
+    )
+    assert oracle_logits is not None
+    assert result.logits.dtype == oracle_logits.dtype == mx.bfloat16
+    _assert_close(result.logits, oracle_logits)
+    for sparse_pair, oracle_pair in zip(
+        _active_kv(sparse_cache), _active_kv(oracle_cache), strict=True
+    ):
+        for sparse_value, oracle_value in zip(sparse_pair, oracle_pair, strict=True):
+            _assert_close(sparse_value, oracle_value)
+
+
+@pytest.mark.parametrize("backend", tuple(GemmaCacheBackend))
+def test_real_proportional_rope_hook_matches_independent_native_offsets(backend):
+    model = _model(GEMMA4_E2B, backend)
+    attention = next(
+        layer.self_attn
+        for layer in model.layers
+        if layer.self_attn.layer_type == "full_attention"
+    )
+    rope = attention.rope
+    positions = (0, 3, 7)
+    x = mx.random.normal((1, 2, len(positions), attention.head_dim)).astype(
+        mx.bfloat16
+    )
+    expected = mx.concatenate(
+        [
+            rope(x[:, :, index : index + 1], offset=logical)
+            for index, logical in enumerate(positions)
+        ],
+        axis=2,
+    )
+    hooks = TargetPositionHooks.for_model(model, GEMMA4_DENSE_TARGET)
+    session = TargetPositionSession(
+        logical_positions=(positions,),
+        physical_starts=(0,),
+        phase=PositionPhase.SPARSE_PREFILL,
+    )
+    with hooks.session(session):
+        actual = rope(x, offset=0)
+        mx.eval(actual)
+    assert actual.dtype == expected.dtype == mx.bfloat16
+    _assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("backend", tuple(GemmaCacheBackend))
+def test_oversized_concat_tail_normalizes_once_then_decodes(backend):
+    model = _model(GEMMA4_E2B, backend)
+    count = GEMMA4_E2B.sliding_window + 3
+    cache = model.make_cache()
+    execute_sparse_target_prefill(
+        model,
+        mx.arange(count, dtype=mx.int32)[None, :] % 31,
+        cache,
+        _state(tuple(range(count))),
+        GEMMA4_DENSE_TARGET,
+        step_size=257,
+    )
+    rotating = [entry for entry in cache if hasattr(entry, "max_size")]
+    assert all(
+        entry.offset == count
+        and entry.keys.shape[2] == entry.max_size
+        and entry._idx == entry.max_size
+        for entry in rotating
+    )
+    logits = _logits(model(mx.array([[1]], dtype=mx.int32), cache=cache))
+    target_executor._eval_forward(logits, cache)
+    assert all(entry.offset == count + 1 for entry in cache)
+
+
+@pytest.mark.parametrize("backend", tuple(GemmaCacheBackend))
+@pytest.mark.parametrize("failure", ("lazy", "cancel"))
+def test_saturated_failure_or_cancel_restores_then_safe_decode(
+    backend, failure, monkeypatch
+):
+    model = _model(GEMMA4_E2B, backend)
+    count = GEMMA4_E2B.sliding_window + 3
+    cache = model.make_cache()
+    session = SparseTargetPrefillSession(
+        model,
+        mx.arange(count, dtype=mx.int32)[None, :] % 31,
+        cache,
+        _state(tuple(range(count))),
+        GEMMA4_DENSE_TARGET,
+        step_size=257,
+    )
+    session.step()
+    session.step()
+    if failure == "lazy":
+        real_eval = target_executor._eval_forward
+        monkeypatch.setattr(
+            target_executor,
+            "_eval_forward",
+            lambda *args: (_ for _ in ()).throw(RuntimeError("lazy failure")),
+        )
+        with pytest.raises(RuntimeError, match="lazy failure"):
+            session.step()
+        monkeypatch.setattr(target_executor, "_eval_forward", real_eval)
+    else:
+        session.cancel()
+    assert all(entry.offset == 0 and entry.keys is None for entry in cache)
+    logits = _logits(model(mx.array([[1]], dtype=mx.int32), cache=cache))
+    target_executor._eval_forward(logits, cache)
+    assert all(entry.offset == 1 for entry in cache)
+
+
+@pytest.mark.parametrize("model_backend", tuple(GemmaCacheBackend))
+def test_crossed_model_cache_backends_fail_before_forward(model_backend):
+    cache_backend = (
+        GemmaCacheBackend.MLX_VLM
+        if model_backend is GemmaCacheBackend.MLX_LM
+        else GemmaCacheBackend.MLX_LM
+    )
+    model = _model(GEMMA4_E2B, model_backend)
+    crossed_cache = _model(GEMMA4_E2B, cache_backend).make_cache()
+    with pytest.raises(SparseTargetPrefillError, match="topology"):
+        SparseTargetPrefillSession(
+            model,
+            [[1]],
+            crossed_cache,
+            _state((0,)),
+            GEMMA4_DENSE_TARGET,
+            step_size=2,
+        )
+
+
+def test_pathological_one_token_chunking_and_batch_rows_fail_closed():
+    model = _model(GEMMA4_E2B, GemmaCacheBackend.MLX_LM)
+    with pytest.raises(SparseTargetPrefillError, match="chunk_size > 1"):
+        SparseTargetPrefillSession(
+            model,
+            [[1, 2]],
+            model.make_cache(),
+            _state((0, 1)),
+            GEMMA4_DENSE_TARGET,
+            step_size=1,
+        )
+    state = SparseCacheState.from_selection(
+        _state((0,)).identities[0], ((0,), (0,)), (1, 1)
+    )
+    with pytest.raises(SparseTargetPrefillError, match="scalar-only"):
+        SparseTargetPrefillSession(
+            model,
+            [[1], [1]],
+            model.make_cache(),
+            state,
+            GEMMA4_DENSE_TARGET,
+            step_size=2,
+        )

--- a/tests/test_specprefill_gemma_runtime.py
+++ b/tests/test_specprefill_gemma_runtime.py
@@ -1,0 +1,724 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Diagnostic-only Gemma prepared runtime and scheduler bridge contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+import vllm_mlx.specprefill_runtime as runtime
+from mlx.utils import tree_map
+from mlx_vlm.models.gemma4.config import TextConfig as VlmGemmaArgs
+from mlx_vlm.models.gemma4.language import LanguageModel as VlmGemmaModel
+from mlx_vlm.models.cache import KVCache, RotatingKVCache
+from vllm_mlx.cooperative_specprefill import CooperativeSpecPrefillConfig
+from vllm_mlx.engine.batched import BatchedEngine
+from vllm_mlx.model_registry import _specprefill_capabilities
+from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler, MLLMSchedulerConfig
+from vllm_mlx.specprefill import SpecPrefillCoverage, SpecPrefillPolicy
+from vllm_mlx.specprefill_gemma_cache import (
+    FULL,
+    GEMMA4_26B_A4B,
+    GEMMA4_31B,
+    GEMMA4_E2B,
+)
+from vllm_mlx.specprefill_positions import (
+    GEMMA4_A4B_TARGET,
+    GEMMA4_DENSE_TARGET,
+)
+from vllm_mlx.specprefill_profiles import (
+    SpecPrefillCalibration,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfile,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillProfileTier,
+    SpecPrefillTuning,
+)
+from vllm_mlx.specprefill_scorer_session import (
+    ScorerSessionPhase,
+    ScorerSessionProgress,
+)
+from vllm_mlx.specprefill_selection import (
+    SPECPREFILL_SELECTOR_VERSION,
+    RotatingTailRequirement,
+)
+from vllm_mlx.scheduler import SchedulerConfig
+
+
+def _artifact(tmp_path, name, contents):
+    path = tmp_path / name
+    path.write_bytes(contents)
+    return str(path), hashlib.sha256(contents).hexdigest()
+
+
+def _registry(
+    target_hash,
+    scorer_hash,
+    *,
+    artifact=GEMMA4_E2B,
+    adapter=GEMMA4_DENSE_TARGET,
+):
+    tuning = SpecPrefillTuning(0.5, 0.0, 0, 1, 2)
+    key = SpecPrefillProfileKey(
+        target_artifact_id=artifact.artifact_id,
+        target_artifact_hash=target_hash,
+        tokenizer_artifact_hash="b" * 64,
+        scorer_artifact_id="gemma-scorer",
+        scorer_artifact_hash=scorer_hash,
+        adapter_id=adapter.adapter_id,
+        engine=SpecPrefillEngine.CONTINUOUS_BATCHING,
+        cell=SpecPrefillCell.SPARSE_ONLY,
+    )
+    calibration = SpecPrefillCalibration(
+        selector_version=SPECPREFILL_SELECTOR_VERSION,
+        tuning=tuning,
+        crossover_tokens=1,
+        max_context_tokens=128,
+        residency_limit_bytes=1024,
+        min_ttft_improvement_pct=1.0,
+        max_total_latency_regression_pct=1.0,
+        max_decode_throughput_regression_pct=1.0,
+        required_context_tokens=(1,),
+        required_concurrency_levels=(1, 2, 4, 8),
+        max_p95_inter_token_latency_regression_pct=1.0,
+        min_prefill_heavy_throughput_improvement_pct=1.0,
+    )
+    profile = SpecPrefillProfile(
+        key,
+        SpecPrefillProfileTier.DIAGNOSTIC,
+        calibration,
+    )
+    return SpecPrefillProfileRegistry((profile,)), key, tuning
+
+
+def _target():
+    text = SimpleNamespace(
+        config=SimpleNamespace(
+            model_type="gemma4_text",
+            layer_types=list(GEMMA4_E2B.layer_types),
+            num_hidden_layers=GEMMA4_E2B.layer_count,
+            num_kv_shared_layers=(
+                GEMMA4_E2B.layer_count - GEMMA4_E2B.owner_count
+            ),
+            sliding_window=GEMMA4_E2B.sliding_window,
+        ),
+        model=SimpleNamespace(previous_kvs=list(GEMMA4_E2B.previous_kvs)),
+    )
+    return SimpleNamespace(language_model=text, vision_tower=object()), text
+
+
+def _scalar_cache(artifact=GEMMA4_E2B):
+    cache = []
+    for layer_type in artifact.layer_types[: artifact.owner_count]:
+        cache.append(
+            KVCache()
+            if layer_type == FULL
+            else RotatingKVCache(artifact.sliding_window, keep=0)
+        )
+    return cache
+
+
+def _real_target(artifact, *, a4b=False):
+    args = VlmGemmaArgs(
+        hidden_size=8,
+        num_hidden_layers=artifact.layer_count,
+        intermediate_size=16,
+        num_attention_heads=2,
+        head_dim=4,
+        global_head_dim=8,
+        global_partial_rotary_factor=0.25,
+        vocab_size=32,
+        vocab_size_per_layer_input=32,
+        num_key_value_heads=1,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=artifact.layer_count - artifact.owner_count,
+        hidden_size_per_layer_input=0,
+        sliding_window=artifact.sliding_window,
+        layer_types=list(artifact.layer_types),
+        final_logit_softcapping=None,
+        use_double_wide_mlp=False,
+        enable_moe_block=a4b,
+        num_experts=2 if a4b else None,
+        top_k_experts=1 if a4b else None,
+        moe_intermediate_size=4 if a4b else None,
+        attention_k_eq_v=artifact is not GEMMA4_E2B,
+        rope_parameters={
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {
+                "partial_rotary_factor": 1.0,
+                "rope_theta": 10000.0,
+                "rope_type": "default",
+            },
+        },
+    )
+    model = VlmGemmaModel(args)
+    model.update(tree_map(lambda value: value.astype(mx.bfloat16), model.parameters()))
+    return model
+
+
+class _Processor:
+    eos_token_id = 31
+    clean_up_tokenization_spaces = False
+
+    def encode(self, _prompt):
+        return [1, 2, 3, 4]
+
+    def decode(self, tokens):
+        return " ".join(str(token) for token in tokens)
+
+
+class _OneQuantumScorerSession:
+    phase = ScorerSessionPhase.PREFILL
+    importance = mx.array([0.0, 0.25, 0.5, 1.0])
+
+    def step(self):
+        self.phase = ScorerSessionPhase.COMPLETE
+        return ScorerSessionProgress(
+            ScorerSessionPhase.COMPLETE,
+            4,
+            1,
+            1,
+            True,
+        )
+
+    def cancel(self):
+        pass
+
+
+def _real_prepare(
+    monkeypatch,
+    tmp_path,
+    artifact,
+    adapter,
+    *,
+    a4b=False,
+    cache_factory=None,
+):
+    scorer_path, scorer_hash = _artifact(
+        tmp_path, f"{artifact.artifact_id}-scorer", b"synthetic scorer"
+    )
+    target_path, target_hash = _artifact(
+        tmp_path, f"{artifact.artifact_id}-target", b"synthetic target"
+    )
+    registry, key, tuning = _registry(
+        target_hash,
+        scorer_hash,
+        artifact=artifact,
+        adapter=adapter,
+    )
+    target = _real_target(artifact, a4b=a4b)
+    processor = _Processor()
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime, "SpecPrefillScorerSession", lambda *_a, **_k: _OneQuantumScorerSession()
+    )
+    factory = cache_factory or (lambda model: model.make_cache())
+    prepare = runtime.build_gemma_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_path=target_path,
+        target_artifact_hash=target_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        gemma_artifact=artifact,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=tuning,
+        estimated_residency_bytes=64,
+        target_identity_attestor=lambda actual_target, actual_processor: (
+            runtime.TargetProcessorAttestation(
+                actual_target,
+                actual_processor,
+                target_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: None
+        ),
+        target_cache_factory=factory,
+        target_prefill_step_size=2,
+    )
+    return prepare, target, processor
+
+
+def _cooperative_config(prepared):
+    execution = prepared.gemma_batch_config.execution_config
+    return CooperativeSpecPrefillConfig(
+        target_id=execution.target_id,
+        tokenizer_id=execution.tokenizer_id,
+        scorer_id=execution.scorer_id,
+        tuning=execution.tuning,
+        rotating_tail_requirement=RotatingTailRequirement(
+            prepared.gemma_batch_config.attestation.artifact.sliding_window
+        ),
+    )
+
+
+def _scheduler_config(prepared, *, session_factory=None):
+    return MLLMSchedulerConfig(
+        enable_prefix_cache=False,
+        specprefill_enabled=True,
+        specprefill_profile_registry=prepared.profile_registry,
+        specprefill_profile_key=prepared.profile_key,
+        specprefill_estimated_residency_bytes=64,
+        specprefill_session_factory=session_factory or prepared.session_factory,
+        specprefill_target_forward_context=prepared.target_forward_context,
+        specprefill_cache_capability=prepared.cache_capability,
+        specprefill_gemma_batch_config=prepared.gemma_batch_config,
+        specprefill_diagnostic=True,
+        specprefill_advertisable=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("artifact", "adapter", "a4b"),
+    (
+        (GEMMA4_E2B, GEMMA4_DENSE_TARGET, False),
+        (GEMMA4_31B, GEMMA4_DENSE_TARGET, False),
+        (GEMMA4_26B_A4B, GEMMA4_A4B_TARGET, True),
+    ),
+)
+def test_real_gemma_layouts_probe_and_create_fresh_scalar_target_session(
+    monkeypatch, tmp_path, artifact, adapter, a4b
+):
+    prepare, target, processor = _real_prepare(
+        monkeypatch, tmp_path, artifact, adapter, a4b=a4b
+    )
+    prepared = prepare(target, processor)
+    admission = prepared.session_factory(
+        SimpleNamespace(request_id=artifact.artifact_id),
+        (1, 2, 3, 4),
+        _cooperative_config(prepared),
+    )
+
+    progress = admission.session.step()
+
+    assert progress.quantum_committed is True
+    assert admission.session.phase.value == "sparse_target_prefill"
+    assert admission.session.outcome.value == "active"
+    target_session = admission.session._target_session
+    assert target_session is not None
+    assert target_session.model is target
+    assert all(entry.offset == 0 for entry in target_session.cache)
+    assert prepared.cache_capability.layout == artifact.artifact_id
+    prepared.cleanup()
+
+
+def test_second_fresh_gemma_cache_topology_drift_fails_before_target_quantum(
+    monkeypatch, tmp_path
+):
+    calls = 0
+
+    def drifting_cache(model):
+        nonlocal calls
+        calls += 1
+        cache = model.make_cache()
+        return cache if calls == 1 else cache[:-1]
+
+    prepare, target, processor = _real_prepare(
+        monkeypatch,
+        tmp_path,
+        GEMMA4_E2B,
+        GEMMA4_DENSE_TARGET,
+        cache_factory=drifting_cache,
+    )
+    prepared = prepare(target, processor)
+    admission = prepared.session_factory(
+        SimpleNamespace(request_id="drift"),
+        (1, 2, 3, 4),
+        _cooperative_config(prepared),
+    )
+
+    admission.session.step()
+
+    assert calls == 2
+    assert admission.session.outcome.value == "fallback"
+    assert admission.session.fallback_reason == "target_setup_failed"
+    prepared.cleanup()
+
+
+def test_real_gemma_scheduler_runs_one_quantum_to_adoption_then_decode_first(
+    monkeypatch, tmp_path
+):
+    prepare, target, processor = _real_prepare(
+        monkeypatch, tmp_path, GEMMA4_E2B, GEMMA4_DENSE_TARGET
+    )
+    prepared = prepare(target, processor)
+    events = []
+    admissions = []
+
+    def tracking_factory(request, tokens, config):
+        admission = prepared.session_factory(request, tokens, config)
+        admissions.append(admission)
+        original_step = admission.session.step
+
+        def tracked_step():
+            events.append("quantum")
+            return original_step()
+
+        admission.session.step = tracked_step
+        return admission
+
+    scheduler = MLLMScheduler(
+        target,
+        processor,
+        _scheduler_config(prepared, session_factory=tracking_factory),
+    )
+    scheduler._ensure_batch_generator()
+    assert scheduler.batch_generator is not None
+    original_next = scheduler.batch_generator.next
+
+    def tracked_next():
+        events.append("decode")
+        return original_next()
+
+    scheduler.batch_generator.next = tracked_next
+    scheduler.add_request(
+        "prompt",
+        request_id="integrated",
+        max_tokens=2,
+        temperature=0.0,
+        specprefill_policy="sparse",
+        specprefill_coverage="selective",
+    )
+
+    first = scheduler.step()
+    second = scheduler.step()
+    third = scheduler.step()
+
+    assert events[:2] == ["decode", "quantum"]
+    assert first.specprefill_progress["integrated"].scorer_quanta == 1
+    assert first.specprefill_progress["integrated"].target_quanta == 0
+    assert second.specprefill_progress["integrated"].target_quanta == 1, (
+        admissions[0].session.failure
+    )
+    assert third.specprefill_progress["integrated"].target_quanta == 2
+    assert scheduler.request_id_to_uid["integrated"] == 0
+    active = scheduler.batch_generator.active_batch
+    assert active is not None
+    assert active.gemma_sparse_config is prepared.gemma_batch_config
+    assert active.sparse_row_states[0].logical_positions == (0, 1, 2, 3)
+    assert active.sparse_row_states[0].next_logical_position == 4
+
+    before = len(events)
+    decode_output = scheduler.step()
+
+    assert events[before:] == ["decode"]
+    assert len(decode_output.outputs) == 1
+    assert decode_output.outputs[0].request_id == "integrated"
+    assert active.sparse_row_states[0].next_logical_position == 5
+    assert active.sparse_row_states[0].physical_valid_length == 5
+    status = scheduler.get_stats()["specprefill"]
+    assert status == {
+        "enabled": False,
+        "advertisable": False,
+        "diagnostic": True,
+    }
+    assert _specprefill_capabilities({"state": "diagnostic", **status}) == []
+    prepared.cleanup()
+
+
+def test_batched_engine_start_propagates_identical_gemma_config_to_generator(
+    monkeypatch, tmp_path
+):
+    import vllm_mlx.mllm_scheduler as scheduler_module
+
+    prepare, target, processor = _real_prepare(
+        monkeypatch, tmp_path, GEMMA4_E2B, GEMMA4_DENSE_TARGET
+    )
+    captured = []
+    real_scheduler = scheduler_module.MLLMScheduler
+
+    class CapturingScheduler:
+        def __init__(self, model, processor, config):
+            self.inner = real_scheduler(model, processor, config)
+            self.inner._ensure_batch_generator()
+            self.config = config
+            self.batch_generator = self.inner.batch_generator
+            captured.append(self)
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            if self.inner.batch_generator is not None:
+                self.inner.batch_generator.close()
+                self.inner.batch_generator = None
+
+        def get_stats(self):
+            return self.inner.get_stats()
+
+    monkeypatch.setattr(scheduler_module, "MLLMScheduler", CapturingScheduler)
+    engine = BatchedEngine(
+        "gemma-diagnostic",
+        scheduler_config=SchedulerConfig(
+            enable_prefix_cache=False,
+            specprefill_enabled=True,
+            specprefill_prepare=prepare,
+        ),
+        force_mllm=True,
+    )
+    engine._model = target
+    engine._processor = processor
+
+    asyncio.run(engine._start_mllm())
+
+    assert len(captured) == 1
+    wired = captured[0]
+    prepared = engine._prepared_specprefill_runtime
+    assert prepared is not None
+    assert wired.config.specprefill_gemma_batch_config is prepared.gemma_batch_config
+    assert wired.batch_generator._expected_gemma_sparse_config is (
+        prepared.gemma_batch_config
+    )
+    assert engine.get_stats()["specprefill"] == {
+        "enabled": False,
+        "advertisable": False,
+        "diagnostic": True,
+    }
+    assert _specprefill_capabilities(
+        {"state": "diagnostic", **engine.get_stats()["specprefill"]}
+    ) == []
+    assert asyncio.run(engine._cleanup_mllm_runtime_ownership()) == []
+
+
+def _prepare(monkeypatch, tmp_path, *, cache_factory=_scalar_cache):
+    scorer_path, scorer_hash = _artifact(
+        tmp_path, "scorer.safetensors", b"gemma scorer"
+    )
+    target_path, target_hash = _artifact(
+        tmp_path, "target.safetensors", b"gemma target"
+    )
+    registry, key, tuning = _registry(target_hash, scorer_hash)
+    target, text = _target()
+    processor = object()
+    events = []
+
+    class FakeScorerSession:
+        phase = ScorerSessionPhase.PREFILL
+
+        def cancel(self):
+            events.append("scorer_cancel")
+
+    class FakeHooks:
+        @contextmanager
+        def session_for_plan(self, plan):
+            events.append(("plan", plan.logical_positions))
+            yield
+
+    class FakeTargetSession:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def step(self):
+            raise AssertionError("not stepped in runtime preparation test")
+
+        def cancel(self):
+            events.append("target_cancel")
+
+    monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
+    monkeypatch.setattr(
+        runtime.TargetPositionHooks,
+        "for_model",
+        lambda actual, adapter: (
+            events.append(("hooks", actual, adapter)) or FakeHooks()
+        ),
+    )
+    monkeypatch.setattr(
+        runtime, "resolve_target_position_adapter", lambda _model: GEMMA4_DENSE_TARGET
+    )
+    monkeypatch.setattr(
+        runtime, "SpecPrefillScorerSession", lambda *_a, **_k: FakeScorerSession()
+    )
+    monkeypatch.setattr(runtime, "SparseTargetPrefillSession", FakeTargetSession)
+
+    prepare = runtime.build_gemma_cb_specprefill_prepare(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_path=target_path,
+        target_artifact_hash=target_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        gemma_artifact=GEMMA4_E2B,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=tuning,
+        estimated_residency_bytes=64,
+        target_identity_attestor=lambda actual_target, actual_processor: (
+            runtime.TargetProcessorAttestation(
+                actual_target,
+                actual_processor,
+                target_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: events.append("cleanup")
+        ),
+        target_cache_factory=lambda _model: cache_factory(),
+        target_prefill_step_size=2,
+    )
+    return prepare(target, processor), target, text, processor, events
+
+
+def test_diagnostic_gemma_runtime_prepares_real_cache_and_scheduler_bridge(
+    monkeypatch, tmp_path
+):
+    prepared, target, text, processor, _events = _prepare(monkeypatch, tmp_path)
+
+    assert prepared.target_model is target
+    assert prepared.processor is processor
+    assert prepared.diagnostic is True
+    assert prepared.advertisable is False
+    assert prepared.cache_capability.layout == GEMMA4_E2B.artifact_id
+    assert prepared.cache_capability.backend == "mlx_vlm"
+    assert prepared.cache_capability.rotating is True
+    assert prepared.gemma_batch_config.attestation.text_model is text
+
+    config = MLLMSchedulerConfig(
+        enable_prefix_cache=False,
+        specprefill_enabled=True,
+        specprefill_profile_registry=prepared.profile_registry,
+        specprefill_profile_key=prepared.profile_key,
+        specprefill_estimated_residency_bytes=64,
+        specprefill_session_factory=prepared.session_factory,
+        specprefill_target_forward_context=prepared.target_forward_context,
+        specprefill_cache_capability=prepared.cache_capability,
+        specprefill_gemma_batch_config=prepared.gemma_batch_config,
+        specprefill_diagnostic=True,
+        specprefill_advertisable=False,
+    )
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.config = config
+    request = MLLMRequest(
+        request_id="gemma-diagnostic",
+        prompt="prompt",
+        prompt_token_ids=(1, 2, 3, 4),
+        specprefill_policy=SpecPrefillPolicy.SPARSE,
+        specprefill_coverage=SpecPrefillCoverage.SELECTIVE,
+    )
+    cooperative, reason = scheduler._cooperative_config_for(request)
+
+    assert reason is None
+    assert cooperative is not None
+    assert cooperative.rotating_tail_requirement == RotatingTailRequirement(
+        GEMMA4_E2B.sliding_window
+    )
+    admission = prepared.session_factory(
+        request, request.prompt_token_ids, cooperative
+    )
+    assert admission.session.config is cooperative
+    scheduler.model = target
+    scheduler.processor = processor
+    scheduler.mm_processor = None
+    scheduler.stop_tokens = set()
+    scheduler.batch_generator = None
+    scheduler._ensure_batch_generator()
+    assert scheduler.batch_generator._expected_gemma_sparse_config is (
+        prepared.gemma_batch_config
+    )
+    assert scheduler.batch_generator._expected_sparse_execution_config == (
+        prepared.gemma_batch_config.execution_config
+    )
+
+
+def test_gemma_runtime_fails_closed_for_forged_bytes_and_cross_backend(
+    monkeypatch, tmp_path
+):
+    prepared, *_ = _prepare(monkeypatch, tmp_path)
+    prepared.cleanup()
+
+    scorer_path, scorer_hash = _artifact(tmp_path, "scorer2", b"scorer2")
+    target_path, target_hash = _artifact(tmp_path, "target2", b"target2")
+    registry, key, tuning = _registry(target_hash, scorer_hash)
+    target, _text = _target()
+    processor = object()
+    base = dict(
+        scorer_artifact_path=scorer_path,
+        scorer_artifact_hash=scorer_hash,
+        target_artifact_path=target_path,
+        target_artifact_hash=target_hash,
+        tokenizer_artifact_hash=key.tokenizer_artifact_hash,
+        gemma_artifact=GEMMA4_E2B,
+        profile_registry=registry,
+        profile_key=key,
+        calibrated_tuning=tuning,
+        estimated_residency_bytes=64,
+        scorer_loader=lambda *_args: runtime.LoadedSpecPrefillScorer(
+            object(), lambda: None
+        ),
+    )
+    wrong_identity = lambda actual_target, actual_processor: (
+        runtime.TargetProcessorAttestation(
+            actual_target,
+            actual_processor,
+            "a" * 64,
+            key.tokenizer_artifact_hash,
+        )
+    )
+    prepare = runtime.build_gemma_cb_specprefill_prepare(
+        **base,
+        target_identity_attestor=wrong_identity,
+        target_cache_factory=lambda _model: _scalar_cache(),
+    )
+    with pytest.raises(Exception, match="artifact bytes"):
+        prepare(target, processor)
+
+    from mlx_lm.models.cache import KVCache as LmKVCache
+
+    prepare = runtime.build_gemma_cb_specprefill_prepare(
+        **base,
+        target_identity_attestor=lambda actual_target, actual_processor: (
+            runtime.TargetProcessorAttestation(
+                actual_target,
+                actual_processor,
+                target_hash,
+                key.tokenizer_artifact_hash,
+            )
+        ),
+        target_cache_factory=lambda _model: [
+            LmKVCache() for _ in range(GEMMA4_E2B.owner_count)
+        ],
+    )
+    with pytest.raises(Exception, match="topology|backend|cache"):
+        prepare(target, processor)
+
+
+@pytest.mark.parametrize(
+    "override",
+    (
+        {"enable_prefix_cache": True},
+        {"enable_prefix_cache": False, "enable_mtp": True},
+        {"enable_prefix_cache": False, "max_kv_size": 16},
+    ),
+)
+def test_gemma_scheduler_compositions_fail_closed(monkeypatch, tmp_path, override):
+    prepared, *_ = _prepare(monkeypatch, tmp_path)
+    kwargs = dict(
+        enable_prefix_cache=False,
+        specprefill_enabled=True,
+        specprefill_profile_registry=prepared.profile_registry,
+        specprefill_profile_key=prepared.profile_key,
+        specprefill_estimated_residency_bytes=64,
+        specprefill_session_factory=prepared.session_factory,
+        specprefill_target_forward_context=prepared.target_forward_context,
+        specprefill_cache_capability=prepared.cache_capability,
+        specprefill_gemma_batch_config=prepared.gemma_batch_config,
+        specprefill_diagnostic=True,
+        specprefill_advertisable=False,
+    )
+    kwargs.update(override)
+    with pytest.raises(ValueError, match="Gemma CB SpecPrefill"):
+        MLLMSchedulerConfig(**kwargs)

--- a/tests/test_specprefill_gemma_runtime.py
+++ b/tests/test_specprefill_gemma_runtime.py
@@ -170,7 +170,8 @@ class _Processor:
     eos_token_id = 31
     clean_up_tokenization_spaces = False
 
-    def encode(self, _prompt):
+    def encode(self, _prompt, *, add_special_tokens=False):
+        assert add_special_tokens is False
         return [1, 2, 3, 4]
 
     def decode(self, tokens):

--- a/tests/test_specprefill_gemma_runtime.py
+++ b/tests/test_specprefill_gemma_runtime.py
@@ -105,9 +105,7 @@ def _target():
             model_type="gemma4_text",
             layer_types=list(GEMMA4_E2B.layer_types),
             num_hidden_layers=GEMMA4_E2B.layer_count,
-            num_kv_shared_layers=(
-                GEMMA4_E2B.layer_count - GEMMA4_E2B.owner_count
-            ),
+            num_kv_shared_layers=(GEMMA4_E2B.layer_count - GEMMA4_E2B.owner_count),
             sliding_window=GEMMA4_E2B.sliding_window,
         ),
         model=SimpleNamespace(previous_kvs=list(GEMMA4_E2B.previous_kvs)),
@@ -222,7 +220,9 @@ def _real_prepare(
     processor = _Processor()
     monkeypatch.setattr(runtime.SpecPrefillScorer, "for_model", lambda _model: object())
     monkeypatch.setattr(
-        runtime, "SpecPrefillScorerSession", lambda *_a, **_k: _OneQuantumScorerSession()
+        runtime,
+        "SpecPrefillScorerSession",
+        lambda *_a, **_k: _OneQuantumScorerSession(),
     )
     factory = cache_factory or (lambda model: model.make_cache())
     prepare = runtime.build_gemma_cb_specprefill_prepare(
@@ -401,9 +401,9 @@ def test_real_gemma_scheduler_runs_one_quantum_to_adoption_then_decode_first(
     assert events[:2] == ["decode", "quantum"]
     assert first.specprefill_progress["integrated"].scorer_quanta == 1
     assert first.specprefill_progress["integrated"].target_quanta == 0
-    assert second.specprefill_progress["integrated"].target_quanta == 1, (
-        admissions[0].session.failure
-    )
+    assert second.specprefill_progress["integrated"].target_quanta == 1, admissions[
+        0
+    ].session.failure
     assert third.specprefill_progress["integrated"].target_quanta == 2
     assert scheduler.request_id_to_uid["integrated"] == 0
     active = scheduler.batch_generator.active_batch
@@ -488,9 +488,12 @@ def test_batched_engine_start_propagates_identical_gemma_config_to_generator(
         "advertisable": False,
         "diagnostic": True,
     }
-    assert _specprefill_capabilities(
-        {"state": "diagnostic", **engine.get_stats()["specprefill"]}
-    ) == []
+    assert (
+        _specprefill_capabilities(
+            {"state": "diagnostic", **engine.get_stats()["specprefill"]}
+        )
+        == []
+    )
     assert asyncio.run(engine._cleanup_mllm_runtime_ownership()) == []
 
 
@@ -616,9 +619,7 @@ def test_diagnostic_gemma_runtime_prepares_real_cache_and_scheduler_bridge(
     assert cooperative.rotating_tail_requirement == RotatingTailRequirement(
         GEMMA4_E2B.sliding_window
     )
-    admission = prepared.session_factory(
-        request, request.prompt_token_ids, cooperative
-    )
+    admission = prepared.session_factory(request, request.prompt_token_ids, cooperative)
     assert admission.session.config is cooperative
     scheduler.model = target
     scheduler.processor = processor

--- a/tests/test_specprefill_generation_context.py
+++ b/tests/test_specprefill_generation_context.py
@@ -45,7 +45,7 @@ class _Hooks:
 
 
 def _state():
-    tuning = SparsePolicyTuning(0.5, 0.0, 0, 0, 2)
+    tuning = SparsePolicyTuning(0.5, 0.0, 0, 1, 2)
     identity = SparseCacheIdentity.from_tokens(
         target_id="target",
         tokenizer_id="tokenizer",

--- a/tests/test_specprefill_generation_context.py
+++ b/tests/test_specprefill_generation_context.py
@@ -200,6 +200,27 @@ def test_finish_reconciles_a_final_speculative_rejection(monkeypatch):
     assert final_state.next_logical_positions == (9,)
 
 
+def test_native_mtp_transfer_seals_context_before_bootstrap_claim(monkeypatch):
+    context, model, cache, _ = _context(monkeypatch)
+
+    snapshot = context.transfer_to_native_mtp()
+
+    assert snapshot == _state()
+    _advance(cache, 1)
+    assert context.finish() == snapshot
+    with pytest.raises(SparseGenerationContextError, match="transferred"):
+        with context(_forward(model, cache, 1, "decode")):
+            pass
+
+
+def test_native_mtp_transfer_rejects_preclaim_external_cache_advance(monkeypatch):
+    context, _, cache, _ = _context(monkeypatch)
+    _advance(cache, 1)
+
+    with pytest.raises(SparseGenerationContextError, match="outside"):
+        context.transfer_to_native_mtp()
+
+
 def test_foreign_draft_forward_delegates_without_target_state_mutation(monkeypatch):
     context, _, _, hooks = _context(monkeypatch)
     draft_cache = [_Cache(8)]

--- a/tests/test_specprefill_generation_context.py
+++ b/tests/test_specprefill_generation_context.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic request-local generation-forward position tests."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from vllm_mlx.specprefill_generation_context import (
+    SparseGenerationContextError,
+    SparseGenerationForwardContext,
+)
+from vllm_mlx.specprefill_positions import (
+    PositionPhase,
+    QWEN_DENSE_TARGET,
+)
+
+
+class _Cache:
+    def __init__(self, offset):
+        self.offset = offset
+
+
+class _Hooks:
+    def __init__(self):
+        self.plans = []
+        self.active = False
+
+    @contextmanager
+    def session_for_plan(self, plan):
+        assert not self.active
+        self.active = True
+        self.plans.append(plan)
+        try:
+            yield
+        finally:
+            self.active = False
+
+
+def _state():
+    tuning = SparsePolicyTuning(0.5, 0.0, 0, 0, 2)
+    identity = SparseCacheIdentity.from_tokens(
+        target_id="target",
+        tokenizer_id="tokenizer",
+        scorer_id="scorer",
+        selector_version="selector-v1",
+        tuning=tuning,
+        tokens=range(8),
+        selection_fingerprint="1" * 64,
+    )
+    return SparseCacheState.from_selection(identity, ((0, 3, 6, 7),), (8,))
+
+
+def _context(monkeypatch):
+    model = object()
+    cache = [_Cache(4), _Cache(4)]
+    hooks = _Hooks()
+    monkeypatch.setattr(
+        "vllm_mlx.specprefill_generation_context.TargetPositionHooks.for_model",
+        lambda actual_model, adapter: hooks,
+    )
+    context = SparseGenerationForwardContext(model, cache, _state(), QWEN_DENSE_TARGET)
+    return context, model, cache, hooks
+
+
+def _forward(model, cache, count, phase):
+    return SimpleNamespace(
+        model=model,
+        cache=cache,
+        input_tokens=mx.zeros((1, count), dtype=mx.int32),
+        phase=SimpleNamespace(value=phase),
+    )
+
+
+def _advance(cache, count):
+    for entry in cache:
+        entry.offset += count
+
+
+def test_decode_uses_logical_cursor_without_overwriting_physical_offset(monkeypatch):
+    context, model, cache, hooks = _context(monkeypatch)
+
+    with context(_forward(model, cache, 1, "decode")):
+        assert hooks.active
+        _advance(cache, 1)
+
+    plan = hooks.plans[-1]
+    assert plan.phase is PositionPhase.DECODE
+    assert plan.logical_positions == ((8,),)
+    assert plan.physical_cache_lengths == (4,)
+    assert context.state.next_logical_positions == (9,)
+    assert context.state.physical_valid_lengths == (5,)
+
+
+def test_verify_rollback_reconciles_before_the_next_target_forward(monkeypatch):
+    context, model, cache, hooks = _context(monkeypatch)
+
+    with context(_forward(model, cache, 3, "verify")):
+        _advance(cache, 3)
+    # The verifier keeps one of the three forwarded tokens.
+    for entry in cache:
+        entry.offset -= 2
+
+    with context(_forward(model, cache, 1, "decode")):
+        plan = hooks.plans[-1]
+        assert plan.logical_positions == ((9,),)
+        assert plan.physical_cache_lengths == (5,)
+        _advance(cache, 1)
+
+    assert context.finish().next_logical_positions == (10,)
+    assert context.state.physical_valid_lengths == (6,)
+
+
+def test_finish_reconciles_a_final_speculative_rejection(monkeypatch):
+    context, model, cache, _ = _context(monkeypatch)
+
+    with context(_forward(model, cache, 4, "verify")):
+        _advance(cache, 4)
+    for entry in cache:
+        entry.offset -= 3
+
+    final_state = context.finish()
+    assert final_state.physical_valid_lengths == (5,)
+    assert final_state.next_logical_positions == (9,)
+
+
+def test_foreign_draft_forward_delegates_without_target_state_mutation(monkeypatch):
+    context, _, _, hooks = _context(monkeypatch)
+    draft_cache = [_Cache(8)]
+
+    with context(_forward(object(), draft_cache, 2, "draft")):
+        _advance(draft_cache, 2)
+
+    assert hooks.plans == []
+    assert context.state == _state()
+
+
+def test_target_forward_rejects_cache_or_phase_drift(monkeypatch):
+    context, model, cache, _ = _context(monkeypatch)
+    with pytest.raises(SparseGenerationContextError, match="replaced"):
+        with context(_forward(model, list(cache), 1, "decode")):
+            pass
+    with pytest.raises(SparseGenerationContextError, match="decode or verify"):
+        with context(_forward(model, cache, 1, "prefill")):
+            pass
+    with pytest.raises(SparseGenerationContextError, match="exactly one"):
+        with context(_forward(model, cache, 2, "decode")):
+            pass
+
+
+def test_forward_error_does_not_publish_a_logical_state_transition(monkeypatch):
+    context, model, cache, hooks = _context(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        with context(_forward(model, cache, 1, "decode")):
+            assert hooks.active
+            raise RuntimeError("forward failed")
+
+    assert not hooks.active
+    assert context.state == _state()
+    assert cache[0].offset == cache[1].offset == 4
+
+
+def test_cache_reconciliation_fails_closed_at_sparse_prompt_boundary(monkeypatch):
+    context, _, cache, _ = _context(monkeypatch)
+    cache[0].offset = cache[1].offset = 3
+
+    with pytest.raises(SparseGenerationContextError, match="prompt boundary"):
+        context.finish()

--- a/tests/test_specprefill_generation_context.py
+++ b/tests/test_specprefill_generation_context.py
@@ -31,15 +31,28 @@ class _Cache:
 class _Hooks:
     def __init__(self):
         self.plans = []
+        self.sessions = []
+        self.acks = []
         self.active = False
 
     @contextmanager
-    def session_for_plan(self, plan):
+    def session_for_plan(self, plan, **kwargs):
         assert not self.active
         self.active = True
         self.plans.append(plan)
+        self.acks.append(kwargs.get("logical_position_ack"))
         try:
             yield
+        finally:
+            self.active = False
+
+    @contextmanager
+    def session(self, session):
+        assert not self.active
+        self.active = True
+        self.sessions.append(session)
+        try:
+            yield session
         finally:
             self.active = False
 
@@ -70,12 +83,14 @@ def _context(monkeypatch):
     return context, model, cache, hooks
 
 
-def _forward(model, cache, count, phase):
+def _forward(model, cache, count, phase, *, positions=None, ack=None):
     return SimpleNamespace(
         model=model,
         cache=cache,
         input_tokens=mx.zeros((1, count), dtype=mx.int32),
         phase=SimpleNamespace(value=phase),
+        logical_positions=positions,
+        logical_position_ack=ack,
     )
 
 
@@ -97,6 +112,60 @@ def test_decode_uses_logical_cursor_without_overwriting_physical_offset(monkeypa
     assert plan.physical_cache_lengths == (4,)
     assert context.state.next_logical_positions == (9,)
     assert context.state.physical_valid_lengths == (5,)
+
+
+def test_attested_target_decode_requires_exact_sparse_logical_positions(monkeypatch):
+    context, model, cache, hooks = _context(monkeypatch)
+    ack = SimpleNamespace(acknowledge=lambda _positions: None)
+
+    with context(_forward(model, cache, 1, "decode", positions=(8,), ack=ack)):
+        _advance(cache, 1)
+
+    assert hooks.acks == [ack]
+    with pytest.raises(SparseGenerationContextError, match="disagree"):
+        with context(_forward(model, cache, 1, "decode", positions=(99,), ack=ack)):
+            pass
+
+
+def test_native_mtp_draft_binds_one_request_cache_and_logical_positions(monkeypatch):
+    context, model, _target_cache, hooks = _context(monkeypatch)
+    mtp_cache = [_Cache(3)]
+    acknowledged = []
+
+    class Ack:
+        def acknowledge(self, positions):
+            acknowledged.append(positions)
+
+    ack = Ack()
+    with context(
+        _forward(
+            model,
+            mtp_cache,
+            2,
+            "mtp_draft",
+            positions=(3, 6),
+            ack=ack,
+        )
+    ) as session:
+        session.acknowledge_forward_positions()
+        _advance(mtp_cache, 2)
+
+    assert acknowledged == [(3, 6)]
+    assert hooks.sessions[-1].phase is PositionPhase.MTP_DRAFT
+    assert hooks.sessions[-1].physical_starts == (3,)
+    replacement_cache = [_Cache(5)]
+    with pytest.raises(SparseGenerationContextError, match="replaced"):
+        with context(
+            _forward(
+                model,
+                replacement_cache,
+                1,
+                "mtp_draft",
+                positions=(7,),
+                ack=Ack(),
+            )
+        ):
+            pass
 
 
 def test_verify_rollback_reconciles_before_the_next_target_forward(monkeypatch):

--- a/tests/test_specprefill_output_telemetry.py
+++ b/tests/test_specprefill_output_telemetry.py
@@ -1,0 +1,56 @@
+"""Engine output telemetry remains independent across prefill and decode."""
+
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.request import RequestOutput
+
+
+def _assert_feature_telemetry(output):
+    assert output.mtp_drafts == 10
+    assert output.mtp_accepted == 7
+    assert output.specprefill_engaged is True
+    assert output.specprefill_requested_policy == "auto"
+    assert output.specprefill_effective_policy == "sparse"
+    assert output.specprefill_coverage == "selective"
+    assert output.specprefill_selector_version == "hybrid-v1"
+    assert output.specprefill_total_tokens == 8192
+    assert output.specprefill_selected_tokens == 3072
+    assert output.specprefill_scorer_ms == 12.5
+    assert output.specprefill_target_prefill_ms == 40.0
+
+
+def test_generation_output_carries_independent_feature_telemetry():
+    output = GenerationOutput(
+        text="ok",
+        mtp_drafts=10,
+        mtp_accepted=7,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="sparse",
+        specprefill_coverage="selective",
+        specprefill_engaged=True,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_total_tokens=8192,
+        specprefill_selected_tokens=3072,
+        specprefill_scorer_ms=12.5,
+        specprefill_target_prefill_ms=40.0,
+    )
+
+    _assert_feature_telemetry(output)
+
+
+def test_request_output_carries_independent_feature_telemetry():
+    output = RequestOutput(
+        request_id="request-1",
+        mtp_drafts=10,
+        mtp_accepted=7,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="sparse",
+        specprefill_coverage="selective",
+        specprefill_engaged=True,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_total_tokens=8192,
+        specprefill_selected_tokens=3072,
+        specprefill_scorer_ms=12.5,
+        specprefill_target_prefill_ms=40.0,
+    )
+
+    _assert_feature_telemetry(output)

--- a/tests/test_specprefill_platform_core.py
+++ b/tests/test_specprefill_platform_core.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused non-model contracts for the SpecPrefill platform core."""
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.specprefill import (
+    ARCHITECTURE_ADAPTERS,
+    SPECPREFILL_SELECTOR_VERSION,
+    SpecPrefillCoverage,
+    SpecPrefillPolicy,
+    _AttentionCapture,
+    _build_layer_to_cache_map,
+    _gemma4_extract_queries,
+    _qwen_extract_queries,
+    build_selection_plan,
+    resolve_specprefill_adapter,
+    resolve_specprefill_decision,
+    select_chunks,
+)
+
+
+def test_production_policy_requires_declared_selective_coverage():
+    allowed = resolve_specprefill_decision(
+        "auto", "selective", production=True, threshold_met=True, admission_allowed=True
+    )
+    assert allowed.requested_policy is SpecPrefillPolicy.AUTO
+    assert allowed.effective_policy is SpecPrefillPolicy.SPARSE
+
+    for coverage in (SpecPrefillCoverage.EXHAUSTIVE, SpecPrefillCoverage.UNKNOWN):
+        denied = resolve_specprefill_decision("auto", coverage, production=True)
+        assert denied.effective_policy is SpecPrefillPolicy.DENSE
+        assert denied.fallback_reason == "coverage_not_selective"
+        diagnostic_auto = resolve_specprefill_decision(
+            "auto", coverage, production=False
+        )
+        assert diagnostic_auto.effective_policy is SpecPrefillPolicy.DENSE
+
+
+def test_explicit_sparse_is_diagnostic_only_in_production():
+    production = resolve_specprefill_decision("sparse", "selective", production=True)
+    assert production.effective_policy is SpecPrefillPolicy.DENSE
+    assert production.fallback_reason == "sparse_forcing_diagnostic_only"
+
+    diagnostic = resolve_specprefill_decision("sparse", "exhaustive", production=False)
+    assert diagnostic.effective_policy is SpecPrefillPolicy.SPARSE
+
+
+def test_non_text_policy_falls_back_before_sparse_admission():
+    decision = resolve_specprefill_decision(
+        "auto", "selective", production=False, text_only=False
+    )
+    assert decision.effective_policy is SpecPrefillPolicy.DENSE
+    assert decision.fallback_reason == "media_request"
+
+
+def test_adapter_registry_is_explicit_for_installed_qwen_and_gemma_families():
+    assert resolve_specprefill_adapter("qwen3").name == "qwen-dense"
+    assert resolve_specprefill_adapter("qwen3_5").name == "qwen3.5-3.6-hybrid-moe"
+    assert (
+        resolve_specprefill_adapter("qwen3_5_moe_text").name == "qwen3.5-3.6-hybrid-moe"
+    )
+    assert resolve_specprefill_adapter("gemma4").name == "gemma4-shared-kv"
+    assert "gemma4" in ARCHITECTURE_ADAPTERS
+    with pytest.raises(ValueError, match="Unsupported SpecPrefill model_type"):
+        resolve_specprefill_adapter("unclassified-model")
+
+
+def test_gemma_shared_kv_mapping_compacts_to_unique_owner_caches():
+    # E2B has 35 decoder layers but only 15 KV owners; the prompt cache is
+    # sized for those 15 owners rather than all decoder layers.
+    previous_kvs = list(range(15)) + [index % 15 for index in range(20)]
+    model = SimpleNamespace(
+        layers=[object() for _ in previous_kvs],
+        model=SimpleNamespace(previous_kvs=previous_kvs),
+    )
+    mapping = _build_layer_to_cache_map(model)
+    assert len(mapping) == 35
+    assert set(mapping.values()) == set(range(15))
+    for layer_idx, owner_idx in enumerate(previous_kvs):
+        assert mapping[layer_idx] == owner_idx
+
+    # Owners need not be adjacent decoder layers; cache slots are compact in
+    # first-owner order rather than the decoder-layer number.
+    sparse_owners = [0, 0, 2, 0, 2]
+    sparse_model = SimpleNamespace(
+        layers=[object() for _ in sparse_owners],
+        previous_kvs=sparse_owners,
+    )
+    assert _build_layer_to_cache_map(sparse_model) == {0: 0, 1: 0, 2: 1, 3: 0, 4: 1}
+
+
+def test_capture_preserves_shared_kv_offset_arguments():
+    recorded = []
+
+    class Attention:
+        def __call__(self, x, mask=None, cache=None, **kwargs):
+            recorded.append((mask, cache, kwargs))
+            return x
+
+    captured = []
+
+    def extractor(attn, x, cache=None, **kwargs):
+        captured.append((cache, kwargs))
+        return x
+
+    wrapper = _AttentionCapture(Attention(), 0, [[]], extractor)
+    offset = mx.array(17)
+    shared_kv = (mx.array([1]), mx.array([2]))
+    wrapper(mx.zeros((1, 1, 1)), shared_kv=shared_kv, offset=offset)
+    assert recorded[0][2]["shared_kv"] is shared_kv
+    assert int(recorded[0][2]["offset"].item()) == 17
+    assert captured[0][1]["shared_kv"] is shared_kv
+
+
+def test_explicit_qwen_and_gemma_extractors_apply_normalization_and_offset():
+    class Norm:
+        def __call__(self, x):
+            return x * 2
+
+    class Rope:
+        def __call__(self, x, offset=0):
+            return x + offset
+
+    class Attention:
+        n_heads = 2
+        q_norm = Norm()
+        rope = Rope()
+
+        def q_proj(self, x):
+            return x
+
+    x = mx.arange(16, dtype=mx.float32).reshape(1, 2, 8)
+    expected = (x.reshape(1, 2, 2, 4) * 2).transpose(0, 2, 1, 3) + 9
+    cache = SimpleNamespace(offset=9)
+    for extractor in (_qwen_extract_queries, _gemma4_extract_queries):
+        actual = extractor(Attention(), x, cache=cache)
+        mx.eval(actual)
+        assert actual.tolist() == expected.tolist()
+
+
+def test_hybrid_selector_retains_importance_halo_anchors_and_backbone():
+    importance = mx.array(
+        [0.1] * 4
+        + [0.2] * 4
+        + [0.3] * 4
+        + [0.99] * 4
+        + [0.4] * 4
+        + [0.5] * 4
+        + [0.6] * 4
+        + [0.7] * 4
+    )
+    plan = build_selection_plan(
+        importance,
+        keep_pct=0.5,
+        chunk_size=4,
+        backbone_pct=0.125,
+        halo_chunks=1,
+        anchor_chunks=1,
+    )
+    assert plan.selector_version == SPECPREFILL_SELECTOR_VERSION
+    assert plan.anchor_chunks == (0, 7)
+    assert plan.backbone_chunks == (4,)
+    assert 3 in plan.importance_chunks
+    assert {2, 3, 4}.issubset(plan.selected_chunks)
+    assert plan.selected_indices == tuple(sorted(plan.selected_indices))
+    assert select_chunks(
+        importance,
+        keep_pct=0.5,
+        chunk_size=4,
+        backbone_pct=0.125,
+        halo_chunks=1,
+        anchor_chunks=1,
+    ).tolist() == list(plan.selected_indices)
+
+
+def test_selector_is_stable_and_validates_invalid_importance():
+    importance = mx.array([1.0] * 16)
+    first = build_selection_plan(importance, keep_pct=0.5, chunk_size=4)
+    second = build_selection_plan(importance, keep_pct=0.5, chunk_size=4)
+    assert first == second
+    assert first.fingerprint == second.fingerprint
+    assert first.selected_chunks[0] == 0
+
+    different_policy = build_selection_plan(importance, keep_pct=0.75, chunk_size=4)
+    assert first.fingerprint != different_policy.fingerprint
+
+    with pytest.raises(ValueError, match="finite"):
+        build_selection_plan(mx.array([0.0, float("nan")]), chunk_size=1)
+    with pytest.raises(ValueError, match="keep_pct"):
+        build_selection_plan(importance, keep_pct=0.0)

--- a/tests/test_specprefill_platform_core.py
+++ b/tests/test_specprefill_platform_core.py
@@ -6,21 +6,29 @@ from types import SimpleNamespace
 import pytest
 
 mx = pytest.importorskip("mlx.core")
+from mlx_lm.models.cache import KVCache, RotatingKVCache
 
 from vllm_mlx.specprefill import (
     ARCHITECTURE_ADAPTERS,
+    GEMMA4_ADAPTER,
+    QWEN_HYBRID_ADAPTER,
     SPECPREFILL_SELECTOR_VERSION,
+    Gemma4Variant,
     SpecPrefillCoverage,
     SpecPrefillPolicy,
     _AttentionCapture,
     _build_layer_to_cache_map,
     _gemma4_extract_queries,
     _qwen_extract_queries,
+    _qwen35_extract_queries,
     build_selection_plan,
+    resolve_gemma4_layout,
     resolve_specprefill_adapter,
     resolve_specprefill_decision,
     select_chunks,
+    validate_specprefill_cache_topology,
 )
+from vllm_mlx.specprefill_scorer_session import SpecPrefillScorerSession
 
 
 def test_production_policy_requires_declared_selective_coverage():
@@ -93,6 +101,148 @@ def test_gemma_shared_kv_mapping_compacts_to_unique_owner_caches():
     assert _build_layer_to_cache_map(sparse_model) == {0: 0, 1: 0, 2: 1, 3: 0, 4: 1}
 
 
+def test_gemma_outer_language_model_resolver_keeps_decoder_and_cache_owners():
+    decoder = SimpleNamespace(
+        layers=[
+            SimpleNamespace(layer_type="full_attention"),
+            SimpleNamespace(layer_type="sliding_attention"),
+            SimpleNamespace(layer_type="full_attention"),
+            SimpleNamespace(layer_type="sliding_attention"),
+        ],
+        previous_kvs=(0, 1, 0, 1),
+        config=SimpleNamespace(num_experts=None),
+    )
+    language_model = SimpleNamespace(
+        model=decoder,
+        make_cache=lambda: [KVCache(), RotatingKVCache(16)],
+    )
+    outer = SimpleNamespace(
+        config=SimpleNamespace(model_type="gemma4"), language_model=language_model
+    )
+
+    layout = resolve_gemma4_layout(outer)
+    mapping = GEMMA4_ADAPTER.cache_map_builder(outer)
+
+    assert layout.decoder_model is decoder
+    assert layout.cache_model is language_model
+    assert layout.variant is Gemma4Variant.DENSE
+    assert mapping == {0: 0, 1: 1, 2: 0, 3: 1}
+    cache = language_model.make_cache()
+    validate_specprefill_cache_topology(GEMMA4_ADAPTER, outer, cache, mapping)
+    assert type(cache[mapping[0]]) is KVCache
+    assert type(cache[mapping[1]]) is RotatingKVCache
+    with pytest.raises(ValueError, match="full_attention owner 0 requires KVCache"):
+        validate_specprefill_cache_topology(
+            GEMMA4_ADAPTER,
+            outer,
+            [RotatingKVCache(16), KVCache()],
+            mapping,
+        )
+
+
+def test_gemma_outer_wrapper_scorer_session_uses_language_owner_compact_cache():
+    class Attention:
+        n_heads = 1
+
+        def __call__(self, x, mask=None, cache=None):
+            del mask, cache
+            return x
+
+    class Outer:
+        def __init__(self):
+            decoder = SimpleNamespace(
+                layers=[
+                    SimpleNamespace(self_attn=Attention(), layer_type="full_attention")
+                ],
+                previous_kvs=(0,),
+                config=SimpleNamespace(num_experts=None),
+            )
+            self.config = SimpleNamespace(model_type="gemma4")
+            self.language_model = SimpleNamespace(
+                model=decoder, make_cache=lambda: [KVCache()]
+            )
+
+    outer = Outer()
+    from vllm_mlx.specprefill import SpecPrefillScorer
+
+    scorer = SpecPrefillScorer.for_model(outer)
+    session = SpecPrefillScorerSession(scorer, [1], n_lookahead=1)
+
+    assert scorer.decoder_model is outer.language_model.model
+    assert scorer.cache_model is outer.language_model
+    assert len(session.cache) == 1
+
+
+def test_gemma_a4b_zero_shared_kv_is_identity_topology_not_shared_owner_guessing():
+    decoder = SimpleNamespace(
+        layers=[
+            SimpleNamespace(layer_type="full_attention"),
+            SimpleNamespace(layer_type="sliding_attention"),
+            SimpleNamespace(layer_type="full_attention"),
+        ],
+        previous_kvs=(0, 1, 2),
+        config=SimpleNamespace(num_experts=128),
+    )
+    wrapper = SimpleNamespace(
+        config=SimpleNamespace(model_type="gemma4"),
+        model=decoder,
+        make_cache=lambda: [KVCache(), RotatingKVCache(16), KVCache()],
+    )
+
+    layout = resolve_gemma4_layout(wrapper)
+    mapping = GEMMA4_ADAPTER.cache_map_builder(wrapper)
+
+    assert layout.variant is Gemma4Variant.A4B
+    assert mapping == {0: 0, 1: 1, 2: 2}
+    validate_specprefill_cache_topology(
+        GEMMA4_ADAPTER, wrapper, wrapper.make_cache(), mapping
+    )
+
+
+@pytest.mark.parametrize(
+    ("previous_kvs", "message"),
+    [((0, 3), "Invalid Gemma 4 KV owner"), ((1, 0), "must precede")],
+)
+def test_gemma_owner_topology_fails_closed_before_cache_use(previous_kvs, message):
+    model = SimpleNamespace(
+        config=SimpleNamespace(model_type="gemma4"),
+        layers=[object(), object()],
+        previous_kvs=previous_kvs,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        resolve_gemma4_layout(model)
+
+
+def test_cache_topology_rejects_wrong_cache_length_and_out_of_bounds_mapping():
+    model = SimpleNamespace(
+        config=SimpleNamespace(model_type="gemma4"),
+        layers=[object(), object()],
+        previous_kvs=(0, 0),
+    )
+    mapping = {0: 0, 1: 0}
+    with pytest.raises(ValueError, match="has 2 entries; expected 1"):
+        validate_specprefill_cache_topology(
+            GEMMA4_ADAPTER, model, [object(), object()], mapping
+        )
+    with pytest.raises(ValueError, match="out of bounds"):
+        validate_specprefill_cache_topology(GEMMA4_ADAPTER, model, [object()], {0: 1})
+
+
+def test_qwen_hybrid_requires_one_cache_entry_per_decoder_layer():
+    model = SimpleNamespace(layers=[object(), object(), object()])
+    mapping = QWEN_HYBRID_ADAPTER.cache_map_builder(model)
+
+    assert mapping == {0: 0, 1: 1, 2: 2}
+    validate_specprefill_cache_topology(
+        QWEN_HYBRID_ADAPTER, model, [object()] * 3, mapping
+    )
+    with pytest.raises(ValueError, match="has 2 entries; expected 3"):
+        validate_specprefill_cache_topology(
+            QWEN_HYBRID_ADAPTER, model, [object(), object()], mapping
+        )
+
+
 def test_capture_preserves_shared_kv_offset_arguments():
     recorded = []
 
@@ -140,6 +290,33 @@ def test_explicit_qwen_and_gemma_extractors_apply_normalization_and_offset():
         actual = extractor(Attention(), x, cache=cache)
         mx.eval(actual)
         assert actual.tolist() == expected.tolist()
+
+
+def test_qwen_hybrid_extractor_keeps_gated_projection_and_q_norm_contract():
+    class Norm:
+        def __call__(self, x):
+            return x * 3
+
+    class Rope:
+        def __call__(self, x, offset=0):
+            return x + offset
+
+    class Attention:
+        num_attention_heads = 2
+        q_norm = Norm()
+        rope = Rope()
+
+        def q_proj(self, x):
+            B, L, _ = x.shape
+            queries = x.reshape(B, L, 2, 4)
+            gates = queries + 100
+            return mx.concatenate((queries, gates), axis=-1).reshape(B, L, -1)
+
+    x = mx.arange(16, dtype=mx.float32).reshape(1, 2, 8)
+    actual = _qwen35_extract_queries(Attention(), x, cache=SimpleNamespace(offset=7))
+    expected = x.reshape(1, 2, 2, 4).transpose(0, 2, 1, 3) * 3 + 7
+    mx.eval(actual, expected)
+    assert actual.tolist() == expected.tolist()
 
 
 def test_hybrid_selector_retains_importance_halo_anchors_and_backbone():

--- a/tests/test_specprefill_policy_api.py
+++ b/tests/test_specprefill_policy_api.py
@@ -22,6 +22,12 @@ def _chat(**overrides):
     return ChatCompletionRequest(**payload)
 
 
+def _completion(**overrides):
+    payload = {"model": "test-model", "prompt": "hello"}
+    payload.update(overrides)
+    return CompletionRequest(**payload)
+
+
 @pytest.mark.parametrize(
     ("legacy", "policy"),
     [(False, "dense"), (True, "sparse")],
@@ -40,6 +46,31 @@ def test_legacy_and_policy_may_agree(legacy, policy):
 def test_conflicting_legacy_and_policy_are_rejected(legacy, policy):
     with pytest.raises(ValidationError, match="conflicts with specprefill_policy"):
         _chat(specprefill=legacy, specprefill_policy=policy)
+    with pytest.raises(ValidationError, match="conflicts with specprefill_policy"):
+        _completion(specprefill=legacy, specprefill_policy=policy)
+
+
+def test_completion_conflicting_policy_body_returns_http_422_without_engine_load():
+    from fastapi.testclient import TestClient
+    import vllm_mlx.server as server
+
+    original_api_key = server._api_key
+    server._api_key = None
+    try:
+        response = TestClient(server.app).post(
+            "/v1/completions",
+            json={
+                "model": "test-model",
+                "prompt": "hello",
+                "specprefill": False,
+                "specprefill_policy": "sparse",
+            },
+        )
+    finally:
+        server._api_key = original_api_key
+
+    assert response.status_code == 422
+    assert "conflicts with specprefill_policy" in response.text
 
 
 @pytest.mark.parametrize("field", ["specprefill_keep_pct", "specprefill_backbone_pct"])
@@ -165,3 +196,155 @@ def test_stream_terminal_chunk_includes_feature_metadata():
     )
     assert terminal["generation_metadata"]["mtp_drafts"] == 2
     assert terminal["generation_metadata"]["specprefill_engaged"] is True
+
+
+def test_completion_nonstreaming_forwards_contract_and_returns_terminal_metadata(
+    monkeypatch,
+):
+    from vllm_mlx.engine.base import GenerationOutput
+    import vllm_mlx.server as server
+
+    class Engine:
+        seen_kwargs = None
+
+        async def generate(self, **kwargs):
+            self.seen_kwargs = kwargs
+            return GenerationOutput(
+                text="ok",
+                new_text="ok",
+                finished=True,
+                finish_reason="stop",
+                prompt_tokens=20,
+                completion_tokens=2,
+                mtp_drafts=4,
+                mtp_accepted=3,
+                specprefill_requested_policy="auto",
+                specprefill_effective_policy="sparse",
+                specprefill_coverage="selective",
+                specprefill_engaged=True,
+                specprefill_selector_version="hybrid-v1",
+                specprefill_fallback_reason=None,
+                specprefill_total_tokens=20,
+                specprefill_selected_tokens=8,
+                specprefill_scorer_ms=1.5,
+                specprefill_target_prefill_ms=2.5,
+            )
+
+    engine = Engine()
+
+    async def acquire(*_args, **_kwargs):
+        return engine
+
+    async def release(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(server, "_model_name", "test-model")
+    monkeypatch.setattr(server, "_acquire_default_engine_for_request", acquire)
+    monkeypatch.setattr(server, "_release_engine_for_request", release)
+    response = asyncio.run(
+        server.create_completion(
+            _completion(specprefill_policy="auto", specprefill_coverage="selective"),
+            raw_request=None,
+        )
+    )
+
+    assert engine.seen_kwargs["specprefill_policy"] == "auto"
+    assert engine.seen_kwargs["specprefill_coverage"] == "selective"
+    assert response.generation_metadata is not None
+    assert response.generation_metadata.mtp_drafts == 4
+    assert response.generation_metadata.mtp_accepted == 3
+    assert response.generation_metadata.specprefill_selected_tokens == 8
+    assert response.generation_metadata.specprefill_target_prefill_ms == 2.5
+
+
+def test_completion_stream_terminal_includes_independent_feature_metadata():
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.server import stream_completion
+
+    class Engine:
+        async def stream_generate(self, **_kwargs):
+            yield GenerationOutput(
+                text="ok",
+                new_text="ok",
+                finished=True,
+                finish_reason="stop",
+                prompt_tokens=11,
+                completion_tokens=1,
+                mtp_drafts=2,
+                mtp_accepted=1,
+                specprefill_requested_policy="auto",
+                specprefill_effective_policy="dense",
+                specprefill_coverage="exhaustive",
+                specprefill_engaged=False,
+                specprefill_selector_version="hybrid-v1",
+                specprefill_fallback_reason="coverage_not_selective",
+                specprefill_total_tokens=11,
+                specprefill_selected_tokens=0,
+                specprefill_scorer_ms=0.0,
+                specprefill_target_prefill_ms=0.0,
+            )
+
+    async def collect():
+        return [
+            chunk
+            async for chunk in stream_completion(
+                Engine(), "hello", _completion(stream=True), max_tokens=2
+            )
+        ]
+
+    chunks = asyncio.run(collect())
+    terminal = next(
+        json.loads(chunk.removeprefix("data: "))
+        for chunk in chunks
+        if chunk.startswith("data: {") and '"finish_reason": "stop"' in chunk
+    )
+    metadata = terminal["generation_metadata"]
+    assert metadata["mtp_drafts"] == 2
+    assert metadata["mtp_accepted"] == 1
+    assert metadata["specprefill_effective_policy"] == "dense"
+    assert metadata["specprefill_engaged"] is False
+    assert metadata["specprefill_fallback_reason"] == "coverage_not_selective"
+
+
+def test_completion_prompt_lists_aggregate_counts_without_misreporting_route():
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.server import _aggregate_completion_generation_metadata
+
+    outputs = [
+        GenerationOutput(
+            text="first",
+            mtp_drafts=2,
+            mtp_accepted=1,
+            specprefill_requested_policy="auto",
+            specprefill_effective_policy="sparse",
+            specprefill_coverage="selective",
+            specprefill_engaged=True,
+            specprefill_total_tokens=10,
+            specprefill_selected_tokens=4,
+            specprefill_scorer_ms=1.0,
+            specprefill_target_prefill_ms=2.0,
+        ),
+        GenerationOutput(
+            text="second",
+            mtp_drafts=3,
+            mtp_accepted=2,
+            specprefill_requested_policy="auto",
+            specprefill_effective_policy="dense",
+            specprefill_coverage="exhaustive",
+            specprefill_engaged=False,
+            specprefill_total_tokens=20,
+            specprefill_selected_tokens=0,
+            specprefill_scorer_ms=0.0,
+            specprefill_target_prefill_ms=0.0,
+        ),
+    ]
+
+    metadata = _aggregate_completion_generation_metadata(outputs)
+
+    assert metadata is not None
+    assert metadata.mtp_drafts == 5
+    assert metadata.mtp_accepted == 3
+    assert metadata.specprefill_total_tokens == 30
+    assert metadata.specprefill_selected_tokens == 4
+    assert metadata.specprefill_effective_policy is None
+    assert metadata.specprefill_engaged is None

--- a/tests/test_specprefill_policy_api.py
+++ b/tests/test_specprefill_policy_api.py
@@ -80,6 +80,20 @@ def test_tuning_percentages_are_bounded(field, value):
         CompletionRequest(model="test-model", prompt="hello", **{field: value})
 
 
+def test_cb_production_rejects_request_tuning_as_http_422():
+    from fastapi import HTTPException
+    from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.server import _validate_cb_specprefill_request_tuning
+
+    engine = BatchedEngine.__new__(BatchedEngine)
+    request = _chat(specprefill_keep_pct=0.5)
+
+    with pytest.raises(HTTPException) as failure:
+        _validate_cb_specprefill_request_tuning(engine, request)
+
+    assert failure.value.status_code == 422
+
+
 def test_policy_and_coverage_values_are_closed_enums():
     with pytest.raises(ValidationError):
         _chat(specprefill_policy="sometimes")
@@ -116,13 +130,23 @@ def test_chat_invocation_forwards_policy_coverage_and_media_state():
     request = _chat(
         specprefill_policy="auto",
         specprefill_coverage="selective",
+        specprefill_control_token_indices=[4, 1],
     )
 
     prepared = _prepare_chat_completion_invocation(engine, request, 16)
 
     assert prepared.chat_kwargs["specprefill_policy"] == "auto"
     assert prepared.chat_kwargs["specprefill_coverage"] == "selective"
+    assert prepared.chat_kwargs["specprefill_control_token_indices"] == [4, 1]
     assert prepared.chat_kwargs["specprefill_has_media"] is False
+
+
+@pytest.mark.parametrize("indices", [[-1], [True]])
+def test_control_token_indices_reject_invalid_public_values(indices):
+    with pytest.raises(ValidationError, match="specprefill_control_token_indices"):
+        _chat(specprefill_control_token_indices=indices)
+    with pytest.raises(ValidationError, match="specprefill_control_token_indices"):
+        _completion(specprefill_control_token_indices=indices)
 
 
 def test_server_metadata_combines_prefill_decode_and_watchdog():

--- a/tests/test_specprefill_policy_api.py
+++ b/tests/test_specprefill_policy_api.py
@@ -1,0 +1,167 @@
+"""Public API contract for request-safe SpecPrefill policy controls."""
+
+import pytest
+from pydantic import ValidationError
+from types import SimpleNamespace
+import asyncio
+import json
+
+from vllm_mlx.api.models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    GenerationMetadata,
+)
+
+
+def _chat(**overrides):
+    payload = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    payload.update(overrides)
+    return ChatCompletionRequest(**payload)
+
+
+@pytest.mark.parametrize(
+    ("legacy", "policy"),
+    [(False, "dense"), (True, "sparse")],
+)
+def test_legacy_and_policy_may_agree(legacy, policy):
+    request = _chat(specprefill=legacy, specprefill_policy=policy)
+
+    assert request.specprefill is legacy
+    assert request.specprefill_policy == policy
+
+
+@pytest.mark.parametrize(
+    ("legacy", "policy"),
+    [(False, "auto"), (False, "sparse"), (True, "auto"), (True, "dense")],
+)
+def test_conflicting_legacy_and_policy_are_rejected(legacy, policy):
+    with pytest.raises(ValidationError, match="conflicts with specprefill_policy"):
+        _chat(specprefill=legacy, specprefill_policy=policy)
+
+
+@pytest.mark.parametrize("field", ["specprefill_keep_pct", "specprefill_backbone_pct"])
+@pytest.mark.parametrize("value", [-0.01, 1.01])
+def test_tuning_percentages_are_bounded(field, value):
+    with pytest.raises(ValidationError):
+        CompletionRequest(model="test-model", prompt="hello", **{field: value})
+
+
+def test_policy_and_coverage_values_are_closed_enums():
+    with pytest.raises(ValidationError):
+        _chat(specprefill_policy="sometimes")
+    with pytest.raises(ValidationError):
+        _chat(specprefill_coverage="maybe")
+
+
+def test_generation_metadata_exposes_independent_specprefill_and_mtp_fields():
+    metadata = GenerationMetadata(
+        mtp_drafts=12,
+        mtp_accepted=8,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="sparse",
+        specprefill_coverage="selective",
+        specprefill_engaged=True,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_total_tokens=10_000,
+        specprefill_selected_tokens=3_000,
+        specprefill_scorer_ms=125.5,
+        specprefill_target_prefill_ms=810.0,
+    )
+
+    dumped = metadata.model_dump(exclude_none=True)
+    assert dumped["mtp_drafts"] == 12
+    assert dumped["mtp_accepted"] == 8
+    assert dumped["specprefill_engaged"] is True
+    assert dumped["specprefill_selected_tokens"] == 3_000
+
+
+def test_chat_invocation_forwards_policy_coverage_and_media_state():
+    from vllm_mlx.server import _prepare_chat_completion_invocation
+
+    engine = SimpleNamespace(is_mllm=False, preserve_native_tool_format=False)
+    request = _chat(
+        specprefill_policy="auto",
+        specprefill_coverage="selective",
+    )
+
+    prepared = _prepare_chat_completion_invocation(engine, request, 16)
+
+    assert prepared.chat_kwargs["specprefill_policy"] == "auto"
+    assert prepared.chat_kwargs["specprefill_coverage"] == "selective"
+    assert prepared.chat_kwargs["specprefill_has_media"] is False
+
+
+def test_server_metadata_combines_prefill_decode_and_watchdog():
+    from vllm_mlx.server import _generation_metadata
+
+    processor = SimpleNamespace(
+        _no_final_content_token_limit=20,
+        watchdog_was_enforced=False,
+    )
+    output = SimpleNamespace(
+        mtp_drafts=12,
+        mtp_accepted=8,
+        specprefill_requested_policy="auto",
+        specprefill_effective_policy="sparse",
+        specprefill_coverage="selective",
+        specprefill_engaged=True,
+        specprefill_selector_version="hybrid-v1",
+        specprefill_fallback_reason=None,
+        specprefill_total_tokens=10_000,
+        specprefill_selected_tokens=3_000,
+        specprefill_scorer_ms=125.5,
+        specprefill_target_prefill_ms=810.0,
+    )
+
+    metadata = _generation_metadata(processor, output)
+
+    assert metadata.no_final_content_watchdog_tokens == 20
+    assert metadata.mtp_drafts == 12
+    assert metadata.specprefill_engaged is True
+
+
+def test_stream_terminal_chunk_includes_feature_metadata():
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.server import stream_chat_completion
+
+    class Engine:
+        model_name = "test-model"
+        preserve_native_tool_format = False
+
+        async def stream_chat(self, **kwargs):
+            yield GenerationOutput(
+                text="ok",
+                new_text="ok",
+                finished=True,
+                finish_reason="stop",
+                prompt_tokens=100,
+                completion_tokens=1,
+                mtp_drafts=2,
+                mtp_accepted=1,
+                specprefill_requested_policy="auto",
+                specprefill_effective_policy="sparse",
+                specprefill_coverage="selective",
+                specprefill_engaged=True,
+            )
+
+    async def collect():
+        return [
+            chunk
+            async for chunk in stream_chat_completion(
+                Engine(),
+                [{"role": "user", "content": "hello"}],
+                _chat(stream=True),
+            )
+        ]
+
+    chunks = asyncio.run(collect())
+    terminal = next(
+        json.loads(chunk.removeprefix("data: "))
+        for chunk in chunks
+        if chunk.startswith("data: {") and '"finish_reason":"stop"' in chunk
+    )
+    assert terminal["generation_metadata"]["mtp_drafts"] == 2
+    assert terminal["generation_metadata"]["specprefill_engaged"] is True

--- a/tests/test_specprefill_profiles.py
+++ b/tests/test_specprefill_profiles.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-free contracts for calibrated SpecPrefill profile resolution."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vllm_mlx.specprefill_profiles import (
+    EMPTY_SPECPREFILL_PROFILE_REGISTRY,
+    SpecPrefillCalibration,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfile,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillProfileTier,
+    SpecPrefillQualificationEvidence,
+    SpecPrefillTuning,
+)
+
+
+def _hash(letter: str) -> str:
+    return letter * 64
+
+
+def _key(
+    *,
+    engine: SpecPrefillEngine = SpecPrefillEngine.SIMPLE,
+    cell: SpecPrefillCell = SpecPrefillCell.SPARSE_ONLY,
+) -> SpecPrefillProfileKey:
+    return SpecPrefillProfileKey(
+        target_artifact_id="gemma-4-31b-bf16",
+        target_artifact_hash=_hash("a"),
+        tokenizer_artifact_hash=_hash("b"),
+        scorer_artifact_id="gemma-4-e2b-bf16",
+        scorer_artifact_hash=_hash("c"),
+        adapter_id="gemma4-shared-kv",
+        engine=engine,
+        cell=cell,
+    )
+
+
+def _calibration(*, keep_pct: float = 0.7) -> SpecPrefillCalibration:
+    return SpecPrefillCalibration(
+        selector_version="hybrid-chunk-v1",
+        tuning=SpecPrefillTuning(
+            keep_pct=keep_pct,
+            backbone_pct=0.1,
+            halo_chunks=1,
+            anchor_chunks=1,
+            chunk_size=32,
+        ),
+        crossover_tokens=8192,
+        max_context_tokens=131072,
+        residency_limit_bytes=80 * 1024**3,
+        min_ttft_improvement_pct=20.0,
+        max_total_latency_regression_pct=5.0,
+        max_decode_throughput_regression_pct=5.0,
+        required_context_tokens=(8192, 16384, 32768, 65536, 98304, 130048),
+        required_concurrency_levels=(1,),
+        max_p95_inter_token_latency_regression_pct=5.0,
+        min_prefill_heavy_throughput_improvement_pct=10.0,
+    )
+
+
+def _evidence(
+    *,
+    key: SpecPrefillProfileKey | None = None,
+    selector_version: str = "hybrid-chunk-v1",
+    **overrides: object,
+) -> SpecPrefillQualificationEvidence:
+    values: dict[str, object] = {
+        "report_id": "run/specprefill/gemma4-31b-simple-sparse/summary.json",
+        "report_sha256": _hash("9"),
+        "key": key or _key(),
+        "selector_version": selector_version,
+        "tested_context_tokens": (8192, 16384, 32768, 65536, 98304, 130048),
+        "tested_concurrency_levels": (1,),
+        "deterministic_baseline_successes": 12,
+        "preserved_baseline_successes": 12,
+        "fabricated_or_source_corruption_count": 0,
+        "quality_noninferiority_ci_lower_points": -1.5,
+        "median_ttft_improvement_pct": 22.0,
+        "median_total_latency_regression_pct": 4.0,
+        "decode_throughput_regression_pct": 4.0,
+        "oom_count": 0,
+        "swap_escalation_count": 0,
+        "unbounded_retry_count": 0,
+        "peak_resident_bytes": 70 * 1024**3,
+        "admission_safety_reserve_pct": 10.0,
+        "cb_p95_inter_token_latency_regression_pct": None,
+        "cb_aggregate_throughput_regression_pct": None,
+        "cb_prefill_heavy_throughput_improvement_pct": None,
+        "mtp_evidence_id": None,
+        "mtp_evidence_sha256": None,
+        "mtp_drafts": 0,
+        "mtp_accepted": 0,
+    }
+    values.update(overrides)
+    return SpecPrefillQualificationEvidence(**values)
+
+
+def _profile(
+    *,
+    key: SpecPrefillProfileKey | None = None,
+    tier: SpecPrefillProfileTier = SpecPrefillProfileTier.PRODUCTION,
+    keep_pct: float = 0.7,
+    evidence: SpecPrefillQualificationEvidence | None = None,
+) -> SpecPrefillProfile:
+    return SpecPrefillProfile(
+        key=key or _key(),
+        tier=tier,
+        calibration=_calibration(keep_pct=keep_pct),
+        qualification_evidence=evidence,
+    )
+
+
+def test_empty_seed_registry_fails_closed_for_every_artifact():
+    decision = EMPTY_SPECPREFILL_PROFILE_REGISTRY.resolve(
+        _key(), prompt_tokens=16384, residency_bytes=1
+    )
+    assert not decision.eligible
+    assert not decision.production_certified
+    assert decision.fallback_reason == "profile_not_registered"
+
+
+def test_production_requires_explicit_profile_calibration_and_certification():
+    registry = SpecPrefillProfileRegistry((_profile(),))
+    decision = registry.resolve(_key(), prompt_tokens=16384, residency_bytes=1)
+    assert not decision.eligible
+    assert decision.fallback_reason == "uncalibrated_profile"
+
+    certified = _profile(evidence=_evidence())
+    decision = SpecPrefillProfileRegistry((certified,)).resolve(
+        _key(), prompt_tokens=16384, residency_bytes=1
+    )
+    assert decision.eligible
+    assert decision.production_certified
+    assert decision.tuning == certified.calibration.tuning
+
+
+def test_artifact_adapter_engine_and_cell_are_independent_eligibility_cells():
+    simple_sparse = _profile(evidence=_evidence())
+    cb_sparse_key = _key(engine=SpecPrefillEngine.CONTINUOUS_BATCHING)
+    simple_combined_key = _key(cell=SpecPrefillCell.COMBINED_MTP)
+    registry = SpecPrefillProfileRegistry((simple_sparse,))
+
+    assert registry.resolve(_key(), prompt_tokens=16384, residency_bytes=1).eligible
+    assert (
+        registry.resolve(
+            cb_sparse_key, prompt_tokens=16384, residency_bytes=1
+        ).fallback_reason
+        == "profile_not_registered"
+    )
+    assert (
+        registry.resolve(
+            simple_combined_key, prompt_tokens=16384, residency_bytes=1
+        ).fallback_reason
+        == "profile_not_registered"
+    )
+
+
+def test_calibrated_bounds_and_residency_have_explicit_dense_fallbacks():
+    registry = SpecPrefillProfileRegistry((_profile(evidence=_evidence()),))
+    assert (
+        registry.resolve(_key(), prompt_tokens=8191, residency_bytes=1).fallback_reason
+        == "below_calibrated_crossover"
+    )
+    assert (
+        registry.resolve(
+            _key(), prompt_tokens=131073, residency_bytes=1
+        ).fallback_reason
+        == "above_calibrated_max_context"
+    )
+    assert (
+        registry.resolve(
+            _key(), prompt_tokens=16384, residency_bytes=80 * 1024**3 + 1
+        ).fallback_reason
+        == "residency_limit_exceeded"
+    )
+
+
+def test_255k_calibration_requires_both_qwen_extension_ladder_rungs():
+    required = (8192, 16384, 32768, 65536, 98304, 130048, 196608, 261120)
+    with pytest.raises(ValueError, match="context ladder"):
+        replace(
+            _calibration(),
+            max_context_tokens=261120,
+            required_context_tokens=required[:-2] + (261120,),
+        )
+    with pytest.raises(ValueError, match="context ladder"):
+        replace(
+            _calibration(),
+            max_context_tokens=261120,
+            required_context_tokens=required[:-1],
+        )
+    calibration = replace(
+        _calibration(),
+        max_context_tokens=261120,
+        required_context_tokens=required,
+    )
+    assert calibration.required_context_tokens == required
+
+
+def test_diagnostic_tuning_is_explicit_but_cannot_claim_production_certification():
+    diagnostic = _profile(
+        tier=SpecPrefillProfileTier.DIAGNOSTIC,
+        keep_pct=0.35,
+    )
+    registry = SpecPrefillProfileRegistry((diagnostic,))
+    decision = registry.resolve(
+        _key(), prompt_tokens=16384, residency_bytes=1, diagnostic=True
+    )
+    assert decision.eligible
+    assert not decision.production_certified
+    assert decision.tuning.keep_pct == 0.35
+    assert (
+        registry.resolve(_key(), prompt_tokens=16384, residency_bytes=1).fallback_reason
+        == "profile_not_registered"
+    )
+
+
+def test_no_universal_keep_ratio_and_selector_or_hash_drift_cannot_match():
+    first = _profile(keep_pct=0.55, evidence=_evidence())
+    second_key = SpecPrefillProfileKey(
+        target_artifact_id="qwen3.6-35b-a3b",
+        target_artifact_hash=_hash("d"),
+        tokenizer_artifact_hash=_hash("e"),
+        scorer_artifact_id="qwen3.5-4b",
+        scorer_artifact_hash=_hash("f"),
+        adapter_id="qwen3.5-3.6-hybrid-moe",
+        engine=SpecPrefillEngine.SIMPLE,
+        cell=SpecPrefillCell.SPARSE_ONLY,
+    )
+    second = _profile(
+        key=second_key,
+        keep_pct=0.8,
+        evidence=_evidence(key=second_key),
+    )
+    registry = SpecPrefillProfileRegistry((first, second))
+    assert (
+        registry.resolve(_key(), prompt_tokens=16384, residency_bytes=1).tuning.keep_pct
+        == 0.55
+    )
+    assert (
+        registry.resolve(
+            second_key, prompt_tokens=16384, residency_bytes=1
+        ).tuning.keep_pct
+        == 0.8
+    )
+
+    selector_drift = SpecPrefillProfile(
+        key=_key(),
+        tier=SpecPrefillProfileTier.PRODUCTION,
+        calibration=replace(_calibration(), selector_version="hybrid-chunk-v2"),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        SpecPrefillProfileRegistry((first, selector_drift))
+
+    hash_drift = replace(_key(), target_artifact_hash=_hash("0"))
+    assert (
+        registry.resolve(
+            hash_drift, prompt_tokens=16384, residency_bytes=1
+        ).fallback_reason
+        == "profile_not_registered"
+    )
+
+
+def test_production_certification_is_evidence_derived_and_rejects_drift_or_failures():
+    with pytest.raises(TypeError, match="production_certified"):
+        SpecPrefillProfile(
+            key=_key(),
+            tier=SpecPrefillProfileTier.PRODUCTION,
+            calibration=_calibration(),
+            production_certified=True,
+        )
+
+    with pytest.raises(ValueError, match="key"):
+        _profile(
+            evidence=_evidence(key=replace(_key(), target_artifact_hash=_hash("0")))
+        )
+    with pytest.raises(ValueError, match="selector"):
+        _profile(evidence=_evidence(selector_version="hybrid-chunk-v2"))
+    with pytest.raises(ValueError, match="baseline"):
+        _profile(evidence=_evidence(preserved_baseline_successes=11))
+    with pytest.raises(ValueError, match="source corruption"):
+        _profile(evidence=_evidence(fabricated_or_source_corruption_count=1))
+    with pytest.raises(ValueError, match="quality"):
+        _profile(evidence=_evidence(quality_noninferiority_ci_lower_points=-2.1))
+    with pytest.raises(ValueError, match="TTFT"):
+        _profile(evidence=_evidence(median_ttft_improvement_pct=19.9))
+    with pytest.raises(ValueError, match="OOM"):
+        _profile(evidence=_evidence(oom_count=1))
+    with pytest.raises(ValueError, match="swap"):
+        _profile(evidence=_evidence(swap_escalation_count=1))
+    with pytest.raises(ValueError, match="context ladder"):
+        _profile(
+            evidence=_evidence(
+                tested_context_tokens=(8192, 16384, 32768, 98304, 130048)
+            )
+        )
+    with pytest.raises(ValueError, match="reserve"):
+        _profile(evidence=_evidence(admission_safety_reserve_pct=9.9))
+    with pytest.raises(ValueError, match="resident peak"):
+        _profile(evidence=_evidence(peak_resident_bytes=81 * 1024**3))
+
+
+def test_cb_and_combined_profiles_require_route_specific_evidence():
+    cb_key = _key(engine=SpecPrefillEngine.CONTINUOUS_BATCHING)
+    with pytest.raises(ValueError, match="CB"):
+        _profile(key=cb_key, evidence=_evidence(key=cb_key))
+
+    cb_evidence = _evidence(
+        key=cb_key,
+        tested_concurrency_levels=(1, 2, 4, 8),
+        cb_p95_inter_token_latency_regression_pct=4.0,
+        cb_aggregate_throughput_regression_pct=0.0,
+        cb_prefill_heavy_throughput_improvement_pct=12.0,
+    )
+    cb_calibration = replace(_calibration(), required_concurrency_levels=(1, 2, 4, 8))
+    cb_profile = SpecPrefillProfile(
+        key=cb_key,
+        tier=SpecPrefillProfileTier.PRODUCTION,
+        calibration=cb_calibration,
+        qualification_evidence=cb_evidence,
+    )
+    assert (
+        SpecPrefillProfileRegistry((cb_profile,))
+        .resolve(cb_key, prompt_tokens=16384, residency_bytes=1)
+        .eligible
+    )
+    with pytest.raises(ValueError, match="concurrency ladder"):
+        SpecPrefillProfile(
+            key=cb_key,
+            tier=SpecPrefillProfileTier.PRODUCTION,
+            calibration=cb_calibration,
+            qualification_evidence=replace(
+                cb_evidence, tested_concurrency_levels=(1, 2, 8)
+            ),
+        )
+
+    combined_key = _key(cell=SpecPrefillCell.COMBINED_MTP)
+    with pytest.raises(ValueError, match="MTP"):
+        _profile(key=combined_key, evidence=_evidence(key=combined_key))

--- a/tests/test_specprefill_profiles.py
+++ b/tests/test_specprefill_profiles.py
@@ -65,6 +65,17 @@ def _calibration(*, keep_pct: float = 0.7) -> SpecPrefillCalibration:
     )
 
 
+def test_profile_tuning_requires_boundary_anchors():
+    with pytest.raises(ValueError, match="anchor_chunks must be positive"):
+        SpecPrefillTuning(
+            keep_pct=0.7,
+            backbone_pct=0.1,
+            halo_chunks=1,
+            anchor_chunks=0,
+            chunk_size=32,
+        )
+
+
 def _evidence(
     *,
     key: SpecPrefillProfileKey | None = None,

--- a/tests/test_specprefill_request_local_hooks.py
+++ b/tests/test_specprefill_request_local_hooks.py
@@ -7,11 +7,13 @@ from types import SimpleNamespace
 import pytest
 
 mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+from mlx.utils import tree_flatten
 
 import vllm_mlx.specprefill as specprefill
 from vllm_mlx.specprefill import (
     SpecPrefillScorer,
-    _AttentionCapture,
+    _compute_importance,
     _gemma4_extract_queries,
 )
 
@@ -34,38 +36,60 @@ class ScorerModel:
         self.layers = [SimpleNamespace(self_attn=RecordingAttention())]
 
 
+class ModuleAttention(nn.Module):
+    n_heads = 1
+    n_kv_heads = 1
+
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4, bias=False)
+
+    def __call__(self, x, mask=None, cache=None):
+        del mask, cache
+        return self.proj(x)
+
+
+class ModuleLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.self_attn = ModuleAttention()
+
+
+class ModuleScorerModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="qwen3")
+        self.layers = [ModuleLayer()]
+
+
 def passthrough_extractor(_attention, x, cache=None, **_kwargs):
     return x
 
 
-def test_scorer_installs_one_stable_wrapper_and_reuses_it():
+def test_scorer_installs_one_stable_dispatch_and_reuses_it():
     model = ScorerModel()
     original = model.layers[0].self_attn
 
     first = SpecPrefillScorer.for_model(model)
-    wrapper = model.layers[0].self_attn
     second = SpecPrefillScorer.for_model(model)
 
     assert first is second
-    assert isinstance(wrapper, _AttentionCapture)
-    assert model.layers[0].self_attn is wrapper
-    assert wrapper._original is original
-    with pytest.raises(RuntimeError, match="already installed"):
+    assert model.layers[0].self_attn is original
+    with pytest.raises(RuntimeError, match="already registered"):
         SpecPrefillScorer(model)
-    assert model.layers[0].self_attn is wrapper
+    assert model.layers[0].self_attn is original
 
 
-def test_idle_wrapper_delegates_original_args_and_kwargs_unchanged():
+def test_idle_dispatch_delegates_original_args_and_kwargs_unchanged():
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
-    wrapper = model.layers[0].self_attn
-    original = wrapper._original
+    original = model.layers[0].self_attn
     x = mx.zeros((1, 1, 1))
     mask = object()
     cache = object()
     shared_kv = object()
 
-    result = wrapper(x, mask, cache, shared_kv=shared_kv, offset=23)
+    result = original(x, mask, cache, shared_kv=shared_kv, offset=23)
 
     assert result is x
     assert len(original.calls) == 1
@@ -80,8 +104,7 @@ def test_idle_wrapper_delegates_original_args_and_kwargs_unchanged():
 def test_request_capture_preserves_call_shape_offset_and_shared_kv():
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
-    wrapper = model.layers[0].self_attn
-    original = wrapper._original
+    original = model.layers[0].self_attn
     x = mx.zeros((1, 1, 1))
     mask = object()
     cache = SimpleNamespace(offset=4)
@@ -94,7 +117,7 @@ def test_request_capture_preserves_call_shape_offset_and_shared_kv():
         return captured_x
 
     with scorer.capture_session(extractor) as session:
-        wrapper(x, mask, cache, offset=offset, shared_kv=shared_kv)
+        original(x, mask, cache, offset=offset, shared_kv=shared_kv)
         assert session.query_buffer[0] == [x]
 
     delegated_args, delegated_kwargs = original.calls[0]
@@ -108,10 +131,42 @@ def test_request_capture_preserves_call_shape_offset_and_shared_kv():
     assert extracted[0][2]["offset"] is offset
     assert extracted[0][2]["shared_kv"] is shared_kv
 
-    wrapper(x, cache=cache)
+    original(x, cache=cache)
     assert session.query_buffer[0] == [x]
-    assert model.layers[0].self_attn is wrapper
+    assert model.layers[0].self_attn is original
     assert not scorer.capture_active
+
+
+def test_real_mlx_module_identity_parameters_children_and_update_are_unchanged():
+    model = ModuleScorerModel()
+    attention = model.layers[0].self_attn
+    with pytest.raises(TypeError):
+        hash(model)
+    before_parameters = tree_flatten(model.parameters())
+    before_keys = tuple(key for key, _value in before_parameters)
+    before_values = tuple(value for _key, value in before_parameters)
+    before_children = model.children()
+    before_output = attention(mx.ones((1, 1, 4)))
+    mx.eval(before_output, model.parameters())
+
+    scorer = SpecPrefillScorer.for_model(model)
+
+    after_parameters = tree_flatten(model.parameters())
+    assert model.layers[0].self_attn is attention
+    assert tuple(key for key, _value in after_parameters) == before_keys
+    assert all(
+        after is before
+        for (_key, after), before in zip(after_parameters, before_values, strict=True)
+    )
+    assert model.children().keys() == before_children.keys()
+    assert model.children()["layers"][0] is before_children["layers"][0]
+    assert model.children()["layers"][0].self_attn is attention
+    model.load_weights(before_parameters, strict=True)
+    model.update(model.parameters())
+    after_output = attention(mx.ones((1, 1, 4)))
+    mx.eval(after_output, model.parameters())
+    assert mx.allclose(before_output, after_output).item()
+    assert SpecPrefillScorer.for_model(model) is scorer
 
 
 def test_gemma_capture_uses_explicit_offset_and_preserves_shared_kv():
@@ -194,14 +249,14 @@ def test_nested_and_foreign_thread_sessions_fail_closed():
 def test_session_exception_clears_state_without_uninstalling_wrapper():
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
-    wrapper = model.layers[0].self_attn
+    attention = model.layers[0].self_attn
 
     with pytest.raises(ValueError, match="cancelled"):
         with scorer.capture_session(passthrough_extractor):
             raise ValueError("cancelled")
 
     assert not scorer.capture_active
-    assert model.layers[0].self_attn is wrapper
+    assert model.layers[0].self_attn is attention
     with scorer.capture_session(passthrough_extractor):
         assert scorer.capture_active
 
@@ -209,7 +264,7 @@ def test_session_exception_clears_state_without_uninstalling_wrapper():
 def test_public_score_tokens_realizes_lazy_work_before_session_release(monkeypatch):
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
-    wrapper = model.layers[0].self_attn
+    attention = model.layers[0].self_attn
     cache = [SimpleNamespace(keys=mx.ones((1, 1, 2, 1)))]
     eval_session_states = []
     real_eval = specprefill.mx.eval
@@ -218,13 +273,13 @@ def test_public_score_tokens_realizes_lazy_work_before_session_release(monkeypat
 
     def prefill(*_args, **_kwargs):
         assert scorer.capture_active
-        wrapper(mx.ones((1, 1, 1)), cache=cache[0])
+        attention(mx.ones((1, 1, 1)), cache=cache[0])
         return mx.zeros((1, 1, 4))
 
     monkeypatch.setattr(specprefill, "_prefill_draft", prefill)
 
     def lookahead(_model, _logits, _cache, _steps, **_kwargs):
-        wrapper(mx.ones((1, 1, 1)), cache=cache[0], offset=2)
+        attention(mx.ones((1, 1, 1)), cache=cache[0], offset=2)
         return [1]
 
     def compute_importance(query_buffer, *_args, **_kwargs):
@@ -249,7 +304,7 @@ def test_public_score_tokens_realizes_lazy_work_before_session_release(monkeypat
     assert importance.tolist() == [0.25, 0.75]
     assert eval_session_states == [True]
     assert not scorer.capture_active
-    assert model.layers[0].self_attn is wrapper
+    assert model.layers[0].self_attn is attention
 
 
 def test_score_tokens_rejects_overlap_before_second_prefill(monkeypatch):
@@ -291,26 +346,28 @@ def test_score_tokens_rejects_overlap_before_second_prefill(monkeypatch):
     assert str(first_errors[0]) == "stop first scorer"
 
 
-def test_partial_wrapper_installation_rolls_back(monkeypatch):
+def test_partial_dispatch_installation_rolls_back(monkeypatch):
     model = ScorerModel()
     model.layers.append(SimpleNamespace(self_attn=RecordingAttention()))
     originals = [layer.self_attn for layer in model.layers]
-    real_set_attention = specprefill._set_attn_module
-    set_calls = 0
+    real_install = specprefill._install_attention_capture
+    install_calls = 0
 
-    def fail_second_install(layer, module):
-        nonlocal set_calls
-        set_calls += 1
-        if set_calls == 2:
+    def fail_second_install(attention, scorer, buffer_index):
+        nonlocal install_calls
+        install_calls += 1
+        if install_calls == 2:
             raise RuntimeError("install failed")
-        real_set_attention(layer, module)
+        real_install(attention, scorer, buffer_index)
 
-    monkeypatch.setattr(specprefill, "_set_attn_module", fail_second_install)
+    monkeypatch.setattr(specprefill, "_install_attention_capture", fail_second_install)
     with pytest.raises(RuntimeError, match="install failed"):
         SpecPrefillScorer(model)
 
     assert model.layers[0].self_attn is originals[0]
     assert model.layers[1].self_attn is originals[1]
+    with specprefill._ATTENTION_DISPATCH_LOCK:
+        assert specprefill._attention_capture_for(originals[0]) is None
 
 
 def test_unknown_family_fails_before_installing_any_wrapper():
@@ -321,13 +378,66 @@ def test_unknown_family_fails_before_installing_any_wrapper():
     assert model.layers[0].self_attn is original
 
 
-def test_wrapper_topology_tamper_fails_closed():
+def test_attention_topology_tamper_fails_closed():
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
     model.layers[0].self_attn = RecordingAttention()
 
-    with pytest.raises(RuntimeError, match="wrapper topology was modified"):
+    with pytest.raises(RuntimeError, match="attention topology was modified"):
         SpecPrefillScorer.for_model(model)
-    with pytest.raises(RuntimeError, match="wrapper topology was modified"):
+    with pytest.raises(RuntimeError, match="attention topology was modified"):
         with scorer.capture_session(passthrough_extractor):
             pass
+
+
+def test_attention_class_dispatch_tamper_fails_closed_and_restores():
+    model = ScorerModel()
+    attention = model.layers[0].self_attn
+    scorer = SpecPrefillScorer.for_model(model)
+    attention_type = type(attention)
+    installed_call = attention_type.__call__
+
+    def tampered_call(instance, *args, **kwargs):
+        return installed_call(instance, *args, **kwargs)
+
+    attention_type.__call__ = tampered_call
+    try:
+        with pytest.raises(RuntimeError, match="class dispatcher was modified"):
+            with scorer.capture_session(passthrough_extractor):
+                pass
+        assert model.layers[0].self_attn is attention
+    finally:
+        attention_type.__call__ = installed_call
+
+    x = mx.ones((1, 1, 1))
+    with scorer.capture_session(passthrough_extractor) as session:
+        assert attention(x) is x
+        assert session.query_buffer == [[x]]
+    assert SpecPrefillScorer.for_model(model) is scorer
+
+
+def test_mixed_gemma_head_groups_are_derived_per_layer():
+    n_prompt = 3
+    query_buffer = [
+        [mx.ones((1, 32, 1, 256))],
+        [mx.ones((1, 32, 1, 512))],
+    ]
+    caches = [
+        SimpleNamespace(keys=mx.ones((1, 16, n_prompt, 256))),
+        SimpleNamespace(keys=mx.ones((1, 4, n_prompt, 512))),
+    ]
+
+    importance = _compute_importance(
+        query_buffer,
+        caches,
+        n_prompt,
+        # Legacy global values describe only the first layer and must not leak
+        # into the full-attention layer's 32-query/4-KV grouping.
+        n_attn_heads=32,
+        n_kv_heads=16,
+        pool_kernel=None,
+    )
+    mx.eval(importance)
+
+    assert importance.shape == (n_prompt,)
+    assert mx.allclose(importance, mx.full((n_prompt,), 1 / n_prompt)).item()

--- a/tests/test_specprefill_request_local_hooks.py
+++ b/tests/test_specprefill_request_local_hooks.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local scorer capture contracts that do not load model weights."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+import vllm_mlx.specprefill as specprefill
+from vllm_mlx.specprefill import (
+    SpecPrefillScorer,
+    _AttentionCapture,
+    _gemma4_extract_queries,
+)
+
+
+class RecordingAttention:
+    n_heads = 1
+    n_kv_heads = 1
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return args[0]
+
+
+class ScorerModel:
+    def __init__(self, model_type="qwen3"):
+        self.config = SimpleNamespace(model_type=model_type)
+        self.layers = [SimpleNamespace(self_attn=RecordingAttention())]
+
+
+def passthrough_extractor(_attention, x, cache=None, **_kwargs):
+    return x
+
+
+def test_scorer_installs_one_stable_wrapper_and_reuses_it():
+    model = ScorerModel()
+    original = model.layers[0].self_attn
+
+    first = SpecPrefillScorer.for_model(model)
+    wrapper = model.layers[0].self_attn
+    second = SpecPrefillScorer.for_model(model)
+
+    assert first is second
+    assert isinstance(wrapper, _AttentionCapture)
+    assert model.layers[0].self_attn is wrapper
+    assert wrapper._original is original
+    with pytest.raises(RuntimeError, match="already installed"):
+        SpecPrefillScorer(model)
+    assert model.layers[0].self_attn is wrapper
+
+
+def test_idle_wrapper_delegates_original_args_and_kwargs_unchanged():
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    wrapper = model.layers[0].self_attn
+    original = wrapper._original
+    x = mx.zeros((1, 1, 1))
+    mask = object()
+    cache = object()
+    shared_kv = object()
+
+    result = wrapper(x, mask, cache, shared_kv=shared_kv, offset=23)
+
+    assert result is x
+    assert len(original.calls) == 1
+    delegated_args, delegated_kwargs = original.calls[0]
+    assert delegated_args[0] is x
+    assert delegated_args[1] is mask
+    assert delegated_args[2] is cache
+    assert delegated_kwargs == {"shared_kv": shared_kv, "offset": 23}
+    assert not scorer.capture_active
+
+
+def test_request_capture_preserves_call_shape_offset_and_shared_kv():
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    wrapper = model.layers[0].self_attn
+    original = wrapper._original
+    x = mx.zeros((1, 1, 1))
+    mask = object()
+    cache = SimpleNamespace(offset=4)
+    offset = mx.array(17)
+    shared_kv = (mx.array([1]), mx.array([2]))
+    extracted = []
+
+    def extractor(_attention, captured_x, cache=None, **kwargs):
+        extracted.append((captured_x, cache, kwargs))
+        return captured_x
+
+    with scorer.capture_session(extractor) as session:
+        wrapper(x, mask, cache, offset=offset, shared_kv=shared_kv)
+        assert session.query_buffer[0] == [x]
+
+    delegated_args, delegated_kwargs = original.calls[0]
+    assert delegated_args[0] is x
+    assert delegated_args[1] is mask
+    assert delegated_args[2] is cache
+    assert delegated_kwargs["offset"] is offset
+    assert delegated_kwargs["shared_kv"] is shared_kv
+    assert extracted[0][0] is x
+    assert extracted[0][1] is cache
+    assert extracted[0][2]["offset"] is offset
+    assert extracted[0][2]["shared_kv"] is shared_kv
+
+    wrapper(x, cache=cache)
+    assert session.query_buffer[0] == [x]
+    assert model.layers[0].self_attn is wrapper
+    assert not scorer.capture_active
+
+
+def test_gemma_capture_uses_explicit_offset_and_preserves_shared_kv():
+    class Norm:
+        def __call__(self, value):
+            return value
+
+    class Rope:
+        def __init__(self):
+            self.offsets = []
+
+        def __call__(self, value, offset=0):
+            self.offsets.append(offset)
+            return value
+
+    class GemmaAttention(RecordingAttention):
+        n_heads = 1
+        q_norm = Norm()
+
+        def __init__(self):
+            super().__init__()
+            self.rope = Rope()
+
+        def q_proj(self, value):
+            return value
+
+    model = ScorerModel(model_type="gemma4")
+    attention = GemmaAttention()
+    model.layers[0].self_attn = attention
+    model.previous_kvs = [0]
+    scorer = SpecPrefillScorer.for_model(model)
+    x = mx.ones((1, 1, 1))
+    cache = SimpleNamespace(offset=3)
+    shared_kv = (mx.array([1]), mx.array([2]))
+    offset = mx.array(19)
+
+    with scorer.capture_session(_gemma4_extract_queries) as session:
+        model.layers[0].self_attn(x, cache=cache, shared_kv=shared_kv, offset=offset)
+        mx.eval(session.query_buffer)
+
+    assert len(attention.rope.offsets) == 1
+    assert attention.rope.offsets[0] is offset
+    assert attention.calls[0][1]["shared_kv"] is shared_kv
+    assert attention.calls[0][1]["offset"] is offset
+
+
+def test_nested_and_foreign_thread_sessions_fail_closed():
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    foreign_errors = []
+    x = mx.zeros((1, 1, 1))
+
+    with scorer.capture_session(passthrough_extractor):
+        with pytest.raises(RuntimeError, match="already has an active session"):
+            with scorer.capture_session(passthrough_extractor):
+                pass
+
+        def invoke_from_foreign_thread():
+            try:
+                model.layers[0].self_attn(x)
+            except Exception as exc:  # noqa: BLE001 - asserted below
+                foreign_errors.append(exc)
+
+            try:
+                with scorer.capture_session(passthrough_extractor):
+                    pass
+            except Exception as exc:  # noqa: BLE001 - asserted below
+                foreign_errors.append(exc)
+
+        thread = threading.Thread(target=invoke_from_foreign_thread)
+        thread.start()
+        thread.join()
+
+    assert len(foreign_errors) == 2
+    assert "outside its active request session" in str(foreign_errors[0])
+    assert "already has an active session" in str(foreign_errors[1])
+    assert not scorer.capture_active
+
+
+def test_session_exception_clears_state_without_uninstalling_wrapper():
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    wrapper = model.layers[0].self_attn
+
+    with pytest.raises(ValueError, match="cancelled"):
+        with scorer.capture_session(passthrough_extractor):
+            raise ValueError("cancelled")
+
+    assert not scorer.capture_active
+    assert model.layers[0].self_attn is wrapper
+    with scorer.capture_session(passthrough_extractor):
+        assert scorer.capture_active
+
+
+def test_public_score_tokens_realizes_lazy_work_before_session_release(monkeypatch):
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    wrapper = model.layers[0].self_attn
+    cache = [SimpleNamespace(keys=mx.ones((1, 1, 2, 1)))]
+    eval_session_states = []
+    real_eval = specprefill.mx.eval
+
+    monkeypatch.setattr(specprefill, "make_prompt_cache", lambda _model: cache)
+
+    def prefill(*_args, **_kwargs):
+        assert scorer.capture_active
+        wrapper(mx.ones((1, 1, 1)), cache=cache[0])
+        return mx.zeros((1, 1, 4))
+
+    monkeypatch.setattr(specprefill, "_prefill_draft", prefill)
+
+    def lookahead(_model, _logits, _cache, _steps, **_kwargs):
+        wrapper(mx.ones((1, 1, 1)), cache=cache[0], offset=2)
+        return [1]
+
+    def compute_importance(query_buffer, *_args, **_kwargs):
+        assert scorer.capture_active
+        assert len(query_buffer[0]) == 1
+        return mx.array([0.25, 0.75])
+
+    def recording_eval(*values):
+        eval_session_states.append(scorer.capture_active)
+        return real_eval(*values)
+
+    monkeypatch.setattr(specprefill, "_lookahead_decode", lookahead)
+    monkeypatch.setattr(specprefill, "_compute_importance", compute_importance)
+    monkeypatch.setattr(specprefill.mx, "eval", recording_eval)
+
+    importance = specprefill.score_tokens(
+        model,
+        [1, 2],
+        query_extractor=passthrough_extractor,
+    )
+
+    assert importance.tolist() == [0.25, 0.75]
+    assert eval_session_states == [True]
+    assert not scorer.capture_active
+    assert model.layers[0].self_attn is wrapper
+
+
+def test_score_tokens_rejects_overlap_before_second_prefill(monkeypatch):
+    model = ScorerModel()
+    SpecPrefillScorer.for_model(model)
+    entered_prefill = threading.Event()
+    release_prefill = threading.Event()
+    first_errors = []
+    prefill_calls = 0
+
+    monkeypatch.setattr(specprefill, "make_prompt_cache", lambda _model: [])
+
+    def blocking_prefill(*_args, **_kwargs):
+        nonlocal prefill_calls
+        prefill_calls += 1
+        entered_prefill.set()
+        release_prefill.wait(timeout=5)
+        raise ValueError("stop first scorer")
+
+    monkeypatch.setattr(specprefill, "_prefill_draft", blocking_prefill)
+
+    def run_first_score():
+        try:
+            specprefill.score_tokens(model, [1, 2])
+        except Exception as exc:  # noqa: BLE001 - asserted below
+            first_errors.append(exc)
+
+    thread = threading.Thread(target=run_first_score)
+    thread.start()
+    assert entered_prefill.wait(timeout=5)
+    with pytest.raises(RuntimeError, match="already has an active session"):
+        specprefill.score_tokens(model, [3, 4])
+    release_prefill.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert prefill_calls == 1
+    assert len(first_errors) == 1
+    assert str(first_errors[0]) == "stop first scorer"
+
+
+def test_partial_wrapper_installation_rolls_back(monkeypatch):
+    model = ScorerModel()
+    model.layers.append(SimpleNamespace(self_attn=RecordingAttention()))
+    originals = [layer.self_attn for layer in model.layers]
+    real_set_attention = specprefill._set_attn_module
+    set_calls = 0
+
+    def fail_second_install(layer, module):
+        nonlocal set_calls
+        set_calls += 1
+        if set_calls == 2:
+            raise RuntimeError("install failed")
+        real_set_attention(layer, module)
+
+    monkeypatch.setattr(specprefill, "_set_attn_module", fail_second_install)
+    with pytest.raises(RuntimeError, match="install failed"):
+        SpecPrefillScorer(model)
+
+    assert model.layers[0].self_attn is originals[0]
+    assert model.layers[1].self_attn is originals[1]
+
+
+def test_unknown_family_fails_before_installing_any_wrapper():
+    model = ScorerModel(model_type="unknown-family")
+    original = model.layers[0].self_attn
+    with pytest.raises(ValueError, match="Unsupported SpecPrefill model_type"):
+        SpecPrefillScorer.for_model(model)
+    assert model.layers[0].self_attn is original
+
+
+def test_wrapper_topology_tamper_fails_closed():
+    model = ScorerModel()
+    scorer = SpecPrefillScorer.for_model(model)
+    model.layers[0].self_attn = RecordingAttention()
+
+    with pytest.raises(RuntimeError, match="wrapper topology was modified"):
+        SpecPrefillScorer.for_model(model)
+    with pytest.raises(RuntimeError, match="wrapper topology was modified"):
+        with scorer.capture_session(passthrough_extractor):
+            pass

--- a/tests/test_specprefill_request_local_hooks.py
+++ b/tests/test_specprefill_request_local_hooks.py
@@ -261,89 +261,40 @@ def test_session_exception_clears_state_without_uninstalling_wrapper():
         assert scorer.capture_active
 
 
-def test_public_score_tokens_realizes_lazy_work_before_session_release(monkeypatch):
+def test_public_score_tokens_delegates_to_bounded_request_local_session(monkeypatch):
     model = ScorerModel()
     scorer = SpecPrefillScorer.for_model(model)
     attention = model.layers[0].self_attn
-    cache = [SimpleNamespace(keys=mx.ones((1, 1, 2, 1)))]
-    eval_session_states = []
-    real_eval = specprefill.mx.eval
+    import vllm_mlx.specprefill_scorer_session as scorer_sessions
 
-    monkeypatch.setattr(specprefill, "make_prompt_cache", lambda _model: cache)
+    observed = {}
 
-    def prefill(*_args, **_kwargs):
-        assert scorer.capture_active
-        attention(mx.ones((1, 1, 1)), cache=cache[0])
-        return mx.zeros((1, 1, 4))
+    class BoundedSession:
+        def __init__(self, session_scorer, tokens, **kwargs):
+            observed.update(scorer=session_scorer, tokens=tokens, kwargs=kwargs)
 
-    monkeypatch.setattr(specprefill, "_prefill_draft", prefill)
+        def run_to_completion(self):
+            assert not scorer.capture_active
+            return mx.array([0.25, 0.75])
 
-    def lookahead(_model, _logits, _cache, _steps, **_kwargs):
-        attention(mx.ones((1, 1, 1)), cache=cache[0], offset=2)
-        return [1]
-
-    def compute_importance(query_buffer, *_args, **_kwargs):
-        assert scorer.capture_active
-        assert len(query_buffer[0]) == 1
-        return mx.array([0.25, 0.75])
-
-    def recording_eval(*values):
-        eval_session_states.append(scorer.capture_active)
-        return real_eval(*values)
-
-    monkeypatch.setattr(specprefill, "_lookahead_decode", lookahead)
-    monkeypatch.setattr(specprefill, "_compute_importance", compute_importance)
-    monkeypatch.setattr(specprefill.mx, "eval", recording_eval)
+    monkeypatch.setattr(scorer_sessions, "SpecPrefillScorerSession", BoundedSession)
 
     importance = specprefill.score_tokens(
         model,
         [1, 2],
+        n_lookahead=3,
+        pool_kernel=7,
         query_extractor=passthrough_extractor,
     )
 
     assert importance.tolist() == [0.25, 0.75]
-    assert eval_session_states == [True]
+    assert observed["scorer"] is scorer
+    assert observed["tokens"] == [1, 2]
+    assert observed["kwargs"]["n_lookahead"] == 3
+    assert observed["kwargs"]["pool_kernel"] == 7
+    assert observed["kwargs"]["query_extractor"] is passthrough_extractor
     assert not scorer.capture_active
     assert model.layers[0].self_attn is attention
-
-
-def test_score_tokens_rejects_overlap_before_second_prefill(monkeypatch):
-    model = ScorerModel()
-    SpecPrefillScorer.for_model(model)
-    entered_prefill = threading.Event()
-    release_prefill = threading.Event()
-    first_errors = []
-    prefill_calls = 0
-
-    monkeypatch.setattr(specprefill, "make_prompt_cache", lambda _model: [])
-
-    def blocking_prefill(*_args, **_kwargs):
-        nonlocal prefill_calls
-        prefill_calls += 1
-        entered_prefill.set()
-        release_prefill.wait(timeout=5)
-        raise ValueError("stop first scorer")
-
-    monkeypatch.setattr(specprefill, "_prefill_draft", blocking_prefill)
-
-    def run_first_score():
-        try:
-            specprefill.score_tokens(model, [1, 2])
-        except Exception as exc:  # noqa: BLE001 - asserted below
-            first_errors.append(exc)
-
-    thread = threading.Thread(target=run_first_score)
-    thread.start()
-    assert entered_prefill.wait(timeout=5)
-    with pytest.raises(RuntimeError, match="already has an active session"):
-        specprefill.score_tokens(model, [3, 4])
-    release_prefill.set()
-    thread.join(timeout=5)
-
-    assert not thread.is_alive()
-    assert prefill_calls == 1
-    assert len(first_errors) == 1
-    assert str(first_errors[0]) == "stop first scorer"
 
 
 def test_partial_dispatch_installation_rolls_back(monkeypatch):

--- a/tests/test_specprefill_scorer_session.py
+++ b/tests/test_specprefill_scorer_session.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded request-local scorer-session contracts without model weights."""
+
+from __future__ import annotations
+
+import threading
+import math
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+import vllm_mlx.specprefill_scorer_session as scorer_sessions
+import vllm_mlx.specprefill as specprefill
+from vllm_mlx.specprefill import (
+    SpecPrefillScorer,
+    _compute_importance,
+    _lookahead_decode,
+    _prefill_draft,
+)
+from vllm_mlx.specprefill_scorer_session import (
+    ScorerSessionPhase,
+    SpecPrefillScorerSession,
+)
+
+
+class _Cache:
+    def __init__(self):
+        self.offset = 0
+        self.keys = mx.zeros((1, 1, 0, 1), dtype=mx.float32)
+
+    @property
+    def state(self):
+        return self.keys
+
+    @state.setter
+    def state(self, value):
+        self.keys = value
+        self.offset = value.shape[-2]
+
+
+class _Attention:
+    n_heads = 1
+    n_kv_heads = 1
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, x, mask=None, cache=None, **_kwargs):
+        del mask
+        self.calls += 1
+        return x
+
+
+class _Model:
+    def __init__(self, *, block_first_call=False, fail_on_call=None):
+        self.config = SimpleNamespace(model_type="qwen3")
+        self.layers = [SimpleNamespace(self_attn=_Attention())]
+        self.block_first_call = block_first_call
+        self.fail_on_call = fail_on_call
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.calls = 0
+        self.token_inputs = []
+
+    @property
+    def attention(self):
+        return self.layers[0].self_attn
+
+    def __call__(self, token_rows, *, cache):
+        self.calls += 1
+        self.token_inputs.append(
+            (getattr(cache[0], "label", None), token_rows.tolist())
+        )
+        if self.block_first_call and self.calls == 1:
+            self.entered.set()
+            assert self.release.wait(timeout=3)
+        if self.fail_on_call == self.calls:
+            raise RuntimeError("draft failure")
+        length = token_rows.shape[1]
+        hidden = mx.ones((1, length, 1), dtype=mx.float32)
+        self.attention(hidden, cache=cache[0])
+        cache[0].keys = mx.concatenate(
+            (cache[0].keys, mx.ones((1, 1, length, 1), dtype=mx.float32)), axis=2
+        )
+        cache[0].offset += length
+        return mx.zeros((1, length, 2), dtype=mx.float32)
+
+
+def _extract_queries(_attention, x, cache=None, **_kwargs):
+    del cache
+    return mx.ones((1, 1, x.shape[1], 1), dtype=mx.float32)
+
+
+def _session(monkeypatch, model, tokens=(1, 2, 3, 4), **kwargs):
+    monkeypatch.setattr(scorer_sessions, "make_prompt_cache", lambda _model: [_Cache()])
+    options = {
+        "n_lookahead": 2,
+        "prefill_step_size": 2,
+        "query_extractor": _extract_queries,
+    }
+    options.update(kwargs)
+    return SpecPrefillScorerSession(
+        SpecPrefillScorer.for_model(model),
+        tokens,
+        **options,
+    )
+
+
+def _legacy_reference(monkeypatch, model, tokens):
+    monkeypatch.setattr(
+        specprefill,
+        "make_sampler",
+        lambda **_kwargs: lambda logits: mx.argmax(logits, axis=-1),
+    )
+    scorer = SpecPrefillScorer.for_model(model)
+    cache = [_Cache()]
+    with scorer.capture_session(_extract_queries, capture_enabled=False) as capture:
+        logits = _prefill_draft(model, tokens, cache, step_size=2)
+        capture.capture_enabled = True
+        _lookahead_decode(model, logits, cache, 2, temp=0.6, top_p=0.95)
+        importance = _compute_importance(capture.query_buffer, cache, len(tokens))
+        mx.eval(importance, capture.query_buffer)
+    return importance
+
+
+def _assert_close(actual, expected):
+    mx.eval(actual, expected)
+    assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item()
+
+
+def test_alternating_request_sessions_release_capture_between_quanta(monkeypatch):
+    model = _Model()
+    first = _session(monkeypatch, model, tokens=(1, 2, 3, 4))
+    second = _session(monkeypatch, model, tokens=(5, 6, 7, 8))
+    scorer = first.scorer
+
+    while not (first.complete and second.complete):
+        if not first.complete:
+            first.step()
+            assert not scorer.capture_active
+        if not second.complete:
+            second.step()
+            assert not scorer.capture_active
+
+    assert first.phase is ScorerSessionPhase.COMPLETE
+    assert second.phase is ScorerSessionPhase.COMPLETE
+    assert first.query_buffer is not second.query_buffer
+    # The default centered pool has zero-padding at prompt edges, so an
+    # otherwise uniform four-token distribution becomes 1 / kernel_size.
+    _assert_close(first.importance, mx.full((4,), 1 / 13))
+    _assert_close(second.importance, mx.full((4,), 1 / 13))
+
+
+def test_bounded_session_matches_clean_monolithic_helper_reference(monkeypatch):
+    tokens = (1, 2, 3, 4)
+    session_model = _Model()
+    session = _session(monkeypatch, session_model, tokens=tokens, temp=0)
+    actual = session.run_to_completion()
+
+    reference_model = _Model()
+    expected = _legacy_reference(monkeypatch, reference_model, tokens)
+
+    _assert_close(actual, expected)
+    assert session_model.calls == reference_model.calls == 5
+    assert not session.scorer.capture_active
+
+
+def test_request_local_rng_is_invariant_when_another_session_interleaves(
+    monkeypatch,
+):
+    baseline_model = _Model()
+    baseline = _session(
+        monkeypatch, baseline_model, tokens=(1, 2, 3, 4), sampling_seed=17
+    )
+    baseline.cache[0].label = "baseline"
+    baseline.run_to_completion()
+    expected_inputs = [
+        tokens for label, tokens in baseline_model.token_inputs if label == "baseline"
+    ]
+
+    model = _Model()
+    first = _session(monkeypatch, model, tokens=(1, 2, 3, 4), sampling_seed=17)
+    second = _session(monkeypatch, model, tokens=(5, 6, 7, 8), sampling_seed=91)
+    first.cache[0].label = "first"
+    second.cache[0].label = "second"
+    while not (first.complete and second.complete):
+        if not first.complete:
+            first.step()
+        if not second.complete:
+            second.step()
+
+    first_inputs = [tokens for label, tokens in model.token_inputs if label == "first"]
+    assert first_inputs == expected_inputs
+
+
+def test_top_p_filters_normalized_logprobabilities_not_raw_logits():
+    logits = mx.array([[2.0, 1.0, 0.0]])
+    normalized = scorer_sessions._normalized_logprobs(logits)
+    filtered = scorer_sessions.apply_top_p(normalized, 0.8)
+    raw_filtered = scorer_sessions.apply_top_p(logits, 0.8)
+    mx.eval(filtered, raw_filtered)
+
+    # At p=0.8 the least likely token is excluded only after normalizing:
+    # raw logits exponentiate to values greater than one and incorrectly keep
+    # every token in mlx-lm's cumulative-probability implementation.
+    assert math.isinf(float(filtered[0, 2])) and float(filtered[0, 2]) < 0
+    assert not math.isinf(float(raw_filtered[0, 2]))
+
+
+@pytest.mark.parametrize("temp", (float("nan"), float("inf"), -0.1, True))
+def test_sampler_rejects_nonfinite_or_negative_temperature(temp):
+    with pytest.raises(ValueError, match="finite non-negative"):
+        scorer_sessions._RequestLocalSampler(temp=temp, top_p=0.9, seed=1)
+
+
+@pytest.mark.parametrize("top_p", (float("nan"), float("inf"), -0.1, 1.1, True))
+def test_sampler_rejects_invalid_top_p(top_p):
+    with pytest.raises(ValueError, match="top_p"):
+        scorer_sessions._RequestLocalSampler(temp=0.6, top_p=top_p, seed=1)
+
+
+def test_session_rejects_zero_lookahead_before_allocating_a_draft_cache(monkeypatch):
+    model = _Model()
+    cache_calls = 0
+
+    def make_cache(_model):
+        nonlocal cache_calls
+        cache_calls += 1
+        return [_Cache()]
+
+    monkeypatch.setattr(scorer_sessions, "make_prompt_cache", make_cache)
+    with pytest.raises(ValueError, match="positive integer"):
+        SpecPrefillScorerSession(
+            SpecPrefillScorer.for_model(model),
+            (1, 2),
+            n_lookahead=0,
+            query_extractor=_extract_queries,
+        )
+    assert cache_calls == 0
+
+
+def test_session_materializes_prompt_token_array_once(monkeypatch):
+    model = _Model()
+    real_array = scorer_sessions.mx.array
+    calls = 0
+
+    def recording_array(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_array(*args, **kwargs)
+
+    monkeypatch.setattr(scorer_sessions.mx, "array", recording_array)
+    session = _session(monkeypatch, model)
+    assert calls == 1
+    session.run_to_completion()
+    assert calls == 1
+
+
+def test_scorer_lane_rejects_overlap_and_leaves_second_session_retryable(monkeypatch):
+    model = _Model()
+    first = _session(monkeypatch, model)
+    second = _session(monkeypatch, model)
+    with first.scorer.scoring_quantum():
+        with pytest.raises(RuntimeError, match="scorer lane is busy"):
+            second.step()
+        assert second.phase is ScorerSessionPhase.PREFILL
+        assert not second.closed
+
+    second.run_to_completion()
+    assert second.complete
+    assert not first.scorer.capture_active
+
+
+@pytest.mark.parametrize("mode", ("cancel", "failure"))
+def test_cancel_or_failure_discards_only_own_session_state(monkeypatch, mode):
+    model = _Model(fail_on_call=1 if mode == "failure" else None)
+    cancel_calls = 0
+
+    def cancel_check():
+        nonlocal cancel_calls
+        cancel_calls += 1
+        if mode == "cancel":
+            raise RuntimeError("cancelled")
+
+    failed = _session(monkeypatch, model, cancel_check=cancel_check)
+    with pytest.raises(RuntimeError, match="cancelled|draft failure"):
+        failed.step()
+    assert failed.closed
+    assert failed.cache is None
+    assert failed.query_buffer == []
+    assert not failed.scorer.capture_active
+
+    healthy = _session(monkeypatch, model, tokens=(6, 7, 8, 9))
+    healthy.run_to_completion()
+    assert healthy.complete

--- a/tests/test_specprefill_selection.py
+++ b/tests/test_specprefill_selection.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python semantic contracts for the sparse selector."""
+
+import pytest
+
+from vllm_mlx.specprefill_selection import (
+    RotatingTailRequirement,
+    SelectionPlan,
+    SelectionPolicy,
+    SelectionProvenance,
+    build_selection_plan_from_chunk_scores,
+)
+
+
+def _policy(**overrides) -> SelectionPolicy:
+    values = {
+        "keep_pct": 0.25,
+        "backbone_pct": 0.0,
+        "halo_chunks": 0,
+        "anchor_chunks": 0,
+        "chunk_size": 4,
+    }
+    values.update(overrides)
+    return SelectionPolicy(**values)
+
+
+def _plan(*, scores=(0.1, 0.2, 0.3, 0.4, 0.5), **kwargs):
+    return build_selection_plan_from_chunk_scores(
+        prompt_length=20,
+        chunk_scores=scores,
+        policy=_policy(**kwargs.pop("policy", {})),
+        **kwargs,
+    )
+
+
+def test_caller_supplied_control_positions_are_mandatory_and_provenanced():
+    plan = _plan(control_token_indices=(14, 5, 5))
+
+    assert plan.control_anchor_indices == (5, 14)
+    assert plan.control_anchor_chunks == (1, 3)
+    assert {1, 3}.issubset(plan.selected_chunks)
+    assert {5, 14}.issubset(plan.selected_indices)
+
+
+def test_control_positions_are_prompt_local_and_never_tokenizer_guessed():
+    with pytest.raises(ValueError, match="prompt-local"):
+        _plan(control_token_indices=(20,))
+    with pytest.raises(ValueError, match="prompt-local"):
+        _plan(control_token_indices=(True,))
+
+
+def test_rotating_tail_is_mandatory_before_plan_fingerprint_and_reuse():
+    tail_five = _plan(rotating_tail_requirement=RotatingTailRequirement(5))
+    tail_six = _plan(rotating_tail_requirement=RotatingTailRequirement(6))
+
+    # Both tail sizes touch chunk 3 at this granularity, but their cache
+    # semantics differ and therefore so must their exact-cache fingerprint.
+    assert tail_five.rotating_tail_chunks == (3, 4)
+    assert tail_six.rotating_tail_chunks == (3, 4)
+    assert {3, 4}.issubset(tail_five.selected_chunks)
+    assert tail_five.fingerprint != tail_six.fingerprint
+
+
+def test_policy_drift_changes_fingerprint_even_when_final_chunks_match():
+    all_chunks = _plan(policy={"keep_pct": 1.0, "halo_chunks": 0})
+    different_halo = _plan(policy={"keep_pct": 1.0, "halo_chunks": 4})
+    different_backbone = _plan(policy={"keep_pct": 1.0, "backbone_pct": 1.0})
+
+    assert all_chunks.selected_chunks == different_halo.selected_chunks
+    assert all_chunks.selected_chunks == different_backbone.selected_chunks
+    assert all_chunks.fingerprint != different_halo.fingerprint
+    assert all_chunks.fingerprint != different_backbone.fingerprint
+
+
+def test_halo_boundary_collision_and_stratified_backbone_are_provenanced():
+    plan = _plan(
+        scores=(0.99, 0.2, 0.3, 0.4, 0.5),
+        control_token_indices=(4,),
+        policy={"keep_pct": 0.6, "halo_chunks": 2, "backbone_pct": 0.4},
+    )
+
+    # The high-scoring first chunk has no negative halo. Chunk 1 is both a
+    # control anchor and a halo candidate; each source remains observable.
+    assert plan.backbone_chunks == (1, 3)
+    assert plan.control_anchor_chunks == (1,)
+    assert plan.importance_chunks == (0,)
+    assert plan.halo_chunks == (2,)
+    assert {0, 1, 2, 3}.issubset(plan.selected_chunks)
+
+
+def test_tail_requirement_rejects_partial_or_unprovenanced_plans():
+    requirement = RotatingTailRequirement(5)
+    with pytest.raises(ValueError, match="rotating_tail_chunks"):
+        SelectionPlan(
+            prompt_length=20,
+            policy=_policy(),
+            selected_chunks=(0,),
+            selected_indices=(0, 1, 2, 3),
+            rotating_tail_requirement=requirement,
+        )
+
+
+def test_rotating_tail_requires_an_integer_window_size():
+    with pytest.raises(ValueError, match="positive integer"):
+        RotatingTailRequirement(5.0)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("keep_pct", True),
+        ("keep_pct", float("nan")),
+        ("keep_pct", "0.25"),
+        ("backbone_pct", True),
+        ("backbone_pct", float("inf")),
+        ("backbone_pct", "0.0"),
+        ("halo_chunks", True),
+        ("halo_chunks", 1.0),
+        ("anchor_chunks", True),
+        ("anchor_chunks", 1.0),
+        ("chunk_size", True),
+        ("chunk_size", 4.0),
+    ),
+)
+def test_policy_rejects_boolean_and_coerced_numeric_values(field, value):
+    values = {
+        "keep_pct": 0.25,
+        "backbone_pct": 0.0,
+        "halo_chunks": 0,
+        "anchor_chunks": 0,
+        "chunk_size": 4,
+    }
+    values[field] = value
+    with pytest.raises(ValueError):
+        SelectionPolicy(**values)
+
+
+def test_builder_requires_an_explicit_selection_policy():
+    with pytest.raises(TypeError, match="SelectionPolicy"):
+        build_selection_plan_from_chunk_scores(
+            prompt_length=4,
+            chunk_scores=(1.0,),
+            policy=None,
+        )
+
+
+def test_budget_rejected_halo_is_not_recorded_as_retained_provenance():
+    plan = _plan(
+        scores=(0.99, 0.2, 0.3, 0.4, 0.5),
+        control_token_indices=(4,),
+        policy={"halo_chunks": 2, "backbone_pct": 0.4},
+    )
+
+    assert plan.selected_chunks == (0, 1, 3)
+    assert plan.importance_chunks == (0,)
+    assert plan.halo_chunks == ()
+
+
+def test_direct_plan_construction_cannot_omit_policy_mandatory_chunks():
+    policy = _policy(anchor_chunks=1)
+    with pytest.raises(ValueError, match="retained in selected_chunks"):
+        SelectionPlan(
+            prompt_length=20,
+            policy=policy,
+            selected_chunks=(0,),
+            selected_indices=(0, 1, 2, 3),
+            provenance=SelectionProvenance(anchor_chunks=(0, 4)),
+        )
+
+
+def test_direct_plan_construction_cannot_forge_control_anchor_mapping():
+    with pytest.raises(ValueError, match="control_anchor_chunks"):
+        SelectionPlan(
+            prompt_length=20,
+            policy=_policy(),
+            selected_chunks=(1,),
+            selected_indices=(4, 5, 6, 7),
+            provenance=SelectionProvenance(control_anchor_indices=(4,)),
+        )
+
+
+def test_direct_plan_construction_cannot_forge_a_tail_without_requirement():
+    with pytest.raises(ValueError, match="require a rotating_tail_requirement"):
+        SelectionPlan(
+            prompt_length=20,
+            policy=_policy(),
+            selected_chunks=(3,),
+            selected_indices=(12, 13, 14, 15),
+            provenance=SelectionProvenance(rotating_tail_chunks=(3,)),
+        )
+
+
+def test_unicode_selector_version_is_fingerprintable():
+    ascii_plan = _plan(policy={"selector_version": "selector-v2"})
+    unicode_plan = _plan(policy={"selector_version": "selector-β"})
+
+    assert len(unicode_plan.fingerprint) == 64
+    assert ascii_plan.fingerprint != unicode_plan.fingerprint

--- a/tests/test_specprefill_selection.py
+++ b/tests/test_specprefill_selection.py
@@ -17,7 +17,7 @@ def _policy(**overrides) -> SelectionPolicy:
         "keep_pct": 0.25,
         "backbone_pct": 0.0,
         "halo_chunks": 0,
-        "anchor_chunks": 0,
+        "anchor_chunks": 1,
         "chunk_size": 4,
     }
     values.update(overrides)
@@ -83,7 +83,9 @@ def test_halo_boundary_collision_and_stratified_backbone_are_provenanced():
     # control anchor and a halo candidate; each source remains observable.
     assert plan.backbone_chunks == (1, 3)
     assert plan.control_anchor_chunks == (1,)
-    assert plan.importance_chunks == (0,)
+    # The highest-scoring first chunk is already a mandatory boundary anchor,
+    # so it is not double-counted as an importance seed.
+    assert plan.importance_chunks == ()
     assert plan.halo_chunks == (2,)
     assert {0, 1, 2, 3}.issubset(plan.selected_chunks)
 
@@ -94,8 +96,9 @@ def test_tail_requirement_rejects_partial_or_unprovenanced_plans():
         SelectionPlan(
             prompt_length=20,
             policy=_policy(),
-            selected_chunks=(0,),
-            selected_indices=(0, 1, 2, 3),
+            selected_chunks=(0, 4),
+            selected_indices=(0, 1, 2, 3, 16, 17, 18, 19),
+            provenance=SelectionProvenance(anchor_chunks=(0, 4)),
             rotating_tail_requirement=requirement,
         )
 
@@ -117,6 +120,7 @@ def test_rotating_tail_requires_an_integer_window_size():
         ("halo_chunks", True),
         ("halo_chunks", 1.0),
         ("anchor_chunks", True),
+        ("anchor_chunks", 0),
         ("anchor_chunks", 1.0),
         ("chunk_size", True),
         ("chunk_size", 4.0),
@@ -127,7 +131,7 @@ def test_policy_rejects_boolean_and_coerced_numeric_values(field, value):
         "keep_pct": 0.25,
         "backbone_pct": 0.0,
         "halo_chunks": 0,
-        "anchor_chunks": 0,
+        "anchor_chunks": 1,
         "chunk_size": 4,
     }
     values[field] = value
@@ -145,14 +149,15 @@ def test_builder_requires_an_explicit_selection_policy():
 
 
 def test_budget_rejected_halo_is_not_recorded_as_retained_provenance():
-    plan = _plan(
-        scores=(0.99, 0.2, 0.3, 0.4, 0.5),
+    plan = build_selection_plan_from_chunk_scores(
+        prompt_length=40,
+        chunk_scores=(0.1, 0.1, 0.1, 0.1, 0.1, 0.99, 0.1, 0.1, 0.1, 0.1),
+        policy=_policy(keep_pct=0.3, halo_chunks=2, backbone_pct=0.2),
         control_token_indices=(4,),
-        policy={"halo_chunks": 2, "backbone_pct": 0.4},
     )
 
-    assert plan.selected_chunks == (0, 1, 3)
-    assert plan.importance_chunks == (0,)
+    assert plan.selected_chunks == (0, 1, 2, 5, 7, 9)
+    assert plan.importance_chunks == (5,)
     assert plan.halo_chunks == ()
 
 
@@ -173,9 +178,11 @@ def test_direct_plan_construction_cannot_forge_control_anchor_mapping():
         SelectionPlan(
             prompt_length=20,
             policy=_policy(),
-            selected_chunks=(1,),
-            selected_indices=(4, 5, 6, 7),
-            provenance=SelectionProvenance(control_anchor_indices=(4,)),
+            selected_chunks=(0, 1, 4),
+            selected_indices=(0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19),
+            provenance=SelectionProvenance(
+                anchor_chunks=(0, 4), control_anchor_indices=(4,)
+            ),
         )
 
 
@@ -184,9 +191,11 @@ def test_direct_plan_construction_cannot_forge_a_tail_without_requirement():
         SelectionPlan(
             prompt_length=20,
             policy=_policy(),
-            selected_chunks=(3,),
-            selected_indices=(12, 13, 14, 15),
-            provenance=SelectionProvenance(rotating_tail_chunks=(3,)),
+            selected_chunks=(0, 3, 4),
+            selected_indices=(0, 1, 2, 3, 12, 13, 14, 15, 16, 17, 18, 19),
+            provenance=SelectionProvenance(
+                anchor_chunks=(0, 4), rotating_tail_chunks=(3,)
+            ),
         )
 
 

--- a/tests/test_specprefill_target_executor.py
+++ b/tests/test_specprefill_target_executor.py
@@ -19,6 +19,9 @@ from vllm_mlx.specprefill_cache import (
 from vllm_mlx.specprefill_positions import QWEN_DENSE_TARGET
 from vllm_mlx.specprefill_target_executor import (
     SparseTargetPrefillError,
+    SparseTargetPrefillLaneBusy,
+    SparseTargetPrefillPhase,
+    SparseTargetPrefillSession,
     execute_sparse_target_prefill,
 )
 from vllm_mlx.specprefill_target_hooks import TargetPositionHooks
@@ -147,6 +150,195 @@ def test_noncontiguous_logical_positions_stay_separate_from_physical_cache():
     assert result.cache_state.logical_positions == ((0, 3, 4),)
     assert result.cache_state.physical_valid_lengths == (3,)
     assert cache[0].offset == 3
+
+
+def test_session_publishes_no_result_until_all_target_chunks_commit():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model, cache = _Model(), [_Cache()]
+    session = SparseTargetPrefillSession(
+        model, tokens, cache, state, QWEN_DENSE_TARGET, step_size=2
+    )
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+
+    progress = session.step()
+
+    assert progress.selected_tokens_processed == 2
+    assert progress.chunk_count == 1
+    assert not progress.complete
+    assert cache[0].offset == 2
+    assert not hooks.active_session
+    with pytest.raises(SparseTargetPrefillError, match="no publishable result"):
+        _ = session.result
+
+    progress = session.step()
+    assert progress.complete
+    assert session.result.cache_state == state
+    assert session.result.telemetry.physical_cache_starts == ((0,), (2,))
+    assert not hooks.active_session
+
+
+def test_session_telemetry_excludes_scheduler_wait_between_target_quanta(monkeypatch):
+    ticks = iter((100.0, 100.01, 107.0, 107.02))
+    monkeypatch.setattr(target_executor.time, "perf_counter", lambda: next(ticks))
+    session = SparseTargetPrefillSession(
+        _Model(),
+        mx.array([[1, 4, 5]], dtype=mx.int32),
+        [_Cache()],
+        _state((0, 3, 4)),
+        QWEN_DENSE_TARGET,
+        step_size=2,
+    )
+
+    session.step()
+    # The mocked clock advances by nearly seven seconds while the scheduler has
+    # control between calls.  It must not inflate target-prefill telemetry.
+    session.step()
+
+    assert session.result.telemetry.target_prefill_ms == pytest.approx(30.0)
+
+
+def test_session_phase_is_read_only():
+    session = SparseTargetPrefillSession(
+        _Model(),
+        mx.array([[1]], dtype=mx.int32),
+        [_Cache()],
+        _state((0,)),
+        QWEN_DENSE_TARGET,
+    )
+
+    with pytest.raises(AttributeError):
+        session.phase = SparseTargetPrefillPhase.COMPLETE
+    assert not session.complete
+
+
+def test_session_rejects_zero_selected_token_rows_before_forward():
+    model = _Model()
+    with pytest.raises(SparseTargetPrefillError, match="at least one selected token"):
+        SparseTargetPrefillSession(
+            model,
+            mx.array([[]], dtype=mx.int32),
+            [_Cache()],
+            _state((0,)),
+            QWEN_DENSE_TARGET,
+        )
+    assert model.calls == []
+
+
+def test_same_target_sessions_alternate_one_chunk_at_a_time_with_distinct_caches():
+    model = _Model()
+    first = SparseTargetPrefillSession(
+        model,
+        mx.array([[1, 2, 3]], dtype=mx.int32),
+        [_Cache()],
+        _state((0, 1, 2)),
+        QWEN_DENSE_TARGET,
+        step_size=2,
+    )
+    second = SparseTargetPrefillSession(
+        model,
+        mx.array([[4, 5, 6]], dtype=mx.int32),
+        [_Cache()],
+        _state((0, 1, 2)),
+        QWEN_DENSE_TARGET,
+        step_size=2,
+    )
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+
+    while not (first.complete and second.complete):
+        if not first.complete:
+            first.step()
+            assert not hooks.active_session
+        if not second.complete:
+            second.step()
+            assert not hooks.active_session
+
+    assert first.result.telemetry.physical_cache_starts == ((0,), (2,))
+    assert second.result.telemetry.physical_cache_starts == ((0,), (2,))
+
+
+def test_busy_target_lane_leaves_waiting_session_retryable():
+    model = _Model()
+    first = SparseTargetPrefillSession(
+        model,
+        mx.array([[1, 2, 3]], dtype=mx.int32),
+        [_Cache()],
+        _state((0, 1, 2)),
+        QWEN_DENSE_TARGET,
+        step_size=2,
+    )
+    second = SparseTargetPrefillSession(
+        model,
+        mx.array([[4, 5, 6]], dtype=mx.int32),
+        [_Cache()],
+        _state((0, 1, 2)),
+        QWEN_DENSE_TARGET,
+        step_size=2,
+    )
+
+    with first._lane:
+        with pytest.raises(SparseTargetPrefillLaneBusy, match="target lane is busy"):
+            second.step()
+        assert not second.closed
+        assert not second.complete
+
+    second.run_to_completion()
+    assert second.complete
+
+
+def test_cancel_after_first_chunk_restores_entry_snapshot_and_publishes_nothing():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model, cache = _Model(), [_Cache()]
+    calls = 0
+
+    def cancel_check():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("cancelled")
+
+    session = SparseTargetPrefillSession(
+        model,
+        tokens,
+        cache,
+        state,
+        QWEN_DENSE_TARGET,
+        step_size=2,
+        cancel_check=cancel_check,
+    )
+    session.step()
+    assert cache[0].offset == 2
+    with pytest.raises(RuntimeError, match="cancelled"):
+        session.step()
+
+    assert session.closed
+    assert cache[0].offset == 0
+    assert cache[0].state.tolist() == [0]
+    with pytest.raises(SparseTargetPrefillError, match="no publishable result"):
+        _ = session.result
+
+
+def test_facade_matches_stepwise_session_result():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    facade_model, facade_cache = _Model(), [_Cache()]
+    facade = execute_sparse_target_prefill(
+        facade_model, tokens, facade_cache, state, QWEN_DENSE_TARGET, step_size=2
+    )
+    session_model, session_cache = _Model(), [_Cache()]
+    session = SparseTargetPrefillSession(
+        session_model, tokens, session_cache, state, QWEN_DENSE_TARGET, step_size=2
+    )
+    stepwise = session.run_to_completion()
+
+    _assert_close(facade.logits, stepwise.logits)
+    assert facade.cache_state == stepwise.cache_state == state
+    assert (
+        facade.telemetry.physical_cache_starts
+        == stepwise.telemetry.physical_cache_starts
+    )
+    assert facade_cache[0].offset == session_cache[0].offset == 3
 
 
 @pytest.mark.parametrize("mode", ("cancel", "failure"))

--- a/tests/test_specprefill_target_executor.py
+++ b/tests/test_specprefill_target_executor.py
@@ -212,6 +212,23 @@ def test_session_phase_is_read_only():
     assert not session.complete
 
 
+def test_adoption_cache_is_exact_executor_cache_only_after_completion():
+    cache = [_Cache()]
+    session = SparseTargetPrefillSession(
+        _Model(),
+        mx.array([[1]], dtype=mx.int32),
+        cache,
+        _state((0,)),
+        QWEN_DENSE_TARGET,
+    )
+
+    with pytest.raises(SparseTargetPrefillError, match="before publishable"):
+        _ = session.adoption_cache
+    session.step()
+
+    assert session.adoption_cache is cache
+
+
 def test_session_rejects_zero_selected_token_rows_before_forward():
     model = _Model()
     with pytest.raises(SparseTargetPrefillError, match="at least one selected token"):

--- a/tests/test_specprefill_target_executor.py
+++ b/tests/test_specprefill_target_executor.py
@@ -18,6 +18,7 @@ from vllm_mlx.specprefill_cache import (
 )
 from vllm_mlx.specprefill_positions import QWEN_DENSE_TARGET
 from vllm_mlx.specprefill_target_executor import (
+    SparseTargetPrefillAuthorityError,
     SparseTargetPrefillError,
     SparseTargetPrefillLaneBusy,
     SparseTargetPrefillPhase,
@@ -32,6 +33,24 @@ class _Cache:
         self.offset = 0
         self.state = mx.array([0], dtype=mx.int32)
         self.meta_state = ()
+
+
+class _FreshKVCache:
+    def __init__(self):
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.meta_state = ()
+
+    @property
+    def state(self):
+        if self.keys is None:
+            raise AttributeError("fresh KV state is unavailable")
+        return self.keys, self.values
+
+    @state.setter
+    def state(self, value):
+        self.keys, self.values = value
 
 
 class _Attention:
@@ -227,6 +246,150 @@ def test_adoption_cache_is_exact_executor_cache_only_after_completion():
     session.step()
 
     assert session.adoption_cache is cache
+
+
+def test_attested_chunk_forward_collects_ordered_receipts_on_exact_cache():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model, cache = _Model(), [_Cache()]
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    receipts = []
+
+    def attested_forward(token_rows, target_cache, plan):
+        assert target_cache is cache
+        receipt = object()
+        with hooks.session_for_plan(plan):
+            logits = model(token_rows, cache=target_cache)
+            target_executor._eval_forward(logits, target_cache)
+        receipts.append(receipt)
+        return logits, receipt
+
+    result = execute_sparse_target_prefill(
+        model,
+        tokens,
+        cache,
+        state,
+        QWEN_DENSE_TARGET,
+        step_size=2,
+        target_forward=attested_forward,
+    )
+
+    assert result.forward_receipts == tuple(receipts)
+    assert len(result.forward_receipts) == 2
+    assert cache[0].offset == 3
+
+
+def test_fresh_unallocated_kv_cache_has_atomic_empty_checkpoint():
+    cache = [_FreshKVCache()]
+    snapshot = target_executor._snapshot_cache(cache)
+    cache[0].keys = mx.ones((1, 1, 1, 1))
+    cache[0].values = mx.ones((1, 1, 1, 1))
+    cache[0].offset = 1
+
+    target_executor._restore_cache(cache, snapshot)
+
+    assert cache[0].keys is None
+    assert cache[0].values is None
+    assert cache[0].offset == 0
+
+
+def test_attested_chunk_failure_restores_cache_and_discards_receipts():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model, cache = _Model(), [_Cache()]
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    calls = 0
+    abandoned = []
+
+    def attested_forward(token_rows, target_cache, plan):
+        nonlocal calls
+        calls += 1
+        with hooks.session_for_plan(plan):
+            logits = model(token_rows, cache=target_cache)
+            target_executor._eval_forward(logits, target_cache)
+        if calls == 2:
+            raise RuntimeError("receipt issuance failed")
+        return logits, object()
+
+    session = SparseTargetPrefillSession(
+        model,
+        tokens,
+        cache,
+        state,
+        QWEN_DENSE_TARGET,
+        step_size=2,
+        target_forward=attested_forward,
+        receipt_abandon=lambda receipts: abandoned.extend(receipts),
+    )
+    session.step()
+    with pytest.raises(RuntimeError, match="receipt issuance failed"):
+        session.step()
+
+    assert session.closed
+    assert cache[0].offset == 0
+    assert session._forward_receipts == []
+    assert len(abandoned) == 1
+
+
+def test_attested_lazy_failure_abandons_issued_receipt_before_dense_retry(
+    monkeypatch,
+):
+    model, cache = _Model(), [_Cache()]
+    receipt = object()
+    abandoned = []
+
+    def attested_forward(token_rows, target_cache, plan):
+        hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+        with hooks.session_for_plan(plan):
+            logits = model(token_rows, cache=target_cache)
+        return logits, receipt
+
+    monkeypatch.setattr(
+        target_executor,
+        "_eval_forward",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("lazy eval failed")),
+    )
+    with pytest.raises(RuntimeError, match="lazy eval failed"):
+        execute_sparse_target_prefill(
+            model,
+            mx.array([[1]], dtype=mx.int32),
+            cache,
+            _state((0,)),
+            QWEN_DENSE_TARGET,
+            target_forward=attested_forward,
+            receipt_abandon=lambda receipts: abandoned.extend(receipts),
+        )
+
+    assert abandoned == [receipt]
+    assert cache[0].offset == 0
+
+
+def test_partial_receipt_abandon_failure_is_terminal_authority_error():
+    model, cache = _Model(), [_Cache()]
+
+    def attested_forward(token_rows, target_cache, plan):
+        hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+        with hooks.session_for_plan(plan):
+            logits = model(token_rows, cache=target_cache)
+        return logits, object()
+
+    session = SparseTargetPrefillSession(
+        model,
+        mx.array([[1, 2]], dtype=mx.int32),
+        cache,
+        _state((0, 1)),
+        QWEN_DENSE_TARGET,
+        step_size=1,
+        target_forward=attested_forward,
+        receipt_abandon=lambda _receipts: (_ for _ in ()).throw(
+            RuntimeError("abandon failed")
+        ),
+    )
+    session.step()
+    with pytest.raises(SparseTargetPrefillAuthorityError, match="partial"):
+        session.cancel()
+    assert session.closed
+    assert cache[0].offset == 0
 
 
 def test_session_rejects_zero_selected_token_rows_before_forward():

--- a/tests/test_specprefill_target_executor.py
+++ b/tests/test_specprefill_target_executor.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic execution oracles for request-local sparse target prefill."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+
+import vllm_mlx.specprefill_target_executor as target_executor
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from vllm_mlx.specprefill_positions import QWEN_DENSE_TARGET
+from vllm_mlx.specprefill_target_executor import (
+    SparseTargetPrefillError,
+    execute_sparse_target_prefill,
+)
+from vllm_mlx.specprefill_target_hooks import TargetPositionHooks
+
+
+class _Cache:
+    def __init__(self):
+        self.offset = 0
+        self.state = mx.array([0], dtype=mx.int32)
+        self.meta_state = ()
+
+
+class _Attention:
+    def __init__(self, rope):
+        self.rope = rope
+
+
+class _Model:
+    def __init__(self, *, fail_on_call: int | None = None):
+        self.layers = [SimpleNamespace(self_attn=_Attention(nn.RoPE(8, base=10000.0)))]
+        self.calls = []
+        self.rotated = []
+        self.fail_on_call = fail_on_call
+
+    @property
+    def rope(self):
+        return self.layers[0].self_attn.rope
+
+    def __call__(self, token_rows, *, cache):
+        self.calls.append((cache[0].offset, token_rows.shape[1]))
+        if self.fail_on_call == len(self.calls):
+            raise RuntimeError("target model failed")
+        hidden = mx.broadcast_to(
+            token_rows.astype(mx.float32)[:, None, :, None],
+            (token_rows.shape[0], 1, token_rows.shape[1], 8),
+        )
+        rotated = self.rope(hidden, offset=cache[0].offset)
+        self.rotated.append(rotated)
+        cache[0].offset += token_rows.shape[1]
+        cache[0].state = mx.array([cache[0].offset], dtype=mx.int32)
+        return rotated[:, :, -1:, :]
+
+
+def _identity() -> SparseCacheIdentity:
+    return SparseCacheIdentity.from_tokens(
+        target_id="target@sha256:target",
+        tokenizer_id="tokenizer@sha256:tokenizer",
+        scorer_id="scorer@sha256:scorer",
+        selector_version="hybrid-v1",
+        tuning=SparsePolicyTuning(0.5, 0.1, 1, 1, 2),
+        tokens=(1, 2, 3, 4, 5),
+        selection_fingerprint="a" * 64,
+    )
+
+
+def _state(positions: tuple[int, ...]) -> SparseCacheState:
+    return SparseCacheState.from_selection(_identity(), (positions,), (5,))
+
+
+def _assert_close(actual, expected):
+    mx.eval(actual, expected)
+    assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item()
+
+
+def _dense_prefill(model, token_rows, cache, *, step_size):
+    logits = None
+    for start in range(0, token_rows.shape[1], step_size):
+        logits = model(token_rows[:, start : start + step_size], cache=cache)
+        mx.eval(logits, cache[0].state)
+    return logits
+
+
+def test_keep_ratio_one_multichunk_matches_dense_logits_and_cache_state(monkeypatch):
+    tokens = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+    state = _state((0, 1, 2, 3, 4))
+    dense_model, dense_cache = _Model(), [_Cache()]
+    dense_logits = _dense_prefill(dense_model, tokens, dense_cache, step_size=2)
+
+    sparse_model, sparse_cache = _Model(), [_Cache()]
+    hooks = TargetPositionHooks.for_model(sparse_model, QWEN_DENSE_TARGET)
+    observed_sessions = []
+    real_eval = target_executor._eval_forward
+
+    def record_eval(logits, cache):
+        observed_sessions.append(hooks.active_session)
+        real_eval(logits, cache)
+
+    monkeypatch.setattr(target_executor, "_eval_forward", record_eval)
+    result = execute_sparse_target_prefill(
+        sparse_model, tokens, sparse_cache, state, QWEN_DENSE_TARGET, step_size=2
+    )
+
+    _assert_close(result.logits, dense_logits)
+    assert result.cache_state == state
+    assert result.cache_state is not state
+    assert sparse_cache[0].offset == dense_cache[0].offset == 5
+    assert sparse_model.calls == dense_model.calls == [(0, 2), (2, 2), (4, 1)]
+    assert result.telemetry.physical_cache_starts == ((0,), (2,), (4,))
+    assert all(session is not None for session in observed_sessions)
+    assert hooks.active_session is None
+
+
+def test_noncontiguous_logical_positions_stay_separate_from_physical_cache():
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model, cache = _Model(), [_Cache()]
+    result = execute_sparse_target_prefill(
+        model, tokens, cache, state, QWEN_DENSE_TARGET, step_size=2
+    )
+
+    reference = _Model()
+    hidden = mx.broadcast_to(tokens.astype(mx.float32)[:, None, :, None], (1, 1, 3, 8))
+    expected_first = mx.concatenate(
+        [
+            reference.rope(hidden[:, :, index : index + 1], offset=position)
+            for index, position in enumerate((0, 3))
+        ],
+        axis=2,
+    )
+    expected_last = reference.rope(hidden[:, :, 2:], offset=4)
+
+    _assert_close(model.rotated[0], expected_first)
+    _assert_close(model.rotated[1], expected_last)
+    assert model.calls == [(0, 2), (2, 1)]
+    assert result.telemetry.physical_cache_starts == ((0,), (2,))
+    assert result.cache_state.logical_positions == ((0, 3, 4),)
+    assert result.cache_state.physical_valid_lengths == (3,)
+    assert cache[0].offset == 3
+
+
+@pytest.mark.parametrize("mode", ("cancel", "failure"))
+def test_cancel_or_model_failure_restores_entry_cache_atomically(mode):
+    tokens = mx.array([[1, 4, 5]], dtype=mx.int32)
+    state = _state((0, 3, 4))
+    model = _Model(fail_on_call=2 if mode == "failure" else None)
+    cache = [_Cache()]
+    cancel_calls = 0
+
+    def cancel_check():
+        nonlocal cancel_calls
+        cancel_calls += 1
+        if mode == "cancel" and cancel_calls == 2:
+            raise RuntimeError("cancelled")
+
+    with pytest.raises(RuntimeError, match="cancelled|target model failed"):
+        execute_sparse_target_prefill(
+            model,
+            tokens,
+            cache,
+            state,
+            QWEN_DENSE_TARGET,
+            step_size=2,
+            cancel_check=cancel_check,
+        )
+
+    assert cache[0].offset == 0
+    assert cache[0].state.tolist() == [0]
+    assert state.physical_valid_lengths == (3,)
+    assert state.logical_positions == ((0, 3, 4),)
+
+
+def test_prefill_rejects_partial_sparse_prefix_reuse_before_target_forward():
+    model, cache = _Model(), [_Cache()]
+    cache[0].offset = 1
+    cache[0].state = mx.array([1], dtype=mx.int32)
+    with pytest.raises(SparseTargetPrefillError, match="prefix reuse is disabled"):
+        execute_sparse_target_prefill(
+            model,
+            mx.array([[1, 4, 5]], dtype=mx.int32),
+            cache,
+            _state((0, 3, 4)),
+            QWEN_DENSE_TARGET,
+        )
+    assert model.calls == []

--- a/tests/test_specprefill_target_hooks.py
+++ b/tests/test_specprefill_target_hooks.py
@@ -138,6 +138,56 @@ def test_keep_ratio_one_matches_native_rope_without_model_weights(traditional):
     _assert_close(model.layers[0].self_attn.rope(x, offset=0), expected)
 
 
+def test_position_acknowledgement_occurs_once_during_rope_model_call():
+    first = nn.RoPE(8, traditional=False, base=10000.0)
+    second = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([first, second])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    events = []
+
+    class Ack:
+        active = False
+
+        def acknowledge(self, positions):
+            assert self.active is True
+            events.append(positions)
+
+    ack = Ack()
+    session = TargetPositionSession(
+        logical_positions=((0, 3),),
+        physical_starts=(0,),
+        phase=PositionPhase.SPARSE_PREFILL,
+        logical_position_ack=ack,
+    )
+    x = mx.random.normal((1, 2, 2, 8))
+
+    with hooks.session(session):
+        assert events == []
+        ack.active = True
+        mx.eval(
+            model.layers[0].self_attn.rope(x, offset=0),
+            model.layers[1].self_attn.rope(x, offset=0),
+        )
+        ack.active = False
+
+    assert events == [(0, 3)]
+
+
+def test_supported_native_mtp_rope_is_owned_by_same_request_local_hooks():
+    backbone_rope = nn.RoPE(8, traditional=False, base=10000.0)
+    mtp_rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([backbone_rope])
+    model.mtp_capability = SimpleNamespace(supported=True)
+    model.mtp = SimpleNamespace(layers=[SimpleNamespace(self_attn=Attention(mtp_rope))])
+
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+
+    assert tuple(wrapper[2] for wrapper in hooks._wrappers) == (
+        backbone_rope,
+        mtp_rope,
+    )
+
+
 def test_install_preserves_real_mlx_module_rope_identity_and_parameter_topology():
     rope = nn.RoPE(8, traditional=False, base=10000.0)
     model = ModuleModel([rope])

--- a/tests/test_specprefill_target_hooks.py
+++ b/tests/test_specprefill_target_hooks.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synthetic, no-weight tests for request-local target RoPE transport."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from types import SimpleNamespace
+
+import pytest
+import vllm_mlx.specprefill_target_hooks as target_hooks
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+
+from vllm_mlx.specprefill_positions import (
+    GEMMA4_DENSE_TARGET,
+    QWEN_DENSE_TARGET,
+    PositionPhase,
+)
+from vllm_mlx.specprefill_target_hooks import (
+    TargetPositionHookError,
+    TargetPositionHooks,
+    TargetPositionSession,
+)
+
+
+class Attention:
+    def __init__(self, rope):
+        self.rope = rope
+
+
+class Model:
+    def __init__(self, ropes):
+        self.layers = [SimpleNamespace(self_attn=Attention(rope)) for rope in ropes]
+
+
+class ModuleAttention(nn.Module):
+    def __init__(self, rope):
+        super().__init__()
+        self.rope = rope
+        self.proj = nn.Linear(8, 8, bias=False)
+
+
+class ModuleDecoder(nn.Module):
+    def __init__(self, rope):
+        super().__init__()
+        self.self_attn = ModuleAttention(rope)
+
+
+class ModuleModel(nn.Module):
+    def __init__(self, ropes):
+        super().__init__()
+        self.layers = [ModuleDecoder(rope) for rope in ropes]
+
+
+class CustomScaledRoPE(nn.Module):
+    """Small MLX-like partial RoPE with `_freqs` and amplitude mscale."""
+
+    def __init__(self):
+        super().__init__()
+        self._dims = 4
+        self._freqs = mx.array([1.0, 2.0])
+        self.mscale = 0.5
+
+    def __call__(self, x, offset=0):
+        positions = mx.arange(offset, offset + x.shape[2], dtype=mx.float32)
+        inv_freq = 1.0 / self._freqs
+        angles = positions[None, None, :, None] * inv_freq[None, None, None, :]
+        cos_a = mx.cos(angles).astype(x.dtype)
+        sin_a = mx.sin(angles).astype(x.dtype)
+        x_rot, x_pass = x[..., : self._dims] * self.mscale, x[..., self._dims :]
+        first, second = x_rot[..., :2], x_rot[..., 2:]
+        rotated = mx.concatenate(
+            (first * cos_a - second * sin_a, first * sin_a + second * cos_a),
+            axis=-1,
+        )
+        return mx.concatenate((rotated, x_pass), axis=-1)
+
+
+class RecordingRope:
+    """A native-only rope used to prove ContextVar isolation across threads."""
+
+    dims = 8
+    base = 10000.0
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, x, offset=0):
+        self.calls.append((x, offset))
+        return ("native", x, offset)
+
+
+def _session(logical_positions, physical_starts, phase=PositionPhase.SPARSE_PREFILL):
+    return TargetPositionSession(
+        logical_positions=logical_positions,
+        physical_starts=physical_starts,
+        phase=phase,
+    )
+
+
+def _assert_close(actual, expected):
+    mx.eval(actual, expected)
+    assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-5).item()
+
+
+def _state_paths(value, prefix=()):
+    if isinstance(value, dict):
+        return tuple(
+            path
+            for key, child in value.items()
+            for path in _state_paths(child, (*prefix, str(key)))
+        )
+    if isinstance(value, list):
+        return tuple(
+            path
+            for index, child in enumerate(value)
+            for path in _state_paths(child, (*prefix, str(index)))
+        )
+    return (prefix,)
+
+
+@pytest.mark.parametrize("traditional", (False, True))
+def test_keep_ratio_one_matches_native_rope_without_model_weights(traditional):
+    rope = nn.RoPE(8, traditional=traditional, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 4, 8))
+    expected = rope(x, offset=0)
+
+    with hooks.session(_session(((0, 1, 2, 3),), (0,))):
+        actual = model.layers[0].self_attn.rope(x, offset=0)
+        # The caller must realize any lazy target work before session release.
+        _assert_close(actual, expected)
+
+    assert hooks.active_session is None
+    _assert_close(model.layers[0].self_attn.rope(x, offset=0), expected)
+
+
+def test_install_preserves_real_mlx_module_rope_identity_and_parameter_topology():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = ModuleModel([rope])
+    before_rope = model.layers[0].self_attn.rope
+    before_parameters = model.parameters()
+    before_children = model.children()
+    before_state_paths = _state_paths(before_parameters)
+
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+
+    assert model.layers[0].self_attn.rope is before_rope
+    assert model.parameters().keys() == before_parameters.keys()
+    assert model.children().keys() == before_children.keys()
+    assert _state_paths(model.parameters()) == before_state_paths
+    assert hooks._wrappers[0][2] is before_rope
+
+    model.update(before_parameters)
+    assert model.layers[0].self_attn.rope is before_rope
+    assert _state_paths(model.parameters()) == before_state_paths
+
+
+@pytest.mark.parametrize("traditional", (False, True))
+def test_noncontiguous_positions_match_native_one_token_calls(traditional):
+    rope = nn.RoPE(8, traditional=traditional, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 4, 8))
+    positions = (0, 3, 7, 8)
+    expected = mx.concatenate(
+        [
+            rope(x[:, :, index : index + 1], offset=position)
+            for index, position in enumerate(positions)
+        ],
+        axis=2,
+    )
+
+    with hooks.session(_session((positions,), (0,))):
+        actual = model.layers[0].self_attn.rope(x, offset=0)
+        _assert_close(actual, expected)
+
+
+def test_custom_frequency_prescale_partial_rope_matches_native_and_keeps_tail():
+    rope = CustomScaledRoPE()
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 3, 8))
+    positions = (2, 5, 11)
+    expected = mx.concatenate(
+        [
+            rope(x[:, :, index : index + 1], offset=position)
+            for index, position in enumerate(positions)
+        ],
+        axis=2,
+    )
+
+    with hooks.session(_session((positions,), (0,))):
+        actual = model.layers[0].self_attn.rope(x, offset=0)
+        _assert_close(actual, expected)
+        _assert_close(actual[..., 4:], x[..., 4:])
+
+
+def test_per_row_heterogeneous_positions_broadcast_as_batch_heads_sequence_dims():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((2, 2, 3, 8))
+    logical = ((0, 2, 5), (10, 12, 17))
+    expected_rows = []
+    for row, row_positions in enumerate(logical):
+        expected_rows.append(
+            mx.concatenate(
+                [
+                    rope(x[row : row + 1, :, index : index + 1], offset=position)
+                    for index, position in enumerate(row_positions)
+                ],
+                axis=2,
+            )
+        )
+    expected = mx.concatenate(expected_rows, axis=0)
+
+    with hooks.session(_session(logical, (0, 4))):
+        actual = model.layers[0].self_attn.rope(x, offset=mx.array([0, 4]))
+        _assert_close(actual, expected)
+
+
+def test_physical_offset_selects_a_chunk_without_mutating_cache_coordinate():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 2, 8))
+    positions = (5, 9)
+    expected = mx.concatenate(
+        [
+            rope(x[:, :, index : index + 1], offset=position)
+            for index, position in enumerate((5, 9))
+        ],
+        axis=2,
+    )
+
+    with hooks.session(_session((positions,), (13,))):
+        actual = model.layers[0].self_attn.rope(x, offset=13)
+        _assert_close(actual, expected)
+
+
+def test_dispatch_has_no_per_layer_host_sync_for_batched_offsets():
+    source = inspect.getsource(target_hooks._validate_scalar_offset)
+    dispatcher = inspect.getsource(target_hooks._install_rope_dispatch)
+    assert ".tolist(" not in source
+    assert ".item(" not in source
+    assert "mx.eval(" not in source
+    assert ".tolist(" not in dispatcher
+    assert ".item(" not in dispatcher
+    assert "mx.eval(" not in dispatcher
+
+
+def test_position_tensor_is_materialized_once_for_all_rope_layers(monkeypatch):
+    first = nn.RoPE(8, traditional=False, base=10000.0)
+    second = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([first, second])
+    hooks = TargetPositionHooks.for_model(model, GEMMA4_DENSE_TARGET)
+    real_array = target_hooks.mx.array
+    calls = 0
+
+    def recording_array(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_array(*args, **kwargs)
+
+    monkeypatch.setattr(target_hooks.mx, "array", recording_array)
+    # Per-RoPE execution metadata is captured at installation.  A dispatcher
+    # must not rebuild device frequencies after every layer invocation.
+    monkeypatch.setattr(
+        target_hooks,
+        "_inverse_frequencies",
+        lambda *_args: pytest.fail("dispatcher recalculated RoPE frequencies"),
+    )
+    session = _session(((0, 3, 7),), (0,))
+    assert calls == 1
+    x = mx.random.normal((1, 2, 3, 8))
+    with hooks.session(session):
+        first_out = model.layers[0].self_attn.rope(x, offset=0)
+        second_out = model.layers[1].self_attn.rope(x, offset=0)
+        mx.eval(first_out, second_out)
+    assert calls == 1
+
+
+def test_gemma_shared_kv_rope_layers_observe_the_same_logical_session():
+    first = nn.RoPE(8, traditional=False, base=10000.0)
+    second = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([first, second])
+    hooks = TargetPositionHooks.for_model(model, GEMMA4_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 3, 8))
+    positions = (1, 4, 9)
+    expected = mx.concatenate(
+        [
+            first(x[:, :, index : index + 1], offset=position)
+            for index, position in enumerate(positions)
+        ],
+        axis=2,
+    )
+
+    with hooks.session(_session((positions,), (5,))):
+        owner = model.layers[0].self_attn.rope(x, offset=5)
+        # Gemma shared-KV followers receive the owner offset; both wrappers
+        # must use the same request-local coordinates without changing it.
+        follower = model.layers[1].self_attn.rope(x, offset=5)
+        _assert_close(owner, expected)
+        _assert_close(follower, expected)
+
+
+def test_concurrent_context_sessions_are_isolated_and_foreign_thread_delegates():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    first = _session(((0,),), (0,))
+    second = _session(((9,),), (0,))
+    barrier = threading.Barrier(2)
+    observed = []
+
+    def worker(session):
+        with hooks.session(session):
+            barrier.wait(timeout=2)
+            observed.append(hooks.active_session)
+
+    threads = [
+        threading.Thread(target=worker, args=(session,)) for session in (first, second)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+    assert set(observed) == {first, second}
+    assert hooks.active_session is None
+
+    foreign_rope = RecordingRope()
+    foreign_model = Model([foreign_rope])
+    foreign_hooks = TargetPositionHooks.for_model(foreign_model, QWEN_DENSE_TARGET)
+    foreign_sessions = []
+    foreign_result = []
+    with hooks.session(first):
+        thread = threading.Thread(
+            target=lambda: (
+                foreign_sessions.append(hooks.active_session),
+                foreign_result.append(
+                    foreign_model.layers[0].self_attn.rope("foreign", offset=17)
+                ),
+            )
+        )
+        thread.start()
+        thread.join(timeout=2)
+    assert foreign_sessions == [None]
+    assert foreign_result == [("native", "foreign", 17)]
+    assert foreign_rope.calls == [("foreign", 17)]
+    assert foreign_hooks.active_session is None
+
+
+def test_vector_offset_requires_a_matching_precomputed_batch_shape():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    x = mx.random.normal((1, 2, 2, 8))
+
+    with hooks.session(_session(((0, 2), (10, 12)), (0, 7))):
+        with pytest.raises(
+            TargetPositionHookError, match="positions must have host shape"
+        ):
+            model.layers[0].self_attn.rope(x, offset=mx.array([0, 7]))
+
+
+def test_nested_session_and_topology_tamper_fail_closed():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    session = _session(((0,),), (0,))
+    with hooks.session(session):
+        with pytest.raises(
+            TargetPositionHookError, match="already has an active session"
+        ):
+            with hooks.session(session):
+                pass
+
+    model.layers[0].self_attn.rope = nn.RoPE(8, traditional=False, base=10000.0)
+    with pytest.raises(TargetPositionHookError, match="topology was modified"):
+        TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    with pytest.raises(TargetPositionHookError, match="topology was modified"):
+        with hooks.session(session):
+            pass
+
+
+def test_class_dispatch_tamper_fails_closed_without_replacing_rope_instance():
+    rope = nn.RoPE(8, traditional=False, base=10000.0)
+    model = Model([rope])
+    hooks = TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+    installed_dispatch = type(rope).__call__
+    type(rope).__call__ = lambda self, *args, **kwargs: args[0]
+    try:
+        with pytest.raises(
+            TargetPositionHookError, match="class dispatcher was modified"
+        ):
+            TargetPositionHooks.for_model(model, QWEN_DENSE_TARGET)
+        assert model.layers[0].self_attn.rope is rope
+    finally:
+        type(rope).__call__ = installed_dispatch
+    hooks._verify_installed()
+
+
+def test_partial_install_failure_rolls_back_prior_dispatch_registration():
+    first = nn.RoPE(8, traditional=False, base=10000.0)
+
+    class UnweakrefableRope:
+        __slots__ = ()
+
+        dims = 8
+        base = 10000.0
+
+        def __call__(self, x, offset=0):
+            return x
+
+    second = UnweakrefableRope()
+
+    model = Model([first, second])
+    with pytest.raises(TargetPositionHookError, match="must support weak references"):
+        TargetPositionHooks(model, QWEN_DENSE_TARGET)
+    assert model.layers[0].self_attn.rope is first
+    assert target_hooks._ROPE_HOOKS.get(first) is None

--- a/tests/test_specprefill_target_positions.py
+++ b/tests/test_specprefill_target_positions.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Host-only position contracts for sparse target execution."""
+
+import pytest
+
+from vllm_mlx.specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from vllm_mlx.specprefill_positions import (
+    GEMMA4_A4B_TARGET,
+    GEMMA4_DENSE_TARGET,
+    QWEN_DENSE_TARGET,
+    QWEN35_TEXT_HYBRID_TARGET,
+    QWEN35_VLM_HYBRID_TARGET,
+    QWEN35_VLM_MOE_TARGET,
+    TargetPositionError,
+    TargetPositionFamily,
+    decode_plan,
+    gemma_previous_kv_cache_map,
+    mtp_decode_plan,
+    sparse_prefill_plan,
+    target_position_adapter,
+    verify_plan,
+)
+
+
+def _identity(tokens: tuple[int, ...], fingerprint: str = "a" * 64):
+    return SparseCacheIdentity.from_tokens(
+        target_id="target@sha256:target",
+        tokenizer_id="tokenizer@sha256:tokenizer",
+        scorer_id="scorer@sha256:scorer",
+        selector_version="hybrid-chunk-v1",
+        tuning=SparsePolicyTuning(
+            keep_pct=0.7,
+            backbone_pct=0.1,
+            halo_chunks=1,
+            anchor_chunks=1,
+            chunk_size=32,
+        ),
+        tokens=tokens,
+        selection_fingerprint=fingerprint,
+    )
+
+
+def _state(
+    selected: tuple[tuple[int, ...], ...] = ((0, 2, 4, 5),),
+    cursors: tuple[int, ...] = (6,),
+) -> SparseCacheState:
+    identities = tuple(
+        _identity(tuple(range(cursor)), chr(ord("a") + index) * 64)
+        for index, cursor in enumerate(cursors)
+    )
+    return SparseCacheState.from_selection(identities, selected, cursors)
+
+
+def test_adapter_matrix_is_explicit_about_position_transport_and_architecture():
+    assert QWEN_DENSE_TARGET.supports_noncontiguous_prefill is False
+    assert QWEN35_TEXT_HYBRID_TARGET.supports_noncontiguous_prefill is False
+    assert QWEN35_TEXT_HYBRID_TARGET.supports_partial_rope
+    assert QWEN35_VLM_HYBRID_TARGET.position_id_planes == 3
+    assert QWEN35_VLM_HYBRID_TARGET.supports_heterogeneous_batch_rows
+    assert QWEN35_VLM_MOE_TARGET.uses_q_norm
+    assert GEMMA4_DENSE_TARGET.supports_shared_kv
+    assert GEMMA4_DENSE_TARGET.supports_partial_rope
+    assert GEMMA4_A4B_TARGET.supports_shared_kv
+    assert target_position_adapter(TargetPositionFamily.GEMMA4_A4B) is GEMMA4_A4B_TARGET
+    with pytest.raises(TargetPositionError, match="unsupported target position family"):
+        target_position_adapter("attribute_guessing_is_not_an_adapter")
+
+
+def test_keep_ratio_one_plan_is_dense_position_equivalent_for_all_families():
+    dense = _state(selected=((0, 1, 2, 3),), cursors=(4,))
+    for adapter in (
+        QWEN_DENSE_TARGET,
+        QWEN35_TEXT_HYBRID_TARGET,
+        QWEN35_VLM_HYBRID_TARGET,
+        QWEN35_VLM_MOE_TARGET,
+        GEMMA4_DENSE_TARGET,
+        GEMMA4_A4B_TARGET,
+    ):
+        prefill = sparse_prefill_plan(adapter, dense)
+        assert prefill.is_dense_equivalent
+        prefill.require_executable()
+
+        decode = decode_plan(adapter, dense)
+        assert decode.logical_positions == ((4,),)
+        assert decode.physical_cache_lengths == (4,)
+        decode.require_executable()
+
+
+def test_sparse_qwen_vlm_plan_uses_exact_three_plane_batch_shape():
+    state = _state(
+        selected=((0, 2, 4, 5), (1, 3, 4, 7)),
+        cursors=(6, 8),
+    )
+    plan = sparse_prefill_plan(QWEN35_VLM_HYBRID_TARGET, state)
+
+    plan.require_executable()
+    assert plan.qwen35_mrope_position_ids() == (
+        ((0, 2, 4, 5), (1, 3, 4, 7)),
+        ((0, 2, 4, 5), (1, 3, 4, 7)),
+        ((0, 2, 4, 5), (1, 3, 4, 7)),
+    )
+
+
+def test_sparse_qwen_vlm_moe_has_same_explicit_mrope_contract():
+    plan = sparse_prefill_plan(QWEN35_VLM_MOE_TARGET, _state())
+    plan.require_executable()
+    assert plan.qwen35_mrope_position_ids() == (
+        ((0, 2, 4, 5),),
+        ((0, 2, 4, 5),),
+        ((0, 2, 4, 5),),
+    )
+
+
+def test_sparse_prefill_fails_closed_for_cache_offset_and_current_gemma_paths():
+    sparse_state = _state()
+    for adapter in (QWEN_DENSE_TARGET, QWEN35_TEXT_HYBRID_TARGET, GEMMA4_DENSE_TARGET):
+        with pytest.raises(
+            TargetPositionError, match="no request-local|cannot execute"
+        ):
+            sparse_prefill_plan(adapter, sparse_state).require_executable()
+
+    # Gemma's owner attention replaces the passed offset with cache.offset;
+    # shared-KV forwarding therefore does not make sparse decode representable.
+    with pytest.raises(TargetPositionError, match="cannot execute"):
+        decode_plan(GEMMA4_DENSE_TARGET, sparse_state).gemma4_offsets()
+
+
+def test_heterogeneous_rows_are_planned_but_only_verified_transport_executes_them():
+    state = _state(
+        selected=((0, 2, 4, 5), (1, 3, 4, 7)),
+        cursors=(6, 8),
+    )
+    qwen = sparse_prefill_plan(QWEN35_VLM_HYBRID_TARGET, state)
+    qwen.require_executable()
+
+    gemma = sparse_prefill_plan(GEMMA4_DENSE_TARGET, state)
+    with pytest.raises(TargetPositionError, match="non-contiguous"):
+        gemma.require_executable()
+
+    # Even normal Gemma decode cannot join rows whose logical cursors differ
+    # until a vector-offset transport is proven in the underlying attention.
+    dense_rows = _state(selected=((0, 1), (0, 1)), cursors=(2, 3))
+    with pytest.raises(TargetPositionError, match="heterogeneous-row"):
+        decode_plan(GEMMA4_DENSE_TARGET, dense_rows).require_executable()
+
+
+def test_verify_rollback_contract_keeps_logical_cursor_independent_of_physical_kv():
+    state = _state()
+    plan = verify_plan(QWEN35_VLM_HYBRID_TARGET, state, 2)
+    assert plan.logical_positions == ((6, 7),)
+    assert plan.physical_cache_lengths == (4,)
+    plan.require_executable()
+
+    advanced = state.append_decode(2)
+    assert advanced.logical_positions == ((0, 2, 4, 5, 6, 7),)
+    assert advanced.physical_valid_lengths == (6,)
+    assert advanced.rollback(2) == state
+
+
+def test_mtp_pairs_logical_positions_but_not_target_assistant_physical_lengths():
+    target = _state(selected=((0, 2, 4, 5),), cursors=(6,))
+    assistant = _state(selected=((0, 1, 2, 3, 4, 5),), cursors=(6,))
+    mtp = mtp_decode_plan(
+        QWEN35_VLM_HYBRID_TARGET,
+        target,
+        QWEN35_VLM_HYBRID_TARGET,
+        assistant,
+    )
+    assert mtp.target.logical_positions == ((6,),)
+    assert mtp.assistant.logical_positions == ((6,),)
+    assert mtp.physical_cache_lengths == ((4,), (6,))
+
+    different_cursor = _state(selected=((0, 2, 4, 5),), cursors=(7,))
+    with pytest.raises(TargetPositionError, match="logical positions must agree"):
+        mtp_decode_plan(
+            QWEN35_VLM_HYBRID_TARGET,
+            target,
+            QWEN35_VLM_HYBRID_TARGET,
+            different_cursor,
+        )
+
+
+def test_gemma_shared_kv_owner_mapping_is_explicit_and_validated():
+    assert gemma_previous_kv_cache_map((0, 1, 2, 1, 2)) == {
+        0: 0,
+        1: 1,
+        2: 2,
+        3: 1,
+        4: 2,
+    }
+    with pytest.raises(TargetPositionError, match="earlier layer"):
+        gemma_previous_kv_cache_map((0, 2))

--- a/tests/test_specprefill_target_positions.py
+++ b/tests/test_specprefill_target_positions.py
@@ -169,18 +169,18 @@ def test_sparse_qwen_vlm_moe_has_same_explicit_mrope_contract():
     )
 
 
-def test_sparse_prefill_fails_closed_for_cache_offset_and_current_gemma_paths():
+def test_sparse_prefill_requires_hook_transport_and_gemma_scalar_is_executable():
     sparse_state = _state()
-    for adapter in (QWEN_DENSE_TARGET, QWEN35_TEXT_HYBRID_TARGET, GEMMA4_DENSE_TARGET):
+    for adapter in (QWEN_DENSE_TARGET, QWEN35_TEXT_HYBRID_TARGET):
         with pytest.raises(
             TargetPositionError, match="no request-local|cannot execute"
         ):
             sparse_prefill_plan(adapter, sparse_state).require_executable()
 
-    # Gemma's owner attention replaces the passed offset with cache.offset;
-    # shared-KV forwarding therefore does not make sparse decode representable.
-    with pytest.raises(TargetPositionError, match="cannot execute"):
-        decode_plan(GEMMA4_DENSE_TARGET, sparse_state).gemma4_offsets()
+    gemma_sparse = sparse_prefill_plan(GEMMA4_DENSE_TARGET, sparse_state)
+    gemma_sparse.require_executable()
+    assert gemma_sparse.gemma4_offsets() == (0,)
+    assert decode_plan(GEMMA4_DENSE_TARGET, sparse_state).gemma4_offsets() == (6,)
 
 
 def test_heterogeneous_rows_are_planned_but_only_verified_transport_executes_them():
@@ -192,7 +192,7 @@ def test_heterogeneous_rows_are_planned_but_only_verified_transport_executes_the
     qwen.require_executable()
 
     gemma = sparse_prefill_plan(GEMMA4_DENSE_TARGET, state)
-    with pytest.raises(TargetPositionError, match="non-contiguous"):
+    with pytest.raises(TargetPositionError, match="heterogeneous-row"):
         gemma.require_executable()
 
     # Even normal Gemma decode cannot join rows whose logical cursors differ

--- a/tests/test_specprefill_target_positions.py
+++ b/tests/test_specprefill_target_positions.py
@@ -20,10 +20,64 @@ from vllm_mlx.specprefill_positions import (
     decode_plan,
     gemma_previous_kv_cache_map,
     mtp_decode_plan,
+    resolve_target_position_adapter,
     sparse_prefill_plan,
     target_position_adapter,
     verify_plan,
 )
+
+
+class _Config:
+    def __init__(self, model_type, **kwargs):
+        self.model_type = model_type
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+
+class _Model:
+    def __init__(self, config=None, *, args=None, language_model=None, vision=False):
+        self.config = config
+        self.args = args
+        self.language_model = language_model
+        if vision:
+            self.vision_tower = object()
+
+
+def test_known_target_resolver_is_config_and_wrapper_bounded():
+    assert (
+        resolve_target_position_adapter(_Model(_Config("qwen3"))) is QWEN_DENSE_TARGET
+    )
+    assert (
+        resolve_target_position_adapter(_Model(_Config("qwen3_5_moe")))
+        is QWEN35_TEXT_HYBRID_TARGET
+    )
+    assert (
+        resolve_target_position_adapter(
+            _Model(
+                _Config("qwen3_5"),
+                language_model=_Model(_Config("qwen3_5")),
+                vision=True,
+            )
+        )
+        is QWEN35_VLM_HYBRID_TARGET
+    )
+    # This matches clean mlx-lm qwen3_5.Model: ``args`` plus a
+    # ``language_model`` text wrapper, with no vision tower.
+    assert (
+        resolve_target_position_adapter(
+            _Model(
+                args=_Config("qwen3_5"),
+                language_model=_Model(_Config("qwen3_5")),
+            )
+        )
+        is QWEN35_TEXT_HYBRID_TARGET
+    )
+    assert (
+        resolve_target_position_adapter(_Model(_Config("gemma4", num_experts=16)))
+        is GEMMA4_A4B_TARGET
+    )
+    with pytest.raises(TargetPositionError, match="unsupported target model layout"):
+        resolve_target_position_adapter(_Model(_Config("unknown")))
 
 
 def _identity(tokens: tuple[int, ...], fingerprint: str = "a" * 64):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -14,7 +14,14 @@ import time
 import uuid
 from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, Field, model_serializer, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    StrictInt,
+    model_serializer,
+    model_validator,
+)
 
 # =============================================================================
 # Content Types (for multimodal messages)
@@ -223,6 +230,7 @@ class ChatCompletionRequest(BaseModel):
     # production profile may decline.
     specprefill_policy: SpecPrefillPolicy | None = None
     specprefill_coverage: SpecPrefillCoverage | None = None
+    specprefill_control_token_indices: list[StrictInt] | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
     specprefill_keep_pct: float | None = Field(default=None, ge=0.0, le=1.0)
     # SpecPrefill: per-request evenly spaced backbone percentage.
@@ -239,6 +247,13 @@ class ChatCompletionRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_specprefill_policy(self):
+        indices = self.specprefill_control_token_indices
+        if indices is not None and any(
+            isinstance(index, bool) or index < 0 for index in indices
+        ):
+            raise ValueError(
+                "specprefill_control_token_indices must be non-negative integers"
+            )
         return _validate_specprefill_policy_compatibility(self)
 
 
@@ -345,6 +360,7 @@ class CompletionRequest(BaseModel):
     specprefill: bool | None = None
     specprefill_policy: SpecPrefillPolicy | None = None
     specprefill_coverage: SpecPrefillCoverage | None = None
+    specprefill_control_token_indices: list[StrictInt] | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
     specprefill_keep_pct: float | None = Field(default=None, ge=0.0, le=1.0)
     # SpecPrefill: per-request evenly spaced backbone percentage.
@@ -352,6 +368,13 @@ class CompletionRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_specprefill_policy(self):
+        indices = self.specprefill_control_token_indices
+        if indices is not None and any(
+            isinstance(index, bool) or index < 0 for index in indices
+        ):
+            raise ValueError(
+                "specprefill_control_token_indices must be non-negative integers"
+            )
         return _validate_specprefill_policy_compatibility(self)
 
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -18,6 +18,7 @@ from pydantic import (
     AliasChoices,
     BaseModel,
     Field,
+    StrictBool,
     StrictInt,
     model_serializer,
     model_validator,
@@ -191,6 +192,15 @@ def _validate_specprefill_policy_compatibility(model):
     return model
 
 
+def _validate_native_mtp_request(model):
+    """Reject ambiguous native/external MTP and seed combinations."""
+    if model.seed is not None and model.mtp is False:
+        raise ValueError("seed conflicts with mtp=false")
+    if model.mtp is True and getattr(model, "mllm_draft", None) is True:
+        raise ValueError("mtp=true conflicts with mllm_draft=true")
+    return model
+
+
 class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
@@ -241,6 +251,10 @@ class ChatCompletionRequest(BaseModel):
     # Text-only requests also use this flag to leave the default TextModel route
     # and run through the MLLM path where the drafter can participate.
     mllm_draft: bool | None = None
+    # Request-local native Qwen MTP. None preserves the server default; this is
+    # independent from the external MLLM assistant-drafter control above.
+    mtp: StrictBool | None = None
+    seed: StrictInt | None = Field(default=None, ge=0, le=0xFFFFFFFF)
     # Thinking token budget: cap reasoning tokens by forcing </think> when
     # budget exhausted (None = no budget, unlimited reasoning)
     thinking_token_budget: int | None = Field(default=None, gt=0)
@@ -254,7 +268,8 @@ class ChatCompletionRequest(BaseModel):
             raise ValueError(
                 "specprefill_control_token_indices must be non-negative integers"
             )
-        return _validate_specprefill_policy_compatibility(self)
+        _validate_specprefill_policy_compatibility(self)
+        return _validate_native_mtp_request(self)
 
 
 class AssistantMessage(BaseModel):
@@ -310,6 +325,7 @@ class GenerationMetadata(BaseModel):
     no_final_content_watchdog_enforced: bool = False
     mtp_drafts: int | None = None
     mtp_accepted: int | None = None
+    mtp_bypass_reason: str | None = None
     specprefill_requested_policy: SpecPrefillPolicy | None = None
     specprefill_effective_policy: SpecPrefillPolicy | None = None
     specprefill_coverage: SpecPrefillCoverage | None = None
@@ -354,6 +370,10 @@ class CompletionRequest(BaseModel):
     stop: list[str] | None = None
     # Sampling penalties
     repetition_penalty: float | None = None  # mlx-lm style (>1.0 penalizes)
+    # Request-local native Qwen MTP. A seed requires an effective explicit or
+    # server-default native-MTP route.
+    mtp: StrictBool | None = None
+    seed: StrictInt | None = Field(default=None, ge=0, le=0xFFFFFFFF)
     # Request timeout in seconds (None = use server default)
     timeout: float | None = None
     # SpecPrefill: per-request enable/disable (None = server decides)
@@ -375,7 +395,8 @@ class CompletionRequest(BaseModel):
             raise ValueError(
                 "specprefill_control_token_indices must be non-negative integers"
             )
-        return _validate_specprefill_policy_compatibility(self)
+        _validate_specprefill_policy_compatibility(self)
+        return _validate_native_mtp_request(self)
 
 
 class CompletionChoice(BaseModel):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -372,6 +372,10 @@ class CompletionResponse(BaseModel):
     model: str
     choices: list[CompletionChoice]
     usage: Usage = Field(default_factory=Usage)
+    # Keep /v1/completions terminal diagnostics at parity with
+    # /v1/chat/completions.  It is optional so standard OpenAI-compatible
+    # clients continue to receive the ordinary completion shape unchanged.
+    generation_metadata: GenerationMetadata | None = None
 
 
 # =============================================================================

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -12,7 +12,7 @@ These models define the request and response schemas for:
 import re
 import time
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, Field, model_serializer, model_validator
 
@@ -165,6 +165,25 @@ class StreamOptions(BaseModel):
     include_usage: bool = False  # Include usage stats in final chunk
 
 
+SpecPrefillPolicy = Literal["auto", "sparse", "dense"]
+SpecPrefillCoverage = Literal["selective", "exhaustive", "unknown"]
+
+
+def _validate_specprefill_policy_compatibility(model):
+    """Reject ambiguous combinations of legacy and policy controls."""
+    legacy = model.specprefill
+    policy = model.specprefill_policy
+    if legacy is None or policy is None:
+        return model
+
+    legacy_policy = "sparse" if legacy else "dense"
+    if policy != legacy_policy:
+        raise ValueError(
+            f"specprefill={legacy!r} conflicts with " f"specprefill_policy={policy!r}"
+        )
+    return model
+
+
 class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
@@ -199,10 +218,15 @@ class ChatCompletionRequest(BaseModel):
     timeout: float | None = None
     # SpecPrefill: per-request enable/disable (None = server decides)
     specprefill: bool | None = None
+    # Request-safe policy. ``auto`` still requires declared selective coverage
+    # and server-side eligibility; ``sparse`` is an expert intent which a
+    # production profile may decline.
+    specprefill_policy: SpecPrefillPolicy | None = None
+    specprefill_coverage: SpecPrefillCoverage | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
-    specprefill_keep_pct: float | None = None
+    specprefill_keep_pct: float | None = Field(default=None, ge=0.0, le=1.0)
     # SpecPrefill: per-request evenly spaced backbone percentage.
-    specprefill_backbone_pct: float | None = None
+    specprefill_backbone_pct: float | None = Field(default=None, ge=0.0, le=1.0)
     # Enable/disable thinking mode (None = server default, typically True)
     enable_thinking: bool | None = None
     # MLLM assistant-drafter path: opt in to using a configured drafter.
@@ -212,6 +236,10 @@ class ChatCompletionRequest(BaseModel):
     # Thinking token budget: cap reasoning tokens by forcing </think> when
     # budget exhausted (None = no budget, unlimited reasoning)
     thinking_token_budget: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_specprefill_policy(self):
+        return _validate_specprefill_policy_compatibility(self)
 
 
 class AssistantMessage(BaseModel):
@@ -265,6 +293,18 @@ class GenerationMetadata(BaseModel):
 
     no_final_content_watchdog_tokens: int | None = None
     no_final_content_watchdog_enforced: bool = False
+    mtp_drafts: int | None = None
+    mtp_accepted: int | None = None
+    specprefill_requested_policy: SpecPrefillPolicy | None = None
+    specprefill_effective_policy: SpecPrefillPolicy | None = None
+    specprefill_coverage: SpecPrefillCoverage | None = None
+    specprefill_engaged: bool | None = None
+    specprefill_selector_version: str | None = None
+    specprefill_fallback_reason: str | None = None
+    specprefill_total_tokens: int | None = None
+    specprefill_selected_tokens: int | None = None
+    specprefill_scorer_ms: float | None = None
+    specprefill_target_prefill_ms: float | None = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -303,10 +343,16 @@ class CompletionRequest(BaseModel):
     timeout: float | None = None
     # SpecPrefill: per-request enable/disable (None = server decides)
     specprefill: bool | None = None
+    specprefill_policy: SpecPrefillPolicy | None = None
+    specprefill_coverage: SpecPrefillCoverage | None = None
     # SpecPrefill: per-request keep percentage (0.0-1.0, None = use server default)
-    specprefill_keep_pct: float | None = None
+    specprefill_keep_pct: float | None = Field(default=None, ge=0.0, le=1.0)
     # SpecPrefill: per-request evenly spaced backbone percentage.
-    specprefill_backbone_pct: float | None = None
+    specprefill_backbone_pct: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def validate_specprefill_policy(self):
+        return _validate_specprefill_policy_compatibility(self)
 
 
 class CompletionChoice(BaseModel):
@@ -573,3 +619,4 @@ class ChatCompletionChunk(BaseModel):
     model: str
     choices: list[ChatCompletionChunkChoice]
     usage: Usage | None = None  # Included when stream_options.include_usage=true
+    generation_metadata: GenerationMetadata | None = None

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -413,6 +413,7 @@ class ModelInfo(BaseModel):
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))
     owned_by: str = "vllm-mlx"
+    capabilities: list[str] = Field(default_factory=list)
 
 
 class ModelsResponse(BaseModel):

--- a/vllm_mlx/cooperative_specprefill.py
+++ b/vllm_mlx/cooperative_specprefill.py
@@ -1,0 +1,623 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-owned orchestration for cooperative SpecPrefill.
+
+This module deliberately contains no scheduler policy and no model wrappers.
+One call to :meth:`CooperativeSpecPrefillSession.step` attempts at most one
+bounded scorer or target quantum.  Selection and exact cache metadata are
+prepared only after the scorer has yielded its final quantum, and target
+results remain non-publishable until the caller explicitly marks adoption by
+the normal decoder.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Callable, Protocol, Sequence
+
+from .specprefill import (
+    SpecPrefillScorerLaneBusy,
+    build_selection_plan,
+)
+from .specprefill_cache import (
+    SparseCacheExecutionConfig,
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from .specprefill_scorer_session import (
+    ScorerSessionPhase,
+    ScorerSessionProgress,
+    SpecPrefillScorerSession,
+)
+from .specprefill_selection import RotatingTailRequirement, SelectionPlan
+from .specprefill_target_executor import (
+    SparseTargetPrefillLaneBusy,
+    SparseTargetPrefillProgress,
+    SparseTargetPrefillResult,
+    SparseTargetPrefillSession,
+)
+
+
+class CooperativeSpecPrefillError(RuntimeError):
+    """A cooperative request is used outside its safe lifecycle."""
+
+
+@dataclass(frozen=True)
+class CooperativeSpecPrefillFailure:
+    """Traceback-free failure facts that cannot retain model/cache frames."""
+
+    error_type: str
+    message: str
+
+
+class CooperativeSpecPrefillCleanupError(CooperativeSpecPrefillError):
+    """Request resources could not be completely cleaned before adoption."""
+
+    def __init__(
+        self,
+        cleanup_failures: Sequence[Exception],
+        prior_failure: Exception | None = None,
+    ) -> None:
+        self.cleanup_failures = tuple(
+            _summarize_failure(failure) for failure in cleanup_failures
+        )
+        self.prior_failure = (
+            None if prior_failure is None else _summarize_failure(prior_failure)
+        )
+        super().__init__(
+            "cooperative SpecPrefill resource cleanup failed: "
+            + ", ".join(failure.error_type for failure in self.cleanup_failures)
+        )
+
+
+class CooperativeSpecPrefillPhase(str, Enum):
+    """Externally visible model-work phases for one sparse request."""
+
+    SCORE_PREFILL = "score_prefill"
+    LOOKAHEAD = "lookahead"
+    IMPORTANCE = "importance"
+    SPARSE_TARGET_PREFILL = "sparse_target_prefill"
+    DECODE = "decode"
+
+
+class CooperativeSpecPrefillOutcome(str, Enum):
+    """Request outcomes kept separate from model-work phase."""
+
+    ACTIVE = "active"
+    READY_FOR_ADOPTION = "ready_for_adoption"
+    DECODE = "decode"
+    FALLBACK = "fallback"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class CooperativeSpecPrefillConfig:
+    """Exact artifacts and selector controls owned by one admitted request."""
+
+    target_id: str
+    tokenizer_id: str
+    scorer_id: str
+    tuning: SparsePolicyTuning
+    control_token_indices: tuple[int, ...] = ()
+    rotating_tail_requirement: RotatingTailRequirement | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tuning, SparsePolicyTuning):
+            raise TypeError("tuning must be a SparsePolicyTuning")
+        try:
+            control_indices = tuple(self.control_token_indices)
+        except TypeError as exc:
+            raise TypeError(
+                "control_token_indices must be an iterable of integers"
+            ) from exc
+        if any(
+            isinstance(index, bool) or not isinstance(index, int) or index < 0
+            for index in control_indices
+        ):
+            raise ValueError(
+                "control_token_indices must contain non-negative integer positions"
+            )
+        object.__setattr__(
+            self, "control_token_indices", tuple(sorted(set(control_indices)))
+        )
+        if self.rotating_tail_requirement is not None and not isinstance(
+            self.rotating_tail_requirement, RotatingTailRequirement
+        ):
+            raise TypeError(
+                "rotating_tail_requirement must be a RotatingTailRequirement or None"
+            )
+        # Validate artifact identifiers at admission rather than after scoring.
+        SparseCacheExecutionConfig(
+            target_id=self.target_id,
+            tokenizer_id=self.tokenizer_id,
+            scorer_id=self.scorer_id,
+            selector_version="pending-selection",
+            tuning=self.tuning,
+        )
+
+
+@dataclass(frozen=True)
+class CooperativeSpecPrefillTelemetry:
+    """Cumulative bounded-work facts; scheduler wait time is excluded."""
+
+    scorer_quanta: int = 0
+    target_quanta: int = 0
+    busy_retries: int = 0
+    scorer_prefill_tokens: int = 0
+    lookahead_steps: int = 0
+    importance_layers: int = 0
+    selected_tokens: int = 0
+    target_chunks: int = 0
+    scorer_ms: float = 0.0
+    target_prefill_ms: float = 0.0
+
+
+@dataclass(frozen=True)
+class CooperativeSpecPrefillProgress:
+    """State after one call that attempted no more than one model quantum."""
+
+    phase: CooperativeSpecPrefillPhase
+    outcome: CooperativeSpecPrefillOutcome
+    attempted_phase: CooperativeSpecPrefillPhase | None
+    quantum_committed: bool
+    busy: bool
+    telemetry: CooperativeSpecPrefillTelemetry
+    fallback_reason: str | None
+
+
+class SparseTargetSessionFactory(Protocol):
+    """Capture a fresh target cache without giving this layer model ownership."""
+
+    def __call__(
+        self,
+        selected_tokens: tuple[int, ...],
+        sparse_state: SparseCacheState,
+    ) -> SparseTargetPrefillSession: ...
+
+
+SelectionBuilder = Callable[..., SelectionPlan]
+
+
+class CooperativeSpecPrefillSession:
+    """A request-local scorer/selector/target state machine.
+
+    The caller retains policy, queueing, and decoder ownership.  In
+    particular, target completion changes the outcome to
+    ``READY_FOR_ADOPTION`` while the phase remains ``SPARSE_TARGET_PREFILL``.
+    Only :meth:`mark_adopted` may cross the first-output boundary into
+    ``DECODE``.
+    """
+
+    def __init__(
+        self,
+        request_id: str,
+        tokens: Sequence[int],
+        scorer_session: SpecPrefillScorerSession,
+        target_session_factory: SparseTargetSessionFactory,
+        config: CooperativeSpecPrefillConfig,
+        *,
+        selection_builder: SelectionBuilder = build_selection_plan,
+    ) -> None:
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise ValueError("request_id must be a non-empty string")
+        if not isinstance(config, CooperativeSpecPrefillConfig):
+            raise TypeError("config must be a CooperativeSpecPrefillConfig")
+        token_values = tuple(tokens)
+        if not token_values:
+            raise ValueError("cooperative SpecPrefill needs at least one token")
+        if any(
+            isinstance(token, bool) or not isinstance(token, int) or token < 0
+            for token in token_values
+        ):
+            raise ValueError("tokens must be non-negative integer IDs")
+        if any(index >= len(token_values) for index in config.control_token_indices):
+            raise ValueError(
+                "control_token_indices must be positions within the request prompt"
+            )
+        if not callable(target_session_factory):
+            raise TypeError("target_session_factory must be callable")
+        if not callable(selection_builder):
+            raise TypeError("selection_builder must be callable")
+
+        try:
+            phase = _scorer_phase(scorer_session.phase)
+        except AttributeError as exc:
+            raise TypeError("scorer_session must expose a scorer phase") from exc
+        if phase not in (
+            CooperativeSpecPrefillPhase.SCORE_PREFILL,
+            CooperativeSpecPrefillPhase.LOOKAHEAD,
+            CooperativeSpecPrefillPhase.IMPORTANCE,
+        ):
+            raise ValueError("scorer_session must be active at admission")
+
+        self.request_id = request_id
+        self.tokens = token_values
+        self.config = config
+        self._scorer_session: SpecPrefillScorerSession | None = scorer_session
+        self._target_session_factory: SparseTargetSessionFactory | None = (
+            target_session_factory
+        )
+        self._selection_builder = selection_builder
+        self._target_session: SparseTargetPrefillSession | None = None
+        self._selection_plan: SelectionPlan | None = None
+        self._identity: SparseCacheIdentity | None = None
+        self._sparse_state: SparseCacheState | None = None
+        self._prepared_result: SparseTargetPrefillResult | None = None
+        self._failure: (
+            CooperativeSpecPrefillFailure | CooperativeSpecPrefillCleanupError | None
+        ) = None
+        self._fallback_reason: str | None = None
+        self._outcome = CooperativeSpecPrefillOutcome.ACTIVE
+        self._phase: CooperativeSpecPrefillPhase = phase
+        self._telemetry = CooperativeSpecPrefillTelemetry()
+
+    @property
+    def phase(self) -> CooperativeSpecPrefillPhase:
+        return self._phase
+
+    @property
+    def outcome(self) -> CooperativeSpecPrefillOutcome:
+        return self._outcome
+
+    @property
+    def telemetry(self) -> CooperativeSpecPrefillTelemetry:
+        return self._telemetry
+
+    @property
+    def selection_plan(self) -> SelectionPlan | None:
+        return self._selection_plan
+
+    @property
+    def identity(self) -> SparseCacheIdentity | None:
+        return self._identity
+
+    @property
+    def sparse_state(self) -> SparseCacheState | None:
+        return self._sparse_state
+
+    @property
+    def fallback_reason(self) -> str | None:
+        return self._fallback_reason
+
+    @property
+    def failure(
+        self,
+    ) -> CooperativeSpecPrefillFailure | CooperativeSpecPrefillCleanupError | None:
+        return self._failure
+
+    @property
+    def ready_for_adoption(self) -> bool:
+        return self._outcome is CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+
+    @property
+    def prepared_result(self) -> SparseTargetPrefillResult:
+        if (
+            self._outcome
+            not in (
+                CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION,
+                CooperativeSpecPrefillOutcome.DECODE,
+            )
+            or self._prepared_result is None
+        ):
+            raise CooperativeSpecPrefillError(
+                "target result is not publishable before decoder adoption readiness"
+            )
+        return self._prepared_result
+
+    def step(self) -> CooperativeSpecPrefillProgress:
+        """Attempt at most one scorer or target model quantum."""
+        if self._outcome is not CooperativeSpecPrefillOutcome.ACTIVE:
+            raise CooperativeSpecPrefillError(
+                f"cannot step cooperative request in outcome {self._outcome.value}"
+            )
+        attempted_phase = self._phase
+        if attempted_phase is CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL:
+            return self._step_target(attempted_phase)
+        return self._step_scorer(attempted_phase)
+
+    def mark_adopted(self) -> SparseTargetPrefillResult:
+        """Cross the output boundary only after decoder adoption succeeds."""
+        if not self.ready_for_adoption or self._prepared_result is None:
+            raise CooperativeSpecPrefillError(
+                "decoder adoption requires a complete sparse target result"
+            )
+        self._phase = CooperativeSpecPrefillPhase.DECODE
+        self._outcome = CooperativeSpecPrefillOutcome.DECODE
+        # The decoder/cache owner now holds the adopted target resources.
+        self._target_session = None
+        self._target_session_factory = None
+        return self._prepared_result
+
+    def fallback(self, reason: str, failure: Exception | None = None) -> None:
+        """Discard cooperative ownership before decoder adoption/output."""
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("fallback reason must be a non-empty string")
+        if self._outcome is CooperativeSpecPrefillOutcome.DECODE:
+            raise CooperativeSpecPrefillError(
+                "dense fallback is unsafe after decoder adoption"
+            )
+        if self._outcome in (
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            CooperativeSpecPrefillOutcome.CANCELLED,
+            CooperativeSpecPrefillOutcome.FAILED,
+        ):
+            return
+        cleanup_failures = self._close_request_resources()
+        if cleanup_failures:
+            self._fail_closed(cleanup_failures, failure)
+            return
+        self._fallback_reason = reason
+        self._failure = None if failure is None else _summarize_failure(failure)
+        self._outcome = CooperativeSpecPrefillOutcome.FALLBACK
+
+    def cancel(self) -> None:
+        """Cancel before adoption; ordinary decode owns later cancellation."""
+        if self._outcome is CooperativeSpecPrefillOutcome.DECODE:
+            raise CooperativeSpecPrefillError(
+                "cooperative cancellation is unavailable after decoder adoption"
+            )
+        if self._outcome in (
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            CooperativeSpecPrefillOutcome.CANCELLED,
+            CooperativeSpecPrefillOutcome.FAILED,
+        ):
+            return
+        cleanup_failures = self._close_request_resources()
+        if cleanup_failures:
+            self._fail_closed(cleanup_failures)
+            return
+        self._outcome = CooperativeSpecPrefillOutcome.CANCELLED
+
+    def _step_scorer(
+        self, attempted_phase: CooperativeSpecPrefillPhase
+    ) -> CooperativeSpecPrefillProgress:
+        if self._scorer_session is None:  # pragma: no cover - invariant guard.
+            raise CooperativeSpecPrefillError("scorer phase has no scorer session")
+        started_at = time.perf_counter()
+        try:
+            scorer_progress = self._scorer_session.step()
+        except SpecPrefillScorerLaneBusy:
+            self._record_busy()
+            return self._progress(attempted_phase, committed=False, busy=True)
+        except Exception as exc:
+            self.fallback("scorer_failed", exc)
+            return self._progress(attempted_phase, committed=False, busy=False)
+
+        elapsed_ms = (time.perf_counter() - started_at) * 1000.0
+        self._record_scorer(scorer_progress, elapsed_ms)
+        if scorer_progress.complete:
+            try:
+                plan = self._build_selection()
+            except Exception as exc:
+                self.fallback("selection_failed", exc)
+                return self._progress(attempted_phase, committed=True, busy=False)
+            self._selection_plan = plan
+            try:
+                self._setup_target(plan)
+            except Exception as exc:
+                self.fallback("target_setup_failed", exc)
+                return self._progress(attempted_phase, committed=True, busy=False)
+            scorer_cleanup_failure = self._release_scorer_after_selection()
+            if scorer_cleanup_failure is not None:
+                cleanup_failures = self._close_request_resources(
+                    (scorer_cleanup_failure,)
+                )
+                self._fail_closed(cleanup_failures)
+        else:
+            self._phase = _scorer_phase(scorer_progress.phase)
+        return self._progress(attempted_phase, committed=True, busy=False)
+
+    def _step_target(
+        self, attempted_phase: CooperativeSpecPrefillPhase
+    ) -> CooperativeSpecPrefillProgress:
+        if self._target_session is None:  # pragma: no cover - invariant guard.
+            raise CooperativeSpecPrefillError("target phase has no target session")
+        try:
+            target_progress = self._target_session.step()
+            result = self._target_session.result if target_progress.complete else None
+        except SparseTargetPrefillLaneBusy:
+            self._record_busy()
+            return self._progress(attempted_phase, committed=False, busy=True)
+        except Exception as exc:
+            self.fallback("target_prefill_failed", exc)
+            return self._progress(attempted_phase, committed=False, busy=False)
+
+        self._record_target(target_progress)
+        if result is not None:
+            self._prepared_result = result
+            self._telemetry = replace(
+                self._telemetry,
+                target_prefill_ms=(
+                    self._telemetry.target_prefill_ms
+                    + result.telemetry.target_prefill_ms
+                ),
+            )
+            self._outcome = CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+        return self._progress(attempted_phase, committed=True, busy=False)
+
+    def _build_selection(self) -> SelectionPlan:
+        if self._scorer_session is None:  # pragma: no cover - invariant guard.
+            raise CooperativeSpecPrefillError("selection has no scorer session")
+        tuning = self.config.tuning
+        plan = self._selection_builder(
+            self._scorer_session.importance,
+            keep_pct=tuning.keep_pct,
+            chunk_size=tuning.chunk_size,
+            backbone_pct=tuning.backbone_pct,
+            halo_chunks=tuning.halo_chunks,
+            anchor_chunks=tuning.anchor_chunks,
+            control_token_indices=self.config.control_token_indices,
+            rotating_tail_requirement=self.config.rotating_tail_requirement,
+        )
+        if plan.prompt_length != len(self.tokens):
+            raise CooperativeSpecPrefillError(
+                "selection importance length must match the full prompt"
+            )
+        if plan.control_anchor_indices != self.config.control_token_indices:
+            raise CooperativeSpecPrefillError(
+                "selection plan dropped request control-token anchors"
+            )
+        if plan.rotating_tail_requirement != self.config.rotating_tail_requirement:
+            raise CooperativeSpecPrefillError(
+                "selection plan dropped the rotating-cache tail requirement"
+            )
+        return plan
+
+    def _setup_target(self, plan: SelectionPlan) -> None:
+        tuning = self.config.tuning
+        identity = SparseCacheIdentity.from_tokens(
+            target_id=self.config.target_id,
+            tokenizer_id=self.config.tokenizer_id,
+            scorer_id=self.config.scorer_id,
+            selector_version=plan.selector_version,
+            tuning=tuning,
+            tokens=self.tokens,
+            selection_fingerprint=plan.fingerprint,
+        )
+        sparse_state = SparseCacheState.from_selection(
+            identity,
+            (plan.selected_indices,),
+            (len(self.tokens),),
+        )
+        selected_tokens = tuple(self.tokens[index] for index in plan.selected_indices)
+        if self._target_session_factory is None:  # pragma: no cover - invariant guard.
+            raise CooperativeSpecPrefillError("target setup has no session factory")
+
+        # Preserve immutable identity before a factory failure so diagnostics
+        # can identify exactly which sparse cache was being constructed.
+        self._identity = identity
+        self._sparse_state = sparse_state
+        target_session = self._target_session_factory(selected_tokens, sparse_state)
+        if target_session is None:
+            raise CooperativeSpecPrefillError(
+                "target_session_factory must return a target session"
+            )
+        # Publish ownership before structural validation so every non-None
+        # factory result is either cleaned or reported as a cleanup failure.
+        self._target_session = target_session
+        self._target_session_factory = None
+        if not callable(getattr(target_session, "step", None)) or not callable(
+            getattr(target_session, "cancel", None)
+        ):
+            raise CooperativeSpecPrefillError(
+                "target session must expose callable step and cancel methods"
+            )
+        try:
+            inspect.getattr_static(target_session, "result")
+        except AttributeError as exc:
+            raise CooperativeSpecPrefillError(
+                "target session must expose a result when completion is reported"
+            ) from exc
+        self._phase = CooperativeSpecPrefillPhase.SPARSE_TARGET_PREFILL
+        self._telemetry = replace(
+            self._telemetry, selected_tokens=plan.selected_token_count
+        )
+
+    def _release_scorer_after_selection(self) -> Exception | None:
+        scorer_session = self._scorer_session
+        self._scorer_session = None
+        if scorer_session is None:
+            return None
+        try:
+            scorer_session.cancel()
+        except Exception as exc:
+            return exc
+        return None
+
+    def _close_request_resources(
+        self, initial_failures: Sequence[Exception] = ()
+    ) -> tuple[Exception, ...]:
+        """Drop all device-owning references even when cleanup itself fails."""
+        failures = list(initial_failures)
+        scorer_session = self._scorer_session
+        target_session = self._target_session
+        self._scorer_session = None
+        self._target_session = None
+        self._target_session_factory = None
+        self._prepared_result = None
+
+        if scorer_session is not None:
+            try:
+                scorer_session.cancel()
+            except Exception as exc:
+                failures.append(exc)
+        if target_session is not None:
+            try:
+                target_session.cancel()
+            except Exception as exc:
+                failures.append(exc)
+        return tuple(failures)
+
+    def _fail_closed(
+        self,
+        cleanup_failures: Sequence[Exception],
+        prior_failure: Exception | None = None,
+    ) -> None:
+        self._prepared_result = None
+        self._fallback_reason = "resource_cleanup_failed"
+        self._failure = CooperativeSpecPrefillCleanupError(
+            cleanup_failures, prior_failure
+        )
+        self._outcome = CooperativeSpecPrefillOutcome.FAILED
+
+    def _record_busy(self) -> None:
+        self._telemetry = replace(
+            self._telemetry, busy_retries=self._telemetry.busy_retries + 1
+        )
+
+    def _record_scorer(
+        self, progress: ScorerSessionProgress, elapsed_ms: float
+    ) -> None:
+        self._telemetry = replace(
+            self._telemetry,
+            scorer_quanta=self._telemetry.scorer_quanta + 1,
+            scorer_prefill_tokens=progress.prefill_tokens,
+            lookahead_steps=progress.lookahead_steps,
+            importance_layers=progress.importance_layers,
+            scorer_ms=self._telemetry.scorer_ms + elapsed_ms,
+        )
+
+    def _record_target(self, progress: SparseTargetPrefillProgress) -> None:
+        self._telemetry = replace(
+            self._telemetry,
+            target_quanta=self._telemetry.target_quanta + 1,
+            target_chunks=progress.chunk_count,
+        )
+
+    def _progress(
+        self,
+        attempted_phase: CooperativeSpecPrefillPhase | None,
+        *,
+        committed: bool,
+        busy: bool,
+    ) -> CooperativeSpecPrefillProgress:
+        return CooperativeSpecPrefillProgress(
+            phase=self._phase,
+            outcome=self._outcome,
+            attempted_phase=attempted_phase,
+            quantum_committed=committed,
+            busy=busy,
+            telemetry=self._telemetry,
+            fallback_reason=self._fallback_reason,
+        )
+
+
+def _scorer_phase(phase: ScorerSessionPhase) -> CooperativeSpecPrefillPhase:
+    if phase is ScorerSessionPhase.PREFILL:
+        return CooperativeSpecPrefillPhase.SCORE_PREFILL
+    if phase is ScorerSessionPhase.LOOKAHEAD:
+        return CooperativeSpecPrefillPhase.LOOKAHEAD
+    if phase is ScorerSessionPhase.IMPORTANCE:
+        return CooperativeSpecPrefillPhase.IMPORTANCE
+    raise CooperativeSpecPrefillError(
+        f"scorer phase {phase!r} has no active cooperative phase"
+    )
+
+
+def _summarize_failure(failure: Exception) -> CooperativeSpecPrefillFailure:
+    """Copy diagnostics without retaining traceback frames or device owners."""
+    return CooperativeSpecPrefillFailure(type(failure).__name__, str(failure))

--- a/vllm_mlx/cooperative_specprefill.py
+++ b/vllm_mlx/cooperative_specprefill.py
@@ -308,6 +308,15 @@ class CooperativeSpecPrefillSession:
             )
         return self._prepared_result
 
+    @property
+    def prepared_cache(self) -> Sequence[object]:
+        """Delegate the exact completed target-executor cache for adoption."""
+        if not self.ready_for_adoption or self._target_session is None:
+            raise CooperativeSpecPrefillError(
+                "target cache is not publishable before decoder adoption readiness"
+            )
+        return self._target_session.adoption_cache
+
     def step(self) -> CooperativeSpecPrefillProgress:
         """Attempt at most one scorer or target model quantum."""
         if self._outcome is not CooperativeSpecPrefillOutcome.ACTIVE:

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -27,14 +27,24 @@ class GenerationOutput:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     finish_reason: str | None = "stop"
-    mtp_drafts: int = 0
-    mtp_accepted: int = 0
     # For streaming
     new_text: str = ""
     finished: bool = True
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # SpecPrefill is independent of decode speculation.  Keep its terminal
+    # state separate so composing MTP cannot erase sparse-prefill evidence.
+    specprefill_requested_policy: str | None = None
+    specprefill_effective_policy: str | None = None
+    specprefill_coverage: str | None = None
+    specprefill_engaged: bool | None = None
+    specprefill_selector_version: str | None = None
+    specprefill_fallback_reason: str | None = None
+    specprefill_total_tokens: int | None = None
+    specprefill_selected_tokens: int | None = None
+    specprefill_scorer_ms: float | None = None
+    specprefill_target_prefill_ms: float | None = None
 
 
 class EngineBusy(RuntimeError):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -33,6 +33,7 @@ class GenerationOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    mtp_bypass_reason: str | None = None
     # SpecPrefill is independent of decode speculation.  Keep its terminal
     # state separate so composing MTP cannot erase sparse-prefill evidence.
     specprefill_requested_policy: str | None = None

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -34,6 +34,10 @@ class GenerationOutput:
     mtp_drafts: int = 0
     mtp_accepted: int = 0
     mtp_bypass_reason: str | None = None
+    # Request-local target distribution for the most recently emitted token.
+    # Native MTP must report target logprobs even when the token came from its
+    # draft head.  ``None`` preserves every existing engine/caller shape.
+    logprobs: Any | None = None
     # SpecPrefill is independent of decode speculation.  Keep its terminal
     # state separate so composing MTP cannot erase sparse-prefill evidence.
     specprefill_requested_policy: str | None = None

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -50,6 +50,8 @@ class PreparedMLLMSpecPrefillRuntime:
     tokenizer_artifact_hash: str
     scorer_artifact_hash: str
     cleanup: Any
+    diagnostic: bool = False
+    advertisable: bool = True
 
     def __post_init__(self) -> None:
         from ..mllm_scheduler import MLLMSpecPrefillCacheCapability
@@ -87,9 +89,23 @@ class PreparedMLLMSpecPrefillRuntime:
             raise ValueError("prepared cache adapter must match the profile key")
         if self.cache_capability.layout != "qwen3_5_nonrotating_hybrid":
             raise ValueError("prepared cache capability is not admitted for CB")
-        if not any(
-            profile.key == self.profile_key and profile.production_certified
+        matching_profiles = tuple(
+            profile
             for profile in self.profile_registry.profiles
+            if profile.key == self.profile_key
+        )
+        if self.diagnostic:
+            from ..specprefill_profiles import SpecPrefillProfileTier
+
+            if self.advertisable:
+                raise ValueError("diagnostic SpecPrefill cannot be advertisable")
+            if not any(
+                profile.tier is SpecPrefillProfileTier.DIAGNOSTIC
+                for profile in matching_profiles
+            ):
+                raise ValueError("prepared diagnostic profile is not registered")
+        elif not self.advertisable or not any(
+            profile.production_certified for profile in matching_profiles
         ):
             raise ValueError("prepared profile is not production-certified")
         expected_hashes = (
@@ -103,6 +119,13 @@ class PreparedMLLMSpecPrefillRuntime:
             self.scorer_artifact_hash,
         ) != expected_hashes:
             raise ValueError("prepared artifact hashes must match the profile key")
+
+
+@dataclass(frozen=True)
+class _RetainedSpecPrefillCleanup:
+    """Cleanup-only ownership retained after a preparation exception."""
+
+    cleanup: Any
 
 
 _SPECPREFILL_OUTPUT_FIELDS = (
@@ -563,6 +586,8 @@ class BatchedEngine(BaseEngine):
                 "specprefill_cache_capability": (
                     prepared_specprefill.cache_capability
                 ),
+                "specprefill_diagnostic": prepared_specprefill.diagnostic,
+                "specprefill_advertisable": prepared_specprefill.advertisable,
             }
         try:
             mllm_config = MLLMSchedulerConfig(
@@ -629,7 +654,17 @@ class BatchedEngine(BaseEngine):
             raise RuntimeError(
                 "enabled CB SpecPrefill requires specprefill_prepare"
             )
-        candidate = prepare(self._model, self._processor)
+        try:
+            candidate = prepare(self._model, self._processor)
+        except BaseException as failure:
+            retained_cleanup = getattr(
+                failure, "specprefill_retained_cleanup", None
+            )
+            if callable(retained_cleanup):
+                self._prepared_specprefill_runtime = _RetainedSpecPrefillCleanup(
+                    retained_cleanup
+                )
+            raise
         if not isinstance(candidate, PreparedMLLMSpecPrefillRuntime):
             cleanup = getattr(candidate, "cleanup", None)
             if callable(cleanup):
@@ -1432,6 +1467,7 @@ class BatchedEngine(BaseEngine):
                 "prefix_cache",
                 "batch_generator",
                 "mtp",
+                "specprefill",
                 "requests",
             ):
                 if key in mllm_stats:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -50,6 +50,9 @@ class PreparedMLLMSpecPrefillRuntime:
     tokenizer_artifact_hash: str
     scorer_artifact_hash: str
     cleanup: Any
+    # Optional combined native-MTP entry point.  Standard-text scheduling owns
+    # its queueing; this callable supplies only an attested sparse session.
+    native_mtp_session_factory: Any = None
     gemma_batch_config: Any = None
     diagnostic: bool = False
     advertisable: bool = True
@@ -86,6 +89,10 @@ class PreparedMLLMSpecPrefillRuntime:
             raise TypeError("target_forward_context must be callable")
         if not callable(self.cleanup):
             raise TypeError("cleanup must be callable")
+        if self.native_mtp_session_factory is not None and not callable(
+            self.native_mtp_session_factory
+        ):
+            raise TypeError("native_mtp_session_factory must be callable or None")
         if self.cache_capability.adapter_id != self.profile_key.adapter_id:
             raise ValueError("prepared cache adapter must match the profile key")
         gemma_layouts = {

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -441,6 +441,39 @@ class BatchedEngine(BaseEngine):
             return getattr(self._processor, "tokenizer", self._processor)
         return self._tokenizer
 
+    def native_mtp_server_state(self, *, has_media: bool = False):
+        """Admission facts for fresh standard-text native-MTP CB only."""
+        from ..native_mtp_request import NativeMTPServerState
+
+        incompatibility = None
+        if self._is_mllm or has_media:
+            incompatibility = "native_mtp_media_unsupported"
+        elif getattr(self._scheduler_config, "specprefill_enabled", False):
+            incompatibility = "native_mtp_specprefill_composition_unsupported"
+        elif getattr(self._scheduler_config, "enable_prefix_cache", True):
+            incompatibility = "native_mtp_prefix_reuse_unsupported"
+        elif getattr(self._scheduler_config, "chunked_prefill_tokens", 0):
+            incompatibility = "native_mtp_chunked_prefill_unsupported"
+        elif getattr(self._scheduler_config, "kv_cache_quantization", False):
+            incompatibility = "native_mtp_quantized_cache_unsupported"
+        elif getattr(self._scheduler_config, "max_kv_size", 0):
+            incompatibility = "native_mtp_max_kv_unsupported"
+        capability = getattr(self._model, "mtp_capability", None)
+        capable = bool(capability is not None and capability.supported)
+        if incompatibility is None and not capable:
+            incompatibility = (
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+        return NativeMTPServerState(
+            server_default=bool(getattr(self._scheduler_config, "enable_mtp", False)),
+            capable=capable,
+            num_draft_tokens=1,
+            supports_penalty_processors=False,
+            incompatibility=incompatibility,
+        )
+
     def prepare_for_start(self) -> None:
         """Load heavyweight model state off the serving event loop."""
         if self._model is not None:
@@ -472,9 +505,7 @@ class BatchedEngine(BaseEngine):
             if self._is_mllm:
                 await self._start_mllm()
             else:
-                if getattr(
-                    self._scheduler_config, "specprefill_enabled", False
-                ):
+                if getattr(self._scheduler_config, "specprefill_enabled", False):
                     raise RuntimeError(
                         "continuous-batching SpecPrefill requires the MLLM scheduler"
                     )
@@ -508,9 +539,9 @@ class BatchedEngine(BaseEngine):
         processor = mllm_instance.processor
 
         if self._scheduler_config and self._scheduler_config.enable_mtp:
-            from ..scheduler import _continuous_batching_mtp_capability
+            from ..scheduler import _reject_native_mtp_mllm
 
-            _continuous_batching_mtp_capability(model, enabled=True)
+            _reject_native_mtp_mllm(model, enabled=True)
 
         self._mllm_instance = mllm_instance
         self._model = model
@@ -560,9 +591,7 @@ class BatchedEngine(BaseEngine):
             or self._prepared_specprefill_runtime is not None
         ):
             with suspend_cancellation():
-                prior_cleanup_failures = (
-                    await self._cleanup_mllm_runtime_ownership()
-                )
+                prior_cleanup_failures = await self._cleanup_mllm_runtime_ownership()
             if prior_cleanup_failures:
                 raise RuntimeError(
                     "previous MLLM startup cleanup remains incomplete"
@@ -571,9 +600,9 @@ class BatchedEngine(BaseEngine):
         if self._model is None or self._processor is None:
             self._prepare_mllm_model()
         if getattr(self._scheduler_config, "enable_mtp", False):
-            from ..scheduler import _continuous_batching_mtp_capability
+            from ..scheduler import _reject_native_mtp_mllm
 
-            _continuous_batching_mtp_capability(self._model, enabled=True)
+            _reject_native_mtp_mllm(self._model, enabled=True)
 
         # Create MLLM scheduler config with batch generator support
         if self._scheduler_config and hasattr(self._scheduler_config, "max_num_seqs"):
@@ -632,22 +661,16 @@ class BatchedEngine(BaseEngine):
         if prepared_specprefill is not None:
             specprefill_config = {
                 "specprefill_enabled": True,
-                "specprefill_profile_registry": (
-                    prepared_specprefill.profile_registry
-                ),
+                "specprefill_profile_registry": (prepared_specprefill.profile_registry),
                 "specprefill_profile_key": prepared_specprefill.profile_key,
                 "specprefill_estimated_residency_bytes": (
                     prepared_specprefill.estimated_residency_bytes
                 ),
-                "specprefill_session_factory": (
-                    prepared_specprefill.session_factory
-                ),
+                "specprefill_session_factory": (prepared_specprefill.session_factory),
                 "specprefill_target_forward_context": (
                     prepared_specprefill.target_forward_context
                 ),
-                "specprefill_cache_capability": (
-                    prepared_specprefill.cache_capability
-                ),
+                "specprefill_cache_capability": (prepared_specprefill.cache_capability),
                 "specprefill_gemma_batch_config": (
                     prepared_specprefill.gemma_batch_config
                 ),
@@ -713,9 +736,7 @@ class BatchedEngine(BaseEngine):
     def _prepare_mllm_specprefill_runtime(
         self,
     ) -> PreparedMLLMSpecPrefillRuntime | None:
-        enabled = bool(
-            getattr(self._scheduler_config, "specprefill_enabled", False)
-        )
+        enabled = bool(getattr(self._scheduler_config, "specprefill_enabled", False))
         if not enabled:
             return None
         if getattr(self._scheduler_config, "enable_mtp", False):
@@ -724,15 +745,11 @@ class BatchedEngine(BaseEngine):
             raise RuntimeError("rotating-cache CB SpecPrefill is not admitted")
         prepare = getattr(self._scheduler_config, "specprefill_prepare", None)
         if not callable(prepare):
-            raise RuntimeError(
-                "enabled CB SpecPrefill requires specprefill_prepare"
-            )
+            raise RuntimeError("enabled CB SpecPrefill requires specprefill_prepare")
         try:
             candidate = prepare(self._model, self._processor)
         except BaseException as failure:
-            retained_cleanup = getattr(
-                failure, "specprefill_retained_cleanup", None
-            )
+            retained_cleanup = getattr(failure, "specprefill_retained_cleanup", None)
             if callable(retained_cleanup):
                 self._prepared_specprefill_runtime = _RetainedSpecPrefillCleanup(
                     retained_cleanup
@@ -810,10 +827,10 @@ class BatchedEngine(BaseEngine):
 
         from mlx_lm.utils import _download
 
-        from ..scheduler import _continuous_batching_mtp_capability
+        from ..scheduler import _reject_native_mtp_mllm
 
         model = self._model
-        _continuous_batching_mtp_capability(model, enabled=True)
+        _reject_native_mtp_mllm(model, enabled=True)
         model_path = Path(_download(self._model_name))
         config_path = model_path / "config.json"
         if not config_path.exists():
@@ -1168,6 +1185,9 @@ class BatchedEngine(BaseEngine):
         # Use LLM engine for text-only (non-MLLM models)
         from ..request import SamplingParams
 
+        native_mtp_config = kwargs.pop("_native_mtp_request_config", None)
+        kwargs.pop("_native_mtp_disabled", None)
+        kwargs.pop("_native_mtp_bypass_reason", None)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -1183,6 +1203,7 @@ class BatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            native_mtp_config=native_mtp_config,
         )
 
         text = clean_output_text(output.output_text)
@@ -1193,6 +1214,14 @@ class BatchedEngine(BaseEngine):
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
+            mtp_drafts=output.mtp_drafts,
+            mtp_accepted=output.mtp_accepted,
+            logprobs=output.logprobs if native_mtp_config is not None else None,
+            mtp_bypass_reason=(
+                output.native_mtp_error_reason
+                if native_mtp_config is not None
+                else None
+            ),
         )
 
     async def stream_generate(
@@ -1264,6 +1293,9 @@ class BatchedEngine(BaseEngine):
         # Use LLM engine for text-only
         from ..request import SamplingParams
 
+        native_mtp_config = kwargs.pop("_native_mtp_request_config", None)
+        kwargs.pop("_native_mtp_disabled", None)
+        kwargs.pop("_native_mtp_bypass_reason", None)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -1281,6 +1313,7 @@ class BatchedEngine(BaseEngine):
             prompt=prompt,
             sampling_params=sampling_params,
             prefix_boundary=prefix_boundary,
+            native_mtp_config=native_mtp_config,
         )
 
         async for output in self._engine.stream_outputs(request_id):
@@ -1293,6 +1326,14 @@ class BatchedEngine(BaseEngine):
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,
                 finish_reason=output.finish_reason,
+                mtp_drafts=output.mtp_drafts,
+                mtp_accepted=output.mtp_accepted,
+                logprobs=output.logprobs if native_mtp_config is not None else None,
+                mtp_bypass_reason=(
+                    output.native_mtp_error_reason
+                    if native_mtp_config is not None
+                    else None
+                ),
             )
 
     async def chat(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -456,7 +456,10 @@ class BatchedEngine(BaseEngine):
         if self._is_mllm or has_media:
             incompatibility = "native_mtp_media_unsupported"
         elif getattr(self._scheduler_config, "specprefill_enabled", False):
-            incompatibility = "native_mtp_specprefill_composition_unsupported"
+            if getattr(
+                self._scheduler_config, "native_mtp_specprefill_runtime", None
+            ) is None or not getattr(self._scheduler_config, "enable_mtp", False):
+                incompatibility = "native_mtp_specprefill_composition_unsupported"
         elif getattr(self._scheduler_config, "enable_prefix_cache", True):
             incompatibility = "native_mtp_prefix_reuse_unsupported"
         elif getattr(self._scheduler_config, "chunked_prefill_tokens", 0):
@@ -497,6 +500,7 @@ class BatchedEngine(BaseEngine):
             return
 
         try:
+            self._preflight_llm_native_mtp_specprefill_startup()
             if self._model is None:
                 if self._uses_default_prepare_for_start():
                     # Load inline on the event-loop thread so mlx-lm's
@@ -512,7 +516,10 @@ class BatchedEngine(BaseEngine):
             if self._is_mllm:
                 await self._start_mllm()
             else:
-                if getattr(self._scheduler_config, "specprefill_enabled", False):
+                if (
+                    getattr(self._scheduler_config, "specprefill_enabled", False)
+                    and not getattr(self._scheduler_config, "enable_mtp", False)
+                ):
                     raise RuntimeError(
                         "continuous-batching SpecPrefill requires the MLLM scheduler"
                     )
@@ -525,6 +532,24 @@ class BatchedEngine(BaseEngine):
         except asyncio.CancelledError:
             await cleanup_startup_cancellation(self.stop)
             raise
+
+    def _preflight_llm_native_mtp_specprefill_startup(self) -> None:
+        """Reject impossible text combined startup before model side effects."""
+        config = self._scheduler_config
+        if self._is_mllm or not bool(getattr(config, "specprefill_enabled", False)):
+            return
+        if not bool(getattr(config, "enable_mtp", False)):
+            return
+        if getattr(config, "enable_prefix_cache", True):
+            raise RuntimeError("native_mtp_prefix_reuse_unsupported")
+        if getattr(config, "chunked_prefill_tokens", 0):
+            raise RuntimeError("native_mtp_chunked_prefill_unsupported")
+        if getattr(config, "kv_cache_quantization", False):
+            raise RuntimeError("native_mtp_quantized_cache_unsupported")
+        if getattr(config, "max_kv_size", 0):
+            raise RuntimeError("native_mtp_max_kv_unsupported")
+        if not callable(getattr(config, "specprefill_prepare", None)):
+            raise RuntimeError("enabled CB SpecPrefill requires specprefill_prepare")
 
     def _uses_default_prepare_for_start(self) -> bool:
         """Return True when prepare_for_start is the class implementation."""
@@ -825,6 +850,10 @@ class BatchedEngine(BaseEngine):
                 failures.append(exc)
             else:
                 self._prepared_specprefill_runtime = None
+                if getattr(
+                    self._scheduler_config, "native_mtp_specprefill_runtime", None
+                ) is prepared:
+                    self._scheduler_config.native_mtp_specprefill_runtime = None
         return failures
 
     def _inject_mtp_mllm(self) -> None:
@@ -941,50 +970,187 @@ class BatchedEngine(BaseEngine):
         from ..engine_core import AsyncEngineCore, EngineConfig
         from ..scheduler import SchedulerConfig
 
-        if self._model is None or self._tokenizer is None:
-            self._prepare_llm_model()
+        if self._engine is not None or self._prepared_specprefill_runtime is not None:
+            with suspend_cancellation():
+                prior_engine_failures = await self._cleanup_llm_engine_ownership()
+                prior_runtime_failures = []
+                if not prior_engine_failures:
+                    prior_runtime_failures = (
+                        await self._cleanup_mllm_runtime_ownership()
+                    )
+            prior_failures = (*prior_engine_failures, *prior_runtime_failures)
+            if prior_failures:
+                raise RuntimeError(
+                    "previous standard-text startup cleanup remains incomplete"
+                ) from prior_failures[0]
 
-        # Validate MTP support if enabled
-        if self._scheduler_config and self._scheduler_config.enable_mtp:
-            from ..patches.qwen3_next_mtp import validate_mtp_support
-            from ..scheduler import _continuous_batching_mtp_capability
+        try:
+            if self._model is None or self._tokenizer is None:
+                self._prepare_llm_model()
 
-            _continuous_batching_mtp_capability(self._model, enabled=True)
-            if validate_mtp_support(self._model):
-                logger.info("[MTP] Model validated for MTP speculative decoding")
-            else:
-                logger.warning(
-                    "[MTP] MTP validation failed — --enable-mtp will be ignored. "
-                    "See warnings above for details."
+            # Validate MTP support if enabled
+            if self._scheduler_config and self._scheduler_config.enable_mtp:
+                from ..patches.qwen3_next_mtp import validate_mtp_support
+                from ..scheduler import _continuous_batching_mtp_capability
+
+                _continuous_batching_mtp_capability(self._model, enabled=True)
+                if validate_mtp_support(self._model):
+                    logger.info("[MTP] Model validated for MTP speculative decoding")
+                else:
+                    logger.warning(
+                        "[MTP] MTP validation failed — --enable-mtp will be ignored. "
+                        "See warnings above for details."
+                    )
+
+            prepared_specprefill = self._prepare_llm_native_mtp_specprefill_runtime()
+            self._prepared_specprefill_runtime = prepared_specprefill
+
+            # Create engine config
+            scheduler_config = self._scheduler_config or SchedulerConfig()
+            engine_config = EngineConfig(
+                model_name=self._model_name,
+                scheduler_config=scheduler_config,
+                stream_interval=self._stream_interval,
+                gpu_memory_utilization=self._gpu_memory_utilization,
+            )
+
+            # Create async engine
+            self._engine = AsyncEngineCore(
+                model=self._model,
+                tokenizer=self._tokenizer,
+                config=engine_config,
+            )
+
+            await self._engine.engine.start()
+        except BaseException:
+            with suspend_cancellation():
+                engine_cleanup_failures = await self._cleanup_llm_engine_ownership()
+                cleanup_failures = []
+                if not engine_cleanup_failures:
+                    cleanup_failures = await self._cleanup_mllm_runtime_ownership()
+            for failure in (*engine_cleanup_failures, *cleanup_failures):
+                logger.error(
+                    "Standard-text SpecPrefill startup cleanup failed while preserving original error",
+                    exc_info=(type(failure), failure, failure.__traceback__),
                 )
+            raise
 
-        # Create engine config
-        scheduler_config = self._scheduler_config or SchedulerConfig()
-        engine_config = EngineConfig(
-            model_name=self._model_name,
-            scheduler_config=scheduler_config,
-            stream_interval=self._stream_interval,
-            gpu_memory_utilization=self._gpu_memory_utilization,
-        )
+    def _prepare_llm_native_mtp_specprefill_runtime(
+        self,
+    ) -> PreparedMLLMSpecPrefillRuntime | None:
+        """Prepare the sole admitted standard-text native-MTP sparse owner.
 
-        # Create async engine
-        self._engine = AsyncEngineCore(
-            model=self._model,
-            tokenizer=self._tokenizer,
-            config=engine_config,
-        )
+        This intentionally reuses the public, fail-atomic SpecPrefill builder.
+        It does not alter the loaded target model or inject a private scheduler
+        dependency: the completed immutable runtime is passed through the
+        existing public ``SchedulerConfig`` seam before ``AsyncEngineCore`` is
+        constructed.
+        """
+        config = self._scheduler_config
+        if not bool(getattr(config, "specprefill_enabled", False)):
+            return None
+        if not bool(getattr(config, "enable_mtp", False)):
+            raise RuntimeError(
+                "continuous-batching SpecPrefill requires the MLLM scheduler"
+            )
+        if self._is_mllm:
+            raise RuntimeError("native_mtp_media_unsupported")
+        if getattr(config, "enable_prefix_cache", True):
+            raise RuntimeError("native_mtp_prefix_reuse_unsupported")
+        if getattr(config, "chunked_prefill_tokens", 0):
+            raise RuntimeError("native_mtp_chunked_prefill_unsupported")
+        if getattr(config, "kv_cache_quantization", False):
+            raise RuntimeError("native_mtp_quantized_cache_unsupported")
+        if getattr(config, "max_kv_size", 0):
+            raise RuntimeError("native_mtp_max_kv_unsupported")
+        prepare = getattr(config, "specprefill_prepare", None)
+        if not callable(prepare):
+            raise RuntimeError("enabled CB SpecPrefill requires specprefill_prepare")
+        if self._model is None or self._tokenizer is None:
+            raise RuntimeError("standard-text target and tokenizer must be loaded")
+        # A stopped or failed prior attempt must not leave a closed bundle
+        # visible to request admission while this replacement is being built.
+        config.native_mtp_specprefill_runtime = None
+        try:
+            candidate = prepare(self._model, self._tokenizer)
+        except BaseException as failure:
+            retained_cleanup = getattr(failure, "specprefill_retained_cleanup", None)
+            if callable(retained_cleanup):
+                self._prepared_specprefill_runtime = _RetainedSpecPrefillCleanup(
+                    retained_cleanup
+                )
+            raise
+        if not isinstance(candidate, PreparedMLLMSpecPrefillRuntime):
+            cleanup = getattr(candidate, "cleanup", None)
+            if callable(cleanup):
+                cleanup()
+            raise TypeError(
+                "specprefill_prepare must return PreparedMLLMSpecPrefillRuntime"
+            )
+        if candidate.target_model is not self._model:
+            self._cleanup_invalid_prepared_specprefill_runtime(
+                candidate, "prepared target model identity mismatch"
+            )
+        if candidate.processor is not self._tokenizer:
+            self._cleanup_invalid_prepared_specprefill_runtime(
+                candidate, "prepared tokenizer identity mismatch"
+            )
+        if not callable(candidate.native_mtp_session_factory):
+            self._cleanup_invalid_prepared_specprefill_runtime(
+                candidate, "prepared native MTP session factory missing"
+            )
+        self._prepared_specprefill_runtime = candidate
+        config.native_mtp_specprefill_runtime = candidate
+        return candidate
 
-        await self._engine.engine.start()
+    def _cleanup_invalid_prepared_specprefill_runtime(
+        self,
+        candidate: PreparedMLLMSpecPrefillRuntime,
+        message: str,
+    ) -> None:
+        """Close a rejected prepared bundle without losing cleanup failures."""
+        mismatch = ValueError(message)
+        self._prepared_specprefill_runtime = candidate
+        try:
+            candidate.cleanup()
+        except BaseException as cleanup_failure:
+            logger.error(
+                "Rejected prepared standard-text SpecPrefill cleanup failed",
+                exc_info=(
+                    type(cleanup_failure),
+                    cleanup_failure,
+                    cleanup_failure.__traceback__,
+                ),
+            )
+            raise mismatch from cleanup_failure
+        self._prepared_specprefill_runtime = None
+        raise mismatch
+
+    async def _cleanup_llm_engine_ownership(self) -> list[BaseException]:
+        """Stop and close a partially started standard-text core exactly once."""
+        failures: list[BaseException] = []
+        engine = self._engine
+        if engine is None:
+            return failures
+        try:
+            await engine.stop()
+        except BaseException as exc:
+            failures.append(exc)
+        try:
+            engine.engine.close()
+        except BaseException as exc:
+            failures.append(exc)
+        if not failures:
+            self._engine = None
+        return failures
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
         with suspend_cancellation():
-            cleanup_failures = await self._cleanup_mllm_runtime_ownership()
-
-        if self._engine:
-            await self._engine.stop()
-            self._engine.engine.close()
-            self._engine = None
+            engine_cleanup_failures = await self._cleanup_llm_engine_ownership()
+            cleanup_failures = []
+            if not engine_cleanup_failures:
+                cleanup_failures = await self._cleanup_mllm_runtime_ownership()
 
         self._model = None
         self._tokenizer = None
@@ -992,6 +1158,8 @@ class BatchedEngine(BaseEngine):
         self._mllm_instance = None
         self._loaded = False
         logger.info("BatchedEngine stopped")
+        if engine_cleanup_failures:
+            raise engine_cleanup_failures[0]
         if cleanup_failures:
             raise cleanup_failures[0]
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -17,6 +17,7 @@ import logging
 import os
 import time
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
@@ -26,10 +27,139 @@ from .base import (
     GenerationOutput,
     cleanup_startup_cancellation,
     run_blocking_startup_work,
+    suspend_cancellation,
 )
 from .chat_template_safety import normalize_messages_for_chat_template
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PreparedMLLMSpecPrefillRuntime:
+    """Fail-atomic, already prepared scorer and target-adapter ownership."""
+
+    profile_registry: Any
+    profile_key: Any
+    estimated_residency_bytes: int
+    session_factory: Any
+    cache_capability: Any
+    target_forward_context: Any
+    target_model: Any
+    processor: Any
+    target_artifact_hash: str
+    tokenizer_artifact_hash: str
+    scorer_artifact_hash: str
+    cleanup: Any
+
+    def __post_init__(self) -> None:
+        from ..mllm_scheduler import MLLMSpecPrefillCacheCapability
+        from ..specprefill_profiles import (
+            SpecPrefillCell,
+            SpecPrefillEngine,
+            SpecPrefillProfileKey,
+            SpecPrefillProfileRegistry,
+        )
+
+        if not isinstance(self.profile_registry, SpecPrefillProfileRegistry):
+            raise TypeError("profile_registry must be SpecPrefillProfileRegistry")
+        if not isinstance(self.profile_key, SpecPrefillProfileKey):
+            raise TypeError("profile_key must be SpecPrefillProfileKey")
+        if (
+            self.profile_key.engine is not SpecPrefillEngine.CONTINUOUS_BATCHING
+            or self.profile_key.cell is not SpecPrefillCell.SPARSE_ONLY
+        ):
+            raise ValueError("prepared SpecPrefill profile must be CB sparse-only")
+        if (
+            isinstance(self.estimated_residency_bytes, bool)
+            or not isinstance(self.estimated_residency_bytes, int)
+            or self.estimated_residency_bytes < 0
+        ):
+            raise ValueError("estimated_residency_bytes must be non-negative")
+        if not callable(self.session_factory):
+            raise TypeError("session_factory must be callable")
+        if not isinstance(self.cache_capability, MLLMSpecPrefillCacheCapability):
+            raise TypeError("cache_capability must be MLLMSpecPrefillCacheCapability")
+        if not callable(self.target_forward_context):
+            raise TypeError("target_forward_context must be callable")
+        if not callable(self.cleanup):
+            raise TypeError("cleanup must be callable")
+        if self.cache_capability.adapter_id != self.profile_key.adapter_id:
+            raise ValueError("prepared cache adapter must match the profile key")
+        if self.cache_capability.layout != "qwen3_5_nonrotating_hybrid":
+            raise ValueError("prepared cache capability is not admitted for CB")
+        if not any(
+            profile.key == self.profile_key and profile.production_certified
+            for profile in self.profile_registry.profiles
+        ):
+            raise ValueError("prepared profile is not production-certified")
+        expected_hashes = (
+            self.profile_key.target_artifact_hash,
+            self.profile_key.tokenizer_artifact_hash,
+            self.profile_key.scorer_artifact_hash,
+        )
+        if (
+            self.target_artifact_hash,
+            self.tokenizer_artifact_hash,
+            self.scorer_artifact_hash,
+        ) != expected_hashes:
+            raise ValueError("prepared artifact hashes must match the profile key")
+
+
+_SPECPREFILL_OUTPUT_FIELDS = (
+    "specprefill_requested_policy",
+    "specprefill_effective_policy",
+    "specprefill_coverage",
+    "specprefill_engaged",
+    "specprefill_selector_version",
+    "specprefill_fallback_reason",
+    "specprefill_total_tokens",
+    "specprefill_selected_tokens",
+    "specprefill_scorer_ms",
+    "specprefill_target_prefill_ms",
+)
+
+
+def _feature_output_kwargs(output: Any) -> dict[str, Any]:
+    return {
+        "mtp_drafts": getattr(output, "mtp_drafts", 0),
+        "mtp_accepted": getattr(output, "mtp_accepted", 0),
+        **{name: getattr(output, name, None) for name in _SPECPREFILL_OUTPUT_FIELDS},
+    }
+
+
+def _specprefill_request_kwargs(
+    kwargs: dict[str, Any],
+    *,
+    has_media: bool,
+) -> dict[str, Any]:
+    """Consume the public contract and return only scheduler-owned controls."""
+    legacy = kwargs.pop("specprefill", None)
+    policy = kwargs.pop("specprefill_policy", None)
+    coverage = kwargs.pop("specprefill_coverage", None)
+    control_indices = kwargs.pop("specprefill_control_token_indices", None)
+    keep_pct = kwargs.pop("specprefill_keep_pct", None)
+    backbone_pct = kwargs.pop("specprefill_backbone_pct", None)
+    explicit_media = bool(kwargs.pop("specprefill_has_media", False))
+    if keep_pct is not None or backbone_pct is not None:
+        raise ValueError(
+            "CB production SpecPrefill does not accept request keep/backbone tuning"
+        )
+    if legacy is not None:
+        legacy_policy = "sparse" if legacy else "dense"
+        if policy is not None and policy != legacy_policy:
+            raise ValueError(
+                f"specprefill={legacy!r} conflicts with specprefill_policy={policy!r}"
+            )
+        policy = legacy_policy
+    result: dict[str, Any] = {}
+    if policy is not None:
+        result["specprefill_policy"] = policy
+    if coverage is not None:
+        result["specprefill_coverage"] = coverage
+    if control_indices is not None:
+        result["specprefill_control_token_indices"] = tuple(control_indices)
+    result["specprefill_has_media"] = explicit_media or has_media
+    return result
 
 
 def _resolve_metal_buffer_cache_limit(
@@ -221,6 +351,7 @@ class BatchedEngine(BaseEngine):
         self._engine = None  # AsyncEngineCore for LLM
         self._mllm_scheduler = None  # MLLMScheduler for MLLM
         self._mllm_instance = None  # MLXMultimodalLM instance
+        self._prepared_specprefill_runtime = None
         self._loaded = False
 
     @property
@@ -271,6 +402,12 @@ class BatchedEngine(BaseEngine):
             if self._is_mllm:
                 await self._start_mllm()
             else:
+                if getattr(
+                    self._scheduler_config, "specprefill_enabled", False
+                ):
+                    raise RuntimeError(
+                        "continuous-batching SpecPrefill requires the MLLM scheduler"
+                    )
                 await self._start_llm()
 
             self._loaded = True
@@ -337,6 +474,19 @@ class BatchedEngine(BaseEngine):
         """Start the MLLM engine with MLLMScheduler (continuous batching)."""
         from ..mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
 
+        if (
+            self._mllm_scheduler is not None
+            or self._prepared_specprefill_runtime is not None
+        ):
+            with suspend_cancellation():
+                prior_cleanup_failures = (
+                    await self._cleanup_mllm_runtime_ownership()
+                )
+            if prior_cleanup_failures:
+                raise RuntimeError(
+                    "previous MLLM startup cleanup remains incomplete"
+                ) from prior_cleanup_failures[0]
+
         if self._model is None or self._processor is None:
             self._prepare_mllm_model()
 
@@ -391,35 +541,69 @@ class BatchedEngine(BaseEngine):
         mllm_extra = {}
         if prefill_step_size is not None:
             mllm_extra["prefill_step_size"] = prefill_step_size
-        mllm_config = MLLMSchedulerConfig(
-            max_num_seqs=max_num_seqs,
-            prefill_batch_size=prefill_batch_size,
-            completion_batch_size=completion_batch_size,
-            enable_vision_cache=True,
-            vision_cache_size=100,
-            cache_memory_mb=cache_memory_mb,
-            enable_prefix_cache=enable_prefix_cache,
-            use_memory_aware_cache=use_memory_aware_cache,
-            prefix_cache_memory_mb=prefix_cache_memory_mb,
-            enable_mtp=enable_mtp,
-            mtp_num_draft_tokens=mtp_num_draft,
-            kv_cache_quantization=kv_quant,
-            kv_cache_quantization_bits=kv_bits,
-            kv_cache_quantization_group_size=kv_group_size,
-            chunked_prefill_tokens=chunked_prefill_tokens,
-            max_kv_size=max_kv_size,
-            ssd_cache_dir=ssd_cache_dir,
-            ssd_cache_max_gb=ssd_cache_max_gb,
-            **mllm_extra,
-        )
+        prepared_specprefill = self._prepare_mllm_specprefill_runtime()
+        self._prepared_specprefill_runtime = prepared_specprefill
+        specprefill_config = {}
+        if prepared_specprefill is not None:
+            specprefill_config = {
+                "specprefill_enabled": True,
+                "specprefill_profile_registry": (
+                    prepared_specprefill.profile_registry
+                ),
+                "specprefill_profile_key": prepared_specprefill.profile_key,
+                "specprefill_estimated_residency_bytes": (
+                    prepared_specprefill.estimated_residency_bytes
+                ),
+                "specprefill_session_factory": (
+                    prepared_specprefill.session_factory
+                ),
+                "specprefill_target_forward_context": (
+                    prepared_specprefill.target_forward_context
+                ),
+                "specprefill_cache_capability": (
+                    prepared_specprefill.cache_capability
+                ),
+            }
+        try:
+            mllm_config = MLLMSchedulerConfig(
+                max_num_seqs=max_num_seqs,
+                prefill_batch_size=prefill_batch_size,
+                completion_batch_size=completion_batch_size,
+                enable_vision_cache=True,
+                vision_cache_size=100,
+                cache_memory_mb=cache_memory_mb,
+                enable_prefix_cache=enable_prefix_cache,
+                use_memory_aware_cache=use_memory_aware_cache,
+                prefix_cache_memory_mb=prefix_cache_memory_mb,
+                enable_mtp=enable_mtp,
+                mtp_num_draft_tokens=mtp_num_draft,
+                kv_cache_quantization=kv_quant,
+                kv_cache_quantization_bits=kv_bits,
+                kv_cache_quantization_group_size=kv_group_size,
+                chunked_prefill_tokens=chunked_prefill_tokens,
+                max_kv_size=max_kv_size,
+                ssd_cache_dir=ssd_cache_dir,
+                ssd_cache_max_gb=ssd_cache_max_gb,
+                **specprefill_config,
+                **mllm_extra,
+            )
 
-        # Create and start MLLM scheduler
-        self._mllm_scheduler = MLLMScheduler(
-            model=self._model,
-            processor=self._processor,
-            config=mllm_config,
-        )
-        await self._mllm_scheduler.start()
+            # Create and start MLLM scheduler only after scorer/adapter prep.
+            self._mllm_scheduler = MLLMScheduler(
+                model=self._model,
+                processor=self._processor,
+                config=mllm_config,
+            )
+            await self._mllm_scheduler.start()
+        except BaseException:
+            with suspend_cancellation():
+                cleanup_failures = await self._cleanup_mllm_runtime_ownership()
+            for failure in cleanup_failures:
+                logger.error(
+                    "MLLM startup cleanup failed while preserving original error",
+                    exc_info=(type(failure), failure, failure.__traceback__),
+                )
+            raise
 
         logger.info(
             f"MLLM Scheduler started with continuous batching: "
@@ -427,6 +611,89 @@ class BatchedEngine(BaseEngine):
             f"completion_batch={completion_batch_size}, "
             f"prefill_step_size={mllm_config.prefill_step_size}"
         )
+
+    def _prepare_mllm_specprefill_runtime(
+        self,
+    ) -> PreparedMLLMSpecPrefillRuntime | None:
+        enabled = bool(
+            getattr(self._scheduler_config, "specprefill_enabled", False)
+        )
+        if not enabled:
+            return None
+        if getattr(self._scheduler_config, "enable_mtp", False):
+            raise RuntimeError("CB SpecPrefill and MTP composition is not admitted")
+        if getattr(self._scheduler_config, "max_kv_size", 0) > 0:
+            raise RuntimeError("rotating-cache CB SpecPrefill is not admitted")
+        prepare = getattr(self._scheduler_config, "specprefill_prepare", None)
+        if not callable(prepare):
+            raise RuntimeError(
+                "enabled CB SpecPrefill requires specprefill_prepare"
+            )
+        candidate = prepare(self._model, self._processor)
+        if not isinstance(candidate, PreparedMLLMSpecPrefillRuntime):
+            cleanup = getattr(candidate, "cleanup", None)
+            if callable(cleanup):
+                cleanup()
+            raise TypeError(
+                "specprefill_prepare must return PreparedMLLMSpecPrefillRuntime"
+            )
+        if candidate.target_model is not self._model:
+            mismatch = ValueError("prepared target model identity mismatch")
+            self._prepared_specprefill_runtime = candidate
+            try:
+                candidate.cleanup()
+            except BaseException as cleanup_failure:
+                logger.error(
+                    "Mismatched prepared target cleanup failed",
+                    exc_info=(
+                        type(cleanup_failure),
+                        cleanup_failure,
+                        cleanup_failure.__traceback__,
+                    ),
+                )
+                raise mismatch from cleanup_failure
+            self._prepared_specprefill_runtime = None
+            raise mismatch
+        if candidate.processor is not self._processor:
+            mismatch = ValueError("prepared processor identity mismatch")
+            self._prepared_specprefill_runtime = candidate
+            try:
+                candidate.cleanup()
+            except BaseException as cleanup_failure:
+                logger.error(
+                    "Mismatched prepared processor cleanup failed",
+                    exc_info=(
+                        type(cleanup_failure),
+                        cleanup_failure,
+                        cleanup_failure.__traceback__,
+                    ),
+                )
+                raise mismatch from cleanup_failure
+            self._prepared_specprefill_runtime = None
+            raise mismatch
+        return candidate
+
+    async def _cleanup_mllm_runtime_ownership(self) -> list[BaseException]:
+        """Attempt every owned cleanup and retain only failed ownership."""
+        failures: list[BaseException] = []
+        scheduler = self._mllm_scheduler
+        if scheduler is not None:
+            try:
+                await scheduler.stop()
+            except BaseException as exc:
+                failures.append(exc)
+            else:
+                self._mllm_scheduler = None
+
+        prepared = self._prepared_specprefill_runtime
+        if prepared is not None:
+            try:
+                prepared.cleanup()
+            except BaseException as exc:
+                failures.append(exc)
+            else:
+                self._prepared_specprefill_runtime = None
+        return failures
 
     def _inject_mtp_mllm(self) -> None:
         """Inject MTP weights into the MLLM model's language_model."""
@@ -580,9 +847,8 @@ class BatchedEngine(BaseEngine):
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
-        if self._mllm_scheduler:
-            await self._mllm_scheduler.stop()
-            self._mllm_scheduler = None
+        with suspend_cancellation():
+            cleanup_failures = await self._cleanup_mllm_runtime_ownership()
 
         if self._engine:
             await self._engine.stop()
@@ -595,6 +861,8 @@ class BatchedEngine(BaseEngine):
         self._mllm_instance = None
         self._loaded = False
         logger.info("BatchedEngine stopped")
+        if cleanup_failures:
+            raise cleanup_failures[0]
 
     def _apply_chat_template(
         self,
@@ -761,6 +1029,10 @@ class BatchedEngine(BaseEngine):
             # Use MLLM scheduler for all requests when model is multimodal.
             # MLLM models only initialise the _mllm_scheduler (not _engine),
             # so text-only requests must also be routed here.
+            specprefill_kwargs = _specprefill_request_kwargs(
+                kwargs,
+                has_media=bool(images or videos or audio),
+            )
             output = await self._mllm_scheduler.generate(
                 prompt=prompt,
                 images=images,
@@ -774,6 +1046,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                **specprefill_kwargs,
             )
 
             return GenerationOutput(
@@ -782,8 +1055,7 @@ class BatchedEngine(BaseEngine):
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 finish_reason=output.finish_reason,
-                mtp_drafts=output.mtp_drafts,
-                mtp_accepted=output.mtp_accepted,
+                **_feature_output_kwargs(output),
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -850,6 +1122,10 @@ class BatchedEngine(BaseEngine):
 
         if self._is_mllm and self._mllm_scheduler:
             # Use MLLM scheduler for all streaming when model is multimodal
+            specprefill_kwargs = _specprefill_request_kwargs(
+                kwargs,
+                has_media=bool(images or videos or audio),
+            )
             request_id = await self._mllm_scheduler.add_request_async(
                 prompt=prompt,
                 images=images,
@@ -863,6 +1139,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                **specprefill_kwargs,
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
@@ -873,8 +1150,7 @@ class BatchedEngine(BaseEngine):
                     completion_tokens=output.completion_tokens,
                     finished=output.finished,
                     finish_reason=output.finish_reason,
-                    mtp_drafts=output.mtp_drafts,
-                    mtp_accepted=output.mtp_accepted,
+                    **_feature_output_kwargs(output),
                 )
             return
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -498,14 +498,23 @@ class BatchedEngine(BaseEngine):
         from ..models.mllm import MLXMultimodalLM
 
         max_kv_size = getattr(self._scheduler_config, "max_kv_size", 0)
-        self._mllm_instance = MLXMultimodalLM(
+        mllm_instance = MLXMultimodalLM(
             self._model_name,
             trust_remote_code=self._trust_remote_code,
             max_kv_size=max_kv_size,
         )
-        self._mllm_instance.load()
-        self._model = self._mllm_instance.model
-        self._processor = self._mllm_instance.processor
+        mllm_instance.load()
+        model = mllm_instance.model
+        processor = mllm_instance.processor
+
+        if self._scheduler_config and self._scheduler_config.enable_mtp:
+            from ..scheduler import _continuous_batching_mtp_capability
+
+            _continuous_batching_mtp_capability(model, enabled=True)
+
+        self._mllm_instance = mllm_instance
+        self._model = model
+        self._processor = processor
 
         # Set Metal memory limits (same as LLM path)
         try:
@@ -538,6 +547,8 @@ class BatchedEngine(BaseEngine):
 
         # Inject MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
+            # Legacy Qwen3-Next setup remains unchanged. Loader-owned
+            # Qwen3.5/3.6 capabilities fail above and never enter injection.
             self._inject_mtp_mllm()
 
     async def _start_mllm(self) -> None:
@@ -559,6 +570,10 @@ class BatchedEngine(BaseEngine):
 
         if self._model is None or self._processor is None:
             self._prepare_mllm_model()
+        if getattr(self._scheduler_config, "enable_mtp", False):
+            from ..scheduler import _continuous_batching_mtp_capability
+
+            _continuous_batching_mtp_capability(self._model, enabled=True)
 
         # Create MLLM scheduler config with batch generator support
         if self._scheduler_config and hasattr(self._scheduler_config, "max_num_seqs"):
@@ -795,7 +810,10 @@ class BatchedEngine(BaseEngine):
 
         from mlx_lm.utils import _download
 
+        from ..scheduler import _continuous_batching_mtp_capability
+
         model = self._model
+        _continuous_batching_mtp_capability(model, enabled=True)
         model_path = Path(_download(self._model_name))
         config_path = model_path / "config.json"
         if not config_path.exists():
@@ -806,6 +824,9 @@ class BatchedEngine(BaseEngine):
             config = json.load(f)
 
         text_config = config.get("text_config", config)
+        model_type = text_config.get("model_type", config.get("model_type", ""))
+        if "qwen3_5" in model_type or "qwen3_6" in model_type:
+            raise RuntimeError("native_mtp_capability_missing")
         num_mtp = text_config.get("mtp_num_hidden_layers", 0)
         if num_mtp == 0:
             num_mtp = text_config.get(
@@ -824,17 +845,7 @@ class BatchedEngine(BaseEngine):
             logger.info("[MTP-MLLM] Model already has MTP, skipping injection")
             return
 
-        model_type = text_config.get("model_type", config.get("model_type", ""))
-        if "qwen3_5" in model_type:
-            from ..patches.qwen3_5_mtp import inject_mtp_support
-
-            ok = inject_mtp_support(model, model_path, config)
-            if ok:
-                logger.info("[MTP-MLLM] Qwen3.5 MTP injected successfully")
-            else:
-                logger.warning("[MTP-MLLM] Qwen3.5 MTP injection failed")
-        else:
-            logger.info(f"[MTP-MLLM] MTP not supported for model_type={model_type}")
+        logger.info(f"[MTP-MLLM] MTP not supported for model_type={model_type}")
 
     def _prepare_llm_model(self) -> None:
         """Load the LLM model/tokenizer before engine loop startup."""
@@ -857,10 +868,11 @@ class BatchedEngine(BaseEngine):
 
         # Validate MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
-            from ..patches.qwen3_5_mtp import validate_mtp_support as validate_35
             from ..patches.qwen3_next_mtp import validate_mtp_support
+            from ..scheduler import _continuous_batching_mtp_capability
 
-            if validate_mtp_support(self._model) or validate_35(self._model):
+            _continuous_batching_mtp_capability(self._model, enabled=True)
+            if validate_mtp_support(self._model):
                 logger.info("[MTP] Model validated for MTP speculative decoding")
             else:
                 logger.warning(
@@ -911,7 +923,9 @@ class BatchedEngine(BaseEngine):
         # Validate MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
             from ..patches.qwen3_next_mtp import validate_mtp_support
+            from ..scheduler import _continuous_batching_mtp_capability
 
+            _continuous_batching_mtp_capability(self._model, enabled=True)
             if validate_mtp_support(self._model):
                 logger.info("[MTP] Model validated for MTP speculative decoding")
             else:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -50,6 +50,7 @@ class PreparedMLLMSpecPrefillRuntime:
     tokenizer_artifact_hash: str
     scorer_artifact_hash: str
     cleanup: Any
+    gemma_batch_config: Any = None
     diagnostic: bool = False
     advertisable: bool = True
 
@@ -87,7 +88,53 @@ class PreparedMLLMSpecPrefillRuntime:
             raise TypeError("cleanup must be callable")
         if self.cache_capability.adapter_id != self.profile_key.adapter_id:
             raise ValueError("prepared cache adapter must match the profile key")
-        if self.cache_capability.layout != "qwen3_5_nonrotating_hybrid":
+        gemma_layouts = {
+            "gemma4-e2b",
+            "gemma4-31b",
+            "gemma4-26b-a4b",
+        }
+        if self.cache_capability.layout == "qwen3_5_nonrotating_hybrid":
+            if self.gemma_batch_config is not None:
+                raise ValueError("Qwen prepared runtime cannot carry Gemma config")
+        elif self.cache_capability.layout in gemma_layouts:
+            from ..mllm_batch_generator import GemmaSparseBatchConfig
+
+            if not isinstance(self.gemma_batch_config, GemmaSparseBatchConfig):
+                raise TypeError(
+                    "Gemma prepared runtime requires GemmaSparseBatchConfig"
+                )
+            if (
+                not self.diagnostic
+                or self.advertisable
+                or self.cache_capability.backend != "mlx_vlm"
+                or not self.cache_capability.rotating
+                or not self.cache_capability.homogeneous_rows_only
+            ):
+                raise ValueError(
+                    "Gemma CB SpecPrefill is diagnostic mlx-vlm homogeneous only"
+                )
+            attestation = self.gemma_batch_config.attestation
+            if (
+                attestation.target_model is not self.target_model
+                or attestation.processor is not self.processor
+                or attestation.artifact.artifact_id != self.cache_capability.layout
+            ):
+                raise ValueError(
+                    "Gemma batch config does not match prepared runtime identity"
+                )
+            execution = self.gemma_batch_config.execution_config
+            if (
+                execution.target_id
+                != f"{self.profile_key.target_artifact_id}@sha256:{self.target_artifact_hash}"
+                or execution.tokenizer_id
+                != f"tokenizer@sha256:{self.tokenizer_artifact_hash}"
+                or execution.scorer_id
+                != f"{self.profile_key.scorer_artifact_id}@sha256:{self.scorer_artifact_hash}"
+            ):
+                raise ValueError(
+                    "Gemma execution identity does not match prepared artifacts"
+                )
+        else:
             raise ValueError("prepared cache capability is not admitted for CB")
         matching_profiles = tuple(
             profile
@@ -586,10 +633,21 @@ class BatchedEngine(BaseEngine):
                 "specprefill_cache_capability": (
                     prepared_specprefill.cache_capability
                 ),
+                "specprefill_gemma_batch_config": (
+                    prepared_specprefill.gemma_batch_config
+                ),
                 "specprefill_diagnostic": prepared_specprefill.diagnostic,
                 "specprefill_advertisable": prepared_specprefill.advertisable,
             }
         try:
+            if (
+                prepared_specprefill is not None
+                and prepared_specprefill.gemma_batch_config is not None
+                and enable_prefix_cache
+            ):
+                raise RuntimeError(
+                    "diagnostic Gemma CB SpecPrefill cannot compose with prefix cache"
+                )
             mllm_config = MLLMSchedulerConfig(
                 max_num_seqs=max_num_seqs,
                 prefill_batch_size=prefill_batch_size,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -516,10 +516,9 @@ class BatchedEngine(BaseEngine):
             if self._is_mllm:
                 await self._start_mllm()
             else:
-                if (
-                    getattr(self._scheduler_config, "specprefill_enabled", False)
-                    and not getattr(self._scheduler_config, "enable_mtp", False)
-                ):
+                if getattr(
+                    self._scheduler_config, "specprefill_enabled", False
+                ) and not getattr(self._scheduler_config, "enable_mtp", False):
                     raise RuntimeError(
                         "continuous-batching SpecPrefill requires the MLLM scheduler"
                     )
@@ -850,9 +849,12 @@ class BatchedEngine(BaseEngine):
                 failures.append(exc)
             else:
                 self._prepared_specprefill_runtime = None
-                if getattr(
-                    self._scheduler_config, "native_mtp_specprefill_runtime", None
-                ) is prepared:
+                if (
+                    getattr(
+                        self._scheduler_config, "native_mtp_specprefill_runtime", None
+                    )
+                    is prepared
+                ):
                     self._scheduler_config.native_mtp_specprefill_runtime = None
         return failures
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -2000,7 +2000,9 @@ class SimpleEngine(BaseEngine):
                             finish_reason = getattr(chunk, "finish_reason", None)
                             if finish_reason is None:
                                 finish_reason = (
-                                    "length" if completion_tokens >= max_tokens else "stop"
+                                    "length"
+                                    if completion_tokens >= max_tokens
+                                    else "stop"
                                 )
 
                         yield GenerationOutput(

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -17,6 +17,7 @@ import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 
 # Re-entrancy guard for SimpleEngine._track_request_stream so that
@@ -32,6 +33,12 @@ import mlx.core as mx
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_output_text, has_media_content, is_mllm_model
+from ..specprefill import (
+    SPECPREFILL_SELECTOR_VERSION,
+    SpecPrefillDecision,
+    SpecPrefillPolicy,
+    resolve_specprefill_decision,
+)
 from .base import (
     BaseEngine,
     EngineBusy,
@@ -119,6 +126,52 @@ class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
 
+@dataclass
+class _SpecPrefillTelemetry:
+    """Mutable, request-local SpecPrefill evidence shared by one stream.
+
+    Selection and execution run in a blocking worker while responses are yielded
+    on the event loop.  Keeping this state request-local means a sparse-prefill
+    failure can atomically turn subsequent output into an explicit dense
+    fallback without changing model-global state or MTP accounting.
+    """
+
+    decision: SpecPrefillDecision
+    total_tokens: int | None
+    selected_tokens: int | None
+    scorer_ms: float | None = None
+    target_prefill_ms: float | None = None
+
+    def fallback(self, reason: str) -> None:
+        self.decision = SpecPrefillDecision(
+            requested_policy=self.decision.requested_policy,
+            effective_policy=SpecPrefillPolicy.DENSE,
+            coverage=self.decision.coverage,
+            fallback_reason=reason,
+        )
+        # Dense fallback retains the complete prompt.  This is also the only
+        # cache state that may be used after a sparse execution error.
+        self.selected_tokens = self.total_tokens
+        # Retain completed phase timings: they are evidence of the failed
+        # sparse attempt and must not be mistaken for a zero-cost dense path.
+
+    def as_output_kwargs(self) -> dict[str, Any]:
+        decision = self.decision
+        return {
+            "specprefill_requested_policy": decision.requested_policy.value,
+            "specprefill_effective_policy": decision.effective_policy.value,
+            "specprefill_coverage": decision.coverage.value,
+            "specprefill_engaged": decision.effective_policy
+            is SpecPrefillPolicy.SPARSE,
+            "specprefill_selector_version": SPECPREFILL_SELECTOR_VERSION,
+            "specprefill_fallback_reason": decision.fallback_reason,
+            "specprefill_total_tokens": self.total_tokens,
+            "specprefill_selected_tokens": self.selected_tokens,
+            "specprefill_scorer_ms": self.scorer_ms,
+            "specprefill_target_prefill_ms": self.target_prefill_ms,
+        }
+
+
 class SimpleEngine(BaseEngine):
     """
     Simple engine for direct model calls.
@@ -141,6 +194,8 @@ class SimpleEngine(BaseEngine):
         specprefill_keep_pct: float = 0.3,
         specprefill_backbone_pct: float = 0.0,
         specprefill_draft_model: str | None = None,
+        specprefill_diagnostic_mode: bool = False,
+        specprefill_max_tokens: int | None = None,
         max_kv_size: int = 0,
         mllm_draft_model: str | None = None,
         mllm_draft_kind: str | None = None,
@@ -163,6 +218,11 @@ class SimpleEngine(BaseEngine):
             specprefill_backbone_pct: Fraction of chunks to reserve for evenly
                 spaced coverage (default: 0.0)
             specprefill_draft_model: Path to small draft model for importance scoring
+            specprefill_diagnostic_mode: Allow forced sparse requests and
+                per-request selector overrides. Production routes keep this off.
+            specprefill_max_tokens: Optional explicit scorer-admission cap.
+                ``None`` leaves long-context admission to the profile/memory
+                controller rather than imposing a hidden engine ceiling.
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
             mllm_draft_model: Optional MLLM speculative draft/assistant model path
             mllm_draft_kind: Optional mlx-vlm draft kind, for example "mtp"
@@ -196,6 +256,10 @@ class SimpleEngine(BaseEngine):
         self._specprefill_keep_pct = specprefill_keep_pct
         self._specprefill_backbone_pct = specprefill_backbone_pct
         self._specprefill_draft_model_path = specprefill_draft_model
+        self._specprefill_diagnostic_mode = specprefill_diagnostic_mode
+        if specprefill_max_tokens is not None and specprefill_max_tokens <= 0:
+            raise ValueError("specprefill_max_tokens must be positive when set")
+        self._specprefill_max_tokens = specprefill_max_tokens
         self._mllm_draft_model_path = mllm_draft_model
         self._mllm_draft_kind = mllm_draft_kind
         self._mllm_draft_block_size = mllm_draft_block_size
@@ -255,6 +319,136 @@ class SimpleEngine(BaseEngine):
         # cache classes such as ``RotatingKVCache`` remain disabled because
         # their extra cursor metadata is not captured by ``.state`` alone.
         self._supports_system_kv_cache: bool = False
+
+    def _resolve_specprefill_telemetry(
+        self,
+        *,
+        legacy: bool | None,
+        policy: str | None,
+        coverage: str | None,
+        has_media: bool,
+        total_tokens: int | None,
+    ) -> _SpecPrefillTelemetry:
+        """Resolve request intent before execution, with a safe dense default.
+
+        API validation rejects conflicts, but this engine may also be used
+        directly.  Its default is deliberately conservative: an omitted
+        coverage declaration is ``unknown`` and therefore never engages sparse
+        prefill in a production engine.
+        """
+        if policy is None:
+            policy = (
+                "sparse" if legacy is True else "dense" if legacy is False else "auto"
+            )
+        if coverage is None:
+            coverage = "unknown"
+
+        requested_policy = SpecPrefillPolicy(policy)
+        # ``sparse`` is a diagnostic forcing control. Its diagnostic-only
+        # meaning includes bypassing the calibrated crossover; production
+        # routes still resolve it dense before any scorer work begins.
+        if (
+            self._specprefill_diagnostic_mode
+            and requested_policy is SpecPrefillPolicy.SPARSE
+        ):
+            threshold_met = True
+        elif total_tokens is None:
+            threshold_met = False
+        else:
+            threshold_met = total_tokens > self._specprefill_threshold
+        # The engine owns no implicit maximum context. A deployment may install
+        # an explicit scorer cap, while the normal long-context admission
+        # decision belongs to the profile/memory controller.
+        admission_allowed = (
+            self._specprefill_max_tokens is None
+            or total_tokens is None
+            or total_tokens <= self._specprefill_max_tokens
+        )
+        decision = resolve_specprefill_decision(
+            policy,
+            coverage,
+            production=not self._specprefill_diagnostic_mode,
+            text_only=not has_media,
+            threshold_met=threshold_met,
+            admission_allowed=admission_allowed,
+        )
+        if (
+            decision.effective_policy is SpecPrefillPolicy.SPARSE
+            and self._draft_model is None
+        ):
+            decision = SpecPrefillDecision(
+                requested_policy=decision.requested_policy,
+                effective_policy=SpecPrefillPolicy.DENSE,
+                coverage=decision.coverage,
+                fallback_reason="specprefill_unavailable",
+            )
+
+        selected_tokens = (
+            total_tokens
+            if decision.effective_policy is SpecPrefillPolicy.DENSE
+            else None
+        )
+        return _SpecPrefillTelemetry(decision, total_tokens, selected_tokens)
+
+    def _specprefill_controls(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Remove public prefill controls before forwarding to model APIs."""
+        controls = {
+            "legacy": kwargs.pop("specprefill", None),
+            "policy": kwargs.pop("specprefill_policy", None),
+            "coverage": kwargs.pop("specprefill_coverage", None),
+            "has_media": bool(kwargs.pop("specprefill_has_media", False)),
+            "keep_pct": kwargs.pop("specprefill_keep_pct", None),
+            "backbone_pct": kwargs.pop("specprefill_backbone_pct", None),
+        }
+        if not self._specprefill_diagnostic_mode and (
+            controls["keep_pct"] is not None or controls["backbone_pct"] is not None
+        ):
+            raise ValueError(
+                "specprefill_keep_pct and specprefill_backbone_pct are "
+                "diagnostic-only controls"
+            )
+        return controls
+
+    def _has_eligible_sparse_chat_intent(self, kwargs: dict[str, Any]) -> bool:
+        """Whether chat must use the stream seam to permit sparse prefill.
+
+        The direct ``model.chat`` path has no sparse-prefill execution seam.
+        This predicate deliberately does not treat a loaded scorer as intent;
+        only a declared selective auto request or diagnostic sparse request may
+        switch a chat request onto that seam. Prompt-length admission remains
+        authoritative in the streaming implementation after template rendering.
+        """
+        policy = kwargs.get("specprefill_policy")
+        legacy = kwargs.get("specprefill")
+        coverage = kwargs.get("specprefill_coverage", "unknown")
+        has_media = bool(kwargs.get("specprefill_has_media", False))
+        if has_media or self._draft_model is None:
+            return False
+        if policy is None:
+            policy = (
+                "sparse" if legacy is True else "dense" if legacy is False else "auto"
+            )
+        if policy == "auto":
+            return coverage == "selective"
+        return policy == "sparse" and self._specprefill_diagnostic_mode
+
+    @staticmethod
+    def _prompt_add_special_tokens(tokenizer: Any, prompt: str) -> bool:
+        """Tokenize without assuming a concrete tokenizer attribute type.
+
+        Third-party wrappers and test doubles may expose ``bos_token`` as a
+        sentinel object rather than a string. Such a value cannot be passed to
+        ``str.startswith`` and should conservatively be treated as no BOS.
+        """
+        bos_token = getattr(tokenizer, "bos_token", None)
+        return not isinstance(bos_token, str) or not prompt.startswith(bos_token)
+
+    @classmethod
+    def _encode_prompt_tokens(cls, tokenizer: Any, prompt: str) -> list[int]:
+        return tokenizer.encode(
+            prompt,
+            add_special_tokens=cls._prompt_add_special_tokens(tokenizer, prompt),
+        )
 
     @staticmethod
     def _clone_cache_state(value: Any) -> Any:
@@ -727,6 +921,16 @@ class SimpleEngine(BaseEngine):
             completion_tokens=last_output.completion_tokens,
             finish_reason=last_output.finish_reason,
             finished=True,
+            specprefill_requested_policy=last_output.specprefill_requested_policy,
+            specprefill_effective_policy=last_output.specprefill_effective_policy,
+            specprefill_coverage=last_output.specprefill_coverage,
+            specprefill_engaged=last_output.specprefill_engaged,
+            specprefill_selector_version=last_output.specprefill_selector_version,
+            specprefill_fallback_reason=last_output.specprefill_fallback_reason,
+            specprefill_total_tokens=last_output.specprefill_total_tokens,
+            specprefill_selected_tokens=last_output.specprefill_selected_tokens,
+            specprefill_scorer_ms=last_output.specprefill_scorer_ms,
+            specprefill_target_prefill_ms=last_output.specprefill_target_prefill_ms,
         )
 
     async def _track_request_stream(
@@ -865,58 +1069,50 @@ class SimpleEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
-        # Per-request specprefill overrides (from extra_body)
-        specprefill_override = kwargs.pop("specprefill", None)
-        specprefill_keep_pct_override = kwargs.pop("specprefill_keep_pct", None)
-        specprefill_backbone_pct_override = kwargs.pop("specprefill_backbone_pct", None)
+        # Resolve the complete public prefill contract before any model call.
+        # These controls must never leak into mlx-lm/mlx-vlm kwargs.
+        specprefill_controls = self._specprefill_controls(kwargs)
         request_id = str(kwargs.pop("request_id", "") or f"simple-{id(prompt):x}")
 
-        # SpecPrefill for non-MLLM models (MLLM+MTP handles it in _stream_generate_text)
-        if not self._is_mllm and self._draft_model is not None:
-            use_specprefill = True
-            if specprefill_override is False:
-                use_specprefill = False
+        tokenizer = self._model.tokenizer
+        tokens_list = self._encode_prompt_tokens(tokenizer, prompt)
+        telemetry = self._resolve_specprefill_telemetry(
+            legacy=specprefill_controls["legacy"],
+            policy=specprefill_controls["policy"],
+            coverage=specprefill_controls["coverage"],
+            has_media=specprefill_controls["has_media"],
+            total_tokens=len(tokens_list),
+        )
 
-            if use_specprefill:
-                tokenizer = self._model.tokenizer
-                add_special = tokenizer.bos_token is None or not prompt.startswith(
-                    tokenizer.bos_token
-                )
-                tokens_list = tokenizer.encode(prompt, add_special_tokens=add_special)
-                n_tokens = len(tokens_list)
-
-                # Threshold check (skip when force-enabled via per-request override)
-                if (
-                    specprefill_override is not True
-                    and n_tokens <= self._specprefill_threshold
-                ):
-                    use_specprefill = False
-
-                # Upper bound: cap to avoid draft model OOM
-                _SPECPREFILL_MAX_TOKENS = 65536
-                if use_specprefill and n_tokens > _SPECPREFILL_MAX_TOKENS:
-                    logger.warning(
-                        "SpecPrefill: prompt %d tokens exceeds max %d, "
-                        "falling back to normal path",
-                        n_tokens,
-                        _SPECPREFILL_MAX_TOKENS,
-                    )
-                    use_specprefill = False
-
-                if use_specprefill:
-                    async for output in self._stream_generate_specprefill(
-                        prompt,
-                        tokens_list,
-                        max_tokens,
-                        temperature,
-                        top_p,
-                        stop=stop,
-                        specprefill_keep_pct=specprefill_keep_pct_override,
-                        specprefill_backbone_pct=specprefill_backbone_pct_override,
-                        **kwargs,
-                    ):
-                        yield output
-                    return
+        # SpecPrefill is independent from MTP. The direct path is used only
+        # for non-MLLM requests; the MLLM text route resolves the same contract
+        # in _stream_generate_text.
+        if (
+            not self._is_mllm
+            and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
+        ):
+            async for output in self._stream_generate_specprefill(
+                prompt,
+                tokens_list,
+                max_tokens,
+                temperature,
+                top_p,
+                stop=stop,
+                telemetry=telemetry,
+                specprefill_keep_pct=(
+                    specprefill_controls["keep_pct"]
+                    if self._specprefill_diagnostic_mode
+                    else None
+                ),
+                specprefill_backbone_pct=(
+                    specprefill_controls["backbone_pct"]
+                    if self._specprefill_diagnostic_mode
+                    else None
+                ),
+                **kwargs,
+            ):
+                yield output
+            return
 
         async with self._acquire_generation_slot(request_id):
             started_at = time.time()
@@ -984,6 +1180,7 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=completion_tokens,
                         finished=finished,
                         finish_reason=finish_reason,
+                        **telemetry.as_output_kwargs(),
                     )
 
                     if finished:
@@ -1007,6 +1204,7 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=completion_tokens,
                         finished=True,
                         finish_reason="stop",
+                        **telemetry.as_output_kwargs(),
                     )
             finally:
                 self._active_requests.pop(request_id, None)
@@ -1066,6 +1264,16 @@ class SimpleEngine(BaseEngine):
                 finish_reason=final_output.finish_reason,
                 mtp_drafts=final_output.mtp_drafts,
                 mtp_accepted=final_output.mtp_accepted,
+                specprefill_requested_policy=final_output.specprefill_requested_policy,
+                specprefill_effective_policy=final_output.specprefill_effective_policy,
+                specprefill_coverage=final_output.specprefill_coverage,
+                specprefill_engaged=final_output.specprefill_engaged,
+                specprefill_selector_version=final_output.specprefill_selector_version,
+                specprefill_fallback_reason=final_output.specprefill_fallback_reason,
+                specprefill_total_tokens=final_output.specprefill_total_tokens,
+                specprefill_selected_tokens=final_output.specprefill_selected_tokens,
+                specprefill_scorer_ms=final_output.specprefill_scorer_ms,
+                specprefill_target_prefill_ms=final_output.specprefill_target_prefill_ms,
             )
 
         # mlx-lm non-streaming chat with tools can stall indefinitely on some
@@ -1073,6 +1281,12 @@ class SimpleEngine(BaseEngine):
         # streaming implementation and aggregate its final state so both chat
         # APIs share the same tool-capable execution path.
         if tools and not self._is_mllm:
+            return await aggregate_stream_chat()
+
+        # Keep the independently configurable prefill path identical for
+        # streaming and non-streaming SimpleEngine chat. This is intentionally
+        # not coupled to MTP.
+        if not self._is_mllm and self._has_eligible_sparse_chat_intent(kwargs):
             return await aggregate_stream_chat()
 
         # Request-local logits processors (response_format / constrained JSON)
@@ -1093,6 +1307,16 @@ class SimpleEngine(BaseEngine):
         template_tools = convert_tools_for_template(tools) if tools else None
 
         if self._is_mllm:
+            specprefill_controls = self._specprefill_controls(kwargs)
+            telemetry = self._resolve_specprefill_telemetry(
+                legacy=specprefill_controls["legacy"],
+                policy=specprefill_controls["policy"],
+                coverage=specprefill_controls["coverage"],
+                has_media=(
+                    has_media_content(messages) or specprefill_controls["has_media"]
+                ),
+                total_tokens=None,
+            )
             if chat_template_kwargs:
                 kwargs["chat_template_kwargs"] = chat_template_kwargs
             output = await self._run_blocking_serialized(
@@ -1111,8 +1335,13 @@ class SimpleEngine(BaseEngine):
                 finish_reason=output.finish_reason,
                 mtp_drafts=getattr(output, "mtp_drafts", 0),
                 mtp_accepted=getattr(output, "mtp_accepted", 0),
+                **telemetry.as_output_kwargs(),
             )
         else:
+            # Direct dense chat cannot accept the public policy kwargs, and a
+            # loaded scorer alone must not alter this route. Resolve after
+            # prompt accounting so this path still publishes full telemetry.
+            specprefill_controls = self._specprefill_controls(kwargs)
             output = await self._run_blocking_serialized(
                 self._model.chat,
                 messages=messages,
@@ -1135,12 +1364,20 @@ class SimpleEngine(BaseEngine):
                 template_kwargs["tools"] = template_tools
             prompt_ids = tokenizer.apply_chat_template(messages, **template_kwargs)
             prompt_token_count = len(prompt_ids)
+            telemetry = self._resolve_specprefill_telemetry(
+                legacy=specprefill_controls["legacy"],
+                policy=specprefill_controls["policy"],
+                coverage=specprefill_controls["coverage"],
+                has_media=specprefill_controls["has_media"],
+                total_tokens=prompt_token_count,
+            )
             return GenerationOutput(
                 text=text,
                 tokens=output.tokens,
                 prompt_tokens=prompt_token_count,
                 completion_tokens=len(output.tokens),
                 finish_reason=output.finish_reason,
+                **telemetry.as_output_kwargs(),
             )
 
     async def stream_chat(
@@ -1202,20 +1439,21 @@ class SimpleEngine(BaseEngine):
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
         mllm_draft_requested = bool(kwargs.pop("mllm_draft", False))
-        has_media = has_media_content(messages)
+        request_has_media = has_media_content(messages)
 
         # Convert tools for template
         template_tools = convert_tools_for_template(tools) if tools else None
 
         # Per-request routing: text-only through mlx_lm TextModel
-        if (
+        routes_text_model = (
             self._is_mllm
             and self._text_model is not None
             and self._should_route_text_through_text_model(
                 mllm_draft_requested=mllm_draft_requested
             )
-            and not has_media
-        ):
+            and not request_has_media
+        )
+        if routes_text_model:
             has_mtp = (
                 hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
             )
@@ -1233,6 +1471,20 @@ class SimpleEngine(BaseEngine):
                 yield chunk
             return
 
+        # Direct MLLM execution (including media) does not implement sparse
+        # token selection. It still consumes and reports the public contract so
+        # a media request is visibly dense rather than silently text-only.
+        direct_mllm_telemetry: _SpecPrefillTelemetry | None = None
+        if self._is_mllm:
+            specprefill_controls = self._specprefill_controls(kwargs)
+            direct_mllm_telemetry = self._resolve_specprefill_telemetry(
+                legacy=specprefill_controls["legacy"],
+                policy=specprefill_controls["policy"],
+                coverage=specprefill_controls["coverage"],
+                has_media=request_has_media or specprefill_controls["has_media"],
+                total_tokens=None,
+            )
+
         def mllm_call_kwargs() -> dict:
             local_kwargs = dict(kwargs)
             if chat_template_kwargs:
@@ -1244,7 +1496,7 @@ class SimpleEngine(BaseEngine):
         # Build prompt using tokenizer
         if self._is_mllm:
             if self._text_model is not None:
-                route_kind = "Media" if has_media else "Text-only"
+                route_kind = "Media" if request_has_media else "Text-only"
                 logger.info("%s request → MLLM path", route_kind)
             # For MLLM, use stream_chat which yields tokens incrementally.
             # Must hold the generation slot to prevent concurrent Metal access
@@ -1287,6 +1539,7 @@ class SimpleEngine(BaseEngine):
                             finish_reason=chunk.finish_reason if finished else None,
                             mtp_drafts=getattr(chunk, "mtp_drafts", 0),
                             mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                            **direct_mllm_telemetry.as_output_kwargs(),
                         )
 
                         if finished:
@@ -1326,6 +1579,7 @@ class SimpleEngine(BaseEngine):
                     finish_reason=chunk.finish_reason if finished else None,
                     mtp_drafts=getattr(chunk, "mtp_drafts", 0),
                     mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                    **direct_mllm_telemetry.as_output_kwargs(),
                 )
             return
 
@@ -1551,9 +1805,7 @@ class SimpleEngine(BaseEngine):
                         system_prefix_text.encode()
                     ).hexdigest()[:16]
 
-                    add_special = tokenizer.bos_token is None or not prompt.startswith(
-                        tokenizer.bos_token
-                    )
+                    add_special = self._prompt_add_special_tokens(tokenizer, prompt)
                     full_tokens_list = tokenizer.encode(
                         prompt, add_special_tokens=add_special
                     )
@@ -1801,6 +2053,7 @@ class SimpleEngine(BaseEngine):
         temperature: float,
         top_p: float,
         stop: list[str] | None = None,
+        telemetry: _SpecPrefillTelemetry | None = None,
         specprefill_keep_pct: float | None = None,
         specprefill_backbone_pct: float | None = None,
         **kwargs,
@@ -1816,6 +2069,14 @@ class SimpleEngine(BaseEngine):
         model = self._model.model
         tokenizer = self._model.tokenizer
         n_tokens = len(tokens)
+        if telemetry is None:
+            telemetry = self._resolve_specprefill_telemetry(
+                legacy=True,
+                policy="sparse",
+                coverage="selective",
+                has_media=False,
+                total_tokens=n_tokens,
+            )
         cancel_requested = Event()
 
         def _request_cancel() -> None:
@@ -1832,6 +2093,7 @@ class SimpleEngine(BaseEngine):
                 raise
             except Exception as e:
                 logger.error("SpecPrefill failed, falling back to normal path: %s", e)
+                telemetry.fallback("sparse_execution_failed")
                 return _run_normal()
 
         def _run_specprefill():
@@ -1862,6 +2124,7 @@ class SimpleEngine(BaseEngine):
                     cancel_check=_cancel_check,
                 )
                 t_score = time.monotonic() - t0
+                telemetry.scorer_ms = t_score * 1000
 
                 # Phase 2: Select important chunks
                 _cancel_check()
@@ -1877,6 +2140,7 @@ class SimpleEngine(BaseEngine):
                     backbone_pct=effective_backbone,
                 )
                 n_selected = selected.shape[0]
+                telemetry.selected_tokens = int(n_selected)
 
                 # Phase 3: Sparse prefill on target model
                 t0 = time.monotonic()
@@ -1889,6 +2153,7 @@ class SimpleEngine(BaseEngine):
                     cancel_check=_cancel_check,
                 )
                 t_prefill = time.monotonic() - t0
+                telemetry.target_prefill_ms = t_prefill * 1000
 
                 logger.info(
                     "SpecPrefill: scored %d tokens in %.1fs, "
@@ -1984,6 +2249,7 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=finished,
                 finish_reason=resp.finish_reason or ("stop" if finished else None),
+                **telemetry.as_output_kwargs(),
             )
 
             if finished:
@@ -1997,6 +2263,7 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
+                **telemetry.as_output_kwargs(),
             )
 
     async def _stream_generate_text(
@@ -2026,10 +2293,19 @@ class SimpleEngine(BaseEngine):
         from mlx_lm.models.cache import make_prompt_cache
         from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
-        # Per-request specprefill overrides (from extra_body)
-        specprefill_override = kwargs.pop("specprefill", None)
-        specprefill_keep_pct = kwargs.pop("specprefill_keep_pct", None)
-        specprefill_backbone_pct = kwargs.pop("specprefill_backbone_pct", None)
+        # The text route has its own prompt rendering, but shares exactly the
+        # same policy resolver as direct SimpleEngine generation.
+        specprefill_controls = self._specprefill_controls(kwargs)
+        specprefill_keep_pct = (
+            specprefill_controls["keep_pct"]
+            if self._specprefill_diagnostic_mode
+            else None
+        )
+        specprefill_backbone_pct = (
+            specprefill_controls["backbone_pct"]
+            if self._specprefill_diagnostic_mode
+            else None
+        )
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
         top_k = kwargs.pop("top_k", 0)
         min_p = kwargs.pop("min_p", 0.0)
@@ -2127,9 +2403,7 @@ class SimpleEngine(BaseEngine):
 
                 # Tokenize both (matching stream_generate's tokenization logic)
                 tokenizer = self._text_tokenizer
-                add_special = tokenizer.bos_token is None or not full_prompt.startswith(
-                    tokenizer.bos_token
-                )
+                add_special = self._prompt_add_special_tokens(tokenizer, full_prompt)
                 full_tokens_list = tokenizer.encode(
                     full_prompt, add_special_tokens=add_special
                 )
@@ -2212,25 +2486,40 @@ class SimpleEngine(BaseEngine):
                     )
                     system_token_count = 0
 
-        # Determine if SpecPrefill should be used
-        # Per-request boolean override: True = force enable, False = force disable
-        if specprefill_override is False:
-            use_specprefill = False
-        elif specprefill_override is True and self._draft_model is not None:
-            use_specprefill = True  # Force enable, skip threshold check
-        else:
-            use_specprefill = self._draft_model is not None
-
-        # For specprefill, ensure we have token IDs (not just prompt text)
-        if use_specprefill and suffix_tokens is None and full_tokens_list is None:
-            tokenizer = self._text_tokenizer
-            add_special = tokenizer.bos_token is None or not full_prompt.startswith(
-                tokenizer.bos_token
+        # Do not tokenize a normal dense text-model request merely to compute
+        # optional feature telemetry: that breaks the no-extra-work contract of
+        # the unsafe system-cache path. Only sparse-capable intent needs prompt
+        # tokenization before the standard mlx-lm prefill.
+        telemetry = self._resolve_specprefill_telemetry(
+            legacy=specprefill_controls["legacy"],
+            policy=specprefill_controls["policy"],
+            coverage=specprefill_controls["coverage"],
+            has_media=specprefill_controls["has_media"],
+            total_tokens=(full_token_count if full_tokens_list is not None else None),
+        )
+        requested_policy = telemetry.decision.requested_policy
+        should_measure_sparse_prompt = not specprefill_controls["has_media"] and (
+            (
+                requested_policy is SpecPrefillPolicy.AUTO
+                and telemetry.decision.coverage.value == "selective"
             )
-            full_tokens_list = tokenizer.encode(
-                full_prompt, add_special_tokens=add_special
+            or (
+                requested_policy is SpecPrefillPolicy.SPARSE
+                and self._specprefill_diagnostic_mode
+            )
+        )
+        if should_measure_sparse_prompt and full_tokens_list is None:
+            full_tokens_list = self._encode_prompt_tokens(
+                self._text_tokenizer, full_prompt
             )
             full_token_count = len(full_tokens_list)
+            telemetry = self._resolve_specprefill_telemetry(
+                legacy=specprefill_controls["legacy"],
+                policy=specprefill_controls["policy"],
+                coverage=specprefill_controls["coverage"],
+                has_media=False,
+                total_tokens=full_token_count,
+            )
 
         # Tokens for specprefill: suffix (if system KV) or full prompt
         specprefill_tokens = (
@@ -2238,33 +2527,9 @@ class SimpleEngine(BaseEngine):
         )
         specprefill_offset = system_token_count if suffix_tokens is not None else 0
 
-        # Threshold check: only use specprefill on long prompts
-        # (skipped when per-request boolean forces enable)
-        if (
-            use_specprefill
-            and specprefill_override is not True
-            and (
-                specprefill_tokens is None
-                or len(specprefill_tokens) <= self._specprefill_threshold
-            )
-        ):
-            use_specprefill = False
-
-        # Upper bound: cap specprefill to avoid draft model OOM on very long prompts
-        # 65536 tokens ~ 2GB draft KV cache on Qwen3.5-4B (32KB/token x 8 attn layers)
-        _SPECPREFILL_MAX_TOKENS = 65536
-        if (
-            use_specprefill
-            and specprefill_tokens is not None
-            and len(specprefill_tokens) > _SPECPREFILL_MAX_TOKENS
-        ):
-            logger.warning(
-                "SpecPrefill: prompt %d tokens exceeds max %d, "
-                "falling back to normal path",
-                len(specprefill_tokens),
-                _SPECPREFILL_MAX_TOKENS,
-            )
-            use_specprefill = False
+        use_specprefill = (
+            telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
+        )
 
         loop = asyncio.get_running_loop()
         response_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
@@ -2403,6 +2668,7 @@ class SimpleEngine(BaseEngine):
                         "SpecPrefill failed, falling back to normal MTP path: %s",
                         e,
                     )
+                    telemetry.fallback("sparse_execution_failed")
                     # Discard potentially corrupted cache
                     backbone_cache = None
                     prompt_to_send = full_prompt
@@ -2513,6 +2779,7 @@ class SimpleEngine(BaseEngine):
                     prefill_step_size=self._prefill_step_size,
                 )
                 t_score = time.monotonic() - t0
+                telemetry.scorer_ms = t_score * 1000
 
                 # Phase 2: Select important chunks
                 effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
@@ -2528,6 +2795,7 @@ class SimpleEngine(BaseEngine):
                 )
                 n_selected = selected.shape[0]
                 n_total = len(specprefill_tokens)
+                telemetry.selected_tokens = specprefill_offset + int(n_selected)
 
                 # Phase 3: Sparse prefill on target model
                 t0 = time.monotonic()
@@ -2540,6 +2808,7 @@ class SimpleEngine(BaseEngine):
                     position_offset=specprefill_offset,
                 )
                 t_prefill = time.monotonic() - t0
+                telemetry.target_prefill_ms = t_prefill * 1000
 
                 logger.info(
                     "SpecPrefill: scored %d tokens in %.1fs, "
@@ -2714,6 +2983,7 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=token_count,
                     finished=finished,
                     finish_reason=finish_reason,
+                    **telemetry.as_output_kwargs(),
                 )
 
                 if finished:
@@ -2731,6 +3001,7 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
+                **telemetry.as_output_kwargs(),
             )
 
     def get_stats(self) -> dict[str, Any]:
@@ -2810,6 +3081,8 @@ class SimpleEngine(BaseEngine):
                 "threshold": self._specprefill_threshold,
                 "keep_pct": self._specprefill_keep_pct,
                 "backbone_pct": self._specprefill_backbone_pct,
+                "max_tokens": self._specprefill_max_tokens,
+                "diagnostic_mode": self._specprefill_diagnostic_mode,
             }
 
         # System KV cache stats (LRU over multiple system prefixes)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -39,6 +39,14 @@ from ..specprefill import (
     SpecPrefillPolicy,
     resolve_specprefill_decision,
 )
+from ..specprefill_profiles import (
+    EMPTY_SPECPREFILL_PROFILE_REGISTRY,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillTuning,
+)
 from .base import (
     BaseEngine,
     EngineBusy,
@@ -122,6 +130,17 @@ def _processors_retired(processors: list[Any] | None) -> bool:
     )
 
 
+def _request_can_compose_mtp(route_mtp: bool, processors: list[Any] | None) -> bool:
+    """Whether this request reaches an MTP decode phase on the text route.
+
+    A permanently active request-local processor disables MTP for the whole
+    request. A retire-capable processor constrains only the thinking phase;
+    its content continuation deliberately resumes native MTP and therefore
+    requires the independently qualified combined profile cell.
+    """
+    return route_mtp and (not processors or _processors_can_retire(processors))
+
+
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
@@ -141,6 +160,8 @@ class _SpecPrefillTelemetry:
     selected_tokens: int | None
     scorer_ms: float | None = None
     target_prefill_ms: float | None = None
+    profile_tuning: SpecPrefillTuning | None = None
+    profile_selector_version: str | None = None
 
     def fallback(self, reason: str) -> None:
         self.decision = SpecPrefillDecision(
@@ -163,7 +184,9 @@ class _SpecPrefillTelemetry:
             "specprefill_coverage": decision.coverage.value,
             "specprefill_engaged": decision.effective_policy
             is SpecPrefillPolicy.SPARSE,
-            "specprefill_selector_version": SPECPREFILL_SELECTOR_VERSION,
+            "specprefill_selector_version": (
+                self.profile_selector_version or SPECPREFILL_SELECTOR_VERSION
+            ),
             "specprefill_fallback_reason": decision.fallback_reason,
             "specprefill_total_tokens": self.total_tokens,
             "specprefill_selected_tokens": self.selected_tokens,
@@ -196,6 +219,10 @@ class SimpleEngine(BaseEngine):
         specprefill_draft_model: str | None = None,
         specprefill_diagnostic_mode: bool = False,
         specprefill_max_tokens: int | None = None,
+        specprefill_profile_registry: SpecPrefillProfileRegistry | None = None,
+        specprefill_sparse_profile_key: SpecPrefillProfileKey | None = None,
+        specprefill_combined_profile_key: SpecPrefillProfileKey | None = None,
+        specprefill_estimated_residency_bytes: int | None = None,
         max_kv_size: int = 0,
         mllm_draft_model: str | None = None,
         mllm_draft_kind: str | None = None,
@@ -223,6 +250,15 @@ class SimpleEngine(BaseEngine):
             specprefill_max_tokens: Optional explicit scorer-admission cap.
                 ``None`` leaves long-context admission to the profile/memory
                 controller rather than imposing a hidden engine ceiling.
+            specprefill_profile_registry: Exact calibrated profiles. ``None``
+                uses an empty fail-closed registry.
+            specprefill_sparse_profile_key: Exact SimpleEngine sparse-only
+                artifact/adapter profile identity.
+            specprefill_combined_profile_key: Exact SimpleEngine
+                SpecPrefill+MTP profile identity.
+            specprefill_estimated_residency_bytes: Estimated resident bytes for
+                this exact request composition. This engine does not estimate
+                or load artifacts.
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
             mllm_draft_model: Optional MLLM speculative draft/assistant model path
             mllm_draft_kind: Optional mlx-vlm draft kind, for example "mtp"
@@ -260,6 +296,43 @@ class SimpleEngine(BaseEngine):
         if specprefill_max_tokens is not None and specprefill_max_tokens <= 0:
             raise ValueError("specprefill_max_tokens must be positive when set")
         self._specprefill_max_tokens = specprefill_max_tokens
+        if specprefill_profile_registry is None:
+            specprefill_profile_registry = EMPTY_SPECPREFILL_PROFILE_REGISTRY
+        if not isinstance(specprefill_profile_registry, SpecPrefillProfileRegistry):
+            raise ValueError(
+                "specprefill_profile_registry must be SpecPrefillProfileRegistry"
+            )
+        for name, key, expected_cell in (
+            (
+                "specprefill_sparse_profile_key",
+                specprefill_sparse_profile_key,
+                SpecPrefillCell.SPARSE_ONLY,
+            ),
+            (
+                "specprefill_combined_profile_key",
+                specprefill_combined_profile_key,
+                SpecPrefillCell.COMBINED_MTP,
+            ),
+        ):
+            if key is not None and not isinstance(key, SpecPrefillProfileKey):
+                raise ValueError(f"{name} must be SpecPrefillProfileKey")
+            if key is not None and key.engine is not SpecPrefillEngine.SIMPLE:
+                raise ValueError(f"{name} must target the SimpleEngine route")
+            if key is not None and key.cell is not expected_cell:
+                raise ValueError(f"{name} must target the {expected_cell.value} cell")
+        if (
+            specprefill_estimated_residency_bytes is not None
+            and specprefill_estimated_residency_bytes < 0
+        ):
+            raise ValueError(
+                "specprefill_estimated_residency_bytes must be non-negative"
+            )
+        self._specprefill_profile_registry = specprefill_profile_registry
+        self._specprefill_sparse_profile_key = specprefill_sparse_profile_key
+        self._specprefill_combined_profile_key = specprefill_combined_profile_key
+        self._specprefill_estimated_residency_bytes = (
+            specprefill_estimated_residency_bytes
+        )
         self._mllm_draft_model_path = mllm_draft_model
         self._mllm_draft_kind = mllm_draft_kind
         self._mllm_draft_block_size = mllm_draft_block_size
@@ -328,6 +401,7 @@ class SimpleEngine(BaseEngine):
         coverage: str | None,
         has_media: bool,
         total_tokens: int | None,
+        combined_mtp: bool = False,
     ) -> _SpecPrefillTelemetry:
         """Resolve request intent before execution, with a safe dense default.
 
@@ -336,6 +410,7 @@ class SimpleEngine(BaseEngine):
         coverage declaration is ``unknown`` and therefore never engages sparse
         prefill in a production engine.
         """
+        explicit_policy = policy is not None
         if policy is None:
             policy = (
                 "sparse" if legacy is True else "dense" if legacy is False else "auto"
@@ -344,13 +419,24 @@ class SimpleEngine(BaseEngine):
             coverage = "unknown"
 
         requested_policy = SpecPrefillPolicy(policy)
+        legacy_sparse_intent = legacy is True and not explicit_policy
+        legacy_profile_managed_intent = (
+            legacy_sparse_intent and not self._specprefill_diagnostic_mode
+        )
+        profile_managed_intent = (
+            requested_policy is SpecPrefillPolicy.AUTO or legacy_profile_managed_intent
+        )
         # ``sparse`` is a diagnostic forcing control. Its diagnostic-only
-        # meaning includes bypassing the calibrated crossover; production
-        # routes still resolve it dense before any scorer work begins.
+        # meaning includes bypassing calibrated profile lookup. Legacy boolean
+        # enablement remains an intent, not a production forcing bypass.
         if (
             self._specprefill_diagnostic_mode
             and requested_policy is SpecPrefillPolicy.SPARSE
         ):
+            threshold_met = True
+        elif profile_managed_intent:
+            # Production and diagnostic auto use the exact profile's calibrated
+            # crossover. Do not impose the old engine-wide threshold here.
             threshold_met = True
         elif total_tokens is None:
             threshold_met = False
@@ -364,14 +450,60 @@ class SimpleEngine(BaseEngine):
             or total_tokens is None
             or total_tokens <= self._specprefill_max_tokens
         )
+        # Legacy ``specprefill=true`` is production sparse intent, not a
+        # production forcing bypass. In a diagnostic profile it retains the
+        # legacy forcing behavior so existing sparse diagnostics do not become
+        # unexpectedly coverage-gated by the new production policy.
+        decision_policy = "auto" if legacy_profile_managed_intent else policy
         decision = resolve_specprefill_decision(
-            policy,
+            decision_policy,
             coverage,
             production=not self._specprefill_diagnostic_mode,
             text_only=not has_media,
             threshold_met=threshold_met,
             admission_allowed=admission_allowed,
         )
+        if legacy_sparse_intent:
+            decision = SpecPrefillDecision(
+                requested_policy=SpecPrefillPolicy.SPARSE,
+                effective_policy=decision.effective_policy,
+                coverage=decision.coverage,
+                fallback_reason=decision.fallback_reason,
+            )
+
+        profile_tuning: SpecPrefillTuning | None = None
+        profile_selector_version: str | None = None
+        requires_profile = decision.effective_policy is SpecPrefillPolicy.SPARSE and (
+            not self._specprefill_diagnostic_mode
+            or requested_policy is SpecPrefillPolicy.AUTO
+        )
+        if requires_profile:
+            profile_key = self._active_specprefill_profile_key(combined_mtp)
+            if profile_key is None:
+                decision = self._specprefill_dense_fallback(
+                    decision, "profile_not_registered"
+                )
+            elif (
+                total_tokens is None
+                or self._specprefill_estimated_residency_bytes is None
+            ):
+                decision = self._specprefill_dense_fallback(
+                    decision, "profile_residency_not_estimated"
+                )
+            else:
+                profile_decision = self._specprefill_profile_registry.resolve(
+                    profile_key,
+                    prompt_tokens=total_tokens,
+                    residency_bytes=self._specprefill_estimated_residency_bytes,
+                    diagnostic=self._specprefill_diagnostic_mode,
+                )
+                if not profile_decision.eligible:
+                    decision = self._specprefill_dense_fallback(
+                        decision, profile_decision.fallback_reason
+                    )
+                else:
+                    profile_tuning = profile_decision.tuning
+                    profile_selector_version = profile_decision.selector_version
         if (
             decision.effective_policy is SpecPrefillPolicy.SPARSE
             and self._draft_model is None
@@ -382,13 +514,42 @@ class SimpleEngine(BaseEngine):
                 coverage=decision.coverage,
                 fallback_reason="specprefill_unavailable",
             )
+            profile_tuning = None
+            profile_selector_version = None
 
         selected_tokens = (
             total_tokens
             if decision.effective_policy is SpecPrefillPolicy.DENSE
             else None
         )
-        return _SpecPrefillTelemetry(decision, total_tokens, selected_tokens)
+        return _SpecPrefillTelemetry(
+            decision,
+            total_tokens,
+            selected_tokens,
+            profile_tuning=profile_tuning,
+            profile_selector_version=profile_selector_version,
+        )
+
+    def _active_specprefill_profile_key(
+        self, combined_mtp: bool
+    ) -> SpecPrefillProfileKey | None:
+        """Return the independently qualified sparse-only or combined cell."""
+        return (
+            self._specprefill_combined_profile_key
+            if combined_mtp
+            else self._specprefill_sparse_profile_key
+        )
+
+    @staticmethod
+    def _specprefill_dense_fallback(
+        decision: SpecPrefillDecision, reason: str | None
+    ) -> SpecPrefillDecision:
+        return SpecPrefillDecision(
+            requested_policy=decision.requested_policy,
+            effective_policy=SpecPrefillPolicy.DENSE,
+            coverage=decision.coverage,
+            fallback_reason=reason,
+        )
 
     def _specprefill_controls(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         """Remove public prefill controls before forwarding to model APIs."""
@@ -1082,6 +1243,10 @@ class SimpleEngine(BaseEngine):
             coverage=specprefill_controls["coverage"],
             has_media=specprefill_controls["has_media"],
             total_tokens=len(tokens_list),
+            # MLXLanguageModel injects native MTP into its decode call when
+            # configured. Other routes pass their request-effective value
+            # explicitly (for example, an MLLM assistant request).
+            combined_mtp=self._mtp,
         )
 
         # SpecPrefill is independent from MTP. The direct path is used only
@@ -1102,11 +1267,34 @@ class SimpleEngine(BaseEngine):
                 specprefill_keep_pct=(
                     specprefill_controls["keep_pct"]
                     if self._specprefill_diagnostic_mode
-                    else None
+                    else (
+                        telemetry.profile_tuning.keep_pct
+                        if telemetry.profile_tuning is not None
+                        else None
+                    )
                 ),
                 specprefill_backbone_pct=(
                     specprefill_controls["backbone_pct"]
                     if self._specprefill_diagnostic_mode
+                    else (
+                        telemetry.profile_tuning.backbone_pct
+                        if telemetry.profile_tuning is not None
+                        else None
+                    )
+                ),
+                specprefill_chunk_size=(
+                    telemetry.profile_tuning.chunk_size
+                    if telemetry.profile_tuning is not None
+                    else None
+                ),
+                specprefill_halo_chunks=(
+                    telemetry.profile_tuning.halo_chunks
+                    if telemetry.profile_tuning is not None
+                    else None
+                ),
+                specprefill_anchor_chunks=(
+                    telemetry.profile_tuning.anchor_chunks
+                    if telemetry.profile_tuning is not None
                     else None
                 ),
                 **kwargs,
@@ -1466,6 +1654,7 @@ class SimpleEngine(BaseEngine):
                 temperature,
                 top_p,
                 tools=template_tools,
+                combined_mtp=has_mtp and self._mtp,
                 **kwargs,
             ):
                 yield chunk
@@ -1483,6 +1672,7 @@ class SimpleEngine(BaseEngine):
                 coverage=specprefill_controls["coverage"],
                 has_media=request_has_media or specprefill_controls["has_media"],
                 total_tokens=None,
+                combined_mtp=mllm_draft_requested,
             )
 
         def mllm_call_kwargs() -> dict:
@@ -2056,6 +2246,9 @@ class SimpleEngine(BaseEngine):
         telemetry: _SpecPrefillTelemetry | None = None,
         specprefill_keep_pct: float | None = None,
         specprefill_backbone_pct: float | None = None,
+        specprefill_chunk_size: int | None = None,
+        specprefill_halo_chunks: int | None = None,
+        specprefill_anchor_chunks: int | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """SpecPrefill path for non-MTP models (Nemotron, GPT-OSS, etc).
@@ -2134,10 +2327,24 @@ class SimpleEngine(BaseEngine):
                     if specprefill_backbone_pct is not None
                     else self._specprefill_backbone_pct
                 )
+                effective_chunk_size = specprefill_chunk_size or 32
+                effective_halo_chunks = (
+                    specprefill_halo_chunks
+                    if specprefill_halo_chunks is not None
+                    else 1
+                )
+                effective_anchor_chunks = (
+                    specprefill_anchor_chunks
+                    if specprefill_anchor_chunks is not None
+                    else 1
+                )
                 selected = select_chunks(
                     importance,
                     keep_pct=effective_keep,
                     backbone_pct=effective_backbone,
+                    chunk_size=effective_chunk_size,
+                    halo_chunks=effective_halo_chunks,
+                    anchor_chunks=effective_anchor_chunks,
                 )
                 n_selected = selected.shape[0]
                 telemetry.selected_tokens = int(n_selected)
@@ -2273,6 +2480,7 @@ class SimpleEngine(BaseEngine):
         temperature: float,
         top_p: float,
         tools: list | None = None,
+        combined_mtp: bool = False,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Text-only generation via mlx_lm TextModel.
@@ -2306,6 +2514,9 @@ class SimpleEngine(BaseEngine):
             if self._specprefill_diagnostic_mode
             else None
         )
+        specprefill_chunk_size: int | None = None
+        specprefill_halo_chunks: int | None = None
+        specprefill_anchor_chunks: int | None = None
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
         top_k = kwargs.pop("top_k", 0)
         min_p = kwargs.pop("min_p", 0.0)
@@ -2358,6 +2569,7 @@ class SimpleEngine(BaseEngine):
         )
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
         custom_logits_active = bool(all_processors)
+        combined_mtp = _request_can_compose_mtp(combined_mtp, all_processors)
         max_tokens = max_tokens or 4096
 
         # --- System prompt KV caching ---
@@ -2496,6 +2708,7 @@ class SimpleEngine(BaseEngine):
             coverage=specprefill_controls["coverage"],
             has_media=specprefill_controls["has_media"],
             total_tokens=(full_token_count if full_tokens_list is not None else None),
+            combined_mtp=combined_mtp,
         )
         requested_policy = telemetry.decision.requested_policy
         should_measure_sparse_prompt = not specprefill_controls["has_media"] and (
@@ -2519,7 +2732,18 @@ class SimpleEngine(BaseEngine):
                 coverage=specprefill_controls["coverage"],
                 has_media=False,
                 total_tokens=full_token_count,
+                combined_mtp=combined_mtp,
             )
+
+        if (
+            not self._specprefill_diagnostic_mode
+            and telemetry.profile_tuning is not None
+        ):
+            specprefill_keep_pct = telemetry.profile_tuning.keep_pct
+            specprefill_backbone_pct = telemetry.profile_tuning.backbone_pct
+            specprefill_chunk_size = telemetry.profile_tuning.chunk_size
+            specprefill_halo_chunks = telemetry.profile_tuning.halo_chunks
+            specprefill_anchor_chunks = telemetry.profile_tuning.anchor_chunks
 
         # Tokens for specprefill: suffix (if system KV) or full prompt
         specprefill_tokens = (
@@ -2788,10 +3012,24 @@ class SimpleEngine(BaseEngine):
                     if specprefill_backbone_pct is not None
                     else self._specprefill_backbone_pct
                 )
+                effective_chunk_size = specprefill_chunk_size or 32
+                effective_halo_chunks = (
+                    specprefill_halo_chunks
+                    if specprefill_halo_chunks is not None
+                    else 1
+                )
+                effective_anchor_chunks = (
+                    specprefill_anchor_chunks
+                    if specprefill_anchor_chunks is not None
+                    else 1
+                )
                 selected = select_chunks(
                     importance,
                     keep_pct=effective_keep,
                     backbone_pct=effective_backbone,
+                    chunk_size=effective_chunk_size,
+                    halo_chunks=effective_halo_chunks,
+                    anchor_chunks=effective_anchor_chunks,
                 )
                 n_selected = selected.shape[0]
                 n_total = len(specprefill_tokens)

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -7,8 +7,10 @@ performance when serving a single user at a time.
 """
 
 import asyncio
+import copy
 import contextvars
 import hashlib
+import inspect
 import logging
 import os
 import threading
@@ -37,8 +39,23 @@ from ..specprefill import (
     SPECPREFILL_SELECTOR_VERSION,
     SpecPrefillDecision,
     SpecPrefillPolicy,
+    build_selection_plan,
     resolve_specprefill_decision,
 )
+from ..specprefill_cache import (
+    SparseCacheIdentity,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from ..specprefill_generation_context import SparseGenerationForwardContext
+from ..specprefill_positions import (
+    TargetPositionAdapter,
+    TargetPositionError,
+    resolve_target_position_adapter,
+)
+from ..specprefill_selection import RotatingTailRequirement, SelectionPlan
+from ..specprefill_target_executor import execute_sparse_target_prefill
+from ..specprefill_target_hooks import TargetPositionHooks
 from ..specprefill_profiles import (
     EMPTY_SPECPREFILL_PROFILE_REGISTRY,
     SpecPrefillCell,
@@ -110,6 +127,82 @@ def _sample_with_processors(
     logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
     tok = sampler(logprobs)
     return tok, logprobs
+
+
+def _new_sparse_detokenizer(tokenizer: Any) -> Any:
+    """Create a request-local mlx-lm-compatible incremental detokenizer."""
+    detokenizer = getattr(tokenizer, "detokenizer", None)
+    for name in ("reset", "add_token", "finalize"):
+        if not callable(getattr(detokenizer, name, None)):
+            raise TargetPositionError(
+                "tokenizer lacks the incremental detokenizer required by sparse decode"
+            )
+    detokenizer.reset()
+    # Access once during admission so a malformed implementation fails before
+    # scorer/RNG state advances.
+    if not isinstance(getattr(detokenizer, "last_segment", None), str):
+        raise TargetPositionError("incremental detokenizer last_segment must be text")
+    return detokenizer
+
+
+def _build_text_tokenizer(processor: Any) -> Any:
+    """Build the mlx-lm tokenizer contract from an mlx-vlm processor.
+
+    mlx-vlm installs the artifact-aware streaming detokenizer on the processor,
+    while ``processor.tokenizer`` is the raw Hugging Face tokenizer.  Dense and
+    sparse text-model generation must receive the same mlx-lm ``TokenizerWrapper``
+    so each request gets an isolated detokenizer with identical token semantics.
+    """
+    from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+    raw_tokenizer = getattr(processor, "tokenizer", None)
+    template = getattr(processor, "detokenizer", None)
+    if raw_tokenizer is None or template is None:
+        raise TargetPositionError(
+            "MLLM text routing requires processor.tokenizer and processor.detokenizer"
+        )
+    for name in ("reset", "add_token", "finalize"):
+        if not callable(getattr(template, name, None)):
+            raise TargetPositionError(
+                "MLLM processor detokenizer does not implement streaming semantics"
+            )
+
+    def _detokenizer_factory(_tokenizer):
+        detokenizer = copy.copy(template)
+        detokenizer.reset()
+        return detokenizer
+
+    eos_ids = getattr(processor, "eos_token_ids", None)
+    if eos_ids is None:
+        eos_ids = getattr(raw_tokenizer, "eos_token_ids", None)
+    if eos_ids is None:
+        eos_ids = getattr(raw_tokenizer, "eos_token_id", None)
+    if isinstance(eos_ids, int):
+        eos_ids = (eos_ids,)
+    return TokenizerWrapper(
+        raw_tokenizer,
+        detokenizer_class=_detokenizer_factory,
+        eos_token_ids=eos_ids,
+    )
+
+
+def _detokenize_sparse_token(
+    detokenizer: Any,
+    token: int,
+    eos_ids: frozenset[int],
+    *,
+    terminal: bool,
+) -> tuple[str, bool]:
+    """Detokenize one sampled token while suppressing EOS token text."""
+    is_eos = token in eos_ids
+    if not is_eos:
+        detokenizer.add_token(token)
+    if terminal or is_eos:
+        detokenizer.finalize()
+    segment = detokenizer.last_segment
+    if not isinstance(segment, str):
+        raise TargetPositionError("incremental detokenizer emitted non-text output")
+    return segment, is_eos
 
 
 def _processors_can_retire(processors: list[Any] | None) -> bool:
@@ -541,6 +634,193 @@ class SimpleEngine(BaseEngine):
         )
 
     @staticmethod
+    def _callable_supports_forward_context(callable_obj: Any) -> bool:
+        """Require an explicit mlx-lm continuation seam, never ``**kwargs``.
+
+        Sparse target cache state has different logical and physical lengths.
+        Forwarding it through an unverified compatibility ``**kwargs`` path
+        risks silently dropping the request-local position context.
+        """
+        try:
+            parameters = inspect.signature(callable_obj).parameters
+        except (TypeError, ValueError):
+            return False
+        return "model_forward_context" in parameters
+
+    def _supports_sparse_continuation(self, continuation: Any) -> bool:
+        """Check every continuation boundary that must retain sparse state."""
+        try:
+            from mlx_lm import stream_generate as mlx_stream_generate
+        except ImportError:
+            return False
+        return self._callable_supports_forward_context(
+            continuation
+        ) and self._callable_supports_forward_context(mlx_stream_generate)
+
+    @staticmethod
+    def _control_token_indices(tokenizer: Any, tokens: list[int]) -> tuple[int, ...]:
+        """Return only tokenizer-declared control-token positions."""
+        candidates: set[int] = set()
+        special = getattr(tokenizer, "all_special_ids", ())
+        if isinstance(special, (list, tuple, set)):
+            candidates.update(
+                value
+                for value in special
+                if isinstance(value, int) and not isinstance(value, bool)
+            )
+        for name in ("bos_token_id", "eos_token_id", "pad_token_id"):
+            value = getattr(tokenizer, name, None)
+            if isinstance(value, int) and not isinstance(value, bool):
+                candidates.add(value)
+        return tuple(index for index, token in enumerate(tokens) if token in candidates)
+
+    @staticmethod
+    def _eos_token_ids(tokenizer: Any) -> frozenset[int]:
+        """Normalize single- and multi-EOS tokenizer contracts safely."""
+        values = getattr(tokenizer, "eos_token_ids", None)
+        if not isinstance(values, (list, tuple, set)):
+            values = (getattr(tokenizer, "eos_token_id", None),)
+        return frozenset(
+            value
+            for value in values
+            if isinstance(value, int) and not isinstance(value, bool)
+        )
+
+    @staticmethod
+    def _rotating_tail_requirement(cache: list[Any]) -> RotatingTailRequirement | None:
+        """Preserve the declared tail of every rotating target cache layer."""
+        maxima: list[int] = []
+        for entry in cache:
+            if type(entry).__name__ != "RotatingKVCache":
+                continue
+            maximum = getattr(entry, "max_size", None)
+            if (
+                not isinstance(maximum, int)
+                or isinstance(maximum, bool)
+                or maximum <= 0
+            ):
+                raise TargetPositionError("rotating cache lacks a positive max_size")
+            maxima.append(maximum)
+        return RotatingTailRequirement(max(maxima)) if maxima else None
+
+    def _admit_sparse_target(
+        self, target_model: Any
+    ) -> tuple[SpecPrefillProfileKey, TargetPositionAdapter]:
+        """Resolve artifact/adapter/hook compatibility before scorer work."""
+        profile_key = self._active_specprefill_profile_key(combined_mtp=False)
+        if profile_key is None:
+            raise TargetPositionError("exact sparse cache identity is unavailable")
+        adapter = resolve_target_position_adapter(target_model)
+        if profile_key.adapter_id != adapter.adapter_id:
+            raise TargetPositionError(
+                "qualified profile adapter does not match the target position adapter"
+            )
+        # Installation is topology-preserving and immutable.  Doing it here
+        # guarantees executor admission before scorer/RNG state can advance.
+        TargetPositionHooks.for_model(target_model, adapter)
+        return profile_key, adapter
+
+    def _prepare_sparse_target_prefill(
+        self,
+        *,
+        target_model: Any,
+        tokenizer: Any,
+        tokens: list[int],
+        importance: Any,
+        cache: list[Any],
+        telemetry: _SpecPrefillTelemetry,
+        keep_pct: float,
+        backbone_pct: float,
+        chunk_size: int,
+        halo_chunks: int,
+        anchor_chunks: int,
+        profile_key: SpecPrefillProfileKey,
+        adapter: TargetPositionAdapter,
+        cancel_check: Any | None = None,
+    ) -> tuple[Any, SparseGenerationForwardContext, SelectionPlan]:
+        """Build exact sparse state and run a fresh target prefill atomically.
+
+        This is intentionally the only SimpleEngine entry point to the new
+        executor.  It rejects missing artifact identity and any non-fresh
+        target cache before a sparse token can be emitted.
+        """
+        if not tokens:
+            raise TargetPositionError("SpecPrefill requires a non-empty prompt")
+        if profile_key.adapter_id != adapter.adapter_id:
+            raise TargetPositionError("sparse profile/adapter admission changed")
+        tuning = SparsePolicyTuning(
+            keep_pct=keep_pct,
+            backbone_pct=backbone_pct,
+            halo_chunks=halo_chunks,
+            anchor_chunks=anchor_chunks,
+            chunk_size=chunk_size,
+        )
+        plan = build_selection_plan(
+            importance,
+            keep_pct=keep_pct,
+            backbone_pct=backbone_pct,
+            chunk_size=chunk_size,
+            halo_chunks=halo_chunks,
+            anchor_chunks=anchor_chunks,
+            control_token_indices=tuple(
+                sorted(
+                    set(self._control_token_indices(tokenizer, tokens))
+                    | {0, len(tokens) - 1}
+                )
+            ),
+            rotating_tail_requirement=self._rotating_tail_requirement(cache),
+        )
+        if (
+            plan.selected_indices[0] != 0
+            or plan.selected_indices[-1] != len(tokens) - 1
+        ):
+            raise TargetPositionError(
+                "selection plan must retain the first and final prompt tokens"
+            )
+        if (
+            telemetry.profile_selector_version is not None
+            and telemetry.profile_selector_version != plan.selector_version
+        ):
+            raise TargetPositionError(
+                "calibrated selector version does not match the executed selection plan"
+            )
+        identity = SparseCacheIdentity.from_tokens(
+            target_id=(
+                f"{profile_key.target_artifact_id}@{profile_key.target_artifact_hash}"
+                f"#adapter={adapter.adapter_id}"
+            ),
+            tokenizer_id=f"sha256:{profile_key.tokenizer_artifact_hash}",
+            scorer_id=f"{profile_key.scorer_artifact_id}@{profile_key.scorer_artifact_hash}",
+            selector_version=plan.selector_version,
+            tuning=tuning,
+            tokens=tokens,
+            selection_fingerprint=plan.fingerprint,
+        )
+        sparse_state = SparseCacheState.from_selection(
+            identity,
+            (plan.selected_indices,),
+            (len(tokens),),
+        )
+        result = execute_sparse_target_prefill(
+            target_model,
+            [tokens[index] for index in plan.selected_indices],
+            cache,
+            sparse_state,
+            adapter,
+            step_size=self._prefill_step_size,
+            cancel_check=cancel_check,
+        )
+        telemetry.selected_tokens = result.telemetry.selected_tokens
+        telemetry.target_prefill_ms = result.telemetry.target_prefill_ms
+        return (
+            result,
+            SparseGenerationForwardContext(
+                target_model, cache, result.cache_state, adapter
+            ),
+            plan,
+        )
+
+    @staticmethod
     def _specprefill_dense_fallback(
         decision: SpecPrefillDecision, reason: str | None
     ) -> SpecPrefillDecision:
@@ -832,7 +1112,9 @@ class SimpleEngine(BaseEngine):
                     )
 
                     if self._text_model is not None:
-                        self._text_tokenizer = self._model.get_tokenizer()
+                        self._text_tokenizer = _build_text_tokenizer(
+                            self._model.processor
+                        )
                         self._supports_system_kv_cache = (
                             self._probe_system_kv_cache_support(
                                 self._text_model,
@@ -845,6 +1127,9 @@ class SimpleEngine(BaseEngine):
                             self._text_tokenizer.eos_token = "<|im_end|>"
                             self._text_tokenizer.eos_token_id = (
                                 self._text_tokenizer.convert_tokens_to_ids("<|im_end|>")
+                            )
+                            self._text_tokenizer.eos_token_ids = (
+                                self._text_tokenizer.eos_token_id,
                             )
 
                         # Probe the derived TextModel's prompt cache for snapshot-safety
@@ -1252,6 +1537,21 @@ class SimpleEngine(BaseEngine):
         # SpecPrefill is independent from MTP. The direct path is used only
         # for non-MLLM requests; the MLLM text route resolves the same contract
         # in _stream_generate_text.
+        if (
+            not self._is_mllm
+            and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
+            and max_tokens <= 0
+        ):
+            telemetry.fallback("sparse_no_completion_requested")
+        if (
+            not self._is_mllm
+            and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
+            and self._mtp
+        ):
+            # Sparse-only is independently qualified first. Native/external
+            # MTP composition cannot borrow this cache/position state yet.
+            telemetry.fallback("mtp_composition_not_implemented")
+
         if (
             not self._is_mllm
             and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
@@ -2251,7 +2551,7 @@ class SimpleEngine(BaseEngine):
         specprefill_anchor_chunks: int | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
-        """SpecPrefill path for non-MTP models (Nemotron, GPT-OSS, etc).
+        """Sparse-only path using request-local target position transport.
 
         Scores token importance with the draft model, sparse-prefills the target
         model, then generates autoregressively. Falls back to normal generation
@@ -2282,6 +2582,7 @@ class SimpleEngine(BaseEngine):
         loop = asyncio.get_running_loop()
         response_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         sparse_output_committed = False
+        sparse_decode_transaction_started = False
 
         def _emit_response(resp: Any) -> None:
             if not cancel_requested.is_set():
@@ -2306,7 +2607,7 @@ class SimpleEngine(BaseEngine):
             except _SpecPrefillCancelled:
                 raise
             except Exception as e:
-                if sparse_output_committed:
+                if sparse_output_committed or sparse_decode_transaction_started:
                     raise
                 logger.error("SpecPrefill failed, falling back to normal path: %s", e)
                 telemetry.fallback("sparse_execution_failed")
@@ -2314,6 +2615,7 @@ class SimpleEngine(BaseEngine):
 
         def _run_specprefill():
             """Score tokens, sparse prefill, generate autoregressively."""
+            nonlocal sparse_decode_transaction_started
             import time
             from types import SimpleNamespace
 
@@ -2321,151 +2623,172 @@ class SimpleEngine(BaseEngine):
             from mlx_lm.models.cache import make_prompt_cache
             from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
-            from ..specprefill import (
-                cleanup_rope,
-                score_tokens,
-                select_chunks,
-                sparse_prefill,
+            from ..specprefill import score_tokens
+
+            if not self._supports_sparse_continuation(self._model.stream_generate):
+                raise TargetPositionError(
+                    "mlx-lm does not expose model_forward_context continuation"
+                )
+
+            profile_key, adapter = self._admit_sparse_target(model)
+            detokenizer = _new_sparse_detokenizer(tokenizer)
+            top_k = kwargs.get("top_k", 0)
+            min_p = kwargs.get("min_p", 0.0)
+            presence_penalty = kwargs.get("presence_penalty", 0.0)
+            repetition_penalty = kwargs.get("repetition_penalty", 1.0)
+            sampler = make_sampler(
+                temp=temperature, top_p=top_p, top_k=top_k, min_p=min_p
+            )
+            penalty_processors = make_logits_processors(
+                repetition_penalty=(
+                    repetition_penalty if repetition_penalty != 1.0 else None
+                ),
+                presence_penalty=(
+                    presence_penalty if presence_penalty != 0.0 else None
+                ),
+            )
+            all_processors = (kwargs.get("logits_processors") or []) + (
+                penalty_processors or []
+            )
+            seeded_processors = _seed_logits_processors(
+                mx.array(tokens, dtype=mx.uint32), all_processors
             )
 
             cache = make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
 
+            # Phase 1: Score with draft model
+            t0 = time.monotonic()
+            importance = score_tokens(
+                self._draft_model,
+                tokens,
+                prefill_step_size=self._prefill_step_size,
+                cancel_check=_cancel_check,
+            )
+            t_score = time.monotonic() - t0
+            telemetry.scorer_ms = t_score * 1000
+
+            # Phase 2/3: semantic selection and request-local target prefill.
+            _cancel_check()
+            effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
+            effective_backbone = (
+                specprefill_backbone_pct
+                if specprefill_backbone_pct is not None
+                else self._specprefill_backbone_pct
+            )
+            effective_chunk_size = specprefill_chunk_size or 32
+            effective_halo_chunks = (
+                specprefill_halo_chunks if specprefill_halo_chunks is not None else 1
+            )
+            effective_anchor_chunks = (
+                specprefill_anchor_chunks
+                if specprefill_anchor_chunks is not None
+                else 1
+            )
+            result, forward_context, plan = self._prepare_sparse_target_prefill(
+                target_model=model,
+                tokenizer=tokenizer,
+                tokens=tokens,
+                importance=importance,
+                cache=cache,
+                telemetry=telemetry,
+                keep_pct=effective_keep,
+                backbone_pct=effective_backbone,
+                chunk_size=effective_chunk_size,
+                halo_chunks=effective_halo_chunks,
+                anchor_chunks=effective_anchor_chunks,
+                profile_key=profile_key,
+                adapter=adapter,
+                cancel_check=_cancel_check,
+            )
+            logits = result.logits
+            n_selected = len(plan.selected_indices)
+            t_prefill = (telemetry.target_prefill_ms or 0.0) / 1000.0
+
+            logger.info(
+                "SpecPrefill: scored %d tokens in %.1fs, sparse prefill %d/%d "
+                "(keep=%.0f%%) in %.1fs",
+                n_tokens,
+                t_score,
+                n_selected,
+                n_tokens,
+                n_selected / n_tokens * 100,
+                t_prefill,
+            )
+
+            # Sample the seed under the complete prompt history, then retain
+            # request-local sparse positions for every continuation forward.
+            _cancel_check()
             try:
-                # Phase 1: Score with draft model
-                t0 = time.monotonic()
-                importance = score_tokens(
-                    self._draft_model,
-                    tokens,
-                    prefill_step_size=self._prefill_step_size,
-                    cancel_check=_cancel_check,
-                )
-                t_score = time.monotonic() - t0
-                telemetry.scorer_ms = t_score * 1000
-
-                # Phase 2: Select important chunks
-                _cancel_check()
-                effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
-                effective_backbone = (
-                    specprefill_backbone_pct
-                    if specprefill_backbone_pct is not None
-                    else self._specprefill_backbone_pct
-                )
-                effective_chunk_size = specprefill_chunk_size or 32
-                effective_halo_chunks = (
-                    specprefill_halo_chunks
-                    if specprefill_halo_chunks is not None
-                    else 1
-                )
-                effective_anchor_chunks = (
-                    specprefill_anchor_chunks
-                    if specprefill_anchor_chunks is not None
-                    else 1
-                )
-                selected = select_chunks(
-                    importance,
-                    keep_pct=effective_keep,
-                    backbone_pct=effective_backbone,
-                    chunk_size=effective_chunk_size,
-                    halo_chunks=effective_halo_chunks,
-                    anchor_chunks=effective_anchor_chunks,
-                )
-                n_selected = selected.shape[0]
-                telemetry.selected_tokens = int(n_selected)
-
-                # Phase 3: Sparse prefill on target model
-                t0 = time.monotonic()
-                logits = sparse_prefill(
-                    model,
-                    tokens,
-                    selected,
-                    cache,
-                    step_size=self._prefill_step_size,
-                    cancel_check=_cancel_check,
-                )
-                t_prefill = time.monotonic() - t0
-                telemetry.target_prefill_ms = t_prefill * 1000
-
-                logger.info(
-                    "SpecPrefill: scored %d tokens in %.1fs, "
-                    "sparse prefill %d/%d (keep=%.0f%%) in %.1fs",
-                    n_tokens,
-                    t_score,
-                    n_selected,
-                    n_tokens,
-                    n_selected / n_tokens * 100,
-                    t_prefill,
-                )
-
-                # Phase 4: Sample from the same sampler/processors as dense
-                # generation. The seed sees the complete prompt token history,
-                # then the standard wrapper owns continuation sampling.
-                top_k = kwargs.get("top_k", 0)
-                min_p = kwargs.get("min_p", 0.0)
-                presence_penalty = kwargs.get("presence_penalty", 0.0)
-                repetition_penalty = kwargs.get("repetition_penalty", 1.0)
-                sampler = make_sampler(
-                    temp=temperature,
-                    top_p=top_p,
-                    top_k=top_k,
-                    min_p=min_p,
-                )
-                penalty_processors = make_logits_processors(
-                    repetition_penalty=(
-                        repetition_penalty if repetition_penalty != 1.0 else None
-                    ),
-                    presence_penalty=(
-                        presence_penalty if presence_penalty != 0.0 else None
-                    ),
-                )
-                all_processors = (kwargs.get("logits_processors") or []) + (
-                    penalty_processors or []
-                )
-                seeded_processors = _seed_logits_processors(
-                    mx.array(tokens, dtype=mx.uint32), all_processors
-                )
-                _cancel_check()
+                # Scoring, selection, and fresh-cache target prefill are an
+                # isolated pre-output transaction: failures above this line
+                # may discard the request-local cache and restart dense.  RNG
+                # and logits-processor state become observable as soon as the
+                # first sample begins, so replay is forbidden from here on.
+                sparse_decode_transaction_started = True
                 first_token, _ = _sample_with_processors(
-                    None,
-                    logits[:, -1, :].squeeze(0),
-                    sampler,
-                    seeded_processors,
+                    None, logits[:, -1, :].squeeze(0), sampler, seeded_processors
                 )
                 mx.eval(first_token)
                 first_token_id = first_token.item()
-                first_text = tokenizer.decode([first_token_id])
-                eos_id = tokenizer.eos_token_id
-
-                _emit_sparse_response(
-                    SimpleNamespace(
-                        text=first_text,
-                        finish_reason="stop" if first_token_id == eos_id else None,
-                    )
+                eos_ids = self._eos_token_ids(tokenizer)
+                first_text, first_is_eos = _detokenize_sparse_token(
+                    detokenizer,
+                    first_token_id,
+                    eos_ids,
+                    terminal=max_tokens == 1,
                 )
-
-                if first_token_id != eos_id:
-                    # The wrapper normally builds penalty processors and gives
-                    # user processors only the continuation token sequence.
-                    # Reuse the seeded processors instead so both seed and
-                    # continuation observe the full prompt history, and avoid
-                    # applying the request penalties twice.
-                    continuation_kwargs = dict(kwargs)
-                    continuation_kwargs["logits_processors"] = seeded_processors
-                    continuation_kwargs["presence_penalty"] = 0.0
-                    continuation_kwargs["repetition_penalty"] = 1.0
+            except BaseException:
+                forward_context.finish()
+                raise
+            _emit_sparse_response(
+                SimpleNamespace(
+                    text=first_text,
+                    finish_reason="stop" if first_is_eos else None,
+                )
+            )
+            if not first_is_eos and max_tokens > 1:
+                continuation_kwargs = dict(kwargs)
+                continuation_kwargs["logits_processors"] = seeded_processors
+                continuation_kwargs["presence_penalty"] = 0.0
+                continuation_kwargs["repetition_penalty"] = 1.0
+                continuation_kwargs["model_forward_context"] = forward_context
+                try:
                     for chunk in self._model.stream_generate(
                         prompt=mx.array([first_token_id]),
                         max_tokens=max_tokens - 1,
                         temperature=temperature,
                         top_p=top_p,
-                        stop=stop,
+                        stop=None,
                         prompt_cache=cache,
                         **continuation_kwargs,
                     ):
                         _cancel_check()
-                        _emit_sparse_response(chunk)
-
-            finally:
-                cleanup_rope(model)
+                        token_id = getattr(chunk, "token", None)
+                        if not isinstance(token_id, int) or isinstance(token_id, bool):
+                            raise TargetPositionError(
+                                "sparse continuation must expose integer token IDs"
+                            )
+                        terminal = bool(getattr(chunk, "finished", False))
+                        text, is_eos = _detokenize_sparse_token(
+                            detokenizer,
+                            token_id,
+                            eos_ids,
+                            terminal=terminal,
+                        )
+                        _emit_sparse_response(
+                            SimpleNamespace(
+                                text=text,
+                                finish_reason=(
+                                    "stop"
+                                    if is_eos
+                                    else getattr(chunk, "finish_reason", None)
+                                ),
+                            )
+                        )
+                finally:
+                    forward_context.finish()
+            else:
+                forward_context.finish()
 
         def _run_normal():
             """Fallback: normal generation without specprefill."""
@@ -2505,6 +2828,8 @@ class SimpleEngine(BaseEngine):
                 if kind == "done":
                     break
                 if kind == "error":
+                    if finished and isinstance(payload, _SpecPrefillCancelled):
+                        break
                     raise payload
                 if finished:
                     # The terminal token was already yielded. Drain until the
@@ -2528,6 +2853,8 @@ class SimpleEngine(BaseEngine):
                     finish_reason = "length"
                 elif finish_reason is not None:
                     finished = True
+                if finished:
+                    _request_cancel()
 
                 yield GenerationOutput(
                     text=accumulated_text,
@@ -2651,7 +2978,12 @@ class SimpleEngine(BaseEngine):
         )
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
         custom_logits_active = bool(all_processors)
-        combined_mtp = _request_can_compose_mtp(combined_mtp, all_processors)
+        combined_mtp = (
+            _request_can_compose_mtp(combined_mtp, all_processors)
+            and self._text_model is not None
+            and getattr(self._text_model, "mtp", None) is not None
+        )
+        sparse_no_completion_requested = max_tokens == 0
         max_tokens = max_tokens or 4096
 
         # --- System prompt KV caching ---
@@ -2836,10 +3168,31 @@ class SimpleEngine(BaseEngine):
         use_specprefill = (
             telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
         )
+        # Sparse target execution starts with an empty target cache.  A saved
+        # system prefix has a different physical/logical topology, and MTP
+        # cache pairing is intentionally qualified separately.
+        if use_specprefill and sparse_no_completion_requested:
+            telemetry.fallback("sparse_no_completion_requested")
+            use_specprefill = False
+        elif use_specprefill and combined_mtp:
+            telemetry.fallback("mtp_composition_not_implemented")
+            use_specprefill = False
+        elif use_specprefill and (backbone_cache is not None or system_token_count):
+            telemetry.fallback("sparse_prefix_cache_not_supported")
+            use_specprefill = False
+        elif use_specprefill and not self._supports_sparse_continuation(
+            mlx_stream_generate
+        ):
+            telemetry.fallback("sparse_forward_context_unavailable")
+            use_specprefill = False
+        elif use_specprefill and _processors_can_retire(all_processors):
+            telemetry.fallback("sparse_processor_retirement_unsupported")
+            use_specprefill = False
 
         loop = asyncio.get_running_loop()
         response_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         sparse_output_committed = False
+        sparse_decode_transaction_started = False
 
         def _emit_response(resp: Any) -> None:
             if abort_event.is_set():
@@ -2902,20 +3255,20 @@ class SimpleEngine(BaseEngine):
 
         # Run all Metal ops in a single serialized thread.
         def _run_all():
-            nonlocal backbone_cache, prompt_to_send
+            nonlocal backbone_cache, prompt_to_send, use_specprefill
 
             model = self._text_model
             can_retire_processors = _processors_can_retire(all_processors)
             use_mtp = (
-                self._mtp
-                and not custom_logits_active
-                and hasattr(model, "mtp")
-                and model.mtp is not None
+                combined_mtp and not custom_logits_active and model.mtp is not None
             )
             if self._mtp and custom_logits_active:
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
                 )
+            if use_specprefill and use_mtp:
+                telemetry.fallback("mtp_composition_not_implemented")
+                use_specprefill = False
 
             # Cache MISS with valid prefix: prefill system tokens and snapshot
             if (
@@ -2980,7 +3333,11 @@ class SimpleEngine(BaseEngine):
                     _run_specprefill(model, backbone_cache, use_mtp)
                     return
                 except Exception as e:
-                    if sparse_output_committed or abort_event.is_set():
+                    if (
+                        sparse_output_committed
+                        or sparse_decode_transaction_started
+                        or abort_event.is_set()
+                    ):
                         raise
                     logger.error(
                         "SpecPrefill failed, falling back to normal MTP path: %s",
@@ -3069,170 +3426,141 @@ class SimpleEngine(BaseEngine):
                     _emit_response(resp)
 
         def _run_specprefill(model, bc, use_mtp):
-            """Score tokens, sparse prefill, then continue on the standard decode path."""
+            """Run sparse-only target prefill and retain its forward context."""
+            nonlocal sparse_decode_transaction_started
             from types import SimpleNamespace
 
             from mlx_lm import stream_generate as mlx_stream_generate
             from mlx_lm.models.cache import make_prompt_cache
 
-            from ..specprefill import (
-                cleanup_rope,
-                score_tokens,
-                select_chunks,
-                sparse_prefill,
+            from ..specprefill import score_tokens
+
+            if bc is not None or use_mtp:
+                raise TargetPositionError(
+                    "sparse-only target prefill requires fresh cache"
+                )
+            profile_key, adapter = self._admit_sparse_target(model)
+            detokenizer = _new_sparse_detokenizer(self._text_tokenizer)
+            seed_tokens = (
+                mx.array(full_tokens_list, dtype=mx.uint32)
+                if full_tokens_list is not None
+                else None
+            )
+            seeded_processors = _seed_logits_processors(seed_tokens, all_processors)
+            cache = make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
+            import time
+
+            def _cancel_check() -> None:
+                if abort_event.is_set():
+                    raise _SpecPrefillCancelled()
+
+            t0 = time.monotonic()
+            importance = score_tokens(
+                self._draft_model,
+                specprefill_tokens,
+                prefill_step_size=self._prefill_step_size,
+                cancel_check=_cancel_check,
+            )
+            t_score = time.monotonic() - t0
+            telemetry.scorer_ms = t_score * 1000
+            effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
+            effective_backbone = (
+                specprefill_backbone_pct
+                if specprefill_backbone_pct is not None
+                else self._specprefill_backbone_pct
+            )
+            effective_chunk_size = specprefill_chunk_size or 32
+            effective_halo_chunks = (
+                specprefill_halo_chunks if specprefill_halo_chunks is not None else 1
+            )
+            effective_anchor_chunks = (
+                specprefill_anchor_chunks
+                if specprefill_anchor_chunks is not None
+                else 1
+            )
+            result, forward_context, plan = self._prepare_sparse_target_prefill(
+                target_model=model,
+                tokenizer=self._text_tokenizer,
+                tokens=specprefill_tokens,
+                importance=importance,
+                cache=cache,
+                telemetry=telemetry,
+                keep_pct=effective_keep,
+                backbone_pct=effective_backbone,
+                chunk_size=effective_chunk_size,
+                halo_chunks=effective_halo_chunks,
+                anchor_chunks=effective_anchor_chunks,
+                profile_key=profile_key,
+                adapter=adapter,
+                cancel_check=_cancel_check,
+            )
+            logits = result.logits
+            n_selected = len(plan.selected_indices)
+            n_total = len(specprefill_tokens)
+            t_prefill = (telemetry.target_prefill_ms or 0.0) / 1000.0
+
+            logger.info(
+                "SpecPrefill: scored %d tokens in %.1fs, sparse prefill %d/%d "
+                "(keep=%.0f%%) in %.1fs",
+                n_total,
+                t_score,
+                n_selected,
+                n_total,
+                n_selected / n_total * 100,
+                t_prefill,
             )
 
-            # Create backbone cache if not already from system KV
-            if bc is None:
-                bc = make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
-
+            # Phase 4: Sample the first token from the prefilled logits, then
+            # continue through mlx_lm with the request-local forward context.
+            eos_ids = self._eos_token_ids(self._text_tokenizer)
             try:
-                # Phase 1: Score with draft model
-                import time
-
-                t0 = time.monotonic()
-                importance = score_tokens(
-                    self._draft_model,
-                    specprefill_tokens,
-                    prefill_step_size=self._prefill_step_size,
-                )
-                t_score = time.monotonic() - t0
-                telemetry.scorer_ms = t_score * 1000
-
-                # Phase 2: Select important chunks
-                effective_keep = specprefill_keep_pct or self._specprefill_keep_pct
-                effective_backbone = (
-                    specprefill_backbone_pct
-                    if specprefill_backbone_pct is not None
-                    else self._specprefill_backbone_pct
-                )
-                effective_chunk_size = specprefill_chunk_size or 32
-                effective_halo_chunks = (
-                    specprefill_halo_chunks
-                    if specprefill_halo_chunks is not None
-                    else 1
-                )
-                effective_anchor_chunks = (
-                    specprefill_anchor_chunks
-                    if specprefill_anchor_chunks is not None
-                    else 1
-                )
-                selected = select_chunks(
-                    importance,
-                    keep_pct=effective_keep,
-                    backbone_pct=effective_backbone,
-                    chunk_size=effective_chunk_size,
-                    halo_chunks=effective_halo_chunks,
-                    anchor_chunks=effective_anchor_chunks,
-                )
-                n_selected = selected.shape[0]
-                n_total = len(specprefill_tokens)
-                telemetry.selected_tokens = specprefill_offset + int(n_selected)
-
-                # Phase 3: Sparse prefill on target model
-                t0 = time.monotonic()
-                logits = sparse_prefill(
-                    model,
-                    specprefill_tokens,
-                    selected,
-                    bc,
-                    step_size=self._prefill_step_size,
-                    position_offset=specprefill_offset,
-                )
-                t_prefill = time.monotonic() - t0
-                telemetry.target_prefill_ms = t_prefill * 1000
-
-                logger.info(
-                    "SpecPrefill: scored %d tokens in %.1fs, "
-                    "sparse prefill %d/%d (keep=%.0f%%) in %.1fs "
-                    "(offset=%d, effective_keep=%.2f)",
-                    n_total,
-                    t_score,
-                    n_selected,
-                    n_total,
-                    n_selected / n_total * 100,
-                    t_prefill,
-                    specprefill_offset,
-                    effective_keep,
-                )
-
-                # Phase 4: Sample the first token from the prefilled logits, then
-                # continue through mlx_lm's normal decode path so MTP and request-
-                # local logits processors remain active after sparse prefill.
-                eos_id = self._text_tokenizer.eos_token_id
-                seed_tokens = (
-                    mx.array(full_tokens_list, dtype=mx.uint32)
-                    if full_tokens_list is not None
-                    else None
-                )
-                seeded_processors = _seed_logits_processors(seed_tokens, all_processors)
+                # Sampling is the exact no-replay boundary.  Everything above
+                # uses request-local scorer/target state and can be discarded
+                # for a dense retry; sampler/processor state cannot.
+                sparse_decode_transaction_started = True
                 y, _ = _sample_with_processors(
-                    None,
-                    logits[:, -1, :].squeeze(0),
-                    sampler,
-                    seeded_processors,
+                    None, logits[:, -1, :].squeeze(0), sampler, seeded_processors
                 )
                 mx.eval(y)
-
-                generated_ids = []
-                prev_decoded = ""
-
                 tok_id = y.item()
-                generated_ids.append(tok_id)
-
-                decoded = self._text_tokenizer.decode(generated_ids)
-                new_text = decoded[len(prev_decoded) :]
-                prev_decoded = decoded
-
-                is_eos = tok_id == eos_id
-                _emit_sparse_response(
-                    SimpleNamespace(
-                        text=new_text,
-                        finish_reason="stop" if is_eos else None,
-                    )
+                new_text, is_eos = _detokenize_sparse_token(
+                    detokenizer,
+                    tok_id,
+                    eos_ids,
+                    terminal=max_tokens == 1,
                 )
-
-                if abort_event.is_set():
-                    logger.info(
-                        "SpecPrefill text route: abort requested after seed token"
-                    )
-                    return
-
-                if is_eos or max_tokens <= 1:
-                    return
-
-                prompt_cache = bc
-                if use_mtp and hasattr(model, "make_mtp_cache"):
-                    prompt_cache = bc + model.make_mtp_cache()
-
-                continuation_prompt = mx.array([tok_id], dtype=mx.uint32)
-                token_count = 1
-                if _processors_retired(all_processors) and token_count < max_tokens:
-                    logger.info(
-                        "SpecPrefill text route: request-local processor retired after seed token; "
-                        "resuming content phase with MTP=%s",
-                        hasattr(model, "make_mtp_cache") and model.mtp is not None,
-                    )
-                    _resume_after_processor_retirement(
-                        model,
-                        bc,
-                        continuation_prompt,
-                        max_tokens - token_count,
-                        emit_response=_emit_sparse_response,
-                    )
-                    return
-
-                last_resp = None
-                retired = False
-                continuation_kwargs = dict(
-                    max_tokens=max_tokens - token_count,
-                    sampler=sampler,
-                    prefill_step_size=self._prefill_step_size,
-                    logits_processors=seeded_processors,
-                    prompt_cache=prompt_cache,
+            except BaseException:
+                forward_context.finish()
+                raise
+            _emit_sparse_response(
+                SimpleNamespace(
+                    text=new_text,
+                    finish_reason=(
+                        "stop" if is_eos else "length" if max_tokens <= 1 else None
+                    ),
                 )
-                if use_mtp:
-                    continuation_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+            )
+
+            if abort_event.is_set():
+                logger.info("SpecPrefill text route: abort requested after seed token")
+                forward_context.finish()
+                return
+
+            if is_eos or max_tokens <= 1:
+                forward_context.finish()
+                return
+
+            continuation_prompt = mx.array([tok_id], dtype=mx.uint32)
+            token_count = 1
+            continuation_kwargs = dict(
+                max_tokens=max_tokens - token_count,
+                sampler=sampler,
+                prefill_step_size=self._prefill_step_size,
+                logits_processors=seeded_processors,
+                prompt_cache=cache,
+                model_forward_context=forward_context,
+            )
+            try:
                 for resp in mlx_stream_generate(
                     model,
                     self._text_tokenizer,
@@ -3244,31 +3572,32 @@ class SimpleEngine(BaseEngine):
                             "SpecPrefill text route: abort requested; stopping decode"
                         )
                         break
-                    _emit_sparse_response(resp)
-                    token_count += 1
-                    last_resp = resp
-                    retired = _processors_retired(all_processors)
-                    if retired:
-                        logger.info(
-                            "SpecPrefill text route: request-local processor retired after %d tokens; "
-                            "resuming content phase with MTP=%s",
-                            token_count,
-                            hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                    response_token = getattr(resp, "token", None)
+                    if not isinstance(response_token, int) or isinstance(
+                        response_token, bool
+                    ):
+                        raise TargetPositionError(
+                            "sparse continuation must expose integer token IDs"
                         )
-                        break
-
-                if retired and token_count < max_tokens and last_resp is not None:
-                    seed = _seed_from_last_response(bc, last_resp)
-                    _resume_after_processor_retirement(
-                        model,
-                        bc,
-                        seed,
-                        max_tokens - token_count,
-                        emit_response=_emit_sparse_response,
+                    terminal = getattr(resp, "finish_reason", None) is not None
+                    text, response_is_eos = _detokenize_sparse_token(
+                        detokenizer,
+                        response_token,
+                        eos_ids,
+                        terminal=terminal,
                     )
-
+                    _emit_sparse_response(
+                        SimpleNamespace(
+                            text=text,
+                            finish_reason=(
+                                "stop"
+                                if response_is_eos
+                                else getattr(resp, "finish_reason", None)
+                            ),
+                        )
+                    )
             finally:
-                cleanup_rope(model)
+                forward_context.finish()
 
         async def _produce_responses() -> None:
             try:
@@ -3295,6 +3624,8 @@ class SimpleEngine(BaseEngine):
                 if kind == "done":
                     break
                 if kind == "error":
+                    if finished and isinstance(payload, _SpecPrefillCancelled):
+                        break
                     raise payload
                 if finished:
                     # Drain producer completion after a terminal sparse token
@@ -3317,6 +3648,8 @@ class SimpleEngine(BaseEngine):
                     finish_reason = "stop"
                 elif finish_reason is not None:
                     finished = True
+                if finished:
+                    abort_event.set()
 
                 yield GenerationOutput(
                     text=accumulated_text,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -267,6 +267,25 @@ class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
 
 
+async def _aclose_async_iterator(
+    iterator: AsyncIterator[Any], primary_error: BaseException | None
+) -> None:
+    """Close a nested async iterator without masking its primary failure."""
+
+    close = getattr(iterator, "aclose", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except BaseException:
+        if primary_error is None:
+            raise
+        logger.warning(
+            "Failed to close nested generation stream after primary error",
+            exc_info=True,
+        )
+
+
 @dataclass
 class _SpecPrefillTelemetry:
     """Mutable, request-local SpecPrefill evidence shared by one stream.
@@ -1438,6 +1457,7 @@ class SimpleEngine(BaseEngine):
             mtp_drafts=last_output.mtp_drafts,
             mtp_accepted=last_output.mtp_accepted,
             mtp_bypass_reason=last_output.mtp_bypass_reason,
+            logprobs=last_output.logprobs,
             specprefill_requested_policy=last_output.specprefill_requested_policy,
             specprefill_effective_policy=last_output.specprefill_effective_policy,
             specprefill_coverage=last_output.specprefill_coverage,
@@ -1481,8 +1501,15 @@ class SimpleEngine(BaseEngine):
         consumed inside this method, so there is no value to preserve.
         """
         if _in_tracker.get():
-            async for output in source_gen:
-                yield output
+            primary_error: BaseException | None = None
+            try:
+                async for output in source_gen:
+                    yield output
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                await _aclose_async_iterator(source_gen, primary_error)
             return
         _in_tracker.set(True)
         request_id = str(uuid.uuid4())
@@ -1506,6 +1533,7 @@ class SimpleEngine(BaseEngine):
         }
         self._active_requests[request_id] = entry
         self._num_running += 1
+        primary_error: BaseException | None = None
         try:
             async for output in source_gen:
                 now = time.time()
@@ -1526,16 +1554,22 @@ class SimpleEngine(BaseEngine):
                     gen_elapsed = max(1e-3, (now - start) - ttft_s)
                     entry["tokens_per_second"] = round(last_c / gen_elapsed, 1)
                 yield output
+        except BaseException as exc:
+            primary_error = exc
+            raise
         finally:
-            self._active_requests.pop(request_id, None)
-            self._num_running = max(0, self._num_running - 1)
-            if last_c > 0:
-                duration = time.time() - start
-                self._total_requests_processed += 1
-                self._total_prompt_tokens += last_p
-                self._total_completion_tokens += last_c
-                self._recent_completions.append((last_c, duration))
-            _in_tracker.set(False)
+            try:
+                await _aclose_async_iterator(source_gen, primary_error)
+            finally:
+                self._active_requests.pop(request_id, None)
+                self._num_running = max(0, self._num_running - 1)
+                if last_c > 0:
+                    duration = time.time() - start
+                    self._total_requests_processed += 1
+                    self._total_prompt_tokens += last_p
+                    self._total_completion_tokens += last_c
+                    self._recent_completions.append((last_c, duration))
+                _in_tracker.set(False)
 
     async def stream_generate(
         self,
@@ -1547,7 +1581,7 @@ class SimpleEngine(BaseEngine):
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Public stream-generate wrapper with request stats tracking."""
-        async for output in self._track_request_stream(
+        tracked = self._track_request_stream(
             self._stream_generate_impl(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1557,8 +1591,16 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ),
             max_tokens=max_tokens,
-        ):
-            yield output
+        )
+        primary_error: BaseException | None = None
+        try:
+            async for output in tracked:
+                yield output
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            await _aclose_async_iterator(tracked, primary_error)
 
     async def _stream_generate_impl(
         self,
@@ -1703,7 +1745,7 @@ class SimpleEngine(BaseEngine):
                     native_mtp_kwargs["native_mtp_request"] = native_mtp_config
                 elif native_mtp_disabled:
                     native_mtp_kwargs["native_mtp_disabled"] = True
-                for chunk in self._model.stream_generate(
+                generation = self._model.stream_generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
                     temperature=temperature,
@@ -1711,49 +1753,73 @@ class SimpleEngine(BaseEngine):
                     stop=stop,
                     **native_mtp_kwargs,
                     **kwargs,
-                ):
-                    prompt_tokens = (
-                        chunk.prompt_tokens
-                        if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
-                        else prompt_tokens
-                    )
-                    completion_tokens += 1
-                    if request_id in self._active_requests:
-                        self._active_requests[request_id].update(
-                            {
-                                "prompt_tokens": prompt_tokens,
-                                "completion_tokens": completion_tokens,
-                                "elapsed_s": round(time.time() - started_at, 1),
-                            }
+                )
+                primary_error: BaseException | None = None
+                try:
+                    for chunk in generation:
+                        prompt_tokens = (
+                            chunk.prompt_tokens
+                            if hasattr(chunk, "prompt_tokens") and chunk.prompt_tokens
+                            else prompt_tokens
                         )
-                    new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                    accumulated_text += new_text
-
-                    finished = (
-                        getattr(chunk, "finished", False)
-                        or completion_tokens >= max_tokens
-                    )
-                    finish_reason = None
-                    if finished:
-                        finish_reason = getattr(chunk, "finish_reason", None)
-                        if finish_reason is None:
-                            finish_reason = (
-                                "length" if completion_tokens >= max_tokens else "stop"
+                        completion_tokens += 1
+                        if request_id in self._active_requests:
+                            self._active_requests[request_id].update(
+                                {
+                                    "prompt_tokens": prompt_tokens,
+                                    "completion_tokens": completion_tokens,
+                                    "elapsed_s": round(time.time() - started_at, 1),
+                                }
                             )
+                        new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
+                        accumulated_text += new_text
 
-                    yield GenerationOutput(
-                        text=accumulated_text,
-                        new_text=new_text,
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        finished=finished,
-                        finish_reason=finish_reason,
-                        mtp_bypass_reason=mtp_bypass_reason,
-                        **telemetry.as_output_kwargs(),
-                    )
+                        finished = (
+                            getattr(chunk, "finished", False)
+                            or completion_tokens >= max_tokens
+                        )
+                        finish_reason = None
+                        if finished:
+                            finish_reason = getattr(chunk, "finish_reason", None)
+                            if finish_reason is None:
+                                finish_reason = (
+                                    "length" if completion_tokens >= max_tokens else "stop"
+                                )
 
-                    if finished:
-                        break
+                        yield GenerationOutput(
+                            text=accumulated_text,
+                            new_text=new_text,
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                            finished=finished,
+                            finish_reason=finish_reason,
+                            mtp_drafts=getattr(chunk, "mtp_drafts", 0),
+                            mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                            mtp_bypass_reason=(
+                                mtp_bypass_reason
+                                or getattr(chunk, "mtp_bypass_reason", None)
+                            ),
+                            logprobs=getattr(chunk, "logprobs", None),
+                            **telemetry.as_output_kwargs(),
+                        )
+
+                        if finished:
+                            break
+                except BaseException as exc:
+                    primary_error = exc
+                    raise
+                finally:
+                    close = getattr(generation, "close", None)
+                    if close is not None:
+                        try:
+                            close()
+                        except BaseException:
+                            if primary_error is None:
+                                raise
+                            logger.warning(
+                                "Failed to close model stream after generation error",
+                                exc_info=True,
+                            )
 
                 if not finished:
                     if prompt_tokens == 0:
@@ -1974,7 +2040,7 @@ class SimpleEngine(BaseEngine):
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """Public stream-chat wrapper with request stats tracking."""
-        async for output in self._track_request_stream(
+        tracked = self._track_request_stream(
             self._stream_chat_impl(
                 messages=messages,
                 max_tokens=max_tokens,
@@ -1986,8 +2052,16 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ),
             max_tokens=max_tokens,
-        ):
-            yield output
+        )
+        primary_error: BaseException | None = None
+        try:
+            async for output in tracked:
+                yield output
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            await _aclose_async_iterator(tracked, primary_error)
 
     async def _stream_chat_impl(
         self,
@@ -2054,7 +2128,7 @@ class SimpleEngine(BaseEngine):
                 kwargs["_native_mtp_disabled"] = True
             elif mtp_bypass_reason is not None:
                 kwargs["_native_mtp_bypass_reason"] = mtp_bypass_reason
-            async for chunk in self._stream_generate_text(
+            text_stream = self._stream_generate_text(
                 messages,
                 max_tokens,
                 temperature,
@@ -2062,8 +2136,16 @@ class SimpleEngine(BaseEngine):
                 tools=template_tools,
                 combined_mtp=use_native_mtp,
                 **kwargs,
-            ):
-                yield chunk
+            )
+            primary_error: BaseException | None = None
+            try:
+                async for chunk in text_stream:
+                    yield chunk
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                await _aclose_async_iterator(text_stream, primary_error)
             return
 
         # Direct MLLM execution (including media) does not implement sparse
@@ -3371,7 +3453,6 @@ class SimpleEngine(BaseEngine):
         ) -> None:
             resume_kwargs = dict(
                 max_tokens=remaining_tokens,
-                sampler=sampler,
                 prefill_step_size=self._prefill_step_size,
                 prompt_cache=prompt_cache,
             )
@@ -3380,6 +3461,8 @@ class SimpleEngine(BaseEngine):
                 # a fresh MTP cache so stale speculative state cannot survive the
                 # processor-to-content handoff.
                 resume_kwargs.update(native_mtp_config.mlx_lm_call_kwargs())
+            else:
+                resume_kwargs["sampler"] = sampler
             for resp in mlx_stream_generate(
                 model,
                 self._text_tokenizer,
@@ -3496,9 +3579,13 @@ class SimpleEngine(BaseEngine):
 
             gen_kwargs = dict(
                 max_tokens=max_tokens,
-                sampler=sampler,
                 prefill_step_size=self._prefill_step_size,
             )
+            if not use_mtp:
+                # Native MTP samples from its immutable request config.  The
+                # ordinary sampler is opaque to transactional replay and must
+                # remain absent from the selected native call.
+                gen_kwargs["sampler"] = sampler
             if all_processors:
                 gen_kwargs["logits_processors"] = all_processors
             if use_mtp:
@@ -3554,16 +3641,34 @@ class SimpleEngine(BaseEngine):
                         max_tokens - token_count,
                     )
             else:
-                for resp in mlx_stream_generate(
+                generation = mlx_stream_generate(
                     model,
                     self._text_tokenizer,
                     prompt=prompt_to_send,
                     **gen_kwargs,
-                ):
-                    if abort_event.is_set():
-                        logger.info("Text route: abort requested; stopping decode")
-                        break
-                    _emit_response(resp)
+                )
+                primary_error: BaseException | None = None
+                try:
+                    for resp in generation:
+                        if abort_event.is_set():
+                            logger.info("Text route: abort requested; stopping decode")
+                            break
+                        _emit_response(resp)
+                except BaseException as exc:
+                    primary_error = exc
+                    raise
+                finally:
+                    close = getattr(generation, "close", None)
+                    if close is not None:
+                        try:
+                            close()
+                        except BaseException:
+                            if primary_error is None:
+                                raise
+                            logger.warning(
+                                "Failed to close mlx-lm text stream after error",
+                                exc_info=True,
+                            )
 
         def _run_specprefill(model, bc, use_mtp):
             """Run sparse-only target prefill and retain its forward context."""
@@ -3758,6 +3863,10 @@ class SimpleEngine(BaseEngine):
         accumulated_text = ""
         token_count = 0
         finished = False
+        mtp_drafts = 0
+        mtp_accepted = 0
+        backend_mtp_bypass_reason = None
+        last_logprobs = None
         try:
             while True:
                 kind, payload = await response_queue.get()
@@ -3774,6 +3883,14 @@ class SimpleEngine(BaseEngine):
                 resp = payload
 
                 token_count += 1
+                # mlx-lm reports cumulative native counters on every response.
+                # Assign rather than sum so Simple does not double-count them.
+                mtp_drafts = getattr(resp, "mtp_drafts", mtp_drafts)
+                mtp_accepted = getattr(resp, "mtp_accepted", mtp_accepted)
+                backend_mtp_bypass_reason = getattr(
+                    resp, "mtp_bypass_reason", backend_mtp_bypass_reason
+                )
+                last_logprobs = getattr(resp, "logprobs", None)
                 new_text = resp.text if hasattr(resp, "text") else str(resp)
                 accumulated_text += new_text
 
@@ -3798,7 +3915,12 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=token_count,
                     finished=finished,
                     finish_reason=finish_reason,
-                    mtp_bypass_reason=mtp_bypass_reason,
+                    mtp_drafts=mtp_drafts,
+                    mtp_accepted=mtp_accepted,
+                    mtp_bypass_reason=(
+                        mtp_bypass_reason or backend_mtp_bypass_reason
+                    ),
+                    logprobs=last_logprobs,
                     **telemetry.as_output_kwargs(),
                 )
 
@@ -3815,7 +3937,10 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
-                mtp_bypass_reason=mtp_bypass_reason,
+                mtp_drafts=mtp_drafts,
+                mtp_accepted=mtp_accepted,
+                mtp_bypass_reason=(mtp_bypass_reason or backend_mtp_bypass_reason),
+                logprobs=last_logprobs,
                 **telemetry.as_output_kwargs(),
             )
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -2279,15 +2279,38 @@ class SimpleEngine(BaseEngine):
             if cancel_requested.is_set():
                 raise _SpecPrefillCancelled()
 
+        loop = asyncio.get_running_loop()
+        response_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+        sparse_output_committed = False
+
+        def _emit_response(resp: Any) -> None:
+            if not cancel_requested.is_set():
+                loop.call_soon_threadsafe(response_queue.put_nowait, ("resp", resp))
+
+        def _emit_sparse_response(resp: Any) -> None:
+            nonlocal sparse_output_committed
+            # This boundary is deliberately before queuing the response: once a
+            # sparse token exists, retrying dense would create a second answer.
+            sparse_output_committed = True
+            _emit_response(resp)
+
+        def _emit_done() -> None:
+            loop.call_soon_threadsafe(response_queue.put_nowait, ("done", None))
+
+        def _emit_error(exc: BaseException) -> None:
+            loop.call_soon_threadsafe(response_queue.put_nowait, ("error", exc))
+
         def _run_all():
             try:
-                return _run_specprefill()
+                _run_specprefill()
             except _SpecPrefillCancelled:
                 raise
             except Exception as e:
+                if sparse_output_committed:
+                    raise
                 logger.error("SpecPrefill failed, falling back to normal path: %s", e)
                 telemetry.fallback("sparse_execution_failed")
-                return _run_normal()
+                _run_normal()
 
         def _run_specprefill():
             """Score tokens, sparse prefill, generate autoregressively."""
@@ -2296,7 +2319,7 @@ class SimpleEngine(BaseEngine):
 
             import mlx.core as mx
             from mlx_lm.models.cache import make_prompt_cache
-            from mlx_lm.sample_utils import make_sampler
+            from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
             from ..specprefill import (
                 cleanup_rope,
@@ -2373,21 +2396,62 @@ class SimpleEngine(BaseEngine):
                     t_prefill,
                 )
 
-                # Phase 4: Generate via engine's standard pipelined path
-                sampler = make_sampler(temp=temperature, top_p=top_p)
+                # Phase 4: Sample from the same sampler/processors as dense
+                # generation. The seed sees the complete prompt token history,
+                # then the standard wrapper owns continuation sampling.
+                top_k = kwargs.get("top_k", 0)
+                min_p = kwargs.get("min_p", 0.0)
+                presence_penalty = kwargs.get("presence_penalty", 0.0)
+                repetition_penalty = kwargs.get("repetition_penalty", 1.0)
+                sampler = make_sampler(
+                    temp=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                )
+                penalty_processors = make_logits_processors(
+                    repetition_penalty=(
+                        repetition_penalty if repetition_penalty != 1.0 else None
+                    ),
+                    presence_penalty=(
+                        presence_penalty if presence_penalty != 0.0 else None
+                    ),
+                )
+                all_processors = (kwargs.get("logits_processors") or []) + (
+                    penalty_processors or []
+                )
+                seeded_processors = _seed_logits_processors(
+                    mx.array(tokens, dtype=mx.uint32), all_processors
+                )
                 _cancel_check()
-                first_token_id = sampler(logits[:, -1, :]).item()
+                first_token, _ = _sample_with_processors(
+                    None,
+                    logits[:, -1, :].squeeze(0),
+                    sampler,
+                    seeded_processors,
+                )
+                mx.eval(first_token)
+                first_token_id = first_token.item()
                 first_text = tokenizer.decode([first_token_id])
                 eos_id = tokenizer.eos_token_id
 
-                results = [
+                _emit_sparse_response(
                     SimpleNamespace(
                         text=first_text,
                         finish_reason="stop" if first_token_id == eos_id else None,
                     )
-                ]
+                )
 
                 if first_token_id != eos_id:
+                    # The wrapper normally builds penalty processors and gives
+                    # user processors only the continuation token sequence.
+                    # Reuse the seeded processors instead so both seed and
+                    # continuation observe the full prompt history, and avoid
+                    # applying the request penalties twice.
+                    continuation_kwargs = dict(kwargs)
+                    continuation_kwargs["logits_processors"] = seeded_processors
+                    continuation_kwargs["presence_penalty"] = 0.0
+                    continuation_kwargs["repetition_penalty"] = 1.0
                     for chunk in self._model.stream_generate(
                         prompt=mx.array([first_token_id]),
                         max_tokens=max_tokens - 1,
@@ -2395,26 +2459,16 @@ class SimpleEngine(BaseEngine):
                         top_p=top_p,
                         stop=stop,
                         prompt_cache=cache,
+                        **continuation_kwargs,
                     ):
                         _cancel_check()
-                        new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                        results.append(
-                            SimpleNamespace(
-                                text=new_text,
-                                finish_reason=getattr(chunk, "finish_reason", None),
-                            )
-                        )
-
-                return results
+                        _emit_sparse_response(chunk)
 
             finally:
                 cleanup_rope(model)
 
         def _run_normal():
             """Fallback: normal generation without specprefill."""
-            from types import SimpleNamespace
-
-            results = []
             for chunk in self._model.stream_generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -2424,43 +2478,71 @@ class SimpleEngine(BaseEngine):
                 **kwargs,
             ):
                 _cancel_check()
-                new_text = chunk.text if hasattr(chunk, "text") else str(chunk)
-                results.append(
-                    SimpleNamespace(
-                        text=new_text,
-                        finish_reason=getattr(chunk, "finish_reason", None),
-                    )
-                )
-            return results
+                _emit_response(chunk)
 
-        all_resps = await self._run_blocking_serialized(
-            _run_all, on_cancel=_request_cancel
-        )
+        async def _produce_responses() -> None:
+            try:
+                await self._run_blocking_serialized(
+                    _run_all,
+                    on_cancel=_request_cancel,
+                )
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:
+                _emit_error(exc)
+            else:
+                _emit_done()
+
+        producer_task = asyncio.create_task(_produce_responses())
 
         # Yield results as GenerationOutput
         accumulated_text = ""
         token_count = 0
         finished = False
-        for i, resp in enumerate(all_resps):
-            token_count += 1
-            new_text = resp.text
-            accumulated_text += new_text
+        try:
+            while True:
+                kind, payload = await response_queue.get()
+                if kind == "done":
+                    break
+                if kind == "error":
+                    raise payload
+                if finished:
+                    # The terminal token was already yielded. Drain until the
+                    # producer's done/error sentinel so a late worker failure
+                    # cannot be hidden by cancelling the producer on EOS.
+                    continue
+                resp = payload
 
-            is_last = i == len(all_resps) - 1
-            finished = is_last or token_count >= max_tokens
+                token_count += 1
+                new_text = resp.text if hasattr(resp, "text") else str(resp)
+                accumulated_text += new_text
 
-            yield GenerationOutput(
-                text=accumulated_text,
-                new_text=new_text,
-                prompt_tokens=n_tokens,
-                completion_tokens=token_count,
-                finished=finished,
-                finish_reason=resp.finish_reason or ("stop" if finished else None),
-                **telemetry.as_output_kwargs(),
-            )
+                stop_hit = bool(stop) and any(
+                    stop_seq in accumulated_text for stop_seq in stop
+                )
+                finished = stop_hit or token_count >= max_tokens
+                finish_reason = getattr(resp, "finish_reason", None)
+                if stop_hit:
+                    finish_reason = "stop"
+                elif finish_reason is None and finished:
+                    finish_reason = "length"
+                elif finish_reason is not None:
+                    finished = True
 
-            if finished:
-                break
+                yield GenerationOutput(
+                    text=accumulated_text,
+                    new_text=new_text,
+                    prompt_tokens=n_tokens,
+                    completion_tokens=token_count,
+                    finished=finished,
+                    finish_reason=finish_reason,
+                    **telemetry.as_output_kwargs(),
+                )
+
+        finally:
+            if not producer_task.done():
+                _request_cancel()
+            await producer_task
 
         if not finished:
             yield GenerationOutput(
@@ -2757,11 +2839,20 @@ class SimpleEngine(BaseEngine):
 
         loop = asyncio.get_running_loop()
         response_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+        sparse_output_committed = False
 
         def _emit_response(resp: Any) -> None:
             if abort_event.is_set():
                 return
             loop.call_soon_threadsafe(response_queue.put_nowait, ("resp", resp))
+
+        def _emit_sparse_response(resp: Any) -> None:
+            nonlocal sparse_output_committed
+            # A sparse token makes dense restart unsafe: callers would observe
+            # two answers from one request. Commit before queueing to preserve
+            # the boundary even if the consumer is cancelled immediately.
+            sparse_output_committed = True
+            _emit_response(resp)
 
         def _emit_done() -> None:
             loop.call_soon_threadsafe(response_queue.put_nowait, ("done", None))
@@ -2784,6 +2875,7 @@ class SimpleEngine(BaseEngine):
             prompt_cache,
             prompt,
             remaining_tokens: int,
+            emit_response=_emit_response,
         ) -> None:
             resume_kwargs = dict(
                 max_tokens=remaining_tokens,
@@ -2806,7 +2898,7 @@ class SimpleEngine(BaseEngine):
                 if abort_event.is_set():
                     logger.info("Text route: abort requested; stopping resume decode")
                     break
-                _emit_response(resp)
+                emit_response(resp)
 
         # Run all Metal ops in a single serialized thread.
         def _run_all():
@@ -2888,6 +2980,8 @@ class SimpleEngine(BaseEngine):
                     _run_specprefill(model, backbone_cache, use_mtp)
                     return
                 except Exception as e:
+                    if sparse_output_committed or abort_event.is_set():
+                        raise
                     logger.error(
                         "SpecPrefill failed, falling back to normal MTP path: %s",
                         e,
@@ -3091,7 +3185,7 @@ class SimpleEngine(BaseEngine):
                 prev_decoded = decoded
 
                 is_eos = tok_id == eos_id
-                _emit_response(
+                _emit_sparse_response(
                     SimpleNamespace(
                         text=new_text,
                         finish_reason="stop" if is_eos else None,
@@ -3124,28 +3218,33 @@ class SimpleEngine(BaseEngine):
                         bc,
                         continuation_prompt,
                         max_tokens - token_count,
+                        emit_response=_emit_sparse_response,
                     )
                     return
 
                 last_resp = None
                 retired = False
-                for resp in mlx_stream_generate(
-                    model,
-                    self._text_tokenizer,
-                    prompt=continuation_prompt,
+                continuation_kwargs = dict(
                     max_tokens=max_tokens - token_count,
                     sampler=sampler,
                     prefill_step_size=self._prefill_step_size,
                     logits_processors=seeded_processors,
                     prompt_cache=prompt_cache,
-                    mtp=use_mtp,
+                )
+                if use_mtp:
+                    continuation_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                for resp in mlx_stream_generate(
+                    model,
+                    self._text_tokenizer,
+                    prompt=continuation_prompt,
+                    **continuation_kwargs,
                 ):
                     if abort_event.is_set():
                         logger.info(
                             "SpecPrefill text route: abort requested; stopping decode"
                         )
                         break
-                    _emit_response(resp)
+                    _emit_sparse_response(resp)
                     token_count += 1
                     last_resp = resp
                     retired = _processors_retired(all_processors)
@@ -3165,6 +3264,7 @@ class SimpleEngine(BaseEngine):
                         bc,
                         seed,
                         max_tokens - token_count,
+                        emit_response=_emit_sparse_response,
                     )
 
             finally:
@@ -3196,6 +3296,10 @@ class SimpleEngine(BaseEngine):
                     break
                 if kind == "error":
                     raise payload
+                if finished:
+                    # Drain producer completion after a terminal sparse token
+                    # rather than cancelling it and masking a late error.
+                    continue
                 resp = payload
 
                 token_count += 1
@@ -3224,8 +3328,6 @@ class SimpleEngine(BaseEngine):
                     **telemetry.as_output_kwargs(),
                 )
 
-                if finished:
-                    break
         finally:
             if not producer_task.done():
                 abort_event.set()

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -3193,6 +3193,7 @@ class SimpleEngine(BaseEngine):
                     # Cancellation before the first resume owns no sample and
                     # must atomically abandon still-unclaimed authority.
                     _cancel_check()
+                    forward_context.transfer_to_native_mtp()
                     generation = self._model.stream_generate(
                         prompt=None,
                         max_tokens=max_tokens,
@@ -4164,6 +4165,11 @@ class SimpleEngine(BaseEngine):
                         )
                     )
                     _cancel_check()
+                    if callable(getattr(model, "generation_forward_context", None)):
+                        forward_context.transfer_to_native_mtp()
+                        # Canonical native MTP owns positioned forwards after
+                        # the validated sparse-context transfer.
+                        gen_kwargs.pop("model_forward_context", None)
                     generation = mlx_stream_generate(
                         model,
                         self._text_tokenizer,

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -64,6 +64,11 @@ from ..specprefill_profiles import (
     SpecPrefillProfileRegistry,
     SpecPrefillTuning,
 )
+from ..native_mtp_request import (
+    NativeMTPRequestConfig,
+    NativeMTPServerState,
+    resolve_native_mtp_consumer,
+)
 from .base import (
     BaseEngine,
     EngineBusy,
@@ -232,6 +237,30 @@ def _request_can_compose_mtp(route_mtp: bool, processors: list[Any] | None) -> b
     requires the independently qualified combined profile cell.
     """
     return route_mtp and (not processors or _processors_can_retire(processors))
+
+
+def _consume_native_mtp_request(
+    kwargs: dict[str, Any], *, server_default: bool
+) -> tuple[NativeMTPRequestConfig | None, bool, bool, str | None]:
+    """Consume private server controls before backend kwargs are constructed."""
+
+    config = kwargs.pop("_native_mtp_request_config", None)
+    disabled = kwargs.pop("_native_mtp_disabled", False)
+    bypass_reason = kwargs.pop("_native_mtp_bypass_reason", None)
+    if config is not None and not isinstance(config, NativeMTPRequestConfig):
+        raise ValueError("invalid native MTP request config")
+    if not isinstance(disabled, bool):
+        raise ValueError("invalid native MTP disable control")
+    if config is not None and disabled:
+        raise ValueError("native MTP request cannot be selected and disabled")
+    if bypass_reason is not None and not isinstance(bypass_reason, str):
+        raise ValueError("invalid native MTP bypass reason")
+    if config is not None and bypass_reason is not None:
+        raise ValueError("native MTP bypass cannot be selected")
+    selected = config is not None or (server_default and not disabled)
+    if bypass_reason is not None:
+        selected = False
+    return config, disabled, selected, bypass_reason
 
 
 class _SpecPrefillCancelled(Exception):
@@ -984,6 +1013,43 @@ class SimpleEngine(BaseEngine):
             return getattr(self._model, "processor", None)
         return self._model.tokenizer
 
+    def native_mtp_server_state(
+        self, *, has_media: bool = False
+    ) -> NativeMTPServerState:
+        """Return native-MTP admission facts without mutating model state."""
+
+        incompatibility = None
+        if has_media:
+            incompatibility = "native_mtp_media_unsupported"
+        elif (self._max_kv_size or 0) > 0:
+            incompatibility = "native_mtp_max_kv_unsupported"
+        elif self._system_kv_cache:
+            # Native MTP cannot consume the cache snapshot contract yet.  Do
+            # not guess that a resident prefix belongs to another request.
+            incompatibility = "native_mtp_prefix_cache_unsupported"
+
+        if self._is_mllm:
+            target = self._text_model
+        else:
+            target = getattr(self._model, "model", None)
+        capability = getattr(target, "mtp_capability", None)
+        capable = bool(capability is not None and capability.supported)
+        if incompatibility is None and not capable:
+            incompatibility = (
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else capability.reason
+            )
+        if incompatibility is None and resolve_native_mtp_consumer() is None:
+            incompatibility = "native_mtp_consumer_contract_missing"
+        return NativeMTPServerState(
+            server_default=bool(self._mtp),
+            capable=capable,
+            num_draft_tokens=self._mtp_num_draft_tokens,
+            supports_penalty_processors=not self._is_mllm,
+            incompatibility=incompatibility,
+        )
+
     def _generation_lock_holder_summary(self) -> str:
         if not self._active_requests:
             return "none"
@@ -1172,9 +1238,11 @@ class SimpleEngine(BaseEngine):
                             )
                             self._supports_system_kv_cache = False
 
-                        has_mtp = (
-                            hasattr(self._text_model, "mtp")
-                            and self._text_model.mtp is not None
+                        capability = getattr(
+                            self._text_model, "mtp_capability", None
+                        )
+                        has_mtp = bool(
+                            capability is not None and capability.supported
                         )
                         logger.info(
                             "MLLM text routing: text-only -> mlx_lm TextModel "
@@ -1367,6 +1435,9 @@ class SimpleEngine(BaseEngine):
             completion_tokens=last_output.completion_tokens,
             finish_reason=last_output.finish_reason,
             finished=True,
+            mtp_drafts=last_output.mtp_drafts,
+            mtp_accepted=last_output.mtp_accepted,
+            mtp_bypass_reason=last_output.mtp_bypass_reason,
             specprefill_requested_policy=last_output.specprefill_requested_policy,
             specprefill_effective_policy=last_output.specprefill_effective_policy,
             specprefill_coverage=last_output.specprefill_coverage,
@@ -1518,6 +1589,9 @@ class SimpleEngine(BaseEngine):
         # Resolve the complete public prefill contract before any model call.
         # These controls must never leak into mlx-lm/mlx-vlm kwargs.
         specprefill_controls = self._specprefill_controls(kwargs)
+        native_mtp_config, native_mtp_disabled, effective_mtp, mtp_bypass_reason = (
+            _consume_native_mtp_request(kwargs, server_default=self._mtp)
+        )
         request_id = str(kwargs.pop("request_id", "") or f"simple-{id(prompt):x}")
 
         tokenizer = self._model.tokenizer
@@ -1531,7 +1605,7 @@ class SimpleEngine(BaseEngine):
             # MLXLanguageModel injects native MTP into its decode call when
             # configured. Other routes pass their request-effective value
             # explicitly (for example, an MLLM assistant request).
-            combined_mtp=self._mtp,
+            combined_mtp=effective_mtp,
         )
 
         # SpecPrefill is independent from MTP. The direct path is used only
@@ -1546,7 +1620,7 @@ class SimpleEngine(BaseEngine):
         if (
             not self._is_mllm
             and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
-            and self._mtp
+            and effective_mtp
         ):
             # Sparse-only is independently qualified first. Native/external
             # MTP composition cannot borrow this cache/position state yet.
@@ -1624,12 +1698,18 @@ class SimpleEngine(BaseEngine):
                 completion_tokens = 0
                 finished = False
 
+                native_mtp_kwargs: dict[str, Any] = {}
+                if native_mtp_config is not None:
+                    native_mtp_kwargs["native_mtp_request"] = native_mtp_config
+                elif native_mtp_disabled:
+                    native_mtp_kwargs["native_mtp_disabled"] = True
                 for chunk in self._model.stream_generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
                     temperature=temperature,
                     top_p=top_p,
                     stop=stop,
+                    **native_mtp_kwargs,
                     **kwargs,
                 ):
                     prompt_tokens = (
@@ -1668,6 +1748,7 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=completion_tokens,
                         finished=finished,
                         finish_reason=finish_reason,
+                        mtp_bypass_reason=mtp_bypass_reason,
                         **telemetry.as_output_kwargs(),
                     )
 
@@ -1692,6 +1773,7 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=completion_tokens,
                         finished=True,
                         finish_reason="stop",
+                        mtp_bypass_reason=mtp_bypass_reason,
                         **telemetry.as_output_kwargs(),
                     )
             finally:
@@ -1752,6 +1834,7 @@ class SimpleEngine(BaseEngine):
                 finish_reason=final_output.finish_reason,
                 mtp_drafts=final_output.mtp_drafts,
                 mtp_accepted=final_output.mtp_accepted,
+                mtp_bypass_reason=final_output.mtp_bypass_reason,
                 specprefill_requested_policy=final_output.specprefill_requested_policy,
                 specprefill_effective_policy=final_output.specprefill_effective_policy,
                 specprefill_coverage=final_output.specprefill_coverage,
@@ -1785,11 +1868,20 @@ class SimpleEngine(BaseEngine):
         if kwargs.get("logits_processors") and not self._is_mllm:
             return await aggregate_stream_chat()
 
+        # Explicit native MTP is implemented by the streaming decode seam.
+        # The legacy blocking chat call does not expose speculative controls.
+        if kwargs.get("_native_mtp_request_config") is not None:
+            return await aggregate_stream_chat()
+
         # Text-only requests on MLLM models should always aggregate the
         # streaming path for non-streaming chat. This keeps one execution seam
         # and avoids mlx_vlm non-stream thread/stream ownership mismatches.
         if self._is_mllm and not has_media_content(messages):
             return await aggregate_stream_chat()
+
+        _, _, _, direct_mtp_bypass_reason = _consume_native_mtp_request(
+            kwargs, server_default=self._mtp
+        )
 
         # Convert tools for template if provided
         template_tools = convert_tools_for_template(tools) if tools else None
@@ -1823,6 +1915,7 @@ class SimpleEngine(BaseEngine):
                 finish_reason=output.finish_reason,
                 mtp_drafts=getattr(output, "mtp_drafts", 0),
                 mtp_accepted=getattr(output, "mtp_accepted", 0),
+                mtp_bypass_reason=direct_mtp_bypass_reason,
                 **telemetry.as_output_kwargs(),
             )
         else:
@@ -1865,6 +1958,7 @@ class SimpleEngine(BaseEngine):
                 prompt_tokens=prompt_token_count,
                 completion_tokens=len(output.tokens),
                 finish_reason=output.finish_reason,
+                mtp_bypass_reason=direct_mtp_bypass_reason,
                 **telemetry.as_output_kwargs(),
             )
 
@@ -1926,6 +2020,14 @@ class SimpleEngine(BaseEngine):
             await self.start()
 
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        (
+            native_mtp_config,
+            native_mtp_disabled,
+            effective_native_mtp,
+            mtp_bypass_reason,
+        ) = (
+            _consume_native_mtp_request(kwargs, server_default=self._mtp)
+        )
         mllm_draft_requested = bool(kwargs.pop("mllm_draft", False))
         request_has_media = has_media_content(messages)
 
@@ -1942,19 +2044,23 @@ class SimpleEngine(BaseEngine):
             and not request_has_media
         )
         if routes_text_model:
-            has_mtp = (
-                hasattr(self._text_model, "mtp") and self._text_model.mtp is not None
-            )
-            logger.info("Text-only request → LLM path (MTP=%s)", has_mtp and self._mtp)
+            use_native_mtp = effective_native_mtp
+            logger.info("Text-only request → LLM path (MTP=%s)", use_native_mtp)
             if chat_template_kwargs:
                 kwargs["chat_template_kwargs"] = chat_template_kwargs
+            if native_mtp_config is not None:
+                kwargs["_native_mtp_request_config"] = native_mtp_config
+            elif native_mtp_disabled:
+                kwargs["_native_mtp_disabled"] = True
+            elif mtp_bypass_reason is not None:
+                kwargs["_native_mtp_bypass_reason"] = mtp_bypass_reason
             async for chunk in self._stream_generate_text(
                 messages,
                 max_tokens,
                 temperature,
                 top_p,
                 tools=template_tools,
-                combined_mtp=has_mtp and self._mtp,
+                combined_mtp=use_native_mtp,
                 **kwargs,
             ):
                 yield chunk
@@ -2029,6 +2135,7 @@ class SimpleEngine(BaseEngine):
                             finish_reason=chunk.finish_reason if finished else None,
                             mtp_drafts=getattr(chunk, "mtp_drafts", 0),
                             mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                            mtp_bypass_reason=mtp_bypass_reason,
                             **direct_mllm_telemetry.as_output_kwargs(),
                         )
 
@@ -2069,6 +2176,7 @@ class SimpleEngine(BaseEngine):
                     finish_reason=chunk.finish_reason if finished else None,
                     mtp_drafts=getattr(chunk, "mtp_drafts", 0),
                     mtp_accepted=getattr(chunk, "mtp_accepted", 0),
+                    mtp_bypass_reason=mtp_bypass_reason,
                     **direct_mllm_telemetry.as_output_kwargs(),
                 )
             return
@@ -2203,7 +2311,7 @@ class SimpleEngine(BaseEngine):
         #   - ``self._max_kv_size`` (when > 0) caps the prompt cache; the cache
         #     branch builds its cache with ``make_prompt_cache(model)`` and has
         #     no equivalent bound.
-        if self._mtp:
+        if effective_native_mtp:
             cache_blocking_controls.append("mtp")
         if self._draft_model is not None:
             cache_blocking_controls.append("specprefill_loaded")
@@ -2499,6 +2607,7 @@ class SimpleEngine(BaseEngine):
                         completion_tokens=token_count,
                         finished=finished,
                         finish_reason=finish_reason,
+                        mtp_bypass_reason=mtp_bypass_reason,
                     )
                     if finished:
                         break
@@ -2514,11 +2623,23 @@ class SimpleEngine(BaseEngine):
                 # Internal fallback to the public stream_generate. The
                 # ``_in_tracker`` context flag prevents double counting
                 # in _track_request_stream.
+                native_forward_kwargs: dict[str, Any] = {}
+                if native_mtp_config is not None:
+                    native_forward_kwargs["_native_mtp_request_config"] = (
+                        native_mtp_config
+                    )
+                elif native_mtp_disabled:
+                    native_forward_kwargs["_native_mtp_disabled"] = True
+                elif mtp_bypass_reason is not None:
+                    native_forward_kwargs["_native_mtp_bypass_reason"] = (
+                        mtp_bypass_reason
+                    )
                 async for output in self.stream_generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
                     temperature=temperature,
                     top_p=top_p,
+                    **native_forward_kwargs,
                     **kwargs,
                 ):
                     yield output
@@ -2526,11 +2647,19 @@ class SimpleEngine(BaseEngine):
 
         # Fallback: no system prefix detected -> original uncached path.
         # Re-entrancy guard in _track_request_stream keeps stats single-counted.
+        native_forward_kwargs = {}
+        if native_mtp_config is not None:
+            native_forward_kwargs["_native_mtp_request_config"] = native_mtp_config
+        elif native_mtp_disabled:
+            native_forward_kwargs["_native_mtp_disabled"] = True
+        elif mtp_bypass_reason is not None:
+            native_forward_kwargs["_native_mtp_bypass_reason"] = mtp_bypass_reason
         async for output in self.stream_generate(
             prompt=prompt,
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            **native_forward_kwargs,
             **kwargs,
         ):
             yield output
@@ -2913,6 +3042,9 @@ class SimpleEngine(BaseEngine):
         # The text route has its own prompt rendering, but shares exactly the
         # same policy resolver as direct SimpleEngine generation.
         specprefill_controls = self._specprefill_controls(kwargs)
+        native_mtp_config, _, combined_mtp, mtp_bypass_reason = (
+            _consume_native_mtp_request(kwargs, server_default=combined_mtp)
+        )
         specprefill_keep_pct = (
             specprefill_controls["keep_pct"]
             if self._specprefill_diagnostic_mode
@@ -2935,6 +3067,14 @@ class SimpleEngine(BaseEngine):
         external_logits_processors = kwargs.pop("logits_processors", None)
         abort_event = threading.Event()
 
+        if native_mtp_config is not None:
+            sampling = native_mtp_config.sampling
+            temperature = sampling.temperature
+            top_p = sampling.top_p
+            top_k = sampling.top_k
+            min_p = sampling.min_p
+            presence_penalty = sampling.presence_penalty
+            repetition_penalty = sampling.repetition_penalty
         # Per-request enable_thinking override; fall back to env var / default True.
         enable_thinking = kwargs.pop("enable_thinking", None)
         if enable_thinking is None:
@@ -2980,8 +3120,7 @@ class SimpleEngine(BaseEngine):
         custom_logits_active = bool(all_processors)
         combined_mtp = (
             _request_can_compose_mtp(combined_mtp, all_processors)
-            and self._text_model is not None
-            and getattr(self._text_model, "mtp", None) is not None
+            and native_mtp_config is not None
         )
         sparse_no_completion_requested = max_tokens == 0
         max_tokens = max_tokens or 4096
@@ -3236,12 +3375,11 @@ class SimpleEngine(BaseEngine):
                 prefill_step_size=self._prefill_step_size,
                 prompt_cache=prompt_cache,
             )
-            if hasattr(model, "make_mtp_cache") and model.mtp is not None:
+            if native_mtp_config is not None:
                 # Resume speculative decode from the retained backbone cache with
                 # a fresh MTP cache so stale speculative state cannot survive the
                 # processor-to-content handoff.
-                resume_kwargs["prompt_cache"] = prompt_cache + model.make_mtp_cache()
-                resume_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                resume_kwargs.update(native_mtp_config.mlx_lm_call_kwargs())
             for resp in mlx_stream_generate(
                 model,
                 self._text_tokenizer,
@@ -3259,9 +3397,7 @@ class SimpleEngine(BaseEngine):
 
             model = self._text_model
             can_retire_processors = _processors_can_retire(all_processors)
-            use_mtp = (
-                combined_mtp and not custom_logits_active and model.mtp is not None
-            )
+            use_mtp = combined_mtp and not custom_logits_active
             if self._mtp and custom_logits_active:
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
@@ -3366,7 +3502,11 @@ class SimpleEngine(BaseEngine):
             if all_processors:
                 gen_kwargs["logits_processors"] = all_processors
             if use_mtp:
-                gen_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
+                if native_mtp_config is None:
+                    raise RuntimeError(
+                        "native MTP selection requires a request-local config"
+                    )
+                gen_kwargs.update(native_mtp_config.mlx_lm_call_kwargs())
             if prompt_cache is not None:
                 gen_kwargs["prompt_cache"] = prompt_cache
             if can_retire_processors and not use_mtp:
@@ -3401,7 +3541,7 @@ class SimpleEngine(BaseEngine):
                             "Text route: request-local processor retired after %d tokens; "
                             "resuming content phase with MTP=%s",
                             token_count,
-                            hasattr(model, "make_mtp_cache") and model.mtp is not None,
+                            native_mtp_config is not None,
                         )
                         break
 
@@ -3658,6 +3798,7 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=token_count,
                     finished=finished,
                     finish_reason=finish_reason,
+                    mtp_bypass_reason=mtp_bypass_reason,
                     **telemetry.as_output_kwargs(),
                 )
 
@@ -3674,6 +3815,7 @@ class SimpleEngine(BaseEngine):
                 completion_tokens=token_count,
                 finished=True,
                 finish_reason="length",
+                mtp_bypass_reason=mtp_bypass_reason,
                 **telemetry.as_output_kwargs(),
             )
 

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from typing import Any
 
@@ -51,10 +51,14 @@ from ..specprefill_generation_context import SparseGenerationForwardContext
 from ..specprefill_positions import (
     TargetPositionAdapter,
     TargetPositionError,
+    TargetPositionFamily,
     resolve_target_position_adapter,
 )
-from ..specprefill_selection import RotatingTailRequirement, SelectionPlan
-from ..specprefill_target_executor import execute_sparse_target_prefill
+from ..specprefill_selection import RotatingTailRequirement
+from ..specprefill_target_executor import (
+    SparseTargetPrefillAuthorityError,
+    execute_sparse_target_prefill,
+)
 from ..specprefill_target_hooks import TargetPositionHooks
 from ..specprefill_profiles import (
     EMPTY_SPECPREFILL_PROFILE_REGISTRY,
@@ -109,6 +113,8 @@ def _seed_logits_processors(
                     merged = mx.concatenate([seed_tokens, tokens_arr])
             return processor(merged, logits)
 
+        if getattr(processor, "native_mtp_replay_safe", False):
+            _seeded.native_mtp_replay_safe = True
         return _seeded
 
     return [_wrap(processor) for processor in processors]
@@ -265,6 +271,30 @@ def _consume_native_mtp_request(
 
 class _SpecPrefillCancelled(Exception):
     """Cooperative cancellation sentinel for blocking SpecPrefill workers."""
+
+
+class _SpecPrefillAuthorityError(RuntimeError):
+    """Receipt/cache authority could not prove that dense replay is safe."""
+
+
+def _try_abandon_sparse_bootstrap(bootstrap: Any) -> bool:
+    """Atomically abandon only authority that has not begun a claim."""
+    abandon = getattr(bootstrap, "try_abandon_unclaimed", None)
+    if not callable(abandon):
+        raise _SpecPrefillAuthorityError(
+            "sparse native MTP bootstrap lacks atomic abandonment"
+        )
+    try:
+        abandoned = abandon()
+    except BaseException as exc:
+        raise _SpecPrefillAuthorityError(
+            "sparse native MTP authority cleanup failed"
+        ) from exc
+    if type(abandoned) is not bool:
+        raise _SpecPrefillAuthorityError(
+            "sparse native MTP abandonment returned a non-boolean result"
+        )
+    return abandoned
 
 
 async def _aclose_async_iterator(
@@ -752,10 +782,14 @@ class SimpleEngine(BaseEngine):
         return RotatingTailRequirement(max(maxima)) if maxima else None
 
     def _admit_sparse_target(
-        self, target_model: Any
+        self, target_model: Any, *, combined_mtp: bool = False
     ) -> tuple[SpecPrefillProfileKey, TargetPositionAdapter]:
         """Resolve artifact/adapter/hook compatibility before scorer work."""
-        profile_key = self._active_specprefill_profile_key(combined_mtp=False)
+        if combined_mtp and self._max_kv_size:
+            raise TargetPositionError(
+                "sparse native MTP requires an exact nonrotating target cache"
+            )
+        profile_key = self._active_specprefill_profile_key(combined_mtp=combined_mtp)
         if profile_key is None:
             raise TargetPositionError("exact sparse cache identity is unavailable")
         adapter = resolve_target_position_adapter(target_model)
@@ -763,10 +797,68 @@ class SimpleEngine(BaseEngine):
             raise TargetPositionError(
                 "qualified profile adapter does not match the target position adapter"
             )
+        if combined_mtp:
+            if adapter.family is not TargetPositionFamily.QWEN35_TEXT_HYBRID:
+                raise TargetPositionError(
+                    "sparse native MTP composition supports exact Qwen text targets only"
+                )
+            capability = getattr(target_model, "mtp_capability", None)
+            if capability is None or not capability.supported:
+                reason = (
+                    "native_mtp_model_capability_missing"
+                    if capability is None
+                    else capability.reason
+                )
+                raise TargetPositionError(reason)
+            self._resolve_native_mtp_sparse_api()
         # Installation is topology-preserving and immutable.  Doing it here
         # guarantees executor admission before scorer/RNG state can advance.
         TargetPositionHooks.for_model(target_model, adapter)
         return profile_key, adapter
+
+    @staticmethod
+    def _resolve_native_mtp_sparse_api() -> tuple[Any, Any, Any, Any]:
+        """Resolve the exact attested sparse-bootstrap API or fail closed."""
+        try:
+            from mlx_lm import stream_generate as mlx_stream_generate
+            from mlx_lm.generate import (
+                GenerationForwardPhase,
+                NativeMTPSparseBootstrap,
+                abandon_native_mtp_sparse_receipts,
+                attested_target_forward,
+            )
+        except (ImportError, AttributeError) as exc:
+            raise TargetPositionError(
+                "mlx-lm does not expose attested native MTP sparse bootstrap"
+            ) from exc
+        try:
+            parameters = inspect.signature(mlx_stream_generate).parameters
+        except (TypeError, ValueError) as exc:
+            raise TargetPositionError(
+                "mlx-lm sparse native MTP public dispatch is unavailable"
+            ) from exc
+        required = {
+            "mtp",
+            "mtp_sampling_config",
+            "model_forward_context",
+            "sparse_bootstrap",
+        }
+        if not required.issubset(parameters):
+            raise TargetPositionError(
+                "mlx-lm sparse native MTP public dispatch is unavailable"
+            )
+        if not callable(
+            getattr(NativeMTPSparseBootstrap, "try_abandon_unclaimed", None)
+        ):
+            raise TargetPositionError(
+                "mlx-lm sparse native MTP atomic abandonment is unavailable"
+            )
+        return (
+            GenerationForwardPhase,
+            NativeMTPSparseBootstrap,
+            attested_target_forward,
+            abandon_native_mtp_sparse_receipts,
+        )
 
     def _prepare_sparse_target_prefill(
         self,
@@ -784,8 +876,9 @@ class SimpleEngine(BaseEngine):
         anchor_chunks: int,
         profile_key: SpecPrefillProfileKey,
         adapter: TargetPositionAdapter,
+        combined_mtp: bool = False,
         cancel_check: Any | None = None,
-    ) -> tuple[Any, SparseGenerationForwardContext, SelectionPlan]:
+    ) -> tuple[Any, ...]:
         """Build exact sparse state and run a fresh target prefill atomically.
 
         This is intentionally the only SimpleEngine entry point to the new
@@ -849,6 +942,80 @@ class SimpleEngine(BaseEngine):
             (plan.selected_indices,),
             (len(tokens),),
         )
+        target_forward = None
+        receipt_abandon = None
+        bootstrap_type = None
+        if combined_mtp:
+            (
+                phase_type,
+                bootstrap_type,
+                attested_target_forward,
+                receipt_abandon,
+            ) = self._resolve_native_mtp_sparse_api()
+            hooks = TargetPositionHooks.for_model(target_model, adapter)
+
+            @contextmanager
+            def _attested_forward_context(forward):
+                if forward.model is not target_model or forward.cache is not cache:
+                    raise TargetPositionError(
+                        "attested target model/cache identity changed"
+                    )
+                if forward.phase is not phase_type.PREFILL:
+                    raise TargetPositionError("attested sparse target phase changed")
+                positions = tuple(forward.logical_positions)
+                if positions != active_plan.logical_positions[0]:
+                    raise TargetPositionError(
+                        "attested sparse target logical positions changed"
+                    )
+                if tuple(forward.input_tokens.shape) != (1, len(positions)):
+                    raise TargetPositionError("attested sparse target requires B=1")
+                ack = getattr(forward, "logical_position_ack", None)
+                if not callable(getattr(ack, "acknowledge", None)):
+                    raise TargetPositionError(
+                        "attested sparse target requires a position consumer"
+                    )
+                with hooks.session_for_plan(active_plan, logical_position_ack=ack):
+                    yield
+
+            active_plan: Any = None
+
+            def _attested_chunk(token_rows, target_cache, chunk_plan):
+                nonlocal active_plan
+                if target_cache is not cache:
+                    raise TargetPositionError("sparse target cache identity changed")
+                positions = chunk_plan.logical_positions[0]
+                token_ids = tuple(tokens[position] for position in positions)
+                if tuple(token_rows.shape) != (1, len(token_ids)):
+                    raise TargetPositionError("attested sparse target requires B=1")
+                successors = tuple(
+                    tokens[position + 1]
+                    for position in positions
+                    if position < len(tokens) - 1
+                )
+                expected_successors = len(positions)
+                if positions[-1] == len(tokens) - 1:
+                    expected_successors -= 1
+                if len(successors) != expected_successors:
+                    raise TargetPositionError(
+                        "receipt chunk does not contain exact original successors"
+                    )
+                active_plan = chunk_plan
+                try:
+                    (logits, _hidden), receipt = attested_target_forward(
+                        target_model,
+                        token_ids,
+                        cache,
+                        phase=phase_type.PREFILL,
+                        logical_positions=positions,
+                        immediate_successor_token_ids=successors,
+                        model_forward_context=_attested_forward_context,
+                    )
+                finally:
+                    active_plan = None
+                return logits, receipt
+
+            target_forward = _attested_chunk
+
         result = execute_sparse_target_prefill(
             target_model,
             [tokens[index] for index in plan.selected_indices],
@@ -857,16 +1024,56 @@ class SimpleEngine(BaseEngine):
             adapter,
             step_size=self._prefill_step_size,
             cancel_check=cancel_check,
+            target_forward=target_forward,
+            receipt_abandon=receipt_abandon,
         )
         telemetry.selected_tokens = result.telemetry.selected_tokens
         telemetry.target_prefill_ms = result.telemetry.target_prefill_ms
-        return (
-            result,
-            SparseGenerationForwardContext(
+        sparse_bootstrap = None
+        forward_context = None
+        receipts = tuple(result.forward_receipts)
+        try:
+            forward_context = SparseGenerationForwardContext(
                 target_model, cache, result.cache_state, adapter
-            ),
+            )
+            if combined_mtp:
+                selected_positions = tuple(plan.selected_indices)
+                selected_token_ids = tuple(
+                    tokens[position] for position in selected_positions
+                )
+                immediate_successors = tuple(
+                    tokens[position + 1] for position in selected_positions[:-1]
+                )
+                sparse_bootstrap = bootstrap_type(
+                    receipts=receipts,
+                    selected_logical_positions=selected_positions,
+                    selected_token_ids=selected_token_ids,
+                    immediate_successor_token_ids=immediate_successors,
+                    target_cache=cache,
+                    next_logical_position=len(tokens),
+                )
+        except BaseException as preparation_error:
+            if combined_mtp:
+                if sparse_bootstrap is None:
+                    try:
+                        receipt_abandon(receipts)
+                    except BaseException as close_error:
+                        raise _SpecPrefillAuthorityError(
+                            "sparse native MTP authority cleanup failed"
+                        ) from close_error
+                elif not _try_abandon_sparse_bootstrap(sparse_bootstrap):
+                    raise _SpecPrefillAuthorityError(
+                        "sparse native MTP bootstrap claim already began"
+                    )
+            if forward_context is not None:
+                forward_context.finish()
+            raise preparation_error
+        prepared = (
+            result,
+            forward_context,
             plan,
         )
+        return (*prepared, sparse_bootstrap) if combined_mtp else prepared
 
     @staticmethod
     def _specprefill_dense_fallback(
@@ -1257,12 +1464,8 @@ class SimpleEngine(BaseEngine):
                             )
                             self._supports_system_kv_cache = False
 
-                        capability = getattr(
-                            self._text_model, "mtp_capability", None
-                        )
-                        has_mtp = bool(
-                            capability is not None and capability.supported
-                        )
+                        capability = getattr(self._text_model, "mtp_capability", None)
+                        has_mtp = bool(capability is not None and capability.supported)
                         logger.info(
                             "MLLM text routing: text-only -> mlx_lm TextModel "
                             "(MTP=%s), media -> mlx_vlm",
@@ -1663,16 +1866,15 @@ class SimpleEngine(BaseEngine):
             not self._is_mllm
             and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
             and effective_mtp
+            and native_mtp_config is None
         ):
-            # Sparse-only is independently qualified first. Native/external
-            # MTP composition cannot borrow this cache/position state yet.
-            telemetry.fallback("mtp_composition_not_implemented")
+            telemetry.fallback("native_mtp_request_contract_missing")
 
         if (
             not self._is_mllm
             and telemetry.decision.effective_policy is SpecPrefillPolicy.SPARSE
         ):
-            async for output in self._stream_generate_specprefill(
+            sparse_stream = self._stream_generate_specprefill(
                 prompt,
                 tokens_list,
                 max_tokens,
@@ -1680,6 +1882,8 @@ class SimpleEngine(BaseEngine):
                 top_p,
                 stop=stop,
                 telemetry=telemetry,
+                native_mtp_request=native_mtp_config,
+                mtp_bypass_reason=mtp_bypass_reason,
                 specprefill_keep_pct=(
                     specprefill_controls["keep_pct"]
                     if self._specprefill_diagnostic_mode
@@ -1714,8 +1918,21 @@ class SimpleEngine(BaseEngine):
                     else None
                 ),
                 **kwargs,
-            ):
-                yield output
+            )
+            primary_error: BaseException | None = None
+            try:
+                async for output in sparse_stream:
+                    yield output
+            except BaseException as exc:
+                primary_error = exc
+                raise
+            finally:
+                # A public GeneratorExit can arrive while this wrapper is
+                # suspended at ``yield``.  ``async for`` does not close the
+                # delegated async iterator in that case, so explicitly drive
+                # its cancellation/worker/request cleanup before the tracker
+                # releases ownership.
+                await _aclose_async_iterator(sparse_stream, primary_error)
             return
 
         async with self._acquire_generation_slot(request_id):
@@ -2099,9 +2316,7 @@ class SimpleEngine(BaseEngine):
             native_mtp_disabled,
             effective_native_mtp,
             mtp_bypass_reason,
-        ) = (
-            _consume_native_mtp_request(kwargs, server_default=self._mtp)
-        )
+        ) = _consume_native_mtp_request(kwargs, server_default=self._mtp)
         mllm_draft_requested = bool(kwargs.pop("mllm_draft", False))
         request_has_media = has_media_content(messages)
 
@@ -2755,6 +2970,8 @@ class SimpleEngine(BaseEngine):
         top_p: float,
         stop: list[str] | None = None,
         telemetry: _SpecPrefillTelemetry | None = None,
+        native_mtp_request: NativeMTPRequestConfig | None = None,
+        mtp_bypass_reason: str | None = None,
         specprefill_keep_pct: float | None = None,
         specprefill_backbone_pct: float | None = None,
         specprefill_chunk_size: int | None = None,
@@ -2818,7 +3035,12 @@ class SimpleEngine(BaseEngine):
             except _SpecPrefillCancelled:
                 raise
             except Exception as e:
-                if sparse_output_committed or sparse_decode_transaction_started:
+                if (
+                    sparse_output_committed
+                    or sparse_decode_transaction_started
+                    or isinstance(e, _SpecPrefillAuthorityError)
+                    or isinstance(e, SparseTargetPrefillAuthorityError)
+                ):
                     raise
                 logger.error("SpecPrefill failed, falling back to normal path: %s", e)
                 telemetry.fallback("sparse_execution_failed")
@@ -2841,7 +3063,13 @@ class SimpleEngine(BaseEngine):
                     "mlx-lm does not expose model_forward_context continuation"
                 )
 
-            profile_key, adapter = self._admit_sparse_target(model)
+            combined_mtp = native_mtp_request is not None
+            if combined_mtp:
+                profile_key, adapter = self._admit_sparse_target(
+                    model, combined_mtp=True
+                )
+            else:
+                profile_key, adapter = self._admit_sparse_target(model)
             detokenizer = _new_sparse_detokenizer(tokenizer)
             top_k = kwargs.get("top_k", 0)
             min_p = kwargs.get("min_p", 0.0)
@@ -2865,7 +3093,15 @@ class SimpleEngine(BaseEngine):
                 mx.array(tokens, dtype=mx.uint32), all_processors
             )
 
-            cache = make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
+            cache = (
+                model.make_cache()
+                if combined_mtp
+                else make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
+            )
+            if combined_mtp and (not isinstance(cache, list) or not cache):
+                raise TargetPositionError(
+                    "sparse native MTP target cache must be a fresh non-empty list"
+                )
 
             # Phase 1: Score with draft model
             t0 = time.monotonic()
@@ -2895,7 +3131,7 @@ class SimpleEngine(BaseEngine):
                 if specprefill_anchor_chunks is not None
                 else 1
             )
-            result, forward_context, plan = self._prepare_sparse_target_prefill(
+            prepare_kwargs = dict(
                 target_model=model,
                 tokenizer=tokenizer,
                 tokens=tokens,
@@ -2911,6 +3147,14 @@ class SimpleEngine(BaseEngine):
                 adapter=adapter,
                 cancel_check=_cancel_check,
             )
+            if combined_mtp:
+                prepare_kwargs["combined_mtp"] = True
+            prepared = self._prepare_sparse_target_prefill(**prepare_kwargs)
+            if combined_mtp:
+                result, forward_context, plan, sparse_bootstrap = prepared
+            else:
+                result, forward_context, plan = prepared
+                sparse_bootstrap = None
             logits = result.logits
             n_selected = len(plan.selected_indices)
             t_prefill = (telemetry.target_prefill_ms or 0.0) / 1000.0
@@ -2925,6 +3169,77 @@ class SimpleEngine(BaseEngine):
                 n_selected / n_tokens * 100,
                 t_prefill,
             )
+
+            if combined_mtp:
+                generation = None
+                authority_abandoned = False
+
+                def _abandon_before_first_output() -> bool:
+                    nonlocal authority_abandoned, sparse_decode_transaction_started
+                    if authority_abandoned:
+                        return True
+                    try:
+                        authority_abandoned = _try_abandon_sparse_bootstrap(
+                            sparse_bootstrap
+                        )
+                    except BaseException:
+                        sparse_decode_transaction_started = True
+                        raise
+                    if not authority_abandoned:
+                        sparse_decode_transaction_started = True
+                    return authority_abandoned
+
+                try:
+                    # Cancellation before the first resume owns no sample and
+                    # must atomically abandon still-unclaimed authority.
+                    _cancel_check()
+                    generation = self._model.stream_generate(
+                        prompt=None,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        stop=None,
+                        native_mtp_request=native_mtp_request,
+                        sparse_bootstrap=sparse_bootstrap,
+                        model_forward_context=forward_context,
+                        # Upstream history starts with the final selected prompt
+                        # token, so prefix all earlier original prompt tokens.
+                        logits_processor_seed_tokens=mx.array(
+                            tokens[:-1], dtype=mx.uint32
+                        ),
+                        **kwargs,
+                    )
+                    iterator = iter(generation)
+                    while True:
+                        try:
+                            chunk = next(iterator)
+                        except StopIteration:
+                            break
+                        except BaseException:
+                            _abandon_before_first_output()
+                            raise
+                        # A yielded chunk proves sampling occurred and the
+                        # bootstrap claim was consumed. Replay is now terminal.
+                        sparse_decode_transaction_started = True
+                        _cancel_check()
+                        _emit_sparse_response(chunk)
+                except BaseException:
+                    if not sparse_decode_transaction_started:
+                        _abandon_before_first_output()
+                    raise
+                finally:
+                    try:
+                        if generation is not None:
+                            close = getattr(generation, "close", None)
+                            if close is not None:
+                                close()
+                    finally:
+                        try:
+                            if not sparse_decode_transaction_started:
+                                _abandon_before_first_output()
+                        finally:
+                            forward_context.finish()
+                return
 
             # Sample the seed under the complete prompt history, then retain
             # request-local sparse positions for every continuation forward.
@@ -3003,13 +3318,16 @@ class SimpleEngine(BaseEngine):
 
         def _run_normal():
             """Fallback: normal generation without specprefill."""
+            normal_kwargs = dict(kwargs)
+            if native_mtp_request is not None:
+                normal_kwargs["native_mtp_request"] = native_mtp_request
             for chunk in self._model.stream_generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
                 stop=stop,
-                **kwargs,
+                **normal_kwargs,
             ):
                 _cancel_check()
                 _emit_response(chunk)
@@ -3033,10 +3351,16 @@ class SimpleEngine(BaseEngine):
         accumulated_text = ""
         token_count = 0
         finished = False
+        producer_exhausted = False
+        mtp_drafts = 0
+        mtp_accepted = 0
+        backend_mtp_bypass_reason = None
+        last_logprobs = None
         try:
             while True:
                 kind, payload = await response_queue.get()
                 if kind == "done":
+                    producer_exhausted = True
                     break
                 if kind == "error":
                     if finished and isinstance(payload, _SpecPrefillCancelled):
@@ -3050,6 +3374,12 @@ class SimpleEngine(BaseEngine):
                 resp = payload
 
                 token_count += 1
+                mtp_drafts = getattr(resp, "mtp_drafts", mtp_drafts)
+                mtp_accepted = getattr(resp, "mtp_accepted", mtp_accepted)
+                backend_mtp_bypass_reason = getattr(
+                    resp, "mtp_bypass_reason", backend_mtp_bypass_reason
+                )
+                last_logprobs = getattr(resp, "logprobs", last_logprobs)
                 new_text = resp.text if hasattr(resp, "text") else str(resp)
                 accumulated_text += new_text
 
@@ -3074,6 +3404,10 @@ class SimpleEngine(BaseEngine):
                     completion_tokens=token_count,
                     finished=finished,
                     finish_reason=finish_reason,
+                    mtp_drafts=mtp_drafts,
+                    mtp_accepted=mtp_accepted,
+                    mtp_bypass_reason=(mtp_bypass_reason or backend_mtp_bypass_reason),
+                    logprobs=last_logprobs,
                     **telemetry.as_output_kwargs(),
                 )
 
@@ -3089,7 +3423,15 @@ class SimpleEngine(BaseEngine):
                 prompt_tokens=n_tokens,
                 completion_tokens=token_count,
                 finished=True,
-                finish_reason="length",
+                # A clean sparse producer end is an ordinary natural stop,
+                # even when it did not emit a backend terminal reason.  Keep
+                # this separate empty terminal frame so the already-observed
+                # token frames and their telemetry remain unchanged.
+                finish_reason="stop" if producer_exhausted else "length",
+                mtp_drafts=mtp_drafts,
+                mtp_accepted=mtp_accepted,
+                mtp_bypass_reason=(mtp_bypass_reason or backend_mtp_bypass_reason),
+                logprobs=last_logprobs,
                 **telemetry.as_output_kwargs(),
             )
 
@@ -3198,10 +3540,18 @@ class SimpleEngine(BaseEngine):
             ),
             presence_penalty=presence_penalty if presence_penalty != 0.0 else None,
         )
+        if native_mtp_config is not None:
+            for processor in penalty_processors or ():
+                try:
+                    processor.native_mtp_replay_safe = True
+                except (AttributeError, TypeError) as exc:
+                    raise ValueError(
+                        "native MTP penalty processor cannot be replayed safely"
+                    ) from exc
         all_processors = (external_logits_processors or []) + (penalty_processors or [])
-        custom_logits_active = bool(all_processors)
+        custom_logits_active = bool(external_logits_processors)
         combined_mtp = (
-            _request_can_compose_mtp(combined_mtp, all_processors)
+            _request_can_compose_mtp(combined_mtp, external_logits_processors)
             and native_mtp_config is not None
         )
         sparse_no_completion_requested = max_tokens == 0
@@ -3395,9 +3745,6 @@ class SimpleEngine(BaseEngine):
         if use_specprefill and sparse_no_completion_requested:
             telemetry.fallback("sparse_no_completion_requested")
             use_specprefill = False
-        elif use_specprefill and combined_mtp:
-            telemetry.fallback("mtp_composition_not_implemented")
-            use_specprefill = False
         elif use_specprefill and (backbone_cache is not None or system_token_count):
             telemetry.fallback("sparse_prefix_cache_not_supported")
             use_specprefill = False
@@ -3485,10 +3832,6 @@ class SimpleEngine(BaseEngine):
                 logger.info(
                     "Text route: disabling MTP for request-local logits processors"
                 )
-            if use_specprefill and use_mtp:
-                telemetry.fallback("mtp_composition_not_implemented")
-                use_specprefill = False
-
             # Cache MISS with valid prefix: prefill system tokens and snapshot
             if (
                 not cache_hit
@@ -3556,6 +3899,8 @@ class SimpleEngine(BaseEngine):
                         sparse_output_committed
                         or sparse_decode_transaction_started
                         or abort_event.is_set()
+                        or isinstance(e, _SpecPrefillAuthorityError)
+                        or isinstance(e, SparseTargetPrefillAuthorityError)
                     ):
                         raise
                     logger.error(
@@ -3680,19 +4025,41 @@ class SimpleEngine(BaseEngine):
 
             from ..specprefill import score_tokens
 
-            if bc is not None or use_mtp:
+            if bc is not None:
                 raise TargetPositionError(
-                    "sparse-only target prefill requires fresh cache"
+                    "sparse target prefill requires a fresh target cache"
                 )
-            profile_key, adapter = self._admit_sparse_target(model)
+            if use_mtp and native_mtp_config is None:
+                raise TargetPositionError(
+                    "native MTP composition requires a request-local config"
+                )
+            if use_mtp:
+                profile_key, adapter = self._admit_sparse_target(
+                    model, combined_mtp=True
+                )
+            else:
+                profile_key, adapter = self._admit_sparse_target(model)
             detokenizer = _new_sparse_detokenizer(self._text_tokenizer)
+            seed_values = full_tokens_list
+            if use_mtp and seed_values is not None:
+                # Native sparse MTP supplies the final selected prompt token as
+                # its initial history; prefix only the preceding original IDs.
+                seed_values = seed_values[:-1]
             seed_tokens = (
-                mx.array(full_tokens_list, dtype=mx.uint32)
-                if full_tokens_list is not None
+                mx.array(seed_values, dtype=mx.uint32)
+                if seed_values is not None
                 else None
             )
             seeded_processors = _seed_logits_processors(seed_tokens, all_processors)
-            cache = make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
+            cache = (
+                model.make_cache()
+                if use_mtp
+                else make_prompt_cache(model, max_kv_size=self._max_kv_size or None)
+            )
+            if use_mtp and (not isinstance(cache, list) or not cache):
+                raise TargetPositionError(
+                    "sparse native MTP target cache must be a fresh non-empty list"
+                )
             import time
 
             def _cancel_check() -> None:
@@ -3723,7 +4090,7 @@ class SimpleEngine(BaseEngine):
                 if specprefill_anchor_chunks is not None
                 else 1
             )
-            result, forward_context, plan = self._prepare_sparse_target_prefill(
+            prepare_kwargs = dict(
                 target_model=model,
                 tokenizer=self._text_tokenizer,
                 tokens=specprefill_tokens,
@@ -3739,6 +4106,14 @@ class SimpleEngine(BaseEngine):
                 adapter=adapter,
                 cancel_check=_cancel_check,
             )
+            if use_mtp:
+                prepare_kwargs["combined_mtp"] = True
+            prepared = self._prepare_sparse_target_prefill(**prepare_kwargs)
+            if use_mtp:
+                result, forward_context, plan, sparse_bootstrap = prepared
+            else:
+                result, forward_context, plan = prepared
+                sparse_bootstrap = None
             logits = result.logits
             n_selected = len(plan.selected_indices)
             n_total = len(specprefill_tokens)
@@ -3754,6 +4129,76 @@ class SimpleEngine(BaseEngine):
                 n_selected / n_total * 100,
                 t_prefill,
             )
+
+            if use_mtp:
+                generation = None
+                authority_abandoned = False
+
+                def _abandon_before_first_output() -> bool:
+                    nonlocal authority_abandoned, sparse_decode_transaction_started
+                    if authority_abandoned:
+                        return True
+                    try:
+                        authority_abandoned = _try_abandon_sparse_bootstrap(
+                            sparse_bootstrap
+                        )
+                    except BaseException:
+                        sparse_decode_transaction_started = True
+                        raise
+                    if not authority_abandoned:
+                        sparse_decode_transaction_started = True
+                    return authority_abandoned
+
+                try:
+                    gen_kwargs = dict(
+                        max_tokens=max_tokens,
+                        prefill_step_size=self._prefill_step_size,
+                        model_forward_context=forward_context,
+                        sparse_bootstrap=sparse_bootstrap,
+                    )
+                    if seeded_processors:
+                        gen_kwargs["logits_processors"] = seeded_processors
+                    gen_kwargs.update(
+                        native_mtp_config.mlx_lm_call_kwargs(
+                            consumer=mlx_stream_generate
+                        )
+                    )
+                    _cancel_check()
+                    generation = mlx_stream_generate(
+                        model,
+                        self._text_tokenizer,
+                        prompt=None,
+                        **gen_kwargs,
+                    )
+                    iterator = iter(generation)
+                    while True:
+                        try:
+                            resp = next(iterator)
+                        except StopIteration:
+                            break
+                        except BaseException:
+                            _abandon_before_first_output()
+                            raise
+                        sparse_decode_transaction_started = True
+                        _cancel_check()
+                        _emit_sparse_response(resp)
+                except BaseException:
+                    if not sparse_decode_transaction_started:
+                        _abandon_before_first_output()
+                    raise
+                finally:
+                    try:
+                        if generation is not None:
+                            close = getattr(generation, "close", None)
+                            if close is not None:
+                                close()
+                    finally:
+                        try:
+                            if not sparse_decode_transaction_started:
+                                _abandon_before_first_output()
+                        finally:
+                            forward_context.finish()
+                return
 
             # Phase 4: Sample the first token from the prefilled logits, then
             # continue through mlx_lm with the request-local forward context.
@@ -3863,6 +4308,7 @@ class SimpleEngine(BaseEngine):
         accumulated_text = ""
         token_count = 0
         finished = False
+        producer_exhausted = False
         mtp_drafts = 0
         mtp_accepted = 0
         backend_mtp_bypass_reason = None
@@ -3871,6 +4317,7 @@ class SimpleEngine(BaseEngine):
             while True:
                 kind, payload = await response_queue.get()
                 if kind == "done":
+                    producer_exhausted = True
                     break
                 if kind == "error":
                     if finished and isinstance(payload, _SpecPrefillCancelled):
@@ -3902,7 +4349,7 @@ class SimpleEngine(BaseEngine):
                 if stop_hit:
                     finish_reason = "stop"
                 elif finish_reason is None and finished:
-                    finish_reason = "stop"
+                    finish_reason = "length"
                 elif finish_reason is not None:
                     finished = True
                 if finished:
@@ -3917,9 +4364,7 @@ class SimpleEngine(BaseEngine):
                     finish_reason=finish_reason,
                     mtp_drafts=mtp_drafts,
                     mtp_accepted=mtp_accepted,
-                    mtp_bypass_reason=(
-                        mtp_bypass_reason or backend_mtp_bypass_reason
-                    ),
+                    mtp_bypass_reason=(mtp_bypass_reason or backend_mtp_bypass_reason),
                     logprobs=last_logprobs,
                     **telemetry.as_output_kwargs(),
                 )
@@ -3936,7 +4381,9 @@ class SimpleEngine(BaseEngine):
                 prompt_tokens=full_token_count or 0,
                 completion_tokens=token_count,
                 finished=True,
-                finish_reason="length",
+                # A clean sparse producer end is an ordinary natural stop,
+                # even when it did not emit a backend terminal reason.
+                finish_reason="stop" if producer_exhausted else "length",
                 mtp_drafts=mtp_drafts,
                 mtp_accepted=mtp_accepted,
                 mtp_bypass_reason=(mtp_bypass_reason or backend_mtp_bypass_reason),

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -341,6 +341,7 @@ class EngineCore:
         images: Optional[List[Any]] = None,
         videos: Optional[List[Any]] = None,
         prefix_boundary: int = 0,
+        native_mtp_config: Any = None,
     ) -> str:
         """
         Add a request for processing.
@@ -369,6 +370,7 @@ class EngineCore:
             images=images,
             videos=videos,
             prefix_boundary=prefix_boundary,
+            native_mtp_config=native_mtp_config,
         )
 
         # Setup output collector with stream_interval from config

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -37,6 +37,19 @@ from .specprefill_cache import (
     SparseCacheRowState,
     SparseCacheState,
 )
+from .specprefill_gemma_cache import (
+    GEMMA4_ARTIFACTS,
+    GemmaArtifactSpec,
+    GemmaCacheBackend,
+    GemmaCacheCheckpoint,
+    GemmaCachePairCheckpoint,
+    GemmaOneTokenTransaction,
+    batch_cache_cursor,
+    atomic_batch_extend,
+    atomic_batch_filter,
+    validate_gemma_cache_topology,
+    validate_homogeneous_batch_lane,
+)
 from .vision_embedding_cache import VisionEmbeddingCache
 
 logger = logging.getLogger(__name__)
@@ -173,6 +186,183 @@ class SparseBatchCompatibilityError(SparseBatchError):
     """Sparse rows do not share one immutable execution configuration."""
 
 
+_GEMMA_PREPARED_ATTESTATION_TOKEN = object()
+
+
+@dataclass(frozen=True, init=False)
+class GemmaPreparedTargetAttestation:
+    """Engine-prepared identity bound to verified bytes and a live Gemma model.
+
+    Instances can only be produced by :func:`prepare_gemma_sparse_target`.
+    Request/row configuration therefore cannot restate its own artifact hash or
+    topology and call those values attested.
+    """
+
+    target_model: Any
+    text_model: Any
+    processor: Any
+    target_artifact_hash: str
+    artifact: GemmaArtifactSpec
+    layer_types: tuple[str, ...]
+    previous_kvs: tuple[int, ...]
+    backend: GemmaCacheBackend
+
+    def __init__(
+        self,
+        *,
+        target_model: Any,
+        text_model: Any,
+        processor: Any,
+        target_artifact_hash: str,
+        artifact: GemmaArtifactSpec,
+        layer_types: tuple[str, ...],
+        previous_kvs: tuple[int, ...],
+        _token: object,
+    ) -> None:
+        if _token is not _GEMMA_PREPARED_ATTESTATION_TOKEN:
+            raise TypeError(
+                "Gemma target attestations must be created by the prepared runtime"
+            )
+        object.__setattr__(self, "target_model", target_model)
+        object.__setattr__(self, "text_model", text_model)
+        object.__setattr__(self, "processor", processor)
+        object.__setattr__(self, "target_artifact_hash", target_artifact_hash)
+        object.__setattr__(self, "artifact", artifact)
+        object.__setattr__(self, "layer_types", layer_types)
+        object.__setattr__(self, "previous_kvs", previous_kvs)
+        object.__setattr__(self, "backend", GemmaCacheBackend.MLX_VLM)
+
+    @property
+    def canonical_target_id(self) -> str:
+        return (
+            f"{self.artifact.artifact_id}@sha256:{self.target_artifact_hash}"
+        )
+
+    def validate_cache(self, cache: Sequence[Any]) -> None:
+        validate_gemma_cache_topology(
+            self.artifact,
+            layer_types=self.layer_types,
+            previous_kvs=self.previous_kvs,
+            cache=cache,
+            backend=self.backend,
+        )
+
+
+def prepare_gemma_sparse_target(
+    *,
+    target_model: Any,
+    processor: Any,
+    target_artifact_path: str,
+    artifact: GemmaArtifactSpec,
+    target_identity_attestation: Any,
+) -> GemmaPreparedTargetAttestation:
+    """Verify and freeze the engine-owned Gemma sparse target identity.
+
+    The generic target/processor attestation establishes the trusted binding
+    to loaded objects. This seam independently hashes the canonical artifact
+    path and derives topology from the live text model before any generator can
+    admit a Gemma sparse row.
+    """
+    # Local import avoids a module cycle: specprefill_runtime uses this module's
+    # target-forward types while startup invokes this function only afterwards.
+    from .specprefill_runtime import TargetProcessorAttestation, sha256_artifact_path
+
+    if not isinstance(target_identity_attestation, TargetProcessorAttestation):
+        raise TypeError(
+            "target_identity_attestation must be TargetProcessorAttestation"
+        )
+    if (
+        target_identity_attestation.target_model is not target_model
+        or target_identity_attestation.processor is not processor
+    ):
+        raise SparseBatchCompatibilityError(
+            "Gemma prepared identity is not bound to the loaded target/processor"
+        )
+    actual_hash = sha256_artifact_path(target_artifact_path)
+    if actual_hash != target_identity_attestation.target_artifact_hash:
+        raise SparseBatchCompatibilityError(
+            "Gemma target artifact bytes do not match the prepared identity"
+        )
+    if GEMMA4_ARTIFACTS.get(artifact.artifact_id) != artifact:
+        raise SparseBatchCompatibilityError("Gemma artifact is not certified")
+
+    text_model = getattr(target_model, "language_model", target_model)
+    model_config = getattr(text_model, "config", None)
+    if model_config is None:
+        model_config = getattr(text_model, "args", None)
+    model_backbone = getattr(text_model, "model", text_model)
+    layer_types = tuple(getattr(model_config, "layer_types", ()))
+    previous_kvs = tuple(getattr(model_backbone, "previous_kvs", ()))
+    if layer_types != artifact.layer_types:
+        raise SparseBatchCompatibilityError(
+            "live Gemma layer topology does not match the certified artifact"
+        )
+    if previous_kvs != artifact.previous_kvs:
+        raise SparseBatchCompatibilityError(
+            "live Gemma cache-owner topology does not match the certified artifact"
+        )
+    return GemmaPreparedTargetAttestation(
+        target_model=target_model,
+        text_model=text_model,
+        processor=processor,
+        target_artifact_hash=actual_hash,
+        artifact=artifact,
+        layer_types=layer_types,
+        previous_kvs=previous_kvs,
+        _token=_GEMMA_PREPARED_ATTESTATION_TOKEN,
+    )
+
+
+@dataclass(frozen=True)
+class GemmaSparseBatchConfig:
+    """Exact, opt-in mlx-vlm Gemma batch-cache contract.
+
+    Scheduler/runtime capability wiring intentionally does not construct this
+    yet.  Tests and a later certified runtime may install it explicitly.
+    """
+
+    attestation: GemmaPreparedTargetAttestation
+    execution_config: SparseCacheExecutionConfig
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.attestation, GemmaPreparedTargetAttestation):
+            raise TypeError("attestation must be GemmaPreparedTargetAttestation")
+        if not isinstance(self.execution_config, SparseCacheExecutionConfig):
+            raise TypeError("execution_config must be SparseCacheExecutionConfig")
+        if self.execution_config.target_id != self.attestation.canonical_target_id:
+            raise SparseBatchCompatibilityError(
+                "Gemma sparse profile target_id does not match target attestation"
+            )
+
+    def validate_cache(self, cache: Sequence[Any]) -> None:
+        self.attestation.validate_cache(cache)
+
+
+def _validate_gemma_cache_rows(
+    cache: Sequence[Any], row_states: Sequence[SparseCacheRowState | None]
+) -> None:
+    if not row_states or any(row is None for row in row_states):
+        raise SparseBatchCompatibilityError(
+            "Gemma sparse cache requires homogeneous sparse rows"
+        )
+    rows = tuple(row for row in row_states if row is not None)
+    logical_positions = tuple(row.next_logical_position for row in rows)
+    expected_writes = tuple(row.physical_valid_length for row in rows)
+    validate_homogeneous_batch_lane(
+        cache,
+        logical_positions=logical_positions,
+    )
+    for entry in cache:
+        cursor = batch_cache_cursor(
+            entry,
+            logical_positions=logical_positions,
+        )
+        if cursor.total_writes != expected_writes:
+            raise SparseBatchCompatibilityError(
+                "Gemma cache physical writes do not match sparse row occupancy"
+            )
+
+
 class SparseAdoptionError(SparseBatchError):
     """Typed sparse-adoption failure with an immutable replay boundary."""
 
@@ -260,6 +450,63 @@ class _ArraysDecodeCheckpoint:
         self.entry.cache = list(self.cache)
         self.entry.left_padding = self.left_padding
         self.entry.lengths = self.lengths
+
+
+@dataclass(frozen=True)
+class _GemmaBatchMetadataState:
+    entry: Any
+    offset: mx.array
+    left_padding: mx.array
+    idx: int
+    physical_offset: int | None
+    rotated: bool | None
+
+
+@dataclass(frozen=True)
+class _GemmaBatchMetadataCheckpoint:
+    """Detached O(rows*owners) cursor metadata; never copies a KV window."""
+
+    states: tuple[_GemmaBatchMetadataState, ...]
+
+    @classmethod
+    def capture(cls, cache: Sequence[Any]) -> "_GemmaBatchMetadataCheckpoint":
+        states = []
+        tensors = []
+        for entry in cache:
+            if getattr(entry, "_right_padding", None) is not None or getattr(
+                entry, "_lengths", None
+            ) is not None:
+                raise SparseBatchError(
+                    "Gemma sparse decode requires finalized batch caches"
+                )
+            offset = entry.offset + mx.zeros_like(entry.offset)
+            left_padding = entry.left_padding + mx.zeros_like(entry.left_padding)
+            tensors.extend((offset, left_padding))
+            states.append(
+                _GemmaBatchMetadataState(
+                    entry=entry,
+                    offset=offset,
+                    left_padding=left_padding,
+                    idx=entry._idx,
+                    physical_offset=getattr(entry, "_offset", None),
+                    rotated=getattr(entry, "rotated", None),
+                )
+            )
+        mx.eval(*tensors)
+        return cls(tuple(states))
+
+    def restore(self) -> None:
+        tensors = []
+        for state in self.states:
+            state.entry.offset = state.offset
+            state.entry.left_padding = state.left_padding
+            state.entry._idx = state.idx
+            if state.physical_offset is not None:
+                state.entry._offset = state.physical_offset
+            if state.rotated is not None:
+                state.entry.rotated = state.rotated
+            tensors.extend((state.entry.offset, state.entry.left_padding))
+        mx.eval(*tensors)
 
 
 @dataclass(frozen=True)
@@ -555,6 +802,7 @@ class MLLMBatch:
     logits_processors: Optional[List[Optional[List[Callable]]]] = None
     samplers: Optional[List[Optional[Callable]]] = None
     sparse_row_states: tuple[SparseCacheRowState | None, ...] = ()
+    gemma_sparse_config: GemmaSparseBatchConfig | None = None
 
     def __post_init__(self) -> None:
         row_count = len(self.uids)
@@ -599,6 +847,20 @@ class MLLMBatch:
                 raise SparseBatchCompatibilityError(
                     "sparse MLLMBatch rows require equal physical occupancy"
                 )
+        if self.gemma_sparse_config is not None:
+            if not self.has_sparse_rows:
+                raise SparseBatchCompatibilityError(
+                    "Gemma sparse cache config requires sparse rows"
+                )
+            if (
+                self.sparse_execution_config
+                != self.gemma_sparse_config.execution_config
+            ):
+                raise SparseBatchCompatibilityError(
+                    "Gemma sparse cache profile does not match row identity"
+                )
+            self.gemma_sparse_config.validate_cache(self.cache)
+            _validate_gemma_cache_rows(self.cache, self.sparse_row_states)
 
     def __len__(self) -> int:
         return len(self.uids)
@@ -655,18 +917,39 @@ class MLLMBatch:
 
         checkpoint = (
             _SupportedSparseCacheCheckpoint.capture(self.cache, self.sparse_row_states)
-            if self.has_sparse_rows
+            if self.has_sparse_rows and self.gemma_sparse_config is None
+            else None
+        )
+        gemma_checkpoint = (
+            GemmaCacheCheckpoint(self.cache)
+            if self.gemma_sparse_config is not None
             else None
         )
         try:
-            for cache_entry in self.cache:
-                if hasattr(cache_entry, "filter"):
-                    cache_entry.filter(keep_idx_array)
-                elif self.has_sparse_rows:
-                    raise SparseBatchError(
-                        "sparse decode cache entries must support atomic filtering"
-                    )
-        except Exception:
+            if self.gemma_sparse_config is not None:
+                atomic_batch_filter(
+                    self.cache,
+                    keep_idx_array,
+                    logical_positions=tuple(
+                        row.next_logical_position
+                        for row in self.sparse_row_states
+                        if row is not None
+                    ),
+                )
+                _validate_gemma_cache_rows(self.cache, next_sparse_rows)
+                assert gemma_checkpoint is not None
+                gemma_checkpoint.seal()
+            else:
+                for cache_entry in self.cache:
+                    if hasattr(cache_entry, "filter"):
+                        cache_entry.filter(keep_idx_array)
+                    elif self.has_sparse_rows:
+                        raise SparseBatchError(
+                            "sparse decode cache entries must support atomic filtering"
+                        )
+        except BaseException:
+            if gemma_checkpoint is not None:
+                gemma_checkpoint.restore()
             if checkpoint is not None:
                 checkpoint.restore()
             raise
@@ -694,6 +977,10 @@ class MLLMBatch:
                 "sparse and dense rows cannot share a target decode batch"
             )
         _sparse_execution_config(self.sparse_row_states + other.sparse_row_states)
+        if self.gemma_sparse_config != other.gemma_sparse_config:
+            raise SparseBatchCompatibilityError(
+                "Gemma sparse batches require one exact topology/profile contract"
+            )
         if (
             self.has_sparse_rows
             and len(
@@ -745,26 +1032,46 @@ class MLLMBatch:
         # through empty()/extend() and do not publish .keys.
         checkpoint = (
             _SupportedSparseCacheCheckpoint.capture(self.cache, self.sparse_row_states)
-            if self.has_sparse_rows
+            if self.has_sparse_rows and self.gemma_sparse_config is None
             else None
         )
         try:
-            for c, o in zip(self.cache, other.cache, strict=True):
-                if c is not None and o is not None and hasattr(c, "extend"):
-                    has_kv = hasattr(c, "keys") and c.keys is not None
-                    has_arrays = hasattr(c, "cache")
-                    has_extendable_state = hasattr(c, "empty") and not c.empty()
-                    if has_kv or has_arrays or has_extendable_state:
-                        c.extend(o)
-                elif (c is None) != (o is None) or (
-                    (self.has_sparse_rows or other.has_sparse_rows)
-                    and c is not None
-                    and not hasattr(c, "extend")
-                ):
-                    raise SparseBatchError(
-                        "sparse decode cache entries must support atomic extension"
+            if self.gemma_sparse_config is not None:
+                combined_logical = tuple(
+                    row.next_logical_position
+                    for row in next_sparse_rows
+                    if row is not None
+                )
+                if len(set(combined_logical)) != 1:
+                    raise SparseBatchCompatibilityError(
+                        "Gemma sparse batches require equal logical write positions"
                     )
-        except Exception:
+                pair = GemmaCachePairCheckpoint(self.cache, other.cache)
+                try:
+                    atomic_batch_extend(self.cache, other.cache)
+                    _validate_gemma_cache_rows(self.cache, next_sparse_rows)
+                    pair.source.restore()
+                    pair.destination.seal()
+                except BaseException:
+                    pair.restore()
+                    raise
+            else:
+                for c, o in zip(self.cache, other.cache, strict=True):
+                    if c is not None and o is not None and hasattr(c, "extend"):
+                        has_kv = hasattr(c, "keys") and c.keys is not None
+                        has_arrays = hasattr(c, "cache")
+                        has_extendable_state = hasattr(c, "empty") and not c.empty()
+                        if has_kv or has_arrays or has_extendable_state:
+                            c.extend(o)
+                    elif (c is None) != (o is None) or (
+                        (self.has_sparse_rows or other.has_sparse_rows)
+                        and c is not None
+                        and not hasattr(c, "extend")
+                    ):
+                        raise SparseBatchError(
+                            "sparse decode cache entries must support atomic extension"
+                        )
+        except BaseException:
             if checkpoint is not None:
                 checkpoint.restore()
             raise
@@ -789,6 +1096,11 @@ class MLLMBatch:
         causing extract() to use Python negative indexing and truncate
         the buffer to only generation tokens instead of the full window.
         """
+        if self.gemma_sparse_config is not None:
+            raise SparseBatchError(
+                "prefix cache extraction is disabled for Gemma sparse rows"
+            )
+
         from mlx_lm.models.cache import (
             BatchRotatingKVCache,
             RotatingKVCache,
@@ -922,6 +1234,7 @@ class MLLMBatchGenerator:
         max_kv_size: int = 0,
         target_forward_context: Optional[TargetForwardContext] = None,
         expected_sparse_execution_config: SparseCacheExecutionConfig | None = None,
+        expected_gemma_sparse_config: GemmaSparseBatchConfig | None = None,
     ):
         """
         Initialize MLLM batch generator.
@@ -943,6 +1256,8 @@ class MLLMBatchGenerator:
             target_forward_context: Request-local context factory for target decode
             expected_sparse_execution_config: Scheduler-selected exact sparse
                 profile/artifact identity admitted by this generator
+            expected_gemma_sparse_config: Explicit Gemma batch-cache foundation
+                contract. No scheduler/runtime currently supplies this value.
         """
         self.model = model
         self.processor = processor
@@ -958,6 +1273,21 @@ class MLLMBatchGenerator:
                 "expected_sparse_execution_config must be SparseCacheExecutionConfig"
             )
         self._expected_sparse_execution_config = expected_sparse_execution_config
+        if expected_gemma_sparse_config is not None and not isinstance(
+            expected_gemma_sparse_config, GemmaSparseBatchConfig
+        ):
+            raise TypeError(
+                "expected_gemma_sparse_config must be GemmaSparseBatchConfig"
+            )
+        if (
+            expected_gemma_sparse_config is not None
+            and expected_sparse_execution_config
+            != expected_gemma_sparse_config.execution_config
+        ):
+            raise SparseBatchCompatibilityError(
+                "Gemma sparse contract must match generator execution identity"
+            )
+        self._expected_gemma_sparse_config = expected_gemma_sparse_config
         # One aggregated predicate scalar is read at each realized sparse
         # boundary. Telemetry separately counts the device metadata scalars
         # examined by that predicate; no KV/state tensor is copied.
@@ -966,6 +1296,18 @@ class MLLMBatchGenerator:
 
         # Get language model for text generation
         self.language_model = getattr(model, "language_model", model)
+        if (
+            expected_gemma_sparse_config is not None
+            and (
+                expected_gemma_sparse_config.attestation.target_model is not model
+                or expected_gemma_sparse_config.attestation.text_model
+                is not self.language_model
+                or expected_gemma_sparse_config.attestation.processor is not processor
+            )
+        ):
+            raise SparseBatchCompatibilityError(
+                "Gemma prepared identity does not match generator-owned objects"
+            )
 
         # Check if this is actually a VLM with separate language model
         self.is_vlm = hasattr(model, "language_model")
@@ -1309,7 +1651,36 @@ class MLLMBatchGenerator:
             raise SparseBatchError(
                 "cannot replace sparse execution identity with sparse rows active"
             )
+        gemma_config = getattr(self, "_expected_gemma_sparse_config", None)
+        if gemma_config is not None and gemma_config.execution_config != config:
+            raise SparseBatchCompatibilityError(
+                "sparse execution identity must match the Gemma contract"
+            )
         self._expected_sparse_execution_config = config
+
+    def set_expected_gemma_sparse_config(
+        self, config: GemmaSparseBatchConfig
+    ) -> None:
+        """Install an exact Gemma foundation contract before sparse ownership."""
+        if not isinstance(config, GemmaSparseBatchConfig):
+            raise TypeError("config must be GemmaSparseBatchConfig")
+        if self.active_batch is not None and self.active_batch.has_sparse_rows:
+            raise SparseBatchError(
+                "cannot replace Gemma sparse contract with sparse rows active"
+            )
+        if self._expected_sparse_execution_config != config.execution_config:
+            raise SparseBatchCompatibilityError(
+                "Gemma sparse contract must match generator execution identity"
+            )
+        if (
+            config.attestation.target_model is not self.model
+            or config.attestation.text_model is not self.language_model
+            or config.attestation.processor is not self.processor
+        ):
+            raise SparseBatchCompatibilityError(
+                "Gemma prepared identity does not match generator-owned objects"
+            )
+        self._expected_gemma_sparse_config = config
 
     def adopt_prefilled_sparse_row(
         self,
@@ -1362,15 +1733,15 @@ class MLLMBatchGenerator:
 
     def _restore_sparse_adoption_checkpoint(
         self,
-        checkpoint: _SupportedSparseCacheCheckpoint,
+        checkpoint: Any,
         active: MLLMBatch,
         *,
-        adoption_failure: Exception,
+        adoption_failure: BaseException,
         sampling_consumed: bool,
     ) -> None:
         try:
             checkpoint.restore()
-        except Exception as rollback_failure:
+        except BaseException as rollback_failure:
             self._poison_active_sparse_batch_after_failed_rollback(active)
             raise SparseAdoptionError(
                 "prepared sparse adoption rollback failed after "
@@ -1425,6 +1796,30 @@ class MLLMBatchGenerator:
             raise SparseBatchCompatibilityError(
                 "prepared sparse identity does not match the generator-selected profile"
             )
+        gemma_config = getattr(self, "_expected_gemma_sparse_config", None)
+        if gemma_config is not None and getattr(self, "_mtp_installed", False):
+            raise SparseBatchCompatibilityError(
+                "Gemma sparse target decode cannot compose with MTP"
+            )
+        if (
+            gemma_config is not None
+            and (
+                gemma_config.attestation.target_model is not self.model
+                or gemma_config.attestation.text_model is not self.language_model
+                or gemma_config.attestation.processor is not self.processor
+            )
+        ):
+            raise SparseBatchCompatibilityError(
+                "prepared Gemma identity does not match generator-owned objects"
+            )
+        if (
+            gemma_config is not None
+            and gemma_config.execution_config
+            != row_state.identity.execution_config
+        ):
+            raise SparseBatchCompatibilityError(
+                "prepared Gemma topology does not match the sparse profile"
+            )
         if request.input_ids is None:
             raise SparseBatchError(
                 "prepared sparse adoption requires the exact full prompt token IDs"
@@ -1442,6 +1837,8 @@ class MLLMBatchGenerator:
                 "prepared sparse logical cursor must equal the full prompt length"
             )
         self._validate_prepared_sparse_cache(cache, row_state)
+        if gemma_config is not None:
+            gemma_config.validate_cache(cache)
 
         if self.active_batch is not None and not self.active_batch.has_sparse_rows:
             raise SparseBatchCompatibilityError(
@@ -1475,12 +1872,20 @@ class MLLMBatchGenerator:
         # held as an unpublished transaction until sampling also succeeds.
         batch_cache = self._merge_prepared_sparse_cache(cache)
         candidate_rows = (row_state.clone(),)
-        _SupportedSparseCacheCheckpoint.capture(batch_cache, candidate_rows)
+        if gemma_config is None:
+            _SupportedSparseCacheCheckpoint.capture(batch_cache, candidate_rows)
+        else:
+            gemma_config.validate_cache(batch_cache)
+            _validate_gemma_cache_rows(batch_cache, candidate_rows)
         _eval_sparse_adoption_cache(batch_cache)
 
         active = self.active_batch
         active_checkpoint = None
         if active is not None:
+            if active.gemma_sparse_config != gemma_config:
+                raise SparseBatchCompatibilityError(
+                    "sparse batches require one exact Gemma topology/profile contract"
+                )
             if active.sparse_execution_config != row_state.identity.execution_config:
                 raise SparseBatchCompatibilityError(
                     "sparse decode rows require one exact execution configuration"
@@ -1500,14 +1905,27 @@ class MLLMBatchGenerator:
                 raise SparseBatchCompatibilityError(
                     "decode batches require identical supported cache topology"
                 )
-            active_checkpoint = _SupportedSparseCacheCheckpoint.capture(
-                active.cache, active.sparse_row_states
+            active_checkpoint = (
+                _SupportedSparseCacheCheckpoint.capture(
+                    active.cache, active.sparse_row_states
+                )
+                if gemma_config is None
+                else GemmaCacheCheckpoint(active.cache)
             )
             try:
-                for current, incoming in zip(active.cache, batch_cache, strict=True):
-                    current.extend(incoming)
-                _eval_sparse_adoption_cache(active.cache)
-            except Exception as exc:
+                if gemma_config is None:
+                    for current, incoming in zip(
+                        active.cache, batch_cache, strict=True
+                    ):
+                        current.extend(incoming)
+                    _eval_sparse_adoption_cache(active.cache)
+                else:
+                    atomic_batch_extend(active.cache, batch_cache)
+                    _validate_gemma_cache_rows(
+                        active.cache,
+                        active.sparse_row_states + candidate_rows,
+                    )
+            except BaseException as exc:
                 self._restore_sparse_adoption_checkpoint(
                     active_checkpoint,
                     active,
@@ -1536,6 +1954,7 @@ class MLLMBatchGenerator:
                 logits_processors=[processors] if processors else None,
                 samplers=[sampler],
                 sparse_row_states=candidate_rows,
+                gemma_sparse_config=gemma_config,
             )
             if active is not None:
                 self_len = len(active)
@@ -1555,7 +1974,7 @@ class MLLMBatchGenerator:
                 )
             else:
                 _eval_sparse_adoption_publication(candidate.y, *candidate.logprobs)
-        except Exception as exc:
+        except BaseException as exc:
             if active_checkpoint is not None:
                 self._restore_sparse_adoption_checkpoint(
                     active_checkpoint,
@@ -1568,6 +1987,8 @@ class MLLMBatchGenerator:
         if active is None:
             self.active_batch = candidate
         else:
+            if isinstance(active_checkpoint, GemmaCacheCheckpoint):
+                active_checkpoint.seal()
             # All values above were staged before these non-failing assignments.
             active.uids = active.uids + candidate.uids
             active.request_ids = active.request_ids + candidate.request_ids
@@ -2552,10 +2973,41 @@ class MLLMBatchGenerator:
         cache_checkpoint = (
             _SupportedSparseCacheCheckpoint.capture(cache, sparse_rows)
             if has_sparse_rows
+            and active_batch is not None
+            and active_batch.gemma_sparse_config is None
             else None
         )
+        gemma_transaction = None
+        gemma_metadata_checkpoint = None
 
         try:
+            if (
+                has_sparse_rows
+                and active_batch is not None
+                and active_batch.gemma_sparse_config is not None
+            ):
+                attestation = active_batch.gemma_sparse_config.attestation
+                if (
+                    attestation.target_model is not self.model
+                    or attestation.text_model is not self.language_model
+                    or attestation.processor is not self.processor
+                ):
+                    raise SparseBatchCompatibilityError(
+                        "live Gemma identity does not match generator-owned objects"
+                    )
+                active_batch.gemma_sparse_config.validate_cache(cache)
+                _validate_gemma_cache_rows(cache, sparse_rows)
+                gemma_metadata_checkpoint = _GemmaBatchMetadataCheckpoint.capture(
+                    cache
+                )
+                gemma_transaction = GemmaOneTokenTransaction(
+                    cache,
+                    logical_positions=tuple(
+                        row.next_logical_position
+                        for row in sparse_rows
+                        if row is not None
+                    ),
+                )
             forward = MLLMTargetForward(
                 input_tokens=input_tokens,
                 cache=cache,
@@ -2616,20 +3068,34 @@ class MLLMBatchGenerator:
                 # logical state. A failure leaves both metadata and response
                 # emission untouched and restores the entry cache snapshot.
                 assert active_batch is not None
-                assert cache_checkpoint is not None
-                occupancy_ok, examined_scalars = (
-                    cache_checkpoint.one_token_advance_predicate(sparse_rows)
-                )
-                mx.eval(sampled, logprobs, occupancy_ok)
-                self._sparse_checkpoint_scalar_reads += examined_scalars
-                self._sparse_checkpoint_host_scalar_reads += 1
-                if not occupancy_ok.item():
-                    raise SparseBatchError(
-                        "sparse cache physical occupancy must advance exactly one per row"
+                if gemma_transaction is not None:
+                    mx.eval(sampled, logprobs)
+                    gemma_transaction.commit(
+                        logical_positions=tuple(
+                            row.next_logical_position + 1
+                            for row in sparse_rows
+                            if row is not None
+                        )
                     )
+                else:
+                    assert cache_checkpoint is not None
+                    occupancy_ok, examined_scalars = (
+                        cache_checkpoint.one_token_advance_predicate(sparse_rows)
+                    )
+                    mx.eval(sampled, logprobs, occupancy_ok)
+                    self._sparse_checkpoint_scalar_reads += examined_scalars
+                    self._sparse_checkpoint_host_scalar_reads += 1
+                    if not occupancy_ok.item():
+                        raise SparseBatchError(
+                            "sparse cache physical occupancy must advance exactly one per row"
+                        )
                 active_batch.commit_sparse_decode(1)
             return sampled, list(logprobs)
-        except Exception:
+        except BaseException:
+            if gemma_transaction is not None:
+                gemma_transaction.rollback()
+            if gemma_metadata_checkpoint is not None:
+                gemma_metadata_checkpoint.restore()
             if cache_checkpoint is not None:
                 cache_checkpoint.restore()
             raise
@@ -3026,6 +3492,8 @@ def install_mtp_mllm(
     _deferred_drafts: Dict[int, dict] = {}
     _attempted_drafts_by_uid: Dict[int, int] = {}
 
+    batch_gen._mtp_installed = True
+
     # MTP stats. These are intentionally exposed through get_mtp_stats() so
     # /v1/status can distinguish "weights injected" from useful draft work.
     _mtp_stats_lock = threading.Lock()
@@ -3087,7 +3555,7 @@ def install_mtp_mllm(
         )
         sparse_rows_bypass = (
             batch_gen.active_batch is not None
-            and batch_gen.active_batch.has_sparse_rows
+            and getattr(batch_gen.active_batch, "has_sparse_rows", False)
         )
         if (
             prefill_bypass

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -173,6 +173,40 @@ class SparseBatchCompatibilityError(SparseBatchError):
     """Sparse rows do not share one immutable execution configuration."""
 
 
+class SparseAdoptionError(SparseBatchError):
+    """Typed sparse-adoption failure with an immutable replay boundary."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        sampling_consumed: bool,
+        rollback_succeeded: bool = True,
+    ) -> None:
+        super().__init__(message)
+        self._sampling_consumed = bool(sampling_consumed)
+        self._rollback_succeeded = bool(rollback_succeeded)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"_sampling_consumed", "_rollback_succeeded"} and hasattr(
+            self, name
+        ):
+            raise AttributeError("sparse adoption replay boundary is immutable")
+        super().__setattr__(name, value)
+
+    @property
+    def sampling_consumed(self) -> bool:
+        return self._sampling_consumed
+
+    @property
+    def rollback_succeeded(self) -> bool:
+        return self._rollback_succeeded
+
+    @property
+    def replay_safe(self) -> bool:
+        return not self.sampling_consumed and self.rollback_succeeded
+
+
 class MLLMTargetForwardPhase(str, Enum):
     """Target call phases supported by the request-local CB seam."""
 
@@ -415,6 +449,24 @@ def _eval_prompt_cache(cache: List[Any]) -> None:
     tensors = _cache_eval_tensors(cache)
     if tensors:
         mx.eval(*tensors)
+
+
+def _eval_sparse_adoption_cache(cache: Sequence[Any]) -> None:
+    """Realize every tensor staged by sparse cache merge or extension."""
+    tensors = _cache_eval_tensors(list(cache))
+    for entry in cache:
+        for name in ("offset", "left_padding", "lengths"):
+            value = getattr(entry, name, None)
+            if value is not None and hasattr(value, "shape"):
+                tensors.append(value)
+    if tensors:
+        mx.eval(*tensors)
+
+
+def _eval_sparse_adoption_publication(*values: Any) -> None:
+    """Realize post-sampling tensors before publishing a sparse row."""
+    if values:
+        mx.eval(*values)
 
 
 @dataclass
@@ -1266,6 +1318,76 @@ class MLLMBatchGenerator:
         first_logits: mx.array,
         sparse_state: SparseCacheState,
     ) -> int:
+        """Adopt with an exact typed boundary for safe dense replay."""
+        sampling_consumed = False
+
+        def mark_sampling_consumed() -> None:
+            nonlocal sampling_consumed
+            sampling_consumed = True
+
+        try:
+            return self._adopt_prefilled_sparse_row(
+                request,
+                cache,
+                first_logits,
+                sparse_state,
+                mark_sampling_consumed=mark_sampling_consumed,
+            )
+        except SparseAdoptionError:
+            raise
+        except Exception as exc:
+            raise SparseAdoptionError(
+                f"prepared sparse adoption failed: {type(exc).__name__}: {exc}",
+                sampling_consumed=sampling_consumed,
+            ) from exc
+
+    def _poison_active_sparse_batch_after_failed_rollback(
+        self,
+        active: MLLMBatch,
+    ) -> None:
+        """Remove a possibly corrupted active batch and fail all owned rows."""
+        if self.active_batch is not active:
+            return
+        self.active_batch = None
+        for uid, request_id in zip(active.uids, active.request_ids, strict=True):
+            self._pending_error_responses.append(
+                MLLMBatchResponse(
+                    uid=uid,
+                    request_id=request_id,
+                    token=0,
+                    logprobs=mx.zeros(1),
+                    finish_reason="error",
+                )
+            )
+
+    def _restore_sparse_adoption_checkpoint(
+        self,
+        checkpoint: _SupportedSparseCacheCheckpoint,
+        active: MLLMBatch,
+        *,
+        adoption_failure: Exception,
+        sampling_consumed: bool,
+    ) -> None:
+        try:
+            checkpoint.restore()
+        except Exception as rollback_failure:
+            self._poison_active_sparse_batch_after_failed_rollback(active)
+            raise SparseAdoptionError(
+                "prepared sparse adoption rollback failed after "
+                f"{type(adoption_failure).__name__}: {adoption_failure}",
+                sampling_consumed=sampling_consumed,
+                rollback_succeeded=False,
+            ) from rollback_failure
+
+    def _adopt_prefilled_sparse_row(
+        self,
+        request: MLLMBatchRequest,
+        cache: Sequence[Any],
+        first_logits: mx.array,
+        sparse_state: SparseCacheState,
+        *,
+        mark_sampling_consumed: Callable[[], None],
+    ) -> int:
         """Atomically adopt one exact, fresh sparse-prefilled text row.
 
         The method never enters the ordinary unprocessed/prefix-cache path and
@@ -1354,6 +1476,7 @@ class MLLMBatchGenerator:
         batch_cache = self._merge_prepared_sparse_cache(cache)
         candidate_rows = (row_state.clone(),)
         _SupportedSparseCacheCheckpoint.capture(batch_cache, candidate_rows)
+        _eval_sparse_adoption_cache(batch_cache)
 
         active = self.active_batch
         active_checkpoint = None
@@ -1383,12 +1506,21 @@ class MLLMBatchGenerator:
             try:
                 for current, incoming in zip(active.cache, batch_cache, strict=True):
                     current.extend(incoming)
-            except Exception:
-                active_checkpoint.restore()
+                _eval_sparse_adoption_cache(active.cache)
+            except Exception as exc:
+                self._restore_sparse_adoption_checkpoint(
+                    active_checkpoint,
+                    active,
+                    adoption_failure=exc,
+                    sampling_consumed=False,
+                )
                 raise
 
+        sampling_started = False
         try:
             processors, sampler = self._sampling_for_request(request)
+            mark_sampling_consumed()
+            sampling_started = True
             sampled, logprobs = self._sample_prepared_first_token(
                 first_logits, full_tokens, processors, sampler
             )
@@ -1418,9 +1550,19 @@ class MLLMBatchGenerator:
                 next_samplers = list(active.samplers or [None] * self_len) + list(
                     candidate.samplers or [None]
                 )
-        except Exception:
+                _eval_sparse_adoption_publication(
+                    candidate.y, *candidate.logprobs, next_y
+                )
+            else:
+                _eval_sparse_adoption_publication(candidate.y, *candidate.logprobs)
+        except Exception as exc:
             if active_checkpoint is not None:
-                active_checkpoint.restore()
+                self._restore_sparse_adoption_checkpoint(
+                    active_checkpoint,
+                    active,
+                    adoption_failure=exc,
+                    sampling_consumed=sampling_started,
+                )
             raise
 
         if active is None:
@@ -2552,6 +2694,11 @@ class MLLMBatchGenerator:
         """
         tic = time.perf_counter()
 
+        # Rollback poisoning can detach the final active batch and leave only
+        # terminal error responses. Drain them before every empty-work return.
+        error_responses = list(self._pending_error_responses)
+        self._pending_error_responses.clear()
+
         prompt_processing = False
         batch = self.active_batch
         num_active = len(batch) if batch else 0
@@ -2568,7 +2715,7 @@ class MLLMBatchGenerator:
 
             if len(requests) == 0:
                 self.active_batch = None
-                return []
+                return error_responses
 
             try:
                 # Save count before _process_prompts which modifies
@@ -2641,9 +2788,8 @@ class MLLMBatchGenerator:
                         )
 
         # Collect any pending error responses (from failed preprocessing)
-        error_responses = []
         if self._pending_error_responses:
-            error_responses = list(self._pending_error_responses)
+            error_responses.extend(self._pending_error_responses)
             self._pending_error_responses.clear()
 
         # Generate next token for active batch

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -234,9 +234,7 @@ class GemmaPreparedTargetAttestation:
 
     @property
     def canonical_target_id(self) -> str:
-        return (
-            f"{self.artifact.artifact_id}@sha256:{self.target_artifact_hash}"
-        )
+        return f"{self.artifact.artifact_id}@sha256:{self.target_artifact_hash}"
 
     def validate_cache(self, cache: Sequence[Any]) -> None:
         validate_gemma_cache_topology(
@@ -473,9 +471,10 @@ class _GemmaBatchMetadataCheckpoint:
         states = []
         tensors = []
         for entry in cache:
-            if getattr(entry, "_right_padding", None) is not None or getattr(
-                entry, "_lengths", None
-            ) is not None:
+            if (
+                getattr(entry, "_right_padding", None) is not None
+                or getattr(entry, "_lengths", None) is not None
+            ):
                 raise SparseBatchError(
                     "Gemma sparse decode requires finalized batch caches"
                 )
@@ -1296,14 +1295,11 @@ class MLLMBatchGenerator:
 
         # Get language model for text generation
         self.language_model = getattr(model, "language_model", model)
-        if (
-            expected_gemma_sparse_config is not None
-            and (
-                expected_gemma_sparse_config.attestation.target_model is not model
-                or expected_gemma_sparse_config.attestation.text_model
-                is not self.language_model
-                or expected_gemma_sparse_config.attestation.processor is not processor
-            )
+        if expected_gemma_sparse_config is not None and (
+            expected_gemma_sparse_config.attestation.target_model is not model
+            or expected_gemma_sparse_config.attestation.text_model
+            is not self.language_model
+            or expected_gemma_sparse_config.attestation.processor is not processor
         ):
             raise SparseBatchCompatibilityError(
                 "Gemma prepared identity does not match generator-owned objects"
@@ -1658,9 +1654,7 @@ class MLLMBatchGenerator:
             )
         self._expected_sparse_execution_config = config
 
-    def set_expected_gemma_sparse_config(
-        self, config: GemmaSparseBatchConfig
-    ) -> None:
+    def set_expected_gemma_sparse_config(self, config: GemmaSparseBatchConfig) -> None:
         """Install an exact Gemma foundation contract before sparse ownership."""
         if not isinstance(config, GemmaSparseBatchConfig):
             raise TypeError("config must be GemmaSparseBatchConfig")
@@ -1801,21 +1795,17 @@ class MLLMBatchGenerator:
             raise SparseBatchCompatibilityError(
                 "Gemma sparse target decode cannot compose with MTP"
             )
-        if (
-            gemma_config is not None
-            and (
-                gemma_config.attestation.target_model is not self.model
-                or gemma_config.attestation.text_model is not self.language_model
-                or gemma_config.attestation.processor is not self.processor
-            )
+        if gemma_config is not None and (
+            gemma_config.attestation.target_model is not self.model
+            or gemma_config.attestation.text_model is not self.language_model
+            or gemma_config.attestation.processor is not self.processor
         ):
             raise SparseBatchCompatibilityError(
                 "prepared Gemma identity does not match generator-owned objects"
             )
         if (
             gemma_config is not None
-            and gemma_config.execution_config
-            != row_state.identity.execution_config
+            and gemma_config.execution_config != row_state.identity.execution_config
         ):
             raise SparseBatchCompatibilityError(
                 "prepared Gemma topology does not match the sparse profile"
@@ -2997,9 +2987,7 @@ class MLLMBatchGenerator:
                     )
                 active_batch.gemma_sparse_config.validate_cache(cache)
                 _validate_gemma_cache_rows(cache, sparse_rows)
-                gemma_metadata_checkpoint = _GemmaBatchMetadataCheckpoint.capture(
-                    cache
-                )
+                gemma_metadata_checkpoint = _GemmaBatchMetadataCheckpoint.capture(cache)
                 gemma_transaction = GemmaOneTokenTransaction(
                     cache,
                     logical_positions=tuple(
@@ -3553,9 +3541,8 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
-        sparse_rows_bypass = (
-            batch_gen.active_batch is not None
-            and getattr(batch_gen.active_batch, "has_sparse_rows", False)
+        sparse_rows_bypass = batch_gen.active_batch is not None and getattr(
+            batch_gen.active_batch, "has_sparse_rows", False
         )
         if (
             prefill_bypass

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -21,14 +21,22 @@ import math
 import os
 import threading
 import time
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig, _trim_cache_offset
 from .multimodal_processor import MultimodalProcessor
+from .specprefill_cache import (
+    SparseCacheExecutionConfig,
+    SparseCacheIdentity,
+    SparseCacheRowState,
+    SparseCacheState,
+)
 from .vision_embedding_cache import VisionEmbeddingCache
 
 logger = logging.getLogger(__name__)
@@ -157,6 +165,225 @@ class PrefillAbortedError(Exception):
         super().__init__(f"Prefill aborted for request {request_id}")
 
 
+class SparseBatchError(RuntimeError):
+    """A prepared sparse row cannot safely enter or advance a decode batch."""
+
+
+class SparseBatchCompatibilityError(SparseBatchError):
+    """Sparse rows do not share one immutable execution configuration."""
+
+
+class MLLMTargetForwardPhase(str, Enum):
+    """Target call phases supported by the request-local CB seam."""
+
+    DECODE = "decode"
+
+
+@dataclass(frozen=True)
+class MLLMTargetForward:
+    """One ordinary target decode graph-construction boundary."""
+
+    input_tokens: mx.array
+    cache: Sequence[Any]
+    phase: MLLMTargetForwardPhase
+    sparse_row_states: tuple[SparseCacheRowState | None, ...]
+
+
+TargetForwardContext = Callable[[MLLMTargetForward], AbstractContextManager[Any]]
+
+
+@dataclass(frozen=True)
+class _BatchKVDecodeCheckpoint:
+    """Reference-only checkpoint for mlx-lm's non-rotating BatchKVCache."""
+
+    entry: Any
+    keys: Any
+    values: Any
+    offset: Any
+    left_padding: Any
+    idx: int
+    right_padding: Any
+
+    def restore(self) -> None:
+        self.entry.keys = self.keys
+        self.entry.values = self.values
+        self.entry.offset = self.offset
+        self.entry.left_padding = self.left_padding
+        self.entry._idx = self.idx
+        self.entry._right_padding = self.right_padding
+
+
+@dataclass(frozen=True)
+class _ArraysDecodeCheckpoint:
+    """Reference-only checkpoint for mlx-lm's recurrent ArraysCache."""
+
+    entry: Any
+    cache: tuple[Any, ...]
+    left_padding: Any
+    lengths: Any
+
+    def restore(self) -> None:
+        self.entry.cache = list(self.cache)
+        self.entry.left_padding = self.left_padding
+        self.entry.lengths = self.lengths
+
+
+@dataclass(frozen=True)
+class _SupportedSparseCacheCheckpoint:
+    """Atomic sparse-cache checkpoint over an explicit mlx-lm allowlist.
+
+    The checkpoint retains MLX array references only. It never copies or
+    realizes KV/state tensors. Rotating caches are intentionally excluded:
+    rotation can overwrite live KV slots and cannot be rolled back from
+    metadata alone.
+    """
+
+    kv_entries: tuple[_BatchKVDecodeCheckpoint, ...]
+    array_entries: tuple[_ArraysDecodeCheckpoint, ...]
+
+    @classmethod
+    def capture(
+        cls,
+        cache: Sequence[Any],
+        row_states: Sequence[SparseCacheRowState | None],
+    ) -> "_SupportedSparseCacheCheckpoint":
+        from mlx_lm.models.cache import ArraysCache, BatchKVCache
+
+        if not row_states or any(row is None for row in row_states):
+            raise SparseBatchCompatibilityError(
+                "sparse target calls cannot share a batch with dense rows"
+            )
+
+        kv_entries: list[_BatchKVDecodeCheckpoint] = []
+        array_entries: list[_ArraysDecodeCheckpoint] = []
+        row_count = len(row_states)
+        for entry in cache:
+            if type(entry) is BatchKVCache:
+                if (
+                    entry.keys is None
+                    or entry.values is None
+                    or getattr(entry, "_right_padding", None) is not None
+                ):
+                    raise SparseBatchError(
+                        "sparse BatchKVCache must be populated and outside an update"
+                    )
+                if (
+                    entry.offset.ndim != 1
+                    or entry.left_padding.ndim != 1
+                    or entry.offset.shape[0] != row_count
+                    or entry.left_padding.shape[0] != row_count
+                ):
+                    raise SparseBatchCompatibilityError(
+                        "sparse BatchKVCache metadata must match batch row count"
+                    )
+                kv_entries.append(
+                    _BatchKVDecodeCheckpoint(
+                        entry=entry,
+                        keys=entry.keys,
+                        values=entry.values,
+                        offset=entry.offset,
+                        left_padding=entry.left_padding,
+                        idx=entry._idx,
+                        right_padding=entry._right_padding,
+                    )
+                )
+            elif type(entry) is ArraysCache:
+                if entry.batch_size != row_count:
+                    raise SparseBatchCompatibilityError(
+                        "sparse ArraysCache metadata must match batch row count"
+                    )
+                array_entries.append(
+                    _ArraysDecodeCheckpoint(
+                        entry=entry,
+                        cache=tuple(entry.cache),
+                        left_padding=entry.left_padding,
+                        lengths=entry.lengths,
+                    )
+                )
+            else:
+                raise SparseBatchError(
+                    "sparse decode supports only non-rotating BatchKVCache and "
+                    "ArraysCache entries"
+                )
+        if not kv_entries:
+            raise SparseBatchError(
+                "sparse decode requires a BatchKVCache occupancy source"
+            )
+        return cls(tuple(kv_entries), tuple(array_entries))
+
+    def restore(self) -> None:
+        # Restore every entry even if an individual assignment unexpectedly
+        # fails, then surface one fail-closed error to the scheduler.
+        failures: list[BaseException] = []
+        for checkpoint in (*self.kv_entries, *self.array_entries):
+            try:
+                checkpoint.restore()
+            except BaseException as exc:
+                failures.append(exc)
+        if failures:
+            raise SparseBatchError("sparse cache rollback failed") from failures[0]
+
+    def one_token_advance_predicate(
+        self,
+        row_states: Sequence[SparseCacheRowState | None],
+    ) -> tuple[mx.array, int]:
+        """Build one aggregated device predicate and examined-scalar count."""
+        expected = [row.physical_valid_length for row in row_states if row is not None]
+        predicates: list[mx.array] = []
+        examined_scalars = 0
+        for checkpoint in self.kv_entries:
+            expected_offsets = mx.array(expected, dtype=checkpoint.offset.dtype)
+            zero_padding = mx.zeros_like(checkpoint.left_padding)
+            predicates.extend(
+                (
+                    mx.all(checkpoint.offset == expected_offsets),
+                    mx.all(checkpoint.entry.offset == expected_offsets + 1),
+                    mx.all(checkpoint.left_padding == zero_padding),
+                    mx.all(checkpoint.entry.left_padding == zero_padding),
+                    mx.array(checkpoint.entry._idx == checkpoint.idx + 1),
+                )
+            )
+            examined_scalars += 4 * len(expected) + 1
+        return mx.all(mx.stack(predicates)), examined_scalars
+
+
+def _sparse_execution_config(
+    row_states: Sequence[SparseCacheRowState | None],
+) -> SparseCacheExecutionConfig | None:
+    configs = {row.identity.execution_config for row in row_states if row is not None}
+    if len(configs) > 1:
+        raise SparseBatchCompatibilityError(
+            "sparse decode rows require one exact execution configuration"
+        )
+    return next(iter(configs), None)
+
+
+def _decode_processor_contexts(
+    requests: Sequence["MLLMBatchRequest"], current_tokens: Sequence[int]
+) -> list[list[int]]:
+    """Exact processor history through the current token for every row."""
+    if len(requests) != len(current_tokens):
+        raise ValueError("processor context rows must stay aligned")
+    return [
+        list(request.output_tokens) + [int(token)]
+        for request, token in zip(requests, current_tokens, strict=True)
+    ]
+
+
+def _apply_first_token_processors(
+    logits: mx.array,
+    full_prompt_tokens: mx.array | Sequence[int],
+    processors: Optional[Sequence[Callable]],
+) -> mx.array:
+    """Apply every first-token processor to the exact full prompt."""
+    if not processors:
+        return logits
+    prompt_tokens = mx.array(full_prompt_tokens, dtype=mx.uint32).reshape(-1)
+    for processor in processors:
+        logits = processor(prompt_tokens, logits)
+    return logits
+
+
 def _cache_eval_tensors(cache: List[Any]) -> List[Any]:
     """Return realized tensors that break lazy cache graphs between chunks."""
     tensors: List[Any] = []
@@ -275,9 +502,69 @@ class MLLMBatch:
     requests: List[MLLMBatchRequest]  # Full request data
     logits_processors: Optional[List[Optional[List[Callable]]]] = None
     samplers: Optional[List[Optional[Callable]]] = None
+    sparse_row_states: tuple[SparseCacheRowState | None, ...] = ()
+
+    def __post_init__(self) -> None:
+        row_count = len(self.uids)
+        if self.y.ndim != 1 or self.y.shape[0] != row_count:
+            raise ValueError("MLLMBatch y must be a row-aligned token vector")
+        aligned_lengths = (
+            len(self.request_ids),
+            len(self.logprobs),
+            len(self.max_tokens),
+            len(self.num_tokens),
+            len(self.requests),
+        )
+        if any(length != row_count for length in aligned_lengths):
+            raise ValueError("MLLMBatch row metadata must have equal lengths")
+        if (
+            self.logits_processors is not None
+            and len(self.logits_processors) != row_count
+        ):
+            raise ValueError("MLLMBatch logits processors must stay row-aligned")
+        if self.samplers is not None and len(self.samplers) != row_count:
+            raise ValueError("MLLMBatch samplers must stay row-aligned")
+        if not self.sparse_row_states:
+            self.sparse_row_states = (None,) * row_count
+        elif len(self.sparse_row_states) != row_count:
+            raise ValueError("MLLMBatch sparse row state must stay row-aligned")
+        _sparse_execution_config(self.sparse_row_states)
+        if self.has_sparse_rows:
+            if any(row is None for row in self.sparse_row_states):
+                raise SparseBatchCompatibilityError(
+                    "sparse and dense rows cannot share an MLLMBatch"
+                )
+            if (
+                len(
+                    {
+                        row.physical_valid_length
+                        for row in self.sparse_row_states
+                        if row is not None
+                    }
+                )
+                != 1
+            ):
+                raise SparseBatchCompatibilityError(
+                    "sparse MLLMBatch rows require equal physical occupancy"
+                )
 
     def __len__(self) -> int:
         return len(self.uids)
+
+    @property
+    def has_sparse_rows(self) -> bool:
+        return any(row is not None for row in self.sparse_row_states)
+
+    @property
+    def sparse_execution_config(self) -> SparseCacheExecutionConfig | None:
+        return _sparse_execution_config(self.sparse_row_states)
+
+    def commit_sparse_decode(self, count: int = 1) -> None:
+        """Replace sparse row metadata after a realized target boundary."""
+        self.sparse_row_states = tuple(
+            None if row is None else row.append_decode(count)
+            for row in self.sparse_row_states
+        )
 
     def filter(self, keep_idx: List[int]) -> None:
         """
@@ -286,24 +573,62 @@ class MLLMBatch:
         Args:
             keep_idx: Indices of requests to keep
         """
-        self.uids = [self.uids[k] for k in keep_idx]
-        self.request_ids = [self.request_ids[k] for k in keep_idx]
-        self.logprobs = [self.logprobs[k] for k in keep_idx]
-        self.max_tokens = [self.max_tokens[k] for k in keep_idx]
-        self.num_tokens = [self.num_tokens[k] for k in keep_idx]
-        self.requests = [self.requests[k] for k in keep_idx]
-        if self.logits_processors is not None:
-            self.logits_processors = [self.logits_processors[k] for k in keep_idx]
-        if self.samplers is not None:
-            self.samplers = [self.samplers[k] for k in keep_idx]
-
+        if len(set(keep_idx)) != len(keep_idx) or any(
+            isinstance(index, bool)
+            or not isinstance(index, int)
+            or index < 0
+            or index >= len(self)
+            for index in keep_idx
+        ):
+            raise ValueError(
+                "MLLMBatch filter indices must be unique in-range integers"
+            )
         keep_idx_array = mx.array(keep_idx, mx.int32)
-        self.y = self.y[keep_idx_array]
+        next_y = self.y[keep_idx_array]
+        next_uids = [self.uids[k] for k in keep_idx]
+        next_request_ids = [self.request_ids[k] for k in keep_idx]
+        next_logprobs = [self.logprobs[k] for k in keep_idx]
+        next_max_tokens = [self.max_tokens[k] for k in keep_idx]
+        next_num_tokens = [self.num_tokens[k] for k in keep_idx]
+        next_requests = [self.requests[k] for k in keep_idx]
+        next_processors = (
+            None
+            if self.logits_processors is None
+            else [self.logits_processors[k] for k in keep_idx]
+        )
+        next_samplers = (
+            None if self.samplers is None else [self.samplers[k] for k in keep_idx]
+        )
+        next_sparse_rows = tuple(self.sparse_row_states[k] for k in keep_idx)
 
-        # Filter cache entries
-        for c in self.cache:
-            if hasattr(c, "filter"):
-                c.filter(keep_idx_array)
+        checkpoint = (
+            _SupportedSparseCacheCheckpoint.capture(self.cache, self.sparse_row_states)
+            if self.has_sparse_rows
+            else None
+        )
+        try:
+            for cache_entry in self.cache:
+                if hasattr(cache_entry, "filter"):
+                    cache_entry.filter(keep_idx_array)
+                elif self.has_sparse_rows:
+                    raise SparseBatchError(
+                        "sparse decode cache entries must support atomic filtering"
+                    )
+        except Exception:
+            if checkpoint is not None:
+                checkpoint.restore()
+            raise
+
+        self.uids = next_uids
+        self.request_ids = next_request_ids
+        self.y = next_y
+        self.logprobs = next_logprobs
+        self.max_tokens = next_max_tokens
+        self.num_tokens = next_num_tokens
+        self.requests = next_requests
+        self.logits_processors = next_processors
+        self.samplers = next_samplers
+        self.sparse_row_states = next_sparse_rows
 
     def extend(self, other: "MLLMBatch") -> None:
         """
@@ -312,43 +637,96 @@ class MLLMBatch:
         Args:
             other: Batch to merge into this one
         """
-        self.uids.extend(other.uids)
-        self.request_ids.extend(other.request_ids)
-        self.y = mx.concatenate([self.y, other.y])
-        self.logprobs.extend(other.logprobs)
-        self.num_tokens.extend(other.num_tokens)
-        self.max_tokens.extend(other.max_tokens)
-        self.requests.extend(other.requests)
+        if self.has_sparse_rows != other.has_sparse_rows:
+            raise SparseBatchCompatibilityError(
+                "sparse and dense rows cannot share a target decode batch"
+            )
+        _sparse_execution_config(self.sparse_row_states + other.sparse_row_states)
+        if (
+            self.has_sparse_rows
+            and len(
+                {
+                    row.physical_valid_length
+                    for row in self.sparse_row_states + other.sparse_row_states
+                    if row is not None
+                }
+            )
+            != 1
+        ):
+            raise SparseBatchCompatibilityError(
+                "sparse target decode rows require equal physical occupancy"
+            )
+        if len(self.cache) != len(other.cache):
+            raise SparseBatchCompatibilityError(
+                "decode batches require identical cache layer topology"
+            )
+
+        self_len = len(self)
+        next_uids = self.uids + other.uids
+        next_request_ids = self.request_ids + other.request_ids
+        next_y = mx.concatenate([self.y, other.y])
+        next_logprobs = self.logprobs + other.logprobs
+        next_num_tokens = self.num_tokens + other.num_tokens
+        next_max_tokens = self.max_tokens + other.max_tokens
+        next_requests = self.requests + other.requests
+        next_sparse_rows = self.sparse_row_states + other.sparse_row_states
 
         # Extend logits_processors
         if self.logits_processors is not None or other.logits_processors is not None:
-            # At this point self.uids already includes other.uids from extend above
-            self_len = len(self.uids) - len(other.uids)
             self_lp = self.logits_processors or [None] * self_len
             other_lp = other.logits_processors or [None] * len(other.uids)
-            self.logits_processors = list(self_lp) + list(other_lp)
+            next_processors = list(self_lp) + list(other_lp)
+        else:
+            next_processors = None
 
         # Extend samplers
         if self.samplers is not None or other.samplers is not None:
-            self_len = len(self.uids) - len(other.uids)
             self_s = self.samplers or [None] * self_len
             other_s = other.samplers or [None] * len(other.uids)
-            self.samplers = list(self_s) + list(other_s)
+            next_samplers = list(self_s) + list(other_s)
+        else:
+            next_samplers = None
 
         # Extend cache - handle both BatchKVCache (.keys/.values) and
         # ArraysCache (.cache list) from hybrid models like Qwen3.5. Some
         # cache integrations, such as quantized SDPA caches, expose state only
         # through empty()/extend() and do not publish .keys.
-        for c, o in zip(self.cache, other.cache):
-            if c is not None and o is not None and hasattr(c, "extend"):
-                try:
+        checkpoint = (
+            _SupportedSparseCacheCheckpoint.capture(self.cache, self.sparse_row_states)
+            if self.has_sparse_rows
+            else None
+        )
+        try:
+            for c, o in zip(self.cache, other.cache, strict=True):
+                if c is not None and o is not None and hasattr(c, "extend"):
                     has_kv = hasattr(c, "keys") and c.keys is not None
                     has_arrays = hasattr(c, "cache")
                     has_extendable_state = hasattr(c, "empty") and not c.empty()
                     if has_kv or has_arrays or has_extendable_state:
                         c.extend(o)
-                except Exception as e:
-                    logger.warning(f"Failed to extend cache: {e}")
+                elif (c is None) != (o is None) or (
+                    (self.has_sparse_rows or other.has_sparse_rows)
+                    and c is not None
+                    and not hasattr(c, "extend")
+                ):
+                    raise SparseBatchError(
+                        "sparse decode cache entries must support atomic extension"
+                    )
+        except Exception:
+            if checkpoint is not None:
+                checkpoint.restore()
+            raise
+
+        self.uids = next_uids
+        self.request_ids = next_request_ids
+        self.y = next_y
+        self.logprobs = next_logprobs
+        self.num_tokens = next_num_tokens
+        self.max_tokens = next_max_tokens
+        self.requests = next_requests
+        self.logits_processors = next_processors
+        self.samplers = next_samplers
+        self.sparse_row_states = next_sparse_rows
 
     def extract_cache(self, idx: int) -> List[Any]:
         """
@@ -490,6 +868,8 @@ class MLLMBatchGenerator:
         vision_cache_size: int = 100,
         prefix_cache_config: Optional[MemoryCacheConfig] = None,
         max_kv_size: int = 0,
+        target_forward_context: Optional[TargetForwardContext] = None,
+        expected_sparse_execution_config: SparseCacheExecutionConfig | None = None,
     ):
         """
         Initialize MLLM batch generator.
@@ -508,11 +888,29 @@ class MLLMBatchGenerator:
             vision_cache_size: Max entries in vision cache
             prefix_cache_config: Config for KV prefix cache (text-only requests)
             max_kv_size: Maximum KV cache size per sequence (0 = unbounded)
+            target_forward_context: Request-local context factory for target decode
+            expected_sparse_execution_config: Scheduler-selected exact sparse
+                profile/artifact identity admitted by this generator
         """
         self.model = model
         self.processor = processor
         self.mm_processor = mm_processor
         self.max_kv_size = max_kv_size
+        if target_forward_context is not None and not callable(target_forward_context):
+            raise TypeError("target_forward_context must be callable or None")
+        self._target_forward_context = target_forward_context
+        if expected_sparse_execution_config is not None and not isinstance(
+            expected_sparse_execution_config, SparseCacheExecutionConfig
+        ):
+            raise TypeError(
+                "expected_sparse_execution_config must be SparseCacheExecutionConfig"
+            )
+        self._expected_sparse_execution_config = expected_sparse_execution_config
+        # One aggregated predicate scalar is read at each realized sparse
+        # boundary. Telemetry separately counts the device metadata scalars
+        # examined by that predicate; no KV/state tensor is copied.
+        self._sparse_checkpoint_scalar_reads = 0
+        self._sparse_checkpoint_host_scalar_reads = 0
 
         # Get language model for text generation
         self.language_model = getattr(model, "language_model", model)
@@ -838,6 +1236,292 @@ class MLLMBatchGenerator:
 
         logger.debug(f"Inserted {len(requests)} requests, UIDs: {uids}")
         return uids
+
+    def set_target_forward_context(self, context_factory: TargetForwardContext) -> None:
+        """Install the per-forward target context before sparse adoption."""
+        if not callable(context_factory):
+            raise TypeError("target forward context factory must be callable")
+        if self.active_batch is not None and self.active_batch.has_sparse_rows:
+            raise SparseBatchError(
+                "cannot replace target forward context with sparse rows active"
+            )
+        self._target_forward_context = context_factory
+
+    def set_expected_sparse_execution_config(
+        self, config: SparseCacheExecutionConfig
+    ) -> None:
+        """Bind scheduler-selected sparse profile/artifact identity."""
+        if not isinstance(config, SparseCacheExecutionConfig):
+            raise TypeError("config must be SparseCacheExecutionConfig")
+        if self.active_batch is not None and self.active_batch.has_sparse_rows:
+            raise SparseBatchError(
+                "cannot replace sparse execution identity with sparse rows active"
+            )
+        self._expected_sparse_execution_config = config
+
+    def adopt_prefilled_sparse_row(
+        self,
+        request: MLLMBatchRequest,
+        cache: Sequence[Any],
+        first_logits: mx.array,
+        sparse_state: SparseCacheState,
+    ) -> int:
+        """Atomically adopt one exact, fresh sparse-prefilled text row.
+
+        The method never enters the ordinary unprocessed/prefix-cache path and
+        never emits a response.  The first sampled token becomes ``batch.y``
+        only after cache conversion and active-batch compatibility succeed.
+        """
+        if self._target_forward_context is None:
+            raise SparseBatchError(
+                "sparse decode requires a request-local target forward context"
+            )
+        if request.max_tokens <= 0:
+            raise SparseBatchError(
+                "sparse requests require max_tokens greater than zero"
+            )
+        if request.images or request.videos or request.audio:
+            raise SparseBatchError("prepared sparse adoption is text-only")
+        if request.request_id in self._aborted_request_ids:
+            raise PrefillAbortedError(request.request_id)
+        if (
+            not isinstance(sparse_state, SparseCacheState)
+            or sparse_state.row_count != 1
+        ):
+            raise SparseBatchError("prepared sparse adoption requires exactly one row")
+        row_state = sparse_state.rows[0]
+        if not isinstance(row_state, SparseCacheRowState):
+            raise SparseBatchError("prepared sparse adoption requires sparse row state")
+        if self._expected_sparse_execution_config is None:
+            raise SparseBatchError(
+                "sparse adoption requires a generator-selected execution identity"
+            )
+        if (
+            row_state.identity.execution_config
+            != self._expected_sparse_execution_config
+        ):
+            raise SparseBatchCompatibilityError(
+                "prepared sparse identity does not match the generator-selected profile"
+            )
+        if request.input_ids is None:
+            raise SparseBatchError(
+                "prepared sparse adoption requires the exact full prompt token IDs"
+            )
+        full_tokens = tuple(request.input_ids.reshape(-1).tolist())
+        if (
+            SparseCacheIdentity.hash_tokens(full_tokens)
+            != row_state.identity.full_token_hash
+        ):
+            raise SparseBatchError(
+                "prepared sparse identity does not match the request token sequence"
+            )
+        if row_state.next_logical_position != len(full_tokens):
+            raise SparseBatchError(
+                "prepared sparse logical cursor must equal the full prompt length"
+            )
+        self._validate_prepared_sparse_cache(cache, row_state)
+
+        if self.active_batch is not None and not self.active_batch.has_sparse_rows:
+            raise SparseBatchCompatibilityError(
+                "sparse and dense rows cannot share a target decode batch"
+            )
+
+        active_uids = (
+            set(self.active_batch.uids) if self.active_batch is not None else set()
+        )
+        queued_uids = {queued.uid for queued in self.unprocessed_requests}
+        queued_request_ids = {queued.request_id for queued in self.unprocessed_requests}
+        active_request_ids = (
+            set(self.active_batch.request_ids)
+            if self.active_batch is not None
+            else set()
+        )
+        if (
+            request.request_id in active_request_ids
+            or request.request_id in queued_request_ids
+        ):
+            raise SparseBatchError("request is already owned by the batch generator")
+
+        candidate_uid = request.uid
+        if candidate_uid < 0:
+            candidate_uid = self.uid_counter
+        if candidate_uid in active_uids or candidate_uid in queued_uids:
+            raise SparseBatchError("prepared sparse request UID is already active")
+
+        # Complete every fallible cache operation before consuming a custom
+        # processor or stochastic sampler. A successful active-cache extend is
+        # held as an unpublished transaction until sampling also succeeds.
+        batch_cache = self._merge_prepared_sparse_cache(cache)
+        candidate_rows = (row_state.clone(),)
+        _SupportedSparseCacheCheckpoint.capture(batch_cache, candidate_rows)
+
+        active = self.active_batch
+        active_checkpoint = None
+        if active is not None:
+            if active.sparse_execution_config != row_state.identity.execution_config:
+                raise SparseBatchCompatibilityError(
+                    "sparse decode rows require one exact execution configuration"
+                )
+            if any(
+                row is None
+                or row.physical_valid_length != row_state.physical_valid_length
+                for row in active.sparse_row_states
+            ):
+                raise SparseBatchCompatibilityError(
+                    "sparse target decode rows require equal physical occupancy"
+                )
+            if len(active.cache) != len(batch_cache) or any(
+                type(current) is not type(incoming)
+                for current, incoming in zip(active.cache, batch_cache, strict=True)
+            ):
+                raise SparseBatchCompatibilityError(
+                    "decode batches require identical supported cache topology"
+                )
+            active_checkpoint = _SupportedSparseCacheCheckpoint.capture(
+                active.cache, active.sparse_row_states
+            )
+            try:
+                for current, incoming in zip(active.cache, batch_cache, strict=True):
+                    current.extend(incoming)
+            except Exception:
+                active_checkpoint.restore()
+                raise
+
+        try:
+            processors, sampler = self._sampling_for_request(request)
+            sampled, logprobs = self._sample_prepared_first_token(
+                first_logits, full_tokens, processors, sampler
+            )
+            candidate = MLLMBatch(
+                uids=[candidate_uid],
+                request_ids=[request.request_id],
+                y=sampled.reshape(-1),
+                logprobs=[logprobs.squeeze(0)],
+                max_tokens=[request.max_tokens],
+                num_tokens=[0],
+                cache=batch_cache,
+                requests=[request],
+                logits_processors=[processors] if processors else None,
+                samplers=[sampler],
+                sparse_row_states=candidate_rows,
+            )
+            if active is not None:
+                self_len = len(active)
+                next_y = mx.concatenate([active.y, candidate.y])
+                next_processors = (
+                    list(active.logits_processors or [None] * self_len)
+                    + list(candidate.logits_processors or [None])
+                    if active.logits_processors is not None
+                    or candidate.logits_processors is not None
+                    else None
+                )
+                next_samplers = list(active.samplers or [None] * self_len) + list(
+                    candidate.samplers or [None]
+                )
+        except Exception:
+            if active_checkpoint is not None:
+                active_checkpoint.restore()
+            raise
+
+        if active is None:
+            self.active_batch = candidate
+        else:
+            # All values above were staged before these non-failing assignments.
+            active.uids = active.uids + candidate.uids
+            active.request_ids = active.request_ids + candidate.request_ids
+            active.y = next_y
+            active.logprobs = active.logprobs + candidate.logprobs
+            active.max_tokens = active.max_tokens + candidate.max_tokens
+            active.num_tokens = active.num_tokens + candidate.num_tokens
+            active.requests = active.requests + candidate.requests
+            active.logits_processors = next_processors
+            active.samplers = next_samplers
+            active.sparse_row_states = active.sparse_row_states + candidate_rows
+
+        request.uid = candidate_uid
+        request.is_text_only = True
+        self.uid_counter = max(self.uid_counter, candidate_uid + 1)
+        return candidate_uid
+
+    def _sampling_for_request(
+        self, request: MLLMBatchRequest
+    ) -> tuple[Optional[List[Callable]], Callable]:
+        from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
+        processors: List[Callable] = []
+        processor_kwargs = {}
+        if request.repetition_penalty and request.repetition_penalty != 1.0:
+            processor_kwargs["repetition_penalty"] = request.repetition_penalty
+        if request.presence_penalty and request.presence_penalty != 0.0:
+            processor_kwargs["presence_penalty"] = request.presence_penalty
+        if processor_kwargs:
+            processors.extend(make_logits_processors(**processor_kwargs))
+        if request.logits_processors:
+            processors.extend(request.logits_processors)
+        sampler = make_sampler(
+            temp=request.temperature,
+            top_p=request.top_p,
+            top_k=request.top_k,
+            min_p=request.min_p,
+        )
+        return processors or None, sampler
+
+    def _sample_prepared_first_token(
+        self,
+        first_logits: mx.array,
+        full_prompt_tokens: Sequence[int],
+        processors: Optional[List[Callable]],
+        sampler: Callable,
+    ) -> tuple[mx.array, mx.array]:
+        logits = (
+            first_logits.logits if hasattr(first_logits, "logits") else first_logits
+        )
+        if logits.ndim == 3:
+            logits = logits[:, -1, :]
+        if logits.ndim != 2 or logits.shape[0] != 1:
+            raise SparseBatchError(
+                "prepared sparse logits must contain exactly one request row"
+            )
+        logits = _apply_first_token_processors(logits, full_prompt_tokens, processors)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        sampled = sampler(logprobs)
+        mx.eval(sampled, logprobs)
+        return sampled, logprobs
+
+    @staticmethod
+    def _validate_prepared_sparse_cache(
+        cache: Sequence[Any], row_state: SparseCacheRowState
+    ) -> None:
+        if not isinstance(cache, Sequence) or not cache:
+            raise SparseBatchError("prepared sparse cache must be non-empty")
+        offsets = []
+        for entry in cache:
+            if not hasattr(entry, "offset"):
+                continue
+            offset = entry.offset
+            if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+                raise SparseBatchError(
+                    "prepared sparse cache offsets must be host integers"
+                )
+            offsets.append(offset)
+        if not offsets or any(
+            offset != row_state.physical_valid_length for offset in offsets
+        ):
+            raise SparseBatchError(
+                "prepared sparse cache occupancy must match immutable row state"
+            )
+
+    @staticmethod
+    def _merge_prepared_sparse_cache(cache: Sequence[Any]) -> List[Any]:
+        merged = []
+        for entry in cache:
+            merge = getattr(entry, "merge", None)
+            if not callable(merge):
+                raise SparseBatchError(
+                    "prepared sparse cache entries must support batch merge"
+                )
+            merged.append(merge([entry]))
+        return merged
 
     def remove(self, uids: List[int]) -> None:
         """
@@ -1343,9 +2027,13 @@ class MLLMBatchGenerator:
             sample_logits = logits
             processors = logits_processors_by_request.get(req.request_id)
             if processors:
-                empty_tokens = mx.array([], dtype=mx.uint32)
-                for processor in processors:
-                    sample_logits = processor(empty_tokens, sample_logits)
+                if req.input_ids is None:
+                    raise ValueError(
+                        "first-token processors require exact prompt tokens"
+                    )
+                sample_logits = _apply_first_token_processors(
+                    sample_logits, req.input_ids, processors
+                )
 
             logprobs = sample_logits - mx.logsumexp(
                 sample_logits, axis=-1, keepdims=True
@@ -1700,44 +2388,160 @@ class MLLMBatchGenerator:
         if input_tokens.ndim == 1:
             input_tokens = input_tokens[:, None]
 
-        # Run language model only (not full VLM)
-        output = self.language_model(input_tokens, cache=cache)
+        active_batch = self.active_batch
+        if (
+            active_batch is not None
+            and active_batch.has_sparse_rows
+            and len(active_batch) != input_tokens.shape[0]
+        ):
+            raise SparseBatchCompatibilityError(
+                "sparse target input row count must match the active batch"
+            )
+        sparse_rows = (
+            active_batch.sparse_row_states
+            if active_batch is not None and len(active_batch) == input_tokens.shape[0]
+            else ()
+        )
+        has_sparse_rows = any(row is not None for row in sparse_rows)
+        if has_sparse_rows and any(row is None for row in sparse_rows):
+            raise SparseBatchCompatibilityError(
+                "sparse and dense rows cannot share a target decode call"
+            )
+        cache_checkpoint = (
+            _SupportedSparseCacheCheckpoint.capture(cache, sparse_rows)
+            if has_sparse_rows
+            else None
+        )
 
-        # Handle LanguageModelOutput or plain tensor
-        if hasattr(output, "logits"):
-            logits = output.logits
+        try:
+            forward = MLLMTargetForward(
+                input_tokens=input_tokens,
+                cache=cache,
+                phase=MLLMTargetForwardPhase.DECODE,
+                sparse_row_states=sparse_rows,
+            )
+            context_factory = getattr(self, "_target_forward_context", None)
+            if has_sparse_rows and context_factory is None:
+                raise SparseBatchError(
+                    "sparse decode cannot run without target forward context"
+                )
+            context = (
+                nullcontext() if context_factory is None else context_factory(forward)
+            )
+            # Run language model only (not full VLM). The context is scoped to
+            # this one graph-construction boundary and never survives return.
+            with context:
+                output = self.language_model(input_tokens, cache=cache)
+
+            # Handle LanguageModelOutput or plain tensor
+            if hasattr(output, "logits"):
+                logits = output.logits
+            else:
+                logits = output
+
+            logits = logits[:, -1, :]
+
+            # Apply per-request logits processors (repetition penalty etc.)
+            if logits_processors and output_tokens and any(logits_processors):
+                processed_logits = []
+                for e in range(logits.shape[0]):
+                    sample_logits = logits[e : e + 1]
+                    if logits_processors[e]:
+                        # ``output_tokens[e]`` already contains all generated
+                        # tokens including the current step's input token (built
+                        # by the caller as ``req.output_tokens + [token]``).
+                        full_context = output_tokens[e]
+                        for processor in logits_processors[e]:
+                            sample_logits = processor(
+                                mx.array(full_context), sample_logits
+                            )
+                    processed_logits.append(sample_logits)
+                logits = mx.concatenate(processed_logits, axis=0)
+
+            # Sample — per-request samplers for top_k/min_p support
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            if samplers and any(samplers):
+                sampled_list = []
+                for e in range(logprobs.shape[0]):
+                    row_sampler = samplers[e] or self.sampler
+                    sampled_list.append(row_sampler(logprobs[e : e + 1]))
+                sampled = mx.concatenate(sampled_list, axis=0)
+            else:
+                sampled = self.sampler(logprobs)
+
+            if has_sparse_rows:
+                # Realize the target/cache mutation before replacing immutable
+                # logical state. A failure leaves both metadata and response
+                # emission untouched and restores the entry cache snapshot.
+                assert active_batch is not None
+                assert cache_checkpoint is not None
+                occupancy_ok, examined_scalars = (
+                    cache_checkpoint.one_token_advance_predicate(sparse_rows)
+                )
+                mx.eval(sampled, logprobs, occupancy_ok)
+                self._sparse_checkpoint_scalar_reads += examined_scalars
+                self._sparse_checkpoint_host_scalar_reads += 1
+                if not occupancy_ok.item():
+                    raise SparseBatchError(
+                        "sparse cache physical occupancy must advance exactly one per row"
+                    )
+                active_batch.commit_sparse_decode(1)
+            return sampled, list(logprobs)
+        except Exception:
+            if cache_checkpoint is not None:
+                cache_checkpoint.restore()
+            raise
+
+    def _pop_terminal_current_tokens(self) -> List[MLLMBatchResponse]:
+        """Emit already-terminal current tokens without speculative lookahead."""
+        batch = self.active_batch
+        if batch is None:
+            return []
+
+        tokens = batch.y.tolist()
+        end_idx = [
+            index
+            for index, (token, num_tokens, max_tokens) in enumerate(
+                zip(tokens, batch.num_tokens, batch.max_tokens, strict=True)
+            )
+            if token in self.stop_tokens or num_tokens + 1 >= max_tokens
+        ]
+        if not end_idx:
+            return []
+
+        responses: list[MLLMBatchResponse] = []
+        for index in end_idx:
+            request = batch.requests[index]
+            token = tokens[index]
+            request.num_tokens = batch.num_tokens[index] + 1
+            batch.num_tokens[index] = request.num_tokens
+            request.output_tokens.append(token)
+            finish_reason = "stop" if token in self.stop_tokens else "length"
+            cache_fn = None
+            if batch.sparse_row_states[index] is None:
+                extracted = batch.extract_cache(index)
+                cache_fn = lambda cache=extracted: cache
+            self._prefill_progress.pop(request.request_id, None)
+            responses.append(
+                MLLMBatchResponse(
+                    uid=batch.uids[index],
+                    request_id=request.request_id,
+                    token=token,
+                    logprobs=batch.logprobs[index],
+                    finish_reason=finish_reason,
+                    prompt_cache=cache_fn,
+                )
+            )
+
+        self._maybe_store_prefix_cache(batch, end_idx)
+        end_set = set(end_idx)
+        keep_idx = [index for index in range(len(batch)) if index not in end_set]
+        if keep_idx:
+            batch.filter(keep_idx)
         else:
-            logits = output
-
-        logits = logits[:, -1, :]
-
-        # Apply per-request logits processors (repetition penalty etc.)
-        if logits_processors and output_tokens and any(logits_processors):
-            processed_logits = []
-            for e in range(logits.shape[0]):
-                sample_logits = logits[e : e + 1]
-                if logits_processors[e]:
-                    # ``output_tokens[e]`` already contains all generated
-                    # tokens including the current step's input token (built
-                    # by the caller as ``req.output_tokens + [token]``).
-                    full_context = output_tokens[e]
-                    for processor in logits_processors[e]:
-                        sample_logits = processor(mx.array(full_context), sample_logits)
-                processed_logits.append(sample_logits)
-            logits = mx.concatenate(processed_logits, axis=0)
-
-        # Sample — per-request samplers for top_k/min_p support
-        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        if samplers and any(samplers):
-            sampled_list = []
-            for e in range(logprobs.shape[0]):
-                s = samplers[e] if samplers[e] else self.sampler
-                sampled_list.append(s(logprobs[e : e + 1]))
-            sampled = mx.concatenate(sampled_list, axis=0)
-        else:
-            sampled = self.sampler(logprobs)
-
-        return sampled, list(logprobs)
+            self.active_batch = None
+        self._stats.generation_tokens += len(responses)
+        return responses
 
     def _next(self) -> List[MLLMBatchResponse]:
         """
@@ -1795,7 +2599,7 @@ class MLLMBatchGenerator:
 
         # Mid-batch extend: text-only requests can join an active batch
         # without vision encoding (no shape mismatch risk).
-        elif self.unprocessed_requests:
+        elif self.unprocessed_requests and not batch.has_sparse_rows:
             text_only = [
                 r for r in self.unprocessed_requests if not r.images and not r.videos
             ][: self.completion_batch_size]
@@ -1847,14 +2651,16 @@ class MLLMBatchGenerator:
         if batch is None:
             return error_responses
 
+        terminal_responses = self._pop_terminal_current_tokens()
+        batch = self.active_batch
+        if batch is None:
+            return error_responses + terminal_responses
+
         y, logprobs = batch.y, batch.logprobs
         output_tokens = None
         if batch.logits_processors:
             y_list = y.tolist()
-            output_tokens = [
-                list(req.output_tokens) + [token]
-                for req, token in zip(batch.requests, y_list)
-            ]
+            output_tokens = _decode_processor_contexts(batch.requests, y_list)
         batch.y, batch.logprobs = self._step(
             y[:, None],
             batch.cache,
@@ -1929,7 +2735,8 @@ class MLLMBatchGenerator:
 
             if finish_reason is not None:
                 # Extract cache for this request
-                cache_fn = lambda idx=i: batch.extract_cache(idx)
+                if batch.sparse_row_states[i] is None:
+                    cache_fn = lambda idx=i: batch.extract_cache(idx)
                 # Cleanup prefill progress tracking
                 self._prefill_progress.pop(request_id, None)
 
@@ -1955,7 +2762,7 @@ class MLLMBatchGenerator:
                 self.active_batch = None
 
         self._stats.generation_tokens += len(responses)
-        return error_responses + responses
+        return error_responses + terminal_responses + responses
 
     def next(self) -> List[MLLMBatchResponse]:
         """
@@ -1987,6 +2794,10 @@ class MLLMBatchGenerator:
         if self.prefix_cache is None or not end_indices:
             return
         for i in end_indices:
+            if batch.sparse_row_states[i] is not None:
+                # Sparse prompt rows are valid only under their exact
+                # SparseCacheIdentity and never enter ordinary LCP/KVQ/SSD.
+                continue
             req = batch.requests[i]
             if req.input_ids is not None:
                 try:
@@ -2078,6 +2889,7 @@ def install_mtp_mllm(
         "no_active_batch": 0,
         "concurrent_batch": 0,
         "logits_processors": 0,
+        "sparse_rows": 0,
     }
 
     def _get_mtp_stats() -> Dict[str, Any]:
@@ -2127,7 +2939,16 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
-        if prefill_bypass or no_active_batch_bypass or logits_processors_bypass:
+        sparse_rows_bypass = (
+            batch_gen.active_batch is not None
+            and batch_gen.active_batch.has_sparse_rows
+        )
+        if (
+            prefill_bypass
+            or no_active_batch_bypass
+            or logits_processors_bypass
+            or sparse_rows_bypass
+        ):
             # Keep the descriptions near the guards so operator-facing
             # telemetry stays dynamic instead of duplicating code predicates:
             # prefill=input_tokens.shape[1] > 1
@@ -2140,6 +2961,8 @@ def install_mtp_mllm(
                     _bypass_counts["no_active_batch"] += 1
                 if logits_processors_bypass:
                     _bypass_counts["logits_processors"] += 1
+                if sparse_rows_bypass:
+                    _bypass_counts["sparse_rows"] += 1
             _skip_state_by_uid.clear()
             return _orig_step(
                 input_tokens, cache, logits_processors, output_tokens, samplers
@@ -2624,10 +3447,15 @@ def install_chunked_prefill_mllm(
         if batch is None:
             return error_responses
 
+        terminal_responses = batch_gen._pop_terminal_current_tokens()
+        batch = batch_gen.active_batch
+        if batch is None:
+            return error_responses + terminal_responses
+
         tic = time.perf_counter()
         y, logprobs = batch.y, batch.logprobs
         output_tokens = (
-            [req.output_tokens for req in batch.requests]
+            _decode_processor_contexts(batch.requests, y.tolist())
             if batch.logits_processors
             else None
         )
@@ -2688,6 +3516,7 @@ def install_chunked_prefill_mllm(
                     prompt_cache=(
                         (lambda idx=i: batch.extract_cache(idx))
                         if finish_reason is not None
+                        and batch.sparse_row_states[i] is None
                         else None
                     ),
                 )
@@ -2704,7 +3533,7 @@ def install_chunked_prefill_mllm(
                 batch_gen.active_batch = None
 
         batch_gen._stats.generation_tokens += len(responses)
-        return error_responses + responses
+        return error_responses + terminal_responses + responses
 
     def _chunked_next() -> List[MLLMBatchResponse]:
         """Interleaved prefill/decode: one prefill chunk + one gen step."""
@@ -2798,25 +3627,6 @@ def install_chunked_prefill_mllm(
                     logits = logits.logits
                 last_logits = logits[:, -1, :]
 
-                # Apply logits processors for first token
-                if getattr(req, "logits_processors", None):
-                    empty_tokens = mx.array([], dtype=mx.int32)
-                    for processor in req.logits_processors:
-                        last_logits = processor(empty_tokens, last_logits)
-
-                logprobs = last_logits - mx.logsumexp(
-                    last_logits, axis=-1, keepdims=True
-                )
-                sampled = batch_gen.sampler(logprobs)
-                mx.eval(sampled, logprobs)
-
-                batch_gen._prefill_progress[req.request_id] = (
-                    partial["total"],
-                    partial["total"],
-                )
-                batch_gen._stats.prompt_time += time.perf_counter() - tic
-
-                # Build single-request batch
                 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
                 req_lp = []
@@ -2832,14 +3642,35 @@ def install_chunked_prefill_mllm(
                 if req.logits_processors:
                     req_lp.extend(req.logits_processors)
 
-                req_sampler = None
-                if req.top_k != 0 or req.min_p != 0.0:
-                    req_sampler = make_sampler(
-                        temp=req.temperature,
-                        top_p=req.top_p,
-                        top_k=req.top_k,
-                        min_p=req.min_p,
+                req_sampler = make_sampler(
+                    temp=req.temperature,
+                    top_p=req.top_p,
+                    top_k=req.top_k,
+                    min_p=req.min_p,
+                )
+
+                # Dense, chunked, and sparse first-token paths all pass the
+                # exact full prompt to the exact same processor stack.
+                if req_lp:
+                    if req.input_ids is None:
+                        raise ValueError(
+                            "first-token processors require exact prompt tokens"
+                        )
+                    last_logits = _apply_first_token_processors(
+                        last_logits, req.input_ids, req_lp
                     )
+
+                logprobs = last_logits - mx.logsumexp(
+                    last_logits, axis=-1, keepdims=True
+                )
+                sampled = req_sampler(logprobs)
+                mx.eval(sampled, logprobs)
+
+                batch_gen._prefill_progress[req.request_id] = (
+                    partial["total"],
+                    partial["total"],
+                )
+                batch_gen._stats.prompt_time += time.perf_counter() - tic
 
                 new_batch = MLLMBatch(
                     uids=[req.uid],
@@ -2851,7 +3682,7 @@ def install_chunked_prefill_mllm(
                     cache=partial["cache"],
                     requests=[req],
                     logits_processors=[req_lp] if req_lp else None,
-                    samplers=[req_sampler] if req_sampler else None,
+                    samplers=[req_sampler],
                 )
 
                 # Extend active batch or set as new

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -18,15 +18,18 @@ Architecture:
 4. Finished requests are removed and outputs returned
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
+import threading
 import time
 import uuid
 
 import mlx.core as mx
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Set, Tuple
 
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
@@ -34,10 +37,31 @@ from .mllm_batch_generator import (
     MLLMBatchGenerator,
     MLLMBatchRequest,
     MLLMBatchResponse,
+    SparseAdoptionError,
+)
+from .cooperative_specprefill import (
+    CooperativeSpecPrefillConfig,
+    CooperativeSpecPrefillOutcome,
+    CooperativeSpecPrefillPhase,
+    CooperativeSpecPrefillProgress,
+    CooperativeSpecPrefillSession,
 )
 from .mlx_streams import bind_generation_streams
 from .multimodal_processor import MultimodalProcessor
 from .request import RequestOutput, RequestStatus, SamplingParams
+from .specprefill import (
+    SpecPrefillCoverage,
+    SpecPrefillPolicy,
+    resolve_specprefill_decision,
+)
+from .specprefill_cache import SparsePolicyTuning
+from .specprefill_profiles import (
+    EMPTY_SPECPREFILL_PROFILE_REGISTRY,
+    SpecPrefillCell,
+    SpecPrefillEngine,
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +114,97 @@ class MLLMSchedulerConfig:
     # evicted entries to disk and promotes them back on hit.
     ssd_cache_dir: Optional[str] = None
     ssd_cache_max_gb: float = 10.0
+    # Cooperative SpecPrefill is fail-closed unless every exact dependency is
+    # supplied. It is independent from native/external MTP composition.
+    specprefill_enabled: bool = False
+    specprefill_profile_registry: SpecPrefillProfileRegistry = field(
+        default_factory=lambda: EMPTY_SPECPREFILL_PROFILE_REGISTRY
+    )
+    specprefill_profile_key: SpecPrefillProfileKey | None = None
+    specprefill_estimated_residency_bytes: int | None = None
+    specprefill_session_factory: Callable[..., "MLLMSpecPrefillAdmission"] | None = None
+    specprefill_target_forward_context: Callable[..., Any] | None = None
+    specprefill_cache_capability: "MLLMSpecPrefillCacheCapability" | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.specprefill_profile_registry, SpecPrefillProfileRegistry):
+            raise TypeError("specprefill_profile_registry must be SpecPrefillProfileRegistry")
+        key = self.specprefill_profile_key
+        if key is not None and (
+            key.engine is not SpecPrefillEngine.CONTINUOUS_BATCHING
+            or key.cell is not SpecPrefillCell.SPARSE_ONLY
+        ):
+            raise ValueError(
+                "MLLM cooperative SpecPrefill requires a CB sparse-only profile key"
+            )
+        if (
+            self.specprefill_estimated_residency_bytes is not None
+            and self.specprefill_estimated_residency_bytes < 0
+        ):
+            raise ValueError("specprefill residency estimate must be non-negative")
+        capability = self.specprefill_cache_capability
+        if capability is not None and not isinstance(
+            capability, MLLMSpecPrefillCacheCapability
+        ):
+            raise TypeError(
+                "specprefill_cache_capability must be MLLMSpecPrefillCacheCapability"
+            )
+        if key is not None and capability is not None and (
+            capability.adapter_id != key.adapter_id
+        ):
+            raise ValueError("SpecPrefill capability adapter must match profile key")
+        for name in (
+            "specprefill_session_factory",
+            "specprefill_target_forward_context",
+        ):
+            value = getattr(self, name)
+            if value is not None and not callable(value):
+                raise TypeError(f"{name} must be callable or None")
+
+
+@dataclass(frozen=True)
+class MLLMSpecPrefillAdmission:
+    """Configured scheduler ownership for one cooperative session."""
+
+    session: CooperativeSpecPrefillSession
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.session, CooperativeSpecPrefillSession):
+            raise TypeError("session must be CooperativeSpecPrefillSession")
+
+
+@dataclass(frozen=True)
+class MLLMSpecPrefillCacheCapability:
+    """Explicitly admitted target adapter/cache slice for sparse CB."""
+
+    adapter_id: str
+    layout: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.adapter_id, str) or not self.adapter_id.strip():
+            raise ValueError("SpecPrefill cache capability needs an adapter_id")
+        if self.layout not in {
+            "qwen3_5_nonrotating_hybrid",
+            "gemma4_dense",
+            "gemma4_a4b",
+            "mixed_rotating",
+        }:
+            raise ValueError("unknown SpecPrefill cache capability layout")
+
+
+@dataclass(frozen=True)
+class MLLMSpecPrefillStepTelemetry:
+    """One scheduler-visible cooperative phase/quantum boundary."""
+
+    phase: CooperativeSpecPrefillPhase
+    outcome: CooperativeSpecPrefillOutcome
+    attempted_phase: CooperativeSpecPrefillPhase | None
+    quantum_committed: bool
+    busy: bool
+    scorer_quanta: int
+    target_quanta: int
+    busy_retries: int
+    fallback_reason: str | None
 
 
 @dataclass
@@ -126,6 +241,21 @@ class MLLMRequest:
     # Timing
     first_token_time: Optional[float] = None
 
+    # Request-local SpecPrefill policy and immutable prompt identity.
+    specprefill_policy: SpecPrefillPolicy = SpecPrefillPolicy.AUTO
+    specprefill_coverage: SpecPrefillCoverage = SpecPrefillCoverage.UNKNOWN
+    specprefill_control_token_indices: tuple[int, ...] = ()
+    prompt_token_ids: tuple[int, ...] = ()
+    specprefill_effective_policy: SpecPrefillPolicy = SpecPrefillPolicy.DENSE
+    specprefill_fallback_reason: str | None = None
+    specprefill_phase: CooperativeSpecPrefillPhase | None = None
+    specprefill_outcome: CooperativeSpecPrefillOutcome | None = None
+    specprefill_selector_version: str | None = None
+    specprefill_total_tokens: int = 0
+    specprefill_selected_tokens: int = 0
+    specprefill_scorer_ms: float = 0.0
+    specprefill_target_prefill_ms: float = 0.0
+
 
 @dataclass
 class MLLMSchedulerOutput:
@@ -145,6 +275,11 @@ class MLLMSchedulerOutput:
     outputs: List[RequestOutput] = field(default_factory=list)
     # Whether any work was done
     has_work: bool = False
+    # At most one request can appear because one scheduler step attempts at
+    # most one round-robin cooperative quantum.
+    specprefill_progress: Dict[str, MLLMSpecPrefillStepTelemetry] = field(
+        default_factory=dict
+    )
 
 
 class MLLMScheduler:
@@ -223,6 +358,13 @@ class MLLMScheduler:
         # Mapping between our request IDs and BatchGenerator UIDs
         self.request_id_to_uid: Dict[str, int] = {}
         self.uid_to_request_id: Dict[int, str] = {}
+
+        # Cooperative requests are scheduler-owned until sparse cache adoption.
+        self._specprefill_queue: deque[str] = deque()
+        self._specprefill_admissions: Dict[str, MLLMSpecPrefillAdmission] = {}
+        self._specprefill_batch_requests: Dict[str, MLLMBatchRequest] = {}
+        self._specprefill_cancel_pending: Set[str] = set()
+        self._specprefill_cancel_lock = threading.RLock()
 
         # Per-request streaming detokenizers for UTF-8-safe incremental decode
         self._detokenizer_pool: Dict[str, Any] = {}
@@ -324,6 +466,7 @@ class MLLMScheduler:
                 prefill_step_size=self.config.prefill_step_size,
                 prefix_cache_config=prefix_cache_config,
                 max_kv_size=self.config.max_kv_size,
+                target_forward_context=self.config.specprefill_target_forward_context,
             )
 
             # Wire the SSD cold tier onto the MLLM prefix cache, mirroring the
@@ -419,6 +562,22 @@ class MLLMScheduler:
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             logits_processors=kwargs.pop("logits_processors", None),
         )
+        specprefill_policy = SpecPrefillPolicy(
+            kwargs.pop("specprefill_policy", SpecPrefillPolicy.AUTO)
+        )
+        specprefill_coverage = SpecPrefillCoverage(
+            kwargs.pop("specprefill_coverage", SpecPrefillCoverage.UNKNOWN)
+        )
+        control_token_indices = tuple(
+            kwargs.pop("specprefill_control_token_indices", ())
+        )
+        if any(
+            isinstance(index, bool) or not isinstance(index, int) or index < 0
+            for index in control_token_indices
+        ):
+            raise ValueError(
+                "specprefill_control_token_indices must be non-negative integers"
+            )
 
         request = MLLMRequest(
             request_id=request_id,
@@ -427,6 +586,11 @@ class MLLMScheduler:
             videos=videos,
             audio=audio,
             sampling_params=sampling_params,
+            specprefill_policy=specprefill_policy,
+            specprefill_coverage=specprefill_coverage,
+            specprefill_control_token_indices=tuple(
+                sorted(set(control_token_indices))
+            ),
         )
 
         # Estimate prompt token count for monitoring (text tokens only;
@@ -438,7 +602,10 @@ class MLLMScheduler:
             else self.processor
         )
         try:
-            request.num_prompt_tokens = len(tokenizer.encode(prompt))
+            prompt_token_ids = tuple(tokenizer.encode(prompt))
+            request.prompt_token_ids = prompt_token_ids
+            request.num_prompt_tokens = len(prompt_token_ids)
+            request.specprefill_total_tokens = len(prompt_token_ids)
         except Exception:
             pass
 
@@ -465,6 +632,12 @@ class MLLMScheduler:
         request = self.requests.get(request_id)
         if request is None:
             return False
+
+        # Cancellation can arrive from the event-loop thread while the
+        # scheduler owns an MLX quantum. Only flag it here; session.cancel()
+        # and cache cleanup run at the next scheduler-thread safe boundary.
+        with self._specprefill_cancel_lock:
+            self._specprefill_cancel_pending.add(request_id)
 
         # Signal batch generator to abort any in-progress prefill for this
         # request.  The prefill loop checks _aborted_request_ids between
@@ -533,7 +706,9 @@ class MLLMScheduler:
 
     def has_requests(self) -> bool:
         """Check if there are any pending or running requests."""
-        return bool(self.waiting or self.running)
+        with self._specprefill_cancel_lock:
+            cooperative_cancel_pending = bool(self._specprefill_cancel_pending)
+        return bool(self.waiting or self.running or cooperative_cancel_pending)
 
     def get_num_waiting(self) -> int:
         """Get number of waiting requests."""
@@ -542,6 +717,137 @@ class MLLMScheduler:
     def get_num_running(self) -> int:
         """Get number of running requests."""
         return len(self.running)
+
+    @staticmethod
+    def _batch_request_for(request: MLLMRequest) -> MLLMBatchRequest:
+        return MLLMBatchRequest(
+            uid=-1,
+            request_id=request.request_id,
+            prompt=request.prompt,
+            images=request.images,
+            videos=request.videos,
+            audio=request.audio,
+            max_tokens=request.sampling_params.max_tokens,
+            temperature=request.sampling_params.temperature,
+            top_p=request.sampling_params.top_p,
+            top_k=request.sampling_params.top_k,
+            min_p=request.sampling_params.min_p,
+            presence_penalty=request.sampling_params.presence_penalty,
+            repetition_penalty=request.sampling_params.repetition_penalty,
+            logits_processors=request.sampling_params.logits_processors,
+        )
+
+    def _cooperative_config_for(
+        self, request: MLLMRequest
+    ) -> tuple[CooperativeSpecPrefillConfig | None, str | None]:
+        text_only = not (request.images or request.videos or request.audio)
+        decision = resolve_specprefill_decision(
+            request.specprefill_policy,
+            request.specprefill_coverage,
+            production=True,
+            text_only=text_only,
+            threshold_met=True,
+            admission_allowed=self.config.specprefill_enabled,
+        )
+        request.specprefill_effective_policy = decision.effective_policy
+        request.specprefill_fallback_reason = decision.fallback_reason
+        if decision.effective_policy is SpecPrefillPolicy.DENSE:
+            return None, decision.fallback_reason
+        if self.config.enable_mtp:
+            return None, "mtp_composition_unavailable"
+        if self.config.max_kv_size > 0:
+            return None, "rotating_tail_requirement_unavailable"
+        key = self.config.specprefill_profile_key
+        capability = self.config.specprefill_cache_capability
+        residency = self.config.specprefill_estimated_residency_bytes
+        if key is None:
+            return None, "profile_key_unavailable"
+        if residency is None:
+            return None, "residency_estimate_unavailable"
+        if capability is None:
+            return None, "cache_capability_unavailable"
+        if (
+            capability.adapter_id != key.adapter_id
+            or capability.layout != "qwen3_5_nonrotating_hybrid"
+        ):
+            return None, "cache_capability_unsupported"
+        if self.config.specprefill_session_factory is None:
+            return None, "cooperative_session_factory_unavailable"
+        if self.config.specprefill_target_forward_context is None:
+            return None, "target_forward_context_unavailable"
+        if not request.prompt_token_ids:
+            return None, "prompt_tokenization_unavailable"
+        profile_decision = self.config.specprefill_profile_registry.resolve(
+            key,
+            prompt_tokens=len(request.prompt_token_ids),
+            residency_bytes=residency,
+        )
+        if not profile_decision.eligible or profile_decision.tuning is None:
+            return None, profile_decision.fallback_reason
+        tuning = profile_decision.tuning
+        return (
+            CooperativeSpecPrefillConfig(
+                target_id=(
+                    f"{key.target_artifact_id}@sha256:{key.target_artifact_hash}"
+                ),
+                tokenizer_id=f"tokenizer@sha256:{key.tokenizer_artifact_hash}",
+                scorer_id=(
+                    f"{key.scorer_artifact_id}@sha256:{key.scorer_artifact_hash}"
+                ),
+                tuning=SparsePolicyTuning(
+                    keep_pct=tuning.keep_pct,
+                    backbone_pct=tuning.backbone_pct,
+                    halo_chunks=tuning.halo_chunks,
+                    anchor_chunks=tuning.anchor_chunks,
+                    chunk_size=tuning.chunk_size,
+                ),
+                control_token_indices=request.specprefill_control_token_indices,
+            ),
+            None,
+        )
+
+    def _admit_cooperative(
+        self,
+        request: MLLMRequest,
+        batch_request: MLLMBatchRequest,
+        cooperative_config: CooperativeSpecPrefillConfig,
+    ) -> bool:
+        factory = self.config.specprefill_session_factory
+        if factory is None:  # pragma: no cover - guarded by policy resolution.
+            return False
+        try:
+            admission = factory(
+                request,
+                request.prompt_token_ids,
+                cooperative_config,
+            )
+            if not isinstance(admission, MLLMSpecPrefillAdmission):
+                raise TypeError(
+                    "specprefill_session_factory must return MLLMSpecPrefillAdmission"
+                )
+            if admission.session.request_id != request.request_id:
+                raise ValueError("cooperative session request identity mismatch")
+            if admission.session.config != cooperative_config:
+                raise ValueError("cooperative session config identity mismatch")
+        except Exception as exc:
+            request.specprefill_effective_policy = SpecPrefillPolicy.DENSE
+            request.specprefill_fallback_reason = "cooperative_admission_failed"
+            logger.warning(
+                "Cooperative SpecPrefill admission failed for %s: %s",
+                request.request_id,
+                exc,
+            )
+            return False
+
+        batch_request.input_ids = mx.array([request.prompt_token_ids])
+        batch_request.is_text_only = True
+        request.specprefill_effective_policy = SpecPrefillPolicy.SPARSE
+        request.specprefill_phase = admission.session.phase
+        request.specprefill_outcome = admission.session.outcome
+        self._specprefill_admissions[request.request_id] = admission
+        self._specprefill_batch_requests[request.request_id] = batch_request
+        self._specprefill_queue.append(request.request_id)
+        return True
 
     def _schedule_waiting(self) -> List[MLLMRequest]:
         """
@@ -558,24 +864,21 @@ class MLLMScheduler:
         while self.waiting and len(self.running) < self.config.max_num_seqs:
             request = self.waiting.popleft()
 
-            # Create batch request
-            batch_req = MLLMBatchRequest(
-                uid=-1,  # Will be assigned by batch generator
-                request_id=request.request_id,
-                prompt=request.prompt,
-                images=request.images,
-                videos=request.videos,
-                audio=request.audio,
-                max_tokens=request.sampling_params.max_tokens,
-                temperature=request.sampling_params.temperature,
-                top_p=request.sampling_params.top_p,
-                top_k=request.sampling_params.top_k,
-                min_p=request.sampling_params.min_p,
-                presence_penalty=request.sampling_params.presence_penalty,
-                repetition_penalty=request.sampling_params.repetition_penalty,
-                logits_processors=request.sampling_params.logits_processors,
+            batch_req = self._batch_request_for(request)
+            cooperative_config, fallback_reason = self._cooperative_config_for(
+                request
             )
-            batch_requests.append(batch_req)
+            cooperative = (
+                cooperative_config is not None
+                and self._admit_cooperative(
+                    request, batch_req, cooperative_config
+                )
+            )
+            if not cooperative:
+                request.specprefill_effective_policy = SpecPrefillPolicy.DENSE
+                if request.specprefill_fallback_reason is None:
+                    request.specprefill_fallback_reason = fallback_reason
+                batch_requests.append(batch_req)
 
             request.status = RequestStatus.RUNNING
             self.running[request.request_id] = request
@@ -584,10 +887,15 @@ class MLLMScheduler:
             self.total_prompt_tokens += request.num_prompt_tokens
 
         # Insert into batch generator
+        dense_scheduled = [
+            request
+            for request in scheduled
+            if request.request_id not in self._specprefill_admissions
+        ]
         if batch_requests and self.batch_generator is not None:
             uids = self.batch_generator.insert(batch_requests)
 
-            for uid, request in zip(uids, scheduled):
+            for uid, request in zip(uids, dense_scheduled, strict=True):
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id
                 request.batch_uid = uid
@@ -637,6 +945,7 @@ class MLLMScheduler:
                     completion_tokens=0,
                     finished=True,
                     finish_reason="error",
+                    **self._specprefill_output_metadata(request),
                 )
                 request.status = RequestStatus.FINISHED_ABORTED
                 request.output_text = ""
@@ -680,6 +989,7 @@ class MLLMScheduler:
                 completion_tokens=request.num_output_tokens,
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
+                **self._specprefill_output_metadata(request),
             )
 
             # Check if finished
@@ -715,6 +1025,43 @@ class MLLMScheduler:
 
         return outputs, finished_ids
 
+    @staticmethod
+    def _specprefill_output_metadata(request: MLLMRequest) -> Dict[str, Any]:
+        return {
+            "specprefill_requested_policy": request.specprefill_policy.value,
+            "specprefill_effective_policy": (
+                request.specprefill_effective_policy.value
+            ),
+            "specprefill_coverage": request.specprefill_coverage.value,
+            "specprefill_engaged": (
+                request.specprefill_effective_policy is SpecPrefillPolicy.SPARSE
+            ),
+            "specprefill_selector_version": request.specprefill_selector_version,
+            "specprefill_fallback_reason": request.specprefill_fallback_reason,
+            "specprefill_total_tokens": request.specprefill_total_tokens,
+            "specprefill_selected_tokens": request.specprefill_selected_tokens,
+            "specprefill_scorer_ms": request.specprefill_scorer_ms,
+            "specprefill_target_prefill_ms": (
+                request.specprefill_target_prefill_ms
+            ),
+        }
+
+    @staticmethod
+    def _update_request_specprefill(
+        request: MLLMRequest, session: CooperativeSpecPrefillSession
+    ) -> None:
+        telemetry = session.telemetry
+        request.specprefill_phase = session.phase
+        request.specprefill_outcome = session.outcome
+        request.specprefill_total_tokens = len(session.tokens)
+        request.specprefill_selected_tokens = telemetry.selected_tokens
+        request.specprefill_scorer_ms = telemetry.scorer_ms
+        request.specprefill_target_prefill_ms = telemetry.target_prefill_ms
+        plan = session.selection_plan
+        request.specprefill_selector_version = (
+            None if plan is None else plan.selector_version
+        )
+
     def _cleanup_finished(self, finished_ids: Set[str]) -> None:
         """Clean up finished requests."""
         for request_id in finished_ids:
@@ -734,6 +1081,8 @@ class MLLMScheduler:
 
             # Clean up detokenizer pool (handles abort/timeout cases)
             self._detokenizer_pool.pop(request_id, None)
+            self._specprefill_admissions.pop(request_id, None)
+            self._specprefill_batch_requests.pop(request_id, None)
 
             # Track as finished
             self.finished_req_ids.add(request_id)
@@ -742,6 +1091,338 @@ class MLLMScheduler:
         # Clear Metal buffer pool after cleanup to release memory
         if finished_ids:
             mx.clear_cache()
+
+    @staticmethod
+    def _specprefill_step_telemetry(
+        session: CooperativeSpecPrefillSession,
+        progress: CooperativeSpecPrefillProgress | None,
+    ) -> MLLMSpecPrefillStepTelemetry:
+        telemetry = session.telemetry
+        return MLLMSpecPrefillStepTelemetry(
+            phase=session.phase,
+            outcome=session.outcome,
+            attempted_phase=(None if progress is None else progress.attempted_phase),
+            quantum_committed=(
+                False if progress is None else progress.quantum_committed
+            ),
+            busy=False if progress is None else progress.busy,
+            scorer_quanta=telemetry.scorer_quanta,
+            target_quanta=telemetry.target_quanta,
+            busy_retries=telemetry.busy_retries,
+            fallback_reason=session.fallback_reason,
+        )
+
+    def _drain_cooperative_cancellations(self) -> None:
+        with self._specprefill_cancel_lock:
+            pending = self._specprefill_cancel_pending
+            self._specprefill_cancel_pending = set()
+        if not pending:
+            return
+        for request_id in pending:
+            admission = self._specprefill_admissions.pop(request_id, None)
+            self._specprefill_batch_requests.pop(request_id, None)
+            if admission is None:
+                continue
+            try:
+                admission.session.cancel()
+            except Exception:
+                logger.exception(
+                    "Failed to cancel cooperative SpecPrefill request %s",
+                    request_id,
+                )
+        self._specprefill_queue = deque(
+            request_id
+            for request_id in self._specprefill_queue
+            if request_id not in pending
+        )
+
+    def _consume_cooperative_cancellation(self, request_id: str) -> bool:
+        with self._specprefill_cancel_lock:
+            if request_id not in self._specprefill_cancel_pending:
+                return False
+            self._specprefill_cancel_pending.remove(request_id)
+        admission = self._specprefill_admissions.pop(request_id, None)
+        self._specprefill_batch_requests.pop(request_id, None)
+        if admission is not None:
+            try:
+                admission.session.cancel()
+            except Exception:
+                logger.exception(
+                    "Failed to cancel cooperative SpecPrefill request %s",
+                    request_id,
+                )
+        return True
+
+    def _remove_published_sparse_orphan(self, uid: int) -> None:
+        """Schedule and drain an orphan row at this owner-thread safe point."""
+        assert self.batch_generator is not None
+        self.batch_generator.schedule_removal([uid])
+        self.batch_generator.process_pending_removals()
+
+    def _fail_cooperative_terminal(
+        self,
+        request_id: str,
+        reason: str,
+        output: MLLMSchedulerOutput,
+        failure: Exception | None = None,
+    ) -> None:
+        admission = self._specprefill_admissions.pop(request_id, None)
+        self._specprefill_batch_requests.pop(request_id, None)
+        request = self.running.get(request_id)
+        if admission is not None and admission.session.outcome not in (
+            CooperativeSpecPrefillOutcome.DECODE,
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            CooperativeSpecPrefillOutcome.FAILED,
+            CooperativeSpecPrefillOutcome.CANCELLED,
+        ):
+            admission.session.fallback(reason, failure)
+        if (
+            admission is not None
+            and admission.session.outcome is CooperativeSpecPrefillOutcome.FAILED
+        ):
+            reason = admission.session.fallback_reason or "resource_cleanup_failed"
+        if request is None:
+            return
+        if admission is not None:
+            self._update_request_specprefill(request, admission.session)
+        request.specprefill_fallback_reason = reason
+        request.finish_reason = "error"
+        request.status = RequestStatus.FINISHED_ABORTED
+        terminal = RequestOutput(
+            request_id=request_id,
+            finished=True,
+            finish_reason="error",
+            prompt_tokens=request.num_prompt_tokens,
+            completion_tokens=0,
+            mtp_drafts=request.mtp_drafts,
+            mtp_accepted=request.mtp_accepted,
+            **self._specprefill_output_metadata(request),
+        )
+        output.outputs.append(terminal)
+        output.finished_request_ids.add(request_id)
+        self.num_requests_processed += 1
+        queue = self.output_queues.get(request_id)
+        if queue is not None:
+            try:
+                queue.put_nowait(terminal)
+                queue.put_nowait(None)
+            except asyncio.QueueFull:
+                pass
+
+    def _fallback_cooperative_to_dense(
+        self,
+        request_id: str,
+        reason: str,
+        output: MLLMSchedulerOutput,
+        failure: Exception | None = None,
+    ) -> bool:
+        admission = self._specprefill_admissions.pop(request_id, None)
+        batch_request = self._specprefill_batch_requests.pop(request_id, None)
+        request = self.running.get(request_id)
+        if admission is not None and admission.session.outcome not in (
+            CooperativeSpecPrefillOutcome.FALLBACK,
+            CooperativeSpecPrefillOutcome.FAILED,
+            CooperativeSpecPrefillOutcome.CANCELLED,
+        ):
+            admission.session.fallback(reason, failure)
+        if (
+            admission is not None
+            and admission.session.outcome is CooperativeSpecPrefillOutcome.FAILED
+        ):
+            # Re-publish ownership temporarily so the common terminal path can
+            # preserve the complete failed-session telemetry before cleanup.
+            self._specprefill_admissions[request_id] = admission
+            if batch_request is not None:
+                self._specprefill_batch_requests[request_id] = batch_request
+            self._fail_cooperative_terminal(
+                request_id, "resource_cleanup_failed", output, failure
+            )
+            return False
+        if request is None or batch_request is None:
+            return False
+        request.specprefill_effective_policy = SpecPrefillPolicy.DENSE
+        request.specprefill_fallback_reason = reason
+        if admission is not None:
+            self._update_request_specprefill(request, admission.session)
+        assert self.batch_generator is not None
+        uid = self.batch_generator.insert([batch_request])[0]
+        self.request_id_to_uid[request_id] = uid
+        self.uid_to_request_id[uid] = request_id
+        request.batch_uid = uid
+        return True
+
+    def _adoption_is_compatible(
+        self, session: CooperativeSpecPrefillSession
+    ) -> bool:
+        assert self.batch_generator is not None
+        active = self.batch_generator.active_batch
+        if active is None:
+            return True
+        if not active.has_sparse_rows or session.identity is None:
+            return False
+        return active.sparse_execution_config == session.identity.execution_config
+
+    def _adopt_ready_cooperative(
+        self, request_id: str, output: MLLMSchedulerOutput
+    ) -> bool:
+        admission = self._specprefill_admissions.get(request_id)
+        batch_request = self._specprefill_batch_requests.get(request_id)
+        request = self.running.get(request_id)
+        if admission is None or batch_request is None or request is None:
+            return False
+        session = admission.session
+        uid = None
+        try:
+            if not session.ready_for_adoption or not self._adoption_is_compatible(
+                session
+            ):
+                return False
+            assert self.batch_generator is not None
+            if session.identity is None:
+                raise RuntimeError("adoption_identity_unavailable")
+            execution_config = session.identity.execution_config
+            active = self.batch_generator.active_batch
+            if active is None:
+                self.batch_generator.set_expected_sparse_execution_config(
+                    execution_config
+                )
+            elif getattr(
+                self.batch_generator, "_expected_sparse_execution_config", None
+            ) != execution_config:
+                return False
+            result = session.prepared_result
+            cache = session.prepared_cache
+            cache_identity = (id(cache), tuple(id(entry) for entry in cache))
+            if session.sparse_state != result.cache_state:
+                raise RuntimeError("prepared_cache_state_identity_mismatch")
+            self._update_request_specprefill(request, session)
+            if self._consume_cooperative_cancellation(request_id):
+                return True
+            # Re-read the authoritative executor property immediately before
+            # publication so a replaced container/entry cannot cross adoption.
+            current_cache = session.prepared_cache
+            if (
+                id(current_cache),
+                tuple(id(entry) for entry in current_cache),
+            ) != cache_identity:
+                raise RuntimeError("adoption_cache_identity_changed")
+            uid = self.batch_generator.adopt_prefilled_sparse_row(
+                batch_request,
+                current_cache,
+                result.logits,
+                result.cache_state,
+            )
+        except SparseAdoptionError as exc:
+            if not exc.rollback_succeeded:
+                self._fail_cooperative_terminal(
+                    request_id, "adoption_rollback_failed", output, exc
+                )
+            elif exc.sampling_consumed:
+                self._fail_cooperative_terminal(
+                    request_id, "adoption_failed_after_sampling", output, exc
+                )
+            else:
+                self._fallback_cooperative_to_dense(
+                    request_id, "adoption_failed", output, exc
+                )
+            return True
+        except Exception as exc:
+            self._fail_cooperative_terminal(
+                request_id, "adoption_failed_unknown_boundary", output, exc
+            )
+            return True
+
+        # Publication succeeded. Coordinate the final cancellation check and
+        # request mapping with abort_request's flagging lock. An injected
+        # mark_adopted/mapping failure schedules removal of the orphan row.
+        try:
+            cancelled = False
+            with self._specprefill_cancel_lock:
+                if request_id in self._specprefill_cancel_pending:
+                    self._specprefill_cancel_pending.remove(request_id)
+                    cancelled = True
+                else:
+                    self.request_id_to_uid[request_id] = uid
+                    self.uid_to_request_id[uid] = request_id
+                    request.batch_uid = uid
+                    session.mark_adopted()
+            if cancelled:
+                self._remove_published_sparse_orphan(uid)
+                self._specprefill_admissions.pop(request_id, None)
+                self._specprefill_batch_requests.pop(request_id, None)
+                session.cancel()
+                return True
+        except Exception as exc:
+            self.request_id_to_uid.pop(request_id, None)
+            self.uid_to_request_id.pop(uid, None)
+            request.batch_uid = None
+            self._remove_published_sparse_orphan(uid)
+            self._fail_cooperative_terminal(
+                request_id, "adoption_transition_failed", output, exc
+            )
+            return True
+        self._specprefill_admissions.pop(request_id, None)
+        self._specprefill_batch_requests.pop(request_id, None)
+        return True
+
+    def _run_one_cooperative_quantum(
+        self, output: MLLMSchedulerOutput
+    ) -> None:
+        while self._specprefill_queue:
+            request_id = self._specprefill_queue.popleft()
+            admission = self._specprefill_admissions.get(request_id)
+            if admission is None:
+                continue
+            session = admission.session
+            progress = None
+            if session.outcome is CooperativeSpecPrefillOutcome.CANCELLED:
+                self.abort_request(request_id)
+            elif session.ready_for_adoption:
+                adopted_or_fallback = self._adopt_ready_cooperative(
+                    request_id, output
+                )
+                if not adopted_or_fallback:
+                    self._specprefill_queue.append(request_id)
+            elif session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+                try:
+                    progress = session.step()
+                except Exception as exc:
+                    self._fallback_cooperative_to_dense(
+                        request_id, "cooperative_step_failed", output, exc
+                    )
+                else:
+                    if session.ready_for_adoption:
+                        adopted_or_fallback = self._adopt_ready_cooperative(
+                            request_id, output
+                        )
+                        if not adopted_or_fallback:
+                            self._specprefill_queue.append(request_id)
+                    elif session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
+                        # Busy is a normal zero-commit retry and still rotates.
+                        self._specprefill_queue.append(request_id)
+                    elif session.outcome in (
+                        CooperativeSpecPrefillOutcome.FALLBACK,
+                        CooperativeSpecPrefillOutcome.FAILED,
+                    ):
+                        self._fallback_cooperative_to_dense(
+                            request_id,
+                            session.fallback_reason or "cooperative_failed",
+                            output,
+                        )
+            else:
+                self._fallback_cooperative_to_dense(
+                    request_id,
+                    session.fallback_reason or "cooperative_failed",
+                    output,
+                )
+            request = self.requests.get(request_id)
+            if request is not None:
+                self._update_request_specprefill(request, session)
+            output.specprefill_progress[request_id] = (
+                self._specprefill_step_telemetry(session, progress)
+            )
+            output.has_work = True
+            return
 
     def step(self) -> MLLMSchedulerOutput:
         """
@@ -756,6 +1437,8 @@ class MLLMScheduler:
             MLLMSchedulerOutput with results of this step
         """
         output = MLLMSchedulerOutput()
+
+        self._drain_cooperative_cancellations()
 
         # Drain any deferred removals queued from other threads (e.g.
         # the asyncio event loop during client-disconnect aborts).
@@ -794,6 +1477,18 @@ class MLLMScheduler:
                 self._cleanup_finished(finished_ids)
                 if finished_ids:
                     mx.clear_cache()
+
+        # Active target decode always gets the first model-work opportunity.
+        # Cooperative scoring/target prefill then receives at most one bounded
+        # round-robin quantum; a busy lane rotates without dense fallback.
+        self._run_one_cooperative_quantum(output)
+        cooperative_finished = {
+            request_id
+            for request_id in output.finished_request_ids
+            if request_id in self.running
+        }
+        if cooperative_finished:
+            self._cleanup_finished(cooperative_finished)
 
         # Adaptive periodic cache clear: scale inversely with concurrency
         # to prevent Metal buffer pool growth during long generations

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -490,6 +490,12 @@ class MLLMScheduler:
     def _ensure_batch_generator(self) -> None:
         """Ensure batch generator exists."""
         if self.batch_generator is None:
+            if self.config.enable_mtp:
+                lm = getattr(self.model, "language_model", self.model)
+                from .scheduler import _continuous_batching_mtp_capability
+
+                _continuous_batching_mtp_capability(lm, enabled=True)
+
             from mlx_lm.sample_utils import make_sampler
 
             from .memory_cache import MemoryCacheConfig

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -132,8 +132,12 @@ class MLLMSchedulerConfig:
     specprefill_advertisable: bool = False
 
     def __post_init__(self) -> None:
-        if not isinstance(self.specprefill_profile_registry, SpecPrefillProfileRegistry):
-            raise TypeError("specprefill_profile_registry must be SpecPrefillProfileRegistry")
+        if not isinstance(
+            self.specprefill_profile_registry, SpecPrefillProfileRegistry
+        ):
+            raise TypeError(
+                "specprefill_profile_registry must be SpecPrefillProfileRegistry"
+            )
         key = self.specprefill_profile_key
         if key is not None and (
             key.engine is not SpecPrefillEngine.CONTINUOUS_BATCHING
@@ -183,8 +187,7 @@ class MLLMSchedulerConfig:
             )
         if gemma_config is not None and (
             capability is None
-            or capability.layout
-            != gemma_config.attestation.artifact.artifact_id
+            or capability.layout != gemma_config.attestation.artifact.artifact_id
             or capability.backend != "mlx_vlm"
             or not capability.rotating
             or not capability.homogeneous_rows_only
@@ -192,8 +195,10 @@ class MLLMSchedulerConfig:
             raise ValueError(
                 "Gemma CB SpecPrefill requires exact rotating mlx-vlm capability"
             )
-        if key is not None and capability is not None and (
-            capability.adapter_id != key.adapter_id
+        if (
+            key is not None
+            and capability is not None
+            and (capability.adapter_id != key.adapter_id)
         ):
             raise ValueError("SpecPrefill capability adapter must match profile key")
         for name in (
@@ -661,9 +666,7 @@ class MLLMScheduler:
             sampling_params=sampling_params,
             specprefill_policy=specprefill_policy,
             specprefill_coverage=specprefill_coverage,
-            specprefill_control_token_indices=tuple(
-                sorted(set(control_token_indices))
-            ),
+            specprefill_control_token_indices=tuple(sorted(set(control_token_indices))),
             specprefill_has_media=specprefill_has_media,
         )
 
@@ -976,14 +979,9 @@ class MLLMScheduler:
             request = self.waiting.popleft()
 
             batch_req = self._batch_request_for(request)
-            cooperative_config, fallback_reason = self._cooperative_config_for(
-                request
-            )
-            cooperative = (
-                cooperative_config is not None
-                and self._admit_cooperative(
-                    request, batch_req, cooperative_config
-                )
+            cooperative_config, fallback_reason = self._cooperative_config_for(request)
+            cooperative = cooperative_config is not None and self._admit_cooperative(
+                request, batch_req, cooperative_config
             )
             if not cooperative:
                 request.specprefill_effective_policy = SpecPrefillPolicy.DENSE
@@ -1152,9 +1150,7 @@ class MLLMScheduler:
             "specprefill_total_tokens": request.specprefill_total_tokens,
             "specprefill_selected_tokens": request.specprefill_selected_tokens,
             "specprefill_scorer_ms": request.specprefill_scorer_ms,
-            "specprefill_target_prefill_ms": (
-                request.specprefill_target_prefill_ms
-            ),
+            "specprefill_target_prefill_ms": (request.specprefill_target_prefill_ms),
         }
 
     @staticmethod
@@ -1362,9 +1358,7 @@ class MLLMScheduler:
         request.batch_uid = uid
         return True
 
-    def _adoption_is_compatible(
-        self, session: CooperativeSpecPrefillSession
-    ) -> bool:
+    def _adoption_is_compatible(self, session: CooperativeSpecPrefillSession) -> bool:
         assert self.batch_generator is not None
         active = self.batch_generator.active_batch
         if active is None:
@@ -1397,9 +1391,10 @@ class MLLMScheduler:
                 self.batch_generator.set_expected_sparse_execution_config(
                     execution_config
                 )
-            elif getattr(
-                self.batch_generator, "_expected_sparse_execution_config", None
-            ) != execution_config:
+            elif (
+                getattr(self.batch_generator, "_expected_sparse_execution_config", None)
+                != execution_config
+            ):
                 return False
             result = session.prepared_result
             cache = session.prepared_cache
@@ -1476,9 +1471,7 @@ class MLLMScheduler:
         self._specprefill_batch_requests.pop(request_id, None)
         return True
 
-    def _run_one_cooperative_quantum(
-        self, output: MLLMSchedulerOutput
-    ) -> None:
+    def _run_one_cooperative_quantum(self, output: MLLMSchedulerOutput) -> None:
         while self._specprefill_queue:
             request_id = self._specprefill_queue.popleft()
             admission = self._specprefill_admissions.get(request_id)
@@ -1489,9 +1482,7 @@ class MLLMScheduler:
             if session.outcome is CooperativeSpecPrefillOutcome.CANCELLED:
                 self.abort_request(request_id)
             elif session.ready_for_adoption:
-                adopted_or_fallback = self._adopt_ready_cooperative(
-                    request_id, output
-                )
+                adopted_or_fallback = self._adopt_ready_cooperative(request_id, output)
                 if not adopted_or_fallback:
                     self._specprefill_queue.append(request_id)
             elif session.outcome is CooperativeSpecPrefillOutcome.ACTIVE:
@@ -1529,8 +1520,8 @@ class MLLMScheduler:
             request = self.requests.get(request_id)
             if request is not None:
                 self._update_request_specprefill(request, session)
-            output.specprefill_progress[request_id] = (
-                self._specprefill_step_telemetry(session, progress)
+            output.specprefill_progress[request_id] = self._specprefill_step_telemetry(
+                session, progress
             )
             output.has_work = True
             return

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -492,9 +492,9 @@ class MLLMScheduler:
         if self.batch_generator is None:
             if self.config.enable_mtp:
                 lm = getattr(self.model, "language_model", self.model)
-                from .scheduler import _continuous_batching_mtp_capability
+                from .scheduler import _reject_native_mtp_mllm
 
-                _continuous_batching_mtp_capability(lm, enabled=True)
+                _reject_native_mtp_mllm(lm, enabled=True)
 
             from mlx_lm.sample_utils import make_sampler
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -125,6 +125,8 @@ class MLLMSchedulerConfig:
     specprefill_session_factory: Callable[..., "MLLMSpecPrefillAdmission"] | None = None
     specprefill_target_forward_context: Callable[..., Any] | None = None
     specprefill_cache_capability: "MLLMSpecPrefillCacheCapability" | None = None
+    specprefill_diagnostic: bool = False
+    specprefill_advertisable: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.specprefill_profile_registry, SpecPrefillProfileRegistry):
@@ -143,6 +145,12 @@ class MLLMSchedulerConfig:
         ):
             raise ValueError("specprefill residency estimate must be non-negative")
         capability = self.specprefill_cache_capability
+        if not isinstance(self.specprefill_diagnostic, bool):
+            raise TypeError("specprefill_diagnostic must be bool")
+        if not isinstance(self.specprefill_advertisable, bool):
+            raise TypeError("specprefill_advertisable must be bool")
+        if self.specprefill_diagnostic and self.specprefill_advertisable:
+            raise ValueError("diagnostic SpecPrefill cannot be advertisable")
         if capability is not None and not isinstance(
             capability, MLLMSpecPrefillCacheCapability
         ):
@@ -754,10 +762,19 @@ class MLLMScheduler:
         decision = resolve_specprefill_decision(
             request.specprefill_policy,
             request.specprefill_coverage,
-            production=True,
+            production=not self.config.specprefill_diagnostic,
             text_only=text_only,
             threshold_met=True,
-            admission_allowed=self.config.specprefill_enabled,
+            admission_allowed=(
+                self.config.specprefill_enabled
+                and (
+                    self.config.specprefill_advertisable
+                    or (
+                        self.config.specprefill_diagnostic
+                        and request.specprefill_policy is SpecPrefillPolicy.SPARSE
+                    )
+                )
+            ),
         )
         request.specprefill_effective_policy = decision.effective_policy
         request.specprefill_fallback_reason = decision.fallback_reason
@@ -791,6 +808,7 @@ class MLLMScheduler:
             key,
             prompt_tokens=len(request.prompt_token_ids),
             residency_bytes=residency,
+            diagnostic=self.config.specprefill_diagnostic,
         )
         if not profile_decision.eligible or profile_decision.tuning is None:
             return None, profile_decision.fallback_reason
@@ -1865,6 +1883,14 @@ class MLLMScheduler:
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
             "requests": self.get_running_requests_info(),
+            "specprefill": {
+                "enabled": (
+                    self.config.specprefill_enabled
+                    and self.config.specprefill_advertisable
+                ),
+                "advertisable": self.config.specprefill_advertisable,
+                "diagnostic": self.config.specprefill_diagnostic,
+            },
         }
 
         if self.batch_generator is not None:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -34,6 +34,7 @@ from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Set, Tupl
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
 from .mllm_batch_generator import (
+    GemmaSparseBatchConfig,
     MLLMBatchGenerator,
     MLLMBatchRequest,
     MLLMBatchResponse,
@@ -55,6 +56,7 @@ from .specprefill import (
     resolve_specprefill_decision,
 )
 from .specprefill_cache import SparsePolicyTuning
+from .specprefill_selection import RotatingTailRequirement
 from .specprefill_profiles import (
     EMPTY_SPECPREFILL_PROFILE_REGISTRY,
     SpecPrefillCell,
@@ -125,6 +127,7 @@ class MLLMSchedulerConfig:
     specprefill_session_factory: Callable[..., "MLLMSpecPrefillAdmission"] | None = None
     specprefill_target_forward_context: Callable[..., Any] | None = None
     specprefill_cache_capability: "MLLMSpecPrefillCacheCapability" | None = None
+    specprefill_gemma_batch_config: GemmaSparseBatchConfig | None = None
     specprefill_diagnostic: bool = False
     specprefill_advertisable: bool = False
 
@@ -157,6 +160,38 @@ class MLLMSchedulerConfig:
             raise TypeError(
                 "specprefill_cache_capability must be MLLMSpecPrefillCacheCapability"
             )
+        gemma_config = self.specprefill_gemma_batch_config
+        if gemma_config is not None and not isinstance(
+            gemma_config, GemmaSparseBatchConfig
+        ):
+            raise TypeError(
+                "specprefill_gemma_batch_config must be GemmaSparseBatchConfig"
+            )
+        if gemma_config is not None and (
+            not self.specprefill_diagnostic or self.specprefill_advertisable
+        ):
+            raise ValueError(
+                "Gemma CB SpecPrefill is diagnostic and nonadvertisable only"
+            )
+        if gemma_config is not None and self.enable_mtp:
+            raise ValueError("Gemma CB SpecPrefill cannot compose with MTP")
+        if gemma_config is not None and self.enable_prefix_cache:
+            raise ValueError("Gemma CB SpecPrefill cannot compose with prefix cache")
+        if gemma_config is not None and self.max_kv_size > 0:
+            raise ValueError(
+                "Gemma CB SpecPrefill uses model-owned rotating cache geometry"
+            )
+        if gemma_config is not None and (
+            capability is None
+            or capability.layout
+            != gemma_config.attestation.artifact.artifact_id
+            or capability.backend != "mlx_vlm"
+            or not capability.rotating
+            or not capability.homogeneous_rows_only
+        ):
+            raise ValueError(
+                "Gemma CB SpecPrefill requires exact rotating mlx-vlm capability"
+            )
         if key is not None and capability is not None and (
             capability.adapter_id != key.adapter_id
         ):
@@ -187,6 +222,9 @@ class MLLMSpecPrefillCacheCapability:
 
     adapter_id: str
     layout: str
+    backend: str = "mlx_lm"
+    rotating: bool = False
+    homogeneous_rows_only: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.adapter_id, str) or not self.adapter_id.strip():
@@ -196,8 +234,17 @@ class MLLMSpecPrefillCacheCapability:
             "gemma4_dense",
             "gemma4_a4b",
             "mixed_rotating",
+            "gemma4-e2b",
+            "gemma4-31b",
+            "gemma4-26b-a4b",
         }:
             raise ValueError("unknown SpecPrefill cache capability layout")
+        if self.backend not in {"mlx_lm", "mlx_vlm"}:
+            raise ValueError("unknown SpecPrefill cache capability backend")
+        if not isinstance(self.rotating, bool):
+            raise TypeError("SpecPrefill rotating capability must be bool")
+        if not isinstance(self.homogeneous_rows_only, bool):
+            raise TypeError("SpecPrefill homogeneous_rows_only must be bool")
 
 
 @dataclass(frozen=True)
@@ -476,6 +523,14 @@ class MLLMScheduler:
                 prefix_cache_config=prefix_cache_config,
                 max_kv_size=self.config.max_kv_size,
                 target_forward_context=self.config.specprefill_target_forward_context,
+                expected_sparse_execution_config=(
+                    self.config.specprefill_gemma_batch_config.execution_config
+                    if self.config.specprefill_gemma_batch_config is not None
+                    else None
+                ),
+                expected_gemma_sparse_config=(
+                    self.config.specprefill_gemma_batch_config
+                ),
             )
 
             # Wire the SSD cold tier onto the MLLM prefix cache, mirroring the
@@ -793,10 +848,25 @@ class MLLMScheduler:
             return None, "residency_estimate_unavailable"
         if capability is None:
             return None, "cache_capability_unavailable"
-        if (
-            capability.adapter_id != key.adapter_id
-            or capability.layout != "qwen3_5_nonrotating_hybrid"
-        ):
+        gemma_config = self.config.specprefill_gemma_batch_config
+        qwen_capability = (
+            capability.adapter_id == key.adapter_id
+            and capability.layout == "qwen3_5_nonrotating_hybrid"
+            and capability.backend == "mlx_lm"
+            and not capability.rotating
+            and gemma_config is None
+        )
+        gemma_capability = (
+            gemma_config is not None
+            and capability.adapter_id == key.adapter_id
+            and capability.layout == gemma_config.attestation.artifact.artifact_id
+            and capability.backend == "mlx_vlm"
+            and capability.rotating
+            and capability.homogeneous_rows_only
+            and gemma_config.execution_config.target_id
+            == f"{key.target_artifact_id}@sha256:{key.target_artifact_hash}"
+        )
+        if not (qwen_capability or gemma_capability):
             return None, "cache_capability_unsupported"
         if self.config.specprefill_session_factory is None:
             return None, "cooperative_session_factory_unavailable"
@@ -830,6 +900,13 @@ class MLLMScheduler:
                     chunk_size=tuning.chunk_size,
                 ),
                 control_token_indices=request.specprefill_control_token_indices,
+                rotating_tail_requirement=(
+                    RotatingTailRequirement(
+                        gemma_config.attestation.artifact.sliding_window
+                    )
+                    if gemma_capability
+                    else None
+                ),
             ),
             None,
         )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -245,6 +245,7 @@ class MLLMRequest:
     specprefill_policy: SpecPrefillPolicy = SpecPrefillPolicy.AUTO
     specprefill_coverage: SpecPrefillCoverage = SpecPrefillCoverage.UNKNOWN
     specprefill_control_token_indices: tuple[int, ...] = ()
+    specprefill_has_media: bool = False
     prompt_token_ids: tuple[int, ...] = ()
     specprefill_effective_policy: SpecPrefillPolicy = SpecPrefillPolicy.DENSE
     specprefill_fallback_reason: str | None = None
@@ -571,6 +572,9 @@ class MLLMScheduler:
         control_token_indices = tuple(
             kwargs.pop("specprefill_control_token_indices", ())
         )
+        specprefill_has_media = kwargs.pop("specprefill_has_media", False)
+        if not isinstance(specprefill_has_media, bool):
+            raise TypeError("specprefill_has_media must be bool")
         if any(
             isinstance(index, bool) or not isinstance(index, int) or index < 0
             for index in control_token_indices
@@ -591,6 +595,7 @@ class MLLMScheduler:
             specprefill_control_token_indices=tuple(
                 sorted(set(control_token_indices))
             ),
+            specprefill_has_media=specprefill_has_media,
         )
 
         # Estimate prompt token count for monitoring (text tokens only;
@@ -740,7 +745,12 @@ class MLLMScheduler:
     def _cooperative_config_for(
         self, request: MLLMRequest
     ) -> tuple[CooperativeSpecPrefillConfig | None, str | None]:
-        text_only = not (request.images or request.videos or request.audio)
+        text_only = not (
+            request.specprefill_has_media
+            or request.images
+            or request.videos
+            or request.audio
+        )
         decision = resolve_specprefill_decision(
             request.specprefill_policy,
             request.specprefill_coverage,

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -1164,6 +1164,16 @@ class ModelManager:
             if entry.specprefill_draft_model is not None
             else self._defaults.specprefill_draft_model
         )
+        if continuous_batching and scheduler_config is not None:
+            scheduler_config.specprefill_enabled = specprefill_enabled
+        if continuous_batching and specprefill_enabled:
+            if scheduler_config is None or not callable(
+                getattr(scheduler_config, "specprefill_prepare", None)
+            ):
+                raise ValueError(
+                    "registry CB SpecPrefill requires an explicit "
+                    "SchedulerConfig.specprefill_prepare builder"
+                )
         stream_interval = (
             entry.stream_interval
             if entry.stream_interval is not None

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -619,6 +619,59 @@ def load_registry_config(
     return manager, registry
 
 
+def _loaded_model_specprefill_status(
+    loaded: "LoadedModel | None",
+) -> dict[str, Any]:
+    if loaded is None:
+        return {
+            "state": "unloaded",
+            "enabled": False,
+            "advertisable": False,
+            "diagnostic": False,
+        }
+    try:
+        specprefill = loaded.engine.get_stats().get("specprefill", {})
+    except Exception:
+        specprefill = {}
+    if not isinstance(specprefill, dict) or not {
+        "enabled",
+        "advertisable",
+        "diagnostic",
+    }.issubset(specprefill):
+        return {
+            "state": "unavailable",
+            "enabled": False,
+            "advertisable": False,
+            "diagnostic": False,
+        }
+    enabled = specprefill.get("enabled") is True
+    advertisable = specprefill.get("advertisable") is True
+    diagnostic = specprefill.get("diagnostic") is True
+    if diagnostic:
+        state = "diagnostic"
+    elif enabled and advertisable:
+        state = "production"
+    else:
+        state = "disabled"
+    return {
+        "state": state,
+        "enabled": enabled,
+        "advertisable": advertisable,
+        "diagnostic": diagnostic,
+    }
+
+
+def _specprefill_capabilities(status: dict[str, Any]) -> list[str]:
+    if (
+        status["state"] == "production"
+        and status["enabled"] is True
+        and status["advertisable"] is True
+        and status["diagnostic"] is False
+    ):
+        return ["specprefill"]
+    return []
+
+
 class ModelManager:
     """Registry-backed model manager with lazy load and memory-budget eviction."""
 
@@ -680,6 +733,7 @@ class ModelManager:
                     )
                 )
             )
+            specprefill = _loaded_model_specprefill_status(loaded)
             data.append(
                 {
                     "id": name,
@@ -688,6 +742,8 @@ class ModelManager:
                     "owned_by": "vllm-mlx",
                     "source": entry.source,
                     "memory_gb": round(estimated / (1024**3), 2) if estimated else None,
+                    "capabilities": _specprefill_capabilities(specprefill),
+                    "specprefill": specprefill,
                 }
             )
         return data
@@ -1167,6 +1223,19 @@ class ModelManager:
         if continuous_batching and scheduler_config is not None:
             scheduler_config.specprefill_enabled = specprefill_enabled
         if continuous_batching and specprefill_enabled:
+            builder_inputs = getattr(
+                scheduler_config, "specprefill_runtime_builder_inputs", None
+            )
+            if (
+                scheduler_config is not None
+                and scheduler_config.specprefill_prepare is None
+                and builder_inputs is not None
+            ):
+                from .specprefill_runtime import build_qwen_cb_specprefill_prepare
+
+                scheduler_config.specprefill_prepare = (
+                    build_qwen_cb_specprefill_prepare(**dict(builder_inputs))
+                )
             if scheduler_config is None or not callable(
                 getattr(scheduler_config, "specprefill_prepare", None)
             ):

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -231,6 +231,7 @@ class MLXLanguageModel:
         stop: list[str] | None = None,
         logits_processors: list | None = None,
         prompt_cache=None,
+        model_forward_context=None,
         **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
@@ -247,6 +248,8 @@ class MLXLanguageModel:
             repetition_penalty: Multiplicative penalty for repeating tokens
             stop: List of stop sequences
             prompt_cache: Pre-populated KV cache (e.g. from SpecPrefill)
+            model_forward_context: Optional request-local context factory passed
+                to mlx-lm for every target model forward.
 
         Yields:
             StreamingOutput for each generated token
@@ -281,6 +284,8 @@ class MLXLanguageModel:
             mtp_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache
+        if model_forward_context is not None:
+            mtp_kwargs["model_forward_context"] = model_forward_context
 
         for token_count, response in enumerate(
             stream_generate(

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -9,7 +9,7 @@ integrating with vLLM's model execution system.
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from ..native_mtp_request import NativeMTPRequestConfig
 
@@ -17,6 +17,29 @@ if TYPE_CHECKING:
     import mlx.core as mx
 
 logger = logging.getLogger(__name__)
+
+
+def _seed_logits_processors(seed_tokens, processors):
+    """Prefix processor history while preserving native-MTP replay attestation."""
+    if not processors or seed_tokens is None or seed_tokens.size == 0:
+        return processors
+    import mlx.core as mx
+
+    wrapped = []
+    for processor in processors:
+
+        def _seeded(tokens, logits, _processor=processor):
+            merged = seed_tokens
+            if tokens is not None:
+                current = tokens if isinstance(tokens, mx.array) else mx.array(tokens)
+                if current.size:
+                    merged = mx.concatenate([seed_tokens, current])
+            return _processor(merged, logits)
+
+        if getattr(processor, "native_mtp_replay_safe", False):
+            _seeded.native_mtp_replay_safe = True
+        wrapped.append(_seeded)
+    return wrapped
 
 
 @dataclass
@@ -226,7 +249,7 @@ class MLXLanguageModel:
 
     def stream_generate(
         self,
-        prompt: Union[str, "mx.array", list[int]],
+        prompt: Union[str, "mx.array", list[int], None],
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -240,6 +263,8 @@ class MLXLanguageModel:
         model_forward_context=None,
         native_mtp_request: NativeMTPRequestConfig | None = None,
         native_mtp_disabled: bool = False,
+        sparse_bootstrap: Any | None = None,
+        logits_processor_seed_tokens=None,
         **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
@@ -295,9 +320,16 @@ class MLXLanguageModel:
         all_processors = None
         if penalty_processors or logits_processors:
             all_processors = (logits_processors or []) + (penalty_processors or [])
+        all_processors = _seed_logits_processors(
+            logits_processor_seed_tokens, all_processors
+        )
 
         # Count prompt tokens once upfront
-        if isinstance(prompt, str):
+        if prompt is None:
+            if sparse_bootstrap is None:
+                raise ValueError("prompt=None requires a sparse native MTP bootstrap")
+            num_prompt_tokens = sparse_bootstrap.next_logical_position
+        elif isinstance(prompt, str):
             num_prompt_tokens = len(self.tokenizer.encode(prompt))
         else:
             num_prompt_tokens = len(prompt)
@@ -311,6 +343,10 @@ class MLXLanguageModel:
             mtp_kwargs.update(
                 native_mtp_request.mlx_lm_call_kwargs(consumer=stream_generate)
             )
+            if sparse_bootstrap is not None:
+                mtp_kwargs["sparse_bootstrap"] = sparse_bootstrap
+        elif sparse_bootstrap is not None:
+            raise ValueError("sparse bootstrap requires request-selected native MTP")
         elif self._mtp and not native_mtp_disabled:
             # The legacy default is preserved only for callers outside the
             # public request contract. Public default-on requests always carry
@@ -376,9 +412,7 @@ class MLXLanguageModel:
                     logprobs=getattr(response, "logprobs", None),
                     mtp_drafts=getattr(response, "mtp_drafts", 0),
                     mtp_accepted=getattr(response, "mtp_accepted", 0),
-                    mtp_bypass_reason=getattr(
-                        response, "mtp_bypass_reason", None
-                    ),
+                    mtp_bypass_reason=getattr(response, "mtp_bypass_reason", None),
                 )
 
                 if finished:

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -37,6 +37,10 @@ class StreamingOutput:
     finished: bool = False
     finish_reason: str | None = None
     prompt_tokens: int = 0
+    logprobs: "mx.array | None" = None
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
+    mtp_bypass_reason: str | None = None
 
 
 class MLXLanguageModel:
@@ -317,47 +321,83 @@ class MLXLanguageModel:
         if model_forward_context is not None:
             mtp_kwargs["model_forward_context"] = model_forward_context
 
-        for token_count, response in enumerate(
-            stream_generate(
-                self.model,
-                self.tokenizer,
-                prompt=prompt,
-                max_tokens=max_tokens,
-                sampler=sampler,
-                logits_processors=all_processors,
-                **mtp_kwargs,
-            ),
-            start=1,
-        ):
-            # response.text is the new token text (not accumulated)
-            new_text = response.text
+        generation_kwargs = {
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "logits_processors": all_processors,
+            **mtp_kwargs,
+        }
+        if native_mtp_request is None:
+            # Native MTP owns its complete request-local sampling policy.
+            # Passing the ordinary opaque sampler makes stochastic replay
+            # impossible and is rejected by the upstream transaction core.
+            generation_kwargs["sampler"] = sampler
 
-            # Check for stop sequences against a bounded tail rather than
-            # accumulating the full response (which is O(n^2) over the loop).
-            should_stop = False
-            if max_stop_len > 0:
-                combined = accumulated_tail + new_text
-                for stop_seq in stop_list:
-                    if stop_seq in combined:
-                        should_stop = True
-                        break
-                accumulated_tail = combined[-max_stop_len:]
+        generation = stream_generate(
+            self.model,
+            self.tokenizer,
+            **generation_kwargs,
+        )
+        primary_error: BaseException | None = None
+        try:
+            for token_count, response in enumerate(generation, start=1):
+                # response.text is the new token text (not accumulated)
+                new_text = response.text
 
-            finished = should_stop or token_count >= max_tokens
-            finish_reason = None
-            if finished:
-                finish_reason = "stop" if should_stop else "length"
+                # Check for stop sequences against a bounded tail rather than
+                # accumulating the full response (which is O(n^2) over the loop).
+                should_stop = False
+                if max_stop_len > 0:
+                    combined = accumulated_tail + new_text
+                    for stop_seq in stop_list:
+                        if stop_seq in combined:
+                            should_stop = True
+                            break
+                    accumulated_tail = combined[-max_stop_len:]
 
-            yield StreamingOutput(
-                text=new_text,
-                token=response.token if hasattr(response, "token") else 0,
-                finished=finished,
-                finish_reason=finish_reason,
-                prompt_tokens=num_prompt_tokens,
-            )
+                backend_finish_reason = getattr(response, "finish_reason", None)
+                finished = (
+                    should_stop
+                    or token_count >= max_tokens
+                    or backend_finish_reason is not None
+                )
+                finish_reason = backend_finish_reason
+                if should_stop:
+                    finish_reason = "stop"
+                elif finish_reason is None and finished:
+                    finish_reason = "length"
 
-            if finished:
-                break
+                yield StreamingOutput(
+                    text=new_text,
+                    token=response.token if hasattr(response, "token") else 0,
+                    finished=finished,
+                    finish_reason=finish_reason,
+                    prompt_tokens=num_prompt_tokens,
+                    logprobs=getattr(response, "logprobs", None),
+                    mtp_drafts=getattr(response, "mtp_drafts", 0),
+                    mtp_accepted=getattr(response, "mtp_accepted", 0),
+                    mtp_bypass_reason=getattr(
+                        response, "mtp_bypass_reason", None
+                    ),
+                )
+
+                if finished:
+                    break
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            close = getattr(generation, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except BaseException:
+                    if primary_error is None:
+                        raise
+                    logger.warning(
+                        "Failed to close mlx-lm stream after generation error",
+                        exc_info=True,
+                    )
 
     def chat(
         self,

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -11,6 +11,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Union
 
+from ..native_mtp_request import NativeMTPRequestConfig
+
 if TYPE_CHECKING:
     import mlx.core as mx
 
@@ -232,6 +234,8 @@ class MLXLanguageModel:
         logits_processors: list | None = None,
         prompt_cache=None,
         model_forward_context=None,
+        native_mtp_request: NativeMTPRequestConfig | None = None,
+        native_mtp_disabled: bool = False,
         **kwargs,
     ) -> Iterator[StreamingOutput]:
         """
@@ -259,11 +263,30 @@ class MLXLanguageModel:
 
         from mlx_lm import stream_generate
 
+        if native_mtp_request is not None and native_mtp_disabled:
+            raise ValueError("native MTP cannot be selected and disabled")
+        if native_mtp_request is not None:
+            sampling = native_mtp_request.sampling
+            temperature = sampling.temperature
+            top_p = sampling.top_p
+            top_k = sampling.top_k
+            min_p = sampling.min_p
+            presence_penalty = sampling.presence_penalty
+            repetition_penalty = sampling.repetition_penalty
+
         # Create sampler and logits processors with full Unsloth params
         sampler = self._create_sampler(temperature, top_p, top_k, min_p)
         penalty_processors = self._create_logits_processors(
             presence_penalty, repetition_penalty
         )
+        if native_mtp_request is not None:
+            for processor in penalty_processors or ():
+                try:
+                    processor.native_mtp_replay_safe = True
+                except (AttributeError, TypeError) as exc:
+                    raise ValueError(
+                        "native MTP penalty processor cannot be replayed safely"
+                    ) from exc
         # Merge any externally-provided logits_processors with penalty processors
         all_processors = None
         if penalty_processors or logits_processors:
@@ -280,7 +303,14 @@ class MLXLanguageModel:
         accumulated_tail = ""
 
         mtp_kwargs = {}
-        if self._mtp:
+        if native_mtp_request is not None:
+            mtp_kwargs.update(
+                native_mtp_request.mlx_lm_call_kwargs(consumer=stream_generate)
+            )
+        elif self._mtp and not native_mtp_disabled:
+            # The legacy default is preserved only for callers outside the
+            # public request contract. Public default-on requests always carry
+            # either an exact config or an explicit disable/bypass control.
             mtp_kwargs["num_draft_tokens"] = self._mtp_num_draft_tokens
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -355,7 +355,18 @@ class MLXLanguageModel:
         if prompt_cache is not None:
             mtp_kwargs["prompt_cache"] = prompt_cache
         if model_forward_context is not None:
-            mtp_kwargs["model_forward_context"] = model_forward_context
+            # Native MTP sparse continuations use immutable logical positions.
+            # Canonical Qwen models publish their own position consumer and
+            # mlx-lm selects it automatically for those calls.  Passing the
+            # SimpleEngine observer as a second consumer is ambiguous and is
+            # rejected before the request can claim its sparse bootstrap.
+            # Keep forwarding explicit contexts for legacy/custom models and
+            # for ordinary generation, where mlx-lm does not auto-select one.
+            canonical_context = getattr(
+                self.model, "generation_forward_context", None
+            )
+            if not (sparse_bootstrap is not None and callable(canonical_context)):
+                mtp_kwargs["model_forward_context"] = model_forward_context
 
         generation_kwargs = {
             "prompt": prompt,

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -362,9 +362,7 @@ class MLXLanguageModel:
             # rejected before the request can claim its sparse bootstrap.
             # Keep forwarding explicit contexts for legacy/custom models and
             # for ordinary generation, where mlx-lm does not auto-select one.
-            canonical_context = getattr(
-                self.model, "generation_forward_context", None
-            )
+            canonical_context = getattr(self.model, "generation_forward_context", None)
             if not (sparse_bootstrap is not None and callable(canonical_context)):
                 mtp_kwargs["model_forward_context"] = model_forward_context
 

--- a/vllm_mlx/native_mtp_batch.py
+++ b/vllm_mlx/native_mtp_batch.py
@@ -1,0 +1,959 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transaction foundation for native-Qwen continuous batching.
+
+This module owns cache and request state only.  It deliberately does not
+install a scheduler hook or execute model forwards.  A future continuous-
+batching consumer must drive the explicit checkpoint, seal, commit, rollback,
+and sequential-replay boundaries defined here.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
+
+from .native_mtp_request import NativeMTPRequestConfig
+
+
+class NativeMTPBatchError(RuntimeError):
+    """A native-MTP batch transaction cannot continue safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPBatchPosition:
+    """Immutable logical and physical cursors for one UID."""
+
+    logical_cursor: int
+    backbone_tokens: int
+    mtp_tokens: int
+
+    def __post_init__(self) -> None:
+        values = (self.logical_cursor, self.backbone_tokens, self.mtp_tokens)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) for value in values
+        ):
+            raise TypeError("native MTP batch positions must be integers")
+        if any(value < 0 for value in values):
+            raise ValueError("native MTP batch positions must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPBatchRow:
+    """Fresh B=1 request ownership admitted into one native-MTP batch."""
+
+    uid: int
+    target_model: Any
+    capability: Any
+    backbone_cache: list[Any]
+    mtp_cache: list[Any]
+    position: NativeMTPBatchPosition
+    request_config: NativeMTPRequestConfig
+    prefix_reused: bool = False
+    has_media: bool = False
+    specprefill_selected: bool = False
+    external_assistant_selected: bool = False
+
+    def __post_init__(self) -> None:
+        if isinstance(self.uid, bool) or not isinstance(self.uid, int) or self.uid < 0:
+            raise ValueError("native MTP batch UID must be a non-negative integer")
+        if not isinstance(self.position, NativeMTPBatchPosition):
+            raise TypeError("native MTP batch row requires NativeMTPBatchPosition")
+        if not isinstance(self.request_config, NativeMTPRequestConfig):
+            raise TypeError("native MTP batch row requires NativeMTPRequestConfig")
+        if not isinstance(self.backbone_cache, list) or not isinstance(
+            self.mtp_cache, list
+        ):
+            raise TypeError("native MTP batch caches must be caller-owned lists")
+        if self.backbone_cache is self.mtp_cache:
+            raise ValueError("native MTP backbone and head caches must be distinct")
+        incompatibilities = (
+            (self.prefix_reused, "native_mtp_prefix_reuse_unsupported"),
+            (self.has_media, "native_mtp_media_unsupported"),
+            (
+                self.specprefill_selected,
+                "native_mtp_specprefill_composition_unsupported",
+            ),
+            (
+                self.external_assistant_selected,
+                "native_mtp_external_assistant_conflict",
+            ),
+        )
+        for selected, reason in incompatibilities:
+            if selected:
+                raise NativeMTPBatchError(reason)
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPReplayPlan:
+    """Rollback result grouped by equal sequential replay work."""
+
+    targets: tuple[tuple[int, NativeMTPBatchPosition], ...]
+    groups: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPCapabilityFingerprint:
+    """Stable value identity for a loader-produced capability snapshot."""
+
+    supported: bool
+    reason: str
+    num_layers: int
+
+
+def _capability_fingerprint(capability: Any) -> NativeMTPCapabilityFingerprint:
+    supported = getattr(capability, "supported", None)
+    reason = getattr(capability, "reason", None)
+    num_layers = getattr(capability, "num_layers", None)
+    if (
+        not isinstance(supported, bool)
+        or not isinstance(reason, str)
+        or isinstance(num_layers, bool)
+        or not isinstance(num_layers, int)
+        or num_layers < 0
+    ):
+        raise NativeMTPBatchError("native_mtp_capability_invalid")
+    return NativeMTPCapabilityFingerprint(supported, reason, num_layers)
+
+
+@dataclass(slots=True)
+class _RowRuntime:
+    row: NativeMTPBatchRow
+    position: NativeMTPBatchPosition
+    rng_key: Any
+    replay_target: NativeMTPBatchPosition | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _AttentionCheckpoint:
+    index: int
+    entry: BatchKVCache
+    idx: int
+    offset: Any
+    left_padding: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _ArraysCheckpoint:
+    index: int
+    entry: ArraysCache
+    state: tuple[Any, ...]
+    left_padding: Any
+    lengths: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _CacheCheckpoint:
+    attention: tuple[_AttentionCheckpoint, ...]
+    arrays: tuple[_ArraysCheckpoint, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchCheckpoint:
+    positions: tuple[tuple[int, NativeMTPBatchPosition], ...]
+    backbone: _CacheCheckpoint
+    mtp: _CacheCheckpoint
+
+
+def _copy_small_array(value: Any) -> Any:
+    if value is None:
+        return None
+    return value + mx.zeros(value.shape, dtype=value.dtype)
+
+
+def _iter_arrays(value: Any) -> Iterable[Any]:
+    if value is None:
+        return
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            yield from _iter_arrays(item)
+    elif hasattr(value, "shape") and hasattr(value, "dtype"):
+        yield value
+
+
+def _force_eval(values: Iterable[Any]) -> None:
+    arrays = list(_iter_arrays(tuple(values)))
+    if arrays:
+        mx.eval(arrays)
+
+
+def _cache_eval_values(entry: Any) -> tuple[Any, ...]:
+    """Return realized cache values without dereferencing empty BatchKV state."""
+
+    if type(entry) is BatchKVCache:
+        return (
+            entry.keys,
+            entry.values,
+            entry.offset,
+            entry.left_padding,
+        )
+    if type(entry) is ArraysCache:
+        return (*entry.cache, entry.left_padding, entry.lengths)
+    raise NativeMTPBatchError("native_mtp_batch_cache_type_mismatch")
+
+
+def _model_layers(model: Any) -> tuple[Any, ...]:
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        layers = getattr(getattr(model, "model", None), "layers", None)
+    if layers is None:
+        raise NativeMTPBatchError("native_mtp_cache_topology_unavailable")
+    return tuple(layers)
+
+
+def _mtp_layers(model: Any) -> tuple[Any, ...]:
+    layers = getattr(getattr(model, "mtp", None), "layers", None)
+    if layers is None:
+        raise NativeMTPBatchError("native_mtp_cache_topology_unavailable")
+    return tuple(layers)
+
+
+class NativeMTPBatch:
+    """Request-owned native-Qwen cache state for a true batched consumer."""
+
+    def __init__(self, rows: Sequence[NativeMTPBatchRow]):
+        if not rows:
+            raise ValueError("native MTP batch requires at least one row")
+        self._closed = False
+        self._poisoned = False
+        self.alignment_checks = 0
+        self.alignment_host_syncs = 0
+        self.alignment_check_ms = 0.0
+        self._checkpoint: _BatchCheckpoint | None = None
+        self._sealed: tuple[tuple[int, NativeMTPBatchPosition], ...] | None = None
+        self._rows = self._validate_rows(rows)
+        self.target_model = next(iter(self._rows.values())).row.target_model
+        self.capability = next(iter(self._rows.values())).row.capability
+        self.capability_fingerprint = _capability_fingerprint(self.capability)
+        self._topology = self._topology_for(self.target_model)
+        self.backbone_cache, self.mtp_cache = self._merge_admission_rows()
+        self._assert_aligned()
+
+    @property
+    def uids(self) -> tuple[int, ...]:
+        return tuple(self._rows)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def poisoned(self) -> bool:
+        return self._poisoned
+
+    @property
+    def checkpoint_active(self) -> bool:
+        return self._checkpoint is not None
+
+    @property
+    def positions(self) -> tuple[tuple[int, NativeMTPBatchPosition], ...]:
+        return tuple((uid, runtime.position) for uid, runtime in self._rows.items())
+
+    @property
+    def replay_targets(self) -> tuple[tuple[int, NativeMTPBatchPosition], ...]:
+        return tuple(
+            (uid, runtime.replay_target)
+            for uid, runtime in self._rows.items()
+            if runtime.replay_target is not None
+        )
+
+    @staticmethod
+    def _topology_for(model: Any) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        backbone = tuple(
+            "arrays" if bool(getattr(layer, "is_linear", False)) else "kv"
+            for layer in _model_layers(model)
+        )
+        mtp = tuple("kv" for _ in _mtp_layers(model))
+        return backbone, mtp
+
+    @classmethod
+    def _validate_rows(
+        cls, rows: Sequence[NativeMTPBatchRow]
+    ) -> OrderedDict[int, _RowRuntime]:
+        if any(not isinstance(row, NativeMTPBatchRow) for row in rows):
+            raise TypeError("native MTP batch requires NativeMTPBatchRow entries")
+        uids = tuple(row.uid for row in rows)
+        if len(set(uids)) != len(uids):
+            raise ValueError("native MTP batch UIDs must be unique")
+        model = rows[0].target_model
+        capability = rows[0].capability
+        capability_fingerprint = _capability_fingerprint(capability)
+        current_capability = getattr(model, "mtp_capability", None)
+        if (
+            current_capability != capability
+            or _capability_fingerprint(current_capability) != capability_fingerprint
+        ):
+            raise NativeMTPBatchError("native_mtp_capability_identity_mismatch")
+        if not capability.supported:
+            reason = getattr(capability, "reason", None)
+            raise NativeMTPBatchError(reason or "native_mtp_unsupported")
+        if (
+            getattr(model, "pipeline_size", 1) != 1
+            or getattr(getattr(model, "model", None), "pipeline_size", 1) != 1
+        ):
+            raise NativeMTPBatchError("native_mtp_pipeline_parallelism_unsupported")
+
+        topology = cls._topology_for(model)
+        entry_ids: list[int] = []
+        result: OrderedDict[int, _RowRuntime] = OrderedDict()
+        for row in rows:
+            if row.target_model is not model:
+                raise NativeMTPBatchError("native_mtp_target_identity_mismatch")
+            if (
+                row.capability != capability
+                or _capability_fingerprint(row.capability) != capability_fingerprint
+            ):
+                raise NativeMTPBatchError("native_mtp_capability_identity_mismatch")
+            current_capability = getattr(row.target_model, "mtp_capability", None)
+            if (
+                current_capability != row.capability
+                or _capability_fingerprint(current_capability) != capability_fingerprint
+            ):
+                raise NativeMTPBatchError("native_mtp_capability_identity_mismatch")
+            cls._validate_row_cache(row, topology)
+            entry_ids.extend(id(entry) for entry in row.backbone_cache)
+            entry_ids.extend(id(entry) for entry in row.mtp_cache)
+            seed = row.request_config.sampling.seed
+            if seed is None:
+                seed = secrets.randbits(63)
+            result[row.uid] = _RowRuntime(
+                row=row,
+                position=row.position,
+                rng_key=mx.random.key(seed),
+            )
+        if len(entry_ids) != len(set(entry_ids)):
+            raise ValueError("native_mtp_cache_entries_must_be_unique")
+        return result
+
+    @staticmethod
+    def _validate_row_cache(
+        row: NativeMTPBatchRow,
+        topology: tuple[tuple[str, ...], tuple[str, ...]],
+    ) -> None:
+        backbone_topology, mtp_topology = topology
+        if len(row.backbone_cache) != len(backbone_topology):
+            raise ValueError("native_mtp_backbone_cache_topology_mismatch")
+        if len(row.mtp_cache) != len(mtp_topology):
+            raise ValueError("native_mtp_head_cache_topology_mismatch")
+        for index, (kind, entry) in enumerate(
+            zip(backbone_topology, row.backbone_cache)
+        ):
+            expected = ArraysCache if kind == "arrays" else KVCache
+            if type(entry) is not expected:
+                raise TypeError(
+                    f"native_mtp_backbone_cache_type_mismatch: entry={index}"
+                )
+            NativeMTPBatch._validate_b1_entry(entry)
+        for index, entry in enumerate(row.mtp_cache):
+            if type(entry) is not KVCache:
+                raise TypeError(f"native_mtp_head_cache_type_mismatch: entry={index}")
+            NativeMTPBatch._validate_b1_entry(entry)
+        for name, entries, expected in (
+            ("backbone", row.backbone_cache, row.position.backbone_tokens),
+            ("mtp", row.mtp_cache, row.position.mtp_tokens),
+        ):
+            for index, entry in enumerate(entries):
+                if type(entry) is KVCache and entry.offset != expected:
+                    raise NativeMTPBatchError(
+                        f"native_mtp_{name}_cache_position_mismatch: entry={index}"
+                    )
+
+    @staticmethod
+    def _validate_b1_entry(entry: Any) -> None:
+        if type(entry) is ArraysCache:
+            if entry.batch_size != 1:
+                raise NativeMTPBatchError("native_mtp_row_cache_must_be_b1")
+            if entry.left_padding is not None or entry.lengths is not None:
+                raise NativeMTPBatchError("native_mtp_arrays_cache_not_finalized")
+            return
+        if entry.keys is not None and entry.keys.shape[0] != 1:
+            raise NativeMTPBatchError("native_mtp_row_cache_must_be_b1")
+
+    def _merge_admission_rows(self) -> tuple[list[Any], list[Any]]:
+        rows = tuple(runtime.row for runtime in self._rows.values())
+        backbone = self._merge_entries(tuple(row.backbone_cache for row in rows))
+        mtp = self._merge_entries(tuple(row.mtp_cache for row in rows))
+        _force_eval(_cache_eval_values(entry) for entry in (*backbone, *mtp))
+        return backbone, mtp
+
+    @staticmethod
+    def _merge_entries(row_entries: Sequence[Sequence[Any]]) -> list[Any]:
+        merged: list[Any] = []
+        for layer_entries in zip(*row_entries):
+            entry_type = type(layer_entries[0])
+            if any(type(entry) is not entry_type for entry in layer_entries):
+                raise NativeMTPBatchError("native_mtp_cache_topology_mismatch")
+            merged.append(entry_type.merge(list(layer_entries)))
+        return merged
+
+    def _ensure_live(self) -> None:
+        if self._closed:
+            raise NativeMTPBatchError("native_mtp_batch_closed")
+        if self._poisoned:
+            raise NativeMTPBatchError("native_mtp_batch_poisoned")
+        current = getattr(self.target_model, "mtp_capability", None)
+        try:
+            current_fingerprint = _capability_fingerprint(current)
+        except NativeMTPBatchError as exc:
+            raise NativeMTPBatchError("native_mtp_capability_changed") from exc
+        if (
+            current != self.capability
+            or current_fingerprint != self.capability_fingerprint
+        ):
+            raise NativeMTPBatchError("native_mtp_capability_changed")
+
+    def _position_map(
+        self, positions: Mapping[int, NativeMTPBatchPosition]
+    ) -> OrderedDict[int, NativeMTPBatchPosition]:
+        if set(positions) != set(self._rows):
+            raise ValueError("native MTP positions must cover the exact active UIDs")
+        result: OrderedDict[int, NativeMTPBatchPosition] = OrderedDict()
+        for uid in self._rows:
+            position = positions[uid]
+            if not isinstance(position, NativeMTPBatchPosition):
+                raise TypeError("native MTP positions must be immutable positions")
+            result[uid] = position
+        return result
+
+    def _assert_aligned(
+        self,
+        positions: Mapping[int, NativeMTPBatchPosition] | None = None,
+    ) -> None:
+        started = time.perf_counter()
+        self.alignment_checks += 1
+        if positions is None:
+            positions = {uid: runtime.position for uid, runtime in self._rows.items()}
+        expected_backbone = mx.array(
+            [positions[uid].backbone_tokens for uid in self._rows]
+        )
+        expected_mtp = mx.array([positions[uid].mtp_tokens for uid in self._rows])
+        predicates = []
+        for name, entries, expected in (
+            ("backbone", self.backbone_cache, expected_backbone),
+            ("mtp", self.mtp_cache, expected_mtp),
+        ):
+            for entry in entries:
+                if type(entry) is BatchKVCache:
+                    if entry.offset.shape[0] != len(self._rows):
+                        raise NativeMTPBatchError(
+                            f"native_mtp_{name}_cache_row_mismatch"
+                        )
+                    predicates.append(mx.all(entry.offset == expected))
+                elif type(entry) is ArraysCache:
+                    if entry.batch_size != len(self._rows):
+                        raise NativeMTPBatchError(
+                            "native_mtp_arrays_cache_row_mismatch"
+                        )
+                    if entry.lengths is not None:
+                        raise NativeMTPBatchError(
+                            "native_mtp_arrays_cache_not_finalized"
+                        )
+                    if entry.left_padding is not None:
+                        if (
+                            entry.left_padding.shape[0] != len(self._rows)
+                            or not entry.empty()
+                        ):
+                            raise NativeMTPBatchError(
+                                "native_mtp_arrays_cache_not_finalized"
+                            )
+                        predicates.append(mx.all(entry.left_padding == 0))
+                else:
+                    raise NativeMTPBatchError("native_mtp_batch_cache_type_mismatch")
+        try:
+            if predicates:
+                self.alignment_host_syncs += 1
+                if not bool(mx.all(mx.stack(predicates)).item()):
+                    raise NativeMTPBatchError(
+                        "native_mtp_batch_cache_position_mismatch"
+                    )
+        finally:
+            self.alignment_check_ms += (time.perf_counter() - started) * 1000
+
+    @staticmethod
+    def _capture_entries(entries: Sequence[Any]) -> _CacheCheckpoint:
+        attention: list[_AttentionCheckpoint] = []
+        arrays: list[_ArraysCheckpoint] = []
+        staged: list[Any] = []
+        for index, entry in enumerate(entries):
+            if type(entry) is BatchKVCache:
+                if entry._right_padding is not None:
+                    raise NativeMTPBatchError("native_mtp_batch_cache_not_finalized")
+                offset = _copy_small_array(entry.offset)
+                left_padding = _copy_small_array(entry.left_padding)
+                attention.append(
+                    _AttentionCheckpoint(
+                        index=index,
+                        entry=entry,
+                        idx=entry._idx,
+                        offset=offset,
+                        left_padding=left_padding,
+                    )
+                )
+                staged.extend((offset, left_padding))
+            elif type(entry) is ArraysCache:
+                if entry.lengths is not None or (
+                    entry.left_padding is not None
+                    and (entry.left_padding.shape[0] == 0 or not entry.empty())
+                ):
+                    raise NativeMTPBatchError("native_mtp_arrays_cache_not_finalized")
+                state = tuple(_copy_small_array(value) for value in entry.cache)
+                left_padding = _copy_small_array(entry.left_padding)
+                arrays.append(
+                    _ArraysCheckpoint(
+                        index=index,
+                        entry=entry,
+                        state=state,
+                        left_padding=left_padding,
+                        lengths=None,
+                    )
+                )
+                staged.extend(value for value in state if value is not None)
+                if left_padding is not None:
+                    staged.append(left_padding)
+            else:
+                raise NativeMTPBatchError("native_mtp_batch_cache_type_mismatch")
+        _force_eval(staged)
+        return _CacheCheckpoint(tuple(attention), tuple(arrays))
+
+    def checkpoint(self) -> None:
+        self._ensure_live()
+        if self._checkpoint is not None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_already_active")
+        if any(runtime.replay_target is not None for runtime in self._rows.values()):
+            raise NativeMTPBatchError("native_mtp_batch_replay_required")
+        self._assert_aligned()
+        self._checkpoint = _BatchCheckpoint(
+            positions=self.positions,
+            backbone=self._capture_entries(self.backbone_cache),
+            mtp=self._capture_entries(self.mtp_cache),
+        )
+
+    def seal_verified(self, positions: Mapping[int, NativeMTPBatchPosition]) -> None:
+        self._ensure_live()
+        if self._checkpoint is None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_missing")
+        if self._sealed is not None:
+            raise NativeMTPBatchError("native_mtp_batch_verification_already_sealed")
+        sealed = self._position_map(positions)
+        starts = dict(self._checkpoint.positions)
+        for uid, position in sealed.items():
+            start = starts[uid]
+            if (
+                position.logical_cursor < start.logical_cursor
+                or position.backbone_tokens < start.backbone_tokens
+                or position.mtp_tokens < start.mtp_tokens
+            ):
+                raise ValueError("native MTP sealed positions cannot move backwards")
+        deltas = {
+            (
+                position.logical_cursor - starts[uid].logical_cursor,
+                position.backbone_tokens - starts[uid].backbone_tokens,
+                position.mtp_tokens - starts[uid].mtp_tokens,
+            )
+            for uid, position in sealed.items()
+        }
+        if len(deltas) != 1:
+            raise NativeMTPBatchError("native_mtp_verified_rows_must_be_homogeneous")
+        _force_eval(
+            _cache_eval_values(entry)
+            for entry in (*self.backbone_cache, *self.mtp_cache)
+        )
+        self._assert_aligned(sealed)
+        self._sealed = tuple(sealed.items())
+
+    def commit(self, positions: Mapping[int, NativeMTPBatchPosition]) -> None:
+        self._ensure_live()
+        if self._checkpoint is None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_missing")
+        if self._sealed is None:
+            raise NativeMTPBatchError("native_mtp_batch_verification_not_sealed")
+        committed = tuple(self._position_map(positions).items())
+        if committed != self._sealed:
+            raise NativeMTPBatchError("native_mtp_batch_partial_commit_requires_replay")
+        for uid, position in committed:
+            self._rows[uid].position = position
+        self._checkpoint = None
+        self._sealed = None
+
+    @staticmethod
+    def _restore_entries(entries: list[Any], checkpoint: _CacheCheckpoint) -> None:
+        staged: list[Any] = []
+        for snapshot in checkpoint.attention:
+            if entries[snapshot.index] is not snapshot.entry:
+                raise NativeMTPBatchError("native_mtp_batch_cache_entry_replaced")
+            entry = snapshot.entry
+            if entry._idx < snapshot.idx:
+                raise NativeMTPBatchError("native_mtp_batch_cache_advanced_backwards")
+            entry._idx = snapshot.idx
+            entry.offset = _copy_small_array(snapshot.offset)
+            entry.left_padding = _copy_small_array(snapshot.left_padding)
+            entry._right_padding = None
+            staged.extend((entry.offset, entry.left_padding))
+        for snapshot in checkpoint.arrays:
+            if entries[snapshot.index] is not snapshot.entry:
+                raise NativeMTPBatchError("native_mtp_batch_cache_entry_replaced")
+            entry = snapshot.entry
+            entry.cache = [
+                _copy_small_array(value) if value is not None else None
+                for value in snapshot.state
+            ]
+            entry.left_padding = snapshot.left_padding
+            entry.lengths = snapshot.lengths
+            staged.extend(value for value in entry.cache if value is not None)
+        _force_eval(staged)
+
+    def rollback(self) -> None:
+        self._ensure_live()
+        if self._checkpoint is None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_missing")
+        checkpoint = self._checkpoint
+        try:
+            self._restore_entries(self.backbone_cache, checkpoint.backbone)
+            self._restore_entries(self.mtp_cache, checkpoint.mtp)
+            for uid, position in checkpoint.positions:
+                self._rows[uid].position = position
+            self._checkpoint = None
+            self._sealed = None
+            self._assert_aligned()
+        except BaseException as exc:
+            self._release_poisoned()
+            raise NativeMTPBatchError("native_mtp_batch_rollback_failed") from exc
+
+    def _release_poisoned(self) -> None:
+        """Drop every request/cache/RNG reference after an inexact restore."""
+
+        self._poisoned = True
+        self._closed = True
+        self._rows.clear()
+        self.backbone_cache = []
+        self.mtp_cache = []
+        self._checkpoint = None
+        self._sealed = None
+        self.capability = None
+        self.capability_fingerprint = None
+        self.target_model = None
+
+    def reject_partial(
+        self, targets: Mapping[int, NativeMTPBatchPosition]
+    ) -> NativeMTPReplayPlan:
+        self._ensure_live()
+        if self._checkpoint is None or self._sealed is None:
+            raise NativeMTPBatchError("native_mtp_batch_verification_not_sealed")
+        replay_targets = self._position_map(targets)
+        starts = dict(self._checkpoint.positions)
+        sealed = dict(self._sealed)
+        strict = False
+        grouped: OrderedDict[tuple[int, int, int], list[int]] = OrderedDict()
+        for uid, target in replay_targets.items():
+            start = starts[uid]
+            end = sealed[uid]
+            if not (
+                start.logical_cursor <= target.logical_cursor <= end.logical_cursor
+                and start.backbone_tokens
+                <= target.backbone_tokens
+                <= end.backbone_tokens
+                and start.mtp_tokens <= target.mtp_tokens <= end.mtp_tokens
+            ):
+                raise ValueError("native MTP replay target exceeds verified positions")
+            strict |= target != end
+            delta = (
+                target.logical_cursor - start.logical_cursor,
+                target.backbone_tokens - start.backbone_tokens,
+                target.mtp_tokens - start.mtp_tokens,
+            )
+            grouped.setdefault(delta, []).append(uid)
+        if not strict:
+            raise ValueError("full verified acceptance must use native MTP commit")
+        self.rollback()
+        for uid, target in replay_targets.items():
+            runtime = self._rows[uid]
+            runtime.replay_target = None if target == runtime.position else target
+        return NativeMTPReplayPlan(
+            targets=tuple(replay_targets.items()),
+            groups=tuple(tuple(uids) for uids in grouped.values()),
+        )
+
+    def replay_retained(self, positions: Mapping[int, NativeMTPBatchPosition]) -> None:
+        self._ensure_live()
+        if self._checkpoint is not None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_active")
+        advanced = self._position_map(positions)
+        deltas = set()
+        for uid, position in advanced.items():
+            runtime = self._rows[uid]
+            target = runtime.replay_target
+            if target is None:
+                raise NativeMTPBatchError("native_mtp_batch_replay_not_required")
+            current = runtime.position
+            delta = (
+                position.logical_cursor - current.logical_cursor,
+                position.backbone_tokens - current.backbone_tokens,
+                position.mtp_tokens - current.mtp_tokens,
+            )
+            if any(value not in (0, 1) for value in delta) or delta == (0, 0, 0):
+                raise ValueError("native MTP replay must advance one token boundary")
+            if (
+                position.logical_cursor > target.logical_cursor
+                or position.backbone_tokens > target.backbone_tokens
+                or position.mtp_tokens > target.mtp_tokens
+            ):
+                raise ValueError("native MTP replay exceeds accepted positions")
+            deltas.add(delta)
+        if len(deltas) != 1:
+            raise NativeMTPBatchError("native_mtp_replay_rows_must_be_homogeneous")
+        self._assert_aligned(advanced)
+        _force_eval(
+            _cache_eval_values(entry)
+            for entry in (*self.backbone_cache, *self.mtp_cache)
+        )
+        for uid, position in advanced.items():
+            runtime = self._rows[uid]
+            runtime.position = position
+            if position == runtime.replay_target:
+                runtime.replay_target = None
+
+    def next_rng_key(self, uid: int) -> Any:
+        self._ensure_live()
+        try:
+            runtime = self._rows[uid]
+        except KeyError as exc:
+            raise KeyError(f"unknown native MTP batch UID: {uid}") from exc
+        keys = mx.random.split(runtime.rng_key)
+        runtime.rng_key = keys[0]
+        return keys[1]
+
+    @staticmethod
+    def _structural_snapshot(entries: Sequence[Any]) -> tuple[tuple[Any, ...], ...]:
+        snapshots = []
+        for entry in entries:
+            if type(entry) is BatchKVCache:
+                snapshots.append(
+                    (
+                        entry,
+                        entry.keys,
+                        entry.values,
+                        entry.offset,
+                        entry.left_padding,
+                        entry._idx,
+                        entry._right_padding,
+                    )
+                )
+            elif type(entry) is ArraysCache:
+                snapshots.append(
+                    (entry, list(entry.cache), entry.left_padding, entry.lengths)
+                )
+            else:
+                raise NativeMTPBatchError("native_mtp_batch_cache_type_mismatch")
+        return tuple(snapshots)
+
+    @staticmethod
+    def _restore_structure(snapshots: Sequence[tuple[Any, ...]]) -> None:
+        staged = []
+        for snapshot in snapshots:
+            entry = snapshot[0]
+            if type(entry) is BatchKVCache:
+                (
+                    entry.keys,
+                    entry.values,
+                    entry.offset,
+                    entry.left_padding,
+                    entry._idx,
+                    entry._right_padding,
+                ) = snapshot[1:]
+                staged.extend(
+                    value
+                    for value in (entry.offset, entry.left_padding)
+                    if value is not None
+                )
+            else:
+                entry.cache = list(snapshot[1])
+                entry.left_padding = snapshot[2]
+                entry.lengths = snapshot[3]
+                staged.extend(value for value in entry.cache if value is not None)
+        _force_eval(staged)
+
+    def filter(self, uids: Sequence[int]) -> None:
+        self._ensure_live()
+        if self._checkpoint is not None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_active")
+        if not uids:
+            raise ValueError("native MTP batch filter cannot produce an empty batch")
+        if len(set(uids)) != len(uids) or any(uid not in self._rows for uid in uids):
+            raise ValueError("native MTP batch filter requires unique active UIDs")
+        indices = [self.uids.index(uid) for uid in uids]
+        snapshots = self._structural_snapshot((*self.backbone_cache, *self.mtp_cache))
+        old_rows = self._rows
+        try:
+            for entry in (*self.backbone_cache, *self.mtp_cache):
+                entry.filter(indices)
+            _force_eval(
+                _cache_eval_values(entry)
+                for entry in (*self.backbone_cache, *self.mtp_cache)
+            )
+            self._rows = OrderedDict((uid, old_rows[uid]) for uid in uids)
+            self._assert_aligned()
+        except BaseException:
+            try:
+                self._restore_structure(snapshots)
+                self._rows = old_rows
+            except BaseException as restore_error:
+                self._release_poisoned()
+                raise NativeMTPBatchError(
+                    "native_mtp_batch_filter_restore_failed"
+                ) from restore_error
+            raise
+
+    @staticmethod
+    def _extract_entry(entry: Any, index: int) -> Any:
+        if type(entry) is BatchKVCache and entry.keys is None:
+            return KVCache()
+        if type(entry) is ArraysCache and entry.empty():
+            return ArraysCache(len(entry.cache))
+        extracted = entry.extract(index)
+        if type(entry) is ArraysCache:
+            extracted.left_padding = None
+            extracted.lengths = None
+        return extracted
+
+    def _extracted_row_caches(self, index: int) -> tuple[list[Any], list[Any]]:
+        return (
+            [self._extract_entry(entry, index) for entry in self.backbone_cache],
+            [self._extract_entry(entry, index) for entry in self.mtp_cache],
+        )
+
+    @classmethod
+    def join(cls, batches: Sequence["NativeMTPBatch"]) -> "NativeMTPBatch":
+        if not batches:
+            raise ValueError("native MTP batch join requires at least one batch")
+        for batch in batches:
+            batch._ensure_live()
+            if batch._checkpoint is not None:
+                raise NativeMTPBatchError("native_mtp_batch_checkpoint_active")
+        model = batches[0].target_model
+        capability = batches[0].capability
+        topology = batches[0]._topology
+        if any(
+            batch.target_model is not model
+            or batch.capability != capability
+            or batch.capability_fingerprint != batches[0].capability_fingerprint
+            or batch._topology != topology
+            for batch in batches
+        ):
+            raise NativeMTPBatchError("native_mtp_batch_join_incompatible")
+        uids = tuple(uid for batch in batches for uid in batch.uids)
+        if len(set(uids)) != len(uids):
+            raise ValueError("native MTP batch join UIDs must be unique")
+
+        rows: list[NativeMTPBatchRow] = []
+        runtime_by_uid: dict[int, _RowRuntime] = {}
+        for batch in batches:
+            for index, uid in enumerate(batch.uids):
+                backbone, mtp = batch._extracted_row_caches(index)
+                runtime = batch._rows[uid]
+                rows.append(
+                    NativeMTPBatchRow(
+                        uid=uid,
+                        target_model=model,
+                        capability=capability,
+                        backbone_cache=backbone,
+                        mtp_cache=mtp,
+                        position=runtime.position,
+                        request_config=runtime.row.request_config,
+                    )
+                )
+                runtime_by_uid[uid] = runtime
+        joined = cls(rows)
+        for uid, runtime in joined._rows.items():
+            source = runtime_by_uid[uid]
+            runtime.rng_key = source.rng_key
+            runtime.replay_target = source.replay_target
+        for batch in batches:
+            batch._closed = True
+            batch._rows.clear()
+            batch.backbone_cache = []
+            batch.mtp_cache = []
+        return joined
+
+    def partition_replay_groups(self) -> tuple["NativeMTPBatch", ...]:
+        self._ensure_live()
+        if self._checkpoint is not None:
+            raise NativeMTPBatchError("native_mtp_batch_checkpoint_active")
+        groups: OrderedDict[tuple[int, int, int], list[int]] = OrderedDict()
+        for uid, runtime in self._rows.items():
+            target = runtime.replay_target
+            current = runtime.position
+            remaining = (
+                (0, 0, 0)
+                if target is None
+                else (
+                    target.logical_cursor - current.logical_cursor,
+                    target.backbone_tokens - current.backbone_tokens,
+                    target.mtp_tokens - current.mtp_tokens,
+                )
+            )
+            groups.setdefault(remaining, []).append(uid)
+        if len(groups) == 1:
+            return (self,)
+
+        partitions = []
+        for uids in groups.values():
+            indices = [self.uids.index(uid) for uid in uids]
+            rows = []
+            for index, uid in zip(indices, uids):
+                backbone, mtp = self._extracted_row_caches(index)
+                runtime = self._rows[uid]
+                rows.append(
+                    NativeMTPBatchRow(
+                        uid=uid,
+                        target_model=self.target_model,
+                        capability=self.capability,
+                        backbone_cache=backbone,
+                        mtp_cache=mtp,
+                        position=runtime.position,
+                        request_config=runtime.row.request_config,
+                    )
+                )
+            partition = type(self)(rows)
+            for uid in uids:
+                partition._rows[uid].rng_key = self._rows[uid].rng_key
+                partition._rows[uid].replay_target = self._rows[uid].replay_target
+            partitions.append(partition)
+        self._closed = True
+        self._rows.clear()
+        self.backbone_cache = []
+        self.mtp_cache = []
+        return tuple(partitions)
+
+    def finish(self, uid: int, reason: str) -> None:
+        if reason not in {"eos", "length", "cancelled", "error"}:
+            raise ValueError(f"unsupported native MTP batch finish reason: {reason}")
+        self._ensure_live()
+        if uid not in self._rows:
+            raise KeyError(f"unknown native MTP batch UID: {uid}")
+        if self._checkpoint is not None:
+            self.rollback()
+        if len(self._rows) == 1:
+            self._rows.clear()
+            self.backbone_cache = []
+            self.mtp_cache = []
+            self._closed = True
+            return
+        self.filter(tuple(active_uid for active_uid in self.uids if active_uid != uid))
+
+    def close(self, reason: str = "cancelled") -> None:
+        if reason not in {"eos", "length", "cancelled", "error"}:
+            raise ValueError(f"unsupported native MTP batch finish reason: {reason}")
+        if self._closed:
+            return
+        if self._checkpoint is not None:
+            self.rollback()
+        self._rows.clear()
+        self.backbone_cache = []
+        self.mtp_cache = []
+        self._closed = True

--- a/vllm_mlx/native_mtp_cb_adapter.py
+++ b/vllm_mlx/native_mtp_cb_adapter.py
@@ -175,7 +175,9 @@ class NativeMTPContinuousBatchAdapter:
             raise RuntimeError("native_mtp_penalty_processors_unsupported")
 
     @staticmethod
-    def _validate_sparse_bootstrap(model: Any, request: Any, bootstrap: Any) -> tuple[int, ...]:
+    def _validate_sparse_bootstrap(
+        model: Any, request: Any, bootstrap: Any
+    ) -> tuple[int, ...]:
         """Bind one bootstrap to this exact request/model before claim.
 
         mlx-lm repeats these provenance checks while atomically claiming the
@@ -202,13 +204,16 @@ class NativeMTPContinuousBatchAdapter:
             or len(successors) != len(positions) - 1
         ):
             raise RuntimeError("native_mtp_sparse_request_cursor_mismatch")
-        if any(
-            isinstance(position, bool)
-            or not isinstance(position, int)
-            or position < 0
-            or position >= len(prompt)
-            for position in positions
-        ) or tuple(sorted(set(positions))) != positions:
+        if (
+            any(
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position < 0
+                or position >= len(prompt)
+                for position in positions
+            )
+            or tuple(sorted(set(positions))) != positions
+        ):
             raise RuntimeError("native_mtp_sparse_positions_invalid")
         if selected != tuple(prompt[position] for position in positions):
             raise RuntimeError("native_mtp_sparse_request_tokens_mismatch")

--- a/vllm_mlx/native_mtp_cb_adapter.py
+++ b/vllm_mlx/native_mtp_cb_adapter.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Public-lifecycle adapter for standard-text native-MTP continuous batching.
+
+This module is deliberately independent from mlx-lm's ordinary
+``BatchGenerator``.  It owns only the exported native-MTP epoch handles and
+request-local cache admission; the Scheduler retains queueing and output I/O.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class _Telemetry:
+    target_tokens: int = 0
+    draft_tokens: int = 0
+    accepted_tokens: int = 0
+
+    def snapshot(self) -> dict[str, int]:
+        return {
+            "target_tokens": self.target_tokens,
+            "draft_tokens": self.draft_tokens,
+            "accepted_tokens": self.accepted_tokens,
+        }
+
+
+class NativeMTPContinuousBatchAdapter:
+    """Drive the public mlx-lm native-MTP lifecycle for one fresh cohort.
+
+    A cohort is intentionally closed as a unit on cancellation or failure:
+    the public lifecycle exposes no safe per-row cancellation handle.  The
+    scheduler can subsequently admit surviving requests as a new fresh cohort.
+    """
+
+    def __init__(self, *, start: Any, requests: Iterable[Any], prefill_step_size: int):
+        self._start = start
+        self._generator = None
+        self._requests = {request.batch_uid: request for request in requests}
+        self._telemetry = {uid: _Telemetry() for uid in self._requests}
+        self._prefill_step_size = prefill_step_size
+        self._epoch = None
+        self._phase = "new"
+        self._active_uids = tuple(self._requests)
+        self._decision = None
+        self._mixed_accepted = ()
+        self._mixed_rejected = ()
+        self._closed = False
+
+    @classmethod
+    def create(
+        cls,
+        model: Any,
+        requests: Iterable[Any],
+        *,
+        lifecycle: Any | None = None,
+        prefill_step_size: int = 512,
+    ) -> "NativeMTPContinuousBatchAdapter":
+        requests = tuple(requests)
+        if not requests:
+            raise RuntimeError("native_mtp_batch_rows_and_caches_required")
+        if lifecycle is None:
+            # ``mlx_lm.generate`` is also re-exported as a callable package
+            # attribute.  Import the module by its exact dotted name so the
+            # public lifecycle classes cannot be shadowed by that function.
+            lifecycle = importlib.import_module("mlx_lm.generate")
+
+        capability = getattr(model, "mtp_capability", None)
+        if capability is None or not getattr(capability, "supported", False):
+            raise RuntimeError(
+                "native_mtp_model_capability_missing"
+                if capability is None
+                else getattr(capability, "reason", "native_mtp_unsupported")
+            )
+        make_cache = getattr(model, "make_mtp_request_cache", None)
+        if not callable(make_cache):
+            raise RuntimeError("native_mtp_request_cache_factory_missing")
+
+        rows = []
+        for request in requests:
+            cls._validate_request(request)
+            sampling = request.native_mtp_config.sampling
+            rows.append(
+                lifecycle.NativeMTPRowSpec(
+                    uid=request.batch_uid,
+                    prompt=tuple(request.prompt_token_ids),
+                    max_tokens=request.sampling_params.max_tokens,
+                    seed=sampling.seed,
+                    eos_token_ids=frozenset(request.native_mtp_eos_token_ids),
+                    sampling_config=lifecycle.NativeMTPSamplingConfig(
+                        temperature=sampling.temperature,
+                        top_p=sampling.top_p,
+                        top_k=sampling.top_k,
+                        min_p=sampling.min_p,
+                        seed=sampling.seed,
+                    ),
+                )
+            )
+
+        def _start():
+            # Delay fresh-cache ownership until the first prefill boundary so a
+            # queued request can be cancelled before any model/cache mutation.
+            request_caches = [make_cache(prompt_cache=None) for _ in rows]
+            admission = lifecycle.NativeMTPAdmission.create(
+                model,
+                rows,
+                request_caches,
+                prefix_cache=None,
+                media=None,
+                external_draft=None,
+                sparse_bootstrap=None,
+                logits_processors=None,
+                kv_bits=None,
+                max_kv_size=None,
+            )
+            return lifecycle.NativeMTPBatchGenerator(admission)
+
+        return cls(
+            start=_start,
+            requests=requests,
+            prefill_step_size=prefill_step_size,
+        )
+
+    @staticmethod
+    def _validate_request(request: Any) -> None:
+        config = getattr(request, "native_mtp_config", None)
+        if config is None:
+            raise RuntimeError("native_mtp_request_config_missing")
+        if not getattr(request, "prompt_token_ids", None):
+            raise RuntimeError("native_mtp_prompt_required")
+        if getattr(request, "prefix_reused", False):
+            raise RuntimeError("native_mtp_prefix_reuse_unsupported")
+        if getattr(request, "chunked_prefill", False):
+            raise RuntimeError("native_mtp_chunked_prefill_unsupported")
+        if getattr(request, "quantized_kv", False):
+            raise RuntimeError("native_mtp_quantized_cache_unsupported")
+        if getattr(request, "has_media", False):
+            raise RuntimeError("native_mtp_media_unsupported")
+        if getattr(request, "external_draft", False):
+            raise RuntimeError("native_mtp_external_draft_unsupported")
+        if getattr(request, "logits_processors", None):
+            raise RuntimeError("native_mtp_logits_processors_unsupported")
+        if (
+            getattr(request.sampling_params, "presence_penalty", 0.0) != 0.0
+            or getattr(request.sampling_params, "repetition_penalty", 1.0) != 1.0
+        ):
+            raise RuntimeError("native_mtp_penalty_processors_unsupported")
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def active_uids(self) -> tuple[int, ...]:
+        return () if self._closed else self._active_uids
+
+    def telemetry_for(self, uid: int) -> dict[str, int]:
+        return self._telemetry[uid].snapshot()
+
+    def _add_target(self, uids: Iterable[int], count: int) -> None:
+        for uid in uids:
+            self._telemetry[uid].target_tokens += count
+
+    def _add_drafts(self, uids: Iterable[int]) -> None:
+        for uid in uids:
+            self._telemetry[uid].draft_tokens += 1
+
+    def _record_emissions(self, emissions: Iterable[Any]) -> tuple[Any, ...]:
+        emissions = tuple(emissions)
+        for emission in emissions:
+            if emission.from_draft:
+                self._telemetry[emission.uid].accepted_tokens += 1
+            if emission.finish_reason is not None:
+                self._active_uids = tuple(
+                    uid for uid in self._active_uids if uid != emission.uid
+                )
+        return emissions
+
+    def _set_epoch(self, epoch: Any) -> None:
+        self._epoch = epoch
+        if hasattr(epoch, "active_uids"):
+            self._active_uids = tuple(epoch.active_uids)
+
+    def step(self) -> tuple[Any, ...]:
+        """Advance exactly one public lifecycle boundary and return emissions."""
+        if self._closed:
+            return ()
+        if self._phase == "new":
+            self._generator = self._start()
+            emissions, epoch = self._generator.prefill(
+                prefill_step_size=self._prefill_step_size
+            )
+            self._set_epoch(epoch)
+            self._add_target((item.uid for item in emissions), 1)
+            self._phase = "initial"
+            return self._record_emissions(emissions)
+        if self._phase == "initial":
+            active = self._epoch.active_uids
+            self._set_epoch(self._epoch.resume())
+            self._add_drafts(active)
+            self._phase = "ready"
+            return ()
+        if self._phase == "ready":
+            active = self._epoch.active_uids
+            self._set_epoch(self._epoch.decide())
+            self._decision = self._epoch
+            self._add_target(active, 2)
+            self._phase = "decision"
+            return ()
+        if self._phase == "decision":
+            accepted = tuple(self._decision.accepted_uids)
+            rejected = tuple(self._decision.rejected_uids)
+            if accepted and rejected:
+                emissions, epoch = self._epoch.resolve()
+                self._set_epoch(epoch)
+                # Accepted rows rerun the verified target call after rollback.
+                self._add_target(accepted, 2)
+                self._mixed_accepted, self._mixed_rejected = accepted, rejected
+                self._phase = "mixed"
+                return self._record_emissions(emissions)
+            if accepted:
+                emissions, epoch = self._epoch.accept()
+                self._set_epoch(epoch)
+                self._phase = "accepted"
+                return self._record_emissions(emissions)
+            emissions, epoch = self._epoch.reject()
+            self._set_epoch(epoch)
+            # Rejection restores then replays the target head in this public
+            # boundary before the replacement token is observable.
+            self._add_target(rejected, 1)
+            self._phase = "rejected"
+            return self._record_emissions(emissions)
+        if self._phase == "accepted":
+            emissions, epoch = self._epoch.bonus()
+            self._set_epoch(epoch)
+            self._phase = "bonus"
+            return self._record_emissions(emissions)
+        if self._phase == "bonus":
+            active = self._epoch.active_uids
+            self._set_epoch(self._epoch.catch_up())
+            self._add_drafts(active)
+            self._phase = "ready"
+            return ()
+        if self._phase == "rejected":
+            active = self._epoch.active_uids
+            self._set_epoch(self._epoch.redraft())
+            self._add_drafts(active)
+            self._phase = "ready"
+            return ()
+        if self._phase == "mixed":
+            emissions, epoch = self._epoch.resume_after_resolution()
+            self._set_epoch(epoch)
+            # Rejected rows replay their head then produce a new draft.
+            self._add_target(self._mixed_rejected, 1)
+            self._add_drafts(self._mixed_rejected)
+            self._phase = "mixed_bonus"
+            return self._record_emissions(emissions)
+        if self._phase == "mixed_bonus":
+            before = set(self._mixed_accepted)
+            self._set_epoch(self._epoch.resume_after_bonus())
+            self._add_drafts(before.intersection(self._epoch.active_uids))
+            self._phase = "ready"
+            return ()
+        raise RuntimeError("native_mtp_batch_lifecycle_phase_invalid")
+
+    def cancel(self) -> tuple[int, ...]:
+        """Cancel the entire public cohort and return affected UIDs."""
+        if self._closed:
+            return ()
+        affected = self.active_uids
+        if self._epoch is not None:
+            self._epoch.cancel()
+        self._closed = True
+        return affected

--- a/vllm_mlx/native_mtp_cb_adapter.py
+++ b/vllm_mlx/native_mtp_cb_adapter.py
@@ -48,6 +48,7 @@ class NativeMTPContinuousBatchAdapter:
         self._mixed_accepted = ()
         self._mixed_rejected = ()
         self._closed = False
+        self._cleanup_error_reason = None
 
     @classmethod
     def create(
@@ -155,6 +156,11 @@ class NativeMTPContinuousBatchAdapter:
     @property
     def active_uids(self) -> tuple[int, ...]:
         return () if self._closed else self._active_uids
+
+    @property
+    def cleanup_error_reason(self) -> str | None:
+        """Return a non-primary terminal cleanup failure, if one occurred."""
+        return self._cleanup_error_reason
 
     def telemetry_for(self, uid: int) -> dict[str, int]:
         return self._telemetry[uid].snapshot()
@@ -270,7 +276,20 @@ class NativeMTPContinuousBatchAdapter:
         if self._closed:
             return ()
         affected = self.active_uids
-        if self._epoch is not None:
-            self._epoch.cancel()
+        # A lifecycle operation can consume its epoch and poison/close the
+        # generator before its exception reaches the scheduler.  That stale
+        # handle is not an actionable cleanup owner: calling ``cancel`` on it
+        # raises ``native_mtp_epoch_moved`` and used to hide the model error.
+        # Mark this adapter closed first so repeated terminal cleanup is also
+        # harmless.  A live epoch is still cancelled normally.
         self._closed = True
+        if self._epoch is None or getattr(self._generator, "closed", False):
+            return affected
+        try:
+            self._epoch.cancel()
+        except Exception as error:
+            # Cancellation has no replacement primary failure of its own.
+            # Keep it observable to scheduler-owned cleanup without allowing
+            # it to replace a model/admission failure already in flight.
+            self._cleanup_error_reason = str(error) or type(error).__name__
         return affected

--- a/vllm_mlx/native_mtp_cb_adapter.py
+++ b/vllm_mlx/native_mtp_cb_adapter.py
@@ -38,6 +38,7 @@ class NativeMTPContinuousBatchAdapter:
     def __init__(self, *, start: Any, requests: Iterable[Any], prefill_step_size: int):
         self._start = start
         self._generator = None
+        self._sparse_start = False
         self._requests = {request.batch_uid: request for request in requests}
         self._telemetry = {uid: _Telemetry() for uid in self._requests}
         self._prefill_step_size = prefill_step_size
@@ -58,6 +59,8 @@ class NativeMTPContinuousBatchAdapter:
         *,
         lifecycle: Any | None = None,
         prefill_step_size: int = 512,
+        sparse_bootstraps: Iterable[Any] | None = None,
+        sparse_adopted: Any | None = None,
     ) -> "NativeMTPContinuousBatchAdapter":
         requests = tuple(requests)
         if not requests:
@@ -75,18 +78,33 @@ class NativeMTPContinuousBatchAdapter:
                 if capability is None
                 else getattr(capability, "reason", "native_mtp_unsupported")
             )
+        bootstraps = None if sparse_bootstraps is None else tuple(sparse_bootstraps)
         make_cache = getattr(model, "make_mtp_request_cache", None)
-        if not callable(make_cache):
+        if bootstraps is None and not callable(make_cache):
             raise RuntimeError("native_mtp_request_cache_factory_missing")
 
+        if bootstraps is not None and len(bootstraps) != len(requests):
+            raise RuntimeError("native_mtp_sparse_bootstrap_count_mismatch")
+        if bootstraps is not None and len({id(item) for item in bootstraps}) != len(
+            bootstraps
+        ):
+            raise RuntimeError("native_mtp_sparse_bootstrap_reused")
+        if sparse_adopted is not None and not callable(sparse_adopted):
+            raise TypeError("native_mtp_sparse_adopted_callback_invalid")
+
         rows = []
-        for request in requests:
+        for index, request in enumerate(requests):
             cls._validate_request(request)
+            prompt = tuple(request.prompt_token_ids)
+            if bootstraps is not None:
+                prompt = cls._validate_sparse_bootstrap(
+                    model, request, bootstraps[index]
+                )
             sampling = request.native_mtp_config.sampling
             rows.append(
                 lifecycle.NativeMTPRowSpec(
                     uid=request.batch_uid,
-                    prompt=tuple(request.prompt_token_ids),
+                    prompt=prompt,
                     max_tokens=request.sampling_params.max_tokens,
                     seed=sampling.seed,
                     eos_token_ids=frozenset(request.native_mtp_eos_token_ids),
@@ -101,6 +119,13 @@ class NativeMTPContinuousBatchAdapter:
             )
 
         def _start():
+            if bootstraps is not None:
+                admission = lifecycle.NativeMTPAdmission.create_from_sparse_bootstraps(
+                    model, rows, bootstraps
+                )
+                if sparse_adopted is not None:
+                    sparse_adopted()
+                return lifecycle.NativeMTPBatchGenerator(admission), True
             # Delay fresh-cache ownership until the first prefill boundary so a
             # queued request can be cancelled before any model/cache mutation.
             request_caches = [make_cache(prompt_cache=None) for _ in rows]
@@ -116,7 +141,7 @@ class NativeMTPContinuousBatchAdapter:
                 kv_bits=None,
                 max_kv_size=None,
             )
-            return lifecycle.NativeMTPBatchGenerator(admission)
+            return lifecycle.NativeMTPBatchGenerator(admission), False
 
         return cls(
             start=_start,
@@ -148,6 +173,58 @@ class NativeMTPContinuousBatchAdapter:
             or getattr(request.sampling_params, "repetition_penalty", 1.0) != 1.0
         ):
             raise RuntimeError("native_mtp_penalty_processors_unsupported")
+
+    @staticmethod
+    def _validate_sparse_bootstrap(model: Any, request: Any, bootstrap: Any) -> tuple[int, ...]:
+        """Bind one bootstrap to this exact request/model before claim.
+
+        mlx-lm repeats these provenance checks while atomically claiming the
+        receipts.  The adapter checks the scheduler-side association first so
+        a misordered cohort cannot consume another request's authority.
+        """
+        prompt = tuple(request.prompt_token_ids)
+        try:
+            positions = tuple(bootstrap.selected_logical_positions)
+            selected = tuple(bootstrap.selected_token_ids)
+            successors = tuple(bootstrap.immediate_successor_token_ids)
+            receipts = tuple(bootstrap.receipts)
+            target_cache = bootstrap.target_cache
+            cursor = bootstrap.next_logical_position
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError("native_mtp_sparse_bootstrap_invalid") from exc
+        if not positions or len(selected) != len(positions):
+            raise RuntimeError("native_mtp_sparse_bootstrap_invalid")
+        if not isinstance(target_cache, list) or not target_cache:
+            raise RuntimeError("native_mtp_sparse_target_cache_invalid")
+        if (
+            positions[-1] != len(prompt) - 1
+            or cursor != len(prompt)
+            or len(successors) != len(positions) - 1
+        ):
+            raise RuntimeError("native_mtp_sparse_request_cursor_mismatch")
+        if any(
+            isinstance(position, bool)
+            or not isinstance(position, int)
+            or position < 0
+            or position >= len(prompt)
+            for position in positions
+        ) or tuple(sorted(set(positions))) != positions:
+            raise RuntimeError("native_mtp_sparse_positions_invalid")
+        if selected != tuple(prompt[position] for position in positions):
+            raise RuntimeError("native_mtp_sparse_request_tokens_mismatch")
+        if successors != tuple(prompt[position + 1] for position in positions[:-1]):
+            raise RuntimeError("native_mtp_sparse_request_successors_mismatch")
+        if not receipts:
+            raise RuntimeError("native_mtp_sparse_receipts_missing")
+        cache_ids = tuple(id(entry) for entry in target_cache)
+        for receipt in receipts:
+            if (
+                getattr(receipt, "model_id", None) != id(model)
+                or getattr(receipt, "cache_container_id", None) != id(target_cache)
+                or getattr(receipt, "cache_entry_ids", None) != cache_ids
+            ):
+                raise RuntimeError("native_mtp_sparse_receipt_provenance_mismatch")
+        return selected
 
     @property
     def closed(self) -> bool:
@@ -194,10 +271,13 @@ class NativeMTPContinuousBatchAdapter:
         if self._closed:
             return ()
         if self._phase == "new":
-            self._generator = self._start()
-            emissions, epoch = self._generator.prefill(
-                prefill_step_size=self._prefill_step_size
-            )
+            self._generator, self._sparse_start = self._start()
+            if self._sparse_start:
+                emissions, epoch = self._generator.start_sparse()
+            else:
+                emissions, epoch = self._generator.prefill(
+                    prefill_step_size=self._prefill_step_size
+                )
             self._set_epoch(epoch)
             self._add_target((item.uid for item in emissions), 1)
             self._phase = "initial"

--- a/vllm_mlx/native_mtp_request.py
+++ b/vllm_mlx/native_mtp_request.py
@@ -76,9 +76,7 @@ class NativeMTPRequestConfig:
         try:
             from mlx_lm.generate import NativeMTPSamplingConfig
         except ImportError as exc:
-            raise NativeMTPRequestError(
-                "native_mtp_consumer_contract_missing"
-            ) from exc
+            raise NativeMTPRequestError("native_mtp_consumer_contract_missing") from exc
         return {
             "mtp": True,
             "mtp_sampling_config": NativeMTPSamplingConfig(

--- a/vllm_mlx/native_mtp_request.py
+++ b/vllm_mlx/native_mtp_request.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local contract for native Qwen MTP decoding.
+
+This module deliberately contains no model or MLX imports.  Public request
+validation and route admission can therefore finish before generation mutates
+model, cache, sampler, or processor state.
+"""
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+class NativeMTPRequestError(ValueError):
+    """An explicit native-MTP request cannot be honored safely."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def native_mtp_consumer_supported(consumer: Callable[..., Any]) -> bool:
+    """Whether a generation callable exposes the exact native-MTP seam."""
+
+    try:
+        parameters = inspect.signature(consumer).parameters
+    except (TypeError, ValueError):
+        return False
+    return "mtp" in parameters and "mtp_sampling_config" in parameters
+
+
+def resolve_native_mtp_consumer() -> Callable[..., Any] | None:
+    """Return the installed mlx-lm consumer only when its contract is exact."""
+
+    try:
+        from mlx_lm import stream_generate
+        from mlx_lm.generate import NativeMTPSamplingConfig  # noqa: F401
+    except (ImportError, AttributeError):
+        return None
+    return stream_generate if native_mtp_consumer_supported(stream_generate) else None
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPSampling:
+    """Immutable sampling inputs consumed only by a selected native-MTP path."""
+
+    temperature: float
+    top_p: float
+    top_k: int
+    min_p: float
+    presence_penalty: float
+    repetition_penalty: float
+    seed: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPRequestConfig:
+    """The complete request-effective native-MTP decode configuration."""
+
+    sampling: NativeMTPSampling
+    num_draft_tokens: int
+
+    def __post_init__(self) -> None:
+        if self.num_draft_tokens < 1:
+            raise ValueError("num_draft_tokens must be positive")
+
+    def mlx_lm_call_kwargs(
+        self, consumer: Callable[..., Any] | None = None
+    ) -> dict[str, Any]:
+        """Build the exact request-local kwargs required by current mlx-lm."""
+
+        consumer = consumer or resolve_native_mtp_consumer()
+        if consumer is None or not native_mtp_consumer_supported(consumer):
+            raise NativeMTPRequestError("native_mtp_consumer_contract_missing")
+        try:
+            from mlx_lm.generate import NativeMTPSamplingConfig
+        except ImportError as exc:
+            raise NativeMTPRequestError(
+                "native_mtp_consumer_contract_missing"
+            ) from exc
+        return {
+            "mtp": True,
+            "mtp_sampling_config": NativeMTPSamplingConfig(
+                temperature=self.sampling.temperature,
+                top_p=self.sampling.top_p,
+                top_k=self.sampling.top_k,
+                min_p=self.sampling.min_p,
+                seed=self.sampling.seed,
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPServerState:
+    """Read-only engine admission state used by the public request layer."""
+
+    server_default: bool
+    capable: bool
+    num_draft_tokens: int = 1
+    supports_penalty_processors: bool = True
+    incompatibility: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPDecision:
+    """Result of resolving public intent against server admission."""
+
+    requested: bool | None
+    selected: bool
+    config: NativeMTPRequestConfig | None = None
+    bypass_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.selected != (self.config is not None):
+            raise ValueError("selected native MTP requires exactly one request config")
+        if self.selected and self.bypass_reason is not None:
+            raise ValueError("selected native MTP cannot have a bypass reason")
+
+
+def resolve_native_mtp_request(
+    *,
+    requested: bool | None,
+    sampling: NativeMTPSampling,
+    server_default: bool,
+    capable: bool,
+    num_draft_tokens: int,
+    incompatibility: str | None = None,
+) -> NativeMTPDecision:
+    """Resolve native MTP without mutating engine or model state.
+
+    ``None`` preserves the existing server default.  Explicit ``False`` is an
+    unreported opt-out.  Explicit ``True`` never silently downgrades: a missing
+    capability or any route incompatibility raises with a stable reason.
+    """
+
+    if requested is False:
+        return NativeMTPDecision(requested=False, selected=False)
+
+    wants_mtp = server_default if requested is None else True
+    if not wants_mtp:
+        return NativeMTPDecision(requested=None, selected=False)
+
+    reason = incompatibility
+    if reason is None and not capable:
+        reason = "native_mtp_unsupported"
+    if reason is not None:
+        if requested is True:
+            raise NativeMTPRequestError(reason)
+        return NativeMTPDecision(
+            requested=None,
+            selected=False,
+            bypass_reason=reason,
+        )
+
+    return NativeMTPDecision(
+        requested=requested,
+        selected=True,
+        config=NativeMTPRequestConfig(
+            sampling=sampling,
+            num_draft_tokens=num_draft_tokens,
+        ),
+    )

--- a/vllm_mlx/native_mtp_specprefill_bridge.py
+++ b/vllm_mlx/native_mtp_specprefill_bridge.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard-text CB admission bridge for attested SpecPrefill native MTP.
+
+This module owns no scheduler policy and never performs dense replay.  It
+advances one request-owned cooperative SpecPrefill quantum at a time, then
+turns the exact completed target receipts into the public mlx-lm sparse
+bootstrap consumed by :class:`NativeMTPContinuousBatchAdapter`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from .cooperative_specprefill import (
+    CooperativeSpecPrefillConfig,
+    CooperativeSpecPrefillOutcome,
+)
+
+
+class NativeMTPSpecPrefillBridgeState(str, Enum):
+    WAITING = "waiting"
+    PREFILLING = "prefilling"
+    BOOTSTRAP_READY = "bootstrap_ready"
+    ADOPTED = "adopted"
+    TERMINAL = "terminal"
+
+
+class NativeMTPSpecPrefillBridgeError(RuntimeError):
+    """A combined sparse admission cannot safely be continued."""
+
+
+@dataclass(frozen=True)
+class NativeMTPSpecPrefillBridgeProgress:
+    state: NativeMTPSpecPrefillBridgeState
+    busy: bool = False
+    fallback_reason: str | None = None
+
+
+class NativeMTPSpecPrefillBridge:
+    """One request's attested sparse admission before cohort ownership.
+
+    ``prepared`` is the eager runtime bundle built at engine start.  The
+    optional factory is the sole route that can produce receipt-bearing target
+    forwards; ordinary SpecPrefill sessions deliberately remain unusable here.
+    """
+
+    def __init__(self, prepared: Any, request: Any, config: CooperativeSpecPrefillConfig):
+        factory = getattr(prepared, "native_mtp_session_factory", None)
+        if not callable(factory):
+            raise NativeMTPSpecPrefillBridgeError(
+                "native_mtp_attested_session_factory_unavailable"
+            )
+        tokens = tuple(getattr(request, "prompt_token_ids", ()) or ())
+        if not tokens:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_prompt_required")
+        self._request = request
+        self._tokens = tokens
+        self._session = factory(request, tokens, config)
+        self._bootstrap = None
+        self._state = NativeMTPSpecPrefillBridgeState.WAITING
+        self._fallback_reason = None
+
+    @property
+    def state(self) -> NativeMTPSpecPrefillBridgeState:
+        return self._state
+
+    @property
+    def bootstrap(self) -> Any:
+        if self._state not in {
+            NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY,
+            NativeMTPSpecPrefillBridgeState.ADOPTED,
+        }:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_bootstrap_unready")
+        return self._bootstrap
+
+    def step(self) -> NativeMTPSpecPrefillBridgeProgress:
+        if self._state is NativeMTPSpecPrefillBridgeState.TERMINAL:
+            return NativeMTPSpecPrefillBridgeProgress(
+                self._state, fallback_reason=self._fallback_reason
+            )
+        if self._state is NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY:
+            return NativeMTPSpecPrefillBridgeProgress(self._state)
+        if self._state is NativeMTPSpecPrefillBridgeState.ADOPTED:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_bootstrap_already_adopted")
+        self._state = NativeMTPSpecPrefillBridgeState.PREFILLING
+        progress = self._session.step()
+        if progress.busy:
+            return NativeMTPSpecPrefillBridgeProgress(self._state, busy=True)
+        if self._session.outcome is not CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION:
+            if self._session.outcome is not CooperativeSpecPrefillOutcome.ACTIVE:
+                self._fallback_reason = self._session.fallback_reason or "sparse_prefill_failed"
+                self._state = NativeMTPSpecPrefillBridgeState.TERMINAL
+            return NativeMTPSpecPrefillBridgeProgress(self._state, fallback_reason=self._fallback_reason)
+        try:
+            self._bootstrap = self._build_bootstrap()
+            self._state = NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY
+            return NativeMTPSpecPrefillBridgeProgress(self._state)
+        except BaseException:
+            self.cancel()
+            raise
+
+    def mark_adopted(self) -> Any:
+        if self._state is not NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_bootstrap_unready")
+        try:
+            self._session.mark_adopted()
+        except BaseException:
+            self.cancel()
+            raise
+        self._state = NativeMTPSpecPrefillBridgeState.ADOPTED
+        return self._bootstrap
+
+    def cancel(self) -> None:
+        if self._state is NativeMTPSpecPrefillBridgeState.TERMINAL:
+            return
+        bootstrap = self._bootstrap
+        self._bootstrap = None
+        if bootstrap is not None:
+            bootstrap.close()
+        if self._state is not NativeMTPSpecPrefillBridgeState.ADOPTED:
+            self._session.cancel()
+        self._state = NativeMTPSpecPrefillBridgeState.TERMINAL
+
+    def _build_bootstrap(self) -> Any:
+        try:
+            from mlx_lm.generate import NativeMTPSparseBootstrap
+        except ImportError as exc:
+            raise NativeMTPSpecPrefillBridgeError(
+                "native_mtp_sparse_bootstrap_api_unavailable"
+            ) from exc
+        plan = self._session.selection_plan
+        result = self._session.prepared_result
+        cache = self._session.prepared_cache
+        if plan is None or not isinstance(cache, list):
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_result_invalid")
+        positions = tuple(plan.selected_indices)
+        if not positions or positions[-1] != len(self._tokens) - 1:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_final_anchor_missing")
+        selected = tuple(self._tokens[position] for position in positions)
+        successors = tuple(self._tokens[position + 1] for position in positions[:-1])
+        receipts = tuple(result.forward_receipts)
+        if not receipts:
+            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_receipts_missing")
+        return NativeMTPSparseBootstrap(
+            receipts=receipts,
+            selected_logical_positions=positions,
+            selected_token_ids=selected,
+            immediate_successor_token_ids=successors,
+            target_cache=cache,
+            next_logical_position=len(self._tokens),
+        )

--- a/vllm_mlx/native_mtp_specprefill_bridge.py
+++ b/vllm_mlx/native_mtp_specprefill_bridge.py
@@ -46,7 +46,9 @@ class NativeMTPSpecPrefillBridge:
     forwards; ordinary SpecPrefill sessions deliberately remain unusable here.
     """
 
-    def __init__(self, prepared: Any, request: Any, config: CooperativeSpecPrefillConfig):
+    def __init__(
+        self, prepared: Any, request: Any, config: CooperativeSpecPrefillConfig
+    ):
         factory = getattr(prepared, "native_mtp_session_factory", None)
         if not callable(factory):
             raise NativeMTPSpecPrefillBridgeError(
@@ -83,16 +85,25 @@ class NativeMTPSpecPrefillBridge:
         if self._state is NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY:
             return NativeMTPSpecPrefillBridgeProgress(self._state)
         if self._state is NativeMTPSpecPrefillBridgeState.ADOPTED:
-            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_bootstrap_already_adopted")
+            raise NativeMTPSpecPrefillBridgeError(
+                "native_mtp_sparse_bootstrap_already_adopted"
+            )
         self._state = NativeMTPSpecPrefillBridgeState.PREFILLING
         progress = self._session.step()
         if progress.busy:
             return NativeMTPSpecPrefillBridgeProgress(self._state, busy=True)
-        if self._session.outcome is not CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION:
+        if (
+            self._session.outcome
+            is not CooperativeSpecPrefillOutcome.READY_FOR_ADOPTION
+        ):
             if self._session.outcome is not CooperativeSpecPrefillOutcome.ACTIVE:
-                self._fallback_reason = self._session.fallback_reason or "sparse_prefill_failed"
+                self._fallback_reason = (
+                    self._session.fallback_reason or "sparse_prefill_failed"
+                )
                 self._state = NativeMTPSpecPrefillBridgeState.TERMINAL
-            return NativeMTPSpecPrefillBridgeProgress(self._state, fallback_reason=self._fallback_reason)
+            return NativeMTPSpecPrefillBridgeProgress(
+                self._state, fallback_reason=self._fallback_reason
+            )
         try:
             self._bootstrap = self._build_bootstrap()
             self._state = NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY
@@ -151,7 +162,9 @@ class NativeMTPSpecPrefillBridge:
             raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_result_invalid")
         positions = tuple(plan.selected_indices)
         if not positions or positions[-1] != len(self._tokens) - 1:
-            raise NativeMTPSpecPrefillBridgeError("native_mtp_sparse_final_anchor_missing")
+            raise NativeMTPSpecPrefillBridgeError(
+                "native_mtp_sparse_final_anchor_missing"
+            )
         selected = tuple(self._tokens[position] for position in positions)
         successors = tuple(self._tokens[position + 1] for position in positions[:-1])
         receipts = tuple(result.forward_receipts)

--- a/vllm_mlx/native_mtp_specprefill_bridge.py
+++ b/vllm_mlx/native_mtp_specprefill_bridge.py
@@ -112,6 +112,20 @@ class NativeMTPSpecPrefillBridge:
         self._state = NativeMTPSpecPrefillBridgeState.ADOPTED
         return self._bootstrap
 
+    def record_public_claim(self) -> None:
+        """Record an already-committed sparse claim without new fallible work.
+
+        ``NativeMTPAdmission.create_from_sparse_bootstraps`` has consumed the
+        receipts before invoking its scheduler callback.  At that point the
+        bridge must not perform another operation that can reject ownership:
+        the native cohort is the cache owner and dropping these references is
+        sufficient.  The normal ``mark_adopted`` method remains available for
+        standalone cooperative consumers which cross their own decode seam.
+        """
+        self._bootstrap = None
+        self._session = None
+        self._state = NativeMTPSpecPrefillBridgeState.ADOPTED
+
     def cancel(self) -> None:
         if self._state is NativeMTPSpecPrefillBridgeState.TERMINAL:
             return

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -149,6 +149,10 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            mtp_drafts=new.mtp_drafts,
+            mtp_accepted=new.mtp_accepted,
+            logprobs=new.logprobs,
+            native_mtp_error_reason=new.native_mtp_error_reason,
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -216,6 +216,19 @@ class RequestOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Request-local sparse-prefill diagnostics.  These fields are deliberately
+    # independent of MTP counters because the two features occupy different
+    # generation phases and may engage separately.
+    specprefill_requested_policy: Optional[str] = None
+    specprefill_effective_policy: Optional[str] = None
+    specprefill_coverage: Optional[str] = None
+    specprefill_engaged: Optional[bool] = None
+    specprefill_selector_version: Optional[str] = None
+    specprefill_fallback_reason: Optional[str] = None
+    specprefill_total_tokens: Optional[int] = None
+    specprefill_selected_tokens: Optional[int] = None
+    specprefill_scorer_ms: Optional[float] = None
+    specprefill_target_prefill_ms: Optional[float] = None
 
     @property
     def usage(self) -> Dict[str, int]:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -141,6 +141,10 @@ class Request:
     cache_hit_type: Optional[str] = (
         None  # Type of cache hit: exact/prefix/supersequence/lcp/miss
     )
+    # Native-MTP CB is a request sidecar, never part of generic sampling
+    # parameters or the upstream BatchGenerator insert contract.
+    native_mtp_config: Any = None
+    native_mtp_eos_token_ids: set[int] = field(default_factory=set)
 
     @property
     def num_output_tokens(self) -> int:
@@ -216,6 +220,11 @@ class RequestOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Present only for native-MTP public emissions; ordinary paths retain None.
+    logprobs: Any = None
+    # A native cohort admission failure is terminal and retains its stable
+    # fail-closed reason without overloading normal finish reasons.
+    native_mtp_error_reason: Optional[str] = None
     # Request-local sparse-prefill diagnostics.  These fields are deliberately
     # independent of MTP counters because the two features occupy different
     # generation phases and may engage separately.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -16,7 +16,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Lock
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import mlx.core as mx
 from mlx_lm.generate import BatchGenerator
@@ -135,9 +135,19 @@ class SchedulerConfig:
     mtp_num_draft_tokens: int = 1  # Number of draft tokens from MTP head
     mtp_optimistic: bool = False  # Skip acceptance check for max speed
 
+    # Continuous-batching SpecPrefill is prepared atomically by BatchedEngine.
+    # The callback returns an immutable bundle of already prepared scorer and
+    # target-adapter components; no first-request artifact/model load is allowed.
+    specprefill_enabled: bool = False
+    specprefill_prepare: Optional[Callable[[Any, Any], Any]] = None
+
     def __post_init__(self) -> None:
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
             raise ValueError("mllm_prefill_step_size must be > 0 when provided")
+        if self.specprefill_prepare is not None and not callable(
+            self.specprefill_prepare
+        ):
+            raise TypeError("specprefill_prepare must be callable or None")
 
 
 @dataclass

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -140,6 +140,7 @@ class SchedulerConfig:
     # target-adapter components; no first-request artifact/model load is allowed.
     specprefill_enabled: bool = False
     specprefill_prepare: Optional[Callable[[Any, Any], Any]] = None
+    specprefill_runtime_builder_inputs: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
@@ -148,6 +149,10 @@ class SchedulerConfig:
             self.specprefill_prepare
         ):
             raise TypeError("specprefill_prepare must be callable or None")
+        if self.specprefill_runtime_builder_inputs is not None and not isinstance(
+            self.specprefill_runtime_builder_inputs, dict
+        ):
+            raise TypeError("specprefill_runtime_builder_inputs must be a dict or None")
 
 
 @dataclass

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -206,6 +206,9 @@ class SchedulerConfig:
     specprefill_enabled: bool = False
     specprefill_prepare: Optional[Callable[[Any, Any], Any]] = None
     specprefill_runtime_builder_inputs: Optional[Dict[str, Any]] = None
+    # Combined native-MTP SpecPrefill is an opt-in, already-prepared owner.
+    # Scheduler never loads artifacts or constructs a sparse target session.
+    native_mtp_specprefill_runtime: Any = None
 
     def __post_init__(self) -> None:
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
@@ -1407,6 +1410,12 @@ class Scheduler:
         self._native_cancelled_ids: Set[str] = set()
         self._native_zero_token_ids: Set[str] = set()
         self._native_admission_errors: Dict[str, str] = {}
+        # These bridges own attested sparse target cache only until the public
+        # native-MTP cohort claims every receipt.  They intentionally never
+        # share a lifetime with an ordinary BatchGenerator.
+        self._native_mtp_specprefill_bridges: Dict[str, Any] = {}
+        self._native_mtp_specprefill_queue: deque[str] = deque()
+        self._native_mtp_specprefill_cohort_ids: tuple[str, ...] = ()
 
         # Prefix cache for KV state reuse
         self.prefix_cache: Optional[PrefixCacheManager] = None
@@ -1750,6 +1759,7 @@ class Scheduler:
     def _close_batch_generator(self) -> None:
         """Properly close BatchGenerator to restore wired_limit."""
         self._cancel_native_mtp_adapter()
+        self._cancel_native_mtp_specprefill_bridges()
         if self.batch_generator is not None:
             try:
                 if hasattr(self.batch_generator, "close"):
@@ -2144,6 +2154,21 @@ class Scheduler:
         if request_id in self._native_cancelled_ids:
             return True
 
+        bridge = self._native_mtp_specprefill_bridges.pop(request_id, None)
+        if bridge is not None:
+            try:
+                bridge.cancel()
+            except Exception:
+                logger.exception(
+                    "Failed to cancel native MTP SpecPrefill bridge for %s",
+                    request_id,
+                )
+            self._native_mtp_specprefill_queue = deque(
+                queued
+                for queued in self._native_mtp_specprefill_queue
+                if queued != request_id
+            )
+
         request = self.requests.get(request_id)
         if self.native_mtp_adapter is not None and request_id in self.request_id_to_uid:
             # Public native lifecycle supports only cohort cancellation.  Do
@@ -2246,9 +2271,193 @@ class Scheduler:
             request.sampling_params.stop_token_ids or ()
         )
 
+    def _native_mtp_specprefill_config(self, request: Request) -> Any | None:
+        """Build the exact attested sparse config, or keep normal MTP intact."""
+        prepared = self.config.native_mtp_specprefill_runtime
+        if prepared is None:
+            return None
+        if request.images or request.videos or request.is_multimodal:
+            return None
+        if not self.config.specprefill_enabled:
+            return None
+        try:
+            from .cooperative_specprefill import CooperativeSpecPrefillConfig
+            from .specprefill_cache import SparsePolicyTuning
+
+            key = prepared.profile_key
+            profile = prepared.profile_registry.resolve(
+                key,
+                prompt_tokens=len(request.prompt_token_ids),
+                residency_bytes=prepared.estimated_residency_bytes,
+                diagnostic=False,
+            )
+            tuning = profile.tuning if profile.eligible else None
+            if tuning is None:
+                return None
+            return CooperativeSpecPrefillConfig(
+                target_id=f"{key.target_artifact_id}@sha256:{key.target_artifact_hash}",
+                tokenizer_id=f"tokenizer@sha256:{key.tokenizer_artifact_hash}",
+                scorer_id=f"{key.scorer_artifact_id}@sha256:{key.scorer_artifact_hash}",
+                tuning=SparsePolicyTuning(
+                    keep_pct=tuning.keep_pct,
+                    backbone_pct=tuning.backbone_pct,
+                    halo_chunks=tuning.halo_chunks,
+                    anchor_chunks=tuning.anchor_chunks,
+                    chunk_size=tuning.chunk_size,
+                ),
+            )
+        except Exception as exc:
+            logger.warning("Native MTP SpecPrefill admission unavailable: %s", exc)
+            return None
+
+    def _start_native_mtp_specprefill_bridges(self) -> List[Request]:
+        """Move one contiguous combined cohort into request-owned prefill."""
+        if self._native_mtp_specprefill_bridges or not self.waiting:
+            return []
+        first = self.waiting[0]
+        if first.native_mtp_config is None:
+            return []
+        config = self._native_mtp_specprefill_config(first)
+        if config is None:
+            return []
+        from .native_mtp_specprefill_bridge import NativeMTPSpecPrefillBridge
+
+        cohort = []
+        for request in self.waiting:
+            if (
+                request.native_mtp_config is None
+                or request.sampling_params.max_tokens == 0
+                or len(cohort) >= self.config.max_num_seqs
+                or self._native_mtp_specprefill_config(request) != config
+            ):
+                break
+            cohort.append(request)
+        bridges = {}
+        try:
+            for request in cohort:
+                bridges[request.request_id] = NativeMTPSpecPrefillBridge(
+                    self.config.native_mtp_specprefill_runtime, request, config
+                )
+        except Exception as exc:
+            for bridge in bridges.values():
+                try:
+                    bridge.cancel()
+                except Exception:
+                    logger.exception("Failed to cancel partial native MTP bridge")
+            reason = str(exc) or "native_mtp_specprefill_admission_failed"
+            for _ in cohort:
+                self.waiting.popleft()
+            for request in cohort:
+                request.status = RequestStatus.RUNNING
+                self.running[request.request_id] = request
+                self._native_admission_errors[request.request_id] = reason
+            return cohort
+        for _ in cohort:
+            self.waiting.popleft()
+        self._native_mtp_specprefill_bridges = bridges
+        self._native_mtp_specprefill_queue.extend(bridges)
+        self._native_mtp_specprefill_cohort_ids = tuple(bridges)
+        for request in cohort:
+            request.status = RequestStatus.RUNNING
+            self.running[request.request_id] = request
+            self.total_prompt_tokens += request.num_prompt_tokens
+        return cohort
+
+    def _cancel_native_mtp_specprefill_bridges(self) -> None:
+        bridges, self._native_mtp_specprefill_bridges = (
+            self._native_mtp_specprefill_bridges,
+            {},
+        )
+        self._native_mtp_specprefill_cohort_ids = ()
+        self._native_mtp_specprefill_queue.clear()
+        for bridge in bridges.values():
+            try:
+                bridge.cancel()
+            except Exception:
+                logger.exception("Failed to cancel native MTP SpecPrefill bridge")
+
+    def _fail_native_mtp_specprefill_cohort(self, reason: str) -> None:
+        """Fail every request that shared one unclaimed bridge cohort."""
+        request_ids = self._native_mtp_specprefill_cohort_ids
+        self._cancel_native_mtp_specprefill_bridges()
+        for request_id in request_ids:
+            request = self.running.get(request_id)
+            if request is not None:
+                self._native_admission_errors[request_id] = reason
+
+    def _advance_native_mtp_specprefill_bridge(self) -> None:
+        """Commit at most one cooperative quantum before sparse cohort claim."""
+        if not self._native_mtp_specprefill_queue:
+            return
+        request_id = self._native_mtp_specprefill_queue.popleft()
+        bridge = self._native_mtp_specprefill_bridges.get(request_id)
+        if bridge is None:
+            return
+        try:
+            progress = bridge.step()
+        except Exception as exc:
+            reason = str(exc) or "native_mtp_specprefill_step_failed"
+            self._fail_native_mtp_specprefill_cohort(reason)
+            return
+        if progress.state.value == "terminal":
+            self._fail_native_mtp_specprefill_cohort(
+                progress.fallback_reason or "native_mtp_specprefill_failed"
+            )
+        elif progress.state.value != "bootstrap_ready":
+            self._native_mtp_specprefill_queue.append(request_id)
+
+    def _start_ready_native_mtp_specprefill_cohort(self) -> bool:
+        """Atomically transfer an all-ready bridge cohort to public MTP."""
+        bridges = self._native_mtp_specprefill_bridges
+        if not bridges or self._native_mtp_specprefill_queue:
+            return False
+        from .native_mtp_specprefill_bridge import NativeMTPSpecPrefillBridgeState
+        if any(
+            bridge.state is not NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY
+            for bridge in bridges.values()
+        ):
+            return False
+        from .native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+        requests = [self.running[request_id] for request_id in bridges]
+        original_uids = tuple(request.batch_uid for request in requests)
+        next_uid = self._next_native_mtp_uid
+        try:
+            for offset, request in enumerate(requests):
+                request.batch_uid = next_uid + offset
+            adapter = NativeMTPContinuousBatchAdapter.create(
+                self.model,
+                requests,
+                prefill_step_size=self.config.prefill_step_size,
+                sparse_bootstraps=[bridge.bootstrap for bridge in bridges.values()],
+                sparse_adopted=lambda: tuple(
+                    bridge.record_public_claim() for bridge in bridges.values()
+                ),
+            )
+        except Exception as exc:
+            for request, uid in zip(requests, original_uids):
+                request.batch_uid = uid
+                self._native_admission_errors[request.request_id] = (
+                    str(exc) or "native_mtp_sparse_adoption_failed"
+                )
+            self._fail_native_mtp_specprefill_cohort(
+                str(exc) or "native_mtp_sparse_adoption_failed"
+            )
+            return False
+        self._next_native_mtp_uid = next_uid + len(requests)
+        self.native_mtp_adapter = adapter
+        for request in requests:
+            self.request_id_to_uid[request.request_id] = request.batch_uid
+            self.uid_to_request_id[request.batch_uid] = request.request_id
+        return True
+
     def _start_native_mtp_cohort(self) -> List[Request]:
         """Admit one contiguous fresh native-MTP cohort without BatchGenerator."""
-        if self.native_mtp_adapter is not None or not self.waiting:
+        if (
+            self.native_mtp_adapter is not None
+            or self._native_mtp_specprefill_bridges
+            or not self.waiting
+        ):
             return []
         first = self.waiting[0]
         if first.native_mtp_config is None:
@@ -2464,6 +2673,9 @@ class Scheduler:
                 )
             else:
                 logger.warning("Native MTP cleanup failed: %s", cleanup_reason)
+        # Before the adapter reaches ``start_sparse``, it has not claimed the
+        # bridge receipts.  The bridge is still the only cleanup owner.
+        self._cancel_native_mtp_specprefill_bridges()
 
     def _schedule_waiting(self) -> List[Request]:
         """
@@ -2479,6 +2691,10 @@ class Scheduler:
             self._try_promote_ssd_pending()
 
         if self.native_mtp_adapter is not None:
+            return []
+        if self._native_mtp_specprefill_bridges:
+            self._advance_native_mtp_specprefill_bridge()
+            self._start_ready_native_mtp_specprefill_cohort()
             return []
         if (
             self.waiting
@@ -2500,6 +2716,9 @@ class Scheduler:
             and self.running
         ):
             return []
+        combined = self._start_native_mtp_specprefill_bridges()
+        if combined:
+            return combined
         native = self._start_native_mtp_cohort()
         if native:
             return native
@@ -3070,6 +3289,14 @@ class Scheduler:
                 # Run generation step if we have running requests
                 if self.native_mtp_adapter is not None and self.running:
                     emissions = self.native_mtp_adapter.step()
+                    if self._native_mtp_specprefill_bridges and all(
+                        bridge.state.value == "adopted"
+                        for bridge in self._native_mtp_specprefill_bridges.values()
+                    ):
+                        # Receipt claim has completed and bridge cleanup must
+                        # no longer touch cache now owned by the adapter.
+                        self._native_mtp_specprefill_bridges = {}
+                        self._native_mtp_specprefill_cohort_ids = ()
                     output.has_work = True
                     if emissions:
                         outputs, finished_ids = self._process_native_mtp_emissions(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1749,9 +1749,7 @@ class Scheduler:
 
     def _close_batch_generator(self) -> None:
         """Properly close BatchGenerator to restore wired_limit."""
-        if self.native_mtp_adapter is not None:
-            self.native_mtp_adapter.cancel()
-            self.native_mtp_adapter = None
+        self._cancel_native_mtp_adapter()
         if self.batch_generator is not None:
             try:
                 if hasattr(self.batch_generator, "close"):
@@ -2150,8 +2148,7 @@ class Scheduler:
         if self.native_mtp_adapter is not None and request_id in self.request_id_to_uid:
             # Public native lifecycle supports only cohort cancellation.  Do
             # not mutate hidden cache owners to remove one row mid-epoch.
-            self.native_mtp_adapter.cancel()
-            self.native_mtp_adapter = None
+            self._cancel_native_mtp_adapter()
             for active_id, active_request in self.running.items():
                 active_request.set_finished(RequestStatus.FINISHED_ABORTED)
                 self._native_cancelled_ids.add(active_id)
@@ -2419,9 +2416,7 @@ class Scheduler:
         self, reason: str
     ) -> tuple[List[RequestOutput], Set[str]]:
         """Close a failed public owner once and retain its primary reason."""
-        if self.native_mtp_adapter is not None:
-            self.native_mtp_adapter.cancel()
-            self.native_mtp_adapter = None
+        self._cancel_native_mtp_adapter(primary_reason=reason)
         failed_ids = set(self.running)
         outputs = []
         for request_id in failed_ids:
@@ -2439,6 +2434,36 @@ class Scheduler:
             )
         self._cleanup_finished(failed_ids)
         return outputs, failed_ids
+
+    def _cancel_native_mtp_adapter(self, *, primary_reason: str | None = None) -> None:
+        """Release a native cohort without allowing cleanup to replace failure.
+
+        Native epochs are move-only.  The public generator can therefore have
+        already consumed and poisoned an epoch when the Scheduler begins
+        terminal cleanup.  The adapter makes that state a no-op; any remaining
+        cleanup problem is recorded on the adapter and logged here.  Abort
+        outputs deliberately remain aborts rather than being reclassified as
+        model errors.
+        """
+        adapter = self.native_mtp_adapter
+        if adapter is None:
+            return
+        self.native_mtp_adapter = None
+        try:
+            adapter.cancel()
+        except Exception as error:
+            cleanup_reason = str(error) or type(error).__name__
+        else:
+            cleanup_reason = getattr(adapter, "cleanup_error_reason", None)
+        if cleanup_reason:
+            if primary_reason:
+                logger.warning(
+                    "Native MTP cleanup failed after terminal error %s: %s",
+                    primary_reason,
+                    cleanup_reason,
+                )
+            else:
+                logger.warning("Native MTP cleanup failed: %s", cleanup_reason)
 
     def _schedule_waiting(self) -> List[Request]:
         """
@@ -3054,8 +3079,7 @@ class Scheduler:
                         output.finished_request_ids = finished_ids
                         self._cleanup_finished(finished_ids)
                     if not self.native_mtp_adapter.active_uids:
-                        self.native_mtp_adapter.cancel()
-                        self.native_mtp_adapter = None
+                        self._cancel_native_mtp_adapter()
                 elif self.batch_generator is not None and self.running:
                     _sanitize_batch_generator_logits_processors(self.batch_generator)
                     result = self.batch_generator.next()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2412,6 +2412,7 @@ class Scheduler:
         if not bridges or self._native_mtp_specprefill_queue:
             return False
         from .native_mtp_specprefill_bridge import NativeMTPSpecPrefillBridgeState
+
         if any(
             bridge.state is not NativeMTPSpecPrefillBridgeState.BOOTSTRAP_READY
             for bridge in bridges.values()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -64,11 +64,11 @@ def _native_qwen_model_type(model: Any) -> str:
 
 
 def _continuous_batching_mtp_capability(model: Any, *, enabled: bool) -> Any | None:
-    """Fail closed for native Qwen MTP until a batched transaction core exists."""
+    """Return native capability; retain legacy gates for unsupported targets."""
     capability = _native_mtp_capability(model)
     if enabled and capability is not None:
         if capability.supported:
-            raise RuntimeError(NATIVE_MTP_CONTINUOUS_BATCHING_UNSUPPORTED)
+            return capability
         reason = getattr(capability, "reason", None)
         raise RuntimeError(
             reason if isinstance(reason, str) and reason else "native_mtp_unsupported"
@@ -77,6 +77,24 @@ def _continuous_batching_mtp_capability(model: Any, *, enabled: bool) -> Any | N
     if enabled and ("qwen3_5" in model_type or "qwen3_6" in model_type):
         raise RuntimeError("native_mtp_capability_missing")
     return capability
+
+
+def _reject_native_mtp_mllm(model: Any, *, enabled: bool) -> None:
+    """Keep native-MTP continuous batching out of every MLLM owner.
+
+    The public native lifecycle is admitted only by the standard-text
+    scheduler.  Qwen3-Next has no loader-owned native capability and retains
+    its existing legacy MLLM route.
+    """
+    if not enabled:
+        return
+    model_type = _native_qwen_model_type(model)
+    if (
+        _native_mtp_capability(model) is not None
+        or "qwen3_5" in model_type
+        or "qwen3_6" in model_type
+    ):
+        raise RuntimeError("native_mtp_mllm_unsupported")
 
 
 # Enable MambaCache batching support for models like Nemotron
@@ -1382,6 +1400,13 @@ class Scheduler:
         # BatchGenerator - the actual batching engine
         self.batch_generator: Optional[BatchGenerator] = None
         self._current_sampler_params: Optional[Tuple] = None
+        # Separate public lifecycle owner for native-Qwen standard-text CB.
+        # It never shares ownership with mlx-lm's ordinary BatchGenerator.
+        self.native_mtp_adapter = None
+        self._next_native_mtp_uid = 1
+        self._native_cancelled_ids: Set[str] = set()
+        self._native_zero_token_ids: Set[str] = set()
+        self._native_admission_errors: Dict[str, str] = {}
 
         # Prefix cache for KV state reuse
         self.prefix_cache: Optional[PrefixCacheManager] = None
@@ -1520,8 +1545,11 @@ class Scheduler:
         self, sampling_params: SamplingParams
     ) -> BatchGenerator:
         """Create a BatchGenerator with the given sampling parameters."""
+        native_capability = None
         if self.config.enable_mtp:
-            _continuous_batching_mtp_capability(self.model, enabled=True)
+            native_capability = _continuous_batching_mtp_capability(
+                self.model, enabled=True
+            )
 
         sampler = make_sampler(
             temp=sampling_params.temperature,
@@ -1586,7 +1614,7 @@ class Scheduler:
                 _install_prompt_cache_save(bg, prompt_cache_cb)
 
         # Install MTP if the model supports it
-        if self.config.enable_mtp:
+        if self.config.enable_mtp and native_capability is None:
             if hasattr(self.model, "mtp") and self.model.mtp is not None:
                 _install_mtp(
                     bg,
@@ -1721,6 +1749,9 @@ class Scheduler:
 
     def _close_batch_generator(self) -> None:
         """Properly close BatchGenerator to restore wired_limit."""
+        if self.native_mtp_adapter is not None:
+            self.native_mtp_adapter.cancel()
+            self.native_mtp_adapter = None
         if self.batch_generator is not None:
             try:
                 if hasattr(self.batch_generator, "close"):
@@ -1968,6 +1999,16 @@ class Scheduler:
                 request.prompt_token_ids = list(request.prompt)
             request.num_prompt_tokens = len(request.prompt_token_ids)
 
+        if request.native_mtp_config is not None:
+            self._validate_native_mtp_request(request)
+            # Native MTP owns fresh request caches at first prefill.  Do not
+            # consult or retain any generic prefix-cache state.
+            request.cache_hit_type = "miss"
+            request.remaining_tokens = request.prompt_token_ids
+            self.requests[request.request_id] = request
+            self.waiting.append(request)
+            return
+
         # Check prefix cache for cached KV state
         if self.block_aware_cache is not None:
             # Use paged cache
@@ -2098,7 +2139,23 @@ class Scheduler:
         Returns:
             True if any cleanup was performed, False otherwise
         """
+        # Cohort cancellation is drained once from ``step()``.  A second
+        # pending abort for another UID in that same owner must not fall
+        # through to ordinary BatchGenerator removal and steal its terminal
+        # output before the cohort drain runs.
+        if request_id in self._native_cancelled_ids:
+            return True
+
         request = self.requests.get(request_id)
+        if self.native_mtp_adapter is not None and request_id in self.request_id_to_uid:
+            # Public native lifecycle supports only cohort cancellation.  Do
+            # not mutate hidden cache owners to remove one row mid-epoch.
+            self.native_mtp_adapter.cancel()
+            self.native_mtp_adapter = None
+            for active_id, active_request in self.running.items():
+                active_request.set_finished(RequestStatus.FINISHED_ABORTED)
+                self._native_cancelled_ids.add(active_id)
+            return True
         was_waiting = False
         was_running = False
         removed_from_batch = False
@@ -2163,6 +2220,226 @@ class Scheduler:
         """Get number of running requests."""
         return len(self.running)
 
+    def _validate_native_mtp_request(self, request: Request) -> None:
+        """Reject every standard-CB composition outside fresh text-only MTP."""
+        if not self.config.enable_mtp:
+            raise RuntimeError("native_mtp_continuous_batching_disabled")
+        if self.config.enable_prefix_cache:
+            raise RuntimeError("native_mtp_prefix_reuse_unsupported")
+        if self.config.chunked_prefill_tokens:
+            raise RuntimeError("native_mtp_chunked_prefill_unsupported")
+        if self.config.kv_cache_quantization:
+            raise RuntimeError("native_mtp_quantized_cache_unsupported")
+        if self.config.max_kv_size:
+            raise RuntimeError("native_mtp_max_kv_unsupported")
+        if request.images or request.videos or request.is_multimodal:
+            raise RuntimeError("native_mtp_media_unsupported")
+        if getattr(request, "external_draft", False):
+            raise RuntimeError("native_mtp_external_draft_unsupported")
+        if request.prompt_cache is not None or request.cached_tokens:
+            raise RuntimeError("native_mtp_prefix_reuse_unsupported")
+        if request.sampling_params.logits_processors:
+            raise RuntimeError("native_mtp_logits_processors_unsupported")
+        if (
+            request.sampling_params.presence_penalty != 0.0
+            or request.sampling_params.repetition_penalty != 1.0
+        ):
+            raise RuntimeError("native_mtp_penalty_processors_unsupported")
+        request.native_mtp_eos_token_ids = self._get_stop_tokens().union(
+            request.sampling_params.stop_token_ids or ()
+        )
+
+    def _start_native_mtp_cohort(self) -> List[Request]:
+        """Admit one contiguous fresh native-MTP cohort without BatchGenerator."""
+        if self.native_mtp_adapter is not None or not self.waiting:
+            return []
+        first = self.waiting[0]
+        if first.native_mtp_config is None:
+            return []
+        if self.batch_generator is not None:
+            # An idle ordinary generator can retain cache ownership even with
+            # no running rows.  Close it before native fresh-cache admission.
+            self._close_batch_generator()
+        cohort = []
+        for request in self.waiting:
+            if (
+                request.native_mtp_config is None
+                or request.sampling_params.max_tokens == 0
+                or len(cohort) >= self.config.max_num_seqs
+            ):
+                break
+            cohort.append(request)
+        from .native_mtp_cb_adapter import NativeMTPContinuousBatchAdapter
+
+        original_uids = tuple(request.batch_uid for request in cohort)
+        next_uid = self._next_native_mtp_uid
+        try:
+            for offset, request in enumerate(cohort):
+                request.batch_uid = next_uid + offset
+            adapter = NativeMTPContinuousBatchAdapter.create(
+                self.model,
+                cohort,
+                prefill_step_size=self.config.prefill_step_size,
+            )
+        except BaseException as exc:
+            for request, original_uid in zip(cohort, original_uids):
+                request.batch_uid = original_uid
+            # Admission is all-or-nothing: convert this exact fresh cohort to
+            # one terminal error each.  Retrying an unchanged create failure
+            # would strand the queue forever.
+            for _ in cohort:
+                self.waiting.popleft()
+            reason = str(exc) or "native_mtp_cohort_admission_failed"
+            for request in cohort:
+                request.status = RequestStatus.RUNNING
+                self.running[request.request_id] = request
+                self._native_admission_errors[request.request_id] = reason
+            return cohort
+        self._next_native_mtp_uid = next_uid + len(cohort)
+        for _ in cohort:
+            self.waiting.popleft()
+        self.native_mtp_adapter = adapter
+        for request in cohort:
+            uid = request.batch_uid
+            self.request_id_to_uid[request.request_id] = uid
+            self.uid_to_request_id[uid] = request.request_id
+            request.status = RequestStatus.RUNNING
+            self.running[request.request_id] = request
+            self.total_prompt_tokens += request.num_prompt_tokens
+        return cohort
+
+    def _process_native_mtp_emissions(
+        self, emissions: List[Any]
+    ) -> Tuple[List[RequestOutput], Set[str]]:
+        """Translate immutable public MTP emissions into ordinary scheduler output."""
+        outputs: List[RequestOutput] = []
+        finished_ids: Set[str] = set()
+        for emission in emissions:
+            request_id = self.uid_to_request_id.get(emission.uid)
+            request = self.running.get(request_id) if request_id else None
+            if request is None:
+                continue
+            request.append_output_token(emission.token)
+            if emission.finish_reason == "eos":
+                finish_reason = "stop"
+            else:
+                finish_reason = emission.finish_reason
+            detok = self._get_detokenizer(request_id)
+            if finish_reason == "stop":
+                new_text = ""
+            else:
+                detok.add_token(emission.token)
+                new_text = detok.last_segment
+            telemetry = self.native_mtp_adapter.telemetry_for(emission.uid)
+            output = RequestOutput(
+                request_id=request_id,
+                new_token_ids=[emission.token],
+                new_text=new_text,
+                output_token_ids=request.output_token_ids,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                mtp_drafts=telemetry["draft_tokens"],
+                mtp_accepted=telemetry["accepted_tokens"],
+                logprobs=emission.logprobs,
+            )
+            if finish_reason is not None:
+                request.set_finished(
+                    (
+                        RequestStatus.FINISHED_STOPPED
+                        if finish_reason == "stop"
+                        else RequestStatus.FINISHED_LENGTH_CAPPED
+                    ),
+                    finish_reason,
+                )
+                output.finished = True
+                output.finish_reason = finish_reason
+                detok.finalize()
+                output.output_text = detok.text
+                request.output_text = output.output_text
+                self._cleanup_detokenizer(request_id)
+                self.total_completion_tokens += request.num_output_tokens
+                self.num_requests_processed += 1
+                finished_ids.add(request_id)
+            outputs.append(output)
+        return outputs, finished_ids
+
+    def _drain_native_zero_token_requests(self) -> SchedulerOutput | None:
+        """Return zero-budget terminal outputs without creating an MTP owner."""
+        if not self._native_zero_token_ids:
+            return None
+        output = SchedulerOutput()
+        zero_token_ids = set(self._native_zero_token_ids)
+        self._native_zero_token_ids.clear()
+        for request_id in zero_token_ids:
+            request = self.running.get(request_id)
+            if request is None:
+                continue
+            request.set_finished(RequestStatus.FINISHED_LENGTH_CAPPED, "length")
+            output.outputs.append(
+                RequestOutput(
+                    request_id=request_id,
+                    finished=True,
+                    finish_reason="length",
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=0,
+                )
+            )
+        output.finished_request_ids = zero_token_ids
+        self._cleanup_finished(zero_token_ids)
+        return output
+
+    def _drain_native_admission_errors(self) -> SchedulerOutput | None:
+        """Emit each failed native admission once, before scheduler retries."""
+        if not self._native_admission_errors:
+            return None
+        output = SchedulerOutput()
+        errors = dict(self._native_admission_errors)
+        self._native_admission_errors.clear()
+        finished_ids = set(errors)
+        for request_id, reason in errors.items():
+            request = self.running.get(request_id)
+            if request is None:
+                continue
+            request.set_finished(RequestStatus.FINISHED_ABORTED, "error")
+            output.outputs.append(
+                RequestOutput(
+                    request_id=request_id,
+                    finished=True,
+                    finish_reason="error",
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=request.num_output_tokens,
+                    native_mtp_error_reason=reason,
+                )
+            )
+        output.finished_request_ids = finished_ids
+        self._cleanup_finished(finished_ids)
+        return output
+
+    def _terminal_native_cohort_error(
+        self, reason: str
+    ) -> tuple[List[RequestOutput], Set[str]]:
+        """Close a failed public owner once and retain its primary reason."""
+        if self.native_mtp_adapter is not None:
+            self.native_mtp_adapter.cancel()
+            self.native_mtp_adapter = None
+        failed_ids = set(self.running)
+        outputs = []
+        for request_id in failed_ids:
+            request = self.running[request_id]
+            request.set_finished(RequestStatus.FINISHED_ABORTED, "error")
+            outputs.append(
+                RequestOutput(
+                    request_id=request_id,
+                    finished=True,
+                    finish_reason="error",
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=request.num_output_tokens,
+                    native_mtp_error_reason=reason,
+                )
+            )
+        self._cleanup_finished(failed_ids)
+        return outputs, failed_ids
+
     def _schedule_waiting(self) -> List[Request]:
         """
         Move requests from waiting queue to running.
@@ -2175,6 +2452,32 @@ class Scheduler:
         # avoiding engine modifications.
         if self._ssd_tier is not None:
             self._try_promote_ssd_pending()
+
+        if self.native_mtp_adapter is not None:
+            return []
+        if (
+            self.waiting
+            and self.waiting[0].native_mtp_config is not None
+            and self.waiting[0].sampling_params.max_tokens == 0
+        ):
+            # This precedes cohort admission: no public lifecycle import,
+            # UID allocation, cache construction, or model mutation occurs.
+            request = self.waiting.popleft()
+            request.status = RequestStatus.RUNNING
+            self.running[request.request_id] = request
+            self._native_zero_token_ids.add(request.request_id)
+            return [request]
+        # The public lifecycle has a single move-only cohort owner.  Never
+        # interleave it with an ordinary BatchGenerator cohort.
+        if (
+            self.waiting
+            and self.waiting[0].native_mtp_config is not None
+            and self.running
+        ):
+            return []
+        native = self._start_native_mtp_cohort()
+        if native:
+            return native
 
         scheduled = []
 
@@ -2690,6 +2993,31 @@ class Scheduler:
 
         # Process pending aborts FIRST (in executor thread, safe for MLX)
         self._process_pending_aborts()
+        zero_output = self._drain_native_zero_token_requests()
+        if zero_output is not None:
+            return zero_output
+        admission_error_output = self._drain_native_admission_errors()
+        if admission_error_output is not None:
+            return admission_error_output
+        if self._native_cancelled_ids:
+            cancelled = set(self._native_cancelled_ids)
+            self._native_cancelled_ids.clear()
+            for request_id in cancelled:
+                request = self.running.get(request_id)
+                if request is None:
+                    continue
+                output.outputs.append(
+                    RequestOutput(
+                        request_id=request_id,
+                        finished=True,
+                        finish_reason="abort",
+                        prompt_tokens=request.num_prompt_tokens,
+                        completion_tokens=request.num_output_tokens,
+                    )
+                )
+            output.finished_request_ids = cancelled
+            self._cleanup_finished(cancelled)
+            return output
 
         for attempt in range(max_retries + 1):
             try:
@@ -2699,9 +3027,36 @@ class Scheduler:
                 output.num_scheduled_tokens = sum(
                     r.num_prompt_tokens for r in scheduled
                 )
+                zero_output = self._drain_native_zero_token_requests()
+                if zero_output is not None:
+                    zero_output.scheduled_request_ids = output.scheduled_request_ids
+                    zero_output.num_scheduled_tokens = output.num_scheduled_tokens
+                    return zero_output
+                admission_error_output = self._drain_native_admission_errors()
+                if admission_error_output is not None:
+                    admission_error_output.scheduled_request_ids = (
+                        output.scheduled_request_ids
+                    )
+                    admission_error_output.num_scheduled_tokens = (
+                        output.num_scheduled_tokens
+                    )
+                    return admission_error_output
 
                 # Run generation step if we have running requests
-                if self.batch_generator is not None and self.running:
+                if self.native_mtp_adapter is not None and self.running:
+                    emissions = self.native_mtp_adapter.step()
+                    output.has_work = True
+                    if emissions:
+                        outputs, finished_ids = self._process_native_mtp_emissions(
+                            list(emissions)
+                        )
+                        output.outputs = outputs
+                        output.finished_request_ids = finished_ids
+                        self._cleanup_finished(finished_ids)
+                    if not self.native_mtp_adapter.active_uids:
+                        self.native_mtp_adapter.cancel()
+                        self.native_mtp_adapter = None
+                elif self.batch_generator is not None and self.running:
                     _sanitize_batch_generator_logits_processors(self.batch_generator)
                     result = self.batch_generator.next()
                     output.has_work = True
@@ -2723,6 +3078,13 @@ class Scheduler:
                 break
 
             except TypeError as e:
+                if self.native_mtp_adapter is not None:
+                    output.outputs, output.finished_request_ids = (
+                        self._terminal_native_cohort_error(
+                            str(e) or "native_mtp_cohort_failed"
+                        )
+                    )
+                    break
                 # Catch the NoneType error specifically
                 if self._is_cache_corruption_error(e):
                     if attempt < max_retries:
@@ -2743,6 +3105,13 @@ class Scheduler:
                 else:
                     raise
             except Exception as e:
+                if self.native_mtp_adapter is not None:
+                    output.outputs, output.finished_request_ids = (
+                        self._terminal_native_cohort_error(
+                            str(e) or "native_mtp_cohort_failed"
+                        )
+                    )
+                    break
                 if self._is_stream_thread_error(e):
                     raise
                 import traceback

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -32,6 +32,53 @@ from .utils.mamba_cache import ensure_mamba_support
 
 logger = logging.getLogger(__name__)
 
+NATIVE_MTP_CONTINUOUS_BATCHING_UNSUPPORTED = (
+    "native_mtp_continuous_batching_unsupported"
+)
+
+
+def _native_mtp_capability(model: Any) -> Any | None:
+    """Return the loader-owned native-MTP contract for one exact target."""
+    candidates = (model, getattr(model, "language_model", None))
+    for candidate in candidates:
+        capability = getattr(candidate, "mtp_capability", None)
+        if capability is None:
+            continue
+        if not isinstance(getattr(capability, "supported", None), bool):
+            raise RuntimeError("native_mtp_capability_invalid")
+        return capability
+    return None
+
+
+def _native_qwen_model_type(model: Any) -> str:
+    candidates = (model, getattr(model, "language_model", None))
+    for candidate in candidates:
+        config = getattr(candidate, "config", None) or getattr(candidate, "args", None)
+        if isinstance(config, dict):
+            model_type = config.get("model_type", "")
+        else:
+            model_type = getattr(config, "model_type", "")
+        if isinstance(model_type, str) and model_type:
+            return model_type.lower()
+    return ""
+
+
+def _continuous_batching_mtp_capability(model: Any, *, enabled: bool) -> Any | None:
+    """Fail closed for native Qwen MTP until a batched transaction core exists."""
+    capability = _native_mtp_capability(model)
+    if enabled and capability is not None:
+        if capability.supported:
+            raise RuntimeError(NATIVE_MTP_CONTINUOUS_BATCHING_UNSUPPORTED)
+        reason = getattr(capability, "reason", None)
+        raise RuntimeError(
+            reason if isinstance(reason, str) and reason else "native_mtp_unsupported"
+        )
+    model_type = _native_qwen_model_type(model)
+    if enabled and ("qwen3_5" in model_type or "qwen3_6" in model_type):
+        raise RuntimeError("native_mtp_capability_missing")
+    return capability
+
+
 # Enable MambaCache batching support for models like Nemotron
 ensure_mamba_support()
 
@@ -1473,6 +1520,9 @@ class Scheduler:
         self, sampling_params: SamplingParams
     ) -> BatchGenerator:
         """Create a BatchGenerator with the given sampling parameters."""
+        if self.config.enable_mtp:
+            _continuous_batching_mtp_capability(self.model, enabled=True)
+
         sampler = make_sampler(
             temp=sampling_params.temperature,
             top_p=sampling_params.top_p,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -570,8 +570,39 @@ def _resolve_no_final_content_token_limit() -> int | None:
 
 def _generation_metadata(
     thinking_processor: object | None,
+    output: GenerationOutput | None = None,
 ) -> GenerationMetadata | None:
-    if thinking_processor is None:
+    feature_fields = {
+        "mtp_drafts": getattr(output, "mtp_drafts", None),
+        "mtp_accepted": getattr(output, "mtp_accepted", None),
+        "specprefill_requested_policy": getattr(
+            output, "specprefill_requested_policy", None
+        ),
+        "specprefill_effective_policy": getattr(
+            output, "specprefill_effective_policy", None
+        ),
+        "specprefill_coverage": getattr(output, "specprefill_coverage", None),
+        "specprefill_engaged": getattr(output, "specprefill_engaged", None),
+        "specprefill_selector_version": getattr(
+            output, "specprefill_selector_version", None
+        ),
+        "specprefill_fallback_reason": getattr(
+            output, "specprefill_fallback_reason", None
+        ),
+        "specprefill_total_tokens": getattr(output, "specprefill_total_tokens", None),
+        "specprefill_selected_tokens": getattr(
+            output, "specprefill_selected_tokens", None
+        ),
+        "specprefill_scorer_ms": getattr(output, "specprefill_scorer_ms", None),
+        "specprefill_target_prefill_ms": getattr(
+            output, "specprefill_target_prefill_ms", None
+        ),
+    }
+    has_feature_metadata = (
+        any(value is not None and value != 0 for value in feature_fields.values())
+        or feature_fields["specprefill_engaged"] is False
+    )
+    if thinking_processor is None and not has_feature_metadata:
         return None
     return GenerationMetadata(
         no_final_content_watchdog_tokens=getattr(
@@ -580,7 +611,29 @@ def _generation_metadata(
         no_final_content_watchdog_enforced=bool(
             getattr(thinking_processor, "watchdog_was_enforced", False)
         ),
+        **feature_fields,
     )
+
+
+def _attach_specprefill_request_kwargs(
+    request: object,
+    kwargs: dict[str, object],
+    *,
+    has_media: bool = False,
+) -> None:
+    """Forward the public policy contract without making a route decision."""
+    for name in (
+        "specprefill",
+        "specprefill_policy",
+        "specprefill_coverage",
+        "specprefill_keep_pct",
+        "specprefill_backbone_pct",
+    ):
+        value = getattr(request, name, None)
+        if value is not None:
+            kwargs[name] = value
+    # Engines use this explicit signal to make text-only support fail safe.
+    kwargs["specprefill_has_media"] = bool(has_media)
 
 
 class _ThinkingAwareLogitsProcessor:
@@ -784,13 +837,7 @@ def _prepare_chat_completion_invocation(
         if video_max_frames:
             chat_kwargs["video_max_frames"] = video_max_frames
 
-    if request.specprefill is not None:
-        chat_kwargs["specprefill"] = request.specprefill
-    if request.specprefill_keep_pct is not None:
-        chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
-    specprefill_backbone_pct = getattr(request, "specprefill_backbone_pct", None)
-    if specprefill_backbone_pct is not None:
-        chat_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
+    _attach_specprefill_request_kwargs(request, chat_kwargs, has_media=has_media)
     resolved_chat_template_kwargs = _resolve_chat_template_kwargs(
         request.chat_template_kwargs
     )
@@ -4837,15 +4884,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(
                 comp_rep_penalty
             )
-            if request.specprefill is not None:
-                generate_kwargs["specprefill"] = request.specprefill
-            if request.specprefill_keep_pct is not None:
-                generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
-            specprefill_backbone_pct = getattr(
-                request, "specprefill_backbone_pct", None
-            )
-            if specprefill_backbone_pct is not None:
-                generate_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
+            _attach_specprefill_request_kwargs(request, generate_kwargs)
             try:
                 if raw_request is None:
                     output = await engine.generate(**generate_kwargs)
@@ -5015,6 +5054,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                             prepared.messages,
                             request,
                             metrics_tracker=tracker,
+                            thinking_processor=prepared.thinking_processor,
                             **prepared.chat_kwargs,
                         ),
                         "data: [DONE]\n\n",
@@ -5105,7 +5145,10 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 completion_tokens=output.completion_tokens,
                 total_tokens=output.prompt_tokens + output.completion_tokens,
             ),
-            generation_metadata=_generation_metadata(prepared.thinking_processor),
+            generation_metadata=_generation_metadata(
+                prepared.thinking_processor,
+                output,
+            ),
         )
     finally:
         if release_on_exit:
@@ -6023,13 +6066,7 @@ async def stream_completion(
     generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(
         repetition_penalty
     )
-    if request.specprefill is not None:
-        generate_kwargs["specprefill"] = request.specprefill
-    if request.specprefill_keep_pct is not None:
-        generate_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
-    specprefill_backbone_pct = getattr(request, "specprefill_backbone_pct", None)
-    if specprefill_backbone_pct is not None:
-        generate_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
+    _attach_specprefill_request_kwargs(request, generate_kwargs)
 
     try:
         async for output in engine.stream_generate(**generate_kwargs):
@@ -6087,6 +6124,7 @@ async def stream_chat_completion(
     messages: list,
     request: ChatCompletionRequest,
     metrics_tracker=None,
+    thinking_processor: object | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response."""
@@ -6143,6 +6181,11 @@ async def stream_chat_completion(
     try:
         # Stream content
         async for output in engine.stream_chat(messages=messages, **kwargs):
+            terminal_metadata = (
+                _generation_metadata(thinking_processor, output)
+                if output.finished
+                else None
+            )
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
             delta_text = output.new_text
@@ -6252,6 +6295,7 @@ async def stream_chat_completion(
                                     )
                                 ],
                                 usage=get_usage(output) if output.finished else None,
+                                generation_metadata=terminal_metadata,
                             )
                             yield f"data: {chunk.model_dump_json()}\n\n"
                             continue
@@ -6287,6 +6331,7 @@ async def stream_chat_completion(
                         )
                     ],
                     usage=get_usage(output) if output.finished else None,
+                    generation_metadata=terminal_metadata,
                 )
                 yield f"data: {chunk.model_dump_json()}\n\n"
             else:
@@ -6357,6 +6402,7 @@ async def stream_chat_completion(
                                     )
                                 ],
                                 usage=get_usage(output) if output.finished else None,
+                                generation_metadata=terminal_metadata,
                             )
                             yield f"data: {chunk.model_dump_json()}\n\n"
                             continue
@@ -6391,6 +6437,7 @@ async def stream_chat_completion(
                         )
                     ],
                     usage=get_usage(output) if output.finished else None,
+                    generation_metadata=terminal_metadata,
                 )
                 yield f"data: {chunk.model_dump_json()}\n\n"
 
@@ -6487,6 +6534,11 @@ async def stream_chat_completion(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                ),
+                generation_metadata=(
+                    _generation_metadata(thinking_processor, last_output)
+                    if last_output is not None
+                    else None
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -615,6 +615,52 @@ def _generation_metadata(
     )
 
 
+def _aggregate_completion_generation_metadata(
+    outputs: list[GenerationOutput],
+) -> GenerationMetadata | None:
+    """Return request-level terminal diagnostics for one or more prompts.
+
+    ``/v1/completions`` accepts a prompt list but has one response-level
+    extension field, unlike its per-choice text.  Counters and timings are
+    additive across independently generated prompts.  A policy/status value
+    is published only when every participating output agrees; reporting the
+    last row's routing decision for a mixed request would be misleading.
+    """
+    metadata = [_generation_metadata(None, output) for output in outputs]
+    if not any(item is not None for item in metadata):
+        return None
+    if len(metadata) == 1:
+        return metadata[0]
+
+    def common(name: str):
+        values = {
+            getattr(item, name) if item is not None else None for item in metadata
+        }
+        return values.pop() if len(values) == 1 else None
+
+    def summed(name: str):
+        values = [
+            getattr(item, name) if item is not None else None for item in metadata
+        ]
+        present = [value for value in values if value is not None]
+        return sum(present) if present else None
+
+    return GenerationMetadata(
+        mtp_drafts=summed("mtp_drafts"),
+        mtp_accepted=summed("mtp_accepted"),
+        specprefill_requested_policy=common("specprefill_requested_policy"),
+        specprefill_effective_policy=common("specprefill_effective_policy"),
+        specprefill_coverage=common("specprefill_coverage"),
+        specprefill_engaged=common("specprefill_engaged"),
+        specprefill_selector_version=common("specprefill_selector_version"),
+        specprefill_fallback_reason=common("specprefill_fallback_reason"),
+        specprefill_total_tokens=summed("specprefill_total_tokens"),
+        specprefill_selected_tokens=summed("specprefill_selected_tokens"),
+        specprefill_scorer_ms=summed("specprefill_scorer_ms"),
+        specprefill_target_prefill_ms=summed("specprefill_target_prefill_ms"),
+    )
+
+
 def _attach_specprefill_request_kwargs(
     request: object,
     kwargs: dict[str, object],
@@ -4868,6 +4914,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         # Non-streaming response with timing and timeout
         start_time = time.perf_counter()
         choices = []
+        terminal_outputs = []
         total_completion_tokens = 0
         total_prompt_tokens = 0
         for i, prompt in enumerate(prompts):
@@ -4916,6 +4963,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     finish_reason=output.finish_reason,
                 )
             )
+            terminal_outputs.append(output)
             total_completion_tokens += output.completion_tokens
             total_prompt_tokens += (
                 output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
@@ -4939,6 +4987,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 prompt_tokens=total_prompt_tokens,
                 completion_tokens=total_completion_tokens,
                 total_tokens=total_prompt_tokens + total_completion_tokens,
+            ),
+            generation_metadata=_aggregate_completion_generation_metadata(
+                terminal_outputs
             ),
         )
     finally:
@@ -6099,6 +6150,11 @@ async def stream_completion(
             }
             if output.finished:
                 data["usage"] = get_usage(output).model_dump()
+                terminal_metadata = _generation_metadata(None, output)
+                if terminal_metadata is not None:
+                    data["generation_metadata"] = terminal_metadata.model_dump(
+                        exclude_none=True
+                    )
             yield f"data: {json.dumps(data)}\n\n"
     except HTTPException as exc:
         result = _metrics_result_from_status(exc.status_code)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -174,6 +174,12 @@ from .model_registry import (
 )
 from .metrics import metrics as _metrics
 from .models.mllm import UnsafeRemoteURLError, _validate_url_safety, is_url
+from .native_mtp_request import (
+    NativeMTPRequestError,
+    NativeMTPSampling,
+    NativeMTPServerState,
+    resolve_native_mtp_request,
+)
 from .reasoning import get_parser as get_reasoning_parser
 from .tool_parsers import ToolParserManager, get_parser_stop_tokens
 
@@ -575,6 +581,7 @@ def _generation_metadata(
     feature_fields = {
         "mtp_drafts": getattr(output, "mtp_drafts", None),
         "mtp_accepted": getattr(output, "mtp_accepted", None),
+        "mtp_bypass_reason": getattr(output, "mtp_bypass_reason", None),
         "specprefill_requested_policy": getattr(
             output, "specprefill_requested_policy", None
         ),
@@ -648,6 +655,7 @@ def _aggregate_completion_generation_metadata(
     return GenerationMetadata(
         mtp_drafts=summed("mtp_drafts"),
         mtp_accepted=summed("mtp_accepted"),
+        mtp_bypass_reason=common("mtp_bypass_reason"),
         specprefill_requested_policy=common("specprefill_requested_policy"),
         specprefill_effective_policy=common("specprefill_effective_policy"),
         specprefill_coverage=common("specprefill_coverage"),
@@ -681,6 +689,114 @@ def _attach_specprefill_request_kwargs(
             kwargs[name] = value
     # Engines use this explicit signal to make text-only support fail safe.
     kwargs["specprefill_has_media"] = bool(has_media)
+
+
+def _attach_native_mtp_request_kwargs(
+    engine: BaseEngine,
+    request: ChatCompletionRequest | CompletionRequest,
+    kwargs: dict[str, object],
+    *,
+    has_media: bool = False,
+) -> None:
+    """Resolve and attach native MTP before invoking an engine method.
+
+    The private kwargs are consumed by ``SimpleEngine`` and never forwarded to
+    mlx-lm/mlx-vlm. Default-off and external-drafter paths get no new kwargs.
+    """
+
+    requested = request.mtp
+    state_resolver = getattr(engine, "native_mtp_server_state", None)
+    if state_resolver is None:
+        state = NativeMTPServerState(
+            server_default=False,
+            capable=False,
+            incompatibility="native_mtp_unsupported_engine",
+        )
+    else:
+        state = state_resolver(has_media=has_media)
+        if not isinstance(state, NativeMTPServerState):
+            raise RuntimeError("native_mtp_server_state returned an invalid contract")
+
+    if requested is False:
+        # An opt-out only needs an internal control when it changes an active
+        # native default. Default-off and external-drafter routes stay byte-for-
+        # byte identical and receive no new backend kwargs.
+        if state.server_default and state.capable:
+            kwargs["_native_mtp_disabled"] = True
+        return
+
+    processors = tuple(kwargs.get("logits_processors") or ())
+    incompatibility = state.incompatibility
+    if getattr(request, "mllm_draft", None) is True:
+        incompatibility = "native_mtp_external_draft_selected"
+    elif processors:
+        # Processor state/opacity is not introspected.  A future capability may
+        # explicitly admit a known immutable processor type, but the default is
+        # deliberately fail closed.
+        incompatibility = "native_mtp_logits_processors_unsupported"
+    elif not state.supports_penalty_processors and (
+        float(kwargs["presence_penalty"]) != 0.0
+        or float(kwargs["repetition_penalty"]) != 1.0
+    ):
+        incompatibility = "native_mtp_penalty_processors_unsupported"
+
+    sampling = NativeMTPSampling(
+        temperature=float(kwargs["temperature"]),
+        top_p=float(kwargs["top_p"]),
+        top_k=int(kwargs["top_k"]),
+        min_p=float(kwargs["min_p"]),
+        presence_penalty=float(kwargs["presence_penalty"]),
+        repetition_penalty=float(kwargs["repetition_penalty"]),
+        seed=request.seed,
+    )
+    try:
+        decision = resolve_native_mtp_request(
+            requested=requested,
+            sampling=sampling,
+            server_default=state.server_default,
+            capable=state.capable,
+            num_draft_tokens=state.num_draft_tokens,
+            incompatibility=incompatibility,
+        )
+    except NativeMTPRequestError as exc:
+        raise HTTPException(status_code=422, detail=exc.reason) from exc
+
+    if request.seed is not None and decision.config is None:
+        raise HTTPException(
+            status_code=422,
+            detail="native_mtp_seed_requires_effective_mtp",
+        )
+    if decision.config is not None:
+        kwargs["_native_mtp_request_config"] = decision.config
+    elif decision.bypass_reason is not None:
+        # Prevent the downstream wrapper's legacy model-global default from
+        # re-enabling MTP after request admission deliberately bypassed it.
+        kwargs["_native_mtp_disabled"] = True
+        kwargs["_native_mtp_bypass_reason"] = decision.bypass_reason
+
+
+def _preflight_streaming_completion_native_mtp(
+    engine: BaseEngine,
+    request: CompletionRequest,
+    *,
+    repetition_penalty: float | None,
+) -> dict[str, object]:
+    """Finish explicit MTP admission before an SSE response starts."""
+
+    kwargs: dict[str, object] = {
+        "temperature": _resolve_temperature(request.temperature),
+        "top_p": _resolve_top_p(request.top_p),
+        "top_k": _resolve_top_k(request.top_k),
+        "min_p": _resolve_min_p(request.min_p),
+        "presence_penalty": _resolve_presence_penalty(request.presence_penalty),
+        "repetition_penalty": _resolve_repetition_penalty(repetition_penalty),
+    }
+    _attach_native_mtp_request_kwargs(engine, request, kwargs)
+    return {
+        name: value
+        for name, value in kwargs.items()
+        if name.startswith("_native_mtp_")
+    }
 
 
 def _configure_batched_specprefill(
@@ -994,6 +1110,13 @@ def _prepare_chat_completion_invocation(
             ):
                 existing_processors = existing_processors[:-1]
             chat_kwargs["logits_processors"] = existing_processors + [thinking_proc]
+
+    _attach_native_mtp_request_kwargs(
+        engine,
+        request,
+        chat_kwargs,
+        has_media=has_media,
+    )
 
     return PreparedChatInvocation(
         messages=messages,
@@ -1758,6 +1881,8 @@ def _metrics_result_from_status(status_code: int) -> str:
         return "timeout"
     if status_code >= 500:
         return "error"
+    if status_code >= 400:
+        return "client_error"
     return "success"
 
 
@@ -4977,6 +5102,15 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
 
     try:
         if request.stream:
+            try:
+                native_mtp_controls = _preflight_streaming_completion_native_mtp(
+                    engine,
+                    request,
+                    repetition_penalty=comp_rep_penalty,
+                )
+            except HTTPException as exc:
+                tracker.finish(result=_metrics_result_from_status(exc.status_code))
+                raise
             response = StreamingResponse(
                 _disconnect_guard(
                     _ensure_sse_terminal(
@@ -4986,6 +5120,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                             request,
                             effective_max_tokens,
                             repetition_penalty=comp_rep_penalty,
+                            native_mtp_controls=native_mtp_controls,
                             metrics_tracker=tracker,
                         ),
                         "data: [DONE]\n\n",
@@ -5019,8 +5154,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             generate_kwargs["repetition_penalty"] = _resolve_repetition_penalty(
                 comp_rep_penalty
             )
-            _attach_specprefill_request_kwargs(request, generate_kwargs)
             try:
+                _attach_specprefill_request_kwargs(request, generate_kwargs)
+                _attach_native_mtp_request_kwargs(engine, request, generate_kwargs)
                 if raw_request is None:
                     output = await engine.generate(**generate_kwargs)
                 else:
@@ -5185,6 +5321,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
         except UnsafeRemoteURLError as exc:
             tracker.finish(result="client_error")
             _raise_remote_media_http_error(exc)
+        except HTTPException as exc:
+            tracker.finish(result=_metrics_result_from_status(exc.status_code))
+            raise
 
         if request.stream:
             response = StreamingResponse(
@@ -6188,6 +6327,7 @@ async def stream_completion(
     request: CompletionRequest,
     max_tokens: int,
     repetition_penalty: float | None = None,
+    native_mtp_controls: dict[str, object] | None = None,
     metrics_tracker=None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
@@ -6208,6 +6348,10 @@ async def stream_completion(
         repetition_penalty
     )
     _attach_specprefill_request_kwargs(request, generate_kwargs)
+    if native_mtp_controls is None:
+        _attach_native_mtp_request_kwargs(engine, request, generate_kwargs)
+    else:
+        generate_kwargs.update(native_mtp_controls)
 
     try:
         async for output in engine.stream_generate(**generate_kwargs):

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -793,9 +793,7 @@ def _preflight_streaming_completion_native_mtp(
     }
     _attach_native_mtp_request_kwargs(engine, request, kwargs)
     return {
-        name: value
-        for name, value in kwargs.items()
-        if name.startswith("_native_mtp_")
+        name: value for name, value in kwargs.items() if name.startswith("_native_mtp_")
     }
 
 
@@ -817,9 +815,7 @@ def _configure_batched_specprefill(
     else:
         configured = copy.copy(scheduler_config)
         configured.specprefill_enabled = True
-    builder_inputs = getattr(
-        configured, "specprefill_runtime_builder_inputs", None
-    )
+    builder_inputs = getattr(configured, "specprefill_runtime_builder_inputs", None)
     if configured.specprefill_prepare is None and builder_inputs is not None:
         from .specprefill_runtime import build_qwen_cb_specprefill_prepare
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -701,6 +701,15 @@ def _configure_batched_specprefill(
     else:
         configured = copy.copy(scheduler_config)
         configured.specprefill_enabled = True
+    builder_inputs = getattr(
+        configured, "specprefill_runtime_builder_inputs", None
+    )
+    if configured.specprefill_prepare is None and builder_inputs is not None:
+        from .specprefill_runtime import build_qwen_cb_specprefill_prepare
+
+        configured.specprefill_prepare = build_qwen_cb_specprefill_prepare(
+            **dict(builder_inputs)
+        )
     if not callable(getattr(configured, "specprefill_prepare", None)):
         raise ValueError(
             "continuous-batching SpecPrefill is unavailable without an explicit "
@@ -3742,6 +3751,8 @@ async def status():
         or stats.get("paged_cache")
         or stats.get("prefix_cache"),
         "mtp": stats.get("mtp") or {"enabled": False},
+        "specprefill": stats.get("specprefill")
+        or {"enabled": False, "advertisable": False, "diagnostic": False},
         "requests": stats.get("requests", []),
     }
 
@@ -3910,9 +3921,27 @@ async def list_models() -> ModelsResponse:
     """List available models."""
     models = []
     if _model_manager is not None:
-        models.extend(ModelInfo(id=item["id"]) for item in _model_manager.list_models())
+        models.extend(
+            ModelInfo(
+                id=item["id"],
+                capabilities=list(item.get("capabilities", ())),
+            )
+            for item in _model_manager.list_models()
+        )
     elif _model_name:
-        models.append(ModelInfo(id=_model_name))
+        capabilities = []
+        if _engine is not None:
+            try:
+                specprefill = _engine.get_stats().get("specprefill", {})
+            except Exception:
+                specprefill = {}
+            if (
+                specprefill.get("enabled") is True
+                and specprefill.get("advertisable") is True
+                and specprefill.get("diagnostic") is False
+            ):
+                capabilities.append("specprefill")
+        models.append(ModelInfo(id=_model_name, capabilities=capabilities))
     if _embedding_engine is not None:
         models.append(
             ModelInfo(id=_embedding_engine.model_name, owned_by="vllm-mlx-embedding")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -704,7 +704,7 @@ def _attach_native_mtp_request_kwargs(
     mlx-lm/mlx-vlm. Default-off and external-drafter paths get no new kwargs.
     """
 
-    requested = request.mtp
+    requested = getattr(request, "mtp", None)
     state_resolver = getattr(engine, "native_mtp_server_state", None)
     if state_resolver is None:
         state = NativeMTPServerState(
@@ -740,6 +740,7 @@ def _attach_native_mtp_request_kwargs(
     ):
         incompatibility = "native_mtp_penalty_processors_unsupported"
 
+    seed = getattr(request, "seed", None)
     sampling = NativeMTPSampling(
         temperature=float(kwargs["temperature"]),
         top_p=float(kwargs["top_p"]),
@@ -747,7 +748,7 @@ def _attach_native_mtp_request_kwargs(
         min_p=float(kwargs["min_p"]),
         presence_penalty=float(kwargs["presence_penalty"]),
         repetition_penalty=float(kwargs["repetition_penalty"]),
-        seed=request.seed,
+        seed=seed,
     )
     try:
         decision = resolve_native_mtp_request(
@@ -761,7 +762,7 @@ def _attach_native_mtp_request_kwargs(
     except NativeMTPRequestError as exc:
         raise HTTPException(status_code=422, detail=exc.reason) from exc
 
-    if request.seed is not None and decision.config is None:
+    if seed is not None and decision.config is None:
         raise HTTPException(
             status_code=422,
             detail="native_mtp_seed_requires_effective_mtp",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -40,8 +40,8 @@ The server provides:
 import argparse
 import asyncio
 import copy
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 import logging
 import os
 import re
@@ -672,6 +672,7 @@ def _attach_specprefill_request_kwargs(
         "specprefill",
         "specprefill_policy",
         "specprefill_coverage",
+        "specprefill_control_token_indices",
         "specprefill_keep_pct",
         "specprefill_backbone_pct",
     ):
@@ -680,6 +681,52 @@ def _attach_specprefill_request_kwargs(
             kwargs[name] = value
     # Engines use this explicit signal to make text-only support fail safe.
     kwargs["specprefill_has_media"] = bool(has_media)
+
+
+def _configure_batched_specprefill(
+    scheduler_config: object | None,
+    *,
+    enabled: bool,
+) -> object | None:
+    """Copy launch config before applying the public CB enable switch."""
+    configured_enabled = enabled or bool(
+        getattr(scheduler_config, "specprefill_enabled", False)
+    )
+    if not configured_enabled:
+        return scheduler_config
+    if scheduler_config is None:
+        from .scheduler import SchedulerConfig
+
+        configured = SchedulerConfig(specprefill_enabled=True)
+    else:
+        configured = copy.copy(scheduler_config)
+        configured.specprefill_enabled = True
+    if not callable(getattr(configured, "specprefill_prepare", None)):
+        raise ValueError(
+            "continuous-batching SpecPrefill is unavailable without an explicit "
+            "SchedulerConfig.specprefill_prepare builder"
+        )
+    return configured
+
+
+def _validate_cb_specprefill_request_tuning(
+    engine: BaseEngine,
+    request: object,
+) -> None:
+    """Reject diagnostic tuning controls on the certified CB production path."""
+    if not isinstance(engine, BatchedEngine):
+        return
+    if (
+        getattr(request, "specprefill_keep_pct", None) is not None
+        or getattr(request, "specprefill_backbone_pct", None) is not None
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "CB production SpecPrefill does not accept request "
+                "keep/backbone tuning"
+            ),
+        )
 
 
 class _ThinkingAwareLogitsProcessor:
@@ -1387,9 +1434,13 @@ def _build_engine(spec: ModelSpec) -> BaseEngine:
         from .engine.batched import BatchedEngine
 
         logger.info(f"Preparing BatchedEngine for residency: {spec.model_name}")
+        scheduler_config = _configure_batched_specprefill(
+            spec.scheduler_config,
+            enabled=spec.specprefill_enabled,
+        )
         return BatchedEngine(
             model_name=spec.model_name,
-            scheduler_config=spec.scheduler_config,
+            scheduler_config=scheduler_config,
             stream_interval=spec.stream_interval,
             force_mllm=spec.force_mllm,
         )
@@ -3329,7 +3380,8 @@ def load_model(
         trust_remote_code: Allow HuggingFace remote code execution during model/tokenizer loading
         mtp: Enable native MTP speculative decoding (SimpleEngine only)
         prefill_step_size: Chunk size for prompt prefill processing (default: 2048)
-        specprefill_enabled: Enable SpecPrefill (SimpleEngine only)
+        specprefill_enabled: Enable SpecPrefill. Continuous batching also
+            requires a fail-atomic ``scheduler_config.specprefill_prepare``.
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_backbone_pct: Fraction of chunks reserved for evenly spaced coverage
@@ -3366,6 +3418,12 @@ def load_model(
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
         raise ValueError(
             "MLLM draft models are not supported with lifecycle residency yet"
+        )
+
+    if use_batching:
+        scheduler_config = _configure_batched_specprefill(
+            scheduler_config,
+            enabled=specprefill_enabled,
         )
 
     if _lifespan_active:
@@ -4885,6 +4943,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     )
     if engine is None:
         return Response(status_code=499)
+    _validate_cb_specprefill_request_tuning(engine, request)
     release_on_exit = True
 
     try:
@@ -5083,6 +5142,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     )
     if engine is None:
         return Response(status_code=499)
+
+    _validate_cb_specprefill_request_tuning(engine, request)
 
     release_on_exit = True
     try:

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -38,12 +38,190 @@ Design notes:
 Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
 """
 
+import hashlib
 import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
 
 import mlx.core as mx
 
 from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.sample_utils import make_sampler
+
+SPECPREFILL_SELECTOR_VERSION = "hybrid-chunk-v1"
+
+
+class SpecPrefillPolicy(str, Enum):
+    """Requested or effective prefill policy for one text request."""
+
+    AUTO = "auto"
+    SPARSE = "sparse"
+    DENSE = "dense"
+
+
+class SpecPrefillCoverage(str, Enum):
+    """Whether a workload can tolerate omitted prompt context."""
+
+    SELECTIVE = "selective"
+    EXHAUSTIVE = "exhaustive"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class SelectionPlan:
+    """Deterministic sparse-token selection for one prompt.
+
+    Indices and chunk IDs are immutable host values so the plan may safely be
+    retained in request telemetry or used as a cache fingerprint. Execution
+    converts ``selected_indices`` to an MLX array at the boundary.
+    """
+
+    prompt_length: int
+    chunk_size: int
+    keep_pct: float
+    selected_chunks: tuple[int, ...]
+    selected_indices: tuple[int, ...]
+    selector_version: str = SPECPREFILL_SELECTOR_VERSION
+    importance_chunks: tuple[int, ...] = ()
+    backbone_chunks: tuple[int, ...] = ()
+    anchor_chunks: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.prompt_length <= 0:
+            raise ValueError("prompt_length must be positive")
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        if not 0 < self.keep_pct <= 1:
+            raise ValueError("keep_pct must be in (0, 1]")
+        if tuple(sorted(set(self.selected_chunks))) != self.selected_chunks:
+            raise ValueError("selected_chunks must be sorted and unique")
+        if tuple(sorted(set(self.selected_indices))) != self.selected_indices:
+            raise ValueError("selected_indices must be sorted and unique")
+        if not self.selected_indices:
+            raise ValueError("SelectionPlan must retain at least one token")
+        if (
+            self.selected_indices[0] < 0
+            or self.selected_indices[-1] >= self.prompt_length
+        ):
+            raise ValueError("selected_indices are outside the prompt")
+
+        expected = tuple(
+            token
+            for chunk in self.selected_chunks
+            for token in range(
+                chunk * self.chunk_size,
+                min((chunk + 1) * self.chunk_size, self.prompt_length),
+            )
+        )
+        if expected != self.selected_indices:
+            raise ValueError("selected_indices must contain complete selected chunks")
+
+    @property
+    def selected_token_count(self) -> int:
+        return len(self.selected_indices)
+
+    @property
+    def fingerprint(self) -> str:
+        """Stable semantic identity for exact sparse-cache reuse."""
+        fields = (
+            self.selector_version,
+            str(self.prompt_length),
+            str(self.chunk_size),
+            self.keep_pct.hex(),
+            ",".join(map(str, self.selected_chunks)),
+            ",".join(map(str, self.importance_chunks)),
+            ",".join(map(str, self.backbone_chunks)),
+            ",".join(map(str, self.anchor_chunks)),
+        )
+        return hashlib.sha256("|".join(fields).encode("ascii")).hexdigest()
+
+    def as_mx_indices(self) -> mx.array:
+        """Return executor-ready indices without changing the immutable plan."""
+        return mx.array(self.selected_indices, dtype=mx.int32)
+
+
+@dataclass(frozen=True)
+class SpecPrefillDecision:
+    """A request-local admission decision, independent from engine execution."""
+
+    requested_policy: SpecPrefillPolicy
+    effective_policy: SpecPrefillPolicy
+    coverage: SpecPrefillCoverage
+    fallback_reason: str | None = None
+    selection_plan: SelectionPlan | None = None
+
+    def __post_init__(self) -> None:
+        if self.effective_policy is SpecPrefillPolicy.AUTO:
+            raise ValueError("effective_policy must resolve auto to sparse or dense")
+        if self.effective_policy is SpecPrefillPolicy.SPARSE and self.fallback_reason:
+            raise ValueError("a sparse decision cannot have a fallback reason")
+        if self.effective_policy is SpecPrefillPolicy.DENSE and self.selection_plan:
+            raise ValueError("a dense decision cannot expose a sparse selection plan")
+
+
+@dataclass(frozen=True)
+class SpecPrefillArchitectureAdapter:
+    """Explicit model-family contract for scoring and cache ownership."""
+
+    name: str
+    model_types: tuple[str, ...]
+    query_extractor: Callable[..., mx.array]
+    cache_map_builder: Callable[[Any], dict[int, int]]
+
+
+def resolve_specprefill_decision(
+    policy: SpecPrefillPolicy | str,
+    coverage: SpecPrefillCoverage | str,
+    *,
+    production: bool,
+    text_only: bool = True,
+    threshold_met: bool = True,
+    admission_allowed: bool = True,
+) -> SpecPrefillDecision:
+    """Resolve a conservative pre-execution policy decision.
+
+    Production may only engage sparse prefill for declared selective text
+    workloads that have passed both value and residency admission. Explicit
+    sparse forcing remains available for diagnostic use only.
+    """
+    requested = SpecPrefillPolicy(policy)
+    declared_coverage = SpecPrefillCoverage(coverage)
+    if requested is SpecPrefillPolicy.DENSE:
+        return SpecPrefillDecision(
+            requested, SpecPrefillPolicy.DENSE, declared_coverage
+        )
+    if not text_only:
+        return SpecPrefillDecision(
+            requested, SpecPrefillPolicy.DENSE, declared_coverage, "media_request"
+        )
+    if (
+        declared_coverage is not SpecPrefillCoverage.SELECTIVE
+        and requested is not SpecPrefillPolicy.SPARSE
+    ):
+        return SpecPrefillDecision(
+            requested,
+            SpecPrefillPolicy.DENSE,
+            declared_coverage,
+            "coverage_not_selective",
+        )
+    if production and requested is SpecPrefillPolicy.SPARSE:
+        return SpecPrefillDecision(
+            requested,
+            SpecPrefillPolicy.DENSE,
+            declared_coverage,
+            "sparse_forcing_diagnostic_only",
+        )
+    if not threshold_met:
+        return SpecPrefillDecision(
+            requested, SpecPrefillPolicy.DENSE, declared_coverage, "below_threshold"
+        )
+    if not admission_allowed:
+        return SpecPrefillDecision(
+            requested, SpecPrefillPolicy.DENSE, declared_coverage, "admission_denied"
+        )
+    return SpecPrefillDecision(requested, SpecPrefillPolicy.SPARSE, declared_coverage)
+
 
 # ===========================================================================
 # Step 1: Token importance scoring (draft model)
@@ -64,16 +242,16 @@ class _AttentionCapture:
         self._query_buffer = query_buffer
         self._query_extractor = query_extractor or _qwen35_extract_queries
 
-    def __call__(self, x, mask=None, cache=None):
-        queries = self._query_extractor(self._original, x, cache)
+    def __call__(self, x, mask=None, cache=None, **kwargs):
+        queries = self._query_extractor(self._original, x, cache=cache, **kwargs)
         self._query_buffer[self._buf_idx].append(queries)
-        return self._original(x, mask=mask, cache=cache)
+        return self._original(x, mask=mask, cache=cache, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._original, name)
 
 
-def _qwen35_extract_queries(attn, x, cache=None):
+def _qwen35_extract_queries(attn, x, cache=None, **_kwargs):
     """Extract post-RoPE queries from Qwen3.5 attention (gate split + q_norm).
 
     Qwen3.5 q_proj output is 2x wider: [queries, gate]. We split, normalize,
@@ -92,7 +270,28 @@ def _qwen35_extract_queries(attn, x, cache=None):
     return queries
 
 
-def _llama_extract_queries(attn, x, cache=None):
+def _qwen_extract_queries(attn, x, cache=None, **_kwargs):
+    """Extract normalized RoPE queries from dense Qwen attention.
+
+    Qwen 3's projection is not gated, unlike the Qwen3.5 hybrid family, but
+    it retains Q/K normalization. Treating it as a generic Llama block drops
+    that normalization and changes the scoring distribution.
+    """
+    B, L, _ = x.shape
+    n_heads = getattr(attn, "n_heads", getattr(attn, "num_attention_heads", None))
+    if n_heads is None:
+        raise ValueError("Cannot determine Qwen attention head count")
+    queries = attn.q_proj(x).reshape(B, L, n_heads, -1)
+    q_norm = getattr(attn, "q_norm", None)
+    if q_norm is not None:
+        queries = q_norm(queries)
+    queries = queries.transpose(0, 2, 1, 3)
+    if cache is not None:
+        return attn.rope(queries, offset=cache.offset)
+    return attn.rope(queries)
+
+
+def _llama_extract_queries(attn, x, cache=None, **_kwargs):
     """Extract post-RoPE queries from standard transformer attention.
 
     Standard architecture: q_proj → reshape → RoPE. No gate, no q_norm.
@@ -113,7 +312,28 @@ def _llama_extract_queries(attn, x, cache=None):
     return queries
 
 
-def _nemotron_h_extract_queries(attn, x, cache=None):
+def _gemma4_extract_queries(attn, x, cache=None, offset=None, **_kwargs):
+    """Extract Gemma 4 normalized partial-RoPE queries.
+
+    KV-shared Gemma layers receive their logical offset explicitly from their
+    owner layer. The capture wrapper must preserve that argument rather than
+    substituting a fresh cache-local position.
+    """
+    B, L, _ = x.shape
+    n_heads = getattr(attn, "n_heads", getattr(attn, "num_attention_heads", None))
+    if n_heads is None:
+        raise ValueError("Cannot determine Gemma 4 attention head count")
+    queries = attn.q_proj(x).reshape(B, L, n_heads, -1)
+    q_norm = getattr(attn, "q_norm", None)
+    if q_norm is not None:
+        queries = q_norm(queries)
+    queries = queries.transpose(0, 2, 1, 3)
+    if offset is None:
+        offset = cache.offset if cache is not None else 0
+    return attn.rope(queries, offset=offset)
+
+
+def _nemotron_h_extract_queries(attn, x, cache=None, **_kwargs):
     """Extract queries from Nemotron-H attention (no RoPE, no gate, no q_norm).
 
     Nemotron-H attention layers have NO positional encoding — RoPE is absent.
@@ -325,23 +545,11 @@ def score_tokens(
         attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
     )
 
-    # Auto-detect query extractor from model_type (explicit registry, not
-    # attribute sniffing -- avoids silent misclassification on new models).
+    # Resolve known model families through an explicit adapter registry. The
+    # generic fallback remains only for legacy callers that pass a custom
+    # extractor; unknown model types must not silently acquire a scoring path.
     if query_extractor is None:
-        model_type = getattr(getattr(model, "config", None), "model_type", "")
-        _EXTRACTOR_REGISTRY = {
-            "qwen3_5": _qwen35_extract_queries,
-            "qwen3_5_moe": _qwen35_extract_queries,
-            "qwen3_vl": _qwen35_extract_queries,
-            "qwen3_vl_moe": _qwen35_extract_queries,
-            "nemotron_h": _nemotron_h_extract_queries,
-        }
-        query_extractor = _EXTRACTOR_REGISTRY.get(model_type)
-        if query_extractor is None:
-            if _get_rope(attn_obj) is not None:
-                query_extractor = _llama_extract_queries
-            else:
-                query_extractor = _nemotron_h_extract_queries
+        query_extractor = resolve_specprefill_adapter(model).query_extractor
 
     # Phase 1: Prefill
     cache = make_prompt_cache(model)
@@ -375,7 +583,7 @@ def score_tokens(
     # Phase 3: Compute importance
     # Map layer indices to cache indices (identity for standard models,
     # compacted for Nemotron-H where only M/* layers have cache entries)
-    layer_to_cache = _build_layer_to_cache_map(model)
+    layer_to_cache = resolve_specprefill_adapter(model).cache_map_builder(model)
     attn_caches = [cache[layer_to_cache[i]] for i in attn_indices]
     if cancel_check is not None:
         cancel_check()
@@ -396,75 +604,169 @@ def score_tokens(
     return importance
 
 
-def select_chunks(importance, keep_pct=0.3, chunk_size=32, backbone_pct=0.0):
-    """Select top-k% token chunks by average importance.
-
-    Args:
-        importance: (M,) per-token importance scores
-        keep_pct: fraction of chunks to keep (default 0.3)
-        chunk_size: tokens per chunk (default 32)
-        backbone_pct: fraction of chunks reserved for evenly-spaced coverage
-
-    Returns:
-        sorted mx.array of kept token indices
-    """
-    M = importance.shape[0]
-    if keep_pct >= 1.0:
-        return mx.arange(M)
-
-    n_chunks = math.ceil(M / chunk_size)
-    target_tokens = max(1, math.ceil(M * keep_pct))
-    keep_n = max(1, math.ceil(n_chunks * keep_pct))
-    backbone_n = max(0, math.ceil(n_chunks * backbone_pct)) if backbone_pct > 0 else 0
-    top_n = max(0, keep_n - backbone_n)
-
-    chunk_scores = []
-    for i in range(n_chunks):
-        start = i * chunk_size
-        end = min(start + chunk_size, M)
-        chunk_scores.append(mx.mean(importance[start:end]).item())
-
-    selected_chunks = set(
-        sorted(range(n_chunks), key=lambda i: chunk_scores[i], reverse=True)[:top_n]
+def _chunk_scores(importance, chunk_size: int) -> tuple[int, list[float]]:
+    """Compute all chunk means in one MLX expression and validate them."""
+    if len(importance.shape) != 1:
+        raise ValueError("importance must be a one-dimensional tensor")
+    prompt_length = int(importance.shape[0])
+    if prompt_length <= 0:
+        raise ValueError("importance must not be empty")
+    n_chunks = math.ceil(prompt_length / chunk_size)
+    padded_length = n_chunks * chunk_size
+    padded = (
+        mx.pad(importance, [(0, padded_length - prompt_length)])
+        if padded_length != prompt_length
+        else importance
     )
-    if backbone_n > 0:
-        if backbone_n >= n_chunks:
-            selected_chunks.update(range(n_chunks))
-        else:
-            for i in range(backbone_n):
-                selected_chunks.add(round(i * (n_chunks - 1) / max(1, backbone_n - 1)))
+    sums = mx.sum(padded.reshape(n_chunks, chunk_size), axis=1)
+    lengths = mx.minimum(
+        mx.full((n_chunks,), chunk_size),
+        prompt_length - mx.arange(n_chunks) * chunk_size,
+    )
+    scores = [float(score) for score in (sums / lengths).tolist()]
+    if not all(math.isfinite(score) for score in scores):
+        raise ValueError("importance must contain only finite values")
+    return prompt_length, scores
 
-    def _selected_token_count(chunks):
-        total = 0
-        for chunk_idx in chunks:
-            start = chunk_idx * chunk_size
-            end = min(start + chunk_size, M)
-            total += end - start
-        return total
 
-    if (
-        len(selected_chunks) < keep_n
-        or _selected_token_count(selected_chunks) < target_tokens
-    ):
-        for chunk_idx in sorted(
-            range(n_chunks), key=lambda i: chunk_scores[i], reverse=True
+def _stratified_chunks(n_chunks: int, count: int) -> tuple[int, ...]:
+    """Select stable center-of-stratum representatives across a prompt."""
+    if count <= 0:
+        return ()
+    if count >= n_chunks:
+        return tuple(range(n_chunks))
+    selected = {
+        min(n_chunks - 1, int((index + 0.5) * n_chunks / count))
+        for index in range(count)
+    }
+    for candidate in range(n_chunks):
+        if len(selected) >= count:
+            break
+        selected.add(candidate)
+    return tuple(sorted(selected))
+
+
+def _anchor_chunk_ids(n_chunks: int, count: int) -> tuple[int, ...]:
+    if count <= 0:
+        return ()
+    count = min(count, n_chunks)
+    anchors = set(range(count))
+    anchors.update(range(max(0, n_chunks - count), n_chunks))
+    return tuple(sorted(anchors))
+
+
+def build_selection_plan(
+    importance,
+    keep_pct: float = 0.3,
+    chunk_size: int = 32,
+    backbone_pct: float = 0.0,
+    *,
+    halo_chunks: int = 1,
+    anchor_chunks: int = 1,
+) -> SelectionPlan:
+    """Build a deterministic, versioned hybrid sparse-prefill plan.
+
+    Fixed anchors preserve prompt framing, a stratified backbone prevents
+    score collapse into one region, and an importance-ranked halo keeps local
+    context around a selected chunk. All chunk means are calculated on device
+    before one O(chunks) host ranking operation.
+    """
+    if not 0 < keep_pct <= 1:
+        raise ValueError("keep_pct must be in (0, 1]")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    if not 0 <= backbone_pct <= 1:
+        raise ValueError("backbone_pct must be in [0, 1]")
+    if halo_chunks < 0 or anchor_chunks < 0:
+        raise ValueError("halo_chunks and anchor_chunks must be non-negative")
+
+    prompt_length, scores = _chunk_scores(importance, chunk_size)
+    n_chunks = len(scores)
+    ranked = tuple(sorted(range(n_chunks), key=lambda chunk: (-scores[chunk], chunk)))
+    desired_chunks = max(1, math.ceil(n_chunks * keep_pct))
+    desired_tokens = max(1, math.ceil(prompt_length * keep_pct))
+    anchors = _anchor_chunk_ids(n_chunks, anchor_chunks)
+    backbone = _stratified_chunks(n_chunks, math.ceil(n_chunks * backbone_pct))
+    selected = set(anchors)
+    selected.update(backbone)
+    # Anchors are a quality floor, not a substitute for importance-ranked
+    # evidence. They may exceed the retention budget on very short prompts.
+    importance_budget = max(1, desired_chunks - len(backbone))
+    chunk_budget = min(n_chunks, desired_chunks + len(anchors))
+    importance_seeds: list[int] = []
+
+    def selected_token_count() -> int:
+        return sum(
+            min(chunk_size, prompt_length - chunk * chunk_size) for chunk in selected
+        )
+
+    for seed in ranked:
+        if (
+            len(importance_seeds) >= importance_budget
+            and selected_token_count() >= desired_tokens
         ):
-            selected_chunks.add(chunk_idx)
-            if (
-                len(selected_chunks) >= keep_n
-                and _selected_token_count(selected_chunks) >= target_tokens
+            break
+        importance_seeds.append(seed)
+        candidates = [seed]
+        for distance in range(1, halo_chunks + 1):
+            candidates.extend((seed - distance, seed + distance))
+        for candidate in candidates:
+            if not 0 <= candidate < n_chunks or (
+                len(selected) >= chunk_budget and candidate not in selected
             ):
-                break
+                continue
+            selected.add(candidate)
 
-    top_chunks = sorted(selected_chunks)
+    # A partial last chunk can meet a chunk budget without meeting the token
+    # retention target; fill deterministically until both are satisfied.
+    for candidate in ranked:
+        if len(selected) >= chunk_budget and selected_token_count() >= desired_tokens:
+            break
+        if (
+            selected_token_count() < desired_tokens
+            or len(selected) < chunk_budget
+            or candidate in selected
+        ):
+            selected.add(candidate)
 
-    indices = []
-    for ci in top_chunks:
-        start = ci * chunk_size
-        end = min(start + chunk_size, M)
-        indices.extend(range(start, end))
+    selected_chunks = tuple(sorted(selected))
+    selected_indices = tuple(
+        token
+        for chunk in selected_chunks
+        for token in range(
+            chunk * chunk_size, min((chunk + 1) * chunk_size, prompt_length)
+        )
+    )
+    return SelectionPlan(
+        prompt_length=prompt_length,
+        chunk_size=chunk_size,
+        keep_pct=keep_pct,
+        selected_chunks=selected_chunks,
+        selected_indices=selected_indices,
+        importance_chunks=tuple(importance_seeds),
+        backbone_chunks=backbone,
+        anchor_chunks=anchors,
+    )
 
-    return mx.array(indices)
+
+def select_chunks(
+    importance,
+    keep_pct=0.3,
+    chunk_size=32,
+    backbone_pct=0.0,
+    *,
+    halo_chunks=1,
+    anchor_chunks=1,
+):
+    """Return executor-ready indices from :func:`build_selection_plan`."""
+    return build_selection_plan(
+        importance,
+        keep_pct=keep_pct,
+        chunk_size=chunk_size,
+        backbone_pct=backbone_pct,
+        halo_chunks=halo_chunks,
+        anchor_chunks=anchor_chunks,
+    ).as_mx_indices()
 
 
 # ===========================================================================
@@ -663,31 +965,153 @@ def _set_attn_module(layer, module):
         layer.mixer = module
 
 
+def _get_model_type(model) -> str:
+    """Return a model type from supported mlx-lm/mlx-vlm wrapper layouts."""
+    if isinstance(model, str):
+        return model
+    candidates = (
+        getattr(model, "config", None),
+        getattr(model, "args", None),
+        getattr(getattr(model, "model", None), "config", None),
+        getattr(getattr(model, "model", None), "args", None),
+    )
+    for candidate in candidates:
+        model_type = getattr(candidate, "model_type", None)
+        if model_type:
+            return str(model_type)
+    return ""
+
+
+def _standard_layer_to_cache_map(model) -> dict[int, int]:
+    """Map standard decoder layers to one cache entry each."""
+    return {index: index for index in range(len(model.layers))}
+
+
+def _gemma4_shared_kv_cache_map(model) -> dict[int, int]:
+    """Map Gemma 4 layers to their physical KV-owning cache entries.
+
+    Gemma's prompt-cache factory materializes one entry per unique KV owner,
+    not one entry per decoder layer. ``previous_kvs`` contains decoder-layer
+    owners, so map first-seen owners to their compact cache-list indices.
+    """
+    inner_model = getattr(model, "model", None)
+    previous_kvs = getattr(model, "previous_kvs", None)
+    if previous_kvs is None and inner_model is not None:
+        previous_kvs = getattr(inner_model, "previous_kvs", None)
+    if previous_kvs is None:
+        raise ValueError("Gemma 4 model is missing previous_kvs cache ownership")
+    if len(previous_kvs) != len(model.layers):
+        raise ValueError("Gemma 4 previous_kvs must cover every decoder layer")
+    owner_to_cache: dict[int, int] = {}
+    mapping: dict[int, int] = {}
+    for layer_idx, owner_idx in enumerate(previous_kvs):
+        if not isinstance(owner_idx, int) or not 0 <= owner_idx < len(model.layers):
+            raise ValueError(
+                f"Invalid Gemma 4 KV owner {owner_idx!r} for layer {layer_idx}"
+            )
+        if owner_idx > layer_idx:
+            raise ValueError(
+                f"Gemma 4 KV owner {owner_idx} must precede layer {layer_idx}"
+            )
+        if owner_idx not in owner_to_cache:
+            owner_to_cache[owner_idx] = len(owner_to_cache)
+        mapping[layer_idx] = owner_to_cache[owner_idx]
+    return mapping
+
+
+def _hybrid_layer_to_cache_map(model) -> dict[int, int]:
+    """Map Qwen3.5/3.6's mixed linear/attention stack to cache slots."""
+    return _standard_layer_to_cache_map(model)
+
+
+def _nemotron_h_layer_to_cache_map(model) -> dict[int, int]:
+    """Map only stateful Nemotron-H blocks into its compact cache list."""
+    layer_to_cache: dict[int, int] = {}
+    cache_idx = 0
+    for layer_idx, layer in enumerate(model.layers):
+        if getattr(layer, "block_type", None) in ("M", "*"):
+            layer_to_cache[layer_idx] = cache_idx
+            cache_idx += 1
+    return layer_to_cache
+
+
+STANDARD_QWEN_ADAPTER = SpecPrefillArchitectureAdapter(
+    name="qwen-dense",
+    model_types=("qwen2", "qwen2_moe", "qwen3", "qwen3_moe"),
+    query_extractor=_qwen_extract_queries,
+    cache_map_builder=_standard_layer_to_cache_map,
+)
+QWEN_HYBRID_ADAPTER = SpecPrefillArchitectureAdapter(
+    name="qwen3.5-3.6-hybrid-moe",
+    model_types=(
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+        "qwen3_vl",
+        "qwen3_vl_moe",
+    ),
+    query_extractor=_qwen35_extract_queries,
+    cache_map_builder=_hybrid_layer_to_cache_map,
+)
+GEMMA4_ADAPTER = SpecPrefillArchitectureAdapter(
+    name="gemma4-shared-kv",
+    model_types=("gemma4", "gemma4_text"),
+    query_extractor=_gemma4_extract_queries,
+    cache_map_builder=_gemma4_shared_kv_cache_map,
+)
+NEMOTRON_H_ADAPTER = SpecPrefillArchitectureAdapter(
+    name="nemotron-h",
+    model_types=("nemotron_h",),
+    query_extractor=_nemotron_h_extract_queries,
+    cache_map_builder=_nemotron_h_layer_to_cache_map,
+)
+_ADAPTERS: tuple[SpecPrefillArchitectureAdapter, ...] = (
+    STANDARD_QWEN_ADAPTER,
+    QWEN_HYBRID_ADAPTER,
+    GEMMA4_ADAPTER,
+    NEMOTRON_H_ADAPTER,
+)
+ARCHITECTURE_ADAPTERS: dict[str, SpecPrefillArchitectureAdapter] = {
+    model_type: adapter for adapter in _ADAPTERS for model_type in adapter.model_types
+}
+
+
+def resolve_specprefill_adapter(model: Any) -> SpecPrefillArchitectureAdapter:
+    """Return the explicit scoring/cache contract for a supported model type."""
+    model_type = _get_model_type(model)
+    adapter = ARCHITECTURE_ADAPTERS.get(model_type)
+    if adapter is None:
+        supported = ", ".join(sorted(ARCHITECTURE_ADAPTERS))
+        raise ValueError(
+            f"Unsupported SpecPrefill model_type {model_type!r}; supported: {supported}"
+        )
+    return adapter
+
+
 def _build_layer_to_cache_map(model):
     """Build mapping from model layer index to cache index.
 
-    Standard models (Qwen3.5, Llama, GPT-OSS): one cache entry per layer,
-    so the mapping is identity (layer_idx → layer_idx).
+    Standard models have one cache entry per layer. Gemma 4 shared-KV layers
+    map to compact cache entries keyed by their physical owner. This
+    compatibility helper intentionally keeps support for existing direct
+    callers; new scoring uses the architecture adapter registry above.
 
     Nemotron-H: only M (Mamba2) and * (attention) layers have cache entries.
     MLP (-) and MoE (E) layers get no cache. The mapping is compacted.
 
     Returns dict {layer_idx: cache_idx}.
     """
+    if (
+        getattr(model, "previous_kvs", None) is not None
+        or getattr(getattr(model, "model", None), "previous_kvs", None) is not None
+    ):
+        return _gemma4_shared_kv_cache_map(model)
+
     has_block_type = any(hasattr(layer, "block_type") for layer in model.layers)
     if not has_block_type:
-        # Standard model: identity mapping
-        return {i: i for i in range(len(model.layers))}
-
-    # Nemotron-H style: count cache entries for M/* layers
-    layer_to_cache = {}
-    cache_idx = 0
-    for layer_idx, layer in enumerate(model.layers):
-        bt = getattr(layer, "block_type", None)
-        if bt in ("M", "*"):
-            layer_to_cache[layer_idx] = cache_idx
-            cache_idx += 1
-    return layer_to_cache
+        return _standard_layer_to_cache_map(model)
+    return _nemotron_h_layer_to_cache_map(model)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -51,7 +51,6 @@ from typing import Any, Callable
 
 import mlx.core as mx
 
-from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.sample_utils import make_sampler
 
 SPECPREFILL_SELECTOR_VERSION = "hybrid-chunk-v1"
@@ -71,6 +70,10 @@ class SpecPrefillCoverage(str, Enum):
     SELECTIVE = "selective"
     EXHAUSTIVE = "exhaustive"
     UNKNOWN = "unknown"
+
+
+class SpecPrefillScorerLaneBusy(RuntimeError):
+    """Another bounded request currently owns the scorer lane."""
 
 
 @dataclass(frozen=True)
@@ -604,6 +607,7 @@ class SpecPrefillScorer:
         self._model_ref = weakref.ref(model)
         self.adapter = resolve_specprefill_adapter(model)
         self._session_lock = threading.Lock()
+        self._quantum_lock = threading.Lock()
         self._active_session = None
         self._session_context = threading.local()
 
@@ -718,6 +722,21 @@ class SpecPrefillScorer:
                 pass
             self._session_lock.release()
 
+    @contextmanager
+    def scoring_quantum(self):
+        """Lease the scorer lane for one bounded request-local session step.
+
+        Capture itself still takes the shorter ``capture_session`` lock.  This
+        companion lock covers cache/query importance work too, then releases
+        before another request's next quantum can run.
+        """
+        if not self._quantum_lock.acquire(blocking=False):
+            raise SpecPrefillScorerLaneBusy("SpecPrefill scorer lane is busy")
+        try:
+            yield
+        finally:
+            self._quantum_lock.release()
+
     def score_tokens(
         self,
         tokens,
@@ -728,58 +747,25 @@ class SpecPrefillScorer:
         prefill_step_size=2048,
         query_extractor=None,
         cancel_check=None,
+        sampling_seed=None,
     ):
-        """Score one prompt with all lazy capture work inside its session."""
-        model = self.model
-        if isinstance(tokens, mx.array):
-            tokens = tokens.tolist()
-        n_prompt = len(tokens)
+        """Score through bounded request-local session quanta for compatibility."""
+        # Local import keeps the session implementation free to reuse this
+        # install-once scorer without a module-import cycle.
+        from .specprefill_scorer_session import SpecPrefillScorerSession
 
-        cache = None
-        logits = None
-        try:
-            with self.capture_session(
-                query_extractor=query_extractor, capture_enabled=False
-            ) as session:
-                cache = make_prompt_cache(model)
-                logits = _prefill_draft(
-                    model,
-                    tokens,
-                    cache,
-                    step_size=prefill_step_size,
-                    cancel_check=cancel_check,
-                )
-                session.capture_enabled = True
-                _lookahead_decode(
-                    model,
-                    logits,
-                    cache,
-                    n_lookahead,
-                    temp=temp,
-                    top_p=top_p,
-                    cancel_check=cancel_check,
-                )
-
-                layer_to_cache = self.adapter.cache_map_builder(model)
-                attn_caches = [
-                    cache[layer_to_cache[index]]
-                    for index in self.attention_layer_indices
-                ]
-                if cancel_check is not None:
-                    cancel_check()
-                importance = _compute_importance(
-                    session.query_buffer,
-                    attn_caches,
-                    n_prompt,
-                    pool_kernel=pool_kernel if pool_kernel > 0 else None,
-                )
-                # MLX execution is lazy. Realize both captured queries and the
-                # final scores while this request still owns the scorer lane.
-                mx.eval(session.query_buffer, importance)
-            return importance
-        finally:
-            del cache, logits
-            mx.clear_cache()
+        return SpecPrefillScorerSession(
+            self,
+            tokens,
+            n_lookahead=n_lookahead,
+            pool_kernel=pool_kernel,
+            temp=temp,
+            top_p=top_p,
+            prefill_step_size=prefill_step_size,
+            query_extractor=query_extractor,
+            cancel_check=cancel_check,
+            sampling_seed=sampling_seed,
+        ).run_to_completion()
 
 
 _SCORER_REGISTRY: dict[int, tuple[weakref.ReferenceType[Any], SpecPrefillScorer]] = {}
@@ -970,6 +956,7 @@ def score_tokens(
     prefill_step_size=2048,
     query_extractor=None,
     cancel_check=None,
+    sampling_seed=None,
 ):
     """Score token importance using attention-based analysis on a draft model.
 
@@ -1005,6 +992,7 @@ def score_tokens(
         prefill_step_size=prefill_step_size,
         query_extractor=query_extractor,
         cancel_check=cancel_check,
+        sampling_seed=sampling_seed,
     )
 
 

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -39,7 +39,6 @@ Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
 """
 
 import functools
-import hashlib
 import inspect
 import math
 import threading
@@ -47,13 +46,20 @@ import weakref
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 import mlx.core as mx
 
+from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.sample_utils import make_sampler
 
-SPECPREFILL_SELECTOR_VERSION = "hybrid-chunk-v1"
+from vllm_mlx.specprefill_selection import (
+    SPECPREFILL_SELECTOR_VERSION,  # noqa: F401 - re-exported public identity
+    RotatingTailRequirement,
+    SelectionPlan,
+    SelectionPolicy,
+    build_selection_plan_from_chunk_scores,
+)
 
 
 class SpecPrefillPolicy(str, Enum):
@@ -74,79 +80,6 @@ class SpecPrefillCoverage(str, Enum):
 
 class SpecPrefillScorerLaneBusy(RuntimeError):
     """Another bounded request currently owns the scorer lane."""
-
-
-@dataclass(frozen=True)
-class SelectionPlan:
-    """Deterministic sparse-token selection for one prompt.
-
-    Indices and chunk IDs are immutable host values so the plan may safely be
-    retained in request telemetry or used as a cache fingerprint. Execution
-    converts ``selected_indices`` to an MLX array at the boundary.
-    """
-
-    prompt_length: int
-    chunk_size: int
-    keep_pct: float
-    selected_chunks: tuple[int, ...]
-    selected_indices: tuple[int, ...]
-    selector_version: str = SPECPREFILL_SELECTOR_VERSION
-    importance_chunks: tuple[int, ...] = ()
-    backbone_chunks: tuple[int, ...] = ()
-    anchor_chunks: tuple[int, ...] = ()
-
-    def __post_init__(self) -> None:
-        if self.prompt_length <= 0:
-            raise ValueError("prompt_length must be positive")
-        if self.chunk_size <= 0:
-            raise ValueError("chunk_size must be positive")
-        if not 0 < self.keep_pct <= 1:
-            raise ValueError("keep_pct must be in (0, 1]")
-        if tuple(sorted(set(self.selected_chunks))) != self.selected_chunks:
-            raise ValueError("selected_chunks must be sorted and unique")
-        if tuple(sorted(set(self.selected_indices))) != self.selected_indices:
-            raise ValueError("selected_indices must be sorted and unique")
-        if not self.selected_indices:
-            raise ValueError("SelectionPlan must retain at least one token")
-        if (
-            self.selected_indices[0] < 0
-            or self.selected_indices[-1] >= self.prompt_length
-        ):
-            raise ValueError("selected_indices are outside the prompt")
-
-        expected = tuple(
-            token
-            for chunk in self.selected_chunks
-            for token in range(
-                chunk * self.chunk_size,
-                min((chunk + 1) * self.chunk_size, self.prompt_length),
-            )
-        )
-        if expected != self.selected_indices:
-            raise ValueError("selected_indices must contain complete selected chunks")
-
-    @property
-    def selected_token_count(self) -> int:
-        return len(self.selected_indices)
-
-    @property
-    def fingerprint(self) -> str:
-        """Stable semantic identity for exact sparse-cache reuse."""
-        fields = (
-            self.selector_version,
-            str(self.prompt_length),
-            str(self.chunk_size),
-            self.keep_pct.hex(),
-            ",".join(map(str, self.selected_chunks)),
-            ",".join(map(str, self.importance_chunks)),
-            ",".join(map(str, self.backbone_chunks)),
-            ",".join(map(str, self.anchor_chunks)),
-        )
-        return hashlib.sha256("|".join(fields).encode("ascii")).hexdigest()
-
-    def as_mx_indices(self) -> mx.array:
-        """Return executor-ready indices without changing the immutable plan."""
-        return mx.array(self.selected_indices, dtype=mx.int32)
 
 
 @dataclass(frozen=True)
@@ -176,6 +109,29 @@ class SpecPrefillArchitectureAdapter:
     model_types: tuple[str, ...]
     query_extractor: Callable[..., mx.array]
     cache_map_builder: Callable[[Any], dict[int, int]]
+
+
+class Gemma4Variant(str, Enum):
+    """Gemma 4 text topology classes supported by the scorer."""
+
+    DENSE = "dense"
+    A4B = "a4b"
+
+
+@dataclass(frozen=True)
+class Gemma4Layout:
+    """Known Gemma wrapper resolution, never an arbitrary attribute walk.
+
+    ``execution_model`` is the object the caller forwards through.  The scorer
+    installs captures on ``decoder_model`` and asks ``cache_model`` to make the
+    compact owner cache.  These are distinct for the Gemma VLM outer wrapper.
+    """
+
+    execution_model: Any
+    decoder_model: Any
+    cache_model: Any
+    previous_kvs: tuple[int, ...]
+    variant: Gemma4Variant
 
 
 def resolve_specprefill_decision(
@@ -606,12 +562,13 @@ class SpecPrefillScorer:
     def __init__(self, model):
         self._model_ref = weakref.ref(model)
         self.adapter = resolve_specprefill_adapter(model)
+        self._decoder_model = _scorer_decoder_model(model, self.adapter)
         self._session_lock = threading.Lock()
         self._quantum_lock = threading.Lock()
         self._active_session = None
         self._session_context = threading.local()
 
-        attention_layers = _find_attention_layers(model)
+        attention_layers = _find_attention_layers(self._decoder_model)
         if not attention_layers:
             raise ValueError("SpecPrefill scorer model has no attention layers")
         attentions = [
@@ -651,11 +608,19 @@ class SpecPrefillScorer:
         return model
 
     @property
+    def decoder_model(self):
+        return self._decoder_model
+
+    @property
+    def cache_model(self):
+        return _scorer_cache_model(self.model, self.adapter)
+
+    @property
     def capture_active(self) -> bool:
         return self._active_session is not None
 
     def _verify_installed(self):
-        model = self.model
+        model = self.decoder_model
         for buffer_index, (layer_idx, attention) in enumerate(
             self._installed_attentions
         ):
@@ -1021,32 +986,6 @@ def _chunk_scores(importance, chunk_size: int) -> tuple[int, list[float]]:
     return prompt_length, scores
 
 
-def _stratified_chunks(n_chunks: int, count: int) -> tuple[int, ...]:
-    """Select stable center-of-stratum representatives across a prompt."""
-    if count <= 0:
-        return ()
-    if count >= n_chunks:
-        return tuple(range(n_chunks))
-    selected = {
-        min(n_chunks - 1, int((index + 0.5) * n_chunks / count))
-        for index in range(count)
-    }
-    for candidate in range(n_chunks):
-        if len(selected) >= count:
-            break
-        selected.add(candidate)
-    return tuple(sorted(selected))
-
-
-def _anchor_chunk_ids(n_chunks: int, count: int) -> tuple[int, ...]:
-    if count <= 0:
-        return ()
-    count = min(count, n_chunks)
-    anchors = set(range(count))
-    anchors.update(range(max(0, n_chunks - count), n_chunks))
-    return tuple(sorted(anchors))
-
-
 def build_selection_plan(
     importance,
     keep_pct: float = 0.3,
@@ -1055,6 +994,8 @@ def build_selection_plan(
     *,
     halo_chunks: int = 1,
     anchor_chunks: int = 1,
+    control_token_indices: tuple[int, ...] = (),
+    rotating_tail_requirement: RotatingTailRequirement | None = None,
 ) -> SelectionPlan:
     """Build a deterministic, versioned hybrid sparse-prefill plan.
 
@@ -1063,81 +1004,20 @@ def build_selection_plan(
     context around a selected chunk. All chunk means are calculated on device
     before one O(chunks) host ranking operation.
     """
-    if not 0 < keep_pct <= 1:
-        raise ValueError("keep_pct must be in (0, 1]")
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be positive")
-    if not 0 <= backbone_pct <= 1:
-        raise ValueError("backbone_pct must be in [0, 1]")
-    if halo_chunks < 0 or anchor_chunks < 0:
-        raise ValueError("halo_chunks and anchor_chunks must be non-negative")
-
     prompt_length, scores = _chunk_scores(importance, chunk_size)
-    n_chunks = len(scores)
-    ranked = tuple(sorted(range(n_chunks), key=lambda chunk: (-scores[chunk], chunk)))
-    desired_chunks = max(1, math.ceil(n_chunks * keep_pct))
-    desired_tokens = max(1, math.ceil(prompt_length * keep_pct))
-    anchors = _anchor_chunk_ids(n_chunks, anchor_chunks)
-    backbone = _stratified_chunks(n_chunks, math.ceil(n_chunks * backbone_pct))
-    selected = set(anchors)
-    selected.update(backbone)
-    # Anchors are a quality floor, not a substitute for importance-ranked
-    # evidence. They may exceed the retention budget on very short prompts.
-    importance_budget = max(1, desired_chunks - len(backbone))
-    chunk_budget = min(n_chunks, desired_chunks + len(anchors))
-    importance_seeds: list[int] = []
-
-    def selected_token_count() -> int:
-        return sum(
-            min(chunk_size, prompt_length - chunk * chunk_size) for chunk in selected
-        )
-
-    for seed in ranked:
-        if (
-            len(importance_seeds) >= importance_budget
-            and selected_token_count() >= desired_tokens
-        ):
-            break
-        importance_seeds.append(seed)
-        candidates = [seed]
-        for distance in range(1, halo_chunks + 1):
-            candidates.extend((seed - distance, seed + distance))
-        for candidate in candidates:
-            if not 0 <= candidate < n_chunks or (
-                len(selected) >= chunk_budget and candidate not in selected
-            ):
-                continue
-            selected.add(candidate)
-
-    # A partial last chunk can meet a chunk budget without meeting the token
-    # retention target; fill deterministically until both are satisfied.
-    for candidate in ranked:
-        if len(selected) >= chunk_budget and selected_token_count() >= desired_tokens:
-            break
-        if (
-            selected_token_count() < desired_tokens
-            or len(selected) < chunk_budget
-            or candidate in selected
-        ):
-            selected.add(candidate)
-
-    selected_chunks = tuple(sorted(selected))
-    selected_indices = tuple(
-        token
-        for chunk in selected_chunks
-        for token in range(
-            chunk * chunk_size, min((chunk + 1) * chunk_size, prompt_length)
-        )
-    )
-    return SelectionPlan(
-        prompt_length=prompt_length,
-        chunk_size=chunk_size,
+    policy = SelectionPolicy(
         keep_pct=keep_pct,
-        selected_chunks=selected_chunks,
-        selected_indices=selected_indices,
-        importance_chunks=tuple(importance_seeds),
-        backbone_chunks=backbone,
-        anchor_chunks=anchors,
+        backbone_pct=backbone_pct,
+        halo_chunks=halo_chunks,
+        anchor_chunks=anchor_chunks,
+        chunk_size=chunk_size,
+    )
+    return build_selection_plan_from_chunk_scores(
+        prompt_length=prompt_length,
+        chunk_scores=scores,
+        policy=policy,
+        control_token_indices=control_token_indices,
+        rotating_tail_requirement=rotating_tail_requirement,
     )
 
 
@@ -1149,16 +1029,21 @@ def select_chunks(
     *,
     halo_chunks=1,
     anchor_chunks=1,
+    control_token_indices=(),
+    rotating_tail_requirement=None,
 ):
     """Return executor-ready indices from :func:`build_selection_plan`."""
-    return build_selection_plan(
+    plan = build_selection_plan(
         importance,
         keep_pct=keep_pct,
         chunk_size=chunk_size,
         backbone_pct=backbone_pct,
         halo_chunks=halo_chunks,
         anchor_chunks=anchor_chunks,
-    ).as_mx_indices()
+        control_token_indices=control_token_indices,
+        rotating_tail_requirement=rotating_tail_requirement,
+    )
+    return mx.array(plan.selected_indices, dtype=mx.int32)
 
 
 # ===========================================================================
@@ -1374,6 +1259,106 @@ def _get_model_type(model) -> str:
     return ""
 
 
+def _has_gemma4_decoder_contract(candidate: Any) -> bool:
+    """Identify a Gemma text decoder without accepting arbitrary wrappers."""
+    return (
+        candidate is not None
+        and hasattr(candidate, "layers")
+        and getattr(candidate, "previous_kvs", None) is not None
+    )
+
+
+def _gemma4_variant(decoder_model: Any) -> Gemma4Variant:
+    """Classify installed Gemma dense and A4B text contracts explicitly."""
+    config = getattr(decoder_model, "config", None)
+    if config is None or not hasattr(config, "num_experts"):
+        config = getattr(getattr(decoder_model, "model", None), "config", None)
+    experts = getattr(config, "num_experts", None)
+    if isinstance(experts, bool) or not isinstance(experts, int) or experts <= 0:
+        return Gemma4Variant.DENSE
+    return Gemma4Variant.A4B
+
+
+def resolve_gemma4_layout(model: Any) -> Gemma4Layout:
+    """Resolve only observed mlx-lm/mlx-vlm Gemma text ownership layouts.
+
+    Supported paths are the direct text decoder, the mlx-lm text wrapper's
+    ``.model``, the extracted text wrapper's ``.model.previous_kvs``, and the
+    mlx-vlm outer wrapper's ``.language_model.model``. Any other shape is
+    rejected rather than guessed: cache ownership is a correctness contract,
+    not a convenience traversal.
+    """
+    decoder_model = None
+    cache_model = None
+    previous_kvs = None
+    if _has_gemma4_decoder_contract(model):
+        decoder_model = model
+        cache_model = model
+        previous_kvs = model.previous_kvs
+    elif _has_gemma4_decoder_contract(getattr(model, "model", None)):
+        decoder_model = model.model
+        cache_model = model
+        previous_kvs = model.model.previous_kvs
+    elif (
+        hasattr(model, "layers")
+        and getattr(getattr(model, "model", None), "previous_kvs", None) is not None
+    ):
+        # mlx-vlm's extracted text route can expose decoder layers on the
+        # wrapper while retaining shared-KV ownership on ``.model``.
+        decoder_model = model
+        cache_model = model
+        previous_kvs = model.model.previous_kvs
+    else:
+        language_model = getattr(model, "language_model", None)
+        language_decoder = getattr(language_model, "model", None)
+        if _has_gemma4_decoder_contract(language_decoder):
+            decoder_model = language_decoder
+            cache_model = language_model
+            previous_kvs = language_decoder.previous_kvs
+    if decoder_model is None or cache_model is None or previous_kvs is None:
+        raise ValueError(
+            "Unsupported Gemma 4 wrapper; expected direct decoder, .model, "
+            "or .language_model.model cache ownership"
+        )
+
+    layers = tuple(decoder_model.layers)
+    previous_kvs = tuple(previous_kvs)
+    if not layers or len(previous_kvs) != len(layers):
+        raise ValueError("Gemma 4 previous_kvs must cover every decoder layer")
+    for layer_idx, owner_idx in enumerate(previous_kvs):
+        if isinstance(owner_idx, bool) or not isinstance(owner_idx, int):
+            raise ValueError("Gemma 4 previous_kvs entries must be integers")
+        if not 0 <= owner_idx < len(layers):
+            raise ValueError(
+                f"Invalid Gemma 4 KV owner {owner_idx!r} for layer {layer_idx}"
+            )
+        if owner_idx > layer_idx:
+            raise ValueError(
+                f"Gemma 4 KV owner {owner_idx} must precede layer {layer_idx}"
+            )
+    return Gemma4Layout(
+        execution_model=model,
+        decoder_model=decoder_model,
+        cache_model=cache_model,
+        previous_kvs=previous_kvs,
+        variant=_gemma4_variant(decoder_model),
+    )
+
+
+def _scorer_decoder_model(model: Any, adapter: SpecPrefillArchitectureAdapter) -> Any:
+    """Return the child that owns decoder attention instances for capture."""
+    if adapter is GEMMA4_ADAPTER:
+        return resolve_gemma4_layout(model).decoder_model
+    return model
+
+
+def _scorer_cache_model(model: Any, adapter: SpecPrefillArchitectureAdapter) -> Any:
+    """Return the model responsible for constructing the forward's KV cache."""
+    if adapter is GEMMA4_ADAPTER:
+        return resolve_gemma4_layout(model).cache_model
+    return model
+
+
 def _standard_layer_to_cache_map(model) -> dict[int, int]:
     """Map standard decoder layers to one cache entry each."""
     return {index: index for index in range(len(model.layers))}
@@ -1386,25 +1371,11 @@ def _gemma4_shared_kv_cache_map(model) -> dict[int, int]:
     not one entry per decoder layer. ``previous_kvs`` contains decoder-layer
     owners, so map first-seen owners to their compact cache-list indices.
     """
-    inner_model = getattr(model, "model", None)
-    previous_kvs = getattr(model, "previous_kvs", None)
-    if previous_kvs is None and inner_model is not None:
-        previous_kvs = getattr(inner_model, "previous_kvs", None)
-    if previous_kvs is None:
-        raise ValueError("Gemma 4 model is missing previous_kvs cache ownership")
-    if len(previous_kvs) != len(model.layers):
-        raise ValueError("Gemma 4 previous_kvs must cover every decoder layer")
+    layout = resolve_gemma4_layout(model)
+    previous_kvs = layout.previous_kvs
     owner_to_cache: dict[int, int] = {}
     mapping: dict[int, int] = {}
     for layer_idx, owner_idx in enumerate(previous_kvs):
-        if not isinstance(owner_idx, int) or not 0 <= owner_idx < len(model.layers):
-            raise ValueError(
-                f"Invalid Gemma 4 KV owner {owner_idx!r} for layer {layer_idx}"
-            )
-        if owner_idx > layer_idx:
-            raise ValueError(
-                f"Gemma 4 KV owner {owner_idx} must precede layer {layer_idx}"
-            )
         if owner_idx not in owner_to_cache:
             owner_to_cache[owner_idx] = len(owner_to_cache)
         mapping[layer_idx] = owner_to_cache[owner_idx]
@@ -1414,6 +1385,85 @@ def _gemma4_shared_kv_cache_map(model) -> dict[int, int]:
 def _hybrid_layer_to_cache_map(model) -> dict[int, int]:
     """Map Qwen3.5/3.6's mixed linear/attention stack to cache slots."""
     return _standard_layer_to_cache_map(model)
+
+
+def validate_specprefill_cache_topology(
+    adapter: SpecPrefillArchitectureAdapter,
+    model: Any,
+    cache: Sequence[Any],
+    layer_to_cache: dict[int, int],
+    *,
+    attention_layer_indices: Sequence[int] = (),
+) -> None:
+    """Fail closed if a real prompt cache disagrees with its adapter topology."""
+    if adapter is GEMMA4_ADAPTER:
+        layout = resolve_gemma4_layout(model)
+        layers = tuple(layout.decoder_model.layers)
+        layer_count = len(layers)
+        expected_cache_count = len(set(layout.previous_kvs))
+    elif adapter is QWEN_HYBRID_ADAPTER:
+        layer_count = len(model.layers)
+        expected_cache_count = layer_count
+    else:
+        return
+
+    if len(cache) != expected_cache_count:
+        raise ValueError(
+            f"{adapter.name} prompt cache has {len(cache)} entries; expected "
+            f"{expected_cache_count} from its decoder topology"
+        )
+    expected_layers = (
+        tuple(attention_layer_indices)
+        if attention_layer_indices
+        else tuple(range(layer_count))
+    )
+    for layer_idx in expected_layers:
+        cache_idx = layer_to_cache.get(layer_idx)
+        if cache_idx is None:
+            raise ValueError(
+                f"{adapter.name} cache map has no entry for decoder layer {layer_idx}"
+            )
+        if isinstance(cache_idx, bool) or not isinstance(cache_idx, int):
+            raise ValueError(f"{adapter.name} cache index must be a host integer")
+        if not 0 <= cache_idx < len(cache):
+            raise ValueError(
+                f"{adapter.name} cache index {cache_idx} is out of bounds for "
+                f"decoder layer {layer_idx}"
+            )
+
+    if adapter is not GEMMA4_ADAPTER:
+        return
+
+    owner_to_cache: dict[int, int] = {}
+    for layer_idx, owner_idx in enumerate(layout.previous_kvs):
+        expected_cache_idx = owner_to_cache.setdefault(owner_idx, len(owner_to_cache))
+        actual_cache_idx = layer_to_cache.get(layer_idx)
+        if actual_cache_idx != expected_cache_idx:
+            raise ValueError(
+                "gemma4-shared-kv cache map disagrees with compact KV owner "
+                f"{owner_idx} for decoder layer {layer_idx}"
+            )
+        layer_type = getattr(layers[layer_idx], "layer_type", None)
+        owner_type = getattr(layers[owner_idx], "layer_type", None)
+        if layer_type not in ("full_attention", "sliding_attention"):
+            raise ValueError(
+                f"Gemma 4 decoder layer {layer_idx} has unknown layer_type "
+                f"{layer_type!r}"
+            )
+        if layer_type != owner_type:
+            raise ValueError(
+                "Gemma 4 shared-KV follower layer_type disagrees with its "
+                f"owner: layer {layer_idx} is {layer_type!r}, owner {owner_idx} "
+                f"is {owner_type!r}"
+            )
+        cache_entry = cache[expected_cache_idx]
+        expected_type = KVCache if layer_type == "full_attention" else RotatingKVCache
+        if type(cache_entry) is not expected_type:
+            raise ValueError(
+                f"Gemma 4 {layer_type} owner {owner_idx} requires "
+                f"{expected_type.__name__} at compact cache index "
+                f"{expected_cache_idx}, got {type(cache_entry).__name__}"
+            )
 
 
 def _nemotron_h_layer_to_cache_map(model) -> dict[int, int]:
@@ -1495,8 +1545,13 @@ def _build_layer_to_cache_map(model):
     Returns dict {layer_idx: cache_idx}.
     """
     if (
-        getattr(model, "previous_kvs", None) is not None
-        or getattr(getattr(model, "model", None), "previous_kvs", None) is not None
+        _get_model_type(model) in GEMMA4_ADAPTER.model_types
+        or _has_gemma4_decoder_contract(model)
+        or _has_gemma4_decoder_contract(getattr(model, "model", None))
+        or (
+            hasattr(model, "layers")
+            and getattr(getattr(model, "model", None), "previous_kvs", None) is not None
+        )
     ):
         return _gemma4_shared_kv_cache_map(model)
 

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -39,7 +39,11 @@ Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
 """
 
 import hashlib
+import inspect
 import math
+import threading
+import weakref
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable
@@ -229,26 +233,129 @@ def resolve_specprefill_decision(
 
 
 class _AttentionCapture:
-    """Wrapper that captures post-RoPE query vectors and delegates to original.
+    """Install-once attention wrapper with immutable delegation.
 
-    Installed on attention layers during lookahead decode to capture query
-    vectors for importance scoring. Supports multiple architectures via
-    query_extractor callback.
+    Normal model calls are delegated without touching scorer state. During a
+    request-local scorer session, the owning :class:`SpecPrefillScorer`
+    supplies the capture buffer and extractor. The legacy buffer arguments are
+    retained for callers that construct a standalone wrapper directly; model
+    installation always uses the scorer-owned path.
     """
 
-    def __init__(self, original, buf_idx, query_buffer, query_extractor=None):
+    def __init__(
+        self,
+        original,
+        buf_idx,
+        query_buffer=None,
+        query_extractor=None,
+        *,
+        scorer=None,
+    ):
+        if isinstance(original, _AttentionCapture):
+            raise RuntimeError("SpecPrefill attention wrappers cannot be nested")
+        if scorer is not None and (
+            query_buffer is not None or query_extractor is not None
+        ):
+            raise ValueError("scorer-owned wrappers cannot use legacy capture state")
         self._original = original
         self._buf_idx = buf_idx
         self._query_buffer = query_buffer
         self._query_extractor = query_extractor or _qwen35_extract_queries
+        self._scorer_ref = weakref.ref(scorer) if scorer is not None else None
+        self._call_plan = _build_capture_call_plan(original)
 
-    def __call__(self, x, mask=None, cache=None, **kwargs):
-        queries = self._query_extractor(self._original, x, cache=cache, **kwargs)
-        self._query_buffer[self._buf_idx].append(queries)
-        return self._original(x, mask=mask, cache=cache, **kwargs)
+    def __call__(self, *args, **kwargs):
+        if self._scorer_ref is None:
+            query_buffer = self._query_buffer
+            query_extractor = self._query_extractor
+        else:
+            scorer = self._scorer_ref()
+            if scorer is None:
+                raise RuntimeError("Detached SpecPrefill capture wrapper")
+            session = scorer._capture_session_for_wrapper()
+            if session is None:
+                return self._original(*args, **kwargs)
+            query_buffer = session.query_buffer
+            query_extractor = session.query_extractor
+
+        x, cache, capture_kwargs = _capture_call_arguments(
+            self._call_plan, args, kwargs
+        )
+        queries = query_extractor(self._original, x, cache=cache, **capture_kwargs)
+        query_buffer[self._buf_idx].append(queries)
+        return self._original(*args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._original, name)
+
+
+@dataclass(frozen=True)
+class _CaptureCallPlan:
+    input_name: str
+    input_position: int | None
+    cache_position: int | None
+    positional_names: tuple[str, ...]
+
+
+def _build_capture_call_plan(original):
+    """Inspect an attention callable once when its stable wrapper is installed."""
+    try:
+        signature = inspect.signature(original)
+        positional_names = tuple(
+            name
+            for name, parameter in signature.parameters.items()
+            if parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        )
+    except (TypeError, ValueError):
+        positional_names = ()
+
+    input_name = "x" if "x" in positional_names else None
+    if input_name is None:
+        input_name = positional_names[0] if positional_names else "x"
+    input_position = (
+        positional_names.index(input_name) if input_name in positional_names else 0
+    )
+    cache_position = (
+        positional_names.index("cache") if "cache" in positional_names else 2
+    )
+    return _CaptureCallPlan(
+        input_name=input_name,
+        input_position=input_position,
+        cache_position=cache_position,
+        positional_names=positional_names,
+    )
+
+
+def _capture_call_arguments(plan, args, kwargs):
+    """Extract scorer inputs without changing the delegated attention call."""
+    if plan.input_name in kwargs:
+        x = kwargs[plan.input_name]
+    elif plan.input_position is not None and len(args) > plan.input_position:
+        x = args[plan.input_position]
+    else:
+        raise RuntimeError("Cannot identify attention input for SpecPrefill")
+
+    if "cache" in kwargs:
+        cache = kwargs["cache"]
+    elif plan.cache_position is not None and len(args) > plan.cache_position:
+        cache = args[plan.cache_position]
+    else:
+        cache = None
+
+    capture_kwargs = dict(kwargs)
+    capture_kwargs.pop(plan.input_name, None)
+    capture_kwargs.pop("mask", None)
+    capture_kwargs.pop("cache", None)
+    for position, name in enumerate(plan.positional_names):
+        if position >= len(args):
+            break
+        if name not in (plan.input_name, "mask", "cache"):
+            capture_kwargs.setdefault(name, args[position])
+    return x, cache, capture_kwargs
 
 
 def _qwen35_extract_queries(attn, x, cache=None, **_kwargs):
@@ -345,34 +452,215 @@ def _nemotron_h_extract_queries(attn, x, cache=None, **_kwargs):
     return queries
 
 
-def _patch_attention_for_capture(model, query_buffer, query_extractor=None):
-    """Replace attention modules on full-attention layers with capture wrappers.
+@dataclass
+class _ScorerCaptureSession:
+    query_extractor: Callable[..., mx.array]
+    query_buffer: list[list[mx.array]]
+    owner_thread_id: int
+    capture_enabled: bool = True
 
-    Supports both `self_attn` (Qwen3.5/Llama/GPT-OSS) and `mixer`
-    (Nemotron-H block_type="*") attribute conventions.
 
-    Returns (originals, attn_layer_indices) for cleanup.
+class SpecPrefillScorer:
+    """Install-once, serialized scorer for one draft model.
+
+    Attention wrappers are a stable part of the scorer model after
+    construction. Only the capture session is request-local and mutable. The
+    initial implementation deliberately rejects overlapping work instead of
+    allowing requests to share capture buffers.
     """
-    originals = []
-    attn_indices = []
-    for layer_idx, layer in _find_attention_layers(model):
-        buf_idx = len(attn_indices)
-        attn_indices.append(layer_idx)
-        orig = _get_attn_module(layer)
-        _set_attn_module(
-            layer,
-            _AttentionCapture(
-                orig, buf_idx, query_buffer, query_extractor=query_extractor
+
+    def __init__(self, model):
+        self._model_ref = weakref.ref(model)
+        self.adapter = resolve_specprefill_adapter(model)
+        self._session_lock = threading.Lock()
+        self._active_session = None
+        self._session_context = threading.local()
+
+        attention_layers = _find_attention_layers(model)
+        if not attention_layers:
+            raise ValueError("SpecPrefill scorer model has no attention layers")
+        originals = [_get_attn_module(layer) for _, layer in attention_layers]
+        if any(isinstance(original, _AttentionCapture) for original in originals):
+            raise RuntimeError("SpecPrefill attention wrappers are already installed")
+
+        wrappers = [
+            (layer_idx, layer, _AttentionCapture(original, buf_idx, scorer=self))
+            for buf_idx, ((layer_idx, layer), original) in enumerate(
+                zip(attention_layers, originals)
+            )
+        ]
+        installed = []
+        try:
+            for (layer_idx, layer, wrapper), original in zip(wrappers, originals):
+                _set_attn_module(layer, wrapper)
+                installed.append((layer, original))
+        except Exception:
+            for layer, original in installed:
+                _set_attn_module(layer, original)
+            raise
+        wrappers = [(layer_idx, wrapper) for layer_idx, _, wrapper in wrappers]
+        self.attention_layer_indices = tuple(layer_idx for layer_idx, _ in wrappers)
+        self._wrappers = tuple(wrappers)
+
+    @classmethod
+    def for_model(cls, model):
+        """Return the sole scorer for ``model``, installing wrappers once."""
+        with _SCORER_REGISTRY_LOCK:
+            try:
+                scorer = _SCORER_REGISTRY.get(model)
+            except TypeError as exc:
+                raise RuntimeError(
+                    "SpecPrefill scorer models must support weak references"
+                ) from exc
+            if scorer is None:
+                scorer = cls(model)
+                _SCORER_REGISTRY[model] = scorer
+            scorer._verify_installed()
+            return scorer
+
+    @property
+    def model(self):
+        model = self._model_ref()
+        if model is None:
+            raise RuntimeError("SpecPrefill scorer model is no longer available")
+        return model
+
+    @property
+    def capture_active(self) -> bool:
+        return self._active_session is not None
+
+    def _verify_installed(self):
+        model = self.model
+        for layer_idx, wrapper in self._wrappers:
+            if _get_attn_module(model.layers[layer_idx]) is not wrapper:
+                raise RuntimeError("SpecPrefill scorer wrapper topology was modified")
+
+    def _capture_session_for_wrapper(self):
+        session = self._active_session
+        if session is None:
+            return None
+        context_session = getattr(self._session_context, "capture", None)
+        if (
+            context_session is not session
+            or session.owner_thread_id != threading.get_ident()
+        ):
+            raise RuntimeError(
+                "SpecPrefill scorer invoked outside its active request session"
+            )
+        return session if session.capture_enabled else None
+
+    @contextmanager
+    def capture_session(self, query_extractor=None, *, capture_enabled=True):
+        """Activate one fail-closed request-local capture session."""
+        self._verify_installed()
+        if not self._session_lock.acquire(blocking=False):
+            raise RuntimeError("SpecPrefill scorer already has an active session")
+        if self._active_session is not None:
+            self._session_lock.release()
+            raise RuntimeError("SpecPrefill scorer already has an active session")
+
+        session = _ScorerCaptureSession(
+            query_extractor=query_extractor or self.adapter.query_extractor,
+            query_buffer=[[] for _ in self.attention_layer_indices],
+            owner_thread_id=threading.get_ident(),
+            capture_enabled=capture_enabled,
+        )
+        self._active_session = session
+        self._session_context.capture = session
+        try:
+            yield session
+        finally:
+            self._active_session = None
+            try:
+                del self._session_context.capture
+            except AttributeError:
+                pass
+            self._session_lock.release()
+
+    def score_tokens(
+        self,
+        tokens,
+        n_lookahead=8,
+        pool_kernel=13,
+        temp=0.6,
+        top_p=0.95,
+        prefill_step_size=2048,
+        query_extractor=None,
+        cancel_check=None,
+    ):
+        """Score one prompt with all lazy capture work inside its session."""
+        model = self.model
+        if isinstance(tokens, mx.array):
+            tokens = tokens.tolist()
+        n_prompt = len(tokens)
+
+        first_attention = self._wrappers[0][1]._original
+        n_attn_heads = getattr(
+            first_attention,
+            "num_attention_heads",
+            getattr(
+                first_attention,
+                "n_heads",
+                getattr(first_attention, "num_heads", None),
             ),
         )
-        originals.append((layer_idx, orig))
-    return originals, attn_indices
+        n_kv_heads = getattr(
+            first_attention,
+            "num_key_value_heads",
+            getattr(first_attention, "n_kv_heads", None),
+        )
+
+        cache = None
+        logits = None
+        try:
+            with self.capture_session(
+                query_extractor=query_extractor, capture_enabled=False
+            ) as session:
+                cache = make_prompt_cache(model)
+                logits = _prefill_draft(
+                    model,
+                    tokens,
+                    cache,
+                    step_size=prefill_step_size,
+                    cancel_check=cancel_check,
+                )
+                session.capture_enabled = True
+                _lookahead_decode(
+                    model,
+                    logits,
+                    cache,
+                    n_lookahead,
+                    temp=temp,
+                    top_p=top_p,
+                    cancel_check=cancel_check,
+                )
+
+                layer_to_cache = self.adapter.cache_map_builder(model)
+                attn_caches = [
+                    cache[layer_to_cache[index]]
+                    for index in self.attention_layer_indices
+                ]
+                if cancel_check is not None:
+                    cancel_check()
+                importance = _compute_importance(
+                    session.query_buffer,
+                    attn_caches,
+                    n_prompt,
+                    n_attn_heads,
+                    n_kv_heads,
+                    pool_kernel=pool_kernel if pool_kernel > 0 else None,
+                )
+                # MLX execution is lazy. Realize both captured queries and the
+                # final scores while this request still owns the scorer lane.
+                mx.eval(session.query_buffer, importance)
+            return importance
+        finally:
+            del cache, logits
+            mx.clear_cache()
 
 
-def _unpatch_attention_capture(model, originals):
-    """Restore original attention modules after capture."""
-    for layer_idx, orig in originals:
-        _set_attn_module(model.layers[layer_idx], orig)
+_SCORER_REGISTRY = weakref.WeakKeyDictionary()
+_SCORER_REGISTRY_LOCK = threading.Lock()
 
 
 def _prefill_draft(model, tokens, cache, step_size=2048, cancel_check=None):
@@ -526,82 +814,17 @@ def score_tokens(
     Returns:
         importance: (M,) mx.array of per-token importance scores
     """
-    if isinstance(tokens, mx.array):
-        tokens = tokens.tolist()
-    n_prompt = len(tokens)
-
-    # Model topology — detect attribute names across architectures
-    attn_layers = _find_attention_layers(model)
-    n_attn_layers = len(attn_layers)
-    attn_obj = _get_attn_module(attn_layers[0][1])
-    # Attribute names vary: num_attention_heads (Qwen3.5), n_heads (Llama),
-    # num_heads (Nemotron-H)
-    n_attn_heads = getattr(
-        attn_obj,
-        "num_attention_heads",
-        getattr(attn_obj, "n_heads", getattr(attn_obj, "num_heads", None)),
-    )
-    n_kv_heads = getattr(
-        attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
-    )
-
-    # Resolve known model families through an explicit adapter registry. The
-    # generic fallback remains only for legacy callers that pass a custom
-    # extractor; unknown model types must not silently acquire a scoring path.
-    if query_extractor is None:
-        query_extractor = resolve_specprefill_adapter(model).query_extractor
-
-    # Phase 1: Prefill
-    cache = make_prompt_cache(model)
-    logits = _prefill_draft(
-        model,
+    scorer = SpecPrefillScorer.for_model(model)
+    return scorer.score_tokens(
         tokens,
-        cache,
-        step_size=prefill_step_size,
+        n_lookahead=n_lookahead,
+        pool_kernel=pool_kernel,
+        temp=temp,
+        top_p=top_p,
+        prefill_step_size=prefill_step_size,
+        query_extractor=query_extractor,
         cancel_check=cancel_check,
     )
-
-    # Phase 2: Lookahead decode with query capture
-    query_buffer = [[] for _ in range(n_attn_layers)]
-    patches, attn_indices = _patch_attention_for_capture(
-        model, query_buffer, query_extractor=query_extractor
-    )
-    try:
-        _lookahead_decode(
-            model,
-            logits,
-            cache,
-            n_lookahead,
-            temp=temp,
-            top_p=top_p,
-            cancel_check=cancel_check,
-        )
-        mx.eval(query_buffer)
-    finally:
-        _unpatch_attention_capture(model, patches)
-
-    # Phase 3: Compute importance
-    # Map layer indices to cache indices (identity for standard models,
-    # compacted for Nemotron-H where only M/* layers have cache entries)
-    layer_to_cache = resolve_specprefill_adapter(model).cache_map_builder(model)
-    attn_caches = [cache[layer_to_cache[i]] for i in attn_indices]
-    if cancel_check is not None:
-        cancel_check()
-    importance = _compute_importance(
-        query_buffer,
-        attn_caches,
-        n_prompt,
-        n_attn_heads,
-        n_kv_heads,
-        pool_kernel=pool_kernel if pool_kernel > 0 else None,
-    )
-    mx.eval(importance)
-
-    # Draft cache is no longer needed — let GC reclaim it
-    del cache, logits, query_buffer, attn_caches
-    mx.clear_cache()
-
-    return importance
 
 
 def _chunk_scores(importance, chunk_size: int) -> tuple[int, list[float]]:

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -38,6 +38,7 @@ Design notes:
 Reference: arxiv.org/abs/2502.02789 (SpecPrefill: Speculative Prefilling)
 """
 
+import functools
 import hashlib
 import inspect
 import math
@@ -233,13 +234,12 @@ def resolve_specprefill_decision(
 
 
 class _AttentionCapture:
-    """Install-once attention wrapper with immutable delegation.
+    """Standalone compatibility wrapper for direct capture tests.
 
-    Normal model calls are delegated without touching scorer state. During a
-    request-local scorer session, the owning :class:`SpecPrefillScorer`
-    supplies the capture buffer and extractor. The legacy buffer arguments are
-    retained for callers that construct a standalone wrapper directly; model
-    installation always uses the scorer-owned path.
+    This helper is never installed on a scorer model. Replacing an MLX child
+    module with a plain proxy removes its parameter subtree from
+    :class:`mlx.nn.Module`. :class:`SpecPrefillScorer` instead installs a
+    class-level dispatcher while retaining the exact attention instances.
     """
 
     def __init__(
@@ -248,41 +248,23 @@ class _AttentionCapture:
         buf_idx,
         query_buffer=None,
         query_extractor=None,
-        *,
-        scorer=None,
     ):
         if isinstance(original, _AttentionCapture):
             raise RuntimeError("SpecPrefill attention wrappers cannot be nested")
-        if scorer is not None and (
-            query_buffer is not None or query_extractor is not None
-        ):
-            raise ValueError("scorer-owned wrappers cannot use legacy capture state")
         self._original = original
         self._buf_idx = buf_idx
         self._query_buffer = query_buffer
         self._query_extractor = query_extractor or _qwen35_extract_queries
-        self._scorer_ref = weakref.ref(scorer) if scorer is not None else None
         self._call_plan = _build_capture_call_plan(original)
 
     def __call__(self, *args, **kwargs):
-        if self._scorer_ref is None:
-            query_buffer = self._query_buffer
-            query_extractor = self._query_extractor
-        else:
-            scorer = self._scorer_ref()
-            if scorer is None:
-                raise RuntimeError("Detached SpecPrefill capture wrapper")
-            session = scorer._capture_session_for_wrapper()
-            if session is None:
-                return self._original(*args, **kwargs)
-            query_buffer = session.query_buffer
-            query_extractor = session.query_extractor
-
         x, cache, capture_kwargs = _capture_call_arguments(
             self._call_plan, args, kwargs
         )
-        queries = query_extractor(self._original, x, cache=cache, **capture_kwargs)
-        query_buffer[self._buf_idx].append(queries)
+        queries = self._query_extractor(
+            self._original, x, cache=cache, **capture_kwargs
+        )
+        self._query_buffer[self._buf_idx].append(queries)
         return self._original(*args, **kwargs)
 
     def __getattr__(self, name):
@@ -295,6 +277,154 @@ class _CaptureCallPlan:
     input_position: int | None
     cache_position: int | None
     positional_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _InstalledAttentionCapture:
+    """Immutable dispatch metadata for one original attention instance."""
+
+    scorer_ref: weakref.ReferenceType["SpecPrefillScorer"]
+    buffer_index: int
+    call_plan: _CaptureCallPlan
+
+
+@dataclass(frozen=True)
+class _AttentionClassDispatch:
+    """Original and stable dispatch callables installed for one Python class."""
+
+    original_call: Callable[..., Any]
+    dispatch_call: Callable[..., Any]
+    call_plan: _CaptureCallPlan
+
+
+_ATTENTION_DISPATCH_LOCK = threading.RLock()
+_ATTENTION_DISPATCHED_CLASSES: dict[type, _AttentionClassDispatch] = {}
+_ATTENTION_CAPTURES: dict[
+    int, tuple[weakref.ReferenceType[Any], _InstalledAttentionCapture]
+] = {}
+
+
+def _attention_capture_for(instance: Any) -> _InstalledAttentionCapture | None:
+    """Return identity-matched state without requiring a hashable nn.Module."""
+    object_id = id(instance)
+    entry = _ATTENTION_CAPTURES.get(object_id)
+    if entry is None:
+        return None
+    instance_ref, installed = entry
+    registered = instance_ref()
+    if registered is instance:
+        return installed
+    if registered is None and _ATTENTION_CAPTURES.get(object_id) is entry:
+        _ATTENTION_CAPTURES.pop(object_id, None)
+        return None
+    raise RuntimeError("SpecPrefill attention registry identity collision")
+
+
+def _attention_registry_ref(instance: Any) -> weakref.ReferenceType[Any]:
+    """Build a weak identity key whose callback cannot delete a reused ID."""
+    object_id = id(instance)
+
+    def _remove(instance_ref):
+        with _ATTENTION_DISPATCH_LOCK:
+            entry = _ATTENTION_CAPTURES.get(object_id)
+            if entry is not None and entry[0] is instance_ref:
+                _ATTENTION_CAPTURES.pop(object_id, None)
+
+    try:
+        return weakref.ref(instance, _remove)
+    except TypeError as exc:
+        raise RuntimeError(
+            "SpecPrefill attention instances must support weak references"
+        ) from exc
+
+
+def _install_attention_capture(
+    attention: Any, scorer: "SpecPrefillScorer", buffer_index: int
+) -> None:
+    """Register one attention instance without changing model topology.
+
+    Python resolves ``instance(...)`` through ``type(instance).__call__``.
+    Installing one stable dispatcher on that class lets us select capture
+    behaviour through a weak per-instance registry while leaving the model's
+    original child module, parameters, and state dictionary untouched.
+    """
+    attention_type = type(attention)
+    with _ATTENTION_DISPATCH_LOCK:
+        class_dispatch = _ATTENTION_DISPATCHED_CLASSES.get(attention_type)
+        if class_dispatch is None:
+            resolved_call = attention_type.__call__
+            inherited_dispatch = next(
+                (
+                    installed_dispatch
+                    for installed_dispatch in _ATTENTION_DISPATCHED_CLASSES.values()
+                    if installed_dispatch.dispatch_call is resolved_call
+                ),
+                None,
+            )
+            if inherited_dispatch is None:
+                original_call = resolved_call
+                call_plan = _build_capture_call_plan(attention)
+            else:
+                # A subclass can inherit a base class dispatcher. Flatten it to
+                # the original callable so capture is performed exactly once.
+                original_call = inherited_dispatch.original_call
+                call_plan = inherited_dispatch.call_plan
+
+            @functools.wraps(original_call)
+            def _dispatch(instance, *args, **kwargs):
+                with _ATTENTION_DISPATCH_LOCK:
+                    installed = _attention_capture_for(instance)
+                if installed is None:
+                    return original_call(instance, *args, **kwargs)
+                owner = installed.scorer_ref()
+                if owner is None:
+                    with _ATTENTION_DISPATCH_LOCK:
+                        entry = _ATTENTION_CAPTURES.get(id(instance))
+                        if entry is not None and entry[0]() is instance:
+                            _ATTENTION_CAPTURES.pop(id(instance), None)
+                    return original_call(instance, *args, **kwargs)
+                session = owner._capture_session_for_attention()
+                if session is not None:
+                    x, cache, capture_kwargs = _capture_call_arguments(
+                        installed.call_plan, args, kwargs
+                    )
+                    queries = session.query_extractor(
+                        instance, x, cache=cache, **capture_kwargs
+                    )
+                    session.query_buffer[installed.buffer_index].append(queries)
+                return original_call(instance, *args, **kwargs)
+
+            try:
+                attention_type.__call__ = _dispatch
+            except (AttributeError, TypeError) as exc:
+                raise RuntimeError(
+                    "Cannot install a stable SpecPrefill dispatcher for "
+                    f"attention class {attention_type}"
+                ) from exc
+            class_dispatch = _AttentionClassDispatch(
+                original_call, _dispatch, call_plan
+            )
+            _ATTENTION_DISPATCHED_CLASSES[attention_type] = class_dispatch
+        elif attention_type.__call__ is not class_dispatch.dispatch_call:
+            raise RuntimeError("SpecPrefill attention class dispatcher was modified")
+        else:
+            call_plan = class_dispatch.call_plan
+
+        existing = _attention_capture_for(attention)
+        if existing is not None and existing.scorer_ref() is not scorer:
+            raise RuntimeError("SpecPrefill attention instance is already registered")
+        _ATTENTION_CAPTURES[id(attention)] = (
+            _attention_registry_ref(attention),
+            _InstalledAttentionCapture(weakref.ref(scorer), buffer_index, call_plan),
+        )
+
+
+def _uninstall_attention_capture(attention: Any, scorer: "SpecPrefillScorer") -> None:
+    """Rollback a failed multi-layer registration without touching the model."""
+    with _ATTENTION_DISPATCH_LOCK:
+        installed = _attention_capture_for(attention)
+        if installed is not None and installed.scorer_ref() is scorer:
+            _ATTENTION_CAPTURES.pop(id(attention), None)
 
 
 def _build_capture_call_plan(original):
@@ -463,10 +593,11 @@ class _ScorerCaptureSession:
 class SpecPrefillScorer:
     """Install-once, serialized scorer for one draft model.
 
-    Attention wrappers are a stable part of the scorer model after
-    construction. Only the capture session is request-local and mutable. The
-    initial implementation deliberately rejects overlapping work instead of
-    allowing requests to share capture buffers.
+    Attention instances remain the exact MLX child modules loaded with the
+    model. Their Python classes receive one stable dispatcher, while immutable
+    weak registry entries associate only this scorer's attention instances
+    with request-local capture state. The initial implementation deliberately
+    rejects overlapping work instead of allowing requests to share buffers.
     """
 
     def __init__(self, model):
@@ -479,42 +610,32 @@ class SpecPrefillScorer:
         attention_layers = _find_attention_layers(model)
         if not attention_layers:
             raise ValueError("SpecPrefill scorer model has no attention layers")
-        originals = [_get_attn_module(layer) for _, layer in attention_layers]
-        if any(isinstance(original, _AttentionCapture) for original in originals):
-            raise RuntimeError("SpecPrefill attention wrappers are already installed")
-
-        wrappers = [
-            (layer_idx, layer, _AttentionCapture(original, buf_idx, scorer=self))
-            for buf_idx, ((layer_idx, layer), original) in enumerate(
-                zip(attention_layers, originals)
-            )
+        attentions = [
+            (layer_idx, _get_attn_module(layer))
+            for layer_idx, layer in attention_layers
         ]
-        installed = []
+        installed: list[Any] = []
         try:
-            for (layer_idx, layer, wrapper), original in zip(wrappers, originals):
-                _set_attn_module(layer, wrapper)
-                installed.append((layer, original))
+            for buffer_index, (_layer_idx, attention) in enumerate(attentions):
+                _install_attention_capture(attention, self, buffer_index)
+                installed.append(attention)
         except Exception:
-            for layer, original in installed:
-                _set_attn_module(layer, original)
+            for attention in reversed(installed):
+                _uninstall_attention_capture(attention, self)
             raise
-        wrappers = [(layer_idx, wrapper) for layer_idx, _, wrapper in wrappers]
-        self.attention_layer_indices = tuple(layer_idx for layer_idx, _ in wrappers)
-        self._wrappers = tuple(wrappers)
+        self.attention_layer_indices = tuple(
+            layer_idx for layer_idx, _attention in attentions
+        )
+        self._installed_attentions = tuple(attentions)
 
     @classmethod
     def for_model(cls, model):
-        """Return the sole scorer for ``model``, installing wrappers once."""
+        """Return the sole scorer for ``model``, installing dispatch once."""
         with _SCORER_REGISTRY_LOCK:
-            try:
-                scorer = _SCORER_REGISTRY.get(model)
-            except TypeError as exc:
-                raise RuntimeError(
-                    "SpecPrefill scorer models must support weak references"
-                ) from exc
+            scorer = _scorer_for_model(model)
             if scorer is None:
                 scorer = cls(model)
-                _SCORER_REGISTRY[model] = scorer
+                _register_scorer_model(model, scorer)
             scorer._verify_installed()
             return scorer
 
@@ -531,11 +652,31 @@ class SpecPrefillScorer:
 
     def _verify_installed(self):
         model = self.model
-        for layer_idx, wrapper in self._wrappers:
-            if _get_attn_module(model.layers[layer_idx]) is not wrapper:
-                raise RuntimeError("SpecPrefill scorer wrapper topology was modified")
+        for buffer_index, (layer_idx, attention) in enumerate(
+            self._installed_attentions
+        ):
+            if _get_attn_module(model.layers[layer_idx]) is not attention:
+                raise RuntimeError("SpecPrefill scorer attention topology was modified")
+            with _ATTENTION_DISPATCH_LOCK:
+                installed = _attention_capture_for(attention)
+                class_dispatch = _ATTENTION_DISPATCHED_CLASSES.get(type(attention))
+            if (
+                installed is None
+                or installed.scorer_ref() is not self
+                or installed.buffer_index != buffer_index
+            ):
+                raise RuntimeError(
+                    "SpecPrefill scorer attention registration was modified"
+                )
+            if (
+                class_dispatch is None
+                or type(attention).__call__ is not class_dispatch.dispatch_call
+            ):
+                raise RuntimeError(
+                    "SpecPrefill scorer attention class dispatcher was modified"
+                )
 
-    def _capture_session_for_wrapper(self):
+    def _capture_session_for_attention(self):
         session = self._active_session
         if session is None:
             return None
@@ -594,22 +735,6 @@ class SpecPrefillScorer:
             tokens = tokens.tolist()
         n_prompt = len(tokens)
 
-        first_attention = self._wrappers[0][1]._original
-        n_attn_heads = getattr(
-            first_attention,
-            "num_attention_heads",
-            getattr(
-                first_attention,
-                "n_heads",
-                getattr(first_attention, "num_heads", None),
-            ),
-        )
-        n_kv_heads = getattr(
-            first_attention,
-            "num_key_value_heads",
-            getattr(first_attention, "n_kv_heads", None),
-        )
-
         cache = None
         logits = None
         try:
@@ -646,8 +771,6 @@ class SpecPrefillScorer:
                     session.query_buffer,
                     attn_caches,
                     n_prompt,
-                    n_attn_heads,
-                    n_kv_heads,
                     pool_kernel=pool_kernel if pool_kernel > 0 else None,
                 )
                 # MLX execution is lazy. Realize both captured queries and the
@@ -659,8 +782,44 @@ class SpecPrefillScorer:
             mx.clear_cache()
 
 
-_SCORER_REGISTRY = weakref.WeakKeyDictionary()
-_SCORER_REGISTRY_LOCK = threading.Lock()
+_SCORER_REGISTRY: dict[int, tuple[weakref.ReferenceType[Any], SpecPrefillScorer]] = {}
+_SCORER_REGISTRY_LOCK = threading.RLock()
+
+
+def _scorer_for_model(model: Any) -> SpecPrefillScorer | None:
+    object_id = id(model)
+    entry = _SCORER_REGISTRY.get(object_id)
+    if entry is None:
+        return None
+    model_ref, scorer = entry
+    registered = model_ref()
+    if registered is model:
+        return scorer
+    if registered is None and _SCORER_REGISTRY.get(object_id) is entry:
+        _SCORER_REGISTRY.pop(object_id, None)
+        return None
+    raise RuntimeError("SpecPrefill scorer registry identity collision")
+
+
+def _register_scorer_model(model: Any, scorer: SpecPrefillScorer) -> None:
+    object_id = id(model)
+
+    def _remove(model_ref):
+        with _SCORER_REGISTRY_LOCK:
+            entry = _SCORER_REGISTRY.get(object_id)
+            if entry is not None and entry[0] is model_ref:
+                _SCORER_REGISTRY.pop(object_id, None)
+
+    try:
+        model_ref = weakref.ref(model, _remove)
+    except TypeError as exc:
+        raise RuntimeError(
+            "SpecPrefill scorer models must support weak references"
+        ) from exc
+    existing = _scorer_for_model(model)
+    if existing is not None and existing is not scorer:
+        raise RuntimeError("SpecPrefill scorer model is already registered")
+    _SCORER_REGISTRY[object_id] = (model_ref, scorer)
 
 
 def _prefill_draft(model, tokens, cache, step_size=2048, cancel_check=None):
@@ -732,7 +891,12 @@ def _avg_pool1d(x, kernel_size):
 
 
 def _compute_importance(
-    query_buffer, attn_caches, n_prompt, n_attn_heads, n_kv_heads, pool_kernel=13
+    query_buffer,
+    attn_caches,
+    n_prompt,
+    n_attn_heads=None,
+    n_kv_heads=None,
+    pool_kernel=13,
 ):
     """Compute per-token importance from captured queries and cached keys.
 
@@ -744,7 +908,11 @@ def _compute_importance(
 
     Returns: (n_prompt,) importance scores.
     """
-    heads_per_group = n_attn_heads // n_kv_heads
+    # ``n_attn_heads`` and ``n_kv_heads`` remain accepted for compatibility
+    # with older private callers, but heterogeneous models cannot use one
+    # model-global pair. Derive the grouping from each realized query/cache
+    # shape instead (Gemma 4 alternates sliding and global KV widths).
+    del n_attn_heads, n_kv_heads
     all_scores = []
 
     for layer_i, captures in enumerate(query_buffer):
@@ -759,6 +927,19 @@ def _compute_importance(
             continue
         head_dim = prompt_keys.shape[-1]
         q_stack = mx.concatenate(captures, axis=2)
+        query_heads = int(q_stack.shape[1])
+        key_heads = int(prompt_keys.shape[1])
+        if query_heads <= 0 or key_heads <= 0 or query_heads % key_heads:
+            raise RuntimeError(
+                "SpecPrefill attention heads must have an integral per-layer "
+                f"query/KV grouping (queries={query_heads}, keys={key_heads})"
+            )
+        if int(q_stack.shape[-1]) != int(head_dim):
+            raise RuntimeError(
+                "SpecPrefill captured query and cache key dimensions differ "
+                f"({q_stack.shape[-1]} != {head_dim})"
+            )
+        heads_per_group = query_heads // key_heads
         if heads_per_group > 1:
             expanded_keys = mx.repeat(prompt_keys, heads_per_group, axis=1)
         else:

--- a/vllm_mlx/specprefill_cache.py
+++ b/vllm_mlx/specprefill_cache.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Authoritative request-local state for sparse SpecPrefill caches.
+
+Sparse prompt caches cannot participate in ordinary prefix-cache matching.
+Their physical KV length is shorter than the logical prompt position, and a
+cache is valid only for the exact target, tokenizer, scorer, selector policy,
+full prompt, and selected-token plan that created it.  This module owns that
+metadata independently of model-layer cache objects.  It deliberately has no
+MLX dependency so scheduler code can validate state before touching device
+memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+import threading
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+SPARSE_CACHE_STATE_VERSION = "specprefill-sparse-cache-v1"
+
+
+class SparseCacheStateError(ValueError):
+    """Sparse cache metadata is incomplete, inconsistent, or unsafe to reuse."""
+
+
+class SparseCacheTransformUnsupported(SparseCacheStateError):
+    """A cache tier cannot yet preserve sparse state as one atomic object."""
+
+
+@dataclass(frozen=True)
+class SparsePolicyTuning:
+    """Versioned selector controls that influence a sparse cache's contents."""
+
+    keep_pct: float
+    backbone_pct: float
+    halo_chunks: int
+    anchor_chunks: int
+    chunk_size: int
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.keep_pct) or not 0.0 < self.keep_pct <= 1.0:
+            raise SparseCacheStateError("keep_pct must be finite and in (0, 1]")
+        if not math.isfinite(self.backbone_pct) or not 0.0 <= self.backbone_pct <= 1.0:
+            raise SparseCacheStateError("backbone_pct must be finite and in [0, 1]")
+        if self.halo_chunks < 0:
+            raise SparseCacheStateError("halo_chunks must be non-negative")
+        if self.anchor_chunks < 0:
+            raise SparseCacheStateError("anchor_chunks must be non-negative")
+        if self.chunk_size <= 0:
+            raise SparseCacheStateError("chunk_size must be positive")
+
+
+@dataclass(frozen=True)
+class SparseCacheExecutionConfig:
+    """Configuration that must match before rows share a CB execution lane."""
+
+    target_id: str
+    tokenizer_id: str
+    scorer_id: str
+    selector_version: str
+    tuning: SparsePolicyTuning
+    state_version: str = SPARSE_CACHE_STATE_VERSION
+
+    def __post_init__(self) -> None:
+        for name in (
+            "target_id",
+            "tokenizer_id",
+            "scorer_id",
+            "selector_version",
+            "state_version",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise SparseCacheStateError(f"{name} must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class SparseCacheIdentity:
+    """One row's complete identity required for exact sparse-cache reuse.
+
+    Artifact IDs are caller-provided immutable identifiers, normally a model
+    revision plus checksum.  Paths or object IDs are not sufficient: sharing a
+    sparse target cache with a different tokenizer, scorer, selection plan, or
+    full token sequence silently corrupts positional semantics.
+    """
+
+    target_id: str
+    tokenizer_id: str
+    scorer_id: str
+    selector_version: str
+    tuning: SparsePolicyTuning
+    full_token_hash: str
+    selection_fingerprint: str
+    state_version: str = SPARSE_CACHE_STATE_VERSION
+
+    def __post_init__(self) -> None:
+        SparseCacheExecutionConfig(
+            target_id=self.target_id,
+            tokenizer_id=self.tokenizer_id,
+            scorer_id=self.scorer_id,
+            selector_version=self.selector_version,
+            tuning=self.tuning,
+            state_version=self.state_version,
+        )
+        self._validate_digest("full_token_hash", self.full_token_hash)
+        self._validate_digest("selection_fingerprint", self.selection_fingerprint)
+
+    @property
+    def execution_config(self) -> SparseCacheExecutionConfig:
+        return SparseCacheExecutionConfig(
+            target_id=self.target_id,
+            tokenizer_id=self.tokenizer_id,
+            scorer_id=self.scorer_id,
+            selector_version=self.selector_version,
+            tuning=self.tuning,
+            state_version=self.state_version,
+        )
+
+    @staticmethod
+    def _validate_digest(name: str, value: str) -> None:
+        if (
+            not isinstance(value, str)
+            or len(value) != 64
+            or any(character not in "0123456789abcdef" for character in value)
+        ):
+            raise SparseCacheStateError(
+                f"{name} must be a lowercase SHA-256 hex digest"
+            )
+
+    @classmethod
+    def from_tokens(
+        cls,
+        *,
+        target_id: str,
+        tokenizer_id: str,
+        scorer_id: str,
+        selector_version: str,
+        tuning: SparsePolicyTuning,
+        tokens: Iterable[int],
+        selection_fingerprint: str,
+        state_version: str = SPARSE_CACHE_STATE_VERSION,
+    ) -> "SparseCacheIdentity":
+        return cls(
+            target_id=target_id,
+            tokenizer_id=tokenizer_id,
+            scorer_id=scorer_id,
+            selector_version=selector_version,
+            tuning=tuning,
+            full_token_hash=cls.hash_tokens(tokens),
+            selection_fingerprint=selection_fingerprint,
+            state_version=state_version,
+        )
+
+    @staticmethod
+    def hash_tokens(tokens: Iterable[int]) -> str:
+        """Hash an exact token sequence without delimiter ambiguity."""
+        token_values = tuple(tokens)
+        digest = hashlib.sha256()
+        digest.update(b"vllm-mlx/specprefill/full-token-sequence/v1\0")
+        digest.update(struct.pack(">Q", len(token_values)))
+        for token in token_values:
+            if isinstance(token, bool) or not isinstance(token, int):
+                raise SparseCacheStateError("token IDs must be integers")
+            if token < 0 or token > 0xFFFFFFFFFFFFFFFF:
+                raise SparseCacheStateError("token ID is outside unsigned 64-bit range")
+            digest.update(struct.pack(">Q", token))
+        return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class SparseCacheRowState:
+    """One batch row's physical KV occupancy and logical token coordinates."""
+
+    identity: SparseCacheIdentity
+    logical_positions: tuple[int, ...]
+    physical_valid_length: int
+    next_logical_position: int
+    prefill_physical_length: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, SparseCacheIdentity):
+            raise SparseCacheStateError("row identity must be SparseCacheIdentity")
+        if self.physical_valid_length != len(self.logical_positions):
+            raise SparseCacheStateError(
+                "physical_valid_length does not match logical_positions"
+            )
+        if self.prefill_physical_length < 0:
+            raise SparseCacheStateError("prefill_physical_length must be non-negative")
+        if self.prefill_physical_length > self.physical_valid_length:
+            raise SparseCacheStateError(
+                "prefill_physical_length cannot exceed physical_valid_length"
+            )
+        if self.next_logical_position < 0:
+            raise SparseCacheStateError("next_logical_position must be non-negative")
+        previous = -1
+        for position in self.logical_positions:
+            if (
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position < 0
+            ):
+                raise SparseCacheStateError(
+                    "logical positions must be non-negative integers"
+                )
+            if position <= previous:
+                raise SparseCacheStateError(
+                    "logical positions must be strictly increasing"
+                )
+            previous = position
+        if (
+            self.logical_positions
+            and self.next_logical_position <= self.logical_positions[-1]
+        ):
+            raise SparseCacheStateError(
+                "next_logical_position must be after all logical positions"
+            )
+        generated_length = self.physical_valid_length - self.prefill_physical_length
+        if generated_length:
+            expected_generated_suffix = tuple(
+                range(
+                    self.next_logical_position - generated_length,
+                    self.next_logical_position,
+                )
+            )
+            if self.logical_positions[-generated_length:] != expected_generated_suffix:
+                raise SparseCacheStateError(
+                    "generated cache entries must form a contiguous decode suffix"
+                )
+
+    @property
+    def generated_physical_length(self) -> int:
+        return self.physical_valid_length - self.prefill_physical_length
+
+    def clone(self) -> "SparseCacheRowState":
+        return SparseCacheRowState(
+            identity=self.identity,
+            logical_positions=tuple(self.logical_positions),
+            physical_valid_length=self.physical_valid_length,
+            next_logical_position=self.next_logical_position,
+            prefill_physical_length=self.prefill_physical_length,
+        )
+
+    def append_decode(self, count: int) -> "SparseCacheRowState":
+        _require_nonnegative_count(count)
+        if count == 0:
+            return self.clone()
+        new_positions = self.logical_positions + tuple(
+            range(self.next_logical_position, self.next_logical_position + count)
+        )
+        return SparseCacheRowState(
+            identity=self.identity,
+            logical_positions=new_positions,
+            physical_valid_length=self.physical_valid_length + count,
+            next_logical_position=self.next_logical_position + count,
+            prefill_physical_length=self.prefill_physical_length,
+        )
+
+    def rollback(self, count: int) -> "SparseCacheRowState":
+        _require_nonnegative_count(count)
+        if count > self.generated_physical_length:
+            raise SparseCacheStateError(
+                "rollback crosses the immutable sparse prefill boundary"
+            )
+        if count == 0:
+            return self.clone()
+        expected_suffix = tuple(
+            range(self.next_logical_position - count, self.next_logical_position)
+        )
+        if self.logical_positions[-count:] != expected_suffix:
+            raise SparseCacheStateError(
+                "rollback requires a contiguous decode suffix at the logical cursor"
+            )
+        return SparseCacheRowState(
+            identity=self.identity,
+            logical_positions=self.logical_positions[:-count],
+            physical_valid_length=self.physical_valid_length - count,
+            next_logical_position=self.next_logical_position - count,
+            prefill_physical_length=self.prefill_physical_length,
+        )
+
+
+@dataclass(frozen=True)
+class SparseCacheState:
+    """Immutable authoritative state for compatible CB sparse-cache rows.
+
+    Exact prompt and selection identity are row-local: different prompts may
+    share a batched execution lane only when their immutable execution config
+    matches.  Prefix matching remains prohibited for every row.
+    """
+
+    rows: tuple[SparseCacheRowState, ...]
+
+    def __post_init__(self) -> None:
+        if any(not isinstance(row, SparseCacheRowState) for row in self.rows):
+            raise SparseCacheStateError(
+                "sparse cache state rows must be SparseCacheRowState"
+            )
+        if not self.rows:
+            return
+        config = self.rows[0].identity.execution_config
+        if any(row.identity.execution_config != config for row in self.rows[1:]):
+            raise SparseCacheStateError(
+                "sparse cache rows have incompatible shared execution config"
+            )
+
+    @classmethod
+    def from_selection(
+        cls,
+        identities: SparseCacheIdentity | Sequence[SparseCacheIdentity],
+        selected_logical_positions: Sequence[Sequence[int]],
+        next_logical_positions: Sequence[int],
+    ) -> "SparseCacheState":
+        row_count = len(selected_logical_positions)
+        if row_count == 0:
+            raise SparseCacheStateError(
+                "a sparse cache state must contain at least one row"
+            )
+        if len(next_logical_positions) != row_count:
+            raise SparseCacheStateError(
+                "selected_logical_positions and next_logical_positions must have one value per row"
+            )
+        if isinstance(identities, SparseCacheIdentity):
+            row_identities = (identities,) * row_count
+        else:
+            row_identities = tuple(identities)
+        if len(row_identities) != row_count:
+            raise SparseCacheStateError(
+                "identities and selected_logical_positions must have one value per row"
+            )
+        if any(not positions for positions in selected_logical_positions):
+            raise SparseCacheStateError(
+                "a sparse cache row must retain at least one selected logical position"
+            )
+        rows = tuple(
+            SparseCacheRowState(
+                identity=identity,
+                logical_positions=tuple(positions),
+                physical_valid_length=len(positions),
+                next_logical_position=next_position,
+                prefill_physical_length=len(positions),
+            )
+            for identity, positions, next_position in zip(
+                row_identities,
+                selected_logical_positions,
+                next_logical_positions,
+                strict=True,
+            )
+        )
+        return cls(rows=rows)
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def logical_positions(self) -> tuple[tuple[int, ...], ...]:
+        return tuple(row.logical_positions for row in self.rows)
+
+    @property
+    def physical_valid_lengths(self) -> tuple[int, ...]:
+        return tuple(row.physical_valid_length for row in self.rows)
+
+    @property
+    def next_logical_positions(self) -> tuple[int, ...]:
+        return tuple(row.next_logical_position for row in self.rows)
+
+    @property
+    def identities(self) -> tuple[SparseCacheIdentity, ...]:
+        return tuple(row.identity for row in self.rows)
+
+    @property
+    def execution_config(self) -> SparseCacheExecutionConfig | None:
+        return self.rows[0].identity.execution_config if self.rows else None
+
+    def clone(self) -> "SparseCacheState":
+        return SparseCacheState(tuple(row.clone() for row in self.rows))
+
+    def filter(self, keep_indices: Sequence[int]) -> "SparseCacheState":
+        indices = tuple(keep_indices)
+        _validate_indices(indices, self.row_count)
+        return SparseCacheState(tuple(self.rows[index].clone() for index in indices))
+
+    def extend(self, other: "SparseCacheState") -> "SparseCacheState":
+        if not isinstance(other, SparseCacheState):
+            raise SparseCacheStateError("can only extend SparseCacheState")
+        if (
+            self.execution_config is not None
+            and other.execution_config is not None
+            and self.execution_config != other.execution_config
+        ):
+            raise SparseCacheStateError(
+                "cannot extend sparse cache state with incompatible shared execution config"
+            )
+        return SparseCacheState(
+            tuple(row.clone() for row in self.rows)
+            + tuple(row.clone() for row in other.rows)
+        )
+
+    def append_decode(self, counts: int | Sequence[int]) -> "SparseCacheState":
+        row_counts = _normalize_row_counts(counts, self.row_count)
+        return SparseCacheState(
+            tuple(
+                row.append_decode(count)
+                for row, count in zip(self.rows, row_counts, strict=True)
+            )
+        )
+
+    def trim(self, counts: int | Sequence[int]) -> "SparseCacheState":
+        """Trim generated suffixes only; sparse prompt entries are immutable.
+
+        Exact sparse reuse has no LCP/supersequence path.  A caller that wants
+        to remove selected prompt entries must discard this state and prefill a
+        fresh exact prompt rather than inventing a new logical cursor.
+        """
+        return self.rollback(counts)
+
+    def rollback(self, counts: int | Sequence[int]) -> "SparseCacheState":
+        row_counts = _normalize_row_counts(counts, self.row_count)
+        # Build all successor rows before returning so a mixed batch never
+        # publishes a partly rolled-back sparse-state object.
+        rows = tuple(
+            row.rollback(count)
+            for row, count in zip(self.rows, row_counts, strict=True)
+        )
+        return SparseCacheState(rows)
+
+    def for_quantized_storage(self) -> None:
+        raise SparseCacheTransformUnsupported(
+            "quantized sparse-cache storage is not supported until cache bytes and "
+            "logical-position state can be transformed atomically"
+        )
+
+    def for_ssd_storage(self) -> None:
+        raise SparseCacheTransformUnsupported(
+            "SSD sparse-cache storage is not supported until cache bytes and "
+            "logical-position state can be serialized atomically"
+        )
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ExactSparseCacheEntry(Generic[T]):
+    """One exact request row; payload lifecycle remains engine-owned."""
+
+    state: SparseCacheState
+    payload: T
+    payload_cloner: Callable[[T], T]
+
+    def clone_for_request(self) -> "ExactSparseCacheEntry[T]":
+        return ExactSparseCacheEntry(
+            state=self.state.clone(),
+            payload=self.payload_cloner(self.payload),
+            payload_cloner=self.payload_cloner,
+        )
+
+
+class ExactSparseCacheStore(Generic[T]):
+    """A deliberately non-prefix store for exact sparse cache reuse only."""
+
+    def __init__(self) -> None:
+        self._entries: dict[SparseCacheIdentity, ExactSparseCacheEntry[T]] = {}
+        self._lock = threading.RLock()
+
+    def store(
+        self,
+        state: SparseCacheState,
+        payload: T,
+        *,
+        clone_payload: Callable[[T], T],
+    ) -> None:
+        # The cache payload may have its own copy-on-write behaviour, but the
+        # authoritative metadata is always detached from the active request.
+        # Reuse entries are request-local; a batched state must be split first.
+        if state.row_count != 1:
+            raise SparseCacheStateError(
+                "exact sparse cache store accepts exactly one request row"
+            )
+        if not callable(clone_payload):
+            raise SparseCacheStateError(
+                "exact sparse cache store requires a payload cloner"
+            )
+        entry = ExactSparseCacheEntry(
+            state=state.clone(),
+            payload=clone_payload(payload),
+            payload_cloner=clone_payload,
+        )
+        with self._lock:
+            self._entries[state.rows[0].identity] = entry
+
+    def lookup(self, identity: SparseCacheIdentity) -> ExactSparseCacheEntry[T] | None:
+        with self._lock:
+            entry = self._entries.get(identity)
+        if entry is None:
+            return None
+        # Payload cloning may touch MLX arrays or acquire engine/cache locks.
+        # Keep the store critical section limited to the immutable entry lookup
+        # so slow clones do not serialize unrelated exact-cache operations.
+        return entry.clone_for_request()
+
+    def discard(self, identity: SparseCacheIdentity) -> None:
+        with self._lock:
+            self._entries.pop(identity, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+def _require_nonnegative_count(count: int) -> None:
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        raise SparseCacheStateError("count must be a non-negative integer")
+
+
+def _validate_indices(indices: tuple[int, ...], row_count: int) -> None:
+    if len(set(indices)) != len(indices):
+        raise SparseCacheStateError("filter indices must be unique")
+    for index in indices:
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise SparseCacheStateError("filter indices must be integers")
+        if index < 0 or index >= row_count:
+            raise SparseCacheStateError("filter index is outside sparse cache state")
+
+
+def _normalize_row_counts(
+    counts: int | Sequence[int], row_count: int
+) -> tuple[int, ...]:
+    if isinstance(counts, int) and not isinstance(counts, bool):
+        _require_nonnegative_count(counts)
+        return (counts,) * row_count
+    if not isinstance(counts, Sequence) or isinstance(counts, (str, bytes)):
+        raise SparseCacheStateError(
+            "row counts must be an integer or an integer sequence"
+        )
+    values = tuple(counts)
+    if len(values) != row_count:
+        raise SparseCacheStateError("row counts must provide one value per row")
+    for count in values:
+        _require_nonnegative_count(count)
+    return values

--- a/vllm_mlx/specprefill_cache.py
+++ b/vllm_mlx/specprefill_cache.py
@@ -48,8 +48,8 @@ class SparsePolicyTuning:
             raise SparseCacheStateError("backbone_pct must be finite and in [0, 1]")
         if self.halo_chunks < 0:
             raise SparseCacheStateError("halo_chunks must be non-negative")
-        if self.anchor_chunks < 0:
-            raise SparseCacheStateError("anchor_chunks must be non-negative")
+        if self.anchor_chunks <= 0:
+            raise SparseCacheStateError("anchor_chunks must be positive")
         if self.chunk_size <= 0:
             raise SparseCacheStateError("chunk_size must be positive")
 

--- a/vllm_mlx/specprefill_gemma_cache.py
+++ b/vllm_mlx/specprefill_gemma_cache.py
@@ -10,15 +10,59 @@ rotating cache's physical cursors.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Sequence
 
 import mlx.core as mx
-from mlx_vlm.models.cache import (
-    BatchKVCache,
-    BatchRotatingKVCache,
-    KVCache,
-    RotatingKVCache,
-)
+from mlx_lm.models.cache import BatchKVCache as LmBatchKVCache
+from mlx_lm.models.cache import BatchRotatingKVCache as LmBatchRotatingKVCache
+from mlx_lm.models.cache import KVCache as LmKVCache
+from mlx_lm.models.cache import RotatingKVCache as LmRotatingKVCache
+from mlx_vlm.models.cache import BatchKVCache as VlmBatchKVCache
+from mlx_vlm.models.cache import BatchRotatingKVCache as VlmBatchRotatingKVCache
+from mlx_vlm.models.cache import KVCache as VlmKVCache
+from mlx_vlm.models.cache import RotatingKVCache as VlmRotatingKVCache
+
+
+class GemmaCacheBackend(str, Enum):
+    MLX_LM = "mlx_lm"
+    MLX_VLM = "mlx_vlm"
+
+
+_BACKEND_TYPES = {
+    GemmaCacheBackend.MLX_LM: (
+        LmKVCache,
+        LmRotatingKVCache,
+        LmBatchKVCache,
+        LmBatchRotatingKVCache,
+    ),
+    GemmaCacheBackend.MLX_VLM: (
+        VlmKVCache,
+        VlmRotatingKVCache,
+        VlmBatchKVCache,
+        VlmBatchRotatingKVCache,
+    ),
+}
+_SCALAR_FULL = (LmKVCache, VlmKVCache)
+_SCALAR_ROTATING = (LmRotatingKVCache, VlmRotatingKVCache)
+_BATCH_FULL = (LmBatchKVCache, VlmBatchKVCache)
+_BATCH_ROTATING = (LmBatchRotatingKVCache, VlmBatchRotatingKVCache)
+_FULL = (*_SCALAR_FULL, *_BATCH_FULL)
+_ROTATING = (*_SCALAR_ROTATING, *_BATCH_ROTATING)
+_BATCH = (*_BATCH_FULL, *_BATCH_ROTATING)
+
+
+def gemma_cache_backend(cache: Sequence[Any]) -> GemmaCacheBackend:
+    if not cache:
+        raise GemmaCacheError("Gemma cache cannot be empty")
+    matches = tuple(
+        backend
+        for backend, types in _BACKEND_TYPES.items()
+        if all(type(entry) in types for entry in cache)
+    )
+    if len(matches) != 1:
+        raise GemmaCacheError("Gemma cache entries cross or lack a known backend")
+    return matches[0]
 
 
 class GemmaCacheError(RuntimeError):
@@ -106,11 +150,11 @@ class GemmaCacheTopology:
 
 
 def _is_full_cache(cache: Any) -> bool:
-    return type(cache) in (KVCache, BatchKVCache)
+    return type(cache) in _FULL
 
 
 def _is_rotating_cache(cache: Any) -> bool:
-    return type(cache) in (RotatingKVCache, BatchRotatingKVCache)
+    return type(cache) in _ROTATING
 
 
 def validate_gemma_cache_topology(
@@ -119,6 +163,7 @@ def validate_gemma_cache_topology(
     layer_types: Sequence[str],
     previous_kvs: Sequence[int],
     cache: Sequence[Any],
+    backend: GemmaCacheBackend | None = None,
 ) -> GemmaCacheTopology:
     """Validate a cache against one of the bounded, observed Gemma layouts."""
 
@@ -134,6 +179,14 @@ def validate_gemma_cache_topology(
         )
     if len({id(entry) for entry in cache}) != len(cache):
         raise GemmaCacheTopologyError("cache owner entries must not alias")
+    resolved_backend = gemma_cache_backend(cache)
+    if backend is not None and resolved_backend is not backend:
+        raise GemmaCacheTopologyError(
+            f"cache backend {resolved_backend.value} does not match {backend.value} model"
+        )
+    full_type, rotating_type, batch_full_type, batch_rotating_type = _BACKEND_TYPES[
+        resolved_backend
+    ]
 
     owner_layers = tuple(dict.fromkeys(spec.previous_kvs))
     if owner_layers != tuple(range(spec.owner_count)):
@@ -146,7 +199,7 @@ def validate_gemma_cache_topology(
 
     batch_kind: bool | None = None
     for owner, entry in enumerate(cache):
-        is_batch = type(entry) in (BatchKVCache, BatchRotatingKVCache)
+        is_batch = type(entry) in (batch_full_type, batch_rotating_type)
         if batch_kind is None:
             batch_kind = is_batch
         elif is_batch != batch_kind:
@@ -163,7 +216,7 @@ def validate_gemma_cache_topology(
                 raise GemmaCacheTopologyError(
                     f"owner {owner} window {entry.max_size} != {spec.sliding_window}"
                 )
-            if type(entry) is RotatingKVCache and entry.keep != 0:
+            if type(entry) is rotating_type and entry.keep != 0:
                 raise GemmaCacheTopologyError("Gemma rotating caches require keep=0")
     return GemmaCacheTopology(
         artifact_id=spec.artifact_id,
@@ -194,9 +247,9 @@ class BatchCacheCursor:
 def scalar_cache_cursor(cache: Any, *, logical_position: int) -> ScalarCacheCursor:
     if logical_position < 0:
         raise GemmaCacheError("logical position must be non-negative")
-    if type(cache) is KVCache:
+    if type(cache) in _SCALAR_FULL:
         return ScalarCacheCursor(cache.offset, cache.offset, cache.offset, logical_position)
-    if type(cache) is RotatingKVCache:
+    if type(cache) in _SCALAR_ROTATING:
         _validate_scalar_rotating(cache, allow_oversized=True)
         return ScalarCacheCursor(
             cache.offset, min(cache.offset, cache.max_size), cache._idx, logical_position
@@ -215,11 +268,11 @@ def batch_cache_cursor(
     logical = tuple(int(position) for position in logical_positions)
     if not logical or min(logical) < 0:
         raise GemmaCacheError("logical positions must be non-empty and non-negative")
-    if type(cache) is BatchKVCache:
+    if type(cache) in _BATCH_FULL:
         total = _host_ints(cache.offset)
         physical, resident, index = cache._idx, cache._idx, cache._idx
         rotated = False
-    elif type(cache) is BatchRotatingKVCache:
+    elif type(cache) in _BATCH_ROTATING:
         _validate_batch_rotating(cache)
         total = _host_ints(cache.offset)
         physical = cache._offset
@@ -253,7 +306,7 @@ def validate_homogeneous_batch_lane(
             physical = cursor.physical_write_cursor
         elif cursor.physical_write_cursor != physical:
             raise GemmaCacheError("Gemma cache owners disagree on write cursor")
-        if type(entry) is BatchRotatingKVCache:
+        if type(entry) in _BATCH_ROTATING:
             state = (
                 cursor.resident_tokens,
                 cursor.circular_index,
@@ -278,7 +331,7 @@ def validate_aligned_scalar_cache(
     rotating = tuple(
         (cursor.resident_tokens, cursor.circular_index)
         for entry, cursor in zip(cache, cursors)
-        if type(entry) is RotatingKVCache
+        if type(entry) in _SCALAR_ROTATING
     )
     if rotating and len(set(rotating)) != 1:
         raise GemmaCacheError("Gemma rotating owners disagree on resident state")
@@ -294,13 +347,13 @@ class _Snapshot:
         cache_type = type(cache)
         common = ("keys", "values", "offset")
         extras: tuple[str, ...]
-        if cache_type is KVCache:
+        if cache_type in _SCALAR_FULL:
             extras = ()
-        elif cache_type is RotatingKVCache:
+        elif cache_type in _SCALAR_ROTATING:
             extras = ("keep", "max_size", "_idx")
-        elif cache_type is BatchKVCache:
+        elif cache_type in _BATCH_FULL:
             extras = ("left_padding", "_idx", "_right_padding")
-        elif cache_type is BatchRotatingKVCache:
+        elif cache_type in _BATCH_ROTATING:
             extras = (
                 "left_padding",
                 "max_size",
@@ -385,7 +438,7 @@ class GemmaCachePairCheckpoint:
 
 
 def _validate_scalar_rotating(
-    cache: RotatingKVCache, *, allow_oversized: bool = False
+    cache: Any, *, allow_oversized: bool = False
 ) -> None:
     if cache.offset < 0 or cache._idx < 0 or cache.max_size <= 0 or cache.keep != 0:
         raise GemmaCacheError("invalid scalar rotating-cache metadata")
@@ -408,10 +461,10 @@ def _validate_scalar_rotating(
         raise GemmaCacheError("unsaturated rotating cache cursors disagree")
 
 
-def normalize_scalar_rotating(cache: RotatingKVCache) -> None:
+def normalize_scalar_rotating(cache: Any) -> None:
     """Normalize resident storage without changing the lifetime write cursor."""
 
-    if type(cache) is not RotatingKVCache:
+    if type(cache) not in _SCALAR_ROTATING:
         raise GemmaCacheError("normalization requires RotatingKVCache")
     _validate_scalar_rotating(cache, allow_oversized=True)
     if cache.keys is None:
@@ -440,7 +493,7 @@ def normalize_scalar_rotating(cache: RotatingKVCache) -> None:
 
 
 def _validate_batch_rotating(
-    cache: BatchRotatingKVCache, *, allow_oversized: bool = False
+    cache: Any, *, allow_oversized: bool = False
 ) -> None:
     if cache.max_size <= 0 or cache._offset < 0 or cache._idx < 0:
         raise GemmaCacheError("invalid batch rotating-cache metadata")
@@ -474,10 +527,10 @@ def _validate_batch_rotating(
         raise GemmaCacheError("invalid wrapped batch rotating state")
 
 
-def normalize_batch_rotating(cache: BatchRotatingKVCache) -> None:
+def normalize_batch_rotating(cache: Any) -> None:
     """Normalize a finalized batch cache while preserving lifetime cursors."""
 
-    if type(cache) is not BatchRotatingKVCache:
+    if type(cache) not in _BATCH_ROTATING:
         raise GemmaCacheError("normalization requires BatchRotatingKVCache")
     if cache._lengths is not None:
         raise GemmaCacheError("right-padded batch cache must be finalized first")
@@ -520,9 +573,9 @@ class GemmaOneTokenTransaction:
         self._state = "active"
         self.logical_before = tuple(int(value) for value in logical_positions)
         for entry in cache:
-            if type(entry) is RotatingKVCache:
+            if type(entry) in _SCALAR_ROTATING:
                 _validate_scalar_rotating(entry)
-            elif type(entry) is BatchRotatingKVCache:
+            elif type(entry) in _BATCH_ROTATING:
                 _validate_batch_rotating(entry)
         self.checkpoint = GemmaCacheCheckpoint(cache)
         self._write_journal = tuple(self._capture_overwrite(entry) for entry in cache)
@@ -534,7 +587,7 @@ class GemmaOneTokenTransaction:
                 for tensor in journal[1:]
             )
         )
-        self._batch = type(cache[0]) in (BatchKVCache, BatchRotatingKVCache)
+        self._batch = type(cache[0]) in _BATCH
         if self._batch:
             validate_homogeneous_batch_lane(cache, logical_positions=self.logical_before)
             self.before = tuple(
@@ -594,13 +647,13 @@ class GemmaOneTokenTransaction:
 
         if cache.keys is None:
             return None
-        if type(cache) is KVCache:
+        if type(cache) in _SCALAR_FULL:
             index = cache.offset
-        elif type(cache) is BatchKVCache:
+        elif type(cache) in _BATCH_FULL:
             index = cache._idx
-        elif type(cache) is RotatingKVCache:
+        elif type(cache) in _SCALAR_ROTATING:
             index = 0 if cache._idx == cache.max_size else cache._idx
-        elif type(cache) is BatchRotatingKVCache:
+        elif type(cache) in _BATCH_ROTATING:
             index = 0 if cache._idx == cache.max_size else cache._idx
         else:  # pragma: no cover - constructor rejects other cache types
             raise GemmaCacheError(f"unsupported cache: {type(cache).__name__}")
@@ -653,7 +706,7 @@ class GemmaOneTokenTransaction:
             # only this metadata bit; no window normalization/copy is needed.
             for entry in self.cache:
                 if (
-                    type(entry) is BatchRotatingKVCache
+                    type(entry) in _BATCH_ROTATING
                     and entry._idx == entry.max_size
                     and entry.rotated
                 ):
@@ -677,7 +730,7 @@ class GemmaOneTokenTransaction:
                         )
                     expected_index = old.circular_index + 1
                     if (
-                        type(entry) is BatchRotatingKVCache
+                        type(entry) in _BATCH_ROTATING
                         and old.circular_index == entry.max_size
                     ):
                         expected_index = 1
@@ -686,7 +739,7 @@ class GemmaOneTokenTransaction:
                             "batch circular index transition is invalid"
                         )
                     expected_rotated = (
-                        type(entry) is BatchRotatingKVCache
+                        type(entry) in _BATCH_ROTATING
                         and new.physical_write_cursor >= entry.max_size
                         and new.circular_index < entry.max_size
                     )
@@ -696,7 +749,7 @@ class GemmaOneTokenTransaction:
                         )
                     expected_resident = (
                         min(old.physical_write_cursor + 1, entry.max_size)
-                        if type(entry) is BatchRotatingKVCache
+                        if type(entry) in _BATCH_ROTATING
                         else old.resident_tokens + 1
                     )
                     if new.resident_tokens != expected_resident:
@@ -718,7 +771,7 @@ class GemmaOneTokenTransaction:
                         )
                     expected_index = old.circular_index + 1
                     if (
-                        type(entry) is RotatingKVCache
+                        type(entry) in _SCALAR_ROTATING
                         and old.circular_index == entry.max_size
                     ):
                         expected_index = 1
@@ -728,7 +781,7 @@ class GemmaOneTokenTransaction:
                         )
                     expected_resident = (
                         min(old.total_writes + 1, entry.max_size)
-                        if type(entry) is RotatingKVCache
+                        if type(entry) in _SCALAR_ROTATING
                         else old.resident_tokens + 1
                     )
                     if new.resident_tokens != expected_resident:
@@ -756,7 +809,7 @@ def atomic_batch_filter(
     checkpoint = GemmaCacheCheckpoint(cache)
     try:
         for entry in cache:
-            if type(entry) not in (BatchKVCache, BatchRotatingKVCache):
+            if type(entry) not in _BATCH:
                 raise GemmaCacheError("filter requires batch cache entries")
             entry.filter(indices)
         selected = tuple(logical_positions[int(index)] for index in indices)
@@ -781,10 +834,7 @@ def atomic_batch_extend(destination: Sequence[Any], source: Sequence[Any]) -> No
     checkpoint = GemmaCachePairCheckpoint(destination, source)
     try:
         for target, addition in zip(destination, source):
-            if type(target) is not type(addition) or type(target) not in (
-                BatchKVCache,
-                BatchRotatingKVCache,
-            ):
+            if type(target) is not type(addition) or type(target) not in _BATCH:
                 raise GemmaCacheError("extend cache types differ")
             if _is_rotating_cache(target) and target.max_size != addition.max_size:
                 raise GemmaCacheError("extend rotating windows differ")
@@ -830,6 +880,7 @@ __all__ = [
     "GEMMA4_ARTIFACTS",
     "GEMMA4_E2B",
     "GemmaArtifactSpec",
+    "GemmaCacheBackend",
     "GemmaCacheCheckpoint",
     "GemmaCacheError",
     "GemmaCachePairCheckpoint",
@@ -841,6 +892,7 @@ __all__ = [
     "atomic_batch_extend",
     "atomic_batch_filter",
     "batch_cache_cursor",
+    "gemma_cache_backend",
     "normalize_scalar_rotating",
     "normalize_batch_rotating",
     "run_atomic_one_token",

--- a/vllm_mlx/specprefill_gemma_cache.py
+++ b/vllm_mlx/specprefill_gemma_cache.py
@@ -248,11 +248,16 @@ def scalar_cache_cursor(cache: Any, *, logical_position: int) -> ScalarCacheCurs
     if logical_position < 0:
         raise GemmaCacheError("logical position must be non-negative")
     if type(cache) in _SCALAR_FULL:
-        return ScalarCacheCursor(cache.offset, cache.offset, cache.offset, logical_position)
+        return ScalarCacheCursor(
+            cache.offset, cache.offset, cache.offset, logical_position
+        )
     if type(cache) in _SCALAR_ROTATING:
         _validate_scalar_rotating(cache, allow_oversized=True)
         return ScalarCacheCursor(
-            cache.offset, min(cache.offset, cache.max_size), cache._idx, logical_position
+            cache.offset,
+            min(cache.offset, cache.max_size),
+            cache._idx,
+            logical_position,
         )
     raise GemmaCacheError(f"unsupported scalar cache: {type(cache).__name__}")
 
@@ -290,7 +295,9 @@ def validate_homogeneous_batch_lane(
 ) -> None:
     logical = tuple(int(value) for value in logical_positions)
     if not logical or len(set(logical)) != 1:
-        raise GemmaCacheError("Gemma sparse cache lane requires equal logical positions")
+        raise GemmaCacheError(
+            "Gemma sparse cache lane requires equal logical positions"
+        )
     reference: tuple[int, ...] | None = None
     physical: int | None = None
     rotating_state: tuple[int, int, bool] | None = None
@@ -315,7 +322,9 @@ def validate_homogeneous_batch_lane(
             if rotating_state is None:
                 rotating_state = state
             elif state != rotating_state:
-                raise GemmaCacheError("Gemma rotating owners disagree on resident state")
+                raise GemmaCacheError(
+                    "Gemma rotating owners disagree on resident state"
+                )
 
 
 def validate_aligned_scalar_cache(
@@ -389,7 +398,9 @@ class GemmaCacheCheckpoint:
         if not self._active:
             return
         if tuple(self._cache) != tuple(snapshot.cache for snapshot in self._snapshots):
-            raise GemmaCacheTransactionError("cache topology changed during transaction")
+            raise GemmaCacheTransactionError(
+                "cache topology changed during transaction"
+            )
         for snapshot in self._snapshots:
             snapshot.restore()
         self._active = False
@@ -437,9 +448,7 @@ class GemmaCachePairCheckpoint:
         self.source.restore()
 
 
-def _validate_scalar_rotating(
-    cache: Any, *, allow_oversized: bool = False
-) -> None:
+def _validate_scalar_rotating(cache: Any, *, allow_oversized: bool = False) -> None:
     if cache.offset < 0 or cache._idx < 0 or cache.max_size <= 0 or cache.keep != 0:
         raise GemmaCacheError("invalid scalar rotating-cache metadata")
     if (cache.keys is None) != (cache.values is None):
@@ -492,9 +501,7 @@ def normalize_scalar_rotating(cache: Any) -> None:
         raise
 
 
-def _validate_batch_rotating(
-    cache: Any, *, allow_oversized: bool = False
-) -> None:
+def _validate_batch_rotating(cache: Any, *, allow_oversized: bool = False) -> None:
     if cache.max_size <= 0 or cache._offset < 0 or cache._idx < 0:
         raise GemmaCacheError("invalid batch rotating-cache metadata")
     if (cache.keys is None) != (cache.values is None):
@@ -589,14 +596,18 @@ class GemmaOneTokenTransaction:
         )
         self._batch = type(cache[0]) in _BATCH
         if self._batch:
-            validate_homogeneous_batch_lane(cache, logical_positions=self.logical_before)
+            validate_homogeneous_batch_lane(
+                cache, logical_positions=self.logical_before
+            )
             self.before = tuple(
                 batch_cache_cursor(entry, logical_positions=self.logical_before)
                 for entry in cache
             )
         else:
             if len(self.logical_before) != 1:
-                raise GemmaCacheError("scalar transaction requires one logical position")
+                raise GemmaCacheError(
+                    "scalar transaction requires one logical position"
+                )
             validate_aligned_scalar_cache(
                 cache, logical_position=self.logical_before[0]
             )
@@ -689,9 +700,7 @@ class GemmaOneTokenTransaction:
 
     def commit(self, *, logical_positions: Sequence[int]) -> None:
         if self._state != "active":
-            raise GemmaCacheTransactionError(
-                f"transaction is already {self._state}"
-            )
+            raise GemmaCacheTransactionError(f"transaction is already {self._state}")
         logical_after = tuple(int(value) for value in logical_positions)
         if logical_after != tuple(value + 1 for value in self.logical_before):
             self.rollback()
@@ -720,7 +729,9 @@ class GemmaOneTokenTransaction:
                     for entry in self.cache
                 )
                 for entry, old, new in zip(self.cache, self.before, after):
-                    if new.total_writes != tuple(value + 1 for value in old.total_writes):
+                    if new.total_writes != tuple(
+                        value + 1 for value in old.total_writes
+                    ):
                         raise GemmaCacheTransactionError(
                             "batch physical writes did not advance by one"
                         )
@@ -858,9 +869,7 @@ def run_atomic_one_token(
 ) -> Any:
     """Run/evaluate one lazy forward and publish cache mutation atomically."""
 
-    transaction = GemmaOneTokenTransaction(
-        cache, logical_positions=logical_positions
-    )
+    transaction = GemmaOneTokenTransaction(cache, logical_positions=logical_positions)
     try:
         result = forward()
         evaluate(result)

--- a/vllm_mlx/specprefill_gemma_cache.py
+++ b/vllm_mlx/specprefill_gemma_cache.py
@@ -1,0 +1,851 @@
+"""Transactional cache primitives for Gemma 4 sparse prefill.
+
+This module deliberately does not integrate with an engine.  It defines the
+small, fail-closed cache contract needed by a later Simple/CB integration.
+Snapshots retain array references (no full-KV copy) and restore *all* mutable
+cache metadata.  Logical positions are caller-owned and never inferred from a
+rotating cache's physical cursors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence
+
+import mlx.core as mx
+from mlx_vlm.models.cache import (
+    BatchKVCache,
+    BatchRotatingKVCache,
+    KVCache,
+    RotatingKVCache,
+)
+
+
+class GemmaCacheError(RuntimeError):
+    """Base error for an unsupported or inconsistent Gemma cache."""
+
+
+class GemmaCacheTopologyError(GemmaCacheError):
+    """The model/cache topology does not match a certified artifact layout."""
+
+
+class GemmaCacheTransactionError(GemmaCacheError):
+    """A cache mutation did not satisfy the declared transaction contract."""
+
+
+FULL = "full_attention"
+SLIDING = "sliding_attention"
+
+
+@dataclass(frozen=True)
+class GemmaArtifactSpec:
+    artifact_id: str
+    layer_types: tuple[str, ...]
+    previous_kvs: tuple[int, ...]
+    owner_count: int
+    sliding_window: int
+
+    @property
+    def layer_count(self) -> int:
+        return len(self.layer_types)
+
+
+def _repeated_layers(sliding_count: int, groups: int) -> tuple[str, ...]:
+    return (tuple([SLIDING] * sliding_count + [FULL])) * groups
+
+
+def _shared_previous_kvs(
+    layer_types: Sequence[str], owner_count: int
+) -> tuple[int, ...]:
+    previous = list(range(len(layer_types)))
+    latest_by_type: dict[str, int] = {}
+    for index, layer_type in enumerate(layer_types):
+        if index < owner_count:
+            latest_by_type[layer_type] = index
+        else:
+            previous[index] = latest_by_type[layer_type]
+    return tuple(previous)
+
+
+_E2B_LAYERS = _repeated_layers(4, 7)
+GEMMA4_E2B = GemmaArtifactSpec(
+    artifact_id="gemma4-e2b",
+    layer_types=_E2B_LAYERS,
+    previous_kvs=_shared_previous_kvs(_E2B_LAYERS, 15),
+    owner_count=15,
+    sliding_window=512,
+)
+_DENSE_31B_LAYERS = _repeated_layers(5, 10)
+GEMMA4_31B = GemmaArtifactSpec(
+    artifact_id="gemma4-31b",
+    layer_types=_DENSE_31B_LAYERS,
+    previous_kvs=tuple(range(60)),
+    owner_count=60,
+    sliding_window=1024,
+)
+_A4B_LAYERS = _repeated_layers(5, 5)
+GEMMA4_26B_A4B = GemmaArtifactSpec(
+    artifact_id="gemma4-26b-a4b",
+    layer_types=_A4B_LAYERS,
+    previous_kvs=tuple(range(30)),
+    owner_count=30,
+    sliding_window=1024,
+)
+
+GEMMA4_ARTIFACTS = {
+    spec.artifact_id: spec for spec in (GEMMA4_E2B, GEMMA4_31B, GEMMA4_26B_A4B)
+}
+
+
+@dataclass(frozen=True)
+class GemmaCacheTopology:
+    artifact_id: str
+    layer_to_slot: tuple[int, ...]
+    owner_layers: tuple[int, ...]
+    sliding_window: int
+
+
+def _is_full_cache(cache: Any) -> bool:
+    return type(cache) in (KVCache, BatchKVCache)
+
+
+def _is_rotating_cache(cache: Any) -> bool:
+    return type(cache) in (RotatingKVCache, BatchRotatingKVCache)
+
+
+def validate_gemma_cache_topology(
+    spec: GemmaArtifactSpec,
+    *,
+    layer_types: Sequence[str],
+    previous_kvs: Sequence[int],
+    cache: Sequence[Any],
+) -> GemmaCacheTopology:
+    """Validate a cache against one of the bounded, observed Gemma layouts."""
+
+    if GEMMA4_ARTIFACTS.get(spec.artifact_id) != spec:
+        raise GemmaCacheTopologyError(f"uncertified Gemma artifact: {spec.artifact_id}")
+    if tuple(layer_types) != spec.layer_types:
+        raise GemmaCacheTopologyError("decoder layer types do not match artifact")
+    if tuple(previous_kvs) != spec.previous_kvs:
+        raise GemmaCacheTopologyError("shared-KV owner mapping does not match artifact")
+    if len(cache) != spec.owner_count:
+        raise GemmaCacheTopologyError(
+            f"expected {spec.owner_count} cache owners, got {len(cache)}"
+        )
+    if len({id(entry) for entry in cache}) != len(cache):
+        raise GemmaCacheTopologyError("cache owner entries must not alias")
+
+    owner_layers = tuple(dict.fromkeys(spec.previous_kvs))
+    if owner_layers != tuple(range(spec.owner_count)):
+        raise GemmaCacheTopologyError("owners must be the compact leading layer range")
+    for layer, owner in enumerate(spec.previous_kvs):
+        if not 0 <= owner < spec.owner_count or owner > layer:
+            raise GemmaCacheTopologyError(f"invalid owner {owner} for layer {layer}")
+        if spec.layer_types[owner] != spec.layer_types[layer]:
+            raise GemmaCacheTopologyError(f"owner type mismatch for layer {layer}")
+
+    batch_kind: bool | None = None
+    for owner, entry in enumerate(cache):
+        is_batch = type(entry) in (BatchKVCache, BatchRotatingKVCache)
+        if batch_kind is None:
+            batch_kind = is_batch
+        elif is_batch != batch_kind:
+            raise GemmaCacheTopologyError("scalar and batch caches cannot be mixed")
+        layer_type = spec.layer_types[owner]
+        if layer_type == FULL and not _is_full_cache(entry):
+            raise GemmaCacheTopologyError(f"owner {owner} requires a full KV cache")
+        if layer_type == SLIDING:
+            if not _is_rotating_cache(entry):
+                raise GemmaCacheTopologyError(
+                    f"owner {owner} requires a rotating KV cache"
+                )
+            if entry.max_size != spec.sliding_window:
+                raise GemmaCacheTopologyError(
+                    f"owner {owner} window {entry.max_size} != {spec.sliding_window}"
+                )
+            if type(entry) is RotatingKVCache and entry.keep != 0:
+                raise GemmaCacheTopologyError("Gemma rotating caches require keep=0")
+    return GemmaCacheTopology(
+        artifact_id=spec.artifact_id,
+        layer_to_slot=spec.previous_kvs,
+        owner_layers=owner_layers,
+        sliding_window=spec.sliding_window,
+    )
+
+
+@dataclass(frozen=True)
+class ScalarCacheCursor:
+    total_writes: int
+    resident_tokens: int
+    circular_index: int
+    logical_position: int
+
+
+@dataclass(frozen=True)
+class BatchCacheCursor:
+    total_writes: tuple[int, ...]
+    physical_write_cursor: int
+    resident_tokens: int
+    circular_index: int
+    rotated: bool
+    logical_positions: tuple[int, ...]
+
+
+def scalar_cache_cursor(cache: Any, *, logical_position: int) -> ScalarCacheCursor:
+    if logical_position < 0:
+        raise GemmaCacheError("logical position must be non-negative")
+    if type(cache) is KVCache:
+        return ScalarCacheCursor(cache.offset, cache.offset, cache.offset, logical_position)
+    if type(cache) is RotatingKVCache:
+        _validate_scalar_rotating(cache, allow_oversized=True)
+        return ScalarCacheCursor(
+            cache.offset, min(cache.offset, cache.max_size), cache._idx, logical_position
+        )
+    raise GemmaCacheError(f"unsupported scalar cache: {type(cache).__name__}")
+
+
+def _host_ints(value: Any) -> tuple[int, ...]:
+    mx.eval(value)
+    return tuple(int(item) for item in value.tolist())
+
+
+def batch_cache_cursor(
+    cache: Any, *, logical_positions: Sequence[int]
+) -> BatchCacheCursor:
+    logical = tuple(int(position) for position in logical_positions)
+    if not logical or min(logical) < 0:
+        raise GemmaCacheError("logical positions must be non-empty and non-negative")
+    if type(cache) is BatchKVCache:
+        total = _host_ints(cache.offset)
+        physical, resident, index = cache._idx, cache._idx, cache._idx
+        rotated = False
+    elif type(cache) is BatchRotatingKVCache:
+        _validate_batch_rotating(cache)
+        total = _host_ints(cache.offset)
+        physical = cache._offset
+        resident, index = min(cache._offset, cache.max_size), cache._idx
+        rotated = cache.rotated
+    else:
+        raise GemmaCacheError(f"unsupported batch cache: {type(cache).__name__}")
+    if len(total) != len(logical):
+        raise GemmaCacheError("logical-position row count does not match cache")
+    return BatchCacheCursor(total, physical, resident, index, rotated, logical)
+
+
+def validate_homogeneous_batch_lane(
+    cache: Sequence[Any], *, logical_positions: Sequence[int]
+) -> None:
+    logical = tuple(int(value) for value in logical_positions)
+    if not logical or len(set(logical)) != 1:
+        raise GemmaCacheError("Gemma sparse cache lane requires equal logical positions")
+    reference: tuple[int, ...] | None = None
+    physical: int | None = None
+    rotating_state: tuple[int, int, bool] | None = None
+    for entry in cache:
+        cursor = batch_cache_cursor(entry, logical_positions=logical)
+        if len(set(cursor.total_writes)) != 1:
+            raise GemmaCacheError("Gemma sparse cache lane has heterogeneous writes")
+        if reference is None:
+            reference = cursor.total_writes
+        elif cursor.total_writes != reference:
+            raise GemmaCacheError("Gemma cache owners disagree on physical writes")
+        if physical is None:
+            physical = cursor.physical_write_cursor
+        elif cursor.physical_write_cursor != physical:
+            raise GemmaCacheError("Gemma cache owners disagree on write cursor")
+        if type(entry) is BatchRotatingKVCache:
+            state = (
+                cursor.resident_tokens,
+                cursor.circular_index,
+                cursor.rotated,
+            )
+            if rotating_state is None:
+                rotating_state = state
+            elif state != rotating_state:
+                raise GemmaCacheError("Gemma rotating owners disagree on resident state")
+
+
+def validate_aligned_scalar_cache(
+    cache: Sequence[Any], *, logical_position: int
+) -> None:
+    cursors = tuple(
+        scalar_cache_cursor(entry, logical_position=logical_position) for entry in cache
+    )
+    if not cursors:
+        raise GemmaCacheError("Gemma scalar cache cannot be empty")
+    if len({cursor.total_writes for cursor in cursors}) != 1:
+        raise GemmaCacheError("Gemma scalar owners disagree on physical writes")
+    rotating = tuple(
+        (cursor.resident_tokens, cursor.circular_index)
+        for entry, cursor in zip(cache, cursors)
+        if type(entry) is RotatingKVCache
+    )
+    if rotating and len(set(rotating)) != 1:
+        raise GemmaCacheError("Gemma rotating owners disagree on resident state")
+
+
+@dataclass
+class _Snapshot:
+    cache: Any
+    fields: dict[str, Any]
+
+    @classmethod
+    def capture(cls, cache: Any) -> "_Snapshot":
+        cache_type = type(cache)
+        common = ("keys", "values", "offset")
+        extras: tuple[str, ...]
+        if cache_type is KVCache:
+            extras = ()
+        elif cache_type is RotatingKVCache:
+            extras = ("keep", "max_size", "_idx")
+        elif cache_type is BatchKVCache:
+            extras = ("left_padding", "_idx", "_right_padding")
+        elif cache_type is BatchRotatingKVCache:
+            extras = (
+                "left_padding",
+                "max_size",
+                "_idx",
+                "_offset",
+                "rotated",
+                "_lengths",
+            )
+        else:
+            raise GemmaCacheError(f"unsupported cache: {cache_type.__name__}")
+        return cls(cache, {name: getattr(cache, name) for name in common + extras})
+
+    def restore(self) -> None:
+        for name, value in self.fields.items():
+            setattr(self.cache, name, value)
+
+
+class GemmaCacheCheckpoint:
+    """Reference-only checkpoint for a complete compact Gemma cache."""
+
+    def __init__(self, cache: Sequence[Any]):
+        if not cache:
+            raise GemmaCacheError("cache checkpoint cannot be empty")
+        self._cache = tuple(cache)
+        self._snapshots = tuple(_Snapshot.capture(entry) for entry in cache)
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def restore(self) -> None:
+        if not self._active:
+            return
+        if tuple(self._cache) != tuple(snapshot.cache for snapshot in self._snapshots):
+            raise GemmaCacheTransactionError("cache topology changed during transaction")
+        for snapshot in self._snapshots:
+            snapshot.restore()
+        self._active = False
+
+    def seal(self) -> None:
+        if not self._active:
+            raise GemmaCacheTransactionError("checkpoint is already closed")
+        self._active = False
+
+
+def _cache_tensors(cache: Sequence[Any]) -> tuple[Any, ...]:
+    names = (
+        "keys",
+        "values",
+        "offset",
+        "left_padding",
+        "_right_padding",
+        "_lengths",
+    )
+    return tuple(
+        value
+        for entry in cache
+        for name in names
+        if (value := getattr(entry, name, None)) is not None
+    )
+
+
+def _evaluate_cache(cache: Sequence[Any]) -> None:
+    tensors = _cache_tensors(cache)
+    if tensors:
+        mx.eval(*tensors)
+
+
+class GemmaCachePairCheckpoint:
+    """Checkpoint both operands because batch extend mutates either operand."""
+
+    def __init__(self, destination: Sequence[Any], source: Sequence[Any]):
+        if len(destination) != len(source):
+            raise GemmaCacheError("cache pair topology differs")
+        self.destination = GemmaCacheCheckpoint(destination)
+        self.source = GemmaCacheCheckpoint(source)
+
+    def restore(self) -> None:
+        self.destination.restore()
+        self.source.restore()
+
+
+def _validate_scalar_rotating(
+    cache: RotatingKVCache, *, allow_oversized: bool = False
+) -> None:
+    if cache.offset < 0 or cache._idx < 0 or cache.max_size <= 0 or cache.keep != 0:
+        raise GemmaCacheError("invalid scalar rotating-cache metadata")
+    if (cache.keys is None) != (cache.values is None):
+        raise GemmaCacheError("rotating cache has only one KV tensor")
+    if cache.keys is None:
+        if cache.offset != 0 or cache._idx != 0:
+            raise GemmaCacheError("empty rotating cache has non-zero cursors")
+        return
+    if cache.keys.shape[2] != cache.values.shape[2]:
+        raise GemmaCacheError("rotating KV resident lengths differ")
+    resident = cache.keys.shape[2]
+    if cache.offset >= cache.max_size and resident < cache.max_size:
+        raise GemmaCacheError("saturated rotating cache has a short resident buffer")
+    if resident == 0 or cache._idx > resident:
+        raise GemmaCacheError("invalid rotating-cache circular index")
+    if not allow_oversized and resident > cache.max_size:
+        raise GemmaCacheError("rotating cache is not normalized")
+    if cache.offset < cache.max_size and cache._idx != cache.offset:
+        raise GemmaCacheError("unsaturated rotating cache cursors disagree")
+
+
+def normalize_scalar_rotating(cache: RotatingKVCache) -> None:
+    """Normalize resident storage without changing the lifetime write cursor."""
+
+    if type(cache) is not RotatingKVCache:
+        raise GemmaCacheError("normalization requires RotatingKVCache")
+    _validate_scalar_rotating(cache, allow_oversized=True)
+    if cache.keys is None:
+        return
+    checkpoint = GemmaCacheCheckpoint([cache])
+    try:
+        total_writes = cache.offset
+        if total_writes < cache.max_size:
+            # Preserve allocator spare capacity.  The cache's logical state is
+            # bounded by ``offset/_idx``; slicing here would force a growth
+            # allocation on the very next decode token.
+            cache._idx = total_writes
+        else:
+            ordered_keys = cache._temporal_order(cache.keys)
+            ordered_values = cache._temporal_order(cache.values)
+            cache.keys = mx.contiguous(ordered_keys[..., -cache.max_size :, :])
+            cache.values = mx.contiguous(ordered_values[..., -cache.max_size :, :])
+            cache._idx = cache.max_size
+        cache.offset = total_writes
+        _evaluate_cache([cache])
+        _validate_scalar_rotating(cache)
+        checkpoint.seal()
+    except BaseException:
+        checkpoint.restore()
+        raise
+
+
+def _validate_batch_rotating(
+    cache: BatchRotatingKVCache, *, allow_oversized: bool = False
+) -> None:
+    if cache.max_size <= 0 or cache._offset < 0 or cache._idx < 0:
+        raise GemmaCacheError("invalid batch rotating-cache metadata")
+    if (cache.keys is None) != (cache.values is None):
+        raise GemmaCacheError("batch rotating cache has only one KV tensor")
+    rows = len(cache.offset)
+    if len(cache.left_padding) != rows:
+        raise GemmaCacheError("batch rotating row metadata differs")
+    if cache.keys is None:
+        if cache._offset != 0 or cache._idx != 0 or cache.rotated:
+            raise GemmaCacheError("empty batch rotating cache has non-zero cursors")
+        return
+    if cache.keys.shape[0] != rows or cache.values.shape[0] != rows:
+        raise GemmaCacheError("batch rotating tensor rows differ from metadata")
+    if cache.keys.shape[2] != cache.values.shape[2]:
+        raise GemmaCacheError("batch rotating KV resident lengths differ")
+    resident = cache.keys.shape[2]
+    if cache._offset >= cache.max_size and resident < cache.max_size:
+        raise GemmaCacheError("saturated batch rotating cache has a short buffer")
+    if (not allow_oversized and resident > cache.max_size) or cache._idx > resident:
+        raise GemmaCacheError("invalid batch rotating resident/circular state")
+    if allow_oversized and resident > cache.max_size:
+        return
+    if cache._offset < cache.max_size:
+        if cache.rotated or cache._idx != cache._offset:
+            raise GemmaCacheError("invalid unsaturated batch rotating state")
+    elif cache._idx == cache.max_size:
+        if cache.rotated:
+            raise GemmaCacheError("normalized saturated cache cannot be rotated")
+    elif not (0 < cache._idx < cache.max_size and cache.rotated):
+        raise GemmaCacheError("invalid wrapped batch rotating state")
+
+
+def normalize_batch_rotating(cache: BatchRotatingKVCache) -> None:
+    """Normalize a finalized batch cache while preserving lifetime cursors."""
+
+    if type(cache) is not BatchRotatingKVCache:
+        raise GemmaCacheError("normalization requires BatchRotatingKVCache")
+    if cache._lengths is not None:
+        raise GemmaCacheError("right-padded batch cache must be finalized first")
+    _validate_batch_rotating(cache, allow_oversized=True)
+    if cache.keys is None:
+        return
+    checkpoint = GemmaCacheCheckpoint([cache])
+    try:
+        row_offsets = cache.offset
+        physical_writes = cache._offset
+        resident = min(physical_writes, cache.max_size)
+        if cache.keys.shape[2] > cache.max_size or cache.rotated:
+            cache._temporal_order()
+            dropped = cache.keys.shape[2] - resident
+            cache.keys = mx.contiguous(cache.keys[..., -resident:, :])
+            cache.values = mx.contiguous(cache.values[..., -resident:, :])
+            if dropped:
+                cache.left_padding = cache.left_padding - dropped
+            cache._idx = resident
+            cache.rotated = False
+        cache.offset = row_offsets
+        cache._offset = physical_writes
+        _evaluate_cache([cache])
+        _validate_batch_rotating(cache)
+        checkpoint.seal()
+    except BaseException:
+        checkpoint.restore()
+        raise
+
+
+class GemmaOneTokenTransaction:
+    """Atomic one-token adoption for a compact scalar or batch cache."""
+
+    def __init__(self, cache: Sequence[Any], *, logical_positions: Sequence[int]):
+        if not cache:
+            raise GemmaCacheError("transaction cache cannot be empty")
+        if len({id(entry) for entry in cache}) != len(cache):
+            raise GemmaCacheError("transaction cache contains duplicate owners")
+        self.cache = tuple(cache)
+        self._state = "active"
+        self.logical_before = tuple(int(value) for value in logical_positions)
+        for entry in cache:
+            if type(entry) is RotatingKVCache:
+                _validate_scalar_rotating(entry)
+            elif type(entry) is BatchRotatingKVCache:
+                _validate_batch_rotating(entry)
+        self.checkpoint = GemmaCacheCheckpoint(cache)
+        self._write_journal = tuple(self._capture_overwrite(entry) for entry in cache)
+        mx.eval(
+            *(
+                tensor
+                for journal in self._write_journal
+                if journal is not None
+                for tensor in journal[1:]
+            )
+        )
+        self._batch = type(cache[0]) in (BatchKVCache, BatchRotatingKVCache)
+        if self._batch:
+            validate_homogeneous_batch_lane(cache, logical_positions=self.logical_before)
+            self.before = tuple(
+                batch_cache_cursor(entry, logical_positions=self.logical_before)
+                for entry in cache
+            )
+        else:
+            if len(self.logical_before) != 1:
+                raise GemmaCacheError("scalar transaction requires one logical position")
+            validate_aligned_scalar_cache(
+                cache, logical_position=self.logical_before[0]
+            )
+            self.before = tuple(
+                scalar_cache_cursor(entry, logical_position=self.logical_before[0])
+                for entry in cache
+            )
+        self._guard_originals: list[tuple[Any, bool, Any]] = []
+        self._update_counts = [0] * len(self.cache)
+        self._install_guards()
+
+    def _install_guards(self) -> None:
+        for index, entry in enumerate(self.cache):
+            had_instance_override = "update_and_fetch" in entry.__dict__
+            instance_override = entry.__dict__.get("update_and_fetch")
+            original = entry.update_and_fetch
+
+            def guarded(keys, values, *, _index=index, _original=original):
+                if keys.shape[2] != 1:
+                    raise GemmaCacheTransactionError(
+                        "one-token transaction received a multi-token update"
+                    )
+                if self._update_counts[_index] != 0:
+                    raise GemmaCacheTransactionError(
+                        "cache owner was updated more than once"
+                    )
+                self._update_counts[_index] = 1
+                return _original(keys, values)
+
+            self._guard_originals.append(
+                (entry, had_instance_override, instance_override)
+            )
+            entry.update_and_fetch = guarded
+
+    def _remove_guards(self) -> None:
+        if not self._guard_originals:
+            return
+        for entry, had_instance_override, instance_override in self._guard_originals:
+            if had_instance_override:
+                entry.update_and_fetch = instance_override
+            else:
+                entry.__dict__.pop("update_and_fetch", None)
+        self._guard_originals.clear()
+
+    @staticmethod
+    def _capture_overwrite(cache: Any) -> tuple[int, Any, Any] | None:
+        """Copy only the one resident slot a decode quantum may overwrite."""
+
+        if cache.keys is None:
+            return None
+        if type(cache) is KVCache:
+            index = cache.offset
+        elif type(cache) is BatchKVCache:
+            index = cache._idx
+        elif type(cache) is RotatingKVCache:
+            index = 0 if cache._idx == cache.max_size else cache._idx
+        elif type(cache) is BatchRotatingKVCache:
+            index = 0 if cache._idx == cache.max_size else cache._idx
+        else:  # pragma: no cover - constructor rejects other cache types
+            raise GemmaCacheError(f"unsupported cache: {type(cache).__name__}")
+        if index >= cache.keys.shape[2]:
+            return None
+        return (
+            index,
+            mx.contiguous(cache.keys[..., index : index + 1, :]),
+            mx.contiguous(cache.values[..., index : index + 1, :]),
+        )
+
+    def rollback(self) -> None:
+        if self._state != "active":
+            return
+        self._remove_guards()
+        self.checkpoint.restore()
+        for entry, journal in zip(self.cache, self._write_journal):
+            if journal is None:
+                continue
+            index, keys, values = journal
+            entry.keys[..., index : index + 1, :] = keys
+            entry.values[..., index : index + 1, :] = values
+        mx.eval(
+            *(
+                tensor
+                for entry in self.cache
+                for tensor in (entry.keys, entry.values)
+                if tensor is not None
+            )
+        )
+        self._write_journal = ()
+        self._state = "rolled_back"
+
+    def commit(self, *, logical_positions: Sequence[int]) -> None:
+        if self._state != "active":
+            raise GemmaCacheTransactionError(
+                f"transaction is already {self._state}"
+            )
+        logical_after = tuple(int(value) for value in logical_positions)
+        if logical_after != tuple(value + 1 for value in self.logical_before):
+            self.rollback()
+            raise GemmaCacheTransactionError("logical positions did not advance by one")
+        try:
+            if self._update_counts != [1] * len(self.cache):
+                raise GemmaCacheTransactionError(
+                    "each cache owner must be updated exactly once"
+                )
+            # Completing a full circular lap leaves mlx-vlm's flag set even
+            # though the physical array is again in temporal order.  Clear
+            # only this metadata bit; no window normalization/copy is needed.
+            for entry in self.cache:
+                if (
+                    type(entry) is BatchRotatingKVCache
+                    and entry._idx == entry.max_size
+                    and entry.rotated
+                ):
+                    entry.rotated = False
+            if self._batch:
+                validate_homogeneous_batch_lane(
+                    self.cache, logical_positions=logical_after
+                )
+                after = tuple(
+                    batch_cache_cursor(entry, logical_positions=logical_after)
+                    for entry in self.cache
+                )
+                for entry, old, new in zip(self.cache, self.before, after):
+                    if new.total_writes != tuple(value + 1 for value in old.total_writes):
+                        raise GemmaCacheTransactionError(
+                            "batch physical writes did not advance by one"
+                        )
+                    if new.physical_write_cursor != old.physical_write_cursor + 1:
+                        raise GemmaCacheTransactionError(
+                            "batch write cursor did not advance by one"
+                        )
+                    expected_index = old.circular_index + 1
+                    if (
+                        type(entry) is BatchRotatingKVCache
+                        and old.circular_index == entry.max_size
+                    ):
+                        expected_index = 1
+                    if new.circular_index != expected_index:
+                        raise GemmaCacheTransactionError(
+                            "batch circular index transition is invalid"
+                        )
+                    expected_rotated = (
+                        type(entry) is BatchRotatingKVCache
+                        and new.physical_write_cursor >= entry.max_size
+                        and new.circular_index < entry.max_size
+                    )
+                    if new.rotated != expected_rotated:
+                        raise GemmaCacheTransactionError(
+                            "batch rotation transition is invalid"
+                        )
+                    expected_resident = (
+                        min(old.physical_write_cursor + 1, entry.max_size)
+                        if type(entry) is BatchRotatingKVCache
+                        else old.resident_tokens + 1
+                    )
+                    if new.resident_tokens != expected_resident:
+                        raise GemmaCacheTransactionError(
+                            "batch resident transition is invalid"
+                        )
+            else:
+                validate_aligned_scalar_cache(
+                    self.cache, logical_position=logical_after[0]
+                )
+                after = tuple(
+                    scalar_cache_cursor(entry, logical_position=logical_after[0])
+                    for entry in self.cache
+                )
+                for entry, old, new in zip(self.cache, self.before, after):
+                    if new.total_writes != old.total_writes + 1:
+                        raise GemmaCacheTransactionError(
+                            "scalar physical writes did not advance by one"
+                        )
+                    expected_index = old.circular_index + 1
+                    if (
+                        type(entry) is RotatingKVCache
+                        and old.circular_index == entry.max_size
+                    ):
+                        expected_index = 1
+                    if new.circular_index != expected_index:
+                        raise GemmaCacheTransactionError(
+                            "scalar circular index transition is invalid"
+                        )
+                    expected_resident = (
+                        min(old.total_writes + 1, entry.max_size)
+                        if type(entry) is RotatingKVCache
+                        else old.resident_tokens + 1
+                    )
+                    if new.resident_tokens != expected_resident:
+                        raise GemmaCacheTransactionError(
+                            "scalar resident transition is invalid"
+                        )
+            _evaluate_cache(self.cache)
+            self._remove_guards()
+            self.checkpoint.seal()
+            self._write_journal = ()
+            self._state = "committed"
+        except BaseException:
+            self.rollback()
+            raise
+
+
+def atomic_batch_filter(
+    cache: Sequence[Any],
+    indices: Any,
+    *,
+    logical_positions: Sequence[int],
+) -> tuple[int, ...]:
+    if len({id(entry) for entry in cache}) != len(cache):
+        raise GemmaCacheError("filter cache contains duplicate owners")
+    checkpoint = GemmaCacheCheckpoint(cache)
+    try:
+        for entry in cache:
+            if type(entry) not in (BatchKVCache, BatchRotatingKVCache):
+                raise GemmaCacheError("filter requires batch cache entries")
+            entry.filter(indices)
+        selected = tuple(logical_positions[int(index)] for index in indices)
+        _evaluate_cache(cache)
+        validate_homogeneous_batch_lane(cache, logical_positions=selected)
+        checkpoint.seal()
+        return selected
+    except BaseException:
+        checkpoint.restore()
+        raise
+
+
+def atomic_batch_extend(destination: Sequence[Any], source: Sequence[Any]) -> None:
+    destination_ids = [id(entry) for entry in destination]
+    source_ids = [id(entry) for entry in source]
+    if len(set(destination_ids)) != len(destination_ids):
+        raise GemmaCacheError("destination cache contains duplicate owners")
+    if len(set(source_ids)) != len(source_ids):
+        raise GemmaCacheError("source cache contains duplicate owners")
+    if set(destination_ids) & set(source_ids):
+        raise GemmaCacheError("destination and source caches overlap")
+    checkpoint = GemmaCachePairCheckpoint(destination, source)
+    try:
+        for target, addition in zip(destination, source):
+            if type(target) is not type(addition) or type(target) not in (
+                BatchKVCache,
+                BatchRotatingKVCache,
+            ):
+                raise GemmaCacheError("extend cache types differ")
+            if _is_rotating_cache(target) and target.max_size != addition.max_size:
+                raise GemmaCacheError("extend rotating windows differ")
+            target.extend(addition)
+        _evaluate_cache((*destination, *source))
+        # BatchRotatingKVCache.extend temporalizes its source.  Restore source
+        # even on success so cache ownership remains request-local.
+        checkpoint.source.restore()
+        checkpoint.destination.seal()
+    except BaseException:
+        checkpoint.restore()
+        raise
+
+
+def run_atomic_one_token(
+    cache: Sequence[Any],
+    *,
+    logical_positions: Sequence[int],
+    forward: Callable[[], Any],
+    evaluate: Callable[[Any], None] = mx.eval,
+) -> Any:
+    """Run/evaluate one lazy forward and publish cache mutation atomically."""
+
+    transaction = GemmaOneTokenTransaction(
+        cache, logical_positions=logical_positions
+    )
+    try:
+        result = forward()
+        evaluate(result)
+        transaction.commit(
+            logical_positions=tuple(value + 1 for value in logical_positions)
+        )
+        return result
+    except BaseException:
+        transaction.rollback()
+        raise
+
+
+__all__ = [
+    "BatchCacheCursor",
+    "GEMMA4_26B_A4B",
+    "GEMMA4_31B",
+    "GEMMA4_ARTIFACTS",
+    "GEMMA4_E2B",
+    "GemmaArtifactSpec",
+    "GemmaCacheCheckpoint",
+    "GemmaCacheError",
+    "GemmaCachePairCheckpoint",
+    "GemmaCacheTopology",
+    "GemmaCacheTopologyError",
+    "GemmaCacheTransactionError",
+    "GemmaOneTokenTransaction",
+    "ScalarCacheCursor",
+    "atomic_batch_extend",
+    "atomic_batch_filter",
+    "batch_cache_cursor",
+    "normalize_scalar_rotating",
+    "normalize_batch_rotating",
+    "run_atomic_one_token",
+    "scalar_cache_cursor",
+    "validate_gemma_cache_topology",
+    "validate_aligned_scalar_cache",
+    "validate_homogeneous_batch_lane",
+]

--- a/vllm_mlx/specprefill_generation_context.py
+++ b/vllm_mlx/specprefill_generation_context.py
@@ -64,6 +64,8 @@ class SparseGenerationForwardContext:
         self._state = state.clone()
         self._hooks = TargetPositionHooks.for_model(target_model, adapter)
         self._mtp_cache: Any | None = None
+        self._native_mtp_transferred = False
+        self._terminal_state: SparseCacheState | None = None
         self._reconcile_cache()
 
     @property
@@ -73,7 +75,28 @@ class SparseGenerationForwardContext:
 
     def __call__(self, forward: Any):
         """Return the request-local context for one mlx-lm forward."""
+        if self._native_mtp_transferred:
+            raise SparseGenerationContextError(
+                "sparse generation context was transferred to native MTP"
+            )
         return self._forward_context(forward)
+
+    def transfer_to_native_mtp(self) -> SparseCacheState:
+        """Seal SimpleEngine sparse state before native MTP adopts its cache.
+
+        Native MTP becomes the sole owner of target-cache reconciliation after
+        its bootstrap claim.  Validate that no external advance occurred before
+        the handoff, then retain a terminal snapshot so later cleanup cannot
+        inspect the cache that native MTP now owns.
+        """
+        if self._native_mtp_transferred:
+            raise SparseGenerationContextError(
+                "sparse generation context was already transferred to native MTP"
+            )
+        self._reconcile_cache()
+        self._terminal_state = self._state.clone()
+        self._native_mtp_transferred = True
+        return self._terminal_state.clone()
 
     @contextmanager
     def _forward_context(self, forward: Any) -> Iterator[None]:
@@ -186,6 +209,9 @@ class SparseGenerationForwardContext:
 
     def finish(self) -> SparseCacheState:
         """Reconcile final speculative rollback and return terminal state."""
+        if self._native_mtp_transferred:
+            assert self._terminal_state is not None
+            return self._terminal_state.clone()
         self._reconcile_cache()
         return self.state
 

--- a/vllm_mlx/specprefill_generation_context.py
+++ b/vllm_mlx/specprefill_generation_context.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local sparse-cache positions for mlx-lm generation forwards.
+
+Sparse target prefill writes selected prompt tokens into contiguous cache
+slots while preserving their original logical positions.  mlx-lm owns the
+subsequent decode and speculative-verification forwards, so this adapter turns
+its ``model_forward_context`` metadata into one bounded
+:class:`TargetPositionHooks` session per target call.
+
+The state transition is optimistic until the next target call (or
+``finish``): speculative generation may trim rejected target tokens after the
+forward context exits.  Reconciliation uses the target cache's host offsets to
+roll back only the contiguous generated suffix.  Sparse prompt entries can
+never be trimmed or reinterpreted here.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator, Sequence
+
+from .specprefill_cache import SparseCacheState, SparseCacheStateError
+from .specprefill_positions import (
+    TargetPositionAdapter,
+    decode_plan,
+    verify_plan,
+)
+from .specprefill_target_hooks import TargetPositionHooks
+
+
+class SparseGenerationContextError(SparseCacheStateError):
+    """A generation forward cannot preserve sparse logical positions."""
+
+
+class SparseGenerationForwardContext:
+    """Own one SimpleEngine request's sparse target decode state.
+
+    Foreign draft-model forwards are delegated unchanged.  Target forwards
+    must use the exact cache object produced by sparse target prefill and must
+    be labelled ``decode`` or ``verify`` by the generation implementation.
+    """
+
+    def __init__(
+        self,
+        target_model: Any,
+        target_cache: Sequence[Any],
+        state: SparseCacheState,
+        adapter: TargetPositionAdapter,
+    ) -> None:
+        if state.row_count != 1:
+            raise SparseGenerationContextError(
+                "SimpleEngine sparse generation requires exactly one cache row"
+            )
+        if not isinstance(adapter, TargetPositionAdapter):
+            raise TypeError("adapter must be a TargetPositionAdapter")
+        if not isinstance(target_cache, Sequence) or not target_cache:
+            raise SparseGenerationContextError(
+                "sparse generation requires a non-empty target cache"
+            )
+        self.target_model = target_model
+        self.target_cache = target_cache
+        self.adapter = adapter
+        self._state = state.clone()
+        self._hooks = TargetPositionHooks.for_model(target_model, adapter)
+        self._reconcile_cache()
+
+    @property
+    def state(self) -> SparseCacheState:
+        """Return an immutable snapshot of the currently retained target KV."""
+        return self._state.clone()
+
+    def __call__(self, forward: Any):
+        """Return the request-local context for one mlx-lm forward."""
+        return self._forward_context(forward)
+
+    @contextmanager
+    def _forward_context(self, forward: Any) -> Iterator[None]:
+        model = getattr(forward, "model", None)
+        cache = getattr(forward, "cache", None)
+        if model is not self.target_model:
+            if cache is self.target_cache:
+                raise SparseGenerationContextError(
+                    "a foreign draft model cannot share the sparse target cache"
+                )
+            yield
+            return
+        if cache is not self.target_cache:
+            raise SparseGenerationContextError(
+                "target generation forward replaced the admitted sparse cache"
+            )
+
+        self._reconcile_cache()
+        tokens = getattr(forward, "input_tokens", None)
+        shape = getattr(tokens, "shape", None)
+        if shape is None or len(shape) != 2 or shape[0] != 1 or shape[1] <= 0:
+            raise SparseGenerationContextError(
+                "target generation tokens must have shape (1, positive_tokens)"
+            )
+        token_count = int(shape[1])
+        phase = getattr(getattr(forward, "phase", None), "value", None)
+        if phase is None:
+            phase = getattr(forward, "phase", None)
+        if phase == "decode":
+            if token_count != 1:
+                raise SparseGenerationContextError(
+                    "decode forwards must contain exactly one target token"
+                )
+            plan = decode_plan(self.adapter, self._state)
+        elif phase == "verify":
+            plan = verify_plan(self.adapter, self._state, token_count)
+        else:
+            raise SparseGenerationContextError(
+                "sparse target continuation accepts only decode or verify forwards"
+            )
+
+        expected_end = self._state.rows[0].physical_valid_length + token_count
+        with self._hooks.session_for_plan(plan):
+            yield
+        actual_end = _cache_offset(self.target_cache)
+        if actual_end != expected_end:
+            raise SparseGenerationContextError(
+                "target cache did not advance by the generation forward token count"
+            )
+        self._state = self._state.append_decode(token_count)
+
+    def finish(self) -> SparseCacheState:
+        """Reconcile final speculative rollback and return terminal state."""
+        self._reconcile_cache()
+        return self.state
+
+    def _reconcile_cache(self) -> None:
+        actual = _cache_offset(self.target_cache)
+        row = self._state.rows[0]
+        expected = row.physical_valid_length
+        if actual > expected:
+            raise SparseGenerationContextError(
+                "target cache advanced outside the request-local forward context"
+            )
+        if actual < row.prefill_physical_length:
+            raise SparseGenerationContextError(
+                "target cache rollback crossed the immutable sparse prompt boundary"
+            )
+        if actual < expected:
+            self._state = self._state.rollback(expected - actual)
+
+
+def _cache_offset(cache: Sequence[Any]) -> int:
+    offsets: list[int] = []
+    for entry in cache:
+        if not hasattr(entry, "offset"):
+            continue
+        offset = entry.offset
+        if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+            raise SparseGenerationContextError(
+                "target cache offsets must be non-negative host integers"
+            )
+        offsets.append(offset)
+    if not offsets:
+        raise SparseGenerationContextError(
+            "target cache exposes no host physical offsets"
+        )
+    if len(set(offsets)) != 1:
+        raise SparseGenerationContextError(
+            "target cache layers disagree on physical occupancy"
+        )
+    return offsets[0]

--- a/vllm_mlx/specprefill_generation_context.py
+++ b/vllm_mlx/specprefill_generation_context.py
@@ -21,11 +21,12 @@ from typing import Any, Iterator, Sequence
 
 from .specprefill_cache import SparseCacheState, SparseCacheStateError
 from .specprefill_positions import (
+    PositionPhase,
     TargetPositionAdapter,
     decode_plan,
     verify_plan,
 )
-from .specprefill_target_hooks import TargetPositionHooks
+from .specprefill_target_hooks import TargetPositionHooks, TargetPositionSession
 
 
 class SparseGenerationContextError(SparseCacheStateError):
@@ -62,6 +63,7 @@ class SparseGenerationForwardContext:
         self.adapter = adapter
         self._state = state.clone()
         self._hooks = TargetPositionHooks.for_model(target_model, adapter)
+        self._mtp_cache: Any | None = None
         self._reconcile_cache()
 
     @property
@@ -84,12 +86,6 @@ class SparseGenerationForwardContext:
                 )
             yield
             return
-        if cache is not self.target_cache:
-            raise SparseGenerationContextError(
-                "target generation forward replaced the admitted sparse cache"
-            )
-
-        self._reconcile_cache()
         tokens = getattr(forward, "input_tokens", None)
         shape = getattr(tokens, "shape", None)
         if shape is None or len(shape) != 2 or shape[0] != 1 or shape[1] <= 0:
@@ -100,6 +96,51 @@ class SparseGenerationForwardContext:
         phase = getattr(getattr(forward, "phase", None), "value", None)
         if phase is None:
             phase = getattr(forward, "phase", None)
+        logical_positions = getattr(forward, "logical_positions", None)
+        logical_position_ack = getattr(forward, "logical_position_ack", None)
+
+        if phase == PositionPhase.MTP_DRAFT.value:
+            if cache is self.target_cache:
+                raise SparseGenerationContextError(
+                    "native MTP draft cannot share the sparse target cache"
+                )
+            if not isinstance(cache, list) or not cache:
+                raise SparseGenerationContextError(
+                    "native MTP draft requires a non-empty request-local cache list"
+                )
+            if self._mtp_cache is None:
+                self._mtp_cache = cache
+            elif cache is not self._mtp_cache:
+                raise SparseGenerationContextError(
+                    "native MTP draft replaced its request-local cache"
+                )
+            positions = _require_attested_positions(
+                logical_positions,
+                logical_position_ack,
+                token_count=token_count,
+            )
+            physical_start = _cache_offset(cache)
+            expected_end = physical_start + token_count
+            session = TargetPositionSession(
+                logical_positions=(positions,),
+                physical_starts=(physical_start,),
+                phase=PositionPhase.MTP_DRAFT,
+                logical_position_ack=logical_position_ack,
+            )
+            with self._hooks.session(session):
+                yield session
+            if _cache_offset(cache) != expected_end:
+                raise SparseGenerationContextError(
+                    "native MTP cache did not advance by the draft token count"
+                )
+            return
+
+        if cache is not self.target_cache:
+            raise SparseGenerationContextError(
+                "target generation forward replaced the admitted sparse cache"
+            )
+
+        self._reconcile_cache()
         if phase == "decode":
             if token_count != 1:
                 raise SparseGenerationContextError(
@@ -113,8 +154,28 @@ class SparseGenerationForwardContext:
                 "sparse target continuation accepts only decode or verify forwards"
             )
 
+        if logical_positions is None and logical_position_ack is not None:
+            raise SparseGenerationContextError(
+                "logical-position acknowledgement is missing immutable positions"
+            )
+        if logical_positions is not None:
+            positions = _require_attested_positions(
+                logical_positions,
+                logical_position_ack,
+                token_count=token_count,
+            )
+            if positions != plan.logical_positions[0]:
+                raise SparseGenerationContextError(
+                    "generation forward logical positions disagree with sparse state"
+                )
+
         expected_end = self._state.rows[0].physical_valid_length + token_count
-        with self._hooks.session_for_plan(plan):
+        session_kwargs = (
+            {"logical_position_ack": logical_position_ack}
+            if logical_position_ack is not None
+            else {}
+        )
+        with self._hooks.session_for_plan(plan, **session_kwargs):
             yield
         actual_end = _cache_offset(self.target_cache)
         if actual_end != expected_end:
@@ -164,3 +225,38 @@ def _cache_offset(cache: Sequence[Any]) -> int:
             "target cache layers disagree on physical occupancy"
         )
     return offsets[0]
+
+
+def _require_attested_positions(
+    logical_positions: Any,
+    logical_position_ack: Any,
+    *,
+    token_count: int,
+) -> tuple[int, ...]:
+    """Validate the host-only B=1 position receipt inputs before a model call."""
+    if (
+        not isinstance(logical_positions, tuple)
+        or len(logical_positions) != token_count
+    ):
+        raise SparseGenerationContextError(
+            "attested generation positions must be a host tuple matching tokens"
+        )
+    if logical_position_ack is None or not callable(
+        getattr(logical_position_ack, "acknowledge", None)
+    ):
+        raise SparseGenerationContextError(
+            "attested generation requires a request-local position consumer"
+        )
+    previous = -1
+    for position in logical_positions:
+        if (
+            isinstance(position, bool)
+            or not isinstance(position, int)
+            or position < 0
+            or position <= previous
+        ):
+            raise SparseGenerationContextError(
+                "attested generation positions must be strictly increasing integers"
+            )
+        previous = position
+    return logical_positions

--- a/vllm_mlx/specprefill_positions.py
+++ b/vllm_mlx/specprefill_positions.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence
 
 from .specprefill_cache import SparseCacheState, SparseCacheStateError
 
@@ -79,6 +79,11 @@ class TargetPositionAdapter:
     uses_q_norm: bool
     cache_layout: str
     position_id_planes: int = 1
+
+    @property
+    def adapter_id(self) -> str:
+        """Stable profile/cache identity for this exact transport contract."""
+        return self.family.value
 
     def __post_init__(self) -> None:
         if not self.model_types:
@@ -192,6 +197,69 @@ def target_position_adapter(
         raise TargetPositionError(
             f"unsupported target position family {family!r}; supported: {supported}"
         ) from exc
+
+
+def resolve_target_position_adapter(model: Any) -> TargetPositionAdapter:
+    """Resolve a target adapter from a bounded, public model layout.
+
+    This deliberately accepts only the layouts exported by mlx-lm text models
+    and their known VLM wrappers.  It never walks arbitrary attributes: an
+    unrecognised wrapper is not evidence that it preserves the target's
+    position/cache contract and is therefore rejected before sparse work.
+    """
+    outer_config = getattr(model, "config", None) or getattr(model, "args", None)
+    inner = getattr(model, "language_model", None)
+    # mlx-lm Qwen3.5 text ``Model`` also owns ``language_model``.  Only the
+    # concrete mlx-vlm outer topology has a vision tower; treating every text
+    # wrapper as VLM would select M-RoPE IDs for ordinary text attention.
+    is_vlm = inner is not None and getattr(model, "vision_tower", None) is not None
+    target = inner if is_vlm else model
+    config = (
+        getattr(target, "config", None)
+        or getattr(target, "args", None)
+        or _config_value(outer_config, "text_config")
+        or outer_config
+    )
+    model_type = _model_type(config)
+    if model_type in QWEN_DENSE_TARGET.model_types:
+        if is_vlm:
+            raise TargetPositionError(
+                "Qwen3 dense targets do not have a supported VLM layout"
+            )
+        return QWEN_DENSE_TARGET
+    if model_type in QWEN35_TEXT_HYBRID_TARGET.model_types:
+        if not is_vlm:
+            return QWEN35_TEXT_HYBRID_TARGET
+        return (
+            QWEN35_VLM_MOE_TARGET
+            if model_type == "qwen3_5_moe"
+            else QWEN35_VLM_HYBRID_TARGET
+        )
+    if model_type in GEMMA4_DENSE_TARGET.model_types:
+        if _positive_int(_config_value(config, "num_experts")):
+            return GEMMA4_A4B_TARGET
+        return GEMMA4_DENSE_TARGET
+    raise TargetPositionError(
+        "unsupported target model layout for SpecPrefill logical positions: "
+        f"model_type={model_type!r}"
+    )
+
+
+def _config_value(config: Any, name: str) -> Any:
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _model_type(config: Any) -> str | None:
+    value = _config_value(config, "model_type")
+    return value.lower() if isinstance(value, str) else None
+
+
+def _positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/specprefill_positions.py
+++ b/vllm_mlx/specprefill_positions.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local logical-position contracts for target SpecPrefill execution.
+
+Sparse prefill stores selected KV entries contiguously while their semantic
+positions are not contiguous.  Consequently a cache's physical occupancy is
+not an authority for RoPE/M-RoPE positions.  This module is deliberately
+host-only: it builds immutable invocation plans from
+:mod:`vllm_mlx.specprefill_cache` and never modifies model modules, cache
+objects, or global RoPE state.
+
+An executor may run a plan only when its target family has an explicit
+transport for the required non-contiguous positions.  The conservative
+capability matrix is intentional:
+
+* normal Qwen attention and Qwen3.5/3.6 text/hybrid targets currently accept
+  cache-derived scalar offsets only, so sparse position transport is blocked;
+* Qwen3.5/3.6 VLM attention accepts explicit M-RoPE IDs shaped ``(3, B, L)``;
+* Gemma4 forwards an explicit scalar offset through shared-KV layers, but its
+  KV-owning attention replaces that value with the physical cache offset.  No
+  current public call accepts a non-contiguous position sequence, so sparse
+  prefill and sparse decode are both blocked pending a future sparse hook.
+
+This prevents the former model-global ``.rope`` replacement from being used as
+an implicit execution mechanism.  A later family-local hook can advertise a
+new capability only after its own keep-ratio-one oracle and batch tests pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+from .specprefill_cache import SparseCacheState, SparseCacheStateError
+
+
+class TargetPositionError(SparseCacheStateError):
+    """A target cannot faithfully execute the requested logical positions."""
+
+
+class TargetPositionFamily(str, Enum):
+    """Explicit target families with materially different position APIs."""
+
+    QWEN_DENSE = "qwen_dense"
+    QWEN35_TEXT_HYBRID = "qwen35_text_hybrid"
+    QWEN35_VLM_HYBRID = "qwen35_vlm_hybrid"
+    QWEN35_VLM_MOE = "qwen35_vlm_moe"
+    GEMMA4_DENSE = "gemma4_dense"
+    GEMMA4_A4B = "gemma4_a4b"
+
+
+class PositionTransport(str, Enum):
+    """How a target receives request-local positions without global mutation."""
+
+    CACHE_DERIVED_OFFSET = "cache_derived_offset"
+    QWEN35_MROPE_IDS = "qwen35_mrope_ids"
+    GEMMA4_EXPLICIT_OFFSET = "gemma4_explicit_offset"
+
+
+class PositionPhase(str, Enum):
+    """One target-cache lifecycle operation represented by a position plan."""
+
+    SPARSE_PREFILL = "sparse_prefill"
+    DECODE = "decode"
+    VERIFY = "verify"
+
+
+@dataclass(frozen=True)
+class TargetPositionAdapter:
+    """Static family contract, including deliberately unsupported cases."""
+
+    family: TargetPositionFamily
+    model_types: tuple[str, ...]
+    transport: PositionTransport
+    supports_noncontiguous_prefill: bool
+    supports_heterogeneous_batch_rows: bool
+    supports_shared_kv: bool
+    supports_partial_rope: bool
+    uses_q_norm: bool
+    cache_layout: str
+    position_id_planes: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.model_types:
+            raise TargetPositionError("target adapter must name model types")
+        if self.position_id_planes <= 0:
+            raise TargetPositionError("position_id_planes must be positive")
+        if self.transport is PositionTransport.QWEN35_MROPE_IDS:
+            if self.position_id_planes != 3:
+                raise TargetPositionError("Qwen3.5 M-RoPE requires exactly 3 planes")
+        elif self.position_id_planes != 1:
+            raise TargetPositionError(
+                "only Qwen3.5 M-RoPE has more than one position-ID plane"
+            )
+
+
+QWEN_DENSE_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.QWEN_DENSE,
+    model_types=("qwen3", "qwen3_moe"),
+    transport=PositionTransport.CACHE_DERIVED_OFFSET,
+    supports_noncontiguous_prefill=False,
+    supports_heterogeneous_batch_rows=False,
+    supports_shared_kv=False,
+    supports_partial_rope=False,
+    uses_q_norm=True,
+    cache_layout="one_attention_cache_per_layer",
+)
+
+QWEN35_TEXT_HYBRID_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.QWEN35_TEXT_HYBRID,
+    model_types=("qwen3_5", "qwen3_5_moe", "qwen3_next"),
+    transport=PositionTransport.CACHE_DERIVED_OFFSET,
+    supports_noncontiguous_prefill=False,
+    supports_heterogeneous_batch_rows=False,
+    supports_shared_kv=False,
+    supports_partial_rope=True,
+    uses_q_norm=True,
+    cache_layout="one_cache_entry_per_hybrid_layer",
+)
+
+QWEN35_VLM_HYBRID_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.QWEN35_VLM_HYBRID,
+    model_types=("qwen3_5",),
+    transport=PositionTransport.QWEN35_MROPE_IDS,
+    supports_noncontiguous_prefill=True,
+    supports_heterogeneous_batch_rows=True,
+    supports_shared_kv=False,
+    supports_partial_rope=True,
+    uses_q_norm=True,
+    cache_layout="one_cache_entry_per_hybrid_layer",
+    position_id_planes=3,
+)
+
+QWEN35_VLM_MOE_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.QWEN35_VLM_MOE,
+    model_types=("qwen3_5_moe",),
+    transport=PositionTransport.QWEN35_MROPE_IDS,
+    supports_noncontiguous_prefill=True,
+    supports_heterogeneous_batch_rows=True,
+    supports_shared_kv=False,
+    supports_partial_rope=True,
+    uses_q_norm=True,
+    cache_layout="one_cache_entry_per_hybrid_layer",
+    position_id_planes=3,
+)
+
+GEMMA4_DENSE_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.GEMMA4_DENSE,
+    model_types=("gemma4", "gemma4_text"),
+    transport=PositionTransport.GEMMA4_EXPLICIT_OFFSET,
+    supports_noncontiguous_prefill=False,
+    supports_heterogeneous_batch_rows=False,
+    supports_shared_kv=True,
+    supports_partial_rope=True,
+    uses_q_norm=True,
+    cache_layout="one_cache_entry_per_layer_or_previous_kv_owner",
+)
+
+GEMMA4_A4B_TARGET = TargetPositionAdapter(
+    family=TargetPositionFamily.GEMMA4_A4B,
+    model_types=("gemma4",),
+    transport=PositionTransport.GEMMA4_EXPLICIT_OFFSET,
+    supports_noncontiguous_prefill=False,
+    supports_heterogeneous_batch_rows=False,
+    supports_shared_kv=True,
+    supports_partial_rope=True,
+    uses_q_norm=True,
+    cache_layout="one_cache_entry_per_layer_or_previous_kv_owner",
+)
+
+TARGET_POSITION_ADAPTERS: dict[TargetPositionFamily, TargetPositionAdapter] = {
+    adapter.family: adapter
+    for adapter in (
+        QWEN_DENSE_TARGET,
+        QWEN35_TEXT_HYBRID_TARGET,
+        QWEN35_VLM_HYBRID_TARGET,
+        QWEN35_VLM_MOE_TARGET,
+        GEMMA4_DENSE_TARGET,
+        GEMMA4_A4B_TARGET,
+    )
+}
+
+
+def target_position_adapter(
+    family: TargetPositionFamily | str,
+) -> TargetPositionAdapter:
+    """Resolve one adapter without attribute-based model-family guessing."""
+    try:
+        return TARGET_POSITION_ADAPTERS[TargetPositionFamily(family)]
+    except (KeyError, ValueError) as exc:
+        supported = ", ".join(adapter.value for adapter in TargetPositionFamily)
+        raise TargetPositionError(
+            f"unsupported target position family {family!r}; supported: {supported}"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class PositionRow:
+    """One row's immutable semantic and physical coordinates for one call."""
+
+    logical_positions: tuple[int, ...]
+    physical_cache_length: int
+
+    def __post_init__(self) -> None:
+        if not self.logical_positions:
+            raise TargetPositionError("position rows must contain at least one token")
+        if self.physical_cache_length < 0:
+            raise TargetPositionError("physical cache length must be non-negative")
+        previous = -1
+        for position in self.logical_positions:
+            if (
+                isinstance(position, bool)
+                or not isinstance(position, int)
+                or position < 0
+            ):
+                raise TargetPositionError(
+                    "logical positions must be non-negative integer coordinates"
+                )
+            if position <= previous:
+                raise TargetPositionError(
+                    "logical positions must be strictly increasing"
+                )
+            previous = position
+
+    @property
+    def token_count(self) -> int:
+        return len(self.logical_positions)
+
+    @property
+    def is_contiguous(self) -> bool:
+        start = self.logical_positions[0]
+        return self.logical_positions == tuple(range(start, start + self.token_count))
+
+
+@dataclass(frozen=True)
+class TargetPositionPlan:
+    """A no-side-effect target invocation plan derived from sparse cache state.
+
+    ``physical_cache_lengths`` describes only the target cache's real KV
+    occupancy.  ``logical_positions`` is the independent RoPE/M-RoPE contract.
+    An executor must pass the latter through an adapter-specific argument and
+    must never rewrite cache ``offset`` to make the two appear equal.
+    """
+
+    adapter: TargetPositionAdapter
+    phase: PositionPhase
+    rows: tuple[PositionRow, ...]
+    source_state: SparseCacheState
+
+    def __post_init__(self) -> None:
+        if not self.rows:
+            raise TargetPositionError("position plan must contain at least one row")
+        if self.source_state.row_count != len(self.rows):
+            raise TargetPositionError("position plan rows must match sparse cache rows")
+        if self.phase is PositionPhase.DECODE and any(
+            row.token_count != 1 for row in self.rows
+        ):
+            raise TargetPositionError("decode plan requires exactly one token per row")
+
+    @property
+    def logical_positions(self) -> tuple[tuple[int, ...], ...]:
+        return tuple(row.logical_positions for row in self.rows)
+
+    @property
+    def physical_cache_lengths(self) -> tuple[int, ...]:
+        return tuple(row.physical_cache_length for row in self.rows)
+
+    @property
+    def is_dense_equivalent(self) -> bool:
+        """True iff every row has ordinary dense zero-origin positions."""
+        return all(
+            row.logical_positions == tuple(range(row.token_count))
+            and row.physical_cache_length == 0
+            for row in self.rows
+        )
+
+    def require_executable(self) -> None:
+        """Fail closed before an engine calls a target model.
+
+        This validates target API capability, not merely that a plan can be
+        represented in host metadata.  It intentionally keeps Gemma and
+        cache-offset-only Qwen sparse prefill disabled until a request-local
+        position hook exists.
+        """
+        has_noncontiguous = any(not row.is_contiguous for row in self.rows)
+        if self.phase is PositionPhase.SPARSE_PREFILL and has_noncontiguous:
+            if not self.adapter.supports_noncontiguous_prefill:
+                raise TargetPositionError(
+                    f"{self.adapter.family.value} has no request-local "
+                    "non-contiguous sparse-position transport"
+                )
+        if len(self.rows) > 1 and not self.adapter.supports_heterogeneous_batch_rows:
+            if len(set(self.logical_positions)) > 1:
+                raise TargetPositionError(
+                    f"{self.adapter.family.value} does not expose verified "
+                    "heterogeneous-row logical-position transport"
+                )
+        token_counts = {row.token_count for row in self.rows}
+        if len(token_counts) > 1:
+            raise TargetPositionError(
+                "a batched target invocation requires equal token counts; "
+                "scheduler must use padded, adapter-verified transport or separate lanes"
+            )
+        if self.adapter.transport in (
+            PositionTransport.CACHE_DERIVED_OFFSET,
+            PositionTransport.GEMMA4_EXPLICIT_OFFSET,
+        ):
+            for row in self.rows:
+                expected = tuple(
+                    range(
+                        row.physical_cache_length,
+                        row.physical_cache_length + row.token_count,
+                    )
+                )
+                if row.logical_positions != expected:
+                    raise TargetPositionError(
+                        f"{self.adapter.family.value} derives owner-layer positions "
+                        "from physical cache offset and cannot execute this "
+                        "logical-position plan"
+                    )
+
+    def qwen35_mrope_position_ids(self) -> tuple[tuple[tuple[int, ...], ...], ...]:
+        """Return exact Qwen3.5 VLM M-RoPE host shape ``(3, B, L)``.
+
+        The current mlx-vlm Qwen3.5 attention accepts three M-RoPE planes. For
+        text-only sparse prefill all three carry the same logical text indices;
+        media M-RoPE is deliberately routed dense outside this module.
+        """
+        if self.adapter.transport is not PositionTransport.QWEN35_MROPE_IDS:
+            raise TargetPositionError("target does not accept Qwen3.5 M-RoPE IDs")
+        self.require_executable()
+        row_ids = self.logical_positions
+        return tuple(row_ids for _ in range(self.adapter.position_id_planes))
+
+    def gemma4_offsets(self) -> tuple[int, ...]:
+        """Return scalar starting offsets for Gemma's explicit-offset call path.
+
+        This helper is valid for normal dense-contiguous decode only.  Gemma's
+        owner attention overwrites its ``offset`` from the physical cache;
+        shared-KV layers merely carry that owner value.  It therefore never
+        claims that the current Gemma API can execute sparse decode, sparse
+        prefill, or batch different row offsets.
+        """
+        if self.adapter.transport is not PositionTransport.GEMMA4_EXPLICIT_OFFSET:
+            raise TargetPositionError("target does not accept Gemma4 explicit offsets")
+        self.require_executable()
+        return tuple(row.logical_positions[0] for row in self.rows)
+
+
+def sparse_prefill_plan(
+    adapter: TargetPositionAdapter | TargetPositionFamily | str,
+    state: SparseCacheState,
+) -> TargetPositionPlan:
+    """Plan initial sparse target prefill from immutable selected positions.
+
+    ``SparseCacheState.from_selection`` describes the cache *after* selected
+    prompt entries are written, so each initial row starts with physical
+    occupancy zero.  Sparse prefix reuse is intentionally not modeled here.
+    """
+    resolved = _resolve_adapter(adapter)
+    rows = tuple(
+        PositionRow(row.logical_positions, physical_cache_length=0)
+        for row in state.rows
+    )
+    return TargetPositionPlan(resolved, PositionPhase.SPARSE_PREFILL, rows, state)
+
+
+def decode_plan(
+    adapter: TargetPositionAdapter | TargetPositionFamily | str,
+    state: SparseCacheState,
+) -> TargetPositionPlan:
+    """Plan one decode token per row at its independent logical cursor."""
+    resolved = _resolve_adapter(adapter)
+    rows = tuple(
+        PositionRow((row.next_logical_position,), row.physical_valid_length)
+        for row in state.rows
+    )
+    return TargetPositionPlan(resolved, PositionPhase.DECODE, rows, state)
+
+
+def verify_plan(
+    adapter: TargetPositionAdapter | TargetPositionFamily | str,
+    state: SparseCacheState,
+    token_counts: int | Sequence[int],
+) -> TargetPositionPlan:
+    """Plan a target speculative-verification block without advancing state."""
+    resolved = _resolve_adapter(adapter)
+    counts = _normalize_counts(token_counts, state.row_count)
+    rows = tuple(
+        PositionRow(
+            tuple(range(row.next_logical_position, row.next_logical_position + count)),
+            row.physical_valid_length,
+        )
+        for row, count in zip(state.rows, counts, strict=True)
+    )
+    return TargetPositionPlan(resolved, PositionPhase.VERIFY, rows, state)
+
+
+@dataclass(frozen=True)
+class MTPPositionPlan:
+    """Pair target and assistant cache positions without conflating occupancy."""
+
+    target: TargetPositionPlan
+    assistant: TargetPositionPlan
+
+    def __post_init__(self) -> None:
+        if self.target.phase is not self.assistant.phase:
+            raise TargetPositionError("target and assistant must have the same phase")
+        if self.target.logical_positions != self.assistant.logical_positions:
+            raise TargetPositionError(
+                "target and assistant logical positions must agree for MTP"
+            )
+
+    @property
+    def physical_cache_lengths(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Independent target/assistant physical occupancy for executor wiring."""
+        return self.target.physical_cache_lengths, self.assistant.physical_cache_lengths
+
+
+def mtp_decode_plan(
+    target_adapter: TargetPositionAdapter | TargetPositionFamily | str,
+    target_state: SparseCacheState,
+    assistant_adapter: TargetPositionAdapter | TargetPositionFamily | str,
+    assistant_state: SparseCacheState,
+) -> MTPPositionPlan:
+    """Build matching logical decode plans for native or external MTP."""
+    return MTPPositionPlan(
+        target=decode_plan(target_adapter, target_state),
+        assistant=decode_plan(assistant_adapter, assistant_state),
+    )
+
+
+def gemma_previous_kv_cache_map(previous_kvs: Iterable[int]) -> dict[int, int]:
+    """Validate Gemma4 compact shared-KV ownership without touching caches.
+
+    Gemma uses a cache slot per layer while late shared-KV layers read the
+    tuple and scalar offset produced by an earlier owner.  The map makes the
+    ownership relation explicit for request-local executor state.
+    """
+    owners = tuple(previous_kvs)
+    if not owners:
+        raise TargetPositionError("Gemma previous_kvs must not be empty")
+    mapping: dict[int, int] = {}
+    for index, owner in enumerate(owners):
+        if isinstance(owner, bool) or not isinstance(owner, int):
+            raise TargetPositionError("Gemma previous_kvs entries must be integers")
+        if owner < 0 or owner > index:
+            raise TargetPositionError(
+                "Gemma previous_kvs owner must reference this or an earlier layer"
+            )
+        mapping[index] = owner
+    return mapping
+
+
+def _resolve_adapter(
+    adapter: TargetPositionAdapter | TargetPositionFamily | str,
+) -> TargetPositionAdapter:
+    if isinstance(adapter, TargetPositionAdapter):
+        return adapter
+    return target_position_adapter(adapter)
+
+
+def _normalize_counts(counts: int | Sequence[int], row_count: int) -> tuple[int, ...]:
+    if isinstance(counts, int) and not isinstance(counts, bool):
+        values = (counts,) * row_count
+    elif isinstance(counts, Sequence) and not isinstance(counts, (str, bytes)):
+        values = tuple(counts)
+    else:
+        raise TargetPositionError(
+            "verification token counts must be an integer sequence"
+        )
+    if len(values) != row_count:
+        raise TargetPositionError("verification token counts need one value per row")
+    for count in values:
+        if isinstance(count, bool) or not isinstance(count, int) or count <= 0:
+            raise TargetPositionError(
+                "verification token counts must be positive integers"
+            )
+    return values

--- a/vllm_mlx/specprefill_positions.py
+++ b/vllm_mlx/specprefill_positions.py
@@ -62,6 +62,7 @@ class PositionPhase(str, Enum):
     SPARSE_PREFILL = "sparse_prefill"
     DECODE = "decode"
     VERIFY = "verify"
+    MTP_DRAFT = "mtp_draft"
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/specprefill_positions.py
+++ b/vllm_mlx/specprefill_positions.py
@@ -15,10 +15,9 @@ capability matrix is intentional:
 * normal Qwen attention and Qwen3.5/3.6 text/hybrid targets currently accept
   cache-derived scalar offsets only, so sparse position transport is blocked;
 * Qwen3.5/3.6 VLM attention accepts explicit M-RoPE IDs shaped ``(3, B, L)``;
-* Gemma4 forwards an explicit scalar offset through shared-KV layers, but its
-  KV-owning attention replaces that value with the physical cache offset.  No
-  current public call accepts a non-contiguous position sequence, so sparse
-  prefill and sparse decode are both blocked pending a future sparse hook.
+* Gemma4's native call still derives owner positions from physical cache
+  offsets, but the install-once request-local RoPE hook provides the separately
+  tested scalar sparse transport without changing cache metadata.
 
 This prevents the former model-global ``.rope`` replacement from being used as
 an implicit execution mechanism.  A later family-local hook can advertise a
@@ -153,7 +152,7 @@ GEMMA4_DENSE_TARGET = TargetPositionAdapter(
     family=TargetPositionFamily.GEMMA4_DENSE,
     model_types=("gemma4", "gemma4_text"),
     transport=PositionTransport.GEMMA4_EXPLICIT_OFFSET,
-    supports_noncontiguous_prefill=False,
+    supports_noncontiguous_prefill=True,
     supports_heterogeneous_batch_rows=False,
     supports_shared_kv=True,
     supports_partial_rope=True,
@@ -165,7 +164,7 @@ GEMMA4_A4B_TARGET = TargetPositionAdapter(
     family=TargetPositionFamily.GEMMA4_A4B,
     model_types=("gemma4",),
     transport=PositionTransport.GEMMA4_EXPLICIT_OFFSET,
-    supports_noncontiguous_prefill=False,
+    supports_noncontiguous_prefill=True,
     supports_heterogeneous_batch_rows=False,
     supports_shared_kv=True,
     supports_partial_rope=True,
@@ -369,10 +368,7 @@ class TargetPositionPlan:
                 "a batched target invocation requires equal token counts; "
                 "scheduler must use padded, adapter-verified transport or separate lanes"
             )
-        if self.adapter.transport in (
-            PositionTransport.CACHE_DERIVED_OFFSET,
-            PositionTransport.GEMMA4_EXPLICIT_OFFSET,
-        ):
+        if self.adapter.transport is PositionTransport.CACHE_DERIVED_OFFSET:
             for row in self.rows:
                 expected = tuple(
                     range(
@@ -403,11 +399,9 @@ class TargetPositionPlan:
     def gemma4_offsets(self) -> tuple[int, ...]:
         """Return scalar starting offsets for Gemma's explicit-offset call path.
 
-        This helper is valid for normal dense-contiguous decode only.  Gemma's
-        owner attention overwrites its ``offset`` from the physical cache;
-        shared-KV layers merely carry that owner value.  It therefore never
-        claims that the current Gemma API can execute sparse decode, sparse
-        prefill, or batch different row offsets.
+        The request-local hook consumes these logical positions while native
+        cache/mask code retains the independent physical cursor. Heterogeneous
+        batch rows remain unsupported by the scalar Gemma adapter.
         """
         if self.adapter.transport is not PositionTransport.GEMMA4_EXPLICIT_OFFSET:
             raise TargetPositionError("target does not accept Gemma4 explicit offsets")

--- a/vllm_mlx/specprefill_profiles.py
+++ b/vllm_mlx/specprefill_profiles.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Calibrated, fail-closed eligibility profiles for SpecPrefill.
+
+This registry is intentionally pure Python.  It does not load a model or
+choose an architecture dynamically: the caller must supply the exact artifact,
+adapter, engine, and speculation-composition cell.  A production request is
+eligible only when that exact cell has an explicit calibrated profile marked
+certified.  The seed registry contains no certified artifact.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+_CONTEXT_QUALIFICATION_LADDER = (
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    96 * 1024,
+    127 * 1024,
+    192 * 1024,
+    255 * 1024,
+)
+_CB_CONCURRENCY_LADDER = (1, 2, 4, 8)
+
+
+class SpecPrefillEngine(str, Enum):
+    """Execution engines whose calibration results cannot be shared."""
+
+    SIMPLE = "simple"
+    CONTINUOUS_BATCHING = "continuous_batching"
+
+
+class SpecPrefillCell(str, Enum):
+    """Independently qualified sparse-only and MTP-composed feature cells."""
+
+    SPARSE_ONLY = "sparse_only"
+    COMBINED_MTP = "combined_mtp"
+
+
+class SpecPrefillProfileTier(str, Enum):
+    """Production profiles and explicitly non-production diagnostic profiles."""
+
+    PRODUCTION = "production"
+    DIAGNOSTIC = "diagnostic"
+
+
+@dataclass(frozen=True)
+class SpecPrefillTuning:
+    """Selector controls calibrated for one exact feature cell."""
+
+    keep_pct: float
+    backbone_pct: float
+    halo_chunks: int
+    anchor_chunks: int
+    chunk_size: int
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.keep_pct) or not 0.0 < self.keep_pct <= 1.0:
+            raise ValueError("keep_pct must be finite and in (0, 1]")
+        if not math.isfinite(self.backbone_pct) or not 0.0 <= self.backbone_pct <= 1.0:
+            raise ValueError("backbone_pct must be finite and in [0, 1]")
+        if self.halo_chunks < 0 or self.anchor_chunks < 0:
+            raise ValueError("halo_chunks and anchor_chunks must be non-negative")
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+
+
+@dataclass(frozen=True)
+class SpecPrefillProfileKey:
+    """Immutable model/artifact/route identity for one eligibility cell."""
+
+    target_artifact_id: str
+    target_artifact_hash: str
+    tokenizer_artifact_hash: str
+    scorer_artifact_id: str
+    scorer_artifact_hash: str
+    adapter_id: str
+    engine: SpecPrefillEngine
+    cell: SpecPrefillCell
+
+    def __post_init__(self) -> None:
+        for name in (
+            "target_artifact_id",
+            "scorer_artifact_id",
+            "adapter_id",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        for name in (
+            "target_artifact_hash",
+            "tokenizer_artifact_hash",
+            "scorer_artifact_hash",
+        ):
+            _validate_sha256(name, getattr(self, name))
+        if not isinstance(self.engine, SpecPrefillEngine):
+            raise ValueError("engine must be SpecPrefillEngine")
+        if not isinstance(self.cell, SpecPrefillCell):
+            raise ValueError("cell must be SpecPrefillCell")
+
+
+@dataclass(frozen=True)
+class SpecPrefillCalibration:
+    """Measured eligibility bounds and value gates for one profile cell."""
+
+    selector_version: str
+    tuning: SpecPrefillTuning
+    crossover_tokens: int
+    max_context_tokens: int
+    residency_limit_bytes: int
+    min_ttft_improvement_pct: float
+    max_total_latency_regression_pct: float
+    max_decode_throughput_regression_pct: float
+    required_context_tokens: tuple[int, ...]
+    required_concurrency_levels: tuple[int, ...]
+    max_p95_inter_token_latency_regression_pct: float
+    min_prefill_heavy_throughput_improvement_pct: float
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.selector_version, str)
+            or not self.selector_version.strip()
+        ):
+            raise ValueError(
+                "selector_version must be a non-empty immutable identifier"
+            )
+        if not isinstance(self.tuning, SpecPrefillTuning):
+            raise ValueError("tuning must be SpecPrefillTuning")
+        if self.crossover_tokens <= 0:
+            raise ValueError("crossover_tokens must be positive")
+        if self.max_context_tokens < self.crossover_tokens:
+            raise ValueError("max_context_tokens must be at least crossover_tokens")
+        if self.residency_limit_bytes <= 0:
+            raise ValueError("residency_limit_bytes must be positive")
+        required_context = _normalize_ladder(
+            "required_context_tokens", self.required_context_tokens
+        )
+        required_concurrency = _normalize_ladder(
+            "required_concurrency_levels", self.required_concurrency_levels
+        )
+        object.__setattr__(self, "required_context_tokens", required_context)
+        object.__setattr__(self, "required_concurrency_levels", required_concurrency)
+        if any(token > self.max_context_tokens for token in required_context):
+            raise ValueError("required_context_tokens cannot exceed max_context_tokens")
+        required_canonical_context = {
+            token
+            for token in _CONTEXT_QUALIFICATION_LADDER
+            if token <= self.max_context_tokens
+        }
+        if not required_canonical_context.issubset(required_context):
+            raise ValueError(
+                "required_context_tokens must include every applicable context ladder rung"
+            )
+        if self.required_concurrency_levels == ():
+            raise ValueError("required_concurrency_levels must not be empty")
+        if self.required_concurrency_levels[0] != 1:
+            raise ValueError("required_concurrency_levels must include one request")
+        if (
+            not math.isfinite(self.min_ttft_improvement_pct)
+            or self.min_ttft_improvement_pct <= 0.0
+        ):
+            raise ValueError("min_ttft_improvement_pct must be finite and positive")
+        for name in (
+            "max_total_latency_regression_pct",
+            "max_decode_throughput_regression_pct",
+            "max_p95_inter_token_latency_regression_pct",
+        ):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        if (
+            not math.isfinite(self.min_prefill_heavy_throughput_improvement_pct)
+            or self.min_prefill_heavy_throughput_improvement_pct <= 0.0
+        ):
+            raise ValueError(
+                "min_prefill_heavy_throughput_improvement_pct must be finite and positive"
+            )
+
+        if self.required_concurrency_levels and any(
+            level > 1 for level in self.required_concurrency_levels
+        ):
+            if not set(_CB_CONCURRENCY_LADDER).issubset(
+                self.required_concurrency_levels
+            ):
+                raise ValueError("CB required_concurrency_levels must include 1/2/4/8")
+
+
+@dataclass(frozen=True)
+class SpecPrefillQualificationEvidence:
+    """Immutable report-backed proof for one production profile cell."""
+
+    report_id: str
+    report_sha256: str
+    key: SpecPrefillProfileKey
+    selector_version: str
+    tested_context_tokens: tuple[int, ...]
+    tested_concurrency_levels: tuple[int, ...]
+    deterministic_baseline_successes: int
+    preserved_baseline_successes: int
+    fabricated_or_source_corruption_count: int
+    quality_noninferiority_ci_lower_points: float
+    median_ttft_improvement_pct: float
+    median_total_latency_regression_pct: float
+    decode_throughput_regression_pct: float
+    oom_count: int
+    swap_escalation_count: int
+    unbounded_retry_count: int
+    peak_resident_bytes: int
+    admission_safety_reserve_pct: float
+    cb_p95_inter_token_latency_regression_pct: float | None
+    cb_aggregate_throughput_regression_pct: float | None
+    cb_prefill_heavy_throughput_improvement_pct: float | None
+    mtp_evidence_id: str | None
+    mtp_evidence_sha256: str | None
+    mtp_drafts: int
+    mtp_accepted: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.report_id, str) or not self.report_id.strip():
+            raise ValueError("report_id must be a non-empty artifact identifier")
+        _validate_sha256("report_sha256", self.report_sha256)
+        if not isinstance(self.key, SpecPrefillProfileKey):
+            raise ValueError("evidence key must be SpecPrefillProfileKey")
+        if (
+            not isinstance(self.selector_version, str)
+            or not self.selector_version.strip()
+        ):
+            raise ValueError("evidence selector_version must be non-empty")
+        for name in (
+            "deterministic_baseline_successes",
+            "preserved_baseline_successes",
+            "fabricated_or_source_corruption_count",
+            "oom_count",
+            "swap_escalation_count",
+            "unbounded_retry_count",
+            "mtp_drafts",
+            "mtp_accepted",
+            "peak_resident_bytes",
+        ):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+        tested_context = _normalize_ladder(
+            "tested_context_tokens", self.tested_context_tokens
+        )
+        tested_concurrency = _normalize_ladder(
+            "tested_concurrency_levels", self.tested_concurrency_levels
+        )
+        object.__setattr__(self, "tested_context_tokens", tested_context)
+        object.__setattr__(self, "tested_concurrency_levels", tested_concurrency)
+        for name in (
+            "quality_noninferiority_ci_lower_points",
+            "median_ttft_improvement_pct",
+            "median_total_latency_regression_pct",
+            "decode_throughput_regression_pct",
+            "admission_safety_reserve_pct",
+        ):
+            if not math.isfinite(getattr(self, name)):
+                raise ValueError(f"{name} must be finite")
+        cb_values = (
+            self.cb_p95_inter_token_latency_regression_pct,
+            self.cb_aggregate_throughput_regression_pct,
+            self.cb_prefill_heavy_throughput_improvement_pct,
+        )
+        if any(value is not None and not math.isfinite(value) for value in cb_values):
+            raise ValueError("CB evidence values must be finite when set")
+        if (self.mtp_evidence_id is None) != (self.mtp_evidence_sha256 is None):
+            raise ValueError(
+                "MTP evidence identifier and hash must be provided together"
+            )
+        if self.mtp_evidence_id is not None:
+            if not self.mtp_evidence_id.strip():
+                raise ValueError("MTP evidence identifier must be non-empty")
+            _validate_sha256("mtp_evidence_sha256", self.mtp_evidence_sha256)
+
+    def assert_certifies(self, calibration: SpecPrefillCalibration) -> None:
+        """Raise unless this evidence proves every gate advertised by a profile."""
+        if self.selector_version != calibration.selector_version:
+            raise ValueError(
+                "qualification evidence selector version does not match calibration"
+            )
+        if not set(calibration.required_context_tokens).issubset(
+            self.tested_context_tokens
+        ):
+            raise ValueError(
+                "qualification evidence is missing required context ladder rungs"
+            )
+        if not set(calibration.required_concurrency_levels).issubset(
+            self.tested_concurrency_levels
+        ):
+            raise ValueError(
+                "qualification evidence is missing required concurrency ladder levels"
+            )
+        if self.deterministic_baseline_successes <= 0:
+            raise ValueError("qualification evidence requires baseline successes")
+        if self.preserved_baseline_successes != self.deterministic_baseline_successes:
+            raise ValueError(
+                "qualification evidence does not preserve baseline successes"
+            )
+        if self.fabricated_or_source_corruption_count != 0:
+            raise ValueError(
+                "qualification evidence records fabricated/source corruption"
+            )
+        if self.quality_noninferiority_ci_lower_points < -2.0:
+            raise ValueError(
+                "qualification evidence fails quality noninferiority CI gate"
+            )
+        if self.median_ttft_improvement_pct < calibration.min_ttft_improvement_pct:
+            raise ValueError("qualification evidence fails TTFT improvement gate")
+        if (
+            self.median_total_latency_regression_pct
+            > calibration.max_total_latency_regression_pct
+        ):
+            raise ValueError("qualification evidence fails total latency gate")
+        if (
+            self.decode_throughput_regression_pct
+            > calibration.max_decode_throughput_regression_pct
+        ):
+            raise ValueError("qualification evidence fails decode throughput gate")
+        if self.oom_count != 0:
+            raise ValueError("qualification evidence records OOM")
+        if self.swap_escalation_count != 0:
+            raise ValueError("qualification evidence records swap escalation")
+        if self.unbounded_retry_count != 0:
+            raise ValueError("qualification evidence records unbounded retry")
+        if self.peak_resident_bytes > calibration.residency_limit_bytes:
+            raise ValueError(
+                "qualification evidence resident peak exceeds residency limit"
+            )
+        if self.admission_safety_reserve_pct < 10.0:
+            raise ValueError(
+                "qualification evidence admission safety reserve is below 10 percent"
+            )
+        if self.key.engine is SpecPrefillEngine.CONTINUOUS_BATCHING:
+            if any(
+                value is None
+                for value in (
+                    self.cb_p95_inter_token_latency_regression_pct,
+                    self.cb_aggregate_throughput_regression_pct,
+                    self.cb_prefill_heavy_throughput_improvement_pct,
+                )
+            ):
+                raise ValueError("qualification evidence is missing CB metrics")
+            if (
+                self.cb_p95_inter_token_latency_regression_pct
+                > calibration.max_p95_inter_token_latency_regression_pct
+            ):
+                raise ValueError("qualification evidence fails CB p95 ITL gate")
+            if self.cb_aggregate_throughput_regression_pct > 0.0:
+                raise ValueError(
+                    "qualification evidence fails CB aggregate throughput gate"
+                )
+            if (
+                self.cb_prefill_heavy_throughput_improvement_pct
+                < calibration.min_prefill_heavy_throughput_improvement_pct
+            ):
+                raise ValueError(
+                    "qualification evidence fails CB prefill-heavy throughput gate"
+                )
+        if self.key.cell is SpecPrefillCell.COMBINED_MTP:
+            if self.mtp_evidence_id is None or self.mtp_drafts <= 0:
+                raise ValueError("qualification evidence is missing MTP evidence")
+
+
+@dataclass(frozen=True)
+class SpecPrefillProfile:
+    """A calibrated profile, not a wildcard default for a model family."""
+
+    key: SpecPrefillProfileKey
+    tier: SpecPrefillProfileTier
+    calibration: SpecPrefillCalibration
+    qualification_evidence: SpecPrefillQualificationEvidence | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.key, SpecPrefillProfileKey):
+            raise ValueError("key must be SpecPrefillProfileKey")
+        if not isinstance(self.tier, SpecPrefillProfileTier):
+            raise ValueError("tier must be SpecPrefillProfileTier")
+        if not isinstance(self.calibration, SpecPrefillCalibration):
+            raise ValueError("calibration must be SpecPrefillCalibration")
+        if self.key.engine is SpecPrefillEngine.CONTINUOUS_BATCHING and not set(
+            _CB_CONCURRENCY_LADDER
+        ).issubset(self.calibration.required_concurrency_levels):
+            raise ValueError("CB profiles must require the 1/2/4/8 concurrency ladder")
+        if self.tier is SpecPrefillProfileTier.DIAGNOSTIC:
+            if self.qualification_evidence is not None:
+                raise ValueError("diagnostic profiles cannot carry production evidence")
+            return
+        if self.qualification_evidence is not None:
+            if self.qualification_evidence.key != self.key:
+                raise ValueError(
+                    "qualification evidence key does not match profile key"
+                )
+            self.qualification_evidence.assert_certifies(self.calibration)
+
+    @property
+    def production_certified(self) -> bool:
+        return (
+            self.tier is SpecPrefillProfileTier.PRODUCTION
+            and self.qualification_evidence is not None
+        )
+
+
+@dataclass(frozen=True)
+class SpecPrefillProfileDecision:
+    """An explicit eligibility outcome for sparse execution or dense fallback."""
+
+    eligible: bool
+    production_certified: bool
+    fallback_reason: str | None
+    profile: SpecPrefillProfile | None = None
+
+    @property
+    def tuning(self) -> SpecPrefillTuning | None:
+        return self.profile.calibration.tuning if self.profile else None
+
+    @property
+    def selector_version(self) -> str | None:
+        return self.profile.calibration.selector_version if self.profile else None
+
+
+class SpecPrefillProfileRegistry:
+    """Immutable profile lookup with no family-level or global tuning fallback."""
+
+    def __init__(self, profiles: Iterable[SpecPrefillProfile] = ()) -> None:
+        entries: dict[
+            tuple[SpecPrefillProfileKey, SpecPrefillProfileTier], SpecPrefillProfile
+        ] = {}
+        for profile in profiles:
+            if not isinstance(profile, SpecPrefillProfile):
+                raise ValueError("profiles must contain SpecPrefillProfile values")
+            profile_key = (profile.key, profile.tier)
+            if profile_key in entries:
+                raise ValueError("duplicate SpecPrefill profile key and tier")
+            entries[profile_key] = profile
+        self._profiles = entries
+
+    @property
+    def profiles(self) -> tuple[SpecPrefillProfile, ...]:
+        return tuple(self._profiles.values())
+
+    def resolve(
+        self,
+        key: SpecPrefillProfileKey,
+        *,
+        prompt_tokens: int,
+        residency_bytes: int,
+        diagnostic: bool = False,
+    ) -> SpecPrefillProfileDecision:
+        if not isinstance(key, SpecPrefillProfileKey):
+            raise ValueError("key must be SpecPrefillProfileKey")
+        if prompt_tokens < 0:
+            raise ValueError("prompt_tokens must be non-negative")
+        if residency_bytes < 0:
+            raise ValueError("residency_bytes must be non-negative")
+
+        tier = (
+            SpecPrefillProfileTier.DIAGNOSTIC
+            if diagnostic
+            else SpecPrefillProfileTier.PRODUCTION
+        )
+        profile = self._profiles.get((key, tier))
+        if profile is None:
+            return _dense_fallback("profile_not_registered")
+        if not diagnostic and not profile.production_certified:
+            return _dense_fallback("uncalibrated_profile", profile)
+
+        calibration = profile.calibration
+        if prompt_tokens < calibration.crossover_tokens:
+            return _dense_fallback("below_calibrated_crossover", profile)
+        if prompt_tokens > calibration.max_context_tokens:
+            return _dense_fallback("above_calibrated_max_context", profile)
+        if residency_bytes > calibration.residency_limit_bytes:
+            return _dense_fallback("residency_limit_exceeded", profile)
+        return SpecPrefillProfileDecision(
+            eligible=True,
+            production_certified=(
+                profile.production_certified
+                and profile.tier is SpecPrefillProfileTier.PRODUCTION
+            ),
+            fallback_reason=None,
+            profile=profile,
+        )
+
+
+def _dense_fallback(
+    reason: str, profile: SpecPrefillProfile | None = None
+) -> SpecPrefillProfileDecision:
+    return SpecPrefillProfileDecision(
+        eligible=False,
+        production_certified=False,
+        fallback_reason=reason,
+        profile=profile,
+    )
+
+
+def _validate_sha256(name: str, value: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 hex digest")
+
+
+def _normalize_ladder(name: str, values: Iterable[int]) -> tuple[int, ...]:
+    normalized = tuple(values)
+    if not normalized:
+        raise ValueError(f"{name} must not be empty")
+    for value in normalized:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must contain positive integer values")
+    if normalized != tuple(sorted(set(normalized))):
+        raise ValueError(f"{name} must be sorted and unique")
+    return normalized
+
+
+# Qualification has not run for this registry program.  New production entries
+# must be added only with artifact-backed calibration evidence and explicit
+# certification; no Qwen or Gemma4 artifact is seeded as production-ready.
+EMPTY_SPECPREFILL_PROFILE_REGISTRY = SpecPrefillProfileRegistry()

--- a/vllm_mlx/specprefill_profiles.py
+++ b/vllm_mlx/specprefill_profiles.py
@@ -64,8 +64,10 @@ class SpecPrefillTuning:
             raise ValueError("keep_pct must be finite and in (0, 1]")
         if not math.isfinite(self.backbone_pct) or not 0.0 <= self.backbone_pct <= 1.0:
             raise ValueError("backbone_pct must be finite and in [0, 1]")
-        if self.halo_chunks < 0 or self.anchor_chunks < 0:
-            raise ValueError("halo_chunks and anchor_chunks must be non-negative")
+        if self.halo_chunks < 0:
+            raise ValueError("halo_chunks must be non-negative")
+        if self.anchor_chunks <= 0:
+            raise ValueError("anchor_chunks must be positive")
         if self.chunk_size <= 0:
             raise ValueError("chunk_size must be positive")
 

--- a/vllm_mlx/specprefill_runtime.py
+++ b/vllm_mlx/specprefill_runtime.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Eager, fail-atomic Qwen continuous-batching SpecPrefill runtime builder."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from mlx_lm.models.cache import ArraysCache, KVCache, make_prompt_cache
+
+from .cooperative_specprefill import (
+    CooperativeSpecPrefillConfig,
+    CooperativeSpecPrefillSession,
+)
+from .engine.batched import PreparedMLLMSpecPrefillRuntime
+from .mllm_batch_generator import MLLMTargetForwardPhase
+from .mllm_scheduler import MLLMSpecPrefillAdmission, MLLMSpecPrefillCacheCapability
+from .specprefill import SpecPrefillScorer
+from .specprefill_cache import SparseCacheState, SparsePolicyTuning
+from .specprefill_positions import (
+    TargetPositionFamily,
+    decode_plan,
+    resolve_target_position_adapter,
+)
+from .specprefill_profiles import (
+    SpecPrefillProfileKey,
+    SpecPrefillProfileRegistry,
+    SpecPrefillProfileTier,
+    SpecPrefillTuning,
+)
+from .specprefill_scorer_session import SpecPrefillScorerSession
+from .specprefill_target_executor import SparseTargetPrefillSession
+from .specprefill_target_hooks import TargetPositionHooks
+
+
+class SpecPrefillRuntimePreparationError(RuntimeError):
+    """The eager scorer/target runtime could not be prepared safely."""
+
+
+@dataclass(frozen=True)
+class LoadedSpecPrefillScorer:
+    """One eagerly loaded scorer artifact and its release callback."""
+
+    model: Any
+    cleanup: Callable[[], None]
+
+    def __post_init__(self) -> None:
+        if self.model is None:
+            raise ValueError("loaded scorer model must not be None")
+        if not callable(self.cleanup):
+            raise TypeError("loaded scorer cleanup must be callable")
+
+
+ScorerLoader = Callable[[str, str], LoadedSpecPrefillScorer]
+TargetCacheFactory = Callable[[Any], Sequence[Any]]
+
+
+@dataclass(frozen=True)
+class TargetProcessorAttestation:
+    """Trusted artifact identities resolved from the exact loaded objects."""
+
+    target_model: Any
+    processor: Any
+    target_artifact_hash: str
+    tokenizer_artifact_hash: str
+
+    def __post_init__(self) -> None:
+        for name in ("target_artifact_hash", "tokenizer_artifact_hash"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or len(value) != 64:
+                raise ValueError(f"{name} must be a SHA-256 hex digest")
+            try:
+                bytes.fromhex(value)
+            except ValueError as exc:
+                raise ValueError(f"{name} must be a SHA-256 hex digest") from exc
+
+
+TargetIdentityAttestor = Callable[[Any, Any], TargetProcessorAttestation]
+
+
+@dataclass(frozen=True)
+class _QwenCacheTopology:
+    entries: tuple[tuple[type[Any], int], ...]
+
+
+def build_qwen_cb_specprefill_prepare(
+    *,
+    scorer_artifact_path: str,
+    scorer_artifact_hash: str,
+    target_artifact_hash: str,
+    tokenizer_artifact_hash: str,
+    profile_registry: SpecPrefillProfileRegistry,
+    profile_key: SpecPrefillProfileKey,
+    calibrated_tuning: SpecPrefillTuning,
+    estimated_residency_bytes: int,
+    target_identity_attestor: TargetIdentityAttestor,
+    diagnostic: bool = False,
+    scorer_loader: ScorerLoader | None = None,
+    target_cache_factory: TargetCacheFactory | None = None,
+    scorer_prefill_step_size: int = 2048,
+    target_prefill_step_size: int = 2048,
+) -> Callable[[Any, Any], PreparedMLLMSpecPrefillRuntime]:
+    """Return a once-per-startup eager runtime preparation callback.
+
+    Artifact loading and hook installation happen inside the returned launch
+    callback, never in the request session factory.
+    """
+    _validate_builder_inputs(
+        scorer_artifact_path=scorer_artifact_path,
+        scorer_artifact_hash=scorer_artifact_hash,
+        target_artifact_hash=target_artifact_hash,
+        tokenizer_artifact_hash=tokenizer_artifact_hash,
+        profile_registry=profile_registry,
+        profile_key=profile_key,
+        calibrated_tuning=calibrated_tuning,
+        estimated_residency_bytes=estimated_residency_bytes,
+        diagnostic=diagnostic,
+        scorer_prefill_step_size=scorer_prefill_step_size,
+        target_prefill_step_size=target_prefill_step_size,
+    )
+    loader = scorer_loader or _default_scorer_loader
+    if not callable(loader):
+        raise TypeError("scorer_loader must be callable")
+    if not callable(target_identity_attestor):
+        raise TypeError("target_identity_attestor must be callable")
+    cache_factory = target_cache_factory or _default_target_cache_factory
+    if not callable(cache_factory):
+        raise TypeError("target_cache_factory must be callable")
+    sparse_tuning = SparsePolicyTuning(
+        keep_pct=calibrated_tuning.keep_pct,
+        backbone_pct=calibrated_tuning.backbone_pct,
+        halo_chunks=calibrated_tuning.halo_chunks,
+        anchor_chunks=calibrated_tuning.anchor_chunks,
+        chunk_size=calibrated_tuning.chunk_size,
+    )
+
+    def prepare(target_model: Any, processor: Any) -> PreparedMLLMSpecPrefillRuntime:
+        loaded: LoadedSpecPrefillScorer | None = None
+        owner: _QwenCBRuntimeOwner | None = None
+        try:
+            actual_scorer_hash = sha256_artifact_path(scorer_artifact_path)
+            if actual_scorer_hash != scorer_artifact_hash:
+                raise ValueError("scorer artifact bytes do not match expected hash")
+            attestation = target_identity_attestor(target_model, processor)
+            if not isinstance(attestation, TargetProcessorAttestation):
+                raise TypeError(
+                    "target_identity_attestor must return TargetProcessorAttestation"
+                )
+            if (
+                attestation.target_model is not target_model
+                or attestation.processor is not processor
+            ):
+                raise ValueError("target attestation is not bound to the loaded objects")
+            if (
+                attestation.target_artifact_hash != target_artifact_hash
+                or attestation.tokenizer_artifact_hash != tokenizer_artifact_hash
+            ):
+                raise ValueError("target/tokenizer attestation does not match profile")
+            loaded = loader(scorer_artifact_path, scorer_artifact_hash)
+            if not isinstance(loaded, LoadedSpecPrefillScorer):
+                raise TypeError("scorer_loader must return LoadedSpecPrefillScorer")
+            if sha256_artifact_path(scorer_artifact_path) != actual_scorer_hash:
+                raise ValueError("scorer artifact changed while it was being loaded")
+            scorer = SpecPrefillScorer.for_model(loaded.model)
+            target_text_model = getattr(target_model, "language_model", target_model)
+            adapter = resolve_target_position_adapter(target_model)
+            if adapter.family not in {
+                TargetPositionFamily.QWEN_DENSE,
+                TargetPositionFamily.QWEN35_TEXT_HYBRID,
+            }:
+                raise SpecPrefillRuntimePreparationError(
+                    "CB SpecPrefill runtime admits proven Qwen text targets only"
+                )
+            hooks = TargetPositionHooks.for_model(target_text_model, adapter)
+            probe_cache = tuple(cache_factory(target_text_model))
+            topology = _qwen_cache_topology(target_text_model, probe_cache)
+            del probe_cache
+            TargetPositionHooks.for_model(target_text_model, adapter)
+            owner = _QwenCBRuntimeOwner(
+                target_model=target_text_model,
+                scorer=scorer,
+                loaded_scorer=loaded,
+                adapter=adapter,
+                hooks=hooks,
+                cache_factory=cache_factory,
+                cache_topology=topology,
+                sparse_tuning=sparse_tuning,
+                target_id=(
+                    f"{profile_key.target_artifact_id}@sha256:{target_artifact_hash}"
+                ),
+                tokenizer_id=f"tokenizer@sha256:{tokenizer_artifact_hash}",
+                scorer_id=(
+                    f"{profile_key.scorer_artifact_id}@sha256:{scorer_artifact_hash}"
+                ),
+                scorer_prefill_step_size=scorer_prefill_step_size,
+                target_prefill_step_size=target_prefill_step_size,
+            )
+            return PreparedMLLMSpecPrefillRuntime(
+                profile_registry=profile_registry,
+                profile_key=profile_key,
+                estimated_residency_bytes=estimated_residency_bytes,
+                session_factory=owner.session_factory,
+                cache_capability=MLLMSpecPrefillCacheCapability(
+                    adapter_id=adapter.adapter_id,
+                    layout="qwen3_5_nonrotating_hybrid",
+                ),
+                target_forward_context=owner.target_forward_context,
+                target_model=target_model,
+                processor=processor,
+                target_artifact_hash=target_artifact_hash,
+                tokenizer_artifact_hash=tokenizer_artifact_hash,
+                scorer_artifact_hash=scorer_artifact_hash,
+                cleanup=owner.close,
+                diagnostic=diagnostic,
+                advertisable=not diagnostic,
+            )
+        except BaseException as failure:
+            try:
+                if owner is not None:
+                    owner.close()
+                elif loaded is not None:
+                    loaded.cleanup()
+            except BaseException as cleanup_failure:
+                failure.add_note(
+                    "SpecPrefill preparation cleanup failed: "
+                    f"{type(cleanup_failure).__name__}: {cleanup_failure}"
+                )
+                retained = owner.close if owner is not None else loaded.cleanup
+                setattr(failure, "specprefill_retained_cleanup", retained)
+            raise
+
+    return prepare
+
+
+class _QwenCBRuntimeOwner:
+    """Mutable lifetime owner captured by immutable prepared-runtime callables."""
+
+    def __init__(
+        self,
+        *,
+        target_model: Any,
+        scorer: SpecPrefillScorer,
+        loaded_scorer: LoadedSpecPrefillScorer,
+        adapter: Any,
+        hooks: TargetPositionHooks,
+        cache_factory: TargetCacheFactory,
+        cache_topology: _QwenCacheTopology,
+        sparse_tuning: SparsePolicyTuning,
+        target_id: str,
+        tokenizer_id: str,
+        scorer_id: str,
+        scorer_prefill_step_size: int,
+        target_prefill_step_size: int,
+    ) -> None:
+        self.target_model = target_model
+        self.scorer = scorer
+        self.loaded_scorer = loaded_scorer
+        self.adapter = adapter
+        self.hooks = hooks
+        self.cache_factory = cache_factory
+        self.cache_topology = cache_topology
+        self.sparse_tuning = sparse_tuning
+        self.target_id = target_id
+        self.tokenizer_id = tokenizer_id
+        self.scorer_id = scorer_id
+        self.scorer_prefill_step_size = scorer_prefill_step_size
+        self.target_prefill_step_size = target_prefill_step_size
+        self.closed = False
+
+    def session_factory(
+        self,
+        request: Any,
+        tokens: tuple[int, ...],
+        config: CooperativeSpecPrefillConfig,
+    ) -> MLLMSpecPrefillAdmission:
+        self._require_open()
+        if (
+            config.tuning != self.sparse_tuning
+            or config.target_id != self.target_id
+            or config.tokenizer_id != self.tokenizer_id
+            or config.scorer_id != self.scorer_id
+        ):
+            raise SpecPrefillRuntimePreparationError(
+                "request artifacts/tuning do not match the prepared profile"
+            )
+        scorer_session = SpecPrefillScorerSession(
+            self.scorer,
+            tokens,
+            prefill_step_size=self.scorer_prefill_step_size,
+        )
+
+        def target_factory(selected_tokens, sparse_state):
+            self._require_open()
+            cache = self._fresh_target_cache()
+            return SparseTargetPrefillSession(
+                self.target_model,
+                selected_tokens,
+                cache,
+                sparse_state,
+                self.adapter,
+                step_size=self.target_prefill_step_size,
+            )
+
+        session = CooperativeSpecPrefillSession(
+            request.request_id,
+            tokens,
+            scorer_session,
+            target_factory,
+            config,
+        )
+        return MLLMSpecPrefillAdmission(session)
+
+    def target_forward_context(self, forward: Any):
+        self._require_open()
+        if forward.phase is not MLLMTargetForwardPhase.DECODE:
+            raise SpecPrefillRuntimePreparationError(
+                "prepared target context supports decode only"
+            )
+        rows = tuple(forward.sparse_row_states)
+        if not rows or all(row is None for row in rows):
+            return nullcontext()
+        if any(row is None for row in rows):
+            raise SpecPrefillRuntimePreparationError(
+                "sparse and dense rows cannot share target forward context"
+            )
+        state = SparseCacheState(tuple(row.clone() for row in rows if row is not None))
+        return self.hooks.session_for_plan(decode_plan(self.adapter, state))
+
+    def _fresh_target_cache(self) -> tuple[Any, ...]:
+        cache = tuple(self.cache_factory(self.target_model))
+        topology = _qwen_cache_topology(self.target_model, cache)
+        if topology != self.cache_topology:
+            raise SpecPrefillRuntimePreparationError(
+                "request cache topology differs from the prepared probe"
+            )
+        return cache
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.loaded_scorer.cleanup()
+        self.closed = True
+        self.scorer = None
+        self.loaded_scorer = None
+        self.hooks = None
+        self.target_model = None
+
+    def _require_open(self) -> None:
+        if self.closed:
+            raise SpecPrefillRuntimePreparationError("prepared runtime is closed")
+
+
+def _validate_builder_inputs(**values: Any) -> None:
+    path = values["scorer_artifact_path"]
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("scorer_artifact_path must be non-empty")
+    registry = values["profile_registry"]
+    key = values["profile_key"]
+    tuning = values["calibrated_tuning"]
+    if not isinstance(registry, SpecPrefillProfileRegistry):
+        raise TypeError("profile_registry must be SpecPrefillProfileRegistry")
+    if not isinstance(key, SpecPrefillProfileKey):
+        raise TypeError("profile_key must be SpecPrefillProfileKey")
+    if not isinstance(tuning, SpecPrefillTuning):
+        raise TypeError("calibrated_tuning must be SpecPrefillTuning")
+    for input_name, key_value in (
+        ("target_artifact_hash", key.target_artifact_hash),
+        ("tokenizer_artifact_hash", key.tokenizer_artifact_hash),
+        ("scorer_artifact_hash", key.scorer_artifact_hash),
+    ):
+        if values[input_name] != key_value:
+            raise ValueError(f"{input_name} must match profile key")
+    diagnostic = values["diagnostic"]
+    tier = (
+        SpecPrefillProfileTier.DIAGNOSTIC
+        if diagnostic
+        else SpecPrefillProfileTier.PRODUCTION
+    )
+    profiles = tuple(
+        profile
+        for profile in registry.profiles
+        if profile.key == key and profile.tier is tier
+    )
+    if not profiles:
+        raise ValueError("requested SpecPrefill profile is not registered")
+    profile = profiles[0]
+    if not diagnostic and not profile.production_certified:
+        raise ValueError("production SpecPrefill requires certified evidence")
+    if profile.calibration.tuning != tuning:
+        raise ValueError("calibrated_tuning must match the registered profile")
+    residency = values["estimated_residency_bytes"]
+    if isinstance(residency, bool) or not isinstance(residency, int) or residency < 0:
+        raise ValueError("estimated_residency_bytes must be non-negative")
+    for name in ("scorer_prefill_step_size", "target_prefill_step_size"):
+        value = values[name]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be positive")
+
+
+def _default_scorer_loader(path: str, _expected_hash: str) -> LoadedSpecPrefillScorer:
+    from mlx_lm import load
+
+    loaded = load(Path(path))
+    model = loaded[0] if isinstance(loaded, tuple) else loaded
+    return LoadedSpecPrefillScorer(
+        model=model,
+        cleanup=lambda: None,
+    )
+
+
+def _default_target_cache_factory(target_model: Any) -> list[Any]:
+    return list(make_prompt_cache(target_model))
+
+
+def sha256_artifact_path(path: str | Path) -> str:
+    """Digest actual artifact bytes using one canonical file/directory manifest."""
+    artifact = Path(path)
+    _reject_symlink_components(artifact)
+    if artifact.is_file():
+        digest = hashlib.sha256()
+        with artifact.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    if not artifact.is_dir() or artifact.is_symlink():
+        raise SpecPrefillRuntimePreparationError(
+            "scorer artifact must be a regular file or directory"
+        )
+    descendants = tuple(sorted(artifact.rglob("*")))
+    if any(candidate.is_symlink() for candidate in descendants):
+        raise SpecPrefillRuntimePreparationError(
+            "scorer artifact manifest cannot contain symlinks"
+        )
+    files = tuple(candidate for candidate in descendants if candidate.is_file())
+    if not files:
+        raise SpecPrefillRuntimePreparationError(
+            "scorer artifact directory must contain only regular files"
+        )
+    digest = hashlib.sha256(b"vllm-mlx-specprefill-artifact-v1\0")
+    for candidate in files:
+        relative = candidate.relative_to(artifact).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(candidate.stat().st_size.to_bytes(8, "big"))
+        with candidate.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.is_symlink():
+            raise SpecPrefillRuntimePreparationError(
+                "scorer artifact path cannot contain symlinked components"
+            )
+
+
+def _qwen_cache_topology(
+    target_model: Any, cache: Sequence[Any]
+) -> _QwenCacheTopology:
+    layers = tuple(getattr(target_model, "layers", ()))
+    if not layers or len(cache) != len(layers):
+        raise SpecPrefillRuntimePreparationError(
+            "target cache must have exactly one entry per Qwen text layer"
+        )
+    entries: list[tuple[type[Any], int]] = []
+    physical_entries = 0
+    for layer, entry in zip(layers, cache, strict=True):
+        linear = bool(getattr(layer, "is_linear", False))
+        if type(entry) is ArraysCache:
+            if not linear or any(value is not None for value in entry.cache):
+                raise SpecPrefillRuntimePreparationError(
+                    "Qwen linear layers require fresh ArraysCache entries"
+                )
+            if entry.left_padding is not None or entry.lengths is not None:
+                raise SpecPrefillRuntimePreparationError(
+                    "Qwen probe ArraysCache must have no batch metadata"
+                )
+            entries.append((ArraysCache, len(entry.cache)))
+        elif type(entry) is KVCache:
+            if linear or entry.offset != 0 or entry.keys is not None or entry.values is not None:
+                raise SpecPrefillRuntimePreparationError(
+                    "Qwen attention layers require fresh nonrotating KVCache entries"
+                )
+            physical_entries += 1
+            entries.append((KVCache, 0))
+        else:
+            raise SpecPrefillRuntimePreparationError(
+                "Qwen CB cache contains an unsupported or rotating entry"
+            )
+    if physical_entries == 0:
+        raise SpecPrefillRuntimePreparationError(
+            "Qwen CB cache has no physical attention cache owners"
+        )
+    return _QwenCacheTopology(tuple(entries))

--- a/vllm_mlx/specprefill_runtime.py
+++ b/vllm_mlx/specprefill_runtime.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import hashlib
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
@@ -233,6 +233,7 @@ def build_qwen_cb_specprefill_prepare(
                 tokenizer_artifact_hash=tokenizer_artifact_hash,
                 scorer_artifact_hash=scorer_artifact_hash,
                 cleanup=owner.close,
+                native_mtp_session_factory=owner.native_mtp_session_factory,
                 diagnostic=diagnostic,
                 advertisable=not diagnostic,
             )
@@ -516,6 +517,119 @@ class _QwenCBRuntimeOwner:
             )
         state = SparseCacheState(tuple(row.clone() for row in rows if row is not None))
         return self.hooks.session_for_plan(decode_plan(self.adapter, state))
+
+    def native_mtp_session_factory(
+        self,
+        request: Any,
+        tokens: tuple[int, ...],
+        config: CooperativeSpecPrefillConfig,
+    ) -> CooperativeSpecPrefillSession:
+        """Create one B=1 cooperative session with public target receipts.
+
+        The returned session is intentionally not an MTP cohort.  Its caller
+        must convert its completed attested result into a public sparse
+        bootstrap and atomically admit that bootstrap with peer rows.
+        """
+        self._require_open()
+        if (
+            config.tuning != self.sparse_tuning
+            or config.target_id != self.target_id
+            or config.tokenizer_id != self.tokenizer_id
+            or config.scorer_id != self.scorer_id
+        ):
+            raise SpecPrefillRuntimePreparationError(
+                "request artifacts/tuning do not match the prepared profile"
+            )
+        try:
+            from mlx_lm.generate import (
+                GenerationForwardPhase,
+                attested_target_forward,
+                abandon_native_mtp_sparse_receipts,
+            )
+        except ImportError as exc:
+            raise SpecPrefillRuntimePreparationError(
+                "mlx-lm attested sparse target API is unavailable"
+            ) from exc
+        scorer_session = SpecPrefillScorerSession(
+            self.scorer, tokens, prefill_step_size=self.scorer_prefill_step_size
+        )
+
+        def target_factory(selected_tokens, sparse_state):
+            self._require_open()
+            cache = list(self._fresh_target_cache())
+            active_plan = None
+
+            @contextmanager
+            def position_context(forward):
+                if forward.model is not self.target_model or forward.cache is not cache:
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target identity changed"
+                    )
+                if forward.phase is not GenerationForwardPhase.PREFILL:
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target phase changed"
+                    )
+                if active_plan is None:
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target plan is unavailable"
+                    )
+                if tuple(forward.logical_positions) != active_plan.logical_positions[0]:
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target positions changed"
+                    )
+                with self.hooks.session_for_plan(
+                    active_plan, logical_position_ack=forward.logical_position_ack
+                ):
+                    yield
+
+            def target_forward(token_rows, target_cache, plan):
+                nonlocal active_plan
+                if target_cache is not cache:
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target cache changed"
+                    )
+                positions = tuple(plan.logical_positions[0])
+                token_ids = tuple(tokens[position] for position in positions)
+                if tuple(token_rows.shape) != (1, len(token_ids)):
+                    raise SpecPrefillRuntimePreparationError(
+                        "attested sparse target requires B=1"
+                    )
+                successors = tuple(
+                    tokens[position + 1] for position in positions if position < len(tokens) - 1
+                )
+                active_plan = plan
+                try:
+                    (logits, _hidden), receipt = attested_target_forward(
+                        self.target_model,
+                        token_ids,
+                        cache,
+                        phase=GenerationForwardPhase.PREFILL,
+                        logical_positions=positions,
+                        immediate_successor_token_ids=successors,
+                        model_forward_context=position_context,
+                    )
+                    return logits, receipt
+                finally:
+                    active_plan = None
+
+            return SparseTargetPrefillSession(
+                self.target_model,
+                selected_tokens,
+                cache,
+                sparse_state,
+                self.adapter,
+                step_size=self.target_prefill_step_size,
+                target_forward=target_forward,
+                receipt_abandon=abandon_native_mtp_sparse_receipts,
+            )
+
+        return CooperativeSpecPrefillSession(
+            request.request_id,
+            tokens,
+            scorer_session,
+            target_factory,
+            config,
+        )
 
     def _fresh_target_cache(self) -> tuple[Any, ...]:
         cache = tuple(self.cache_factory(self.target_model))

--- a/vllm_mlx/specprefill_runtime.py
+++ b/vllm_mlx/specprefill_runtime.py
@@ -16,10 +16,23 @@ from .cooperative_specprefill import (
     CooperativeSpecPrefillSession,
 )
 from .engine.batched import PreparedMLLMSpecPrefillRuntime
-from .mllm_batch_generator import MLLMTargetForwardPhase
+from .mllm_batch_generator import (
+    GemmaSparseBatchConfig,
+    MLLMTargetForwardPhase,
+    prepare_gemma_sparse_target,
+)
 from .mllm_scheduler import MLLMSpecPrefillAdmission, MLLMSpecPrefillCacheCapability
 from .specprefill import SpecPrefillScorer
-from .specprefill_cache import SparseCacheState, SparsePolicyTuning
+from .specprefill_cache import (
+    SparseCacheExecutionConfig,
+    SparseCacheState,
+    SparsePolicyTuning,
+)
+from .specprefill_gemma_cache import (
+    GEMMA4_ARTIFACTS,
+    GemmaArtifactSpec,
+    validate_aligned_scalar_cache,
+)
 from .specprefill_positions import (
     TargetPositionFamily,
     decode_plan,
@@ -32,6 +45,7 @@ from .specprefill_profiles import (
     SpecPrefillTuning,
 )
 from .specprefill_scorer_session import SpecPrefillScorerSession
+from .specprefill_selection import SPECPREFILL_SELECTOR_VERSION
 from .specprefill_target_executor import SparseTargetPrefillSession
 from .specprefill_target_hooks import TargetPositionHooks
 
@@ -84,6 +98,11 @@ TargetIdentityAttestor = Callable[[Any, Any], TargetProcessorAttestation]
 @dataclass(frozen=True)
 class _QwenCacheTopology:
     entries: tuple[tuple[type[Any], int], ...]
+
+
+@dataclass(frozen=True)
+class _GemmaCacheTopology:
+    entries: tuple[tuple[type[Any], int | None, int | None], ...]
 
 
 def build_qwen_cb_specprefill_prepare(
@@ -235,6 +254,175 @@ def build_qwen_cb_specprefill_prepare(
     return prepare
 
 
+def build_gemma_cb_specprefill_prepare(
+    *,
+    scorer_artifact_path: str,
+    scorer_artifact_hash: str,
+    target_artifact_path: str,
+    target_artifact_hash: str,
+    tokenizer_artifact_hash: str,
+    gemma_artifact: GemmaArtifactSpec,
+    profile_registry: SpecPrefillProfileRegistry,
+    profile_key: SpecPrefillProfileKey,
+    calibrated_tuning: SpecPrefillTuning,
+    estimated_residency_bytes: int,
+    target_identity_attestor: TargetIdentityAttestor,
+    scorer_loader: ScorerLoader | None = None,
+    target_cache_factory: TargetCacheFactory | None = None,
+    scorer_prefill_step_size: int = 2048,
+    target_prefill_step_size: int = 2048,
+) -> Callable[[Any, Any], PreparedMLLMSpecPrefillRuntime]:
+    """Prepare diagnostic-only Gemma CB SpecPrefill ownership eagerly.
+
+    This is deliberately not a production or discovery capability. The exact
+    target bytes, live object/topology, mlx-vlm scalar cache backend, scorer,
+    hooks, and request cache factory are all proven before startup publishes a
+    scheduler.
+    """
+    _validate_builder_inputs(
+        scorer_artifact_path=scorer_artifact_path,
+        scorer_artifact_hash=scorer_artifact_hash,
+        target_artifact_hash=target_artifact_hash,
+        tokenizer_artifact_hash=tokenizer_artifact_hash,
+        profile_registry=profile_registry,
+        profile_key=profile_key,
+        calibrated_tuning=calibrated_tuning,
+        estimated_residency_bytes=estimated_residency_bytes,
+        diagnostic=True,
+        scorer_prefill_step_size=scorer_prefill_step_size,
+        target_prefill_step_size=target_prefill_step_size,
+    )
+    if GEMMA4_ARTIFACTS.get(gemma_artifact.artifact_id) != gemma_artifact:
+        raise ValueError("gemma_artifact must be a certified Gemma artifact")
+    if profile_key.target_artifact_id != gemma_artifact.artifact_id:
+        raise ValueError("Gemma artifact must match the diagnostic profile key")
+    loader = scorer_loader or _default_scorer_loader
+    cache_factory = target_cache_factory or _default_target_cache_factory
+    if not callable(loader):
+        raise TypeError("scorer_loader must be callable")
+    if not callable(target_identity_attestor):
+        raise TypeError("target_identity_attestor must be callable")
+    if not callable(cache_factory):
+        raise TypeError("target_cache_factory must be callable")
+    sparse_tuning = SparsePolicyTuning(
+        keep_pct=calibrated_tuning.keep_pct,
+        backbone_pct=calibrated_tuning.backbone_pct,
+        halo_chunks=calibrated_tuning.halo_chunks,
+        anchor_chunks=calibrated_tuning.anchor_chunks,
+        chunk_size=calibrated_tuning.chunk_size,
+    )
+
+    def prepare(target_model: Any, processor: Any) -> PreparedMLLMSpecPrefillRuntime:
+        loaded: LoadedSpecPrefillScorer | None = None
+        owner: _GemmaCBRuntimeOwner | None = None
+        try:
+            actual_scorer_hash = sha256_artifact_path(scorer_artifact_path)
+            if actual_scorer_hash != scorer_artifact_hash:
+                raise ValueError("scorer artifact bytes do not match expected hash")
+            identity = target_identity_attestor(target_model, processor)
+            prepared_target = prepare_gemma_sparse_target(
+                target_model=target_model,
+                processor=processor,
+                target_artifact_path=target_artifact_path,
+                artifact=gemma_artifact,
+                target_identity_attestation=identity,
+            )
+            if identity.tokenizer_artifact_hash != tokenizer_artifact_hash:
+                raise ValueError("tokenizer attestation does not match profile")
+            if prepared_target.target_artifact_hash != target_artifact_hash:
+                raise ValueError("target attestation does not match profile")
+            loaded = loader(scorer_artifact_path, scorer_artifact_hash)
+            if not isinstance(loaded, LoadedSpecPrefillScorer):
+                raise TypeError("scorer_loader must return LoadedSpecPrefillScorer")
+            if sha256_artifact_path(scorer_artifact_path) != actual_scorer_hash:
+                raise ValueError("scorer artifact changed while it was being loaded")
+            scorer = SpecPrefillScorer.for_model(loaded.model)
+            adapter = resolve_target_position_adapter(target_model)
+            expected_family = (
+                TargetPositionFamily.GEMMA4_A4B
+                if gemma_artifact.artifact_id == "gemma4-26b-a4b"
+                else TargetPositionFamily.GEMMA4_DENSE
+            )
+            if adapter.family is not expected_family:
+                raise SpecPrefillRuntimePreparationError(
+                    "Gemma adapter does not match the certified artifact"
+                )
+            text_model = prepared_target.text_model
+            hooks = TargetPositionHooks.for_model(text_model, adapter)
+            probe_cache = tuple(cache_factory(text_model))
+            prepared_target.validate_cache(probe_cache)
+            validate_aligned_scalar_cache(probe_cache, logical_position=0)
+            topology = _gemma_cache_topology(probe_cache)
+            del probe_cache
+            owner = _GemmaCBRuntimeOwner(
+                prepared_target=prepared_target,
+                scorer=scorer,
+                loaded_scorer=loaded,
+                adapter=adapter,
+                hooks=hooks,
+                cache_factory=cache_factory,
+                cache_topology=topology,
+                sparse_tuning=sparse_tuning,
+                target_id=prepared_target.canonical_target_id,
+                tokenizer_id=f"tokenizer@sha256:{tokenizer_artifact_hash}",
+                scorer_id=(
+                    f"{profile_key.scorer_artifact_id}@sha256:{scorer_artifact_hash}"
+                ),
+                scorer_prefill_step_size=scorer_prefill_step_size,
+                target_prefill_step_size=target_prefill_step_size,
+            )
+            execution_config = SparseCacheExecutionConfig(
+                target_id=owner.target_id,
+                tokenizer_id=owner.tokenizer_id,
+                scorer_id=owner.scorer_id,
+                selector_version=SPECPREFILL_SELECTOR_VERSION,
+                tuning=sparse_tuning,
+            )
+            gemma_batch_config = GemmaSparseBatchConfig(
+                prepared_target,
+                execution_config,
+            )
+            return PreparedMLLMSpecPrefillRuntime(
+                profile_registry=profile_registry,
+                profile_key=profile_key,
+                estimated_residency_bytes=estimated_residency_bytes,
+                session_factory=owner.session_factory,
+                cache_capability=MLLMSpecPrefillCacheCapability(
+                    adapter_id=adapter.adapter_id,
+                    layout=gemma_artifact.artifact_id,
+                    backend="mlx_vlm",
+                    rotating=True,
+                    homogeneous_rows_only=True,
+                ),
+                target_forward_context=owner.target_forward_context,
+                target_model=target_model,
+                processor=processor,
+                target_artifact_hash=target_artifact_hash,
+                tokenizer_artifact_hash=tokenizer_artifact_hash,
+                scorer_artifact_hash=scorer_artifact_hash,
+                cleanup=owner.close,
+                gemma_batch_config=gemma_batch_config,
+                diagnostic=True,
+                advertisable=False,
+            )
+        except BaseException as failure:
+            try:
+                if owner is not None:
+                    owner.close()
+                elif loaded is not None:
+                    loaded.cleanup()
+            except BaseException as cleanup_failure:
+                failure.add_note(
+                    "SpecPrefill preparation cleanup failed: "
+                    f"{type(cleanup_failure).__name__}: {cleanup_failure}"
+                )
+                retained = owner.close if owner is not None else loaded.cleanup
+                setattr(failure, "specprefill_retained_cleanup", retained)
+            raise
+
+    return prepare
+
+
 class _QwenCBRuntimeOwner:
     """Mutable lifetime owner captured by immutable prepared-runtime callables."""
 
@@ -347,6 +535,148 @@ class _QwenCBRuntimeOwner:
         self.loaded_scorer = None
         self.hooks = None
         self.target_model = None
+
+    def _require_open(self) -> None:
+        if self.closed:
+            raise SpecPrefillRuntimePreparationError("prepared runtime is closed")
+
+
+class _GemmaCBRuntimeOwner:
+    """Lifetime owner for one exact diagnostic Gemma CB target."""
+
+    def __init__(
+        self,
+        *,
+        prepared_target: Any,
+        scorer: SpecPrefillScorer,
+        loaded_scorer: LoadedSpecPrefillScorer,
+        adapter: Any,
+        hooks: TargetPositionHooks,
+        cache_factory: TargetCacheFactory,
+        cache_topology: _GemmaCacheTopology,
+        sparse_tuning: SparsePolicyTuning,
+        target_id: str,
+        tokenizer_id: str,
+        scorer_id: str,
+        scorer_prefill_step_size: int,
+        target_prefill_step_size: int,
+    ) -> None:
+        self.prepared_target = prepared_target
+        self.target_model = prepared_target.text_model
+        self.scorer = scorer
+        self.loaded_scorer = loaded_scorer
+        self.adapter = adapter
+        self.hooks = hooks
+        self.cache_factory = cache_factory
+        self.cache_topology = cache_topology
+        self.sparse_tuning = sparse_tuning
+        self.target_id = target_id
+        self.tokenizer_id = tokenizer_id
+        self.scorer_id = scorer_id
+        self.scorer_prefill_step_size = scorer_prefill_step_size
+        self.target_prefill_step_size = target_prefill_step_size
+        self.closed = False
+
+    def session_factory(
+        self,
+        request: Any,
+        tokens: tuple[int, ...],
+        config: CooperativeSpecPrefillConfig,
+    ) -> MLLMSpecPrefillAdmission:
+        self._require_open()
+        expected_tail = self.prepared_target.artifact.sliding_window
+        actual_tail = (
+            None
+            if config.rotating_tail_requirement is None
+            else config.rotating_tail_requirement.window_tokens
+        )
+        if (
+            config.tuning != self.sparse_tuning
+            or config.target_id != self.target_id
+            or config.tokenizer_id != self.tokenizer_id
+            or config.scorer_id != self.scorer_id
+            or actual_tail != expected_tail
+        ):
+            raise SpecPrefillRuntimePreparationError(
+                "request artifacts/tuning/tail do not match prepared Gemma profile"
+            )
+        scorer_session = SpecPrefillScorerSession(
+            self.scorer,
+            tokens,
+            prefill_step_size=self.scorer_prefill_step_size,
+        )
+
+        def target_factory(selected_tokens, sparse_state):
+            self._require_open()
+            return SparseTargetPrefillSession(
+                self.target_model,
+                selected_tokens,
+                self._fresh_target_cache(),
+                sparse_state,
+                self.adapter,
+                step_size=self.target_prefill_step_size,
+            )
+
+        return MLLMSpecPrefillAdmission(
+            CooperativeSpecPrefillSession(
+                request.request_id,
+                tokens,
+                scorer_session,
+                target_factory,
+                config,
+            )
+        )
+
+    def target_forward_context(self, forward: Any):
+        self._require_open()
+        if forward.phase is not MLLMTargetForwardPhase.DECODE:
+            raise SpecPrefillRuntimePreparationError(
+                "prepared target context supports decode only"
+            )
+        rows = tuple(forward.sparse_row_states)
+        if not rows or all(row is None for row in rows):
+            return nullcontext()
+        if any(row is None for row in rows):
+            raise SpecPrefillRuntimePreparationError(
+                "sparse and dense rows cannot share target forward context"
+            )
+        logical_positions = {
+            row.next_logical_position for row in rows if row is not None
+        }
+        physical_lengths = {
+            row.physical_valid_length for row in rows if row is not None
+        }
+        if len(logical_positions) != 1 or len(physical_lengths) != 1:
+            raise SpecPrefillRuntimePreparationError(
+                "Gemma target context requires homogeneous sparse rows"
+            )
+        state = SparseCacheState(tuple(row.clone() for row in rows if row is not None))
+        return self.hooks.session_for_plan(decode_plan(self.adapter, state))
+
+    def _fresh_target_cache(self) -> Sequence[Any]:
+        cache = self.cache_factory(self.target_model)
+        if not isinstance(cache, Sequence):
+            raise SpecPrefillRuntimePreparationError(
+                "Gemma cache factory must return an ordered cache sequence"
+            )
+        self.prepared_target.validate_cache(cache)
+        validate_aligned_scalar_cache(cache, logical_position=0)
+        if _gemma_cache_topology(cache) != self.cache_topology:
+            raise SpecPrefillRuntimePreparationError(
+                "request Gemma cache topology differs from prepared probe"
+            )
+        return cache
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.loaded_scorer.cleanup()
+        self.closed = True
+        self.scorer = None
+        self.loaded_scorer = None
+        self.hooks = None
+        self.target_model = None
+        self.prepared_target = None
 
     def _require_open(self) -> None:
         if self.closed:
@@ -500,3 +830,20 @@ def _qwen_cache_topology(
             "Qwen CB cache has no physical attention cache owners"
         )
     return _QwenCacheTopology(tuple(entries))
+
+
+def _gemma_cache_topology(cache: Sequence[Any]) -> _GemmaCacheTopology:
+    if not cache or len({id(entry) for entry in cache}) != len(cache):
+        raise SpecPrefillRuntimePreparationError(
+            "Gemma probe cache owners must be non-empty and unaliased"
+        )
+    return _GemmaCacheTopology(
+        tuple(
+            (
+                type(entry),
+                getattr(entry, "max_size", None),
+                getattr(entry, "keep", None),
+            )
+            for entry in cache
+        )
+    )

--- a/vllm_mlx/specprefill_runtime.py
+++ b/vllm_mlx/specprefill_runtime.py
@@ -172,7 +172,9 @@ def build_qwen_cb_specprefill_prepare(
                 attestation.target_model is not target_model
                 or attestation.processor is not processor
             ):
-                raise ValueError("target attestation is not bound to the loaded objects")
+                raise ValueError(
+                    "target attestation is not bound to the loaded objects"
+                )
             if (
                 attestation.target_artifact_hash != target_artifact_hash
                 or attestation.tokenizer_artifact_hash != tokenizer_artifact_hash
@@ -595,7 +597,9 @@ class _QwenCBRuntimeOwner:
                         "attested sparse target requires B=1"
                     )
                 successors = tuple(
-                    tokens[position + 1] for position in positions if position < len(tokens) - 1
+                    tokens[position + 1]
+                    for position in positions
+                    if position < len(tokens) - 1
                 )
                 active_plan = plan
                 try:
@@ -906,9 +910,7 @@ def _reject_symlink_components(path: Path) -> None:
             )
 
 
-def _qwen_cache_topology(
-    target_model: Any, cache: Sequence[Any]
-) -> _QwenCacheTopology:
+def _qwen_cache_topology(target_model: Any, cache: Sequence[Any]) -> _QwenCacheTopology:
     layers = tuple(getattr(target_model, "layers", ()))
     if not layers or len(cache) != len(layers):
         raise SpecPrefillRuntimePreparationError(
@@ -929,7 +931,12 @@ def _qwen_cache_topology(
                 )
             entries.append((ArraysCache, len(entry.cache)))
         elif type(entry) is KVCache:
-            if linear or entry.offset != 0 or entry.keys is not None or entry.values is not None:
+            if (
+                linear
+                or entry.offset != 0
+                or entry.keys is not None
+                or entry.values is not None
+            ):
                 raise SpecPrefillRuntimePreparationError(
                     "Qwen attention layers require fresh nonrotating KVCache entries"
                 )

--- a/vllm_mlx/specprefill_scorer_session.py
+++ b/vllm_mlx/specprefill_scorer_session.py
@@ -26,7 +26,12 @@ import mlx.core as mx
 from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.sample_utils import apply_top_p
 
-from .specprefill import SpecPrefillScorer, SpecPrefillScorerLaneBusy, _avg_pool1d
+from .specprefill import (
+    SpecPrefillScorer,
+    SpecPrefillScorerLaneBusy,
+    _avg_pool1d,
+    validate_specprefill_cache_topology,
+)
 
 _MX_ARRAY_TYPE = type(mx.array([0]))
 
@@ -100,8 +105,15 @@ class SpecPrefillScorerSession:
             raise ValueError("prefill_step_size must be a positive integer")
 
         self.scorer = scorer
-        self.cache = make_prompt_cache(scorer.model)
+        self.cache = make_prompt_cache(scorer.cache_model)
         self._layer_to_cache = scorer.adapter.cache_map_builder(scorer.model)
+        validate_specprefill_cache_topology(
+            scorer.adapter,
+            scorer.model,
+            self.cache,
+            self._layer_to_cache,
+            attention_layer_indices=scorer.attention_layer_indices,
+        )
         try:
             for layer_index in scorer.attention_layer_indices:
                 self._layer_to_cache[layer_index]

--- a/vllm_mlx/specprefill_scorer_session.py
+++ b/vllm_mlx/specprefill_scorer_session.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, request-local SpecPrefill draft-scoring sessions.
+
+The scorer model keeps its topology-preserving attention dispatch installed
+once, but no request capture session survives a yielded quantum.  A scheduler
+can therefore alternate sessions on one scorer model: each session owns its
+draft cache, captured-query buffers, sampler/RNG closure, and importance
+reducer while the scorer only owns the short active-forward capture context.
+
+Importance is reduced one attention layer per quantum.  That avoids the old
+all-layer ``concatenate`` and one giant realization.  A single layer still
+forms ``lookahead × prompt`` attention scores and must be realized together;
+the scheduler treats that bounded layer reduction as a scorer-lane quantum.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Sequence
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.sample_utils import apply_top_p
+
+from .specprefill import SpecPrefillScorer, SpecPrefillScorerLaneBusy, _avg_pool1d
+
+_MX_ARRAY_TYPE = type(mx.array([0]))
+
+
+class SpecPrefillScorerSessionError(RuntimeError):
+    """A bounded scorer session cannot safely advance."""
+
+
+class ScorerSessionPhase(str, Enum):
+    PREFILL = "prefill"
+    LOOKAHEAD = "lookahead"
+    IMPORTANCE = "importance"
+    COMPLETE = "complete"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class ScorerSessionProgress:
+    """One completed scheduler quantum, suitable for CB scorer-lane telemetry."""
+
+    phase: ScorerSessionPhase
+    prefill_tokens: int
+    lookahead_steps: int
+    importance_layers: int
+    complete: bool
+
+
+class SpecPrefillScorerSession:
+    """A request-owned, bounded scorer pipeline.
+
+    ``step`` never retains an active scorer capture context when it returns.
+    It raises ``SpecPrefillScorerSessionError`` when another request currently
+    owns the scorer lane, leaving this session unchanged for scheduler retry.
+    """
+
+    def __init__(
+        self,
+        scorer: SpecPrefillScorer,
+        tokens: Sequence[int] | mx.array,
+        *,
+        n_lookahead: int = 8,
+        pool_kernel: int = 13,
+        temp: float = 0.6,
+        top_p: float = 0.95,
+        prefill_step_size: int = 2048,
+        query_extractor: Callable[..., mx.array] | None = None,
+        cancel_check: Callable[[], None] | None = None,
+        sampling_seed: int | None = None,
+    ):
+        if not isinstance(scorer, SpecPrefillScorer):
+            raise TypeError("scorer must be a SpecPrefillScorer")
+        if isinstance(tokens, _MX_ARRAY_TYPE):
+            # Token IDs normally originate on the host tokenizer path.  An
+            # array input requires this one explicit conversion at admission;
+            # no per-quantum host/device token synchronization occurs.
+            tokens = tokens.tolist()
+        self._tokens = tuple(_validate_token(token) for token in tokens)
+        if not self._tokens:
+            raise ValueError("SpecPrefill scorer session needs at least one token")
+        if (
+            isinstance(n_lookahead, bool)
+            or not isinstance(n_lookahead, int)
+            or n_lookahead <= 0
+        ):
+            raise ValueError("n_lookahead must be a positive integer")
+        if (
+            isinstance(prefill_step_size, bool)
+            or not isinstance(prefill_step_size, int)
+            or prefill_step_size <= 0
+        ):
+            raise ValueError("prefill_step_size must be a positive integer")
+
+        self.scorer = scorer
+        self.cache = make_prompt_cache(scorer.model)
+        self._layer_to_cache = scorer.adapter.cache_map_builder(scorer.model)
+        try:
+            for layer_index in scorer.attention_layer_indices:
+                self._layer_to_cache[layer_index]
+        except KeyError as exc:
+            raise SpecPrefillScorerSessionError(
+                "scorer cache map has no entry for an installed attention layer"
+            ) from exc
+        self._query_extractor = query_extractor or scorer.adapter.query_extractor
+        self._sampler = _RequestLocalSampler(
+            temp=temp,
+            top_p=top_p,
+            seed=_resolve_sampling_seed(self._tokens, sampling_seed),
+        )
+        self._cancel_check = cancel_check
+        self._pool_kernel = pool_kernel if pool_kernel > 0 else None
+        self._prefill_step_size = prefill_step_size
+        self._n_lookahead = n_lookahead
+        # Convert token IDs once at admission; every later prefill quantum is
+        # a device slice rather than a host-to-device reconstruction.
+        self._prompt_tokens = mx.array(self._tokens)
+        self._query_buffer: list[list[mx.array]] = [
+            [] for _ in scorer.attention_layer_indices
+        ]
+        self._prefill_offset = 0
+        self._lookahead_done = 0
+        self._next_token: mx.array | None = None
+        self._last_logits: mx.array | None = None
+        self._importance_layer = 0
+        self._reduced_max: mx.array | None = None
+        self._importance: mx.array | None = None
+        self.phase = ScorerSessionPhase.PREFILL
+
+    @property
+    def complete(self) -> bool:
+        return self.phase is ScorerSessionPhase.COMPLETE
+
+    @property
+    def closed(self) -> bool:
+        return self.phase is ScorerSessionPhase.CLOSED
+
+    @property
+    def importance(self) -> mx.array:
+        if self._importance is None:
+            raise SpecPrefillScorerSessionError("scorer session is not complete")
+        return self._importance
+
+    @property
+    def query_buffer(self) -> list[list[mx.array]]:
+        """Request-owned captured queries; never stored in the scorer object."""
+        return self._query_buffer
+
+    def step(self) -> ScorerSessionProgress:
+        """Run exactly one bounded scorer lane quantum and release it."""
+        if self.closed:
+            raise SpecPrefillScorerSessionError("scorer session is closed")
+        if self.complete:
+            return self._progress()
+        try:
+            with self.scorer.scoring_quantum():
+                self._check_cancelled()
+                if self.phase is ScorerSessionPhase.PREFILL:
+                    self._step_prefill()
+                elif self.phase is ScorerSessionPhase.LOOKAHEAD:
+                    self._step_lookahead()
+                elif self.phase is ScorerSessionPhase.IMPORTANCE:
+                    self._step_importance()
+                else:  # pragma: no cover - enum exhaustiveness guard
+                    raise SpecPrefillScorerSessionError(
+                        f"invalid scorer session phase {self.phase!r}"
+                    )
+                return self._progress()
+        except SpecPrefillScorerLaneBusy:
+            # A busy lane is a scheduler retry signal, not a request failure.
+            # Preserve every cache/buffer/RNG field so this exact quantum can
+            # resume after another request yields.
+            raise
+        except BaseException:
+            self.cancel()
+            raise
+
+    def run_to_completion(self) -> mx.array:
+        """Compatibility facade for the former monolithic ``score_tokens`` API."""
+        while not self.complete:
+            self.step()
+        return self.importance
+
+    def cancel(self) -> None:
+        """Discard only this request's draft/cache/capture state."""
+        if self.closed:
+            return
+        self._query_buffer.clear()
+        self.cache = None
+        self._last_logits = None
+        self._next_token = None
+        self._reduced_max = None
+        self.phase = ScorerSessionPhase.CLOSED
+
+    def _step_prefill(self) -> None:
+        remaining = len(self._tokens) - self._prefill_offset
+        if remaining <= 0:
+            raise SpecPrefillScorerSessionError("scorer prefill cursor exceeded prompt")
+        if remaining > 1:
+            count = min(self._prefill_step_size, remaining - 1)
+            prompt = self._prompt_tokens[
+                self._prefill_offset : self._prefill_offset + count
+            ]
+            with self.scorer.capture_session(
+                self._query_extractor, capture_enabled=False
+            ) as capture:
+                logits = self.scorer.model(prompt[None], cache=self.cache)
+                _eval_quantum(logits, self.cache, capture.query_buffer)
+            self._prefill_offset += count
+            return
+
+        prompt = self._prompt_tokens[self._prefill_offset :]
+        with self.scorer.capture_session(
+            self._query_extractor, capture_enabled=False
+        ) as capture:
+            self._last_logits = self.scorer.model(prompt[None], cache=self.cache)
+            _eval_quantum(self._last_logits, self.cache, capture.query_buffer)
+        self._prefill_offset = len(self._tokens)
+        self.phase = (
+            ScorerSessionPhase.LOOKAHEAD
+            if self._n_lookahead
+            else ScorerSessionPhase.IMPORTANCE
+        )
+
+    def _step_lookahead(self) -> None:
+        if self._last_logits is None:
+            raise SpecPrefillScorerSessionError("lookahead requires prefill logits")
+        if self._next_token is None:
+            self._next_token = self._sampler(self._last_logits[:, -1, :])
+            mx.eval(self._next_token)
+        with self.scorer.capture_session(self._query_extractor) as capture:
+            # Keep the request's buffer through capture-session turnover; the
+            # installed dispatcher references only this short-lived context.
+            capture.query_buffer = self._query_buffer
+            logits = self.scorer.model(
+                self._next_token.reshape(1, -1), cache=self.cache
+            )
+            self._next_token = self._sampler(logits[:, -1, :])
+            _eval_quantum(self._next_token, self.cache, self._query_buffer)
+        self._lookahead_done += 1
+        if self._lookahead_done >= self._n_lookahead:
+            self.phase = ScorerSessionPhase.IMPORTANCE
+
+    def _step_importance(self) -> None:
+        if self._importance_layer >= len(self._query_buffer):
+            if self._reduced_max is None:
+                raise SpecPrefillScorerSessionError(
+                    "no attention scores captured — check model/patching"
+                )
+            self._importance = mx.mean(self._reduced_max, axis=0)
+            mx.eval(self._importance)
+            self.phase = ScorerSessionPhase.COMPLETE
+            return
+
+        layer_index = self._importance_layer
+        self._importance_layer += 1
+        captures = self._query_buffer[layer_index]
+        if not captures:
+            return
+        cache_index = self._layer_to_cache[
+            self.scorer.attention_layer_indices[layer_index]
+        ]
+        layer_scores = _reduce_importance_layer(
+            captures,
+            self.cache[cache_index],
+            len(self._tokens),
+            pool_kernel=self._pool_kernel,
+        )
+        if layer_scores is None:
+            return
+        if self._reduced_max is None:
+            self._reduced_max = layer_scores
+        else:
+            self._reduced_max = mx.maximum(self._reduced_max, layer_scores)
+        # A layer × lookahead × prompt realization is the bounded unavoidable
+        # reduction.  Do not concatenate every layer/head before yielding.
+        mx.eval(self._reduced_max)
+
+    def _check_cancelled(self) -> None:
+        if self._cancel_check is not None:
+            self._cancel_check()
+
+    def _progress(self) -> ScorerSessionProgress:
+        return ScorerSessionProgress(
+            phase=self.phase,
+            prefill_tokens=self._prefill_offset,
+            lookahead_steps=self._lookahead_done,
+            importance_layers=self._importance_layer,
+            complete=self.complete,
+        )
+
+
+def _reduce_importance_layer(
+    captures: list[mx.array], cache: Any, n_prompt: int, *, pool_kernel: int | None
+) -> mx.array | None:
+    """Exactly one layer's contribution to legacy importance aggregation."""
+    prompt_keys = cache.keys[..., :n_prompt, :]
+    if prompt_keys.shape[-2] < n_prompt:
+        return None
+    q_stack = mx.concatenate(captures, axis=2)
+    query_heads = int(q_stack.shape[1])
+    key_heads = int(prompt_keys.shape[1])
+    if query_heads <= 0 or key_heads <= 0 or query_heads % key_heads:
+        raise SpecPrefillScorerSessionError(
+            "SpecPrefill attention heads must have an integral per-layer query/KV grouping"
+        )
+    if int(q_stack.shape[-1]) != int(prompt_keys.shape[-1]):
+        raise SpecPrefillScorerSessionError(
+            "SpecPrefill captured query and cache key dimensions differ"
+        )
+    expanded_keys = (
+        mx.repeat(prompt_keys, query_heads // key_heads, axis=1)
+        if query_heads > key_heads
+        else prompt_keys
+    )
+    scores = (q_stack @ expanded_keys.transpose(0, 1, 3, 2)) * (
+        prompt_keys.shape[-1] ** -0.5
+    )
+    weights = mx.softmax(scores.astype(mx.float32), axis=-1).squeeze(0)
+    if pool_kernel and pool_kernel > 1:
+        weights = _avg_pool1d(weights, pool_kernel)
+    return mx.max(weights, axis=0)
+
+
+def _eval_quantum(
+    logits: mx.array, cache: Any, query_buffer: list[list[mx.array]]
+) -> None:
+    """Realize all lazy work before the capture context and scorer lane yield."""
+    mx.eval(logits, [entry.state for entry in cache], query_buffer)
+
+
+def _validate_token(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("scorer tokens must be non-negative integer IDs")
+    return value
+
+
+class _RequestLocalSampler:
+    """Top-p categorical sampler with an independent MLX PRNG key chain."""
+
+    def __init__(self, *, temp: float, top_p: float, seed: int):
+        if (
+            isinstance(temp, bool)
+            or not isinstance(temp, (int, float))
+            or not math.isfinite(temp)
+            or temp < 0
+        ):
+            raise ValueError(
+                "scorer sampling temperature must be a finite non-negative number"
+            )
+        if (
+            isinstance(top_p, bool)
+            or not isinstance(top_p, (int, float))
+            or not math.isfinite(top_p)
+            or not 0 <= top_p <= 1
+        ):
+            raise ValueError("scorer top_p must be a finite number in [0, 1]")
+        self._temp = temp
+        self._top_p = top_p
+        self._key = mx.random.key(seed)
+
+    def __call__(self, logits: mx.array) -> mx.array:
+        if self._temp == 0:
+            return mx.argmax(logits, axis=-1)
+        logprobs = _normalized_logprobs(logits)
+        filtered = (
+            apply_top_p(logprobs, self._top_p) if 0 < self._top_p < 1.0 else logprobs
+        )
+        key_pair = mx.random.split(self._key)
+        self._key, sample_key = key_pair[0], key_pair[1]
+        return mx.random.categorical(filtered * (1.0 / self._temp), key=sample_key)
+
+
+def _normalized_logprobs(logits: mx.array) -> mx.array:
+    """Normalize logits before top-p; mlx-lm's filter accepts log-probabilities."""
+    return logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+
+def _resolve_sampling_seed(tokens: tuple[int, ...], explicit_seed: int | None) -> int:
+    """Derive deterministic request-local draft randomness without global RNG."""
+    if explicit_seed is not None:
+        if isinstance(explicit_seed, bool) or not isinstance(explicit_seed, int):
+            raise ValueError("scorer sampling_seed must be an integer or None")
+        return explicit_seed & 0xFFFFFFFF
+    digest = hashlib.blake2s(digest_size=4, person=b"sprefill")
+    for token in tokens:
+        digest.update(str(token).encode("ascii"))
+        digest.update(b",")
+    return int.from_bytes(digest.digest(), "big")

--- a/vllm_mlx/specprefill_selection.py
+++ b/vllm_mlx/specprefill_selection.py
@@ -54,9 +54,9 @@ class SelectionPolicy:
         if (
             isinstance(self.anchor_chunks, bool)
             or not isinstance(self.anchor_chunks, int)
-            or self.anchor_chunks < 0
+            or self.anchor_chunks <= 0
         ):
-            raise ValueError("anchor_chunks must be non-negative")
+            raise ValueError("anchor_chunks must be positive")
         if (
             isinstance(self.chunk_size, bool)
             or not isinstance(self.chunk_size, int)

--- a/vllm_mlx/specprefill_selection.py
+++ b/vllm_mlx/specprefill_selection.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python semantic selection contracts for SpecPrefill.
+
+The scorer computes chunk importance on device, but selection identity must be
+defined without device state.  This module keeps policy, mandatory retention
+sources, and the final selection fingerprint immutable and independently
+testable.  Callers provide control-token positions after tokenization; this
+module deliberately never guesses tokenizer-specific control IDs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from numbers import Real
+from typing import Iterable, Sequence
+
+SPECPREFILL_SELECTOR_VERSION = "hybrid-chunk-v2"
+
+
+@dataclass(frozen=True)
+class SelectionPolicy:
+    """Every policy control that can alter a sparse target cache."""
+
+    keep_pct: float
+    backbone_pct: float
+    halo_chunks: int
+    anchor_chunks: int
+    chunk_size: int
+    selector_version: str = SPECPREFILL_SELECTOR_VERSION
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.keep_pct, bool)
+            or not isinstance(self.keep_pct, Real)
+            or not math.isfinite(self.keep_pct)
+            or not 0 < self.keep_pct <= 1
+        ):
+            raise ValueError("keep_pct must be finite and in (0, 1]")
+        if (
+            isinstance(self.backbone_pct, bool)
+            or not isinstance(self.backbone_pct, Real)
+            or not math.isfinite(self.backbone_pct)
+            or not 0 <= self.backbone_pct <= 1
+        ):
+            raise ValueError("backbone_pct must be finite and in [0, 1]")
+        if (
+            isinstance(self.halo_chunks, bool)
+            or not isinstance(self.halo_chunks, int)
+            or self.halo_chunks < 0
+        ):
+            raise ValueError("halo_chunks must be non-negative")
+        if (
+            isinstance(self.anchor_chunks, bool)
+            or not isinstance(self.anchor_chunks, int)
+            or self.anchor_chunks < 0
+        ):
+            raise ValueError("anchor_chunks must be non-negative")
+        if (
+            isinstance(self.chunk_size, bool)
+            or not isinstance(self.chunk_size, int)
+            or self.chunk_size <= 0
+        ):
+            raise ValueError("chunk_size must be positive")
+        if not isinstance(self.selector_version, str) or not self.selector_version:
+            raise ValueError("selector_version must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class RotatingTailRequirement:
+    """Logical tail which a rotating target cache must retain in full.
+
+    Chunk selection can retain a few extra tokens immediately before the tail;
+    it must never omit a token in the final ``window_tokens`` logical range.
+    ``window_tokens`` is part of the selection semantic identity even when two
+    nearby window sizes happen to expand to the same chunk boundary.
+    """
+
+    window_tokens: int
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.window_tokens, bool)
+            or not isinstance(self.window_tokens, int)
+            or self.window_tokens <= 0
+        ):
+            raise ValueError("window_tokens must be a positive integer")
+
+    def tail_start(self, prompt_length: int) -> int:
+        return max(0, prompt_length - self.window_tokens)
+
+    def required_chunks(self, prompt_length: int, chunk_size: int) -> tuple[int, ...]:
+        if prompt_length <= 0:
+            raise ValueError("prompt_length must be positive")
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        start_chunk = self.tail_start(prompt_length) // chunk_size
+        final_chunk = (prompt_length - 1) // chunk_size
+        return tuple(range(start_chunk, final_chunk + 1))
+
+
+@dataclass(frozen=True)
+class SelectionProvenance:
+    """Immutable explanation of every source that retained a chunk."""
+
+    importance_chunks: tuple[int, ...] = ()
+    backbone_chunks: tuple[int, ...] = ()
+    anchor_chunks: tuple[int, ...] = ()
+    control_anchor_indices: tuple[int, ...] = ()
+    control_anchor_chunks: tuple[int, ...] = ()
+    rotating_tail_chunks: tuple[int, ...] = ()
+    halo_chunks: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class SelectionPlan:
+    """Deterministic sparse-token selection for one prompt.
+
+    Positions and provenance are immutable host values, suitable for request
+    telemetry and exact cache identity.  The MLX execution boundary converts
+    ``selected_indices`` to a device array; it must not reinterpret this plan.
+    """
+
+    prompt_length: int
+    policy: SelectionPolicy
+    selected_chunks: tuple[int, ...]
+    selected_indices: tuple[int, ...]
+    provenance: SelectionProvenance = SelectionProvenance()
+    rotating_tail_requirement: RotatingTailRequirement | None = None
+
+    def __post_init__(self) -> None:
+        if self.prompt_length <= 0:
+            raise ValueError("prompt_length must be positive")
+        if tuple(sorted(set(self.selected_chunks))) != self.selected_chunks:
+            raise ValueError("selected_chunks must be sorted and unique")
+        if tuple(sorted(set(self.selected_indices))) != self.selected_indices:
+            raise ValueError("selected_indices must be sorted and unique")
+        if not self.selected_indices:
+            raise ValueError("SelectionPlan must retain at least one token")
+        if (
+            self.selected_indices[0] < 0
+            or self.selected_indices[-1] >= self.prompt_length
+        ):
+            raise ValueError("selected_indices are outside the prompt")
+
+        expected = tuple(
+            token
+            for chunk in self.selected_chunks
+            for token in range(
+                chunk * self.policy.chunk_size,
+                min((chunk + 1) * self.policy.chunk_size, self.prompt_length),
+            )
+        )
+        if expected != self.selected_indices:
+            raise ValueError("selected_indices must contain complete selected chunks")
+
+        n_chunks = math.ceil(self.prompt_length / self.policy.chunk_size)
+        self._validate_chunks(
+            "importance_chunks",
+            self.provenance.importance_chunks,
+            n_chunks,
+            ordered=True,
+        )
+        for source_name, values in (
+            ("backbone_chunks", self.provenance.backbone_chunks),
+            ("anchor_chunks", self.provenance.anchor_chunks),
+            ("control_anchor_chunks", self.provenance.control_anchor_chunks),
+            ("rotating_tail_chunks", self.provenance.rotating_tail_chunks),
+            ("halo_chunks", self.provenance.halo_chunks),
+        ):
+            self._validate_chunks(source_name, values, n_chunks)
+        self._validate_indices(
+            "control_anchor_indices", self.provenance.control_anchor_indices
+        )
+        selected = set(self.selected_chunks)
+        for source_name, chunks in (
+            ("importance_chunks", self.provenance.importance_chunks),
+            ("backbone_chunks", self.provenance.backbone_chunks),
+            ("anchor_chunks", self.provenance.anchor_chunks),
+            ("control_anchor_chunks", self.provenance.control_anchor_chunks),
+            ("rotating_tail_chunks", self.provenance.rotating_tail_chunks),
+            ("halo_chunks", self.provenance.halo_chunks),
+        ):
+            if not set(chunks).issubset(selected):
+                raise ValueError(f"{source_name} must be retained in selected_chunks")
+
+        expected_anchors = _anchor_chunk_ids(n_chunks, self.policy.anchor_chunks)
+        if self.provenance.anchor_chunks != expected_anchors:
+            raise ValueError("anchor_chunks must match the policy-derived anchors")
+        expected_backbone = _stratified_chunks(
+            n_chunks, math.ceil(n_chunks * self.policy.backbone_pct)
+        )
+        if self.provenance.backbone_chunks != expected_backbone:
+            raise ValueError("backbone_chunks must match the policy-derived backbone")
+        expected_control_chunks = tuple(
+            sorted(
+                {
+                    index // self.policy.chunk_size
+                    for index in self.provenance.control_anchor_indices
+                }
+            )
+        )
+        if self.provenance.control_anchor_chunks != expected_control_chunks:
+            raise ValueError("control_anchor_chunks must match control_anchor_indices")
+        if self.rotating_tail_requirement is not None:
+            required_tail = self.rotating_tail_requirement.required_chunks(
+                self.prompt_length, self.policy.chunk_size
+            )
+            if self.provenance.rotating_tail_chunks != required_tail:
+                raise ValueError(
+                    "rotating_tail_chunks must exactly describe the tail requirement"
+                )
+            if not set(required_tail).issubset(self.selected_chunks):
+                raise ValueError("selected_chunks must retain the rotating tail")
+        elif self.provenance.rotating_tail_chunks:
+            raise ValueError("rotating_tail_chunks require a rotating_tail_requirement")
+
+    def _validate_chunks(
+        self,
+        source_name: str,
+        chunks: tuple[int, ...],
+        n_chunks: int,
+        *,
+        ordered: bool = False,
+    ) -> None:
+        if len(set(chunks)) != len(chunks):
+            raise ValueError(f"{source_name} must be unique")
+        if not ordered and tuple(sorted(chunks)) != chunks:
+            raise ValueError(f"{source_name} must be sorted")
+        if any(
+            not isinstance(chunk, int) or chunk < 0 or chunk >= n_chunks
+            for chunk in chunks
+        ):
+            raise ValueError(f"{source_name} contains an invalid chunk")
+
+    def _validate_indices(self, source_name: str, indices: tuple[int, ...]) -> None:
+        if tuple(sorted(set(indices))) != indices:
+            raise ValueError(f"{source_name} must be sorted and unique")
+        if any(
+            not isinstance(index, int) or index < 0 or index >= self.prompt_length
+            for index in indices
+        ):
+            raise ValueError(f"{source_name} contains an invalid token index")
+
+    @property
+    def chunk_size(self) -> int:
+        """Compatibility view of :attr:`policy.chunk_size`."""
+        return self.policy.chunk_size
+
+    @property
+    def keep_pct(self) -> float:
+        """Compatibility view of :attr:`policy.keep_pct`."""
+        return self.policy.keep_pct
+
+    @property
+    def selector_version(self) -> str:
+        """Compatibility view of :attr:`policy.selector_version`."""
+        return self.policy.selector_version
+
+    @property
+    def importance_chunks(self) -> tuple[int, ...]:
+        return self.provenance.importance_chunks
+
+    @property
+    def backbone_chunks(self) -> tuple[int, ...]:
+        return self.provenance.backbone_chunks
+
+    @property
+    def anchor_chunks(self) -> tuple[int, ...]:
+        return self.provenance.anchor_chunks
+
+    @property
+    def control_anchor_indices(self) -> tuple[int, ...]:
+        return self.provenance.control_anchor_indices
+
+    @property
+    def control_anchor_chunks(self) -> tuple[int, ...]:
+        return self.provenance.control_anchor_chunks
+
+    @property
+    def rotating_tail_chunks(self) -> tuple[int, ...]:
+        return self.provenance.rotating_tail_chunks
+
+    @property
+    def halo_chunks(self) -> tuple[int, ...]:
+        return self.provenance.halo_chunks
+
+    @property
+    def selected_token_count(self) -> int:
+        return len(self.selected_indices)
+
+    def as_mx_indices(self):
+        """Return executor-ready MLX indices at the explicit device boundary.
+
+        The local import keeps selector construction and validation usable in
+        non-MLX scheduling and cache-admission code.
+        """
+        import mlx.core as mx
+
+        return mx.array(self.selected_indices, dtype=mx.int32)
+
+    @property
+    def fingerprint(self) -> str:
+        """Stable semantic identity for exact sparse-cache reuse."""
+        tail_window = (
+            "none"
+            if self.rotating_tail_requirement is None
+            else str(self.rotating_tail_requirement.window_tokens)
+        )
+        fields = (
+            self.selector_version,
+            str(self.prompt_length),
+            self.keep_pct.hex(),
+            self.policy.backbone_pct.hex(),
+            str(self.policy.halo_chunks),
+            str(self.policy.anchor_chunks),
+            str(self.chunk_size),
+            ",".join(map(str, self.selected_chunks)),
+            ",".join(map(str, self.selected_indices)),
+            ",".join(map(str, self.importance_chunks)),
+            ",".join(map(str, self.backbone_chunks)),
+            ",".join(map(str, self.anchor_chunks)),
+            ",".join(map(str, self.control_anchor_indices)),
+            ",".join(map(str, self.control_anchor_chunks)),
+            tail_window,
+            ",".join(map(str, self.rotating_tail_chunks)),
+            ",".join(map(str, self.halo_chunks)),
+        )
+        return hashlib.sha256("|".join(fields).encode("utf-8")).hexdigest()
+
+
+def _stratified_chunks(n_chunks: int, count: int) -> tuple[int, ...]:
+    """Select stable center-of-stratum representatives across a prompt."""
+    if count <= 0:
+        return ()
+    if count >= n_chunks:
+        return tuple(range(n_chunks))
+    selected = {
+        min(n_chunks - 1, int((index + 0.5) * n_chunks / count))
+        for index in range(count)
+    }
+    for candidate in range(n_chunks):
+        if len(selected) >= count:
+            break
+        selected.add(candidate)
+    return tuple(sorted(selected))
+
+
+def _anchor_chunk_ids(n_chunks: int, count: int) -> tuple[int, ...]:
+    if count <= 0:
+        return ()
+    count = min(count, n_chunks)
+    anchors = set(range(count))
+    anchors.update(range(max(0, n_chunks - count), n_chunks))
+    return tuple(sorted(anchors))
+
+
+def _canonical_control_indices(
+    control_token_indices: Iterable[int], prompt_length: int
+) -> tuple[int, ...]:
+    values = tuple(control_token_indices)
+    if any(
+        isinstance(index, bool)
+        or not isinstance(index, int)
+        or index < 0
+        or index >= prompt_length
+        for index in values
+    ):
+        raise ValueError("control_token_indices must be prompt-local integer positions")
+    return tuple(sorted(set(values)))
+
+
+def build_selection_plan_from_chunk_scores(
+    *,
+    prompt_length: int,
+    chunk_scores: Sequence[float],
+    policy: SelectionPolicy,
+    control_token_indices: Iterable[int] = (),
+    rotating_tail_requirement: RotatingTailRequirement | None = None,
+) -> SelectionPlan:
+    """Build a plan from host-resident chunk scores without MLX dependencies."""
+    if not isinstance(policy, SelectionPolicy):
+        raise TypeError("policy must be a SelectionPolicy")
+    if prompt_length <= 0:
+        raise ValueError("prompt_length must be positive")
+    n_chunks = math.ceil(prompt_length / policy.chunk_size)
+    if len(chunk_scores) != n_chunks:
+        raise ValueError("chunk_scores length must match the prompt chunk count")
+    if not all(math.isfinite(score) for score in chunk_scores):
+        raise ValueError("chunk_scores must contain only finite values")
+
+    control_indices = _canonical_control_indices(control_token_indices, prompt_length)
+    control_chunks = tuple(
+        sorted({index // policy.chunk_size for index in control_indices})
+    )
+    tail_chunks = (
+        ()
+        if rotating_tail_requirement is None
+        else rotating_tail_requirement.required_chunks(prompt_length, policy.chunk_size)
+    )
+    anchors = _anchor_chunk_ids(n_chunks, policy.anchor_chunks)
+    backbone = _stratified_chunks(n_chunks, math.ceil(n_chunks * policy.backbone_pct))
+    mandatory = set(anchors)
+    mandatory.update(control_chunks)
+    mandatory.update(tail_chunks)
+    selected = set(mandatory)
+    ranked = tuple(
+        sorted(range(n_chunks), key=lambda chunk: (-chunk_scores[chunk], chunk))
+    )
+    desired_chunks = max(1, math.ceil(n_chunks * policy.keep_pct))
+    desired_tokens = max(1, math.ceil(prompt_length * policy.keep_pct))
+    selected.update(backbone)
+    # Mandatory sources are a correctness floor.  They may exceed the score
+    # budget, exactly like the old fixed first/last anchors.
+    importance_budget = max(1, desired_chunks - len(backbone))
+    chunk_budget = min(n_chunks, desired_chunks + len(mandatory))
+    importance_seeds: list[int] = []
+    halo_chunks: set[int] = set()
+
+    def selected_token_count() -> int:
+        return sum(
+            min(policy.chunk_size, prompt_length - chunk * policy.chunk_size)
+            for chunk in selected
+        )
+
+    for seed in ranked:
+        if (
+            len(importance_seeds) >= importance_budget
+            and selected_token_count() >= desired_tokens
+        ):
+            break
+        was_seed_selected = seed in selected
+        candidates = [seed]
+        for distance in range(1, policy.halo_chunks + 1):
+            candidates.extend((seed - distance, seed + distance))
+        for candidate in candidates:
+            if not 0 <= candidate < n_chunks:
+                continue
+            was_selected = candidate in selected
+            if len(selected) >= chunk_budget and candidate not in selected:
+                continue
+            selected.add(candidate)
+            if candidate == seed and not was_seed_selected:
+                importance_seeds.append(seed)
+            elif candidate != seed and not was_selected:
+                halo_chunks.add(candidate)
+
+    # A partial last chunk can meet a chunk budget without meeting the token
+    # retention target; fill deterministically until both are satisfied.
+    for candidate in ranked:
+        if len(selected) >= chunk_budget and selected_token_count() >= desired_tokens:
+            break
+        if (
+            selected_token_count() < desired_tokens
+            or len(selected) < chunk_budget
+            or candidate in selected
+        ):
+            selected.add(candidate)
+
+    selected_chunks = tuple(sorted(selected))
+    selected_indices = tuple(
+        token
+        for chunk in selected_chunks
+        for token in range(
+            chunk * policy.chunk_size,
+            min((chunk + 1) * policy.chunk_size, prompt_length),
+        )
+    )
+    return SelectionPlan(
+        prompt_length=prompt_length,
+        policy=policy,
+        selected_chunks=selected_chunks,
+        selected_indices=selected_indices,
+        provenance=SelectionProvenance(
+            importance_chunks=tuple(importance_seeds),
+            backbone_chunks=backbone,
+            anchor_chunks=anchors,
+            control_anchor_indices=control_indices,
+            control_anchor_chunks=control_chunks,
+            rotating_tail_chunks=tail_chunks,
+            halo_chunks=tuple(sorted(halo_chunks)),
+        ),
+        rotating_tail_requirement=rotating_tail_requirement,
+    )

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -25,13 +25,37 @@ from typing import Any, Callable, Iterable, Sequence
 import mlx.core as mx
 
 from .specprefill_cache import SparseCacheState, SparseCacheStateError
+from .specprefill_gemma_cache import (
+    GEMMA4_26B_A4B,
+    GEMMA4_31B,
+    GEMMA4_E2B,
+    GemmaArtifactSpec,
+    GemmaCacheBackend,
+    GemmaCacheCheckpoint,
+    GemmaCacheTopology,
+    GemmaOneTokenTransaction,
+    normalize_scalar_rotating,
+    gemma_cache_backend,
+    validate_aligned_scalar_cache,
+    validate_gemma_cache_topology,
+)
 from .specprefill_positions import (
     PositionPhase,
     PositionRow,
     TargetPositionAdapter,
+    TargetPositionFamily,
     TargetPositionPlan,
 )
 from .specprefill_target_hooks import TargetPositionHooks
+
+from mlx_lm.models.cache import RotatingKVCache as LmGemmaRotatingKVCache
+from mlx_lm.models.gemma4_text import Model as LmGemmaTextModel
+from mlx_vlm.models.base import LanguageModelOutput
+from mlx_vlm.models.cache import RotatingKVCache as VlmGemmaRotatingKVCache
+from mlx_vlm.models.gemma4.language import LanguageModel as VlmGemmaLanguageModel
+from mlx_vlm.models.gemma4_text.language import (
+    LanguageModel as VlmGemmaTextLanguageModel,
+)
 
 
 class SparseTargetPrefillError(SparseCacheStateError):
@@ -83,6 +107,20 @@ class _CacheSnapshot:
     states: tuple[Any, ...]
     meta_states: tuple[Any | None, ...]
     offsets: tuple[int | None, ...]
+
+
+@dataclass(frozen=True)
+class _GemmaScalarExecution:
+    spec: GemmaArtifactSpec
+    topology: GemmaCacheTopology
+    backend: GemmaCacheBackend
+
+
+@dataclass(frozen=True)
+class _GemmaChunkCursor:
+    offset: int
+    circular_index: int | None
+    allocated_tokens: int
 
 
 _TARGET_LANE_LOCK = threading.RLock()
@@ -153,7 +191,17 @@ class SparseTargetPrefillSession:
         self._cancel_check = cancel_check
         self._physical_entries = _physical_cache_entries(cache)
         _require_fresh_physical_cache(self._physical_entries, sparse_state.row_count)
-        self._snapshot = _snapshot_cache(cache)
+        self._gemma = _resolve_gemma_scalar_execution(
+            model, cache, adapter, sparse_state.row_count
+        )
+        if self._gemma is not None and step_size == 1 and self._token_rows.shape[1] > 1:
+            raise SparseTargetPrefillError(
+                "Gemma sparse prefill requires chunk_size > 1 except its final tail"
+            )
+        self._gemma_checkpoint = (
+            GemmaCacheCheckpoint(cache) if self._gemma is not None else None
+        )
+        self._snapshot = None if self._gemma is not None else _snapshot_cache(cache)
         self._hooks = TargetPositionHooks.for_model(model, adapter)
         self._lane = _target_lane_for(model)
         self._processed = 0
@@ -225,12 +273,19 @@ class SparseTargetPrefillSession:
                 physical_start,
             )
             forward_started_at = time.perf_counter()
-            with self._hooks.session_for_plan(plan):
-                self._logits = self.model(
-                    self._token_rows[:, self._processed : self._processed + chunk_size],
-                    cache=self.cache,
+            if self._gemma is None:
+                with self._hooks.session_for_plan(plan):
+                    self._logits = self.model(
+                        self._token_rows[
+                            :, self._processed : self._processed + chunk_size
+                        ],
+                        cache=self.cache,
+                    )
+                    _eval_forward(self._logits, self.cache)
+            else:
+                self._logits = self._run_gemma_chunk(
+                    plan, chunk_size, physical_start[0]
                 )
-                _eval_forward(self._logits, self.cache)
             self._target_prefill_seconds += time.perf_counter() - forward_started_at
             self._processed += chunk_size
             actual_end = _physical_cache_lengths(
@@ -242,6 +297,8 @@ class SparseTargetPrefillSession:
                     "target cache did not advance by the bounded sparse target chunk"
                 )
             if self._processed == self._total:
+                if self._gemma is not None:
+                    self._finalize_gemma_sparse_boundary()
                 self._publish_result()
             return self._progress()
         except BaseException:
@@ -260,7 +317,10 @@ class SparseTargetPrefillSession:
         """Restore the entry cache snapshot and discard this request's state."""
         if self.closed or self.complete:
             return
-        _restore_cache(self.cache, self._snapshot)
+        if self._gemma_checkpoint is not None:
+            self._gemma_checkpoint.restore()
+        elif self._snapshot is not None:
+            _restore_cache(self.cache, self._snapshot)
         self._logits = None
         self._phase = SparseTargetPrefillPhase.CLOSED
 
@@ -285,7 +345,62 @@ class SparseTargetPrefillSession:
                 physical_cache_starts=tuple(self._starts),
             ),
         )
+        if self._gemma_checkpoint is not None:
+            self._gemma_checkpoint.seal()
         self._phase = SparseTargetPrefillPhase.COMPLETE
+
+    def _run_gemma_chunk(
+        self, plan: TargetPositionPlan, chunk_size: int, physical_start: int
+    ) -> mx.array:
+        """Execute one compact scalar Gemma cache quantum atomically."""
+
+        transaction: GemmaOneTokenTransaction | GemmaCacheCheckpoint
+        transaction = (
+            GemmaOneTokenTransaction(
+                self.cache, logical_positions=(physical_start,)
+            )
+            if chunk_size == 1 and _gemma_one_token_guardable(self.cache)
+            else GemmaCacheCheckpoint(self.cache)
+        )
+        before = _gemma_chunk_cursors(self.cache)
+        try:
+            with self._hooks.session_for_plan(plan):
+                output = self.model(
+                    self._token_rows[
+                        :, self._processed : self._processed + chunk_size
+                    ],
+                    cache=self.cache,
+                )
+                logits = _normalize_gemma_logits(output, self._gemma.backend)
+                _eval_forward(logits, self.cache)
+            if isinstance(transaction, GemmaOneTokenTransaction):
+                transaction.commit(logical_positions=(physical_start + 1,))
+            else:
+                _validate_gemma_chunk_transition(
+                    self.cache,
+                    before,
+                    chunk_size,
+                    physical_start + chunk_size,
+                )
+                _eval_forward(logits, self.cache)
+                transaction.seal()
+            return logits
+        except BaseException:
+            transaction.rollback() if isinstance(
+                transaction, GemmaOneTokenTransaction
+            ) else transaction.restore()
+            raise
+
+    def _finalize_gemma_sparse_boundary(self) -> None:
+        """Normalize rotating owners once, after all sparse chunks commit."""
+
+        for entry in self.cache:
+            if type(entry) in (
+                LmGemmaRotatingKVCache,
+                VlmGemmaRotatingKVCache,
+            ):
+                normalize_scalar_rotating(entry)
+        validate_aligned_scalar_cache(self.cache, logical_position=self._total)
 
     def _progress(self) -> SparseTargetPrefillProgress:
         return SparseTargetPrefillProgress(
@@ -326,6 +441,206 @@ def execute_sparse_target_prefill(
         step_size=step_size,
         cancel_check=cancel_check,
     ).run_to_completion()
+
+
+def _config_value(config: Any, name: str) -> Any:
+    if config is None:
+        return None
+    return config.get(name) if isinstance(config, dict) else getattr(config, name, None)
+
+
+def _gemma_one_token_guardable(cache: Sequence[Any]) -> bool:
+    """Use the overwrite journal only from a normalized rotating boundary."""
+
+    return all(
+        type(entry)
+        not in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
+        or entry.keys is None
+        or entry.keys.shape[2] <= entry.max_size
+        for entry in cache
+    )
+
+
+def _gemma_chunk_cursors(cache: Sequence[Any]) -> tuple[_GemmaChunkCursor, ...]:
+    return tuple(
+        _GemmaChunkCursor(
+            offset=entry.offset,
+            circular_index=(
+                entry._idx
+                if type(entry)
+                in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
+                else None
+            ),
+            allocated_tokens=(entry.keys.shape[2] if entry.keys is not None else 0),
+        )
+        for entry in cache
+    )
+
+
+def _validate_gemma_chunk_transition(
+    cache: Sequence[Any],
+    before: Sequence[_GemmaChunkCursor],
+    chunk_size: int,
+    logical_position: int,
+) -> None:
+    for entry, old in zip(cache, before, strict=True):
+        if entry.offset != old.offset + chunk_size:
+            raise SparseTargetPrefillError(
+                "Gemma cache owners did not advance by the target chunk"
+            )
+        if type(entry) not in (
+            LmGemmaRotatingKVCache,
+            VlmGemmaRotatingKVCache,
+        ):
+            continue
+        allocated = entry.keys.shape[2] if entry.keys is not None else 0
+        if chunk_size > 1:
+            if entry._idx != allocated or allocated > entry.max_size + chunk_size - 1:
+                raise SparseTargetPrefillError(
+                    "Gemma rotating cache concat cursor is inconsistent"
+                )
+            if allocated < min(entry.offset, entry.max_size):
+                raise SparseTargetPrefillError(
+                    "Gemma rotating cache lost resident target tokens"
+                )
+        else:
+            expected_index = (
+                1
+                if old.circular_index is not None
+                and old.circular_index >= entry.max_size
+                else (old.circular_index or 0) + 1
+            )
+            if entry._idx != expected_index or allocated > entry.max_size:
+                raise SparseTargetPrefillError(
+                    "Gemma rotating cache one-token cursor is inconsistent"
+                )
+    validate_aligned_scalar_cache(cache, logical_position=logical_position)
+
+
+def _gemma_config(model: Any) -> Any:
+    candidates = (
+        model,
+        getattr(model, "language_model", None),
+        getattr(model, "model", None),
+        getattr(getattr(model, "language_model", None), "model", None),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        config = getattr(candidate, "config", None) or getattr(candidate, "args", None)
+        text_config = _config_value(config, "text_config")
+        if text_config is not None:
+            config = text_config
+        if _config_value(config, "layer_types") is not None:
+            return config
+    raise SparseTargetPrefillError("Gemma target does not expose a known text config")
+
+
+def _gemma_model_backend(model: Any) -> GemmaCacheBackend:
+    if type(model) is LmGemmaTextModel:
+        return GemmaCacheBackend.MLX_LM
+    if type(model) in (VlmGemmaLanguageModel, VlmGemmaTextLanguageModel):
+        return GemmaCacheBackend.MLX_VLM
+    raise SparseTargetPrefillError(
+        "Gemma sparse target requires an exact mlx-lm or mlx-vlm text model"
+    )
+
+
+def _normalize_gemma_logits(output: Any, backend: GemmaCacheBackend) -> mx.array:
+    if backend is GemmaCacheBackend.MLX_LM:
+        if not isinstance(output, mx.array):
+            raise SparseTargetPrefillError("mlx-lm Gemma must return raw logits")
+        return output
+    if type(output) is not LanguageModelOutput or not isinstance(
+        output.logits, mx.array
+    ):
+        raise SparseTargetPrefillError(
+            "mlx-vlm Gemma must return LanguageModelOutput logits"
+        )
+    return output.logits
+
+
+def _gemma_previous_kvs(model: Any) -> tuple[int, ...]:
+    candidates = (
+        model,
+        getattr(model, "model", None),
+        getattr(model, "language_model", None),
+        getattr(getattr(model, "language_model", None), "model", None),
+    )
+    for candidate in candidates:
+        previous = getattr(candidate, "previous_kvs", None)
+        if previous is not None:
+            return tuple(previous)
+    raise SparseTargetPrefillError(
+        "Gemma target does not expose the known compact cache-owner mapping"
+    )
+
+
+def _resolve_gemma_scalar_execution(
+    model: Any,
+    cache: Sequence[Any],
+    adapter: TargetPositionAdapter,
+    row_count: int,
+) -> _GemmaScalarExecution | None:
+    if adapter.family not in (
+        TargetPositionFamily.GEMMA4_DENSE,
+        TargetPositionFamily.GEMMA4_A4B,
+    ):
+        return None
+    if row_count != 1:
+        raise SparseTargetPrefillError(
+            "Gemma sparse target execution is scalar-only; CB remains disabled"
+        )
+    backend = _gemma_model_backend(model)
+    config = _gemma_config(model)
+    layer_types = tuple(_config_value(config, "layer_types") or ())
+    layer_count = _config_value(config, "num_hidden_layers")
+    shared_count = _config_value(config, "num_kv_shared_layers")
+    window = _config_value(config, "sliding_window")
+    if not all(
+        isinstance(value, int) and not isinstance(value, bool)
+        for value in (layer_count, shared_count, window)
+    ):
+        raise SparseTargetPrefillError("Gemma target config is incomplete")
+    owner_count = layer_count - shared_count
+    matches = tuple(
+        spec
+        for spec in (GEMMA4_E2B, GEMMA4_31B, GEMMA4_26B_A4B)
+        if (
+            spec.layer_types == layer_types
+            and spec.layer_count == layer_count
+            and spec.owner_count == owner_count
+            and spec.sliding_window == window
+        )
+    )
+    if len(matches) != 1:
+        raise SparseTargetPrefillError(
+            "Gemma target config is not one of the bounded E2B/31B/A4B layouts"
+        )
+    spec = matches[0]
+    if (spec is GEMMA4_26B_A4B) != (
+        adapter.family is TargetPositionFamily.GEMMA4_A4B
+    ):
+        raise SparseTargetPrefillError(
+            "Gemma target position adapter disagrees with cache architecture"
+        )
+    previous_kvs = _gemma_previous_kvs(model)
+    try:
+        topology = validate_gemma_cache_topology(
+            spec,
+            layer_types=layer_types,
+            previous_kvs=previous_kvs,
+            cache=cache,
+            backend=backend,
+        )
+        validate_aligned_scalar_cache(cache, logical_position=0)
+    except Exception as exc:
+        raise SparseTargetPrefillError(
+            "Gemma target cache topology is not safe for sparse execution"
+        ) from exc
+    if gemma_cache_backend(cache) is not backend:  # defensive typed pairing
+        raise SparseTargetPrefillError("Gemma model/cache backend pairing changed")
+    return _GemmaScalarExecution(spec, topology, backend)
 
 
 def _chunk_plan(

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -401,9 +401,7 @@ class SparseTargetPrefillSession:
 
         transaction: GemmaOneTokenTransaction | GemmaCacheCheckpoint
         transaction = (
-            GemmaOneTokenTransaction(
-                self.cache, logical_positions=(physical_start,)
-            )
+            GemmaOneTokenTransaction(self.cache, logical_positions=(physical_start,))
             if chunk_size == 1 and _gemma_one_token_guardable(self.cache)
             else GemmaCacheCheckpoint(self.cache)
         )
@@ -411,9 +409,7 @@ class SparseTargetPrefillSession:
         try:
             with self._hooks.session_for_plan(plan):
                 output = self.model(
-                    self._token_rows[
-                        :, self._processed : self._processed + chunk_size
-                    ],
+                    self._token_rows[:, self._processed : self._processed + chunk_size],
                     cache=self.cache,
                 )
                 logits = _normalize_gemma_logits(output, self._gemma.backend)
@@ -431,9 +427,11 @@ class SparseTargetPrefillSession:
                 transaction.seal()
             return logits
         except BaseException:
-            transaction.rollback() if isinstance(
-                transaction, GemmaOneTokenTransaction
-            ) else transaction.restore()
+            (
+                transaction.rollback()
+                if isinstance(transaction, GemmaOneTokenTransaction)
+                else transaction.restore()
+            )
             raise
 
     def _finalize_gemma_sparse_boundary(self) -> None:
@@ -504,8 +502,7 @@ def _gemma_one_token_guardable(cache: Sequence[Any]) -> bool:
     """Use the overwrite journal only from a normalized rotating boundary."""
 
     return all(
-        type(entry)
-        not in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
+        type(entry) not in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
         or entry.keys is None
         or entry.keys.shape[2] <= entry.max_size
         for entry in cache
@@ -518,8 +515,7 @@ def _gemma_chunk_cursors(cache: Sequence[Any]) -> tuple[_GemmaChunkCursor, ...]:
             offset=entry.offset,
             circular_index=(
                 entry._idx
-                if type(entry)
-                in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
+                if type(entry) in (LmGemmaRotatingKVCache, VlmGemmaRotatingKVCache)
                 else None
             ),
             allocated_tokens=(entry.keys.shape[2] if entry.keys is not None else 0),
@@ -669,9 +665,7 @@ def _resolve_gemma_scalar_execution(
             "Gemma target config is not one of the bounded E2B/31B/A4B layouts"
         )
     spec = matches[0]
-    if (spec is GEMMA4_26B_A4B) != (
-        adapter.family is TargetPositionFamily.GEMMA4_A4B
-    ):
+    if (spec is GEMMA4_26B_A4B) != (adapter.family is TargetPositionFamily.GEMMA4_A4B):
         raise SparseTargetPrefillError(
             "Gemma target position adapter disagrees with cache architecture"
         )

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -66,6 +66,10 @@ class SparseTargetPrefillLaneBusy(SparseTargetPrefillError):
     """Another request owns this target model's bounded execution quantum."""
 
 
+class SparseTargetPrefillAuthorityError(SparseTargetPrefillError):
+    """Issued target-forward receipt authority could not be abandoned safely."""
+
+
 @dataclass(frozen=True)
 class SparseTargetPrefillTelemetry:
     """Executor-local facts suitable for request terminal metadata."""
@@ -83,6 +87,7 @@ class SparseTargetPrefillResult:
     logits: mx.array
     cache_state: SparseCacheState
     telemetry: SparseTargetPrefillTelemetry
+    forward_receipts: tuple[Any, ...] = ()
 
 
 class SparseTargetPrefillPhase(str, Enum):
@@ -125,6 +130,7 @@ class _GemmaChunkCursor:
 
 _TARGET_LANE_LOCK = threading.RLock()
 _TARGET_LANES: dict[int, tuple[weakref.ReferenceType[Any], threading.Lock]] = {}
+_EMPTY_KV_CACHE_STATE = object()
 
 
 def _target_lane_for(model: Any) -> threading.Lock:
@@ -180,6 +186,11 @@ class SparseTargetPrefillSession:
         *,
         step_size: int = 2048,
         cancel_check: Callable[[], None] | None = None,
+        target_forward: (
+            Callable[[Any, Sequence[Any], TargetPositionPlan], tuple[mx.array, Any]]
+            | None
+        ) = None,
+        receipt_abandon: Callable[[Sequence[Any]], None] | None = None,
     ):
         _validate_execution_inputs(cache, sparse_state, adapter, step_size)
         self._token_rows = _normalize_selected_tokens(selected_tokens, sparse_state)
@@ -189,11 +200,21 @@ class SparseTargetPrefillSession:
         self.adapter = adapter
         self._step_size = step_size
         self._cancel_check = cancel_check
+        self._target_forward = target_forward
+        self._receipt_abandon = receipt_abandon
         self._physical_entries = _physical_cache_entries(cache)
         _require_fresh_physical_cache(self._physical_entries, sparse_state.row_count)
         self._gemma = _resolve_gemma_scalar_execution(
             model, cache, adapter, sparse_state.row_count
         )
+        if target_forward is not None and sparse_state.row_count != 1:
+            raise SparseTargetPrefillError(
+                "attested sparse target execution is supported only for B=1"
+            )
+        if target_forward is not None and self._gemma is not None:
+            raise SparseTargetPrefillError(
+                "attested sparse target execution is not supported for Gemma"
+            )
         if self._gemma is not None and step_size == 1 and self._token_rows.shape[1] > 1:
             raise SparseTargetPrefillError(
                 "Gemma sparse prefill requires chunk_size > 1 except its final tail"
@@ -207,6 +228,7 @@ class SparseTargetPrefillSession:
         self._processed = 0
         self._starts: list[tuple[int, ...]] = []
         self._logits: mx.array | None = None
+        self._forward_receipts: list[Any] = []
         self._result: SparseTargetPrefillResult | None = None
         self._target_prefill_seconds = 0.0
         self._phase = SparseTargetPrefillPhase.ACTIVE
@@ -274,13 +296,22 @@ class SparseTargetPrefillSession:
             )
             forward_started_at = time.perf_counter()
             if self._gemma is None:
-                with self._hooks.session_for_plan(plan):
-                    self._logits = self.model(
-                        self._token_rows[
-                            :, self._processed : self._processed + chunk_size
-                        ],
-                        cache=self.cache,
+                token_rows = self._token_rows[
+                    :, self._processed : self._processed + chunk_size
+                ]
+                if self._target_forward is None:
+                    with self._hooks.session_for_plan(plan):
+                        self._logits = self.model(token_rows, cache=self.cache)
+                        _eval_forward(self._logits, self.cache)
+                else:
+                    self._logits, receipt = self._target_forward(
+                        token_rows, self.cache, plan
                     )
+                    if receipt is None:
+                        raise SparseTargetPrefillError(
+                            "attested target forward did not return a receipt"
+                        )
+                    self._forward_receipts.append(receipt)
                     _eval_forward(self._logits, self.cache)
             else:
                 self._logits = self._run_gemma_chunk(
@@ -317,12 +348,25 @@ class SparseTargetPrefillSession:
         """Restore the entry cache snapshot and discard this request's state."""
         if self.closed or self.complete:
             return
-        if self._gemma_checkpoint is not None:
-            self._gemma_checkpoint.restore()
-        elif self._snapshot is not None:
-            _restore_cache(self.cache, self._snapshot)
-        self._logits = None
-        self._phase = SparseTargetPrefillPhase.CLOSED
+        authority_error = None
+        try:
+            if self._forward_receipts and self._receipt_abandon is not None:
+                try:
+                    self._receipt_abandon(tuple(self._forward_receipts))
+                except BaseException as exc:
+                    authority_error = exc
+            if self._gemma_checkpoint is not None:
+                self._gemma_checkpoint.restore()
+            elif self._snapshot is not None:
+                _restore_cache(self.cache, self._snapshot)
+        finally:
+            self._logits = None
+            self._forward_receipts.clear()
+            self._phase = SparseTargetPrefillPhase.CLOSED
+        if authority_error is not None:
+            raise SparseTargetPrefillAuthorityError(
+                "failed to abandon partial sparse target receipts"
+            ) from authority_error
 
     @property
     def _total(self) -> int:
@@ -344,6 +388,7 @@ class SparseTargetPrefillSession:
                 chunk_count=len(self._starts),
                 physical_cache_starts=tuple(self._starts),
             ),
+            forward_receipts=tuple(self._forward_receipts),
         )
         if self._gemma_checkpoint is not None:
             self._gemma_checkpoint.seal()
@@ -419,6 +464,10 @@ def execute_sparse_target_prefill(
     *,
     step_size: int = 2048,
     cancel_check: Callable[[], None] | None = None,
+    target_forward: (
+        Callable[[Any, Sequence[Any], TargetPositionPlan], tuple[mx.array, Any]] | None
+    ) = None,
+    receipt_abandon: Callable[[Sequence[Any]], None] | None = None,
 ) -> SparseTargetPrefillResult:
     """Run selected target tokens under request-local logical positions.
 
@@ -440,6 +489,8 @@ def execute_sparse_target_prefill(
         adapter,
         step_size=step_size,
         cancel_check=cancel_check,
+        target_forward=target_forward,
+        receipt_abandon=receipt_abandon,
     ).run_to_completion()
 
 
@@ -758,7 +809,17 @@ def _clone_cache_value(value: Any) -> Any:
 
 def _snapshot_cache(cache: Sequence[Any]) -> _CacheSnapshot:
     try:
-        states = tuple(_clone_cache_value(entry.state) for entry in cache)
+        states = tuple(
+            (
+                _EMPTY_KV_CACHE_STATE
+                if hasattr(entry, "keys")
+                and hasattr(entry, "values")
+                and entry.keys is None
+                and entry.values is None
+                else _clone_cache_value(entry.state)
+            )
+            for entry in cache
+        )
         meta_states = tuple(
             (
                 _clone_cache_value(entry.meta_state)
@@ -784,7 +845,11 @@ def _restore_cache(cache: Sequence[Any], snapshot: _CacheSnapshot) -> None:
             snapshot.offsets,
             strict=True,
         ):
-            entry.state = _clone_cache_value(state)
+            if state is _EMPTY_KV_CACHE_STATE:
+                entry.keys = None
+                entry.values = None
+            else:
+                entry.state = _clone_cache_value(state)
             if meta_state is not None:
                 entry.meta_state = _clone_cache_value(meta_state)
             if offset is not None:

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded, request-local target execution for SpecPrefill.
+
+This module is intentionally separate from the legacy :func:`sparse_prefill`
+implementation.  The legacy function replaces RoPE children globally and
+cannot safely coexist with concurrent requests.  Here each bounded target
+forward uses :class:`TargetPositionHooks` and releases its request-local
+session only after both logits and cache writes have been evaluated.
+
+``SparseCacheState`` is immutable *post*-prefill metadata.  It records the
+full selected logical sequence and the final physical KV occupancy.  The
+executor derives a smaller ``TargetPositionPlan`` for every chunk; its physical
+start is the committed KV length before that chunk, not its logical position.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Sequence
+
+import mlx.core as mx
+
+from .specprefill_cache import SparseCacheState, SparseCacheStateError
+from .specprefill_positions import (
+    PositionPhase,
+    PositionRow,
+    TargetPositionAdapter,
+    TargetPositionPlan,
+)
+from .specprefill_target_hooks import TargetPositionHooks
+
+
+class SparseTargetPrefillError(SparseCacheStateError):
+    """Sparse target execution cannot safely begin or finish."""
+
+
+@dataclass(frozen=True)
+class SparseTargetPrefillTelemetry:
+    """Executor-local facts suitable for request terminal metadata."""
+
+    selected_tokens: int
+    target_prefill_ms: float
+    chunk_count: int
+    physical_cache_starts: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class SparseTargetPrefillResult:
+    """Successful target logits and the sole authoritative sparse cache state."""
+
+    logits: mx.array
+    cache_state: SparseCacheState
+    telemetry: SparseTargetPrefillTelemetry
+
+
+@dataclass(frozen=True)
+class _CacheSnapshot:
+    """A shallow MLX-safe cache checkpoint for all-or-nothing request execution."""
+
+    states: tuple[Any, ...]
+    meta_states: tuple[Any | None, ...]
+    offsets: tuple[int | None, ...]
+
+
+def execute_sparse_target_prefill(
+    model: Any,
+    selected_tokens: mx.array | Sequence[int] | Sequence[Sequence[int]],
+    cache: Sequence[Any],
+    sparse_state: SparseCacheState,
+    adapter: TargetPositionAdapter,
+    *,
+    step_size: int = 2048,
+    cancel_check: Callable[[], None] | None = None,
+) -> SparseTargetPrefillResult:
+    """Run selected target tokens under request-local logical positions.
+
+    The input contains already-selected token IDs in the same row/order as
+    ``sparse_state.logical_positions``.  This narrow boundary prevents an
+    executor from reinterpreting a selector plan or expanding a rotating-cache
+    tail.  Initially only fresh target caches are admissible: sparse prefix
+    reuse needs a separately proven atomic payload serializer.
+
+    On cancellation, model failure, lazy-evaluation failure, or topology/cache
+    disagreement the entry cache checkpoint is restored before the exception
+    is raised.  The immutable ``sparse_state`` is returned only on success.
+    """
+    _validate_execution_inputs(cache, sparse_state, adapter, step_size)
+    token_rows = _normalize_selected_tokens(selected_tokens, sparse_state)
+    physical_entries = _physical_cache_entries(cache)
+    _require_fresh_physical_cache(physical_entries, sparse_state.row_count)
+    snapshot = _snapshot_cache(cache)
+    hooks = TargetPositionHooks.for_model(model, adapter)
+    starts: list[tuple[int, ...]] = []
+    logits: mx.array | None = None
+    started_at = time.perf_counter()
+    processed = 0
+    total = token_rows.shape[1]
+
+    try:
+        while processed < total:
+            if cancel_check is not None:
+                cancel_check()
+            chunk_size = min(step_size, total - processed)
+            physical_start = _physical_cache_lengths(
+                physical_entries, sparse_state.row_count
+            )
+            expected_start = (processed,) * sparse_state.row_count
+            if physical_start != expected_start:
+                raise SparseTargetPrefillError(
+                    "target cache physical length disagrees with committed sparse "
+                    "target chunk boundary"
+                )
+            starts.append(physical_start)
+            plan = _chunk_plan(
+                adapter, sparse_state, processed, chunk_size, physical_start
+            )
+            with hooks.session_for_plan(plan):
+                logits = model(
+                    token_rows[:, processed : processed + chunk_size], cache=cache
+                )
+                _eval_forward(logits, cache)
+            processed += chunk_size
+            actual_end = _physical_cache_lengths(
+                physical_entries, sparse_state.row_count
+            )
+            expected_end = (processed,) * sparse_state.row_count
+            if actual_end != expected_end:
+                raise SparseTargetPrefillError(
+                    "target cache did not advance by the bounded sparse target chunk"
+                )
+        if logits is None:  # validation makes this unreachable; keep fail-closed.
+            raise SparseTargetPrefillError("sparse target prefill produced no logits")
+    except BaseException:
+        _restore_cache(cache, snapshot)
+        raise
+
+    return SparseTargetPrefillResult(
+        logits=logits,
+        cache_state=sparse_state.clone(),
+        telemetry=SparseTargetPrefillTelemetry(
+            selected_tokens=total,
+            target_prefill_ms=(time.perf_counter() - started_at) * 1000.0,
+            chunk_count=len(starts),
+            physical_cache_starts=tuple(starts),
+        ),
+    )
+
+
+def _chunk_plan(
+    adapter: TargetPositionAdapter,
+    sparse_state: SparseCacheState,
+    start: int,
+    count: int,
+    physical_starts: tuple[int, ...],
+) -> TargetPositionPlan:
+    rows = tuple(
+        PositionRow(row.logical_positions[start : start + count], physical_start)
+        for row, physical_start in zip(sparse_state.rows, physical_starts, strict=True)
+    )
+    return TargetPositionPlan(adapter, PositionPhase.SPARSE_PREFILL, rows, sparse_state)
+
+
+def _validate_execution_inputs(
+    cache: Sequence[Any],
+    sparse_state: SparseCacheState,
+    adapter: TargetPositionAdapter,
+    step_size: int,
+) -> None:
+    if not isinstance(sparse_state, SparseCacheState) or not sparse_state.rows:
+        raise SparseTargetPrefillError(
+            "sparse target prefill needs non-empty cache state"
+        )
+    if not isinstance(adapter, TargetPositionAdapter):
+        raise SparseTargetPrefillError(
+            "sparse target prefill needs an explicit adapter"
+        )
+    if isinstance(step_size, bool) or not isinstance(step_size, int) or step_size <= 0:
+        raise SparseTargetPrefillError(
+            "sparse target prefill step_size must be positive"
+        )
+    if not isinstance(cache, Sequence) or not cache:
+        raise SparseTargetPrefillError(
+            "sparse target prefill needs a non-empty target cache"
+        )
+
+
+def _normalize_selected_tokens(
+    selected_tokens: mx.array | Sequence[int] | Sequence[Sequence[int]],
+    sparse_state: SparseCacheState,
+) -> mx.array:
+    tokens = (
+        selected_tokens
+        if isinstance(selected_tokens, mx.array)
+        else mx.array(selected_tokens)
+    )
+    if tokens.ndim == 1:
+        tokens = tokens[None, :]
+    if tokens.ndim != 2:
+        raise SparseTargetPrefillError(
+            "selected target tokens must have shape (batch, selected_tokens)"
+        )
+    expected = (sparse_state.row_count, sparse_state.rows[0].physical_valid_length)
+    if tokens.shape != expected:
+        raise SparseTargetPrefillError(
+            "selected target token shape must match sparse cache rows and selected length"
+        )
+    if any(row.physical_valid_length != expected[1] for row in sparse_state.rows):
+        raise SparseTargetPrefillError(
+            "mixed selected lengths require scheduler lane splitting before sparse target prefill"
+        )
+    return tokens
+
+
+def _physical_cache_entries(cache: Sequence[Any]) -> tuple[Any, ...]:
+    entries = tuple(entry for entry in cache if hasattr(entry, "offset"))
+    if not entries:
+        raise SparseTargetPrefillError(
+            "target cache exposes no physical offset entries; explicit adapter support is required"
+        )
+    return entries
+
+
+def _physical_cache_lengths(entries: Iterable[Any], row_count: int) -> tuple[int, ...]:
+    lengths = []
+    for entry in entries:
+        offset = getattr(entry, "offset", None)
+        if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+            raise SparseTargetPrefillError(
+                "target cache physical offsets must be non-negative host integers"
+            )
+        lengths.append(offset)
+    if len(set(lengths)) != 1:
+        raise SparseTargetPrefillError(
+            "target cache offset-bearing entries must share one physical length"
+        )
+    return (lengths[0],) * row_count
+
+
+def _require_fresh_physical_cache(entries: Iterable[Any], row_count: int) -> None:
+    if _physical_cache_lengths(entries, row_count) != (0,) * row_count:
+        raise SparseTargetPrefillError(
+            "sparse target prefix reuse is disabled; target cache must start empty"
+        )
+
+
+def _clone_cache_value(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return tuple(_clone_cache_value(item) for item in value)
+    if isinstance(value, list):
+        return [_clone_cache_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _clone_cache_value(item) for key, item in value.items()}
+    # MLX arrays are immutable values until a cache replaces them; retaining an
+    # array avoids a device copy while container cloning prevents aliasing.
+    return value
+
+
+def _snapshot_cache(cache: Sequence[Any]) -> _CacheSnapshot:
+    try:
+        states = tuple(_clone_cache_value(entry.state) for entry in cache)
+        meta_states = tuple(
+            (
+                _clone_cache_value(entry.meta_state)
+                if hasattr(entry, "meta_state")
+                else None
+            )
+            for entry in cache
+        )
+        offsets = tuple(getattr(entry, "offset", None) for entry in cache)
+    except Exception as exc:
+        raise SparseTargetPrefillError(
+            "target cache cannot produce an atomic sparse target checkpoint"
+        ) from exc
+    return _CacheSnapshot(states, meta_states, offsets)
+
+
+def _restore_cache(cache: Sequence[Any], snapshot: _CacheSnapshot) -> None:
+    try:
+        for entry, state, meta_state, offset in zip(
+            cache,
+            snapshot.states,
+            snapshot.meta_states,
+            snapshot.offsets,
+            strict=True,
+        ):
+            entry.state = _clone_cache_value(state)
+            if meta_state is not None:
+                entry.meta_state = _clone_cache_value(meta_state)
+            if offset is not None:
+                entry.offset = offset
+    except Exception as exc:
+        raise SparseTargetPrefillError(
+            "target cache rollback failed; request cache must be discarded"
+        ) from exc
+
+
+def _iter_cache_arrays(value: Any) -> Iterable[mx.array]:
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            yield from _iter_cache_arrays(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_cache_arrays(item)
+    elif hasattr(value, "shape") and hasattr(value, "dtype"):
+        yield value
+
+
+def _eval_forward(logits: mx.array, cache: Sequence[Any]) -> None:
+    """Realize model/cache work while the request-local hook is still active."""
+    values = [logits]
+    for entry in cache:
+        values.extend(_iter_cache_arrays(entry.state))
+    mx.eval(values)

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -16,7 +16,10 @@ start is the committed KV length before that chunk, not its logical position.
 from __future__ import annotations
 
 import time
+import threading
+import weakref
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Iterable, Sequence
 
 import mlx.core as mx
@@ -33,6 +36,10 @@ from .specprefill_target_hooks import TargetPositionHooks
 
 class SparseTargetPrefillError(SparseCacheStateError):
     """Sparse target execution cannot safely begin or finish."""
+
+
+class SparseTargetPrefillLaneBusy(SparseTargetPrefillError):
+    """Another request owns this target model's bounded execution quantum."""
 
 
 @dataclass(frozen=True)
@@ -54,6 +61,21 @@ class SparseTargetPrefillResult:
     telemetry: SparseTargetPrefillTelemetry
 
 
+class SparseTargetPrefillPhase(str, Enum):
+    ACTIVE = "active"
+    COMPLETE = "complete"
+    CLOSED = "closed"
+
+
+@dataclass(frozen=True)
+class SparseTargetPrefillProgress:
+    """Non-publishable request-local progress after one target chunk quantum."""
+
+    selected_tokens_processed: int
+    chunk_count: int
+    complete: bool
+
+
 @dataclass(frozen=True)
 class _CacheSnapshot:
     """A shallow MLX-safe cache checkpoint for all-or-nothing request execution."""
@@ -61,6 +83,207 @@ class _CacheSnapshot:
     states: tuple[Any, ...]
     meta_states: tuple[Any | None, ...]
     offsets: tuple[int | None, ...]
+
+
+_TARGET_LANE_LOCK = threading.RLock()
+_TARGET_LANES: dict[int, tuple[weakref.ReferenceType[Any], threading.Lock]] = {}
+
+
+def _target_lane_for(model: Any) -> threading.Lock:
+    """Return the non-reentrant target-forward lane for this exact model object."""
+    model_id = id(model)
+    with _TARGET_LANE_LOCK:
+        entry = _TARGET_LANES.get(model_id)
+        if entry is not None:
+            model_ref, lane = entry
+            if model_ref() is model:
+                return lane
+            if model_ref() is None:
+                _TARGET_LANES.pop(model_id, None)
+            else:
+                raise SparseTargetPrefillError(
+                    "target lane registry identity collision"
+                )
+
+        def _remove(model_ref: weakref.ReferenceType[Any]) -> None:
+            with _TARGET_LANE_LOCK:
+                current = _TARGET_LANES.get(model_id)
+                if current is not None and current[0] is model_ref:
+                    _TARGET_LANES.pop(model_id, None)
+
+        try:
+            model_ref = weakref.ref(model, _remove)
+        except TypeError as exc:
+            raise SparseTargetPrefillError(
+                "target models must support weak references for execution lanes"
+            ) from exc
+        lane = threading.Lock()
+        _TARGET_LANES[model_id] = (model_ref, lane)
+        return lane
+
+
+class SparseTargetPrefillSession:
+    """One request's bounded sparse target prefill state machine.
+
+    Static class dispatch remains installed on target RoPE objects.  This
+    session never leaves a request position context or a target model lane
+    active when ``step`` returns, so a scheduler can interleave compatible
+    request caches one chunk at a time without globally serializing the full
+    sparse prefill.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        selected_tokens: mx.array | Sequence[int] | Sequence[Sequence[int]],
+        cache: Sequence[Any],
+        sparse_state: SparseCacheState,
+        adapter: TargetPositionAdapter,
+        *,
+        step_size: int = 2048,
+        cancel_check: Callable[[], None] | None = None,
+    ):
+        _validate_execution_inputs(cache, sparse_state, adapter, step_size)
+        self._token_rows = _normalize_selected_tokens(selected_tokens, sparse_state)
+        self.model = model
+        self.cache = cache
+        self.sparse_state = sparse_state
+        self.adapter = adapter
+        self._step_size = step_size
+        self._cancel_check = cancel_check
+        self._physical_entries = _physical_cache_entries(cache)
+        _require_fresh_physical_cache(self._physical_entries, sparse_state.row_count)
+        self._snapshot = _snapshot_cache(cache)
+        self._hooks = TargetPositionHooks.for_model(model, adapter)
+        self._lane = _target_lane_for(model)
+        self._processed = 0
+        self._starts: list[tuple[int, ...]] = []
+        self._logits: mx.array | None = None
+        self._result: SparseTargetPrefillResult | None = None
+        self._target_prefill_seconds = 0.0
+        self._phase = SparseTargetPrefillPhase.ACTIVE
+
+    @property
+    def phase(self) -> SparseTargetPrefillPhase:
+        """Read-only lifecycle state; only executor transitions may change it."""
+        return self._phase
+
+    @property
+    def complete(self) -> bool:
+        return self.phase is SparseTargetPrefillPhase.COMPLETE
+
+    @property
+    def closed(self) -> bool:
+        return self.phase is SparseTargetPrefillPhase.CLOSED
+
+    @property
+    def result(self) -> SparseTargetPrefillResult:
+        """Return terminal metadata only after every chunk has committed."""
+        if self._result is None:
+            raise SparseTargetPrefillError(
+                "sparse target prefill has no publishable result before completion"
+            )
+        return self._result
+
+    def step(self) -> SparseTargetPrefillProgress:
+        """Run one target chunk quantum, then release hook context and lane."""
+        if self.closed:
+            raise SparseTargetPrefillError("sparse target prefill session is closed")
+        if self.complete:
+            return self._progress()
+        if not self._lane.acquire(blocking=False):
+            raise SparseTargetPrefillLaneBusy(
+                "sparse target prefill target lane is busy"
+            )
+        try:
+            self._check_cancelled()
+            chunk_size = min(self._step_size, self._total - self._processed)
+            physical_start = _physical_cache_lengths(
+                self._physical_entries, self.sparse_state.row_count
+            )
+            expected_start = (self._processed,) * self.sparse_state.row_count
+            if physical_start != expected_start:
+                raise SparseTargetPrefillError(
+                    "target cache physical length disagrees with committed sparse "
+                    "target chunk boundary"
+                )
+            self._starts.append(physical_start)
+            plan = _chunk_plan(
+                self.adapter,
+                self.sparse_state,
+                self._processed,
+                chunk_size,
+                physical_start,
+            )
+            forward_started_at = time.perf_counter()
+            with self._hooks.session_for_plan(plan):
+                self._logits = self.model(
+                    self._token_rows[:, self._processed : self._processed + chunk_size],
+                    cache=self.cache,
+                )
+                _eval_forward(self._logits, self.cache)
+            self._target_prefill_seconds += time.perf_counter() - forward_started_at
+            self._processed += chunk_size
+            actual_end = _physical_cache_lengths(
+                self._physical_entries, self.sparse_state.row_count
+            )
+            expected_end = (self._processed,) * self.sparse_state.row_count
+            if actual_end != expected_end:
+                raise SparseTargetPrefillError(
+                    "target cache did not advance by the bounded sparse target chunk"
+                )
+            if self._processed == self._total:
+                self._publish_result()
+            return self._progress()
+        except BaseException:
+            self.cancel()
+            raise
+        finally:
+            self._lane.release()
+
+    def run_to_completion(self) -> SparseTargetPrefillResult:
+        """Compatibility facade for the former monolithic executor."""
+        while not self.complete:
+            self.step()
+        return self.result
+
+    def cancel(self) -> None:
+        """Restore the entry cache snapshot and discard this request's state."""
+        if self.closed or self.complete:
+            return
+        _restore_cache(self.cache, self._snapshot)
+        self._logits = None
+        self._phase = SparseTargetPrefillPhase.CLOSED
+
+    @property
+    def _total(self) -> int:
+        return self._token_rows.shape[1]
+
+    def _check_cancelled(self) -> None:
+        if self._cancel_check is not None:
+            self._cancel_check()
+
+    def _publish_result(self) -> None:
+        if self._logits is None:  # pragma: no cover - step always sets logits.
+            raise SparseTargetPrefillError("sparse target prefill produced no logits")
+        self._result = SparseTargetPrefillResult(
+            logits=self._logits,
+            cache_state=self.sparse_state.clone(),
+            telemetry=SparseTargetPrefillTelemetry(
+                selected_tokens=self._total,
+                target_prefill_ms=self._target_prefill_seconds * 1000.0,
+                chunk_count=len(self._starts),
+                physical_cache_starts=tuple(self._starts),
+            ),
+        )
+        self._phase = SparseTargetPrefillPhase.COMPLETE
+
+    def _progress(self) -> SparseTargetPrefillProgress:
+        return SparseTargetPrefillProgress(
+            selected_tokens_processed=self._processed,
+            chunk_count=len(self._starts),
+            complete=self.complete,
+        )
 
 
 def execute_sparse_target_prefill(
@@ -85,66 +308,15 @@ def execute_sparse_target_prefill(
     disagreement the entry cache checkpoint is restored before the exception
     is raised.  The immutable ``sparse_state`` is returned only on success.
     """
-    _validate_execution_inputs(cache, sparse_state, adapter, step_size)
-    token_rows = _normalize_selected_tokens(selected_tokens, sparse_state)
-    physical_entries = _physical_cache_entries(cache)
-    _require_fresh_physical_cache(physical_entries, sparse_state.row_count)
-    snapshot = _snapshot_cache(cache)
-    hooks = TargetPositionHooks.for_model(model, adapter)
-    starts: list[tuple[int, ...]] = []
-    logits: mx.array | None = None
-    started_at = time.perf_counter()
-    processed = 0
-    total = token_rows.shape[1]
-
-    try:
-        while processed < total:
-            if cancel_check is not None:
-                cancel_check()
-            chunk_size = min(step_size, total - processed)
-            physical_start = _physical_cache_lengths(
-                physical_entries, sparse_state.row_count
-            )
-            expected_start = (processed,) * sparse_state.row_count
-            if physical_start != expected_start:
-                raise SparseTargetPrefillError(
-                    "target cache physical length disagrees with committed sparse "
-                    "target chunk boundary"
-                )
-            starts.append(physical_start)
-            plan = _chunk_plan(
-                adapter, sparse_state, processed, chunk_size, physical_start
-            )
-            with hooks.session_for_plan(plan):
-                logits = model(
-                    token_rows[:, processed : processed + chunk_size], cache=cache
-                )
-                _eval_forward(logits, cache)
-            processed += chunk_size
-            actual_end = _physical_cache_lengths(
-                physical_entries, sparse_state.row_count
-            )
-            expected_end = (processed,) * sparse_state.row_count
-            if actual_end != expected_end:
-                raise SparseTargetPrefillError(
-                    "target cache did not advance by the bounded sparse target chunk"
-                )
-        if logits is None:  # validation makes this unreachable; keep fail-closed.
-            raise SparseTargetPrefillError("sparse target prefill produced no logits")
-    except BaseException:
-        _restore_cache(cache, snapshot)
-        raise
-
-    return SparseTargetPrefillResult(
-        logits=logits,
-        cache_state=sparse_state.clone(),
-        telemetry=SparseTargetPrefillTelemetry(
-            selected_tokens=total,
-            target_prefill_ms=(time.perf_counter() - started_at) * 1000.0,
-            chunk_count=len(starts),
-            physical_cache_starts=tuple(starts),
-        ),
-    )
+    return SparseTargetPrefillSession(
+        model,
+        selected_tokens,
+        cache,
+        sparse_state,
+        adapter,
+        step_size=step_size,
+        cancel_check=cancel_check,
+    ).run_to_completion()
 
 
 def _chunk_plan(
@@ -199,6 +371,10 @@ def _normalize_selected_tokens(
     if tokens.ndim != 2:
         raise SparseTargetPrefillError(
             "selected target tokens must have shape (batch, selected_tokens)"
+        )
+    if tokens.shape[1] == 0:
+        raise SparseTargetPrefillError(
+            "sparse target prefill requires at least one selected token"
         )
     expected = (sparse_state.row_count, sparse_state.rows[0].physical_valid_length)
     if tokens.shape != expected:

--- a/vllm_mlx/specprefill_target_executor.py
+++ b/vllm_mlx/specprefill_target_executor.py
@@ -185,6 +185,15 @@ class SparseTargetPrefillSession:
             )
         return self._result
 
+    @property
+    def adoption_cache(self) -> Sequence[Any]:
+        """Return the exact executor-owned cache only after completion."""
+        if not self.complete or self._result is None:
+            raise SparseTargetPrefillError(
+                "sparse target cache is unavailable before publishable completion"
+            )
+        return self.cache
+
     def step(self) -> SparseTargetPrefillProgress:
         """Run one target chunk quantum, then release hook context and lane."""
         if self.closed:

--- a/vllm_mlx/specprefill_target_hooks.py
+++ b/vllm_mlx/specprefill_target_hooks.py
@@ -53,7 +53,13 @@ class TargetPositionSession:
     logical_positions: tuple[tuple[int, ...], ...]
     physical_starts: tuple[int, ...]
     phase: PositionPhase
+    logical_position_ack: Any | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
     position_tensor: mx.array = field(init=False, repr=False, compare=False, hash=False)
+    _position_acknowledged: list[bool] = field(
+        default_factory=lambda: [False], repr=False, compare=False, hash=False
+    )
 
     def __post_init__(self) -> None:
         if not self.logical_positions:
@@ -114,7 +120,9 @@ class TargetPositionSession:
         return len(self.logical_positions[0])
 
     @classmethod
-    def from_plan(cls, plan: TargetPositionPlan) -> "TargetPositionSession":
+    def from_plan(
+        cls, plan: TargetPositionPlan, *, logical_position_ack: Any | None = None
+    ) -> "TargetPositionSession":
         """Build an execution session from the cache-local position contract.
 
         The caller intentionally does not invoke ``plan.require_executable()``:
@@ -126,6 +134,7 @@ class TargetPositionSession:
             logical_positions=plan.logical_positions,
             physical_starts=plan.physical_cache_lengths,
             phase=plan.phase,
+            logical_position_ack=logical_position_ack,
         )
 
     def positions_for_forward(self, sequence_length: int) -> mx.array:
@@ -136,6 +145,22 @@ class TargetPositionSession:
                 "session for the next sparse-prefill chunk"
             )
         return self.position_tensor
+
+    def acknowledge_forward_positions(self) -> None:
+        """Acknowledge once, from the first RoPE call inside the model call."""
+        if self.logical_position_ack is None or self._position_acknowledged[0]:
+            return
+        if self.batch_size != 1:
+            raise TargetPositionHookError(
+                "logical-position acknowledgement is supported only for B=1"
+            )
+        acknowledge = getattr(self.logical_position_ack, "acknowledge", None)
+        if not callable(acknowledge):
+            raise TargetPositionHookError(
+                "logical-position acknowledgement consumer is invalid"
+            )
+        acknowledge(self.logical_positions[0])
+        self._position_acknowledged[0] = True
 
 
 @dataclass(frozen=True)
@@ -259,6 +284,7 @@ def _install_rope_dispatch(
                     )
                 offset = kwargs.get("offset", args[1] if len(args) > 1 else 0)
                 _validate_scalar_offset(offset, session)
+                session.acknowledge_forward_positions()
                 if session.batch_size == 1 and session.logical_positions[0] == tuple(
                     range(
                         session.physical_starts[0],
@@ -424,10 +450,17 @@ class TargetPositionHooks:
 
     @contextmanager
     def session_for_plan(
-        self, plan: TargetPositionPlan
+        self,
+        plan: TargetPositionPlan,
+        *,
+        logical_position_ack: Any | None = None,
     ) -> Iterator[TargetPositionSession]:
         """Activate a cache-local plan for the caller's entire model forward."""
-        with self.session(TargetPositionSession.from_plan(plan)) as session:
+        with self.session(
+            TargetPositionSession.from_plan(
+                plan, logical_position_ack=logical_position_ack
+            )
+        ) as session:
             yield session
 
 
@@ -441,11 +474,24 @@ def _target_attention_layers(model: Any) -> list[tuple[int, Any]]:
         layers = getattr(getattr(model, "model", None), "layers", None)
     if layers is None:
         raise TargetPositionHookError("target model does not expose decoder layers")
-    return [
+    attention_layers = [
         (index, layer.self_attn)
         for index, layer in enumerate(layers)
         if getattr(layer, "self_attn", None) is not None
     ]
+    capability = getattr(model, "mtp_capability", None)
+    if capability is not None and getattr(capability, "supported", False):
+        mtp = getattr(model, "mtp", None)
+        if mtp is None:
+            mtp = getattr(getattr(model, "language_model", None), "mtp", None)
+        mtp_layers = getattr(mtp, "layers", ())
+        next_index = len(attention_layers)
+        attention_layers.extend(
+            (next_index + index, layer.self_attn)
+            for index, layer in enumerate(mtp_layers)
+            if getattr(layer, "self_attn", None) is not None
+        )
+    return attention_layers
 
 
 def _validate_scalar_offset(offset: Any, session: TargetPositionSession) -> None:

--- a/vllm_mlx/specprefill_target_hooks.py
+++ b/vllm_mlx/specprefill_target_hooks.py
@@ -259,6 +259,17 @@ def _install_rope_dispatch(
                     )
                 offset = kwargs.get("offset", args[1] if len(args) > 1 else 0)
                 _validate_scalar_offset(offset, session)
+                if session.batch_size == 1 and session.logical_positions[0] == tuple(
+                    range(
+                        session.physical_starts[0],
+                        session.physical_starts[0] + session.token_count,
+                    )
+                ):
+                    # Keep-ratio-one and any other dense-equivalent quantum
+                    # must use the model's native fused RoPE implementation.
+                    # Besides avoiding redundant position tensors/elementwise
+                    # work, this preserves BF16 rounding through deep stacks.
+                    return original_call(self, *args, **kwargs)
                 return _apply_request_positions(
                     x,
                     session.positions_for_forward(x.shape[2]),

--- a/vllm_mlx/specprefill_target_hooks.py
+++ b/vllm_mlx/specprefill_target_hooks.py
@@ -1,0 +1,575 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Install-once, request-local target RoPE transport for SpecPrefill.
+
+The old SpecPrefill executor temporarily replaced every target attention
+module's ``rope`` object, then left a different wrapper installed for decode.
+That makes a target model's positional semantics depend on whichever request
+last entered prefill.  This module makes the one allowed model mutation at
+installation time: each eligible RoPE class receives a stable dispatcher keyed
+by its original instance. Every call thereafter is governed by a
+:class:`contextvars.ContextVar` session owned by the request that is currently
+forwarding the model.
+
+The wrapper never writes cache offsets.  Cache offsets remain physical KV
+coordinates for cache allocation and attention masks; the session supplies the
+independent logical RoPE coordinates.  No active session means an exact
+delegation to the original RoPE module.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import threading
+import weakref
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+import mlx.core as mx
+
+from .specprefill_positions import (
+    PositionPhase,
+    TargetPositionAdapter,
+    TargetPositionError,
+    TargetPositionPlan,
+)
+
+
+class TargetPositionHookError(TargetPositionError):
+    """Target position wrappers are missing, unsafe, or used inconsistently."""
+
+
+@dataclass(frozen=True)
+class TargetPositionSession:
+    """Immutable logical/physical coordinates for one target forward phase.
+
+    ``logical_positions`` are per-row coordinates for one bounded target
+    forward quantum. ``physical_starts`` are the corresponding physical cache
+    lengths before its first token in each row. The scheduler validates those
+    host values while constructing the request/cache-local plan; each RoPE
+    layer then reuses precomputed positions without reading device metadata.
+    """
+
+    logical_positions: tuple[tuple[int, ...], ...]
+    physical_starts: tuple[int, ...]
+    phase: PositionPhase
+    position_tensor: mx.array = field(init=False, repr=False, compare=False, hash=False)
+
+    def __post_init__(self) -> None:
+        if not self.logical_positions:
+            raise TargetPositionHookError(
+                "target-position session needs at least one row"
+            )
+        if len(self.logical_positions) != len(self.physical_starts):
+            raise TargetPositionHookError(
+                "target-position logical rows and physical starts must match"
+            )
+        token_count: int | None = None
+        for positions, start in zip(
+            self.logical_positions, self.physical_starts, strict=True
+        ):
+            if not positions:
+                raise TargetPositionHookError(
+                    "target-position rows must include at least one position"
+                )
+            if isinstance(start, bool) or not isinstance(start, int) or start < 0:
+                raise TargetPositionHookError(
+                    "target-position physical starts must be non-negative integers"
+                )
+            previous = -1
+            for position in positions:
+                if (
+                    isinstance(position, bool)
+                    or not isinstance(position, int)
+                    or position < 0
+                ):
+                    raise TargetPositionHookError(
+                        "target logical positions must be non-negative integers"
+                    )
+                if position <= previous:
+                    raise TargetPositionHookError(
+                        "target logical positions must be strictly increasing"
+                    )
+                previous = position
+            if token_count is None:
+                token_count = len(positions)
+            elif len(positions) != token_count:
+                raise TargetPositionHookError(
+                    "target-position sessions require equal row token counts; "
+                    "scheduler must split unequal rows into separate lanes"
+                )
+        # Materialize once per bounded target-forward quantum. Every installed
+        # RoPE layer reuses this device tensor; do not recreate host positions
+        # or synchronize cache metadata in a per-layer dispatcher.
+        position_tensor = mx.array(self.logical_positions, dtype=mx.float32)
+        mx.eval(position_tensor)
+        object.__setattr__(self, "position_tensor", position_tensor)
+
+    @property
+    def batch_size(self) -> int:
+        return len(self.logical_positions)
+
+    @property
+    def token_count(self) -> int:
+        return len(self.logical_positions[0])
+
+    @classmethod
+    def from_plan(cls, plan: TargetPositionPlan) -> "TargetPositionSession":
+        """Build an execution session from the cache-local position contract.
+
+        The caller intentionally does not invoke ``plan.require_executable()``:
+        that method describes pre-hook native target capability.  This hook is
+        the separately tested transport that makes scalar-offset Qwen and Gemma
+        sparse positions executable without mutating their cache metadata.
+        """
+        return cls(
+            logical_positions=plan.logical_positions,
+            physical_starts=plan.physical_cache_lengths,
+            phase=plan.phase,
+        )
+
+    def positions_for_forward(self, sequence_length: int) -> mx.array:
+        """Return precomputed ``(batch, sequence)`` coordinates for this quantum."""
+        if sequence_length != self.token_count:
+            raise TargetPositionHookError(
+                "target-position session covers one forward quantum; create a new "
+                "session for the next sparse-prefill chunk"
+            )
+        return self.position_tensor
+
+
+@dataclass(frozen=True)
+class _RoPEExecutionMetadata:
+    """Immutable, device-ready RoPE data reused by every target layer call."""
+
+    dims: int
+    traditional: bool
+    pre_scale: float
+    inverse_frequencies: mx.array
+
+
+@dataclass(frozen=True)
+class _InstalledRope:
+    """One original RoPE object registered with its hook-owning target model."""
+
+    hooks_ref: weakref.ReferenceType["TargetPositionHooks"]
+    layer_index: int
+    metadata: _RoPEExecutionMetadata
+
+
+@dataclass(frozen=True)
+class _RoPEClassDispatch:
+    """Original and installed class callables for topology/tamper verification."""
+
+    original_call: Any
+    dispatcher: Any
+
+
+class _IdentityWeakRegistry:
+    """Weak registry for MLX modules, which are intentionally unhashable."""
+
+    def __init__(self) -> None:
+        self._entries: dict[int, tuple[weakref.ReferenceType[Any], Any]] = {}
+        self._lock = threading.RLock()
+
+    def get(self, value: Any) -> Any | None:
+        with self._lock:
+            key = id(value)
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            reference, stored = entry
+            if reference() is value:
+                return stored
+            self._entries.pop(key, None)
+            return None
+
+    def set(self, value: Any, stored: Any) -> None:
+        with self._lock:
+            key = id(value)
+
+            def _cleanup(reference: weakref.ReferenceType[Any]) -> None:
+                with self._lock:
+                    entry = self._entries.get(key)
+                    if entry is not None and entry[0] is reference:
+                        self._entries.pop(key, None)
+
+            try:
+                reference = weakref.ref(value, _cleanup)
+            except TypeError as exc:
+                raise TargetPositionHookError(
+                    "target position registry objects must support weak references"
+                ) from exc
+            self._entries[key] = (reference, stored)
+
+    def pop(self, value: Any) -> None:
+        with self._lock:
+            key = id(value)
+            entry = self._entries.get(key)
+            if entry is not None and entry[0]() is value:
+                self._entries.pop(key, None)
+
+
+_ROPE_DISPATCH_LOCK = threading.RLock()
+_ROPE_DISPATCHED_CLASSES: dict[type, _RoPEClassDispatch] = {}
+_ROPE_HOOKS = _IdentityWeakRegistry()
+
+
+def _install_rope_dispatch(
+    rope: Any, hooks: "TargetPositionHooks", layer_index: int
+) -> None:
+    """Install one class dispatcher without replacing the rope child module.
+
+    Assigning a plain proxy to ``attention.rope`` makes MLX remove the original
+    child module and its state subtree.  Instead the original instance stays
+    installed and its class receives one stable dispatcher.  A weak instance
+    registry selects request-local behaviour only for the target model's RoPE
+    objects; every other instance delegates to the original implementation.
+    """
+    # Capture the complete device-ready execution contract before changing the
+    # class.  If introspection fails, this instance and every class topology
+    # remain untouched.  Dispatch never re-reads mutable module attributes.
+    metadata = _rope_execution_metadata(rope)
+    rope_type = type(rope)
+    with _ROPE_DISPATCH_LOCK:
+        class_dispatch = _ROPE_DISPATCHED_CLASSES.get(rope_type)
+        if class_dispatch is None:
+            original_call = rope_type.__call__
+
+            def _dispatch(self, *args, **kwargs):
+                with _ROPE_DISPATCH_LOCK:
+                    installed = _ROPE_HOOKS.get(self)
+                if installed is None:
+                    return original_call(self, *args, **kwargs)
+                owner = installed.hooks_ref()
+                if owner is None:
+                    with _ROPE_DISPATCH_LOCK:
+                        _ROPE_HOOKS.pop(self)
+                    return original_call(self, *args, **kwargs)
+                session = owner._active_session.get()
+                if session is None:
+                    return original_call(self, *args, **kwargs)
+                if not args:
+                    x = kwargs.get("x")
+                else:
+                    x = args[0]
+                if x is None:
+                    raise TargetPositionHookError(
+                        "target RoPE call is missing its input"
+                    )
+                offset = kwargs.get("offset", args[1] if len(args) > 1 else 0)
+                _validate_scalar_offset(offset, session)
+                return _apply_request_positions(
+                    x,
+                    session.positions_for_forward(x.shape[2]),
+                    installed.metadata,
+                )
+
+            try:
+                rope_type.__call__ = _dispatch
+            except (AttributeError, TypeError) as exc:
+                raise TargetPositionHookError(
+                    f"cannot install a stable dispatcher for RoPE class {rope_type}"
+                ) from exc
+            class_dispatch = _RoPEClassDispatch(original_call, _dispatch)
+            _ROPE_DISPATCHED_CLASSES[rope_type] = class_dispatch
+        elif rope_type.__call__ is not class_dispatch.dispatcher:
+            raise TargetPositionHookError("target RoPE class dispatcher was modified")
+        existing = _ROPE_HOOKS.get(rope)
+        if existing is not None and existing.hooks_ref() is not hooks:
+            raise TargetPositionHookError("target RoPE instance is already registered")
+        _ROPE_HOOKS.set(
+            rope,
+            _InstalledRope(
+                weakref.ref(hooks),
+                layer_index,
+                metadata,
+            ),
+        )
+
+
+def _uninstall_rope_dispatch(rope: Any, hooks: "TargetPositionHooks") -> None:
+    """Rollback a failed multi-layer installation without touching child topology."""
+    with _ROPE_DISPATCH_LOCK:
+        installed = _ROPE_HOOKS.get(rope)
+        if installed is not None and installed.hooks_ref() is hooks:
+            _ROPE_HOOKS.pop(rope)
+
+
+class TargetPositionHooks:
+    """Install-once target RoPE dispatch with concurrent request-local sessions."""
+
+    def __init__(self, model: Any, adapter: TargetPositionAdapter):
+        self._model_ref = weakref.ref(model)
+        self.adapter = adapter
+        self._active_session: contextvars.ContextVar[TargetPositionSession | None] = (
+            contextvars.ContextVar(
+                f"specprefill_target_positions_{id(self)}", default=None
+            )
+        )
+
+        layers = _target_attention_layers(model)
+        if not layers:
+            raise TargetPositionHookError(
+                "target model has no rope-bearing attention layers"
+            )
+        originals: list[tuple[int, Any, Any]] = []
+        for layer_index, attention in layers:
+            rope = getattr(attention, "rope", None)
+            if rope is None:
+                continue
+            originals.append((layer_index, attention, rope))
+        if not originals:
+            raise TargetPositionHookError(
+                "target model does not expose patchable `.rope` modules; "
+                "use its explicit family position API instead"
+            )
+
+        installed: list[tuple[int, Any, Any]] = []
+        try:
+            for layer_index, attention, rope in originals:
+                _install_rope_dispatch(rope, self, layer_index)
+                installed.append((layer_index, attention, rope))
+        except Exception:
+            for _layer_index, _attention, rope in reversed(installed):
+                _uninstall_rope_dispatch(rope, self)
+            raise
+        self._wrappers = tuple(installed)
+
+    @classmethod
+    def for_model(
+        cls, model: Any, adapter: TargetPositionAdapter
+    ) -> "TargetPositionHooks":
+        """Return the sole hook set for ``model`` and verify stable topology."""
+        with _TARGET_HOOK_REGISTRY_LOCK:
+            try:
+                hooks = _TARGET_HOOK_REGISTRY.get(model)
+            except TypeError as exc:
+                raise TargetPositionHookError(
+                    "target models must support weak references for position hooks"
+                ) from exc
+            if hooks is None:
+                hooks = cls(model, adapter)
+                _TARGET_HOOK_REGISTRY.set(model, hooks)
+            elif hooks.adapter != adapter:
+                raise TargetPositionHookError(
+                    "target model already has hooks for a different position adapter"
+                )
+            hooks._verify_installed()
+            return hooks
+
+    @property
+    def active_session(self) -> TargetPositionSession | None:
+        return self._active_session.get()
+
+    def _verify_installed(self) -> None:
+        model = self._model_ref()
+        if model is None:
+            raise TargetPositionHookError("target model is no longer available")
+        for layer_index, attention, rope in self._wrappers:
+            del layer_index
+            if getattr(attention, "rope", None) is not rope:
+                raise TargetPositionHookError(
+                    "target RoPE wrapper topology was modified"
+                )
+            with _ROPE_DISPATCH_LOCK:
+                installed = _ROPE_HOOKS.get(rope)
+                class_dispatch = _ROPE_DISPATCHED_CLASSES.get(type(rope))
+            if installed is None or installed.hooks_ref() is not self:
+                raise TargetPositionHookError(
+                    "target RoPE dispatcher registration was modified"
+                )
+            if (
+                class_dispatch is None
+                or type(rope).__call__ is not class_dispatch.dispatcher
+            ):
+                raise TargetPositionHookError(
+                    "target RoPE class dispatcher was modified"
+                )
+
+    @contextmanager
+    def session(
+        self, session: TargetPositionSession
+    ) -> Iterator[TargetPositionSession]:
+        """Activate one request's positions for its complete target forward/eval.
+
+        Sessions are context-local, so concurrent scheduler tasks can use the
+        same installed model without one request's logical coordinates leaking
+        into another.  Nested activation in the same context is rejected: a
+        target forward has exactly one authoritative logical-position source.
+        """
+        if not isinstance(session, TargetPositionSession):
+            raise TargetPositionHookError("target hooks require TargetPositionSession")
+        self._verify_installed()
+        if self._active_session.get() is not None:
+            raise TargetPositionHookError(
+                "target context already has an active session"
+            )
+        token = self._active_session.set(session)
+        try:
+            yield session
+        finally:
+            self._active_session.reset(token)
+
+    @contextmanager
+    def session_for_plan(
+        self, plan: TargetPositionPlan
+    ) -> Iterator[TargetPositionSession]:
+        """Activate a cache-local plan for the caller's entire model forward."""
+        with self.session(TargetPositionSession.from_plan(plan)) as session:
+            yield session
+
+
+_TARGET_HOOK_REGISTRY = _IdentityWeakRegistry()
+_TARGET_HOOK_REGISTRY_LOCK = threading.RLock()
+
+
+def _target_attention_layers(model: Any) -> list[tuple[int, Any]]:
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        layers = getattr(getattr(model, "model", None), "layers", None)
+    if layers is None:
+        raise TargetPositionHookError("target model does not expose decoder layers")
+    return [
+        (index, layer.self_attn)
+        for index, layer in enumerate(layers)
+        if getattr(layer, "self_attn", None) is not None
+    ]
+
+
+def _validate_scalar_offset(offset: Any, session: TargetPositionSession) -> None:
+    """Validate scalar offsets without synchronizing batched cache metadata.
+
+    Batched caches may pass an MLX offset vector. The scheduler/cache-state
+    transition admitted its physical starts before this session was created;
+    the vector remains owned by the target's mask/cache code and cannot alter
+    this dispatcher’s precomputed logical coordinates. Therefore the per-layer
+    RoPE dispatcher must not call ``tolist``/``item``/``eval`` to rediscover it.
+    Scalar Python offsets remain useful single-row guards.
+    """
+    if isinstance(offset, bool):
+        raise TargetPositionHookError("target cache offset cannot be boolean")
+    if isinstance(offset, int):
+        if any(start != offset for start in session.physical_starts):
+            raise TargetPositionHookError(
+                "scalar target cache offset disagrees with request-local physical starts"
+            )
+    elif not isinstance(offset, mx.array):
+        raise TargetPositionHookError(
+            "target cache offset must be a Python int or an MLX array"
+        )
+
+
+def _apply_request_positions(
+    x: mx.array,
+    positions: mx.array,
+    metadata: _RoPEExecutionMetadata,
+) -> mx.array:
+    """Apply a native RoPE-equivalent rotation at per-row logical positions."""
+    if x.ndim != 4:
+        raise TargetPositionHookError(
+            "request-local target RoPE expects (batch, heads, sequence, dims)"
+        )
+    batch_size, _heads, sequence_length, head_dim = x.shape
+    if positions.ndim != 2 or positions.shape != (batch_size, sequence_length):
+        raise TargetPositionHookError(
+            "request-local target RoPE positions must have host shape (batch, sequence)"
+        )
+    dims = metadata.dims
+    if dims <= 0 or dims > head_dim or dims % 2:
+        raise TargetPositionHookError(
+            "target RoPE dimensions must be positive, even, and <= head size"
+        )
+
+    angles = (
+        positions[:, None, :, None] * metadata.inverse_frequencies[None, None, None, :]
+    )
+    cos_a = mx.cos(angles).astype(x.dtype)
+    sin_a = mx.sin(angles).astype(x.dtype)
+    x_rot, x_pass = x[..., :dims], x[..., dims:]
+    if metadata.pre_scale != 1.0:
+        x_rot = x_rot * metadata.pre_scale
+    if metadata.traditional:
+        paired = x_rot.reshape(*x_rot.shape[:-1], dims // 2, 2)
+        first, second = paired[..., 0], paired[..., 1]
+        rotated = mx.stack(
+            (first * cos_a - second * sin_a, first * sin_a + second * cos_a), axis=-1
+        ).reshape(*x_rot.shape)
+    else:
+        first, second = x_rot[..., : dims // 2], x_rot[..., dims // 2 :]
+        rotated = mx.concatenate(
+            (first * cos_a - second * sin_a, first * sin_a + second * cos_a), axis=-1
+        )
+    return mx.concatenate((rotated, x_pass), axis=-1)
+
+
+def _rope_execution_metadata(rope: Any) -> _RoPEExecutionMetadata:
+    """Capture/evaluate immutable RoPE settings once at hook installation."""
+    dims = _rope_dimensions(rope)
+    inverse_frequencies = _inverse_frequencies(rope, dims)
+    mx.eval(inverse_frequencies)
+    return _RoPEExecutionMetadata(
+        dims=dims,
+        traditional=_rope_traditional(rope),
+        pre_scale=_rope_pre_scale(rope),
+        inverse_frequencies=inverse_frequencies,
+    )
+
+
+def _rope_dimensions(rope: Any) -> int:
+    for name in ("dims", "_dims", "dim"):
+        value = getattr(rope, name, None)
+        if value is not None:
+            return int(value)
+    raise TargetPositionHookError(f"cannot determine RoPE dimensions from {type(rope)}")
+
+
+def _rope_traditional(rope: Any) -> bool:
+    for name in ("traditional", "_traditional"):
+        value = getattr(rope, name, None)
+        if value is not None:
+            return bool(value)
+    return False
+
+
+def _inverse_frequencies(rope: Any, dims: int) -> mx.array:
+    """Use model-provided scaled frequencies when available, else native params."""
+    freqs = getattr(rope, "_freqs", None)
+    if freqs is None:
+        freqs = getattr(rope, "freqs", None)
+    if freqs is not None:
+        freqs = mx.array(freqs).astype(mx.float32)
+        if freqs.size != dims // 2:
+            raise TargetPositionHookError(
+                "target RoPE frequency count does not match dims"
+            )
+        return 1.0 / freqs
+    base = getattr(rope, "base", getattr(rope, "_base", None))
+    if base is None:
+        raise TargetPositionHookError(
+            "target RoPE has no public frequencies or base for request-local positions"
+        )
+    scale = getattr(rope, "scale", 1.0)
+    if not isinstance(scale, (float, int)) or float(scale) <= 0:
+        raise TargetPositionHookError("target RoPE scale must be a positive scalar")
+    indices = mx.arange(0, dims, 2, dtype=mx.float32)
+    return 1.0 / (float(base) ** (indices / dims)) / float(scale)
+
+
+def _rope_pre_scale(rope: Any) -> float:
+    """Match MLX custom RoPE amplitude scaling for scaled-frequency variants."""
+    mscale = getattr(rope, "mscale", None)
+    if mscale is not None:
+        if not isinstance(mscale, (float, int)) or float(mscale) <= 0:
+            raise TargetPositionHookError(
+                "target RoPE mscale must be a positive scalar"
+            )
+        return float(mscale)
+    # MLX SuScaled/Yarn-style modules expose `_scale` alongside `dim`; plain
+    # nn.RoPE instead exposes public `scale` and must not be treated here.
+    scale = getattr(rope, "_scale", None)
+    if scale is not None and getattr(rope, "dim", None) is not None:
+        if not isinstance(scale, (float, int)) or float(scale) <= 0:
+            raise TargetPositionHookError("target RoPE pre-scale must be positive")
+        return float(scale)
+    return 1.0

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -43,9 +43,11 @@ def _import_qwen_model_classes(model_type: str):
 def _import_text_model_classes(model_type: str):
     """Compatibility helper retained for the separate Gemma extraction path."""
 
-    if model_type == "gemma4_text":
+    if _is_gemma_text_model_type(model_type):
         return _import_gemma_text_model_classes()
-    return _import_qwen_model_classes(model_type)
+    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+    return TextModel, TextModelArgs
 
 
 def _safetensors_shapes(shard_path: Path, keys: set[str]) -> dict[str, tuple[int, ...]]:
@@ -335,6 +337,8 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
                 capability.reason,
             )
         elif _is_gemma_text_model_type(model_type):
+            Model, _ = _import_gemma_text_model_classes()
+            text_model_cls = f"{Model.__module__}.{Model.__qualname__}"
             text_model = _build_gemma_text_model(vlm_lm, config, text_config)
         else:
             raise ValueError(

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -1,17 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Construct an mlx_lm TextModel from mlx_vlm-loaded model weights.
 
-When mlx_vlm loads a model, it strips MTP weights in sanitize().
-This module builds a parallel mlx_lm TextModel that:
+When mlx_vlm loads a model, it strips native Qwen MTP weights in sanitize().
+This module builds a parallel mlx_lm text model that:
 1. Shares backbone + lm_head weights with the vlm model (zero-copy)
-2. Loads MTP weights from safetensors on disk
-3. Provides full mlx_lm API: return_hidden, n_confirmed, mtp_forward, make_mtp_cache
+2. Loads the exact MTP subtree from safetensors on disk
+3. Uses mlx-lm's native sanitize/load capability handshake
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import struct
 from pathlib import Path
 from typing import Any
 
@@ -22,48 +23,287 @@ import mlx.utils
 logger = logging.getLogger(__name__)
 
 
-# Text-model classes keyed by config ``model_type`` *prefix*, longest first.
-# A family has to cover its variants: Gemma 4 reports ``gemma4_text`` on some
-# checkpoints and ``gemma4_unified_text`` on others, and an exact match on the
-# former silently sent the latter to the generic fallback below.
-_TEXT_MODEL_FAMILIES: tuple[tuple[str, str, tuple[str, str]], ...] = (
-    ("gemma4", "mlx_lm.models.gemma4_text", ("Model", "ModelArgs")),
-)
+def _import_gemma_text_model_classes():
+    from mlx_lm.models.gemma4_text import Model, ModelArgs
 
-# Fallback. qwen3_5.TextModel and TextModelArgs handle both dense and MoE
-# natively (MTPDecoderLayer auto-selects SparseMoeBlock when
-# args.num_experts > 0), which makes them a reasonable generic choice — but it
-# is a guess, and a wrong guess dies deep inside the constructor with an error
-# that names neither the model nor the class. Hence the logging either side.
-_DEFAULT_TEXT_MODEL = ("mlx_lm.models.qwen3_5", ("TextModel", "TextModelArgs"))
+    return Model, ModelArgs
+
+
+def _import_qwen_model_classes(model_type: str):
+    """Import the outer wrapper that owns Qwen's sanitize/load handshake."""
+
+    if "moe" in model_type:
+        from mlx_lm.models.qwen3_5_moe import Model, ModelArgs
+    else:
+        from mlx_lm.models.qwen3_5 import Model, ModelArgs
+
+    return Model, ModelArgs
 
 
 def _import_text_model_classes(model_type: str):
-    """Return ``(Model, ModelArgs)`` for a text config's ``model_type``."""
-    import importlib
+    """Compatibility helper retained for the separate Gemma extraction path."""
 
-    module_name, (model_attr, args_attr) = _DEFAULT_TEXT_MODEL
-    matched = False
-    for prefix, family_module, (family_model, family_args) in sorted(
-        _TEXT_MODEL_FAMILIES, key=lambda f: len(f[0]), reverse=True
-    ):
-        if model_type.startswith(prefix):
-            module_name, model_attr, args_attr = (
-                family_module,
-                family_model,
-                family_args,
+    if model_type == "gemma4_text":
+        return _import_gemma_text_model_classes()
+    return _import_qwen_model_classes(model_type)
+
+
+def _safetensors_shapes(
+    shard_path: Path, keys: set[str]
+) -> dict[str, tuple[int, ...]]:
+    """Read selected shapes from a safetensors header without loading arrays."""
+
+    with shard_path.open("rb") as shard:
+        header_size_bytes = shard.read(8)
+        if len(header_size_bytes) != 8:
+            raise ValueError(f"Invalid safetensors header: {shard_path.name}")
+        (header_size,) = struct.unpack("<Q", header_size_bytes)
+        # Headers are normally a few MiB. Bound corrupt lengths before reading.
+        if header_size <= 0 or header_size > 256 * 1024 * 1024:
+            raise ValueError(f"Invalid safetensors header size: {shard_path.name}")
+        header = json.loads(shard.read(header_size))
+
+    shapes: dict[str, tuple[int, ...]] = {}
+    for key in keys:
+        entry = header.get(key)
+        if not isinstance(entry, dict) or not isinstance(entry.get("shape"), list):
+            raise ValueError(
+                f"Safetensors index entry missing from shard header: {key}"
             )
-            matched = True
-            break
+        shapes[key] = tuple(int(dim) for dim in entry["shape"])
+    return shapes
 
-    if not matched:
-        logger.debug(
-            "No text-model family matches model_type=%r; falling back to %s",
-            model_type,
-            module_name,
+
+def _qwen_checkpoint_requires_norm_shift(model_path: Path) -> bool:
+    """Recover the official Qwen sanitizer convention from canonical headers.
+
+    mlx-vlm has already normalized the live backbone and removed the evidence
+    used by mlx-lm's sanitizer.  Inspecting raw checkpoint shapes restores that
+    evidence without loading or duplicating any backbone tensors.
+    """
+
+    index_file = model_path / "model.safetensors.index.json"
+    if not index_file.exists():
+        raise ValueError("Native Qwen extraction requires an indexed checkpoint")
+    index = json.loads(index_file.read_text())
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError("Invalid native Qwen safetensors index")
+
+    conv_entries = {
+        key: shard
+        for key, shard in weight_map.items()
+        if "conv1d.weight" in key and ".mtp." not in key
+    }
+    if not conv_entries:
+        raise ValueError(
+            "Native Qwen checkpoint sanitation convention cannot be proven"
         )
-    module = importlib.import_module(module_name)
-    return getattr(module, model_attr), getattr(module, args_attr)
+
+    by_shard: dict[str, set[str]] = {}
+    for key, shard in conv_entries.items():
+        if not isinstance(shard, str):
+            raise ValueError(f"Invalid safetensors shard for {key}")
+        by_shard.setdefault(shard, set()).add(key)
+
+    conventions: set[bool] = set()
+    for shard_name, keys in by_shard.items():
+        shard_path = model_path / shard_name
+        if not shard_path.exists():
+            raise FileNotFoundError(f"Native Qwen shard not found: {shard_name}")
+        for shape in _safetensors_shapes(shard_path, keys).values():
+            if len(shape) < 3:
+                raise ValueError("Invalid native Qwen conv1d checkpoint shape")
+            conventions.add(shape[-1] != 1)
+    if len(conventions) != 1:
+        raise ValueError("Mixed native Qwen conv1d checkpoint conventions")
+    return conventions.pop()
+
+
+def _sanitize_raw_qwen_mtp(
+    wrapper: Any,
+    raw_mtp_weights: dict[str, mx.array],
+    *,
+    shift_norm_weights: bool,
+) -> dict[str, mx.array]:
+    """Normalize raw MTP through the exact official outer-model sanitizer.
+
+    The live VLM backbone has already been sanitized.  A shape-only sentinel
+    recreates the raw backbone signal for this isolated MTP normalization pass;
+    it is discarded before the final one-shot identity handshake and strict
+    load.  This also applies the official dense/MoE layout normalization.
+    """
+
+    probe = dict(raw_mtp_weights)
+    sentinel_key = "model.language_model.layers.0.linear_attn.conv1d.weight"
+    if shift_norm_weights:
+        probe[sentinel_key] = mx.zeros((1, 1, 2), dtype=mx.float32)
+    sanitized = wrapper.sanitize(probe)
+    normalized = {
+        key: value
+        for key, value in sanitized.items()
+        if key.startswith("language_model.mtp.")
+    }
+    if not normalized and raw_mtp_weights:
+        raise ValueError("Native Qwen MTP sanitizer removed the configured subtree")
+    return normalized
+
+
+def _is_native_qwen_model_type(model_type: str) -> bool:
+    return model_type in {
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    }
+
+
+def _is_gemma_text_model_type(model_type: str) -> bool:
+    """Match the Gemma 4 text-model family, including unified variants."""
+
+    return model_type.startswith("gemma4")
+
+
+def _quantize_extracted_model(
+    model: Any,
+    *,
+    config: dict[str, Any],
+    text_config: dict[str, Any],
+    weight_names: set[str],
+) -> None:
+    """Mirror mlx-lm's per-leaf quantization decision before strict loading."""
+
+    quantization = text_config.get("quantization", config.get("quantization"))
+    if quantization is None:
+        return
+
+    per_layer_overrides = {
+        key: value for key, value in quantization.items() if isinstance(value, dict)
+    }
+
+    def _class_predicate(path, module):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if f"{path}.scales" not in weight_names:
+            return False
+        if path in quantization:
+            return quantization[path]
+        for key, override in per_layer_overrides.items():
+            if key.endswith("." + path) or path.endswith("." + key):
+                return override
+        return True
+
+    nn.quantize(
+        model,
+        group_size=quantization.get("group_size", 64),
+        bits=quantization.get("bits", 8),
+        mode=quantization.get("mode", "affine"),
+        class_predicate=_class_predicate,
+    )
+
+
+def _realize_model_arrays(model: Any) -> None:
+    """Realize parameters and private arrays before crossing MLX threads."""
+
+    if hasattr(model, "modules"):
+        mx.eval(
+            [
+                value
+                for module in model.modules()
+                for value in module.values()
+                if isinstance(value, mx.array)
+            ]
+        )
+
+
+def _build_qwen_text_model(
+    vlm_language_model: Any,
+    model_path: Path,
+    config: dict[str, Any],
+    text_config: dict[str, Any],
+) -> Any:
+    """Build Qwen through the official outer sanitize/load handshake.
+
+    The wrapper is temporary but essential: its sanitizer maps VLM checkpoint
+    namespaces to ``language_model.*`` and delegates the one-shot MTP key/array
+    identity handshake to the native TextModel.  Loading the backbone and head
+    separately, or loading a bare TextModel, can never activate the capability.
+    """
+
+    model_type = text_config.get("model_type", "")
+    Model, ModelArgs = _import_qwen_model_classes(model_type)
+    wrapper = Model(ModelArgs.from_dict(config))
+
+    raw_weights = {
+        f"language_model.{name}": value
+        for name, value in mlx.utils.tree_flatten(vlm_language_model.parameters())
+    }
+    raw_mtp_weights = _load_mtp_weights(model_path)
+    configured_layers = int(text_config.get("mtp_num_hidden_layers", 0) or 0)
+    if configured_layers and not raw_mtp_weights:
+        raise ValueError(
+            "Native Qwen MTP is configured but its indexed weight subtree is missing"
+        )
+    mtp_weights = raw_mtp_weights
+    if configured_layers:
+        mtp_weights = _sanitize_raw_qwen_mtp(
+            wrapper,
+            raw_mtp_weights,
+            shift_norm_weights=_qwen_checkpoint_requires_norm_shift(model_path),
+        )
+    duplicate_keys = raw_weights.keys() & mtp_weights.keys()
+    if duplicate_keys:
+        raise ValueError(
+            "Native Qwen extraction contains duplicate checkpoint keys: "
+            + ", ".join(sorted(duplicate_keys)[:3])
+        )
+    raw_weights.update(mtp_weights)
+
+    sanitized = wrapper.sanitize(raw_weights)
+    sanitized_items = list(sanitized.items())
+    _quantize_extracted_model(
+        wrapper,
+        config=config,
+        text_config=text_config,
+        weight_names=set(sanitized),
+    )
+    # One strict load is part of the capability contract.  The exact arrays
+    # returned by sanitize must reach this call; copying or separate partial
+    # loads invalidate the native one-shot handshake.
+    wrapper.load_weights(sanitized_items, strict=True)
+
+    text_model = wrapper.language_model
+    capability = getattr(text_model, "mtp_capability", None)
+    if configured_layers and not (
+        capability is not None and capability.supported is True
+    ):
+        reason = (
+            "native_mtp_capability_missing"
+            if capability is None
+            else capability.reason
+        )
+        raise ValueError(f"Native Qwen MTP load did not activate capability: {reason}")
+    return text_model
+
+
+def _build_gemma_text_model(
+    vlm_language_model: Any,
+    config: dict[str, Any],
+    text_config: dict[str, Any],
+) -> Any:
+    """Preserve the independent Gemma extraction behavior."""
+
+    TextModel, TextModelArgs = _import_gemma_text_model_classes()
+    text_model = TextModel(TextModelArgs.from_dict(text_config))
+    vlm_weights = mlx.utils.tree_flatten(vlm_language_model.parameters())
+    _quantize_extracted_model(
+        text_model,
+        config=config,
+        text_config=text_config,
+        weight_names={name for name, _ in vlm_weights},
+    )
+    text_model.load_weights(vlm_weights, strict=False)
+    return text_model
 
 
 def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
@@ -89,96 +329,23 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         config = json.loads((model_path / "config.json").read_text())
         text_config = config.get("text_config", config)
         model_type = text_config.get("model_type") or config.get("model_type", "")
-        TextModel, TextModelArgs = _import_text_model_classes(model_type)
-        text_model_cls = f"{TextModel.__module__}.{TextModel.__qualname__}"
-        logger.debug(
-            "Building TextModel for model_type=%r using %s", model_type, text_model_cls
-        )
-
-        # Build args with proper __post_init__ (handles partial_rotary_factor,
-        # rope_scaling, head_dim derivation)
-        args = TextModelArgs.from_dict(text_config)
-        text_model = TextModel(args)
-
-        # Collect all weights first: backbone from vlm + MTP from safetensors
         vlm_lm = vlm_model.language_model
-        vlm_weights = mlx.utils.tree_flatten(vlm_lm.parameters())
-        mtp_weights = _load_mtp_weights(model_path)
-
-        all_weight_names = set(name for name, _ in vlm_weights)
-        all_weight_names.update(name for name, _ in mtp_weights)
-
-        # Quantize the TextModel skeleton to match source weights.
-        # Use a predicate that only quantizes layers that have .scales in source.
-        # This prevents quantizing layers like mtp.fc which are BF16.
-        quantization = text_config.get("quantization", config.get("quantization", None))
-        if quantization is not None:
-            # Per-layer quantization overrides (e.g. 8-bit MoE gates over a 4-bit
-            # body) may be keyed with the source checkpoint's "language_model."
-            # wrapper prefix, which the extracted TextModel doesn't carry. Index
-            # them by suffix so the prefix-stripped module path resolves to the
-            # correct bits/group_size; without this the override is ignored and the
-            # layer is quantized at the global width, producing a quantized_matmul
-            # shape mismatch at decode.
-            per_layer_overrides = {
-                k: v for k, v in quantization.items() if isinstance(v, dict)
-            }
-
-            def _class_predicate(path, module):
-                if not hasattr(module, "to_quantized"):
-                    return False
-                if f"{path}.scales" not in all_weight_names:
-                    return False
-                if path in quantization:
-                    return quantization[path]
-                for key, override in per_layer_overrides.items():
-                    if key.endswith("." + path):
-                        return override
-                return True
-
-            nn.quantize(
-                text_model,
-                group_size=quantization.get("group_size", 64),
-                bits=quantization.get("bits", 8),
-                class_predicate=_class_predicate,
+        if _is_native_qwen_model_type(model_type):
+            text_model = _build_qwen_text_model(
+                vlm_lm, model_path, config, text_config
             )
-
-        # Transfer backbone + lm_head weights from vlm language_model (zero-copy).
-        # strict=False because TextModel has MTP params that vlm doesn't have yet.
-        text_model.load_weights(vlm_weights, strict=False)
-
-        logger.info(
-            "Transferred %d weight arrays from vlm language_model", len(vlm_weights)
-        )
-
-        # Load MTP weights from safetensors
-        if mtp_weights:
-            text_model.load_weights(mtp_weights, strict=False)
-            logger.info("Loaded %d MTP weights from safetensors", len(mtp_weights))
-        else:
-            logger.warning("No MTP weights found in %s", model_path.name)
-
-        # Inject MTP if TextModel doesn't have native MTP support.
-        # mlx_lm's qwen3_5.TextModel strips MTP weights in sanitize(),
-        # so we inject MTP module + methods at runtime.
-        if not hasattr(text_model, "mtp") or text_model.mtp is None:
-            num_mtp = text_config.get("mtp_num_hidden_layers", 0)
-            if num_mtp == 0:
-                num_mtp = text_config.get("num_nextn_predict_layers", 0)
-            if num_mtp > 0:
-                from .patches.qwen3_5_mtp import inject_mtp_support
-
-                inject_mtp_support(text_model, model_path, config)
-
-        if hasattr(text_model, "mtp") and text_model.mtp is not None:
-            mx.eval(text_model.mtp.parameters())
-            num_mtp = text_config.get(
-                "mtp_num_hidden_layers",
-                text_config.get("num_nextn_predict_layers", 0),
+            capability = text_model.mtp_capability
+            logger.info(
+                "Built native Qwen TextModel (MTP=%s, reason=%s)",
+                capability.supported,
+                capability.reason,
             )
-            logger.info("TextModel built with MTP support (%d layers)", num_mtp)
+        elif _is_gemma_text_model_type(model_type):
+            text_model = _build_gemma_text_model(vlm_lm, config, text_config)
         else:
-            logger.info("TextModel built without MTP")
+            raise ValueError(
+                f"Unsupported VLM text extraction model_type={model_type!r}"
+            )
 
         # Put the derived TextModel in eval mode. mlx_lm.load / mlx_vlm.load both
         # eval() their models (this is also what LM Studio's mlx-engine does), but
@@ -195,20 +362,12 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         # surviving into generation dies with "There is no Stream(gpu, N) in
         # current thread" the moment a worker on another thread evaluates it
         # (Gemma 4: the scaled-RoPE _freqs of the first full_attention layer).
-        if hasattr(text_model, "modules"):
-            mx.eval(
-                [
-                    v
-                    for module in text_model.modules()
-                    for v in module.values()
-                    if isinstance(v, mx.array)
-                ]
-            )
+        _realize_model_arrays(text_model)
 
         return text_model
 
     except ImportError as e:
-        logger.error("Cannot import mlx_lm TextModel (need PR #990): %s", e)
+        logger.error("Cannot import mlx_lm native text model support: %s", e)
         return None
     except Exception as e:
         # Name the model_type and the class that was picked. Without them this
@@ -225,48 +384,40 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         return None
 
 
-def _load_mtp_weights(model_path: Path) -> list[tuple[str, mx.array]]:
-    """Load MTP weights from safetensors, stripping the language_model. prefix.
-
-    mlx_vlm's sanitize() strips mtp.* keys during model loading,
-    but the weights are still on disk in the safetensors files.
-    """
+def _load_mtp_weights(model_path: Path) -> dict[str, mx.array]:
+    """Load exact indexed MTP entries without rewriting their namespaces."""
     index_file = model_path / "model.safetensors.index.json"
     if not index_file.exists():
-        return []
+        return {}
 
     index = json.loads(index_file.read_text())
     weight_map = index.get("weight_map", {})
 
     # Find MTP keys and their shard files
-    mtp_keys: dict[str, tuple[str, str]] = {}
+    mtp_keys: dict[str, str] = {}
     for key, shard in weight_map.items():
         if ".mtp." in key:
-            # Strip "language_model." prefix to match mlx_lm namespace
-            clean = (
-                key.replace("language_model.", "", 1)
-                if key.startswith("language_model.")
-                else key
-            )
-            mtp_keys[key] = (clean, shard)
+            mtp_keys[key] = shard
 
     if not mtp_keys:
-        return []
+        return {}
 
     # Group by shard to minimize I/O
-    shards: dict[str, list[tuple[str, str]]] = {}
-    for orig, (clean, shard) in mtp_keys.items():
-        shards.setdefault(shard, []).append((orig, clean))
+    shards: dict[str, list[str]] = {}
+    for key, shard in mtp_keys.items():
+        shards.setdefault(shard, []).append(key)
 
-    weights = []
-    for shard_file, key_pairs in shards.items():
+    weights = {}
+    for shard_file, keys in shards.items():
         shard_path = model_path / shard_file
         if not shard_path.exists():
-            logger.warning("MTP shard not found: %s", shard_file)
-            continue
+            raise FileNotFoundError(f"Native Qwen MTP shard not found: {shard_file}")
         shard_data = mx.load(str(shard_path))
-        for orig, clean in key_pairs:
-            if orig in shard_data:
-                weights.append((clean, shard_data[orig]))
+        for key in keys:
+            if key not in shard_data:
+                raise ValueError(
+                    f"Native Qwen MTP index entry missing from shard: {key}"
+                )
+            weights[key] = shard_data[key]
 
     return weights

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -48,9 +48,7 @@ def _import_text_model_classes(model_type: str):
     return _import_qwen_model_classes(model_type)
 
 
-def _safetensors_shapes(
-    shard_path: Path, keys: set[str]
-) -> dict[str, tuple[int, ...]]:
+def _safetensors_shapes(shard_path: Path, keys: set[str]) -> dict[str, tuple[int, ...]]:
     """Read selected shapes from a safetensors header without loading arrays."""
 
     with shard_path.open("rb") as shard:
@@ -278,9 +276,7 @@ def _build_qwen_text_model(
         capability is not None and capability.supported is True
     ):
         reason = (
-            "native_mtp_capability_missing"
-            if capability is None
-            else capability.reason
+            "native_mtp_capability_missing" if capability is None else capability.reason
         )
         raise ValueError(f"Native Qwen MTP load did not activate capability: {reason}")
     return text_model
@@ -331,9 +327,7 @@ def build_text_model(vlm_model: Any, model_path: str | Path) -> Any | None:
         model_type = text_config.get("model_type") or config.get("model_type", "")
         vlm_lm = vlm_model.language_model
         if _is_native_qwen_model_type(model_type):
-            text_model = _build_qwen_text_model(
-                vlm_lm, model_path, config, text_config
-            )
+            text_model = _build_qwen_text_model(vlm_lm, model_path, config, text_config)
             capability = text_model.mtp_capability
             logger.info(
                 "Built native Qwen TextModel (MTP=%s, reason=%s)",

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -154,30 +154,28 @@ def _load_strict_false(model_name: str, tokenizer_config: dict = None):
 
 
 def _try_inject_mtp(model, model_path, config):
-    """Inject MTP support if model has MTP config + weights."""
-    # Qwen3-Next: flat num_nextn_predict_layers
-    if config.get("num_nextn_predict_layers", 0) > 0:
-        # Detect Qwen3.5 vs Qwen3-Next by checking text_config or model_type
-        text_config = config.get("text_config", config)
-        model_type = text_config.get("model_type", config.get("model_type", ""))
-        if "qwen3_5" in model_type:
-            from ..patches.qwen3_5_mtp import inject_mtp_support
-        else:
-            from ..patches.qwen3_next_mtp import inject_mtp_support
-        inject_mtp_support(model, model_path, config)
-        return
+    """Retain legacy injection only for unrelated Qwen3-Next checkpoints.
 
-    # Qwen3.5: mtp_num_hidden_layers in text_config
+    Qwen3.5/3.6 native MTP is owned by mlx-lm's sanitize/load handshake.  A
+    post-load injector would create a mixed object whose head exists without a
+    verified native capability, so this helper deliberately does nothing for
+    that family.
+    """
+
     text_config = config.get("text_config", config)
-    num_mtp = text_config.get("mtp_num_hidden_layers", 0)
-    if num_mtp > 0:
-        from ..patches.qwen3_5_mtp import inject_mtp_support
+    model_type = text_config.get("model_type", config.get("model_type", ""))
+    if "qwen3_5" in model_type:
+        return
+    if "qwen3_next" not in model_type:
+        return
+    if config.get("num_nextn_predict_layers", 0) > 0:
+        from ..patches.qwen3_next_mtp import inject_mtp_support
 
         inject_mtp_support(model, model_path, config)
 
 
 def _try_inject_mtp_post_load(model, model_name):
-    """Check if MTP weights exist but were stripped by sanitize(), and inject."""
+    """Apply the legacy Qwen3-Next post-load injector only."""
     import json
 
     from mlx_lm.utils import _download
@@ -188,13 +186,17 @@ def _try_inject_mtp_post_load(model, model_name):
         return
     with open(config_path) as f:
         config = json.load(f)
+    text_config = config.get("text_config", config)
+    model_type = text_config.get("model_type", config.get("model_type", ""))
+    if "qwen3_5" in model_type:
+        return
+    if "qwen3_next" not in model_type:
+        return
+
     # Check for MTP in flat config and nested text_config
-    text_config = config.get("text_config", {})
     num_mtp = config.get("num_nextn_predict_layers", 0)
     if num_mtp == 0:
         num_mtp = text_config.get("num_nextn_predict_layers", 0)
-    if num_mtp == 0:
-        num_mtp = text_config.get("mtp_num_hidden_layers", 0)
     # Also check mtp attribute on language_model for VLM wrappers
     check_model = model
     if hasattr(model, "language_model"):


### PR DESCRIPTION
## Summary

Adds request-local SpecPrefill policy and execution, then composes it with native Qwen MTP for SimpleEngine and standard text continuous batching. The continuous-batching path consumes the public typed lifecycle proposed in ml-explore/mlx-lm#1724.

Refs #641.

## Why

Sparse target prefill and native MTP both mutate target-cache state. Combining them safely requires attested sparse receipts, explicit logical positions, atomic cache/RNG ownership transfer, and cohort-wide cancellation/error cleanup. The previous legacy MTP installers and generic BatchGenerator hooks cannot provide those guarantees.

## Main changes

- request-safe SpecPrefill policy, profiles, telemetry, and API metadata
- request-local sparse target-cache state and logical-position hooks
- cooperative scorer and target-prefill scheduling
- SimpleEngine sparse SpecPrefill and native-Qwen MTP composition
- request-local native-MTP contract and validated Qwen loader path
- public-lifecycle-only continuous-batching adapter
- attested SpecPrefill-to-MTP bridge with all-or-nothing cohort adoption
- scheduler round-robin bridge progression, cancellation, and exact terminal cleanup
- standard-text engine startup preparation and retry-safe ownership cleanup
- fail-closed gates for unsupported prefix/chunked/KVQ/max-KV, opaque processor, media, and MLLM combinations

## Validation

- final combined startup/scheduler/adapter/bridge/SimpleEngine preservation matrix: 141 passed
- focused bridge/adapter: 34 passed
- scheduler lifecycle: 35 passed
- engine startup/cleanup: 38 passed
- Simple/VLM native position ownership: 43 passed
- Runtime governance verification: 650 + 2 + 5 passed
- independent P0/P1 reviews cleared the cache ownership, admission atomicity, cancellation, and retry-cleanup boundaries

Tests use tiny synthetic dense and MoE Qwen configurations and independent B=1 oracles. No external checkpoint, service, or benchmark was run during final integration. This remains a draft until the mlx-lm dependency is reviewed and real-model performance/memory evidence is attached.

## Dependency

- ml-explore/mlx-lm#1724

## Preserved behavior

- ordinary dense BatchGenerator construction/insertion is unchanged
- native-MTP-only request behavior remains request-local
- existing Qwen3-Next legacy MTP path remains available
- MLLM combined native MTP + SpecPrefill remains explicitly unsupported