### PR TITLE
Add VLM-aware SpecPrefill to batched media routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
             tests/test_memory_cache.py \
             tests/test_prefix_cache.py \
             tests/test_mllm_cache.py \
+            tests/test_mllm_media_specprefill.py \
+            tests/test_batched_engine_mllm_config.py \
             tests/test_api_models.py \
             tests/test_api_utils.py \
             tests/test_request.py \

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -225,10 +225,22 @@ Optional:
 - `specprefill`
 - `specprefill_threshold`
 - `specprefill_keep_pct`
+- `specprefill_backbone_pct`
 - `specprefill_draft_model`
 - `stream_interval`
 - `gpu_memory_utilization`
 - `estimated_memory_gb`
+
+For continuous-batching multimodal routes, SpecPrefill is opt-in and currently
+supports exact Qwen3-VL and Qwen3.5 dense and MoE runtime modules. It preserves
+visual placeholders, fused media embeddings, deep-stack visual state, and
+request-local MRoPE positions. Media requests use fresh request-local caches:
+token-only prefix keys cannot identify the media or restore its MRoPE delta.
+Unsupported models, installed native MTP, request-enabled external assistants,
+interleaved chunked prefill, rotating caches, audio, and unavailable drafts use
+normal dense media prefill. When SpecPrefill is requested, the final OpenAI chat
+response reports the decision in `generation_metadata.specprefill_engaged` and
+`generation_metadata.specprefill_reason`.
 
 ## Sizing Rules
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -32,6 +32,7 @@ from vllm_mlx.api.models import (
     EmbeddingResponse,
     EmbeddingUsage,
     FunctionCall,
+    GenerationMetadata,
     ImageUrl,
     MCPExecuteRequest,
     MCPExecuteResponse,
@@ -669,6 +670,24 @@ class TestStreamingModels:
             usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
         )
         assert chunk.usage.total_tokens == 15
+
+    def test_chat_completion_chunk_with_specprefill_metadata(self):
+        chunk = ChatCompletionChunk(
+            model="test-model",
+            choices=[],
+            generation_metadata=GenerationMetadata(
+                specprefill_requested=True,
+                specprefill_engaged=True,
+                specprefill_reason="engaged",
+                specprefill_route="mllm_media",
+                specprefill_original_tokens=100,
+                specprefill_selected_tokens=40,
+            ),
+        )
+
+        data = chunk.model_dump()
+        assert data["generation_metadata"]["specprefill_engaged"] is True
+        assert data["generation_metadata"]["specprefill_selected_tokens"] == 40
 
 
 class TestModelSerialization:

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -5,10 +5,99 @@ SchedulerConfig fields survive the BatchedEngine -> MLLMSchedulerConfig bridge.
 """
 
 import asyncio
+import importlib.machinery
 import sys
 import types
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _install_mlx_stubs() -> bool:
+    """Make the configuration bridge importable on non-Apple CI runners."""
+    try:  # pragma: no cover - depends on the environment
+        import mlx.core  # noqa: F401
+
+        return False
+    except Exception:
+        pass
+
+    core = types.ModuleType("mlx.core")
+    core.__spec__ = importlib.machinery.ModuleSpec("mlx.core", loader=None)
+
+    class _Array:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _Stream:
+        def __init__(self, idx: int = 0) -> None:
+            self.idx = idx
+
+    core.array = _Array
+    core.Stream = _Stream
+    core.clear_cache = lambda: None
+    core.default_device = lambda: "gpu"
+    core.new_stream = lambda *args, **kwargs: _Stream()
+    core.set_default_stream = lambda *args, **kwargs: None
+    core.metal = SimpleNamespace(
+        is_available=lambda: False,
+        get_active_memory=lambda: 0,
+        get_peak_memory=lambda: 0,
+        get_cache_memory=lambda: 0,
+    )
+    mlx = types.ModuleType("mlx")
+    mlx.__spec__ = importlib.machinery.ModuleSpec("mlx", loader=None, is_package=True)
+    mlx.__path__ = []
+    mlx.core = core
+    sys.modules["mlx"] = mlx
+    sys.modules["mlx.core"] = core
+    return True
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _scoped_mlx_stubs():
+    """Keep non-Apple import stubs confined to this test module."""
+    missing = object()
+    prefixes = ("mlx", "vllm_mlx")
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    }
+    child_links = (
+        ("mlx", "core"),
+        ("vllm_mlx", "engine"),
+        ("vllm_mlx.engine", "batched"),
+    )
+    saved_child_attrs = {
+        (parent_name, child_name): getattr(
+            saved_modules.get(parent_name), child_name, missing
+        )
+        for parent_name, child_name in child_links
+    }
+    installed = _install_mlx_stubs()
+    yield
+    if not installed:
+        return
+
+    for name in list(sys.modules):
+        if (
+            any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+            and name not in saved_modules
+        ):
+            sys.modules.pop(name, None)
+    sys.modules.update(saved_modules)
+
+    for (parent_name, child_name), saved_attr in saved_child_attrs.items():
+        parent = saved_modules.get(parent_name)
+        if parent is None:
+            continue
+        if saved_attr is missing:
+            parent.__dict__.pop(child_name, None)
+        else:
+            setattr(parent, child_name, saved_attr)
 
 
 def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch):
@@ -31,8 +120,9 @@ def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch)
             self.__dict__.update(kwargs)
 
     class FakeMLLMScheduler:
-        def __init__(self, model, processor, config):
+        def __init__(self, model, processor, config, **kwargs):
             captured["scheduler_config"] = config
+            captured["scheduler_kwargs"] = kwargs
 
         async def start(self):
             return None
@@ -81,6 +171,7 @@ def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch)
     # SSD fields default to (None, 10.0) when absent from SchedulerConfig.
     assert captured["config_kwargs"]["ssd_cache_dir"] is None
     assert captured["config_kwargs"]["ssd_cache_max_gb"] == 10.0
+    assert captured["scheduler_kwargs"]["specprefill_draft_model"] is None
 
 
 def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
@@ -137,6 +228,7 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
     assert captured["model_kwargs"]["draft_kind"] == "mtp"
     assert captured["model_kwargs"]["draft_block_size"] == 6
     assert captured["scheduler_kwargs"] == {
+        "specprefill_draft_model": None,
         "draft_model": loaded_drafter,
         "draft_kind": "mtp",
         "draft_block_size": 6,
@@ -254,7 +346,7 @@ def test_idle_stats_report_configured_mllm_draft_default():
     }
 
 
-def _run_start_mllm(monkeypatch, scheduler_config):
+def _run_start_mllm(monkeypatch, scheduler_config, **engine_kwargs):
     """Run BatchedEngine._start_mllm with fakes, return captured kwargs."""
     from vllm_mlx.engine.batched import BatchedEngine
 
@@ -274,8 +366,8 @@ def _run_start_mllm(monkeypatch, scheduler_config):
             self.__dict__.update(kwargs)
 
     class FakeMLLMScheduler:
-        def __init__(self, model, processor, config):
-            pass
+        def __init__(self, model, processor, config, **kwargs):
+            captured["scheduler_kwargs"] = kwargs
 
         async def start(self):
             return None
@@ -297,6 +389,7 @@ def _run_start_mllm(monkeypatch, scheduler_config):
         model_name="fake-qwen",
         scheduler_config=scheduler_config,
         force_mllm=True,
+        **engine_kwargs,
     )
     asyncio.run(engine._start_mllm())
     return captured
@@ -331,3 +424,50 @@ def test_start_mllm_forwards_ssd_cache_fields(monkeypatch):
     )
     assert captured["config_kwargs"]["ssd_cache_dir"] == "/tmp/ssd-kv"
     assert captured["config_kwargs"]["ssd_cache_max_gb"] == 42.0
+
+
+def test_start_mllm_forwards_specprefill_configuration(monkeypatch):
+    captured = _run_start_mllm(
+        monkeypatch,
+        _base_scheduler_config(),
+        specprefill_enabled=True,
+        specprefill_threshold=4096,
+        specprefill_keep_pct=0.25,
+        specprefill_backbone_pct=0.1,
+    )
+
+    assert captured["config_kwargs"]["specprefill_enabled"] is True
+    assert captured["config_kwargs"]["specprefill_threshold"] == 4096
+    assert captured["config_kwargs"]["specprefill_keep_pct"] == 0.25
+    assert captured["config_kwargs"]["specprefill_backbone_pct"] == 0.1
+    assert captured["scheduler_kwargs"]["specprefill_draft_model"] is None
+
+
+def test_prepare_mllm_loads_specprefill_draft_after_target_is_prepared(monkeypatch):
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    import vllm_mlx.engine.batched as batched_mod
+
+    draft = object()
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_mlx_lm.load = lambda path: (draft, object())
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    fake_mllm_model = types.ModuleType("vllm_mlx.models.mllm")
+    fake_mllm_model.MLXMultimodalLM = object
+    monkeypatch.setitem(sys.modules, "vllm_mlx.models.mllm", fake_mllm_model)
+
+    engine = BatchedEngine(
+        model_name="fake-qwen",
+        force_mllm=True,
+        specprefill_enabled=True,
+        specprefill_draft_model="draft-model",
+    )
+    engine._model = object()
+    engine._processor = object()
+    monkeypatch.setattr(
+        batched_mod.BatchedEngine, "_inject_mtp_mllm", lambda self: None
+    )
+
+    engine._prepare_mllm_model()
+
+    assert engine._specprefill_draft_model is draft

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -357,6 +357,7 @@ class TestMLLMBatch:
             num_tokens=[0, 0, 0, 0],
             cache=[],
             requests=requests,
+            decode_rope_deltas=mx.array([[10], [20], [30], [40]]),
         )
 
         # Keep only indices 1 and 3
@@ -365,6 +366,7 @@ class TestMLLMBatch:
         assert len(batch) == 2
         assert batch.uids == [1, 3]
         assert batch.request_ids == ["req-1", "req-3"]
+        assert batch.decode_rope_deltas.tolist() == [[20], [40]]
 
     def test_batch_extend_handles_empty_protocol_caches_without_keys(self):
         """Caches with empty()/extend() but no .keys still need batch extension."""
@@ -393,6 +395,7 @@ class TestMLLMBatch:
             num_tokens=[0],
             cache=[primary_cache],
             requests=[MLLMBatchRequest(uid=1, request_id="req-1", prompt="one")],
+            decode_rope_deltas=mx.array([[7]]),
         )
         other = MLLMBatch(
             uids=[2],
@@ -408,8 +411,50 @@ class TestMLLMBatch:
         primary.extend(other)
 
         assert primary.y.shape == (2,)
+        assert primary.decode_rope_deltas.tolist() == [[7], [0]]
         assert primary_cache.extend_calls == 1
         assert primary_cache.extended_with is other_cache
+
+    def test_specprefill_gating_uses_installed_mtp_state(self, monkeypatch):
+        from vllm_mlx import mllm_batch_generator as batch_module
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+        from vllm_mlx.mllm_specprefill import SpecPrefillRequestConfig
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.model = object()
+        generator.specprefill_draft_model = object()
+        generator.specprefill_threshold = 10
+        generator.specprefill_runtime_reason = None
+        generator._mtp_runtime_implementation = None
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="media",
+            prompt="prompt",
+            mllm_draft=False,
+        )
+        config = SpecPrefillRequestConfig(enabled=True, keep_pct=0.3)
+        monkeypatch.setattr(
+            batch_module, "request_eligibility_reason", lambda *a, **k: None
+        )
+
+        assert generator._specprefill_eligibility_reason(request, config, True) is None
+
+        generator._mtp_runtime_implementation = "native_target_head"
+        assert (
+            generator._specprefill_eligibility_reason(request, config, True)
+            == "mtp_incompatible"
+        )
+
+        generator._mtp_runtime_implementation = "external_assistant"
+        assert generator._specprefill_eligibility_reason(request, config, True) is None
+        request.mllm_draft = True
+        assert (
+            generator._specprefill_eligibility_reason(request, config, True)
+            == "mtp_incompatible"
+        )
 
 
 class TestMLLMBatchStats:
@@ -1074,6 +1119,7 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         install_mtp_mllm(batch_gen, language_model, num_draft_tokens=4)
 
+        assert batch_gen._mtp_runtime_implementation == "native_target_head"
         stats = batch_gen.get_mtp_stats()
         assert stats["enabled"] is True
         assert stats["requested_draft_tokens"] == 4
@@ -1136,6 +1182,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         language_model = MagicMock()
         install_mtp_mllm(batch_gen, language_model, draft_model=draft_model)
 
+        assert batch_gen._mtp_runtime_implementation == "external_assistant"
         assert batch_gen._allow_mid_batch_extend is False
 
         tokens, logprobs = batch_gen._step(
@@ -1991,6 +2038,7 @@ class TestPreprocessIdempotent:
         # Must return immediately without touching prepare_inputs
         gen._preprocess_request(req)
         assert req.input_ids.shape == (1, 3)
+        assert req.is_text_only is True
 
     def test_vision_request_not_skipped(self):
         """Vision requests should NOT be skipped even with input_ids set."""
@@ -2015,6 +2063,7 @@ class TestPreprocessIdempotent:
         # Should NOT return early — will try to import prepare_inputs
         with pytest.raises(Exception):
             gen._preprocess_request(req)
+        assert req.is_text_only is False
 
 
 class TestChunkedPrefillCacheHandling:
@@ -2265,6 +2314,37 @@ class TestChunkedPrefillCacheHandling:
         assert orig_next_called == [
             1
         ], f"Short prompt should fall through to _orig_next, got {orig_next_called}"
+
+    def test_audio_request_bypasses_interleaved_text_prefill(self):
+        """Audio requests must remain on the multimodal prefill path."""
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen.prefix_cache = MagicMock()
+        gen.language_model = MagicMock()
+        original_next = MagicMock(return_value=[])
+        gen._next = original_next
+
+        install_chunked_prefill_mllm(gen, budget=1)
+
+        request = MLLMBatchRequest(
+            uid=5,
+            request_id="req-audio",
+            prompt="transcribe",
+            audio=["fake.wav"],
+        )
+        request.input_ids = mx.array([[10, 20, 30]])
+        gen.unprocessed_requests.append(request)
+        gen._preprocess_request = MagicMock()
+
+        gen._next()
+
+        gen._preprocess_request.assert_not_called()
+        gen.prefix_cache.fetch.assert_not_called()
+        original_next.assert_called_once()
 
 
 def test_external_mtp_drafts_mixed_position_rows_independently():

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1963,8 +1963,9 @@ class TestBatchedMLLMConfigWiring:
                 self.__dict__.update(kwargs)
 
         class FakeMLLMScheduler:
-            def __init__(self, model, processor, config):
+            def __init__(self, model, processor, config, **kwargs):
                 captured["scheduler_config"] = config
+                captured["scheduler_kwargs"] = kwargs
 
             async def start(self):
                 return None
@@ -2004,6 +2005,7 @@ class TestBatchedMLLMConfigWiring:
         assert captured["config_kwargs"]["use_memory_aware_cache"] is False
         assert captured["config_kwargs"]["cache_memory_mb"] == 123
         assert captured["config_kwargs"]["prefix_cache_memory_mb"] == 123
+        assert captured["scheduler_kwargs"]["specprefill_draft_model"] is None
 
 
 class TestPreprocessIdempotent:

--- a/tests/test_mllm_media_specprefill.py
+++ b/tests/test_mllm_media_specprefill.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Linux-runnable tests for the request-local media SpecPrefill adapter."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_mlx.mllm_specprefill import (
+    SUPPORTED_QWEN_MEDIA_MODULES,
+    ModelIdentity,
+    SpecPrefillOutcome,
+    SpecPrefillRequestConfig,
+    capability_reason,
+    model_identity,
+    request_eligibility_reason,
+    required_media_indices,
+    run_media_specprefill,
+)
+
+SUPPORTED_IDENTITIES = (
+    (
+        "mlx_vlm.models.qwen3_vl.qwen3_vl",
+        "mlx_vlm.models.qwen3_vl.language",
+        "qwen3_vl",
+    ),
+    (
+        "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe",
+        "mlx_vlm.models.qwen3_vl_moe.language",
+        "qwen3_vl_moe",
+    ),
+    (
+        "mlx_vlm.models.qwen3_5.qwen3_5",
+        "mlx_vlm.models.qwen3_5.language",
+        "qwen3_5",
+    ),
+    (
+        "mlx_vlm.models.qwen3_5_moe.qwen3_5_moe",
+        "mlx_vlm.models.qwen3_5_moe.language",
+        "qwen3_5_moe",
+    ),
+)
+
+
+def _model(
+    model_module: str,
+    language_module: str,
+    model_type: str,
+    *,
+    image_token: int = 90,
+    video_token: int = 91,
+):
+    language_cls = type("LanguageModel", (), {"__module__": language_module})
+    model_cls = type(
+        "Model",
+        (),
+        {
+            "__module__": model_module,
+            "get_input_embeddings": lambda self, **kwargs: None,
+        },
+    )
+    instance = model_cls()
+    instance.language_model = language_cls()
+    if model_type.startswith("qwen3_5"):
+        instance.config = SimpleNamespace(
+            model_type=model_type,
+            image_token_index=image_token,
+            video_token_index=video_token,
+            vision_start_token_id=92,
+            vision_end_token_id=93,
+        )
+    else:
+        instance.config = SimpleNamespace(
+            model_type=model_type,
+            image_token_id=image_token,
+            video_token_id=video_token,
+            vision_start_token_id=92,
+            vision_end_token_id=93,
+        )
+    return instance
+
+
+def test_public_dataclass_defaults_are_stable():
+    assert SpecPrefillRequestConfig() == SpecPrefillRequestConfig(
+        enabled=None,
+        keep_pct=None,
+        backbone_pct=None,
+    )
+    assert SpecPrefillOutcome() == SpecPrefillOutcome(
+        requested=None,
+        engaged=False,
+        reason="not_evaluated",
+        route="mllm_media",
+        model_module=None,
+        language_module=None,
+        model_type=None,
+        original_tokens=0,
+        selected_tokens=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_module", "language_module", "model_type"), SUPPORTED_IDENTITIES
+)
+def test_exact_dense_and_moe_runtime_identities_are_supported(
+    model_module, language_module, model_type
+):
+    model = _model(model_module, language_module, model_type)
+
+    assert model_module in SUPPORTED_QWEN_MEDIA_MODULES
+    assert model_identity(model) == ModelIdentity(
+        model_module=model_module,
+        language_module=language_module,
+        model_type=model_type,
+    )
+    assert capability_reason(model) is None
+
+
+def test_identity_checks_fail_closed_on_module_or_config_mismatch():
+    unsupported = _model("custom.Model", "custom.LanguageModel", "qwen3_5")
+    assert capability_reason(unsupported) == "unsupported_model_module"
+
+    mismatched = _model(
+        "mlx_vlm.models.qwen3_5.qwen3_5",
+        "mlx_vlm.models.qwen3_5_moe.language",
+        "qwen3_5_moe",
+    )
+    assert capability_reason(mismatched) == "model_module_mismatch"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        SimpleNamespace(
+            image_token_index=90,
+            video_token_index=91,
+            vision_start_token_id=89,
+            vision_end_token_id=92,
+        ),
+        {
+            "image_token_id": 90,
+            "video_token_id": 91,
+            "vision_start_token_id": 89,
+            "vision_end_token_id": 92,
+        },
+    ],
+)
+def test_required_media_indices_keep_visual_positions_and_final_token(config):
+    input_ids = np.array([[89, 90, 90, 92, 91, 6]])
+
+    assert required_media_indices(input_ids, config) == {0, 1, 2, 3, 4, 5}
+
+
+def test_request_eligibility_honors_controls_and_media_type():
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    request = SimpleNamespace(
+        input_ids=np.array([[1, 90, 2, 3]]),
+        audio=None,
+    )
+
+    assert (
+        request_eligibility_reason(
+            model,
+            object(),
+            request,
+            SpecPrefillRequestConfig(enabled=False),
+        )
+        == "disabled_by_request"
+    )
+    assert (
+        request_eligibility_reason(
+            model,
+            object(),
+            request,
+            SpecPrefillRequestConfig(),
+            threshold=4,
+        )
+        == "below_threshold"
+    )
+    assert (
+        request_eligibility_reason(
+            model,
+            object(),
+            request,
+            SpecPrefillRequestConfig(enabled=True, keep_pct=0.3, backbone_pct=0.1),
+            threshold=100,
+        )
+        is None
+    )
+    request.audio = ["clip.wav"]
+    assert (
+        request_eligibility_reason(
+            model,
+            object(),
+            request,
+            SpecPrefillRequestConfig(enabled=True),
+        )
+        == "unsupported_media_type"
+    )
+
+
+def test_request_eligibility_caps_draft_scoring_length():
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    input_ids = np.zeros((1, 65537), dtype=np.int64)
+    input_ids[0, 5] = 90
+    request = SimpleNamespace(input_ids=input_ids, audio=None)
+
+    assert (
+        request_eligibility_reason(
+            model,
+            object(),
+            request,
+            SpecPrefillRequestConfig(enabled=True),
+        )
+        == "prompt_too_long"
+    )
+
+
+def _install_numpy_runtime(monkeypatch, selected):
+    mx = types.ModuleType("mlx.core")
+    mx.uint32 = np.uint32
+    mx.array = lambda value, dtype=None: np.array(value, dtype=dtype)
+    mx.eval = lambda *values: None
+    mx.clear_cache = lambda: None
+
+    mlx = types.ModuleType("mlx")
+    mlx.core = mx
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mx)
+
+    calls = {"score": [], "select": []}
+    specprefill = types.ModuleType("vllm_mlx.specprefill")
+
+    def score_tokens(model, tokens, **kwargs):
+        calls["score"].append((model, list(tokens), kwargs))
+        return np.arange(len(tokens), dtype=np.float32)
+
+    def select_chunks(importance, **kwargs):
+        calls["select"].append((importance.copy(), kwargs))
+        return np.array(selected, dtype=np.uint32)
+
+    specprefill.score_tokens = score_tokens
+    specprefill.select_chunks = select_chunks
+    specprefill._qwen35_extract_queries = object()
+    monkeypatch.setitem(sys.modules, "vllm_mlx.specprefill", specprefill)
+    return calls
+
+
+class _CacheLayer:
+    def __init__(self):
+        self.state = [np.array([1], dtype=np.float32)]
+
+
+def test_full_keep_returns_before_scoring_or_target_prefill(monkeypatch):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[])
+    model = _model(*SUPPORTED_IDENTITIES[0])
+    model.get_input_embeddings = lambda **kwargs: pytest.fail(
+        "full selection must not prepare target media features"
+    )
+    type(model.language_model).__call__ = lambda self, tokens, **kwargs: pytest.fail(
+        "full selection must not run target prefill"
+    )
+    request = SimpleNamespace(input_ids=np.array([[92, 90, 93, 4]]))
+
+    logits, decode_delta, selected_count = run_media_specprefill(
+        model,
+        model.language_model,
+        object(),
+        request,
+        [],
+        keep_pct=1.0,
+        backbone_pct=0.0,
+        step_size=32,
+    )
+
+    assert logits is None
+    assert decode_delta is None
+    assert selected_count == 4
+    assert runtime_calls["score"] == []
+
+
+def test_required_chunks_detect_non_sparse_before_target_prefill(monkeypatch):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0])
+    model = _model(*SUPPORTED_IDENTITIES[0])
+    model.get_input_embeddings = lambda **kwargs: pytest.fail(
+        "required full selection must not prepare target media features"
+    )
+    type(model.language_model).__call__ = lambda self, tokens, **kwargs: pytest.fail(
+        "required full selection must not run target prefill"
+    )
+    input_ids = np.arange(32, dtype=np.int64)[None, :] % 20
+    input_ids[0, :3] = [92, 90, 93]
+    request = SimpleNamespace(input_ids=input_ids)
+
+    logits, decode_delta, selected_count = run_media_specprefill(
+        model,
+        model.language_model,
+        object(),
+        request,
+        [],
+        keep_pct=0.1,
+        backbone_pct=0.0,
+        step_size=32,
+    )
+
+    assert logits is None
+    assert decode_delta is None
+    assert selected_count == 32
+    assert len(runtime_calls["score"]) == 1
+
+
+def test_sparse_media_prefill_gathers_fused_state_and_adjusts_decode_delta(
+    monkeypatch,
+):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0, 1])
+    model = _model(*SUPPORTED_IDENTITIES[0])
+    sequence_length = 100
+    input_ids = (np.arange(sequence_length, dtype=np.int64) % 50)[None, :]
+    input_ids[0, 34] = 92
+    input_ids[0, 35:37] = 90
+    input_ids[0, 37] = 93
+    visual_mask = np.zeros((1, sequence_length), dtype=bool)
+    visual_mask[0, 35:37] = True
+    fused = np.arange(sequence_length * 3, dtype=np.float32).reshape(1, 100, 3)
+    positions = np.stack(
+        [np.arange(sequence_length) + axis * 1000 for axis in range(3)], axis=0
+    )[:, None, :]
+    deepstack = [
+        np.array([[10, 11], [12, 13]], dtype=np.float32),
+        np.array([[20, 21], [22, 23]], dtype=np.float32),
+    ]
+    feature_calls = []
+
+    def get_input_embeddings(**kwargs):
+        feature_calls.append(kwargs)
+        return SimpleNamespace(
+            inputs_embeds=fused,
+            position_ids=positions,
+            rope_deltas=np.array([[-4]], dtype=np.int64),
+            visual_pos_masks=visual_mask,
+            deepstack_visual_embeds=deepstack,
+        )
+
+    model.get_input_embeddings = get_input_embeddings
+
+    language_calls = []
+
+    def language_model(tokens, **kwargs):
+        language_calls.append((tokens.copy(), kwargs))
+        return SimpleNamespace(
+            logits=np.ones((1, tokens.shape[1], 7), dtype=np.float32)
+        )
+
+    model.language_model.__call__ = language_model
+    # Special methods are resolved on the class, so install the callable there.
+    type(model.language_model).__call__ = lambda self, tokens, **kwargs: language_model(
+        tokens, **kwargs
+    )
+
+    request = SimpleNamespace(
+        input_ids=input_ids,
+        pixel_values=np.array([[5]], dtype=np.float32),
+        attention_mask=np.ones_like(input_ids),
+        image_grid_thw=np.array([[1, 2, 2]]),
+        extra_kwargs={"video_grid_thw": np.array([[1, 2, 2]])},
+    )
+    cache = [_CacheLayer()]
+    draft = object()
+    cancellation_checks = []
+
+    logits, decode_delta, selected_count = run_media_specprefill(
+        model,
+        model.language_model,
+        draft,
+        request,
+        cache,
+        keep_pct=0.2,
+        backbone_pct=0.0,
+        step_size=20,
+        cancel_check=lambda: cancellation_checks.append(True),
+    )
+
+    expected = [0, 1, *range(32, 64), *range(96, 100)]
+    assert selected_count == len(expected) == 38
+    assert len(language_calls) == 2
+    np.testing.assert_array_equal(
+        np.concatenate([call[0] for call in language_calls], axis=1),
+        input_ids[:, expected],
+    )
+    np.testing.assert_array_equal(
+        np.concatenate([call[1]["inputs_embeds"] for call in language_calls], axis=1),
+        fused[:, expected, :],
+    )
+    np.testing.assert_array_equal(
+        np.concatenate([call[1]["position_ids"] for call in language_calls], axis=-1),
+        positions[..., expected],
+    )
+    np.testing.assert_array_equal(
+        np.concatenate(
+            [call[1]["visual_pos_masks"] for call in language_calls], axis=-1
+        ),
+        visual_mask[..., expected],
+    )
+    assert "rope_deltas" not in language_calls[0][1]
+    assert "mask" not in language_calls[0][1]
+    np.testing.assert_array_equal(
+        language_calls[0][1]["deepstack_visual_embeds"][0], deepstack[0]
+    )
+    assert language_calls[1][1]["deepstack_visual_embeds"][0].shape == (0, 2)
+    np.testing.assert_array_equal(decode_delta, np.array([[58]]))
+    assert logits.shape == (1, 18, 7)
+    assert len(feature_calls) == 1
+    assert feature_calls[0]["mask"].shape == (1, sequence_length)
+    assert runtime_calls["score"][0][0] is draft
+    assert runtime_calls["select"][0][1] == {
+        "keep_pct": 0.2,
+        "backbone_pct": 0.0,
+    }
+    assert cancellation_checks
+
+
+def test_sparse_media_prefill_cancels_before_scoring(monkeypatch):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0])
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    request = SimpleNamespace(input_ids=np.array([[1, 90, 2]]))
+
+    def cancel():
+        raise RuntimeError("cancelled")
+
+    with pytest.raises(RuntimeError, match="cancelled"):
+        run_media_specprefill(
+            model,
+            model.language_model,
+            object(),
+            request,
+            [],
+            keep_pct=0.5,
+            backbone_pct=0.0,
+            step_size=32,
+            cancel_check=cancel,
+        )
+
+    assert runtime_calls["score"] == []
+
+
+def test_sparse_media_prefill_masks_only_out_of_vocab_placeholder_ids(monkeypatch):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0])
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    draft = SimpleNamespace(args=SimpleNamespace(text_config={"vocab_size": 80}))
+    input_ids = np.arange(64, dtype=np.int64)[None, :] % 20
+    input_ids[0, 31:34] = [92, 90, 93]
+    request = SimpleNamespace(
+        input_ids=input_ids,
+        pixel_values=np.array([[1]], dtype=np.float32),
+        attention_mask=np.ones_like(input_ids),
+        image_grid_thw=np.array([[1, 1, 1]]),
+        extra_kwargs={},
+    )
+    fused = np.ones((1, 64, 4), dtype=np.float32)
+    positions = np.stack([np.arange(64)] * 3, axis=0)[:, None, :]
+    model.get_input_embeddings = lambda **kwargs: SimpleNamespace(
+        inputs_embeds=fused,
+        position_ids=positions,
+        rope_deltas=np.zeros((1, 1), dtype=np.int64),
+        visual_pos_masks=input_ids == 90,
+        deepstack_visual_embeds=None,
+    )
+    type(model.language_model).__call__ = (
+        lambda self, tokens, **kwargs: SimpleNamespace(
+            logits=np.ones((1, tokens.shape[1], 7), dtype=np.float32)
+        )
+    )
+
+    run_media_specprefill(
+        model,
+        model.language_model,
+        draft,
+        request,
+        [_CacheLayer()],
+        keep_pct=0.5,
+        backbone_pct=0.0,
+        step_size=32,
+    )
+
+    assert runtime_calls["score"][0][1][31:34] == [0, 0, 0]
+    assert max(runtime_calls["score"][0][1]) < 80
+
+
+@pytest.mark.parametrize(
+    ("draft_model_type", "expects_explicit_extractor"),
+    [("qwen3_5", True), ("qwen3_vl", False)],
+)
+def test_sparse_media_prefill_selects_extractor_from_draft_args(
+    monkeypatch, draft_model_type, expects_explicit_extractor
+):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0])
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    draft = SimpleNamespace(
+        args=SimpleNamespace(model_type=draft_model_type, vocab_size=100)
+    )
+    input_ids = np.arange(64, dtype=np.int64)[None, :] % 20
+    input_ids[0, 31:34] = [92, 90, 93]
+    request = SimpleNamespace(
+        input_ids=input_ids,
+        pixel_values=np.array([[1]], dtype=np.float32),
+        attention_mask=np.ones_like(input_ids),
+        image_grid_thw=np.array([[1, 1, 1]]),
+        extra_kwargs={},
+    )
+    positions = np.stack([np.arange(64)] * 3, axis=0)[:, None, :]
+    model.get_input_embeddings = lambda **kwargs: SimpleNamespace(
+        inputs_embeds=np.ones((1, 64, 4), dtype=np.float32),
+        position_ids=positions,
+        rope_deltas=np.zeros((1, 1), dtype=np.int64),
+        visual_pos_masks=input_ids == 90,
+        deepstack_visual_embeds=None,
+    )
+    type(model.language_model).__call__ = (
+        lambda self, tokens, **kwargs: SimpleNamespace(
+            logits=np.ones((1, tokens.shape[1], 7), dtype=np.float32)
+        )
+    )
+
+    run_media_specprefill(
+        model,
+        model.language_model,
+        draft,
+        request,
+        [_CacheLayer()],
+        keep_pct=0.5,
+        backbone_pct=0.0,
+        step_size=32,
+    )
+
+    assert (
+        "query_extractor" in runtime_calls["score"][0][2]
+    ) is expects_explicit_extractor
+
+
+def test_sparse_media_prefill_rejects_nonmedia_token_outside_draft_vocab(
+    monkeypatch,
+):
+    runtime_calls = _install_numpy_runtime(monkeypatch, selected=[0])
+    model = _model(*SUPPORTED_IDENTITIES[2])
+    draft = SimpleNamespace(args=SimpleNamespace(vocab_size=80))
+    request = SimpleNamespace(input_ids=np.array([[81, 90, 2]]))
+
+    with pytest.raises(ValueError, match="draft vocabulary"):
+        run_media_specprefill(
+            model,
+            model.language_model,
+            draft,
+            request,
+            [],
+            keep_pct=0.5,
+            backbone_pct=0.0,
+            step_size=32,
+        )
+
+    assert runtime_calls["score"] == []

--- a/tests/test_no_final_content_watchdog.py
+++ b/tests/test_no_final_content_watchdog.py
@@ -130,6 +130,36 @@ def test_generation_metadata_preserves_zero_mllm_mtp_acceptance():
     assert metadata.mtp_accepted == 0
 
 
+def test_generation_metadata_reports_media_specprefill_fallback():
+    from vllm_mlx import server
+
+    outcome = SimpleNamespace(
+        requested=True,
+        engaged=False,
+        reason="unsupported_model_module",
+        route="mllm_media",
+        model_module="custom.model",
+        language_module="custom.language",
+        model_type="custom_vlm",
+        original_tokens=9000,
+        selected_tokens=0,
+    )
+    output = SimpleNamespace(
+        mtp_drafts=0,
+        mtp_accepted=0,
+        specprefill_outcome=outcome,
+    )
+
+    metadata = server._generation_metadata(None, output)
+
+    assert metadata is not None
+    assert metadata.specprefill_requested is True
+    assert metadata.specprefill_engaged is False
+    assert metadata.specprefill_reason == "unsupported_model_module"
+    assert metadata.specprefill_route == "mllm_media"
+    assert metadata.specprefill_original_tokens == 9000
+
+
 def test_build_thinking_processor_warns_when_watchdog_cannot_fire(monkeypatch, caplog):
     from vllm_mlx import server
 

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,6 +6,7 @@ These tests verify the PrefixCacheManager for KV cache reuse
 to speed up inference with repeated prompts.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -597,7 +598,9 @@ class TestMLLMCompletionCacheStore:
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
         request = SimpleNamespace(
-            request_id="saturated", input_ids=mx.array([[1, 2, 3, 4]])
+            request_id="saturated",
+            input_ids=mx.array([[1, 2, 3, 4]]),
+            is_text_only=True,
         )
         batch = SimpleNamespace(
             requests=[request],
@@ -627,7 +630,11 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
-        request = SimpleNamespace(request_id="flat", input_ids=mx.array([[1, 2, 3, 4]]))
+        request = SimpleNamespace(
+            request_id="flat",
+            input_ids=mx.array([[1, 2, 3, 4]]),
+            is_text_only=True,
+        )
         batch = SimpleNamespace(
             requests=[request],
             num_tokens=[4],
@@ -654,7 +661,11 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
-        request = SimpleNamespace(request_id="plain", input_ids=mx.array([[1, 2, 3]]))
+        request = SimpleNamespace(
+            request_id="plain",
+            input_ids=mx.array([[1, 2, 3]]),
+            is_text_only=True,
+        )
         batch = SimpleNamespace(
             requests=[request],
             num_tokens=[1],
@@ -667,6 +678,17 @@ class TestMLLMCompletionCacheStore:
         _, stored = generator.prefix_cache.store.call_args.args
         assert estimate_kv_cache_memory(stored) > 0
         assert [child.offset for child in stored[0].caches] == [3, 3]
+
+    def test_media_cache_is_never_stored_under_dense_prompt_tokens(self):
+        from vllm_mlx.memory_cache import is_text_only_prefix_cache_request
+
+        request = SimpleNamespace(
+            request_id="media",
+            input_ids=object(),
+            is_text_only=False,
+        )
+
+        assert is_text_only_prefix_cache_request(request) is False
 
     def test_zero_trim_flat_snapshot_does_not_alias_live_cache(self):
         mx = pytest.importorskip("mlx.core")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2029,10 +2029,11 @@ class TestStreamChatCompletion:
     """Tests for streaming chat completion behavior."""
 
     @pytest.mark.anyio
-    async def test_suppressed_final_delta_still_emits_specprefill_metadata(
-        self, monkeypatch
+    @pytest.mark.parametrize("suppress_final", [False, True])
+    async def test_final_delta_attaches_metadata_to_terminal_choice(
+        self, monkeypatch, suppress_final
     ):
-        """A parser-suppressed final token must not hide route diagnostics."""
+        """Direct and parser-suppressed finals keep a compatible shape."""
         from vllm_mlx.engine.base import GenerationOutput
         from vllm_mlx.server import (
             ChatCompletionRequest,
@@ -2058,8 +2059,8 @@ class TestStreamChatCompletion:
 
             async def stream_chat(self, messages, **kwargs):
                 yield GenerationOutput(
-                    text="",
-                    new_text="</think>",
+                    text="" if suppress_final else "ok",
+                    new_text="</think>" if suppress_final else "ok",
                     finished=True,
                     finish_reason="stop",
                     specprefill_outcome=SimpleNamespace(
@@ -2076,7 +2077,11 @@ class TestStreamChatCompletion:
                 )
 
         monkeypatch.setattr(server, "_model_name", "served-model")
-        monkeypatch.setattr(server, "_reasoning_parser_name", "suppressing")
+        monkeypatch.setattr(
+            server,
+            "_reasoning_parser_name",
+            "suppressing" if suppress_final else None,
+        )
         monkeypatch.setattr(server, "_reasoning_parser", None)
         monkeypatch.setattr(
             server, "get_reasoning_parser", lambda name: SuppressingReasoningParser
@@ -2102,14 +2107,105 @@ class TestStreamChatCompletion:
             if chunk != "data: [DONE]\n\n"
         ]
 
-        metadata_payload = payloads[-1]
-        assert metadata_payload["choices"] == []
+        assert request.stream_options is None
+        assert all(payload["choices"] for payload in payloads)
+        metadata_payloads = [
+            payload
+            for payload in payloads
+            if payload.get("generation_metadata") is not None
+        ]
+        assert len(metadata_payloads) == 1
+
+        metadata_payload = metadata_payloads[0]
+        assert metadata_payload["choices"][0]["finish_reason"] == "stop"
         assert metadata_payload["generation_metadata"]["specprefill_requested"] is True
         assert metadata_payload["generation_metadata"]["specprefill_engaged"] is False
         assert (
             metadata_payload["generation_metadata"]["specprefill_reason"]
             == "unsupported_media_type"
         )
+
+    @pytest.mark.anyio
+    async def test_usage_chunk_preserves_thinking_processor_through_builder(
+        self, monkeypatch
+    ):
+        """Opted-in usage metadata preserves the live thinking processor state."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            _build_chat_streaming_response,
+            ChatCompletionRequest,
+            Message,
+        )
+        import vllm_mlx.server as server
+
+        thinking_processor = SimpleNamespace(
+            _no_final_content_token_limit=7,
+            watchdog_was_enforced=True,
+        )
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                assert "thinking_processor" not in kwargs
+                assert kwargs["logits_processors"] == [thinking_processor]
+                yield GenerationOutput(
+                    text="ok",
+                    new_text="ok",
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=5,
+                    completion_tokens=2,
+                )
+
+        async def passthrough_disconnect_guard(generator, *_args, **_kwargs):
+            async for chunk in generator:
+                yield chunk
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser_name", None)
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+        monkeypatch.setattr(server, "_disconnect_guard", passthrough_disconnect_guard)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        response, release_on_exit = await _build_chat_streaming_response(
+            FakeEngine(),
+            request.messages,
+            request,
+            SimpleNamespace(),
+            None,
+            {"logits_processors": [thinking_processor]},
+            None,
+            None,
+            thinking_processor=thinking_processor,
+        )
+        chunks = [chunk async for chunk in response.body_iterator]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        assert release_on_exit is False
+        usage_payloads = [payload for payload in payloads if payload["choices"] == []]
+        assert len(usage_payloads) == 1
+        usage_payload = usage_payloads[0]
+        assert usage_payload["usage"] == {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }
+        metadata = usage_payload["generation_metadata"]
+        assert metadata["no_final_content_watchdog_tokens"] == 7
+        assert metadata["no_final_content_watchdog_enforced"] is True
 
     @pytest.mark.anyio
     async def test_interleaved_streams_keep_reasoning_parser_state_isolated(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2029,6 +2029,89 @@ class TestStreamChatCompletion:
     """Tests for streaming chat completion behavior."""
 
     @pytest.mark.anyio
+    async def test_suppressed_final_delta_still_emits_specprefill_metadata(
+        self, monkeypatch
+    ):
+        """A parser-suppressed final token must not hide route diagnostics."""
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class SuppressingReasoningParser:
+            def __init__(self, tokenizer=None):
+                pass
+
+            def reset_state(self):
+                pass
+
+            def extract_reasoning_streaming(
+                self, previous_text, current_text, delta_text
+            ):
+                return None
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="",
+                    new_text="</think>",
+                    finished=True,
+                    finish_reason="stop",
+                    specprefill_outcome=SimpleNamespace(
+                        requested=True,
+                        engaged=False,
+                        reason="unsupported_media_type",
+                        route="mllm_media",
+                        model_module="mlx_vlm.models.qwen3_vl.qwen3_vl",
+                        language_module="mlx_vlm.models.qwen3_vl.language",
+                        model_type="qwen3_vl",
+                        original_tokens=9000,
+                        selected_tokens=0,
+                    ),
+                )
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser_name", "suppressing")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(
+            server, "get_reasoning_parser", lambda name: SuppressingReasoningParser
+        )
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        metadata_payload = payloads[-1]
+        assert metadata_payload["choices"] == []
+        assert metadata_payload["generation_metadata"]["specprefill_requested"] is True
+        assert metadata_payload["generation_metadata"]["specprefill_engaged"] is False
+        assert (
+            metadata_payload["generation_metadata"]["specprefill_reason"]
+            == "unsupported_media_type"
+        )
+
+    @pytest.mark.anyio
     async def test_interleaved_streams_keep_reasoning_parser_state_isolated(
         self, monkeypatch
     ):

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -267,6 +267,15 @@ class GenerationMetadata(BaseModel):
     no_final_content_watchdog_enforced: bool = False
     mtp_drafts: int | None = None
     mtp_accepted: int | None = None
+    specprefill_requested: bool | None = None
+    specprefill_engaged: bool | None = None
+    specprefill_reason: str | None = None
+    specprefill_route: str | None = None
+    specprefill_model_module: str | None = None
+    specprefill_language_module: str | None = None
+    specprefill_model_type: str | None = None
+    specprefill_original_tokens: int | None = None
+    specprefill_selected_tokens: int | None = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -577,3 +586,4 @@ class ChatCompletionChunk(BaseModel):
     model: str
     choices: list[ChatCompletionChunkChoice]
     usage: Usage | None = None  # Included when stream_options.include_usage=true
+    generation_metadata: GenerationMetadata | None = None

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1300,7 +1300,8 @@ Examples:
         default=False,
         help="Enable SpecPrefill: use a small draft model to score token importance, "
         "then sparse-prefill only the important tokens on the target model. "
-        "Reduces TTFT on long prompts. Requires --specprefill-draft-model.",
+        "Reduces TTFT on long prompts. Supported Qwen media routes preserve "
+        "visual embeddings and MRoPE state. Requires --specprefill-draft-model.",
     )
     serve_parser.add_argument(
         "--specprefill-threshold",

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -10,7 +10,10 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..mllm_specprefill import SpecPrefillOutcome
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +39,8 @@ class GenerationOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Request-level sparse-prefill decision and diagnostics.
+    specprefill_outcome: "SpecPrefillOutcome | None" = None
 
 
 class EngineBusy(RuntimeError):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -201,6 +201,11 @@ class BatchedEngine(BaseEngine):
         mllm_draft_kind: str | None = None,
         mllm_draft_block_size: int | None = None,
         default_mllm_draft: bool = False,
+        specprefill_enabled: bool = False,
+        specprefill_threshold: int = 8192,
+        specprefill_keep_pct: float = 0.3,
+        specprefill_backbone_pct: float = 0.0,
+        specprefill_draft_model: str | None = None,
     ):
         """
         Initialize the batched engine.
@@ -215,6 +220,11 @@ class BatchedEngine(BaseEngine):
                 limit and emergency threshold (0.0-1.0, default 0.90)
             default_mllm_draft: Enable the configured assistant drafter unless a
                 request explicitly sets ``mllm_draft`` to false.
+            specprefill_enabled: Enable media-aware SpecPrefill for supported VLMs
+            specprefill_threshold: Minimum media prompt tokens before engagement
+            specprefill_keep_pct: Fraction of prompt chunks to retain
+            specprefill_backbone_pct: Fraction reserved for uniform coverage
+            specprefill_draft_model: Small text model used to score prompt tokens
         """
         self._model_name = model_name
         self._created_at = time.time()
@@ -226,6 +236,12 @@ class BatchedEngine(BaseEngine):
         self._mllm_draft_kind = mllm_draft_kind
         self._mllm_draft_block_size = mllm_draft_block_size
         self._default_mllm_draft = default_mllm_draft
+        self._specprefill_enabled = specprefill_enabled
+        self._specprefill_threshold = specprefill_threshold
+        self._specprefill_keep_pct = specprefill_keep_pct
+        self._specprefill_backbone_pct = specprefill_backbone_pct
+        self._specprefill_draft_model_path = specprefill_draft_model
+        self._specprefill_draft_model = None
         self._is_mllm = force_mllm or is_mllm_model(model_name)
 
         self._model = None
@@ -350,18 +366,43 @@ class BatchedEngine(BaseEngine):
         """Load the MLLM model before scheduler startup."""
         from ..models.mllm import MLXMultimodalLM
 
-        max_kv_size = getattr(self._scheduler_config, "max_kv_size", 0)
-        self._mllm_instance = MLXMultimodalLM(
-            self._model_name,
-            trust_remote_code=self._trust_remote_code,
-            max_kv_size=max_kv_size,
-            draft_model=self._mllm_draft_model,
-            draft_kind=self._mllm_draft_kind,
-            draft_block_size=self._mllm_draft_block_size,
-        )
-        self._mllm_instance.load()
-        self._model = self._mllm_instance.model
-        self._processor = self._mllm_instance.processor
+        if self._model is None or self._processor is None:
+            max_kv_size = getattr(self._scheduler_config, "max_kv_size", 0)
+            self._mllm_instance = MLXMultimodalLM(
+                self._model_name,
+                trust_remote_code=self._trust_remote_code,
+                max_kv_size=max_kv_size,
+                draft_model=self._mllm_draft_model,
+                draft_kind=self._mllm_draft_kind,
+                draft_block_size=self._mllm_draft_block_size,
+            )
+            self._mllm_instance.load()
+            self._model = self._mllm_instance.model
+            self._processor = self._mllm_instance.processor
+
+        if (
+            self._specprefill_enabled
+            and self._specprefill_draft_model_path
+            and self._specprefill_draft_model is None
+        ):
+            try:
+                from mlx_lm import load as mlx_lm_load
+
+                self._specprefill_draft_model, _ = mlx_lm_load(
+                    self._specprefill_draft_model_path
+                )
+                logger.info(
+                    "Media SpecPrefill draft loaded: model=%s threshold=%d keep=%.0f%%",
+                    self._specprefill_draft_model_path,
+                    self._specprefill_threshold,
+                    self._specprefill_keep_pct * 100,
+                )
+            except Exception:
+                self._specprefill_draft_model = None
+                logger.exception(
+                    "Media SpecPrefill draft load failed; media requests will "
+                    "use dense prefill"
+                )
 
         # Set Metal memory limits (same as LLM path)
         try:
@@ -477,17 +518,25 @@ class BatchedEngine(BaseEngine):
             max_kv_size=max_kv_size,
             ssd_cache_dir=ssd_cache_dir,
             ssd_cache_max_gb=ssd_cache_max_gb,
+            specprefill_enabled=self._specprefill_enabled,
+            specprefill_threshold=self._specprefill_threshold,
+            specprefill_keep_pct=self._specprefill_keep_pct,
+            specprefill_backbone_pct=self._specprefill_backbone_pct,
             **mllm_extra,
         )
 
         # Create and start MLLM scheduler
-        scheduler_kwargs = {}
+        scheduler_kwargs = {
+            "specprefill_draft_model": self._specprefill_draft_model,
+        }
         if self._mllm_draft_model is not None:
-            scheduler_kwargs = {
-                "draft_model": getattr(self._mllm_instance, "_draft_model", None),
-                "draft_kind": self._mllm_draft_kind,
-                "draft_block_size": self._mllm_draft_block_size,
-            }
+            scheduler_kwargs.update(
+                {
+                    "draft_model": getattr(self._mllm_instance, "_draft_model", None),
+                    "draft_kind": self._mllm_draft_kind,
+                    "draft_block_size": self._mllm_draft_block_size,
+                }
+            )
         self._mllm_scheduler = MLLMScheduler(
             model=self._model,
             processor=self._processor,
@@ -669,6 +718,7 @@ class BatchedEngine(BaseEngine):
         self._tokenizer = None
         self._processor = None
         self._mllm_instance = None
+        self._specprefill_draft_model = None
         self._loaded = False
         if self._generation_executor is not None:
             # The model and its streams lived on this thread; both go with it.
@@ -856,6 +906,9 @@ class BatchedEngine(BaseEngine):
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
                 mllm_draft=bool(kwargs.pop("mllm_draft", self._default_mllm_draft)),
+                specprefill=kwargs.pop("specprefill", None),
+                specprefill_keep_pct=kwargs.pop("specprefill_keep_pct", None),
+                specprefill_backbone_pct=kwargs.pop("specprefill_backbone_pct", None),
             )
 
             return GenerationOutput(
@@ -866,6 +919,7 @@ class BatchedEngine(BaseEngine):
                 finish_reason=output.finish_reason,
                 mtp_drafts=output.mtp_drafts,
                 mtp_accepted=output.mtp_accepted,
+                specprefill_outcome=getattr(output, "specprefill_outcome", None),
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -946,6 +1000,9 @@ class BatchedEngine(BaseEngine):
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
                 mllm_draft=bool(kwargs.pop("mllm_draft", self._default_mllm_draft)),
+                specprefill=kwargs.pop("specprefill", None),
+                specprefill_keep_pct=kwargs.pop("specprefill_keep_pct", None),
+                specprefill_backbone_pct=kwargs.pop("specprefill_backbone_pct", None),
             )
 
             async for output in self._mllm_scheduler.stream_outputs(request_id):
@@ -958,6 +1015,7 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     mtp_drafts=output.mtp_drafts,
                     mtp_accepted=output.mtp_accepted,
+                    specprefill_outcome=getattr(output, "specprefill_outcome", None),
                 )
             return
 
@@ -1239,6 +1297,7 @@ class BatchedEngine(BaseEngine):
                 "prefix_cache",
                 "batch_generator",
                 "mtp",
+                "specprefill",
                 "requests",
             ):
                 if key in mllm_stats:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -33,6 +33,15 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
+
+def is_text_only_prefix_cache_request(request: Any) -> bool:
+    """Return whether a request can safely use the token-only prefix cache."""
+    return (
+        bool(getattr(request, "is_text_only", False))
+        and getattr(request, "input_ids", None) is not None
+    )
+
+
 logger = logging.getLogger(__name__)
 
 # Constants

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -27,8 +27,20 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
-from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+from .memory_cache import (
+    MemoryAwarePrefixCache,
+    MemoryCacheConfig,
+    is_text_only_prefix_cache_request,
+)
 from .multimodal_processor import MultimodalProcessor
+from .mllm_specprefill import (
+    SpecPrefillOutcome,
+    SpecPrefillRequestConfig,
+    capability_reason,
+    model_identity,
+    request_eligibility_reason,
+    run_media_specprefill,
+)
 from .vision_embedding_cache import VisionEmbeddingCache
 
 logger = logging.getLogger(__name__)
@@ -210,6 +222,9 @@ class MLLMBatchRequest:
     # Merged with built-in repetition/presence penalty processors in
     # ``_prefill_batch``.
     logits_processors: Optional[List[Callable]] = None
+    specprefill_config: Optional[SpecPrefillRequestConfig] = None
+    specprefill_outcome: Optional[SpecPrefillOutcome] = None
+    decode_rope_delta: Optional[mx.array] = None
 
     # Processed inputs (set after vision preprocessing)
     input_ids: Optional[mx.array] = None
@@ -248,6 +263,7 @@ class MLLMBatchResponse:
     from_draft: bool = False  # True when this response is an accepted MTP draft
     mtp_attempted: bool = False  # True when the primary step attempted MTP
     mtp_attempted_count: int = 0  # Number of draft tokens attempted
+    specprefill_outcome: Optional[SpecPrefillOutcome] = None
 
 
 @dataclass
@@ -269,6 +285,7 @@ class MLLMBatch:
     requests: List[MLLMBatchRequest]  # Full request data
     logits_processors: Optional[List[Optional[List[Callable]]]] = None
     samplers: Optional[List[Optional[Callable]]] = None
+    decode_rope_deltas: Optional[mx.array] = None
 
     def __len__(self) -> int:
         return len(self.uids)
@@ -292,6 +309,8 @@ class MLLMBatch:
             self.samplers = [self.samplers[k] for k in keep_idx]
 
         keep_idx_array = mx.array(keep_idx, mx.int32)
+        if self.decode_rope_deltas is not None:
+            self.decode_rope_deltas = self.decode_rope_deltas[keep_idx_array]
         self.y = self.y[keep_idx_array]
 
         # Filter cache entries
@@ -328,6 +347,21 @@ class MLLMBatch:
             self_s = self.samplers or [None] * self_len
             other_s = other.samplers or [None] * len(other.uids)
             self.samplers = list(self_s) + list(other_s)
+
+        if self.decode_rope_deltas is not None or other.decode_rope_deltas is not None:
+            template = (
+                self.decode_rope_deltas
+                if self.decode_rope_deltas is not None
+                else other.decode_rope_deltas
+            )
+            self_len = len(self.uids) - len(other.uids)
+            left = self.decode_rope_deltas
+            right = other.decode_rope_deltas
+            if left is None:
+                left = mx.zeros((self_len, 1), dtype=template.dtype)
+            if right is None:
+                right = mx.zeros((len(other.uids), 1), dtype=template.dtype)
+            self.decode_rope_deltas = mx.concatenate([left, right], axis=0)
 
         # Extend cache - handle both BatchKVCache (.keys/.values) and
         # ArraysCache (.cache list) from hybrid models like Qwen3.5. Some
@@ -484,6 +518,12 @@ class MLLMBatchGenerator:
         vision_cache_size: int = 100,
         prefix_cache_config: Optional[MemoryCacheConfig] = None,
         max_kv_size: int = 0,
+        specprefill_draft_model: Optional[Any] = None,
+        specprefill_enabled: bool = False,
+        specprefill_threshold: int = 8192,
+        specprefill_keep_pct: float = 0.3,
+        specprefill_backbone_pct: float = 0.0,
+        specprefill_runtime_reason: Optional[str] = None,
     ):
         """
         Initialize MLLM batch generator.
@@ -507,6 +547,21 @@ class MLLMBatchGenerator:
         self.processor = processor
         self.mm_processor = mm_processor
         self.max_kv_size = max_kv_size
+        self.specprefill_draft_model = specprefill_draft_model
+        self.specprefill_enabled = specprefill_enabled
+        self.specprefill_threshold = specprefill_threshold
+        self.specprefill_keep_pct = specprefill_keep_pct
+        self.specprefill_backbone_pct = specprefill_backbone_pct
+        self.specprefill_runtime_reason = specprefill_runtime_reason
+        self._mtp_runtime_implementation: Optional[str] = None
+        self._specprefill_stats = {
+            "decisions": 0,
+            "engaged": 0,
+            "fallbacks": 0,
+            "original_tokens": 0,
+            "selected_tokens": 0,
+            "bypass_counts": {},
+        }
 
         # Get language model for text generation
         self.language_model = getattr(model, "language_model", model)
@@ -892,6 +947,13 @@ class MLLMBatchGenerator:
         Args:
             request: Request to preprocess
         """
+        # Classify from the original payload, not successfully processed media.
+        # A failed image/audio conversion must never make the request eligible
+        # for the token-only prefix cache.
+        request.is_text_only = not bool(
+            request.images or request.videos or request.audio
+        )
+
         # Already preprocessed (e.g. by early executor offloading in
         # _process_loop or chunked prefill interleaving).  Only skip for
         # text-only requests; media requests need pixel/audio cache lookup
@@ -1019,9 +1081,6 @@ class MLLMBatchGenerator:
 
         self._stats.num_images_processed += len(all_images)
         self._stats.vision_encoding_time += processing_time
-
-        # Mark text-only requests (eligible for prefix cache)
-        request.is_text_only = not bool(all_images or all_audio)
 
         logger.debug(
             f"Preprocessed request {request.request_id}: "
@@ -1225,10 +1284,7 @@ class MLLMBatchGenerator:
             output = self.language_model(input_ids, cache=cache)
             request.vision_encoded = True
             # Release preprocessed inputs after encoding (issue #442)
-            request.pixel_values = None
-            request.attention_mask = None
-            request.image_grid_thw = None
-            request.extra_kwargs.clear()
+            self._release_preprocessed_inputs(request)
             if hasattr(output, "logits"):
                 return output.logits
             return output
@@ -1283,10 +1339,7 @@ class MLLMBatchGenerator:
         output = self.language_model(last_chunk, cache=cache)
         request.vision_encoded = True
         # Release preprocessed inputs after encoding (issue #442)
-        request.pixel_values = None
-        request.attention_mask = None
-        request.image_grid_thw = None
-        request.extra_kwargs.clear()
+        self._release_preprocessed_inputs(request)
         self._prefill_progress[request.request_id] = (total, total)
 
         if chunk_count > 0:
@@ -1341,15 +1394,204 @@ class MLLMBatchGenerator:
         # into the KV cache.  pixel_values can be hundreds of MB for multi-
         # image requests; holding them pins Metal buffers for the entire
         # generation duration (issue #442).
-        request.pixel_values = None
-        request.attention_mask = None
-        request.image_grid_thw = None
-        request.extra_kwargs.clear()
+        self._release_preprocessed_inputs(request)
 
         # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
             return output.logits
         return output
+
+    @staticmethod
+    def _release_preprocessed_inputs(request: MLLMBatchRequest) -> None:
+        """Release request-local media tensors after prefill has consumed them."""
+        request.pixel_values = None
+        request.attention_mask = None
+        request.image_grid_thw = None
+        request.extra_kwargs.clear()
+
+    def _record_specprefill_outcome(
+        self,
+        request: MLLMBatchRequest,
+        *,
+        requested: bool,
+        engaged: bool,
+        reason: str,
+        original_tokens: int,
+        selected_tokens: int = 0,
+    ) -> None:
+        """Attach stable diagnostics and update aggregate SpecPrefill counters."""
+        identity = model_identity(self.model)
+        request.specprefill_outcome = SpecPrefillOutcome(
+            requested=requested,
+            engaged=engaged,
+            reason=reason,
+            model_module=identity.model_module,
+            language_module=identity.language_module,
+            model_type=identity.model_type,
+            original_tokens=original_tokens,
+            selected_tokens=selected_tokens,
+        )
+        self._specprefill_stats["decisions"] += 1
+        if engaged:
+            self._specprefill_stats["engaged"] += 1
+            self._specprefill_stats["original_tokens"] += original_tokens
+            self._specprefill_stats["selected_tokens"] += selected_tokens
+        else:
+            self._specprefill_stats["fallbacks"] += 1
+            bypass_counts = self._specprefill_stats["bypass_counts"]
+            bypass_counts[reason] = bypass_counts.get(reason, 0) + 1
+
+    def _resolved_specprefill_config(
+        self, request: MLLMBatchRequest
+    ) -> tuple[SpecPrefillRequestConfig, bool]:
+        """Resolve request overrides without losing threshold semantics."""
+        overrides = request.specprefill_config or SpecPrefillRequestConfig()
+        requested = (
+            overrides.enabled
+            if overrides.enabled is not None
+            else self.specprefill_enabled
+        )
+        return (
+            SpecPrefillRequestConfig(
+                enabled=overrides.enabled,
+                keep_pct=(
+                    overrides.keep_pct
+                    if overrides.keep_pct is not None
+                    else self.specprefill_keep_pct
+                ),
+                backbone_pct=(
+                    overrides.backbone_pct
+                    if overrides.backbone_pct is not None
+                    else self.specprefill_backbone_pct
+                ),
+            ),
+            requested,
+        )
+
+    def _specprefill_eligibility_reason(
+        self,
+        request: MLLMBatchRequest,
+        config: SpecPrefillRequestConfig,
+        requested: bool,
+    ) -> Optional[str]:
+        if not requested:
+            return (
+                "disabled_by_request"
+                if config.enabled is False
+                else "disabled_by_server"
+            )
+        if self.specprefill_runtime_reason is not None:
+            return self.specprefill_runtime_reason
+        if self._mtp_runtime_implementation == "native_target_head":
+            return "mtp_incompatible"
+        if (
+            self._mtp_runtime_implementation == "external_assistant"
+            and request.mllm_draft
+        ):
+            return "mtp_incompatible"
+        return request_eligibility_reason(
+            self.model,
+            self.specprefill_draft_model,
+            request,
+            config,
+            threshold=self.specprefill_threshold,
+        )
+
+    def _try_media_specprefill(
+        self,
+        request: MLLMBatchRequest,
+        cache: List[Any],
+    ) -> Tuple[Optional[mx.array], bool]:
+        """Return sparse logits and whether dense fallback needs a fresh cache."""
+        config, requested = self._resolved_specprefill_config(request)
+        original_tokens = (
+            int(request.input_ids.size) if request.input_ids is not None else 0
+        )
+        reason = self._specprefill_eligibility_reason(request, config, requested)
+        if reason is not None:
+            self._record_specprefill_outcome(
+                request,
+                requested=requested,
+                engaged=False,
+                reason=reason,
+                original_tokens=original_tokens,
+            )
+            return None, False
+
+        def _cancel_check() -> None:
+            if request.request_id in self._aborted_request_ids:
+                self._aborted_request_ids.discard(request.request_id)
+                raise PrefillAbortedError(request.request_id)
+
+        try:
+            logits, decode_rope_delta, selected_tokens = run_media_specprefill(
+                self.model,
+                self.language_model,
+                self.specprefill_draft_model,
+                request,
+                cache,
+                keep_pct=config.keep_pct,
+                backbone_pct=config.backbone_pct,
+                step_size=self.prefill_step_size,
+                cancel_check=_cancel_check,
+            )
+            if selected_tokens >= original_tokens:
+                self._record_specprefill_outcome(
+                    request,
+                    requested=requested,
+                    engaged=False,
+                    reason="selection_not_sparse",
+                    original_tokens=original_tokens,
+                    selected_tokens=selected_tokens,
+                )
+                return None, False
+        except PrefillAbortedError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Media SpecPrefill failed for %s; using dense VLM prefill: %s: %s",
+                request.request_id,
+                type(exc).__name__,
+                exc,
+            )
+            self._record_specprefill_outcome(
+                request,
+                requested=requested,
+                engaged=False,
+                reason="sparse_prefill_failed",
+                original_tokens=original_tokens,
+            )
+            return None, True
+
+        request.decode_rope_delta = decode_rope_delta
+        request.vision_encoded = True
+        self._release_preprocessed_inputs(request)
+        self._prefill_progress[request.request_id] = (
+            original_tokens,
+            original_tokens,
+        )
+        self._record_specprefill_outcome(
+            request,
+            requested=requested,
+            engaged=True,
+            reason="engaged",
+            original_tokens=original_tokens,
+            selected_tokens=selected_tokens,
+        )
+        logger.info(
+            "Media SpecPrefill engaged for %s: selected=%d/%d",
+            request.request_id,
+            selected_tokens,
+            original_tokens,
+        )
+        return logits, False
+
+    def _capture_dense_rope_delta(self, request: MLLMBatchRequest) -> None:
+        """Capture request-local Qwen MRoPE state before another prefill mutates it."""
+        if capability_reason(self.model) is None:
+            request.decode_rope_delta = getattr(
+                self.language_model, "_rope_deltas", None
+            )
 
     def _process_prompts(self, requests: List[MLLMBatchRequest]) -> MLLMBatch:
         """
@@ -1394,6 +1636,7 @@ class MLLMBatchGenerator:
                         token=0,
                         logprobs=mx.zeros(1),
                         finish_reason="error",
+                        specprefill_outcome=req.specprefill_outcome,
                     )
                 )
 
@@ -1490,15 +1733,14 @@ class MLLMBatchGenerator:
                     self._aborted_request_ids.discard(req.request_id)
                     raise PrefillAbortedError(req.request_id)
 
-                # Try prefix cache for all requests (text-only and multimodal).
-                # VLM forward writes the same KV state as language model forward
-                # for text tokens, so cached KV from a previous VLM run is valid.
-                # However, if the remaining (uncached) tokens contain image
-                # placeholders, we must fall back to VLM forward instead of
-                # running them through the language model alone.
+                # Media state is not represented in the token-only cache key,
+                # and supported Qwen routes also need request-local MRoPE
+                # deltas. Restrict shared prefix state to text-only requests.
                 cached_kv = None
                 remaining_ids = None
-                if self.prefix_cache is not None and req.input_ids is not None:
+                if self.prefix_cache is not None and is_text_only_prefix_cache_request(
+                    req
+                ):
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Strip think suffix from lookup key so stored entries
                     # (also stripped) match as clean PREFIX.
@@ -1509,19 +1751,6 @@ class MLLMBatchGenerator:
                     # sees the full generation prompt (<think>\n).
                     if cached_kv is not None and S > 0:
                         remaining_ids = list(remaining_ids) + input_ids_list[-S:]
-
-                    # If remaining tokens contain image placeholders, the
-                    # language-model-only path cannot handle them — clear the
-                    # cache hit so we fall through to full VLM forward.
-                    if cached_kv is not None and remaining_ids:
-                        img_tok = getattr(
-                            getattr(self.model, "config", None),
-                            "image_token_index",
-                            None,
-                        )
-                        if img_tok is not None and img_tok in remaining_ids:
-                            cached_kv = None
-                            remaining_ids = None
 
                 # Detect empty RotatingKVCache in cached entry — if any sliding-window
                 # layer has keys=None (all entries trimmed), the cache is unusable.
@@ -1680,7 +1909,28 @@ class MLLMBatchGenerator:
                                 req, cache=request_cache
                             )
                         else:
-                            logits = self._run_vision_encoding(req, cache=request_cache)
+                            _, specprefill_requested = (
+                                self._resolved_specprefill_config(req)
+                            )
+                            logits = None
+                            needs_fresh_cache = False
+                            if specprefill_requested:
+                                logits, needs_fresh_cache = self._try_media_specprefill(
+                                    req, request_cache
+                                )
+                            if logits is None:
+                                # Only a failed sparse target execution may
+                                # have advanced this cache. Ineligible and
+                                # non-sparse decisions reuse the untouched one.
+                                if needs_fresh_cache:
+                                    request_cache = make_prompt_cache(
+                                        self.language_model,
+                                        max_kv_size=self.max_kv_size or None,
+                                    )
+                                logits = self._run_vision_encoding(
+                                    req, cache=request_cache
+                                )
+                                self._capture_dense_rope_delta(req)
 
                         # Extract last token logits
                         last_logits = logits[:, -1, :]
@@ -1702,6 +1952,7 @@ class MLLMBatchGenerator:
                         token=0,
                         logprobs=mx.zeros(1),
                         finish_reason="abort",
+                        specprefill_outcome=req.specprefill_outcome,
                     )
                 )
 
@@ -1772,6 +2023,24 @@ class MLLMBatchGenerator:
         has_any_lp = any(batch_logits_processors)
         batch_samplers = [samplers_by_request.get(req.request_id) for req in requests]
         has_any_sampler = any(batch_samplers)
+        decode_rope_deltas = None
+        if any(req.decode_rope_delta is not None for req in requests):
+            template = next(
+                req.decode_rope_delta
+                for req in requests
+                if req.decode_rope_delta is not None
+            )
+            decode_rope_deltas = mx.concatenate(
+                [
+                    (
+                        req.decode_rope_delta
+                        if req.decode_rope_delta is not None
+                        else mx.zeros((1, 1), dtype=template.dtype)
+                    )
+                    for req in requests
+                ],
+                axis=0,
+            )
 
         self._stats.prompt_time += time.perf_counter() - tic
 
@@ -1780,10 +2049,7 @@ class MLLMBatchGenerator:
         # input_ids, etc. can be hundreds of MB per request; holding them
         # for the entire generation duration pins Metal buffers (issue #442).
         for req in requests:
-            req.pixel_values = None
-            req.attention_mask = None
-            req.image_grid_thw = None
-            req.extra_kwargs.clear()
+            self._release_preprocessed_inputs(req)
 
         return MLLMBatch(
             uids=[req.uid for req in requests],
@@ -1796,6 +2062,7 @@ class MLLMBatchGenerator:
             requests=requests,
             logits_processors=batch_logits_processors if has_any_lp else None,
             samplers=batch_samplers if has_any_sampler else None,
+            decode_rope_deltas=decode_rope_deltas,
         )
 
     def _step(
@@ -1823,8 +2090,16 @@ class MLLMBatchGenerator:
         if input_tokens.ndim == 1:
             input_tokens = input_tokens[:, None]
 
-        # Run language model only (not full VLM)
-        output = self.language_model(input_tokens, cache=cache)
+        # Run language model only (not full VLM). Supported Qwen media models
+        # require request-local MRoPE deltas during every decode step.
+        model_kwargs = {}
+        if (
+            self.active_batch is not None
+            and self.active_batch.decode_rope_deltas is not None
+            and len(self.active_batch) == int(input_tokens.shape[0])
+        ):
+            model_kwargs["rope_deltas"] = self.active_batch.decode_rope_deltas
+        output = self.language_model(input_tokens, cache=cache, **model_kwargs)
 
         # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
@@ -1919,6 +2194,7 @@ class MLLMBatchGenerator:
                             token=0,
                             logprobs=mx.zeros(1),
                             finish_reason="error",
+                            specprefill_outcome=req.specprefill_outcome,
                         )
                     )
 
@@ -1965,6 +2241,7 @@ class MLLMBatchGenerator:
                                 token=0,
                                 logprobs=mx.zeros(1),
                                 finish_reason="error",
+                                specprefill_outcome=req.specprefill_outcome,
                             )
                         )
 
@@ -2073,6 +2350,7 @@ class MLLMBatchGenerator:
                     logprobs=logprobs[i],
                     finish_reason=finish_reason,
                     prompt_cache=cache_fn,
+                    specprefill_outcome=req.specprefill_outcome,
                 )
             )
 
@@ -2144,7 +2422,7 @@ class MLLMBatchGenerator:
             return
         for i in end_indices:
             req = batch.requests[i]
-            if req.input_ids is not None:
+            if is_text_only_prefix_cache_request(req):
                 try:
                     extracted = batch.extract_cache(i)
                     input_ids_list = req.input_ids.reshape(-1).tolist()
@@ -2191,6 +2469,26 @@ class MLLMBatchGenerator:
             "memory_utilization": 0.0,
             "entry_count": 0,
         }
+
+    def get_specprefill_stats(self) -> Dict[str, Any]:
+        """Return aggregate media SpecPrefill decisions and compression."""
+        stats = dict(self._specprefill_stats)
+        stats["bypass_counts"] = dict(stats["bypass_counts"])
+        stats.update(
+            {
+                "enabled": self.specprefill_enabled,
+                "threshold": self.specprefill_threshold,
+                "keep_pct": self.specprefill_keep_pct,
+                "backbone_pct": self.specprefill_backbone_pct,
+                "draft_loaded": self.specprefill_draft_model is not None,
+                "runtime_reason": self.specprefill_runtime_reason,
+                "mtp_implementation": self._mtp_runtime_implementation,
+            }
+        )
+        original = stats["original_tokens"]
+        selected = stats["selected_tokens"]
+        stats["selection_rate"] = selected / original if original else 0.0
+        return stats
 
     def has_pending(self) -> bool:
         """Check if there are pending or active requests."""
@@ -2792,6 +3090,7 @@ def install_mtp_mllm(
                                 logprobs=draft_lp,
                                 finish_reason="stop",
                                 from_draft=from_draft,
+                                specprefill_outcome=r.specprefill_outcome,
                             )
                         )
                         draft_end_uids.add(uid)
@@ -2816,6 +3115,7 @@ def install_mtp_mllm(
                                 logprobs=draft_lp,
                                 finish_reason=draft_finish,
                                 from_draft=from_draft,
+                                specprefill_outcome=r.specprefill_outcome,
                             )
                         )
 
@@ -2851,6 +3151,9 @@ def install_mtp_mllm(
 
     batch_gen._step = _mtp_step
     batch_gen._next = _mtp_next
+    batch_gen._mtp_runtime_implementation = (
+        "external_assistant" if external_drafter else "native_target_head"
+    )
 
     if num_draft_tokens != 1:
         logger.warning(
@@ -2970,6 +3273,7 @@ def install_chunked_prefill_mllm(
                         if finish_reason is not None
                         else None
                     ),
+                    specprefill_outcome=req.specprefill_outcome,
                 )
             )
 
@@ -3007,6 +3311,7 @@ def install_chunked_prefill_mllm(
                         token=0,
                         logprobs=mx.zeros(1),
                         finish_reason="abort",
+                        specprefill_outcome=req.specprefill_outcome,
                     )
                 )
                 return _generation_step()
@@ -3189,7 +3494,10 @@ def install_chunked_prefill_mllm(
                     batch_gen.active_batch = new_batch
 
                 # Store in prefix cache (prompt-only)
-                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    batch_gen.prefix_cache is not None
+                    and is_text_only_prefix_cache_request(req)
+                ):
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
                         S = batch_gen._think_suffix_len
@@ -3234,7 +3542,7 @@ def install_chunked_prefill_mllm(
                 len(batch_gen.unprocessed_requests),
             )
             for r in compatible_pending:
-                if not r.images and not r.videos:
+                if not r.images and not r.videos and not r.audio:
                     text_only_req = r
                     break
 
@@ -3255,6 +3563,7 @@ def install_chunked_prefill_mllm(
                             token=0,
                             logprobs=mx.zeros(1),
                             finish_reason="error",
+                            specprefill_outcome=text_only_req.specprefill_outcome,
                         )
                     )
                     return _generation_step()
@@ -3269,7 +3578,9 @@ def install_chunked_prefill_mllm(
                 cached_count = 0
                 total_tokens = input_ids.shape[1]
 
-                if batch_gen.prefix_cache is not None:
+                if batch_gen.prefix_cache is not None and (
+                    is_text_only_prefix_cache_request(text_only_req)
+                ):
                     input_ids_list = input_ids.reshape(-1).tolist()
                     S = batch_gen._think_suffix_len
                     lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -26,7 +26,7 @@ import uuid
 import mlx.core as mx
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Set, Tuple
 
 from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
 
@@ -38,6 +38,9 @@ from .mllm_batch_generator import (
 from .mlx_streams import bind_generation_streams
 from .multimodal_processor import MultimodalProcessor
 from .request import RequestOutput, RequestStatus, SamplingParams
+
+if TYPE_CHECKING:
+    from .mllm_specprefill import SpecPrefillOutcome, SpecPrefillRequestConfig
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +93,11 @@ class MLLMSchedulerConfig:
     # evicted entries to disk and promotes them back on hit.
     ssd_cache_dir: Optional[str] = None
     ssd_cache_max_gb: float = 10.0
+    # Attention-based sparse prefill for eligible media-bearing requests.
+    specprefill_enabled: bool = False
+    specprefill_threshold: int = 8192
+    specprefill_keep_pct: float = 0.3
+    specprefill_backbone_pct: float = 0.0
 
 
 @dataclass
@@ -107,6 +115,8 @@ class MLLMRequest:
     audio: Optional[List[str]] = None
     sampling_params: SamplingParams = field(default_factory=SamplingParams)
     mllm_draft: bool = False
+    specprefill_config: Optional["SpecPrefillRequestConfig"] = None
+    specprefill_outcome: Optional["SpecPrefillOutcome"] = None
     arrival_time: float = field(default_factory=time.time)
 
     # Batch generator UID (assigned when scheduled)
@@ -189,6 +199,7 @@ class MLLMScheduler:
         draft_model: Any = None,
         draft_kind: Optional[str] = None,
         draft_block_size: Optional[int] = None,
+        specprefill_draft_model: Optional[Any] = None,
     ):
         """
         Initialize MLLM scheduler.
@@ -197,6 +208,7 @@ class MLLMScheduler:
             model: The VLM model
             processor: The VLM processor
             config: Scheduler configuration
+            specprefill_draft_model: Loaded draft model used for token scoring
         """
         self.model = model
         self.processor = processor
@@ -204,6 +216,7 @@ class MLLMScheduler:
         self.draft_model = draft_model
         self.draft_kind = draft_kind
         self.draft_block_size = draft_block_size
+        self.specprefill_draft_model = specprefill_draft_model
 
         # Get model config
         self.model_config = getattr(model, "config", None)
@@ -335,6 +348,20 @@ class MLLMScheduler:
                 prefill_step_size=self.config.prefill_step_size,
                 prefix_cache_config=prefix_cache_config,
                 max_kv_size=self.config.max_kv_size,
+                specprefill_draft_model=self.specprefill_draft_model,
+                specprefill_enabled=self.config.specprefill_enabled,
+                specprefill_threshold=self.config.specprefill_threshold,
+                specprefill_keep_pct=self.config.specprefill_keep_pct,
+                specprefill_backbone_pct=self.config.specprefill_backbone_pct,
+                specprefill_runtime_reason=(
+                    "chunked_prefill_incompatible"
+                    if self.config.chunked_prefill_tokens > 0
+                    else (
+                        "rotating_cache_incompatible"
+                        if self.config.max_kv_size > 0
+                        else None
+                    )
+                ),
             )
 
             # Wire the SSD cold tier onto the MLLM prefix cache, mirroring the
@@ -437,6 +464,14 @@ class MLLMScheduler:
         if request_id is None:
             request_id = str(uuid.uuid4())
 
+        from .mllm_specprefill import SpecPrefillRequestConfig
+
+        specprefill_config = SpecPrefillRequestConfig(
+            enabled=kwargs.pop("specprefill", None),
+            keep_pct=kwargs.pop("specprefill_keep_pct", None),
+            backbone_pct=kwargs.pop("specprefill_backbone_pct", None),
+        )
+
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
             temperature=temperature,
@@ -456,6 +491,7 @@ class MLLMScheduler:
             audio=audio,
             sampling_params=sampling_params,
             mllm_draft=bool(kwargs.pop("mllm_draft", False)),
+            specprefill_config=specprefill_config,
         )
 
         # Estimate prompt token count for monitoring (text tokens only;
@@ -604,6 +640,7 @@ class MLLMScheduler:
                 repetition_penalty=request.sampling_params.repetition_penalty,
                 logits_processors=request.sampling_params.logits_processors,
                 mllm_draft=request.mllm_draft,
+                specprefill_config=request.specprefill_config,
             )
             batch_requests.append(batch_req)
 
@@ -656,6 +693,9 @@ class MLLMScheduler:
             if request is None:
                 continue
 
+            if response.specprefill_outcome is not None:
+                request.specprefill_outcome = response.specprefill_outcome
+
             # Handle error responses from failed preprocessing
             if response.finish_reason == "error":
                 output = RequestOutput(
@@ -667,6 +707,7 @@ class MLLMScheduler:
                     completion_tokens=0,
                     finished=True,
                     finish_reason="error",
+                    specprefill_outcome=request.specprefill_outcome,
                 )
                 request.status = RequestStatus.FINISHED_ABORTED
                 request.output_text = ""
@@ -710,6 +751,7 @@ class MLLMScheduler:
                 completion_tokens=request.num_output_tokens,
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
+                specprefill_outcome=request.specprefill_outcome,
             )
 
             # Check if finished
@@ -1253,6 +1295,7 @@ class MLLMScheduler:
             stats["vision_embedding_cache"] = vec_stats
             if hasattr(self.batch_generator, "get_mtp_stats"):
                 stats["mtp"] = self.batch_generator.get_mtp_stats()
+            stats["specprefill"] = self.batch_generator.get_specprefill_stats()
 
         # Include Metal memory stats
         try:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -348,7 +348,7 @@ class MLLMScheduler:
                 prefill_step_size=self.config.prefill_step_size,
                 prefix_cache_config=prefix_cache_config,
                 max_kv_size=self.config.max_kv_size,
-                specprefill_draft_model=self.specprefill_draft_model,
+                specprefill_draft_model=getattr(self, "specprefill_draft_model", None),
                 specprefill_enabled=self.config.specprefill_enabled,
                 specprefill_threshold=self.config.specprefill_threshold,
                 specprefill_keep_pct=self.config.specprefill_keep_pct,

--- a/vllm_mlx/mllm_specprefill.py
+++ b/vllm_mlx/mllm_specprefill.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local SpecPrefill helpers for supported Qwen media models.
+
+This module deliberately does not use :func:`specprefill.sparse_prefill`.
+That helper installs RoPE wrappers on a shared model, which is unsuitable for
+continuous batching.  Instead, this adapter asks mlx-vlm for the already fused
+media/text embeddings and exact MRoPE positions, selects both at the same
+indices, and passes them directly to the language model.
+
+The public identity and eligibility helpers do not import MLX.  Runtime tensor
+dependencies are imported lazily by :func:`run_media_specprefill`, allowing
+Linux control-plane tests to import this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+_QWEN_CHUNK_SIZE = 32
+_MAX_SCORED_TOKENS = 65536
+
+
+@dataclass(frozen=True)
+class ModelIdentity:
+    """Runtime classes and model type used for fail-closed capability checks."""
+
+    model_module: str | None = None
+    language_module: str | None = None
+    model_type: str | None = None
+
+
+@dataclass(frozen=True)
+class SpecPrefillRequestConfig:
+    """Per-request overrides forwarded by the MLLM scheduler."""
+
+    enabled: bool | None = None
+    keep_pct: float | None = None
+    backbone_pct: float | None = None
+
+
+@dataclass
+class SpecPrefillOutcome:
+    """Stable request diagnostics for API and scheduler metadata."""
+
+    requested: bool | None = None
+    engaged: bool = False
+    reason: str = "not_evaluated"
+    route: str = "mllm_media"
+    model_module: str | None = None
+    language_module: str | None = None
+    model_type: str | None = None
+    original_tokens: int = 0
+    selected_tokens: int = 0
+
+
+_SUPPORTED_IDENTITIES: dict[str, ModelIdentity] = {
+    "mlx_vlm.models.qwen3_vl.qwen3_vl": ModelIdentity(
+        model_module="mlx_vlm.models.qwen3_vl.qwen3_vl",
+        language_module="mlx_vlm.models.qwen3_vl.language",
+        model_type="qwen3_vl",
+    ),
+    "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe": ModelIdentity(
+        model_module="mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe",
+        language_module="mlx_vlm.models.qwen3_vl_moe.language",
+        model_type="qwen3_vl_moe",
+    ),
+    "mlx_vlm.models.qwen3_5.qwen3_5": ModelIdentity(
+        model_module="mlx_vlm.models.qwen3_5.qwen3_5",
+        language_module="mlx_vlm.models.qwen3_5.language",
+        model_type="qwen3_5",
+    ),
+    "mlx_vlm.models.qwen3_5_moe.qwen3_5_moe": ModelIdentity(
+        model_module="mlx_vlm.models.qwen3_5_moe.qwen3_5_moe",
+        language_module="mlx_vlm.models.qwen3_5_moe.language",
+        model_type="qwen3_5_moe",
+    ),
+}
+
+
+SUPPORTED_QWEN_MEDIA_MODULES = frozenset(_SUPPORTED_IDENTITIES)
+
+
+@dataclass(frozen=True)
+class _PreparedMediaFeatures:
+    input_ids: Any
+    inputs_embeds: Any
+    position_ids: Any
+    rope_deltas: Any
+    visual_pos_masks: Any
+    deepstack_visual_embeds: Any
+
+
+def _config_value(config: Any, name: str) -> Any:
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def model_identity(model: Any) -> ModelIdentity:
+    """Return the exact runtime identity used by the capability allowlist."""
+
+    language_model = getattr(model, "language_model", None)
+    config = getattr(model, "config", None)
+    return ModelIdentity(
+        model_module=getattr(type(model), "__module__", None),
+        language_module=(
+            getattr(type(language_model), "__module__", None)
+            if language_model is not None
+            else None
+        ),
+        model_type=_config_value(config, "model_type"),
+    )
+
+
+def capability_reason(model: Any) -> str | None:
+    """Return ``None`` only for an exact supported Qwen runtime identity."""
+
+    identity = model_identity(model)
+    expected = _SUPPORTED_IDENTITIES.get(identity.model_module or "")
+    if expected is None:
+        return "unsupported_model_module"
+    if (
+        identity.language_module != expected.language_module
+        or identity.model_type != expected.model_type
+    ):
+        return "model_module_mismatch"
+    if not callable(getattr(model, "get_input_embeddings", None)):
+        return "embedding_state_unavailable"
+    return None
+
+
+def _flatten_list(value: Any) -> list[Any]:
+    if isinstance(value, (list, tuple)):
+        flattened: list[Any] = []
+        for item in value:
+            flattened.extend(_flatten_list(item))
+        return flattened
+    return [value]
+
+
+def _token_list(input_ids: Any) -> list[int]:
+    if input_ids is None:
+        return []
+    value = input_ids.tolist() if hasattr(input_ids, "tolist") else input_ids
+    return [int(token) for token in _flatten_list(value)]
+
+
+def _media_token_ids(model_config: Any) -> set[int]:
+    token_ids = set()
+    for name in (
+        "image_token_index",
+        "video_token_index",
+        "image_token_id",
+        "video_token_id",
+    ):
+        value = _config_value(model_config, name)
+        if value is not None:
+            token_ids.add(int(value))
+    return token_ids
+
+
+def _media_boundary_token_ids(model_config: Any) -> set[int]:
+    token_ids = set()
+    for name in (
+        "vision_start_token_id",
+        "vision_start_token_index",
+        "vision_end_token_id",
+        "vision_end_token_index",
+    ):
+        value = _config_value(model_config, name)
+        if value is not None:
+            token_ids.add(int(value))
+    return token_ids
+
+
+def _media_placeholder_indices(input_ids: Any, model_config: Any) -> set[int]:
+    tokens = _token_list(input_ids)
+    media_ids = _media_token_ids(model_config)
+    return {index for index, token in enumerate(tokens) if token in media_ids}
+
+
+def required_media_indices(input_ids: Any, model_config: Any) -> set[int]:
+    """Return visual placeholder indices plus the required final prompt token."""
+
+    tokens = _token_list(input_ids)
+    if not tokens:
+        return set()
+    required_ids = _media_token_ids(model_config) | _media_boundary_token_ids(
+        model_config
+    )
+    required = {i for i, token in enumerate(tokens) if token in required_ids}
+    required.add(len(tokens) - 1)
+    return required
+
+
+def request_eligibility_reason(
+    model: Any,
+    draft_model: Any,
+    request: Any,
+    config: SpecPrefillRequestConfig,
+    *,
+    threshold: int = 0,
+) -> str | None:
+    """Evaluate request-local controls and static compatibility fail closed."""
+
+    if config.enabled is False:
+        return "disabled_by_request"
+    reason = capability_reason(model)
+    if reason is not None:
+        return reason
+    if draft_model is None:
+        return "draft_unavailable"
+    if getattr(request, "audio", None):
+        return "unsupported_media_type"
+    input_ids = getattr(request, "input_ids", None)
+    tokens = _token_list(input_ids)
+    if not tokens:
+        return "embedding_state_unavailable"
+    if len(tokens) > _MAX_SCORED_TOKENS:
+        return "prompt_too_long"
+    media_indices = _media_placeholder_indices(
+        input_ids, getattr(model, "config", None)
+    )
+    if not media_indices:
+        return "unsupported_media_type"
+    if config.enabled is not True and len(tokens) <= threshold:
+        return "below_threshold"
+    keep_pct = config.keep_pct
+    backbone_pct = config.backbone_pct
+    if keep_pct is not None and not 0.0 < keep_pct <= 1.0:
+        return "invalid_request_controls"
+    if backbone_pct is not None and not 0.0 <= backbone_pct <= 1.0:
+        return "invalid_request_controls"
+    if keep_pct is not None and backbone_pct is not None and backbone_pct > keep_pct:
+        return "invalid_request_controls"
+    return None
+
+
+def _feature_value(features: Any, name: str) -> Any:
+    if isinstance(features, dict):
+        return features.get(name)
+    return getattr(features, name, None)
+
+
+def _ensure_batched(array: Any) -> Any:
+    if getattr(array, "ndim", None) == 1:
+        return array[None, :]
+    return array
+
+
+def _visual_mask_from_tokens(input_ids: Any, model_config: Any, mx: Any) -> Any:
+    tokens = _token_list(input_ids)
+    media_ids = _media_token_ids(model_config)
+    return mx.array([[token in media_ids for token in tokens]])
+
+
+def _prepare_media_features(
+    model: Any, request: Any, mx: Any
+) -> _PreparedMediaFeatures:
+    input_ids = _ensure_batched(getattr(request, "input_ids", None))
+    if input_ids is None or getattr(input_ids, "ndim", None) != 2:
+        raise ValueError("media SpecPrefill requires one batched input_ids sequence")
+    if int(input_ids.shape[0]) != 1:
+        raise ValueError("media SpecPrefill prepares one request at a time")
+
+    kwargs = dict(getattr(request, "extra_kwargs", {}) or {})
+    for duplicate in ("input_ids", "pixel_values", "attention_mask"):
+        kwargs.pop(duplicate, None)
+
+    attention_mask = getattr(request, "attention_mask", None)
+    if attention_mask is not None:
+        attention_mask = _ensure_batched(attention_mask)
+        kwargs["mask"] = attention_mask
+
+    image_grid_thw = getattr(request, "image_grid_thw", None)
+    if image_grid_thw is not None:
+        kwargs["image_grid_thw"] = image_grid_thw
+
+    features = model.get_input_embeddings(
+        input_ids=input_ids,
+        pixel_values=getattr(request, "pixel_values", None),
+        **kwargs,
+    )
+    inputs_embeds = _feature_value(features, "inputs_embeds")
+    position_ids = _feature_value(features, "position_ids")
+    rope_deltas = _feature_value(features, "rope_deltas")
+    if inputs_embeds is None or position_ids is None or rope_deltas is None:
+        raise ValueError("mlx-vlm did not return complete media embedding state")
+
+    sequence_length = int(input_ids.shape[-1])
+    if int(inputs_embeds.shape[-2]) != sequence_length:
+        raise ValueError("fused embedding length does not match input_ids")
+    if int(position_ids.shape[-1]) != sequence_length:
+        raise ValueError("position_ids length does not match input_ids")
+
+    visual_pos_masks = _feature_value(features, "visual_pos_masks")
+    if visual_pos_masks is None:
+        visual_pos_masks = _visual_mask_from_tokens(
+            input_ids, getattr(model, "config", None), mx
+        )
+    else:
+        visual_pos_masks = _ensure_batched(visual_pos_masks)
+    if int(visual_pos_masks.shape[-1]) != sequence_length:
+        raise ValueError("visual position mask length does not match input_ids")
+
+    return _PreparedMediaFeatures(
+        input_ids=input_ids,
+        inputs_embeds=inputs_embeds,
+        position_ids=position_ids,
+        rope_deltas=rope_deltas,
+        visual_pos_masks=visual_pos_masks,
+        deepstack_visual_embeds=_feature_value(features, "deepstack_visual_embeds"),
+    )
+
+
+def _as_indices(value: Any) -> list[int]:
+    values = value.tolist() if hasattr(value, "tolist") else value
+    return sorted({int(index) for index in _flatten_list(values)})
+
+
+def _required_chunks(required: set[int], length: int) -> set[int]:
+    indices: set[int] = set()
+    for index in required:
+        start = (index // _QWEN_CHUNK_SIZE) * _QWEN_CHUNK_SIZE
+        indices.update(range(start, min(start + _QWEN_CHUNK_SIZE, length)))
+    return indices
+
+
+def _take_sequence(values: Any, indices: Any) -> Any:
+    """Gather the sequence axis from a batched embedding tensor."""
+
+    return values[:, indices, :]
+
+
+def _take_last_axis(values: Any, indices: Any) -> Any:
+    return values[..., indices]
+
+
+def _visual_ordinals(mask: Any, selected: list[int]) -> list[int]:
+    flat_mask = [bool(value) for value in _flatten_list(mask.tolist())]
+    ordinal_by_position: dict[int, int] = {}
+    ordinal = 0
+    for position, is_visual in enumerate(flat_mask):
+        if is_visual:
+            ordinal_by_position[position] = ordinal
+            ordinal += 1
+    return [
+        ordinal_by_position[index] for index in selected if index in ordinal_by_position
+    ]
+
+
+def _take_deepstack(deepstack: Any, ordinals: list[int], mx: Any) -> Any:
+    if deepstack is None:
+        return None
+    indices = mx.array(ordinals, dtype=mx.uint32)
+    return [embeds[indices] for embeds in deepstack]
+
+
+def _cache_eval_values(cache: Any) -> list[Any]:
+    values: list[Any] = []
+    for layer in cache or ():
+        state = getattr(layer, "state", None)
+        if isinstance(state, (list, tuple)):
+            values.extend(value for value in state if value is not None)
+        elif state is not None:
+            values.append(state)
+        else:
+            for name in ("keys", "values"):
+                value = getattr(layer, name, None)
+                if value is not None:
+                    values.append(value)
+    return values
+
+
+def _slice_deepstack_window(
+    deepstack: Any,
+    selected_visual_mask: Any,
+    start: int,
+    end: int,
+) -> Any:
+    if deepstack is None:
+        return None
+    mask = [bool(value) for value in _flatten_list(selected_visual_mask.tolist())]
+    before = sum(mask[:start])
+    count = sum(mask[start:end])
+    return [embeds[before : before + count] for embeds in deepstack]
+
+
+def _draft_vocab_size(model: Any) -> int | None:
+    args = getattr(model, "args", None)
+    value = _config_value(args, "vocab_size")
+    if value is None:
+        value = _config_value(_config_value(args, "text_config"), "vocab_size")
+    if value is None:
+        value = _config_value(getattr(model, "config", None), "vocab_size")
+    return int(value) if value is not None else None
+
+
+def _draft_model_type(model: Any) -> str | None:
+    for source in (
+        getattr(model, "config", None),
+        getattr(model, "args", None),
+        model,
+    ):
+        value = _config_value(source, "model_type")
+        if value:
+            return str(value)
+    return None
+
+
+def run_media_specprefill(
+    model: Any,
+    language_model: Any,
+    draft_model: Any,
+    request: Any,
+    cache: Any,
+    keep_pct: float,
+    backbone_pct: float,
+    step_size: int,
+    cancel_check: Callable[[], None] | None = None,
+) -> tuple[Any, Any, int]:
+    """Run media-aware sparse prefill without modifying shared RoPE modules.
+
+    The returned ``decode_rope_delta`` is adjusted for the difference between
+    the original and sparse cache lengths and must be passed explicitly on
+    every subsequent decode call. A non-sparse selection returns
+    ``(None, None, selected_count)`` before mutating the target cache.
+    """
+
+    reason = capability_reason(model)
+    if reason is not None:
+        raise ValueError(f"media SpecPrefill unavailable: {reason}")
+    if language_model is not getattr(model, "language_model", None):
+        raise ValueError("language_model does not belong to the target model")
+    if draft_model is None:
+        raise ValueError("media SpecPrefill requires a draft model")
+    if not 0.0 < keep_pct <= 1.0:
+        raise ValueError("keep_pct must be in (0, 1]")
+    if not 0.0 <= backbone_pct <= keep_pct:
+        raise ValueError("backbone_pct must be in [0, keep_pct]")
+    if step_size <= 0:
+        raise ValueError("step_size must be positive")
+    import mlx.core as mx
+
+    from .specprefill import _qwen35_extract_queries, score_tokens, select_chunks
+
+    if cancel_check is not None:
+        cancel_check()
+
+    tokens = _token_list(getattr(request, "input_ids", None))
+    if not tokens:
+        raise ValueError("media SpecPrefill requires input_ids")
+    config = getattr(model, "config", None)
+    required = required_media_indices(getattr(request, "input_ids", None), config)
+    media_positions = _media_placeholder_indices(
+        getattr(request, "input_ids", None), config
+    )
+    if not media_positions:
+        raise ValueError("media SpecPrefill requires visual placeholder tokens")
+    if keep_pct >= 1.0:
+        return None, None, len(tokens)
+
+    draft_vocab_size = _draft_vocab_size(draft_model)
+    if draft_vocab_size is not None:
+        media_scoring_ids = _media_token_ids(config) | _media_boundary_token_ids(config)
+        score_input_ids = [
+            0 if token in media_scoring_ids and token >= draft_vocab_size else token
+            for token in tokens
+        ]
+        if max(score_input_ids) >= draft_vocab_size:
+            raise ValueError("draft vocabulary cannot score target prompt tokens")
+    else:
+        score_input_ids = tokens
+
+    score_kwargs = {
+        "prefill_step_size": step_size,
+        "cancel_check": cancel_check,
+    }
+    if _draft_model_type(draft_model) in {"qwen3_5", "qwen3_5_moe"}:
+        score_kwargs["query_extractor"] = _qwen35_extract_queries
+    importance = score_tokens(draft_model, score_input_ids, **score_kwargs)
+    if cancel_check is not None:
+        cancel_check()
+    selected = select_chunks(
+        importance,
+        keep_pct=keep_pct,
+        backbone_pct=backbone_pct,
+    )
+    selected_indices = set(_as_indices(selected))
+    selected_indices.update(_required_chunks(required, len(tokens)))
+    selected_list = sorted(selected_indices)
+    if not selected_list or selected_list[-1] != len(tokens) - 1:
+        raise RuntimeError("SpecPrefill selection omitted the final prompt token")
+    selected_count = len(selected_list)
+    if selected_count >= len(tokens):
+        return None, None, selected_count
+
+    if cancel_check is not None:
+        cancel_check()
+    features = _prepare_media_features(model, request, mx)
+    index_array = mx.array(selected_list, dtype=mx.uint32)
+    selected_tokens = features.input_ids[:, index_array]
+    selected_embeds = _take_sequence(features.inputs_embeds, index_array)
+    selected_positions = _take_last_axis(features.position_ids, index_array)
+    selected_visual_mask = _take_last_axis(features.visual_pos_masks, index_array)
+    visual_ordinals = _visual_ordinals(features.visual_pos_masks, selected_list)
+    selected_deepstack = _take_deepstack(
+        features.deepstack_visual_embeds, visual_ordinals, mx
+    )
+
+    output = None
+    for start in range(0, selected_count, step_size):
+        if cancel_check is not None:
+            cancel_check()
+        end = min(start + step_size, selected_count)
+        call_kwargs = {
+            "cache": cache,
+            "inputs_embeds": selected_embeds[:, start:end, :],
+            "position_ids": selected_positions[..., start:end],
+            "visual_pos_masks": selected_visual_mask[..., start:end],
+        }
+        deepstack_window = _slice_deepstack_window(
+            selected_deepstack, selected_visual_mask, start, end
+        )
+        if deepstack_window is not None:
+            call_kwargs["deepstack_visual_embeds"] = deepstack_window
+        output = language_model(selected_tokens[:, start:end], **call_kwargs)
+
+        if end < selected_count:
+            eval_values = _cache_eval_values(cache)
+            if eval_values:
+                mx.eval(*eval_values)
+            mx.clear_cache()
+
+    if output is None:
+        raise RuntimeError("media SpecPrefill produced no target output")
+    logits = getattr(output, "logits", output)
+    mx.eval(logits)
+
+    original_count = len(tokens)
+    compression_adjustment = original_count - selected_count
+    decode_rope_delta = features.rope_deltas + compression_adjustment
+    mx.eval(decode_rope_delta)
+    return logits, decode_rope_delta, selected_count
+
+
+__all__ = [
+    "SUPPORTED_QWEN_MEDIA_MODULES",
+    "ModelIdentity",
+    "SpecPrefillOutcome",
+    "SpecPrefillRequestConfig",
+    "capability_reason",
+    "model_identity",
+    "request_eligibility_reason",
+    "required_media_indices",
+    "run_media_specprefill",
+]

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -1157,6 +1157,11 @@ class ModelManager:
                 stream_interval=config.stream_interval,
                 force_mllm=config.force_mllm,
                 gpu_memory_utilization=config.gpu_memory_utilization,
+                specprefill_enabled=config.specprefill_enabled,
+                specprefill_threshold=config.specprefill_threshold,
+                specprefill_keep_pct=config.specprefill_keep_pct,
+                specprefill_backbone_pct=config.specprefill_backbone_pct,
+                specprefill_draft_model=config.specprefill_draft_model,
             )
         else:
             engine = SimpleEngine(

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
+    from .mllm_specprefill import SpecPrefillOutcome
     from .paged_cache import BlockTable
 
 
@@ -217,6 +218,8 @@ class RequestOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Request-level sparse-prefill decision and diagnostics.
+    specprefill_outcome: Optional["SpecPrefillOutcome"] = None
 
     @property
     def usage(self) -> Dict[str, int]:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -591,7 +591,12 @@ def _generation_metadata(
     mtp_drafts = getattr(output, "mtp_drafts", 0) or 0
     mtp_accepted = getattr(output, "mtp_accepted", 0) or 0
     has_mtp_activity = bool(mtp_drafts or mtp_accepted)
-    if thinking_processor is None and not has_mtp_activity:
+    specprefill_outcome = getattr(output, "specprefill_outcome", None)
+    if (
+        thinking_processor is None
+        and not has_mtp_activity
+        and specprefill_outcome is None
+    ):
         return None
     return GenerationMetadata(
         no_final_content_watchdog_tokens=getattr(
@@ -602,6 +607,25 @@ def _generation_metadata(
         ),
         mtp_drafts=mtp_drafts if has_mtp_activity else None,
         mtp_accepted=mtp_accepted if has_mtp_activity else None,
+        specprefill_requested=getattr(specprefill_outcome, "requested", None),
+        specprefill_engaged=(
+            getattr(specprefill_outcome, "engaged", None)
+            if specprefill_outcome is not None
+            else None
+        ),
+        specprefill_reason=getattr(specprefill_outcome, "reason", None),
+        specprefill_route=getattr(specprefill_outcome, "route", None),
+        specprefill_model_module=getattr(specprefill_outcome, "model_module", None),
+        specprefill_language_module=getattr(
+            specprefill_outcome, "language_module", None
+        ),
+        specprefill_model_type=getattr(specprefill_outcome, "model_type", None),
+        specprefill_original_tokens=getattr(
+            specprefill_outcome, "original_tokens", None
+        ),
+        specprefill_selected_tokens=getattr(
+            specprefill_outcome, "selected_tokens", None
+        ),
     )
 
 
@@ -1357,6 +1381,11 @@ def _build_engine(spec: ModelSpec) -> BaseEngine:
             scheduler_config=spec.scheduler_config,
             stream_interval=spec.stream_interval,
             force_mllm=spec.force_mllm,
+            specprefill_enabled=spec.specprefill_enabled,
+            specprefill_threshold=spec.specprefill_threshold,
+            specprefill_keep_pct=spec.specprefill_keep_pct,
+            specprefill_backbone_pct=spec.specprefill_backbone_pct,
+            specprefill_draft_model=spec.specprefill_draft_model,
         )
 
     from .engine.simple import SimpleEngine
@@ -3401,7 +3430,7 @@ def load_model(
         trust_remote_code: Allow HuggingFace remote code execution during model/tokenizer loading
         mtp: Enable native MTP speculative decoding (SimpleEngine only)
         prefill_step_size: Chunk size for prompt prefill processing (default: 2048)
-        specprefill_enabled: Enable SpecPrefill (SimpleEngine only)
+        specprefill_enabled: Enable SpecPrefill
         specprefill_threshold: Minimum suffix tokens to trigger SpecPrefill (default: 8192)
         specprefill_keep_pct: Fraction of tokens to keep (default: 0.3)
         specprefill_backbone_pct: Fraction of chunks reserved for evenly spaced coverage
@@ -3547,6 +3576,11 @@ def load_model(
             mllm_draft_kind=mllm_draft_kind,
             mllm_draft_block_size=mllm_draft_block_size,
             default_mllm_draft=default_mllm_draft,
+            specprefill_enabled=specprefill_enabled,
+            specprefill_threshold=specprefill_threshold,
+            specprefill_keep_pct=specprefill_keep_pct,
+            specprefill_backbone_pct=specprefill_backbone_pct,
+            specprefill_draft_model=specprefill_draft_model,
         )
         # BatchedEngine will be started in lifespan (uvicorn's event loop)
         # Just log for now
@@ -6880,6 +6914,10 @@ async def stream_chat_completion(
             f"Chat completion (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
+        terminal_metadata = (
+            _generation_metadata(None, last_output) if last_output is not None else None
+        )
+
         # Send final chunk with usage if requested
         if include_usage:
             usage_chunk = ChatCompletionChunk(
@@ -6891,8 +6929,17 @@ async def stream_chat_completion(
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
                 ),
+                generation_metadata=terminal_metadata,
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"
+        elif terminal_metadata is not None:
+            metadata_chunk = ChatCompletionChunk(
+                id=response_id,
+                model=_response_model_name(request.model),
+                choices=[],
+                generation_metadata=terminal_metadata,
+            )
+            yield f"data: {metadata_chunk.model_dump_json()}\n\n"
 
         yield "data: [DONE]\n\n"
     except HTTPException as exc:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -4568,6 +4568,8 @@ async def _build_chat_streaming_response(
     chat_kwargs,
     total_timeout,
     deadline,
+    *,
+    thinking_processor=None,
 ) -> tuple[StreamingResponse | Response, bool]:
     """Build a chat stream and report whether caller cleanup remains required."""
     stream_generator = stream_chat_completion(
@@ -4575,6 +4577,7 @@ async def _build_chat_streaming_response(
         messages,
         request,
         metrics_tracker=metrics_tracker,
+        thinking_processor=thinking_processor,
         **chat_kwargs,
     )
     if _response_format_type(request.response_format) in (
@@ -5344,6 +5347,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 prepared.chat_kwargs,
                 total_timeout,
                 deadline,
+                thinking_processor=prepared.thinking_processor,
             )
             return response
 
@@ -6445,6 +6449,8 @@ async def stream_chat_completion(
     messages: list,
     request: ChatCompletionRequest,
     metrics_tracker=None,
+    *,
+    thinking_processor: object | None = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response."""
@@ -6456,6 +6462,16 @@ async def stream_chat_completion(
     # compute once instead of model_dump()-ing the whole request on every
     # tool-call delta during streaming.
     tool_request_context, tools_dict, include_usage = _stream_request_metadata(request)
+
+    def attach_terminal_metadata(
+        chunk: ChatCompletionChunk, output: object | None
+    ) -> None:
+        if (
+            not include_usage
+            and chunk.choices
+            and chunk.choices[0].finish_reason is not None
+        ):
+            chunk.generation_metadata = _generation_metadata(thinking_processor, output)
 
     # First chunk with role
     first_chunk = ChatCompletionChunk(
@@ -6641,6 +6657,7 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
+                            attach_terminal_metadata(chunk, output)
                             yield f"data: {chunk.model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
@@ -6691,6 +6708,7 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
+                attach_terminal_metadata(chunk, output)
                 yield f"data: {chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
@@ -6775,6 +6793,7 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
+                            attach_terminal_metadata(chunk, output)
                             yield f"data: {chunk.model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
@@ -6824,6 +6843,7 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
+                attach_terminal_metadata(chunk, output)
                 yield f"data: {chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
@@ -6870,6 +6890,7 @@ async def stream_chat_completion(
                         )
                     ],
                 )
+                attach_terminal_metadata(tool_chunk, last_output)
                 yield f"data: {tool_chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = True
 
@@ -6898,6 +6919,7 @@ async def stream_chat_completion(
                 ],
                 usage=get_usage(last_output),
             )
+            attach_terminal_metadata(terminal_chunk, last_output)
             yield f"data: {terminal_chunk.model_dump_json()}\n\n"
 
         # Structured streams are buffered by the endpoint until this independent
@@ -6914,12 +6936,13 @@ async def stream_chat_completion(
             f"Chat completion (stream): {completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)"
         )
 
-        terminal_metadata = (
-            _generation_metadata(None, last_output) if last_output is not None else None
-        )
-
         # Send final chunk with usage if requested
         if include_usage:
+            terminal_metadata = (
+                _generation_metadata(thinking_processor, last_output)
+                if last_output is not None
+                else None
+            )
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
                 model=_response_model_name(request.model),
@@ -6932,14 +6955,6 @@ async def stream_chat_completion(
                 generation_metadata=terminal_metadata,
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"
-        elif terminal_metadata is not None:
-            metadata_chunk = ChatCompletionChunk(
-                id=response_id,
-                model=_response_model_name(request.model),
-                choices=[],
-                generation_metadata=terminal_metadata,
-            )
-            yield f"data: {metadata_chunk.model_dump_json()}\n\n"
 
         yield "data: [DONE]\n\n"
     except HTTPException as exc:


### PR DESCRIPTION
## Summary

Closes #506.
Closes #511.

Media-bearing requests use `MLLMScheduler` and `MLLMBatchGenerator`, while the existing SpecPrefill implementation only covered TextModel-direct routes. This PR adds an opt-in VLM-aware SpecPrefill path for batched Qwen media requests.

Supported runtime identities:

- Qwen3-VL dense
- Qwen3-VL MoE
- Qwen3.5 dense
- Qwen3.5 MoE

Unknown or mismatched implementations fail closed and continue through the existing dense media prefill path.

### Media-aware sparse prefill

The new `vllm_mlx/mllm_specprefill.py` adapter obtains the model’s fused media state through `get_input_embeddings` before selecting prompt chunks:

```python
features = model.get_input_embeddings(
    input_ids=input_ids,
    pixel_values=request.pixel_values,
    **kwargs,
)
```

The adapter selects the same positions across all request-local media state:

```python
selected_tokens = features.input_ids[:, index_array]
selected_embeds = features.inputs_embeds[:, index_array, :]
selected_positions = features.position_ids[..., index_array]
selected_visual_mask = features.visual_pos_masks[..., index_array]
```

Selection always retains:

- image and video placeholder chunks
- visual start and end boundary chunks
- the final prompt token
- the first uncached chunk when composing a cached text prefix

Deep-stack visual embeddings are gathered using visual-token ordinals, so selected visual state stays aligned with its placeholders.

### Request-local MRoPE handling

The implementation does not install or mutate shared RoPE wrappers.

Instead, each request carries its own adjusted decode delta:

```python
compression_adjustment = original_count - selected_count
decode_rope_delta = features.rope_deltas + compression_adjustment
```

`MLLMBatch` keeps these deltas aligned when rows are created, filtered, or extended. Decode calls pass the current batch values explicitly:

```python
model_kwargs["rope_deltas"] = self.active_batch.decode_rope_deltas
output = self.language_model(input_tokens, cache=cache, **model_kwargs)
```

This prevents one media request from leaking mutable MRoPE state into another row during continuous batching.

### Safe prefix-cache composition

A media request may reuse a text prefix only when the cached portion ends before the visual start marker:

```python
if remaining_ids and can_compose_text_prefix_cache(
    request.input_ids,
    model.config,
    cached_count,
):
    media_prefix_for_specprefill = True
```

The uncached suffix still contains the full visual span and is processed through the media-aware adapter.

Qwen3.5 hybrid `ArraysCache` containers are cloned before reuse, including their mutable state list and batching metadata:

```python
new_cache = ArraysCache(len(cache.cache))
new_cache.cache = list(cache.cache)
new_cache.left_padding = cache.left_padding
new_cache.lengths = cache.lengths
```

This prevents a media suffix from modifying the recurrent state stored under an earlier text-prefix key.

Sparse media caches are not stored as reusable token-only prefix entries.

### Draft-model compatibility

Media placeholder and visual-boundary IDs may be outside the draft model’s vocabulary. Only those known media IDs are replaced for importance scoring. Any unrelated out-of-vocabulary token rejects sparse scoring and uses the dense fallback.

Qwen3.5 drafts receive the gated-query extractor explicitly:

```python
if draft_model_type in {"qwen3_5", "qwen3_5_moe"}:
    score_kwargs["query_extractor"] = _qwen35_extract_queries
```

Qwen3-VL drafts retain the standard Qwen attention extractor selected by `score_tokens`.

### Eligibility and fallbacks

Server defaults and request-level overrides are represented by:

```python
SpecPrefillRequestConfig(
    enabled=...,
    keep_pct=...,
    backbone_pct=...,
)
```

The sparse route fails closed for:

- unsupported or mismatched model identities
- missing or incompatible draft models
- audio inputs
- prompts below the configured threshold
- prompts above the scoring safety cap
- invalid keep or backbone percentages
- MTP execution
- interleaved chunked prefill
- rotating caches
- non-sparse selections
- runtime scoring or prefill failures

All these cases use a fresh dense media cache so a partial sparse attempt cannot contaminate the fallback.

### Diagnostics

Each request receives a `SpecPrefillOutcome` containing:

- whether SpecPrefill was requested
- whether it engaged
- the decision or fallback reason
- target model identity
- original, selected, and cached token counts

The final OpenAI response exposes this information through `generation_metadata`:

```json
{
  "specprefill_requested": true,
  "specprefill_engaged": true,
  "specprefill_reason": "engaged",
  "specprefill_route": "mllm_media",
  "specprefill_original_tokens": 9000,
  "specprefill_selected_tokens": 3100,
  "specprefill_cached_tokens": 256
}
```

Streaming responses preserve the metadata even when a reasoning or tool parser suppresses the final text delta. When necessary, a terminal metadata-only chunk is emitted before `[DONE]`.

Scheduler statistics also report aggregate decisions, fallback counts, selected tokens, and selection rate.

SpecPrefill remains disabled by default. Existing TextModel-direct behavior is unchanged.

## Type of change

- New feature
- Performance
- Documentation

## Surface touched

- CLI / serve command
- OpenAI API endpoints
- Scheduler / batching
- KV cache / prefix cache
- Multimodal pipeline

## Test plan

Linux-compatible tests use synthetic Qwen runtime identities and NumPy-backed media state. Apple Silicon CI runs the MLX-dependent server, cache, scheduler, and continuous-batching coverage.

```bash
pytest -q \
  tests/test_mllm_media_specprefill.py \
  tests/test_batched_engine_mllm_config.py \
  tests/test_request.py \
  tests/test_api_models.py \
  tests/test_batched_engine.py \
  tests/test_server.py

ruff check vllm_mlx/ tests/ \
  --select E,F,W \
  --ignore E402,E501,E731,F811,F841

black --check vllm_mlx/ tests/

python -m py_compile \
  vllm_mlx/mllm_specprefill.py \
  vllm_mlx/mllm_batch_generator.py \
  vllm_mlx/mllm_scheduler.py \
  vllm_mlx/engine/batched.py \
  vllm_mlx/server.py

git diff --check
```

CI now includes:

- `tests/test_mllm_media_specprefill.py`
- `tests/test_batched_engine_mllm_config.py`
- Apple Silicon prefix-cache coverage for hybrid `ArraysCache` isolation

Regression coverage includes:

- exact Qwen dense and MoE capability identities
- unsupported and mismatched model fallback
- image, video, boundary, and final-token retention
- fused embedding and MRoPE position gathering
- deep-stack visual embedding alignment
- prefix-cache composition boundaries
- hybrid recurrent-cache isolation
- request-level controls and threshold behavior
- audio and runtime incompatibility fallbacks
- draft vocabulary safety
- Qwen3.5 and Qwen3-VL draft extractor selection
- cancellation
- engine and scheduler configuration forwarding
- API diagnostics and suppressed-final-delta streaming metadata

## Test results

- Focused suite: `171 passed, 123 skipped, 3 deselected`
- Media SpecPrefill and engine wiring: `21 passed`
- Ruff: pass
- Black: pass
- Python compilation: pass
- `git diff --check`: pass
- Independent frozen-diff review: clean


## Performance impact

Eligible long media prompts prefill only selected target-model chunks while retaining the complete required visual state. The draft model still scores the full prompt.

No Apple Silicon benchmark was run locally, so this PR does not claim a measured TTFT or throughput improvement. The feature remains opt-in and uses dense prefill whenever sparse execution is unsafe or unavailable.

## Output parity

With SpecPrefill disabled, below threshold, or unavailable, requests continue through the existing dense media path.

When SpecPrefill engages, byte-for-byte parity is not expected because sparse prefill intentionally removes low-importance text chunks. The implementation preserves media embeddings, visual masks, deep-stack state, request-local MRoPE positions, logits processors, sampling parameters, EOS handling, stop tokens, and the final prompt token.

Apple Silicon output validation is delegated to CI because MLX cannot run in the local Linux environment.

## Risk notes

- Support uses an exact runtime allowlist and fails closed for unknown implementations.
- Audio, MTP, interleaved chunked prefill, and rotating caches use explicit dense fallbacks.
- Shared model RoPE modules are never patched.
- Decode deltas remain request-local throughout continuous batching.
- Media prefix-cache composition is restricted to prefixes ending before the visual span.
- Hybrid cache containers and mutable state lists are cloned before reuse.
- Dense fallback starts with a fresh cache after any sparse attempt.
- Sparse media caches are not stored as token-only reusable prefixes.
- API additions are optional diagnostics and do not remove or rename existing response fields.
