### PR TITLE
test(cache): cover real scheduler replay parity

### DIFF
--- a/tests/test_prefix_cache_real_model_parity.py
+++ b/tests/test_prefix_cache_real_model_parity.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-checkpoint scheduler parity for prefix-cache safety."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from mlx_lm import load  # noqa: E402
+from mlx_lm.models.cache import ArraysCache, KVCache, make_prompt_cache  # noqa: E402
+
+from vllm_mlx.request import Request, SamplingParams  # noqa: E402
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig  # noqa: E402
+
+pytestmark = pytest.mark.slow
+
+
+def _required_model_path(variable):
+    if os.environ.get("VLLM_MLX_REAL_CACHE_MODEL_TESTS") != "1":
+        pytest.skip("set VLLM_MLX_REAL_CACHE_MODEL_TESTS=1 for real checkpoints")
+    value = os.environ.get(variable)
+    if not value or not Path(value).joinpath("config.json").is_file():
+        pytest.fail(f"{variable} must name a complete local model artifact")
+    return value
+
+
+def _scheduler(model, tokenizer):
+    return Scheduler(
+        model,
+        tokenizer,
+        SchedulerConfig(
+            enable_prefix_cache=True,
+            use_memory_aware_cache=True,
+            cache_memory_mb=256,
+            max_num_seqs=1,
+            prefill_batch_size=1,
+            completion_batch_size=1,
+        ),
+    )
+
+
+def _load_vlm_text_model(path):
+    from mlx_vlm import load as load_vlm
+
+    from vllm_mlx.text_model_from_vlm import build_text_model
+
+    vlm_model, processor = load_vlm(path, strict=False)
+    text_model = build_text_model(vlm_model, path)
+    assert text_model is not None
+    tokenizer = getattr(processor, "tokenizer", processor)
+    assert callable(getattr(tokenizer, "encode", None))
+    return text_model, tokenizer
+
+
+def _long_prompt(tokenizer, minimum=144):
+    seed = tokenizer.encode(
+        "The cache must preserve every represented token across scheduler reuse."
+    )
+    assert seed
+    prompt = (seed * ((minimum + len(seed) - 1) // len(seed)))[:minimum]
+    return [int(token) for token in prompt]
+
+
+def _generate(scheduler, request_id, prompt, max_tokens=4):
+    request = Request(
+        request_id=request_id,
+        prompt=list(prompt),
+        sampling_params=SamplingParams(max_tokens=max_tokens, temperature=0.0),
+    )
+    scheduler.add_request(request)
+    emitted = []
+    for _ in range(32):
+        result = scheduler.step()
+        for output in result.outputs:
+            emitted.extend(output.new_token_ids)
+        if request_id in result.finished_request_ids:
+            return emitted, request
+    raise AssertionError(f"request {request_id} did not finish")
+
+
+def test_real_arrays_cache_next_turn_matches_cold():
+    path = _required_model_path("VLLM_MLX_ARRAYS_MODEL")
+    model, tokenizer = load(path)
+    topology = make_prompt_cache(model)
+    assert topology and all(isinstance(layer, ArraysCache) for layer in topology)
+
+    warm = _scheduler(model, tokenizer)
+    prompt = _long_prompt(tokenizer)
+    first_tokens, _ = _generate(warm, "arrays-first", prompt)
+    assert first_tokens
+    assert list(warm.memory_aware_cache._entries) == []
+
+    suffix = tokenizer.encode(" Next turn.")
+    assert suffix
+    next_prompt = prompt + first_tokens + [int(suffix[0])]
+    warm_tokens, warm_request = _generate(warm, "arrays-next", next_prompt)
+    cold_tokens, cold_request = _generate(
+        _scheduler(model, tokenizer), "arrays-cold", next_prompt
+    )
+
+    assert warm_request.cached_tokens == cold_request.cached_tokens == 0
+    assert warm_request.remaining_tokens == cold_request.remaining_tokens == next_prompt
+    assert warm_tokens == cold_tokens
+
+
+def test_real_kv_cache_identical_prompt_matches_cold_without_replay():
+    path = _required_model_path("VLLM_MLX_KV_MODEL")
+    model, tokenizer = load(path)
+    topology = make_prompt_cache(model)
+    assert topology and all(isinstance(layer, KVCache) for layer in topology)
+
+    warm = _scheduler(model, tokenizer)
+    prompt = _long_prompt(tokenizer)
+    first_tokens, _ = _generate(warm, "kv-first", prompt)
+    assert first_tokens
+
+    entries = list(warm.memory_aware_cache._entries)
+    assert len(entries) == 1
+    assert list(entries[0]) == prompt + first_tokens
+
+    replay_tokens, replay_request = _generate(warm, "kv-identical", prompt)
+    cold_tokens, _ = _generate(_scheduler(model, tokenizer), "kv-cold", prompt)
+
+    assert replay_tokens == cold_tokens == first_tokens, (
+        f"warm={replay_tokens} cold={cold_tokens} first={first_tokens} "
+        f"hit={replay_request.cache_hit_type} cached={replay_request.cached_tokens}"
+    )
+    assert replay_request.cached_tokens == 0
+    assert replay_request.remaining_tokens == prompt
+    assert replay_request.cached_tokens + len(replay_request.remaining_tokens) == len(
+        prompt
+    )
+    assert len(warm.memory_aware_cache._entries) == 1
+
+
+def test_real_hybrid_qwen_next_turn_matches_cold():
+    path = _required_model_path("VLLM_MLX_HYBRID_MODEL")
+    model, tokenizer = _load_vlm_text_model(path)
+    topology = make_prompt_cache(model)
+    assert any(isinstance(layer, ArraysCache) for layer in topology)
+    assert any(isinstance(layer, KVCache) for layer in topology)
+
+    warm = _scheduler(model, tokenizer)
+    prompt = _long_prompt(tokenizer)
+    first_tokens, _ = _generate(warm, "hybrid-first", prompt)
+    assert first_tokens
+
+    suffix = tokenizer.encode(" Next turn.")
+    next_prompt = prompt + first_tokens + [int(suffix[0])]
+    warm_tokens, warm_request = _generate(warm, "hybrid-next", next_prompt)
+    cold_tokens, cold_request = _generate(
+        _scheduler(model, tokenizer), "hybrid-cold", next_prompt
+    )
+
+    assert warm_tokens == cold_tokens
+    assert warm_request.cache_hit_type == "prefix"
+    assert warm_request.cached_tokens > 0
+    assert warm_request.cached_tokens + len(warm_request.remaining_tokens) == len(
+        next_prompt
+    )
+    assert cold_request.cached_tokens == 0
+
+
+def test_real_gemma_identical_prompt_matches_cold_without_replay():
+    path = _required_model_path("VLLM_MLX_GEMMA_MODEL")
+    model, tokenizer = _load_vlm_text_model(path)
+    topology = make_prompt_cache(model)
+    assert topology
+    assert not any(isinstance(layer, ArraysCache) for layer in topology)
+
+    warm = _scheduler(model, tokenizer)
+    prompt = _long_prompt(tokenizer)
+    first_tokens, _ = _generate(warm, "gemma-first", prompt)
+    assert first_tokens
+    entries = list(warm.memory_aware_cache._entries)
+    assert len(entries) == 1
+    assert list(entries[0]) == prompt + first_tokens
+
+    replay_tokens, replay_request = _generate(warm, "gemma-identical", prompt)
+    cold_tokens, _ = _generate(_scheduler(model, tokenizer), "gemma-cold", prompt)
+
+    assert replay_tokens == cold_tokens == first_tokens
+    assert replay_request.cached_tokens == 0
+    assert replay_request.remaining_tokens == prompt
+    assert replay_request.cached_tokens + len(replay_request.remaining_tokens) == len(
+        prompt
+    )

--- a/tests/test_prefix_cache_scheduler_parity.py
+++ b/tests/test_prefix_cache_scheduler_parity.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler-level parity for prefix-cache reuse safety.
+
+These tests use tiny deterministic MLX modules that write real ``ArraysCache``
+and ``KVCache`` state through mlx-lm's ``BatchGenerator``.  They intentionally
+avoid model downloads while exercising the production scheduler/cache boundary.
+"""
+
+from dataclasses import replace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+cache_mod = pytest.importorskip("mlx_lm.models.cache")
+
+from vllm_mlx.request import Request, SamplingParams  # noqa: E402
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig  # noqa: E402
+
+
+class _Tokenizer:
+    eos_token_id = 99
+    clean_up_tokenization_spaces = False
+
+    @staticmethod
+    def encode(text, **_kwargs):
+        return [int(token) for token in text.split()]
+
+    @staticmethod
+    def decode(tokens, **_kwargs):
+        return "".join(chr(65 + int(token) % 26) for token in tokens)
+
+
+class _CacheWritingModel(nn.Module):
+    """A deterministic model whose logits depend on cumulative cache state."""
+
+    def __init__(self, cache_kind):
+        super().__init__()
+        self.cache_kind = cache_kind
+        # ``make_prompt_cache`` only needs a layer count when no model-owned
+        # factory exists.  Keep this populated to match a normal language model.
+        self.layers = [object()]
+
+    def make_cache(self):
+        if self.cache_kind == "arrays":
+            return [cache_mod.ArraysCache(1)]
+        return [cache_mod.KVCache()]
+
+    def __call__(self, tokens, cache=None):
+        values = tokens.astype(mx.float32)
+        layer = cache[0]
+
+        if self.cache_kind == "arrays":
+            prior = mx.zeros((values.shape[0], 1)) if layer[0] is None else layer[0]
+            cumulative = prior + mx.cumsum(values, axis=1)
+            layer[0] = cumulative[:, -1:]
+        else:
+            prior = (
+                mx.zeros((values.shape[0], 1))
+                if layer.keys is None
+                else mx.sum(layer.keys, axis=(1, 2, 3))[:, None]
+            )
+            cumulative = prior + mx.cumsum(values, axis=1)
+            kv = values[:, None, :, None]
+            layer.update_and_fetch(kv, kv)
+
+        selected = cumulative.astype(mx.int32) % 8
+        vocabulary = mx.arange(8)[None, None, :]
+        return mx.where(vocabulary == selected[:, :, None], 10.0, -10.0)
+
+
+def _scheduler(cache_kind):
+    scheduler = Scheduler(
+        _CacheWritingModel(cache_kind),
+        _Tokenizer(),
+        SchedulerConfig(
+            enable_prefix_cache=True,
+            use_memory_aware_cache=True,
+            cache_memory_mb=32,
+            max_num_seqs=1,
+            prefill_batch_size=1,
+            completion_batch_size=1,
+        ),
+    )
+    # Keep the production minimum unchanged; these tiny prompts need a lower
+    # threshold solely so the completion-store/reuse path is exercised.
+    scheduler.memory_aware_cache._config = replace(
+        scheduler.memory_aware_cache._config, min_prefix_tokens=1
+    )
+    return scheduler
+
+
+def _generate(scheduler, request_id, prompt, max_tokens=2):
+    request = Request(
+        request_id=request_id,
+        prompt=list(prompt),
+        sampling_params=SamplingParams(max_tokens=max_tokens, temperature=0.0),
+    )
+    scheduler.add_request(request)
+    emitted = []
+    for _ in range(16):
+        result = scheduler.step()
+        for output in result.outputs:
+            emitted.extend(output.new_token_ids)
+        if request_id in result.finished_request_ids:
+            return emitted, request
+    raise AssertionError(f"request {request_id} did not finish")
+
+
+def test_arrays_cache_next_turn_matches_cold_when_coverage_is_unknown():
+    warm = _scheduler("arrays")
+    prompt = [1, 2, 3]
+    first_tokens, _ = _generate(warm, "arrays-first", prompt)
+
+    # ArraysCache has cumulative recurrent state but no authoritative offset.
+    # The first response must not create a guessed prompt-keyed entry.
+    assert list(warm.memory_aware_cache._entries) == []
+
+    next_prompt = prompt + first_tokens + [7]
+    warm_tokens, warm_request = _generate(warm, "arrays-next", next_prompt)
+    cold_tokens, cold_request = _generate(
+        _scheduler("arrays"), "arrays-cold", next_prompt
+    )
+
+    assert warm_request.cached_tokens == cold_request.cached_tokens == 0
+    assert warm_request.remaining_tokens == cold_request.remaining_tokens == next_prompt
+    assert warm_tokens == cold_tokens
+
+
+def test_identical_plain_kv_prompt_never_replays_a_supersequence():
+    warm = _scheduler("kv")
+    prompt = [1, 2, 3]
+    cold_tokens, _ = _generate(warm, "kv-first", prompt)
+
+    entries = list(warm.memory_aware_cache._entries)
+    assert len(entries) == 1
+    assert list(entries[0]) == prompt + cold_tokens
+
+    replay_tokens, replay_request = _generate(warm, "kv-identical", prompt)
+    oracle_tokens, _ = _generate(_scheduler("kv"), "kv-cold", prompt)
+
+    # The only stored entry is N+completion tokens and must not be trimmed into
+    # an apparent N-token hit.  Cache coverage plus replay is therefore exactly N.
+    assert replay_request.cached_tokens == 0
+    assert replay_request.remaining_tokens == prompt
+    assert replay_request.cached_tokens + len(replay_request.remaining_tokens) == len(
+        prompt
+    )
+    assert replay_tokens == oracle_tokens == cold_tokens
+    assert len(warm.memory_aware_cache._entries) == 1

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2139,10 +2139,14 @@ class Scheduler:
                 # corrupted context (measured: same prompt, different output).
                 # Entries stored post-prefill cover the full key, so drop the
                 # cache and prefill instead of guessing which kind this is.
-                if getattr(request, "cache_hit_type", None) == "exact":
+                if getattr(request, "cache_hit_type", None) in {
+                    "exact",
+                    "supersequence",
+                }:
                     logger.debug(
-                        "[cache] exact match on a full-coverage entry; "
-                        "prefilling to avoid duplicating the last token"
+                        "[cache] %s match on a full-coverage entry; "
+                        "prefilling to avoid duplicating the last token",
+                        request.cache_hit_type,
                     )
                     cache_to_use = None
                     request.prompt_cache = None


### PR DESCRIPTION
## Summary

- add deterministic tiny MLX models that write real `ArraysCache` and `KVCache` state through the production `Scheduler` and mlx-lm `BatchGenerator`
- prove unknown recurrent coverage takes the cold path and its next-turn continuation matches an independent cold run
- prove an identical prompt cannot reuse a trimmed `N+completion` KV supersequence and replay the final prompt token
- fail closed for full-coverage `supersequence` matches in the same way as existing full-coverage `exact` matches

## Root cause

Merged #683 correctly stopped first-response snapshots for ordinary KV caches and stopped guessing keys for unknown recurrent coverage. Its direct gate tests could not expose a pre-existing interaction: the completion path still stores `prompt + output`; `MemoryAwarePrefixCache.fetch()` trims that longer entry to an identical `N`-token prompt and reports `supersequence` with no remaining tokens; `_schedule_waiting()` only rejected full-coverage `exact`, then replayed `prompt[-1]` into a cache already covering all `N` tokens.

## Validation tiers

### Hosted GitHub CI

The normal CI matrix validates the fast deterministic regression suite. The Apple Silicon jobs explicitly use `-m "not slow"`, so they **do not execute** `tests/test_prefix_cache_real_model_parity.py`.

Fast focused result:

```text
48 passed in 1.89s
```

### Local real-checkpoint qualification

The real-model file is intentionally marked `slow` and opt-in because it requires locally available checkpoints, including a 58 GB Gemma artifact. These results were produced locally through the production `Scheduler` and mlx-lm `BatchGenerator`; they are qualification evidence, not GitHub-hosted CI results:

```text
Mamba 130M pure ArraysCache: 1 passed in 2.96s
Qwen3.5 4B hybrid ArraysCache+KVCache: 1 passed in 4.36s
Gemma 4 31B BF16 attention cache: 1 passed in 36.83s
Qwen3 1.7B plain KVCache: 1 passed in 2.72s
```

The exact artifact identities, hashes, cache-topology assertions, and unpatched-main failure are recorded in the PR comment: https://github.com/waybarrios/vllm-mlx/pull/702#issuecomment-5285733862

On unpatched merged `main`, the real Qwen KV case reaches `cache_hit_type=supersequence`, `cached_tokens=144`, and `remaining_tokens=[]`; this PR forces a cold prefill for that full-coverage state.

Static checks: `python3 -m py_compile` and `git diff --check` pass.

Upstream-local-repro preflight: `/opt/ai-runtime/run/upstream-local-repro-preflight/20260813T194013Z-upstream-local-repro-preflight.json`
