### PR TITLE
Add PostgreSQL output to bench-serve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil tabulate transformers requests
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -82,6 +82,7 @@ jobs:
             tests/test_request.py \
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \
+            tests/test_bench_serve.py \
             tests/test_dependency_floors.py \
             tests/test_harmony_parsers.py \
             tests/test_endpoint_model_policies.py \

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ vllm-mlx bench-serve --url http://localhost:8000 --workload workload.json --repe
 
 # Append workload rows into SQLite for longitudinal comparisons
 vllm-mlx bench-serve --url http://localhost:8000 --workload workload.json --repetitions 5 --format sqlite --output bench.db
+
+# Append workload rows into PostgreSQL (requires: pip install "vllm-mlx[postgres]")
+export BENCH_SERVE_PG_URL='postgresql://user:password@localhost/benchmarks'
+vllm-mlx bench-serve --url http://localhost:8000 --workload workload.json --repetitions 5 --format postgres
 ```
 
 ### Model acquisition and conversion

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -100,7 +100,12 @@ policy?" after first measuring what the model and serving stack can actually do.
 Workload output defaults to JSON for full provenance. Use `--format csv` for
 flat per-case rows, `--format sql` to emit importable SQL, or
 `--format sqlite --output bench.db` to append rows directly into a local
-benchmark database.
+benchmark database. PostgreSQL output is available after installing
+`vllm-mlx[postgres]`. Pass its connection URL with `--output`, or set
+`BENCH_SERVE_PG_URL` to avoid passing credentials as a `bench-serve` argument.
+PostgreSQL uses `bench_serve_results` for prompt sweeps and
+`bench_serve_workload_results` for workloads. Override either safe, unqualified
+table name with `--pg-table`.
 
 `--request-timeout-s` is the HTTP transport ceiling for each request in
 workload mode. Product policy timeouts belong in the workload as
@@ -112,6 +117,10 @@ vllm-mlx bench-serve --url http://localhost:8000 \
 
 vllm-mlx bench-serve --url http://localhost:8000 \
   --workload ./workload.json --repetitions 5 --format sqlite --output bench.db
+
+export BENCH_SERVE_PG_URL='postgresql://user:password@localhost/benchmarks'
+vllm-mlx bench-serve --url http://localhost:8000 \
+  --workload ./workload.json --repetitions 5 --format postgres
 ```
 
 ## Standalone Test Defaults

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -222,8 +222,9 @@ vllm-mlx bench-serve --url http://localhost:8000 [options]
 | `--include-content` | Include full generated content in workload JSON | False |
 | `--request-timeout-s` | Workload HTTP transport timeout, `0` disables | `300` |
 | `--cache-policy` | Workload cache handling: `preserve`, `before-run`, `before-case` | Workload default or `preserve` |
-| `--output` | Output file | stdout |
-| `--format` | Output format: `auto`, `table`, `json`, `csv`, `sql`, `sqlite` | `auto` = `table` for prompt sweeps, `json` for workloads |
+| `--output` | Output file, or PostgreSQL connection URL with `--format postgres` | stdout or `BENCH_SERVE_PG_URL` |
+| `--format` | Output format: `auto`, `table`, `json`, `csv`, `sql`, `sqlite`, `postgres` | `auto` = `table` for prompt sweeps, `json` for workloads |
+| `--pg-table` | Custom PostgreSQL table using lowercase letters, digits, and underscores | Mode-specific default |
 
 In workload mode, `--request-timeout-s` is the HTTP transport ceiling for each
 request. Product policy timeouts should live in the workload as
@@ -231,6 +232,12 @@ request. Product policy timeouts should live in the workload as
 Python regex patterns, so literal strings are valid. Workload JSON may spell
 cache policy values with underscores, such as `before_case`; they normalize to
 the hyphenated CLI values.
+
+PostgreSQL output requires `pip install "vllm-mlx[postgres]"`. A connection URL
+passed through `--output` takes precedence over `BENCH_SERVE_PG_URL`. The
+default tables are `bench_serve_results` for prompt sweeps and
+`bench_serve_workload_results` for workloads. Each row includes the regular
+searchable columns plus its full source record in `raw_result` JSONB.
 
 ### Examples
 
@@ -246,6 +253,11 @@ vllm-mlx bench-serve --url http://localhost:8000 \
 # Append contract rows directly into SQLite for longitudinal comparisons
 vllm-mlx bench-serve --url http://localhost:8000 \
   --workload workload.json --repetitions 5 --format sqlite --output bench.db
+
+# Append contract rows without passing the connection URL to bench-serve
+export BENCH_SERVE_PG_URL='postgresql://user:password@localhost/benchmarks'
+vllm-mlx bench-serve --url http://localhost:8000 \
+  --workload workload.json --repetitions 5 --format postgres
 ```
 
 ## `vllm-mlx-bench`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ vision = [
     "torch>=2.8.0",
     "torchvision>=0.23.0",
 ]
+postgres = [
+    "psycopg[binary]>=3.1",
+]
 # Harmony prompt rendering for GPT-OSS models (see #568). With this installed
 # and ``--tool-call-parser harmony``/``gpt-oss`` set, the engine routes prompt
 # building through OpenAI's canonical renderer instead of the Jinja chat

--- a/tests/test_bench_serve.py
+++ b/tests/test_bench_serve.py
@@ -18,6 +18,8 @@ from vllm_mlx.bench_serve import (
     SweepConfig,
     Workload,
     WorkloadCase,
+    _load_psycopg,
+    _resolve_postgres_url,
     _validate_sql_identifier,
     accumulate_tool_calls,
     compute_request_metrics,
@@ -38,13 +40,16 @@ from vllm_mlx.bench_serve import (
     parse_metrics_text,
     parse_sse_line,
     parse_status_response,
+    run_bench_serve,
     run_bench_serve_workload,
     run_workload_case,
     stream_chat_completion,
     summarize_workload_results,
     validate_quality_checks,
     validate_response,
+    write_postgres,
     write_sqlite,
+    write_workload_postgres,
     write_workload_sqlite,
 )
 
@@ -1629,6 +1634,54 @@ def _make_sample_workload_payload() -> dict:
 class TestFormatters:
     """Unit tests for output formatter functions."""
 
+    @staticmethod
+    def _fake_postgres():
+        class FakeJsonb:
+            def __init__(self, value):
+                self.value = value
+
+        class FakeCursor:
+            def __init__(self):
+                self.executed = []
+                self.batches = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def execute(self, query):
+                self.executed.append(query)
+
+            def executemany(self, query, values):
+                self.batches.append((query, values))
+
+        class FakeConnection:
+            def __init__(self, cursor):
+                self._cursor = cursor
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def cursor(self):
+                return self._cursor
+
+        cursor = FakeCursor()
+
+        class FakePsycopg:
+            def __init__(self):
+                self.connection_urls = []
+
+            def connect(self, connection_url):
+                self.connection_urls.append(connection_url)
+                return FakeConnection(cursor)
+
+        return FakePsycopg(), FakeJsonb, cursor
+
     def test_format_table_not_empty(self):
         r = _make_sample_result()
         output = format_table([r])
@@ -1683,6 +1736,26 @@ class TestFormatters:
             ).fetchone()
         assert row == ("sqlite-run", "mlx-community/gemma-3-4b-it-4bit", 0)
 
+    def test_write_postgres_creates_and_inserts_prompt_rows(self, monkeypatch):
+        psycopg, Jsonb, cursor = self._fake_postgres()
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve._load_psycopg", lambda: (psycopg, Jsonb)
+        )
+        result = _make_sample_result(ttft_ms=float("nan"), tag="it's bound")
+
+        write_postgres([result], "postgresql://user:secret@db/bench")
+
+        assert psycopg.connection_urls == ["postgresql://user:secret@db/bench"]
+        assert 'CREATE TABLE IF NOT EXISTS "bench_serve_results"' in cursor.executed[0]
+        assert "id BIGSERIAL PRIMARY KEY" in cursor.executed[0]
+        assert "raw_result JSONB NOT NULL" in cursor.executed[0]
+        insert_query, values = cursor.batches[0]
+        assert "%s" in insert_query
+        assert "it's bound" not in insert_query
+        assert values[0][RESULT_COLUMNS.index("ttft_ms")] is None
+        assert values[0][-1].value["ttft_ms"] is None
+        assert values[0][-1].value["tag"] == "it's bound"
+
     def test_result_columns_match_dataclass(self):
         import dataclasses
 
@@ -1714,12 +1787,116 @@ class TestFormatters:
             ).fetchone()
         assert row == ("resume-smoke", 0, 1)
 
+    def test_write_workload_postgres_preserves_raw_record(self, monkeypatch):
+        psycopg, Jsonb, cursor = self._fake_postgres()
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve._load_psycopg", lambda: (psycopg, Jsonb)
+        )
+        payload = _make_sample_workload_payload()
+
+        write_workload_postgres(
+            payload,
+            "postgresql://db/bench",
+            table="custom_bench_results",
+        )
+
+        assert 'CREATE TABLE IF NOT EXISTS "custom_bench_results"' in cursor.executed[0]
+        insert_query, values = cursor.batches[0]
+        assert 'INSERT INTO "custom_bench_results"' in insert_query
+        raw_record = values[0][-1].value
+        assert raw_record["case_id"] == "resume-smoke"
+        assert raw_record["request"]["extra_body"] == {"temperature": 0.6}
+        assert raw_record["quality"]["ok"] is True
+
+    def test_resolve_postgres_url_prefers_output_then_environment(self, monkeypatch):
+        monkeypatch.setenv("BENCH_SERVE_PG_URL", "postgresql://environment")
+
+        assert _resolve_postgres_url("postgresql://output") == "postgresql://output"
+        assert _resolve_postgres_url(None) == "postgresql://environment"
+
+    def test_resolve_postgres_url_requires_configuration(self, monkeypatch):
+        monkeypatch.delenv("BENCH_SERVE_PG_URL", raising=False)
+
+        with pytest.raises(ValueError, match="BENCH_SERVE_PG_URL"):
+            _resolve_postgres_url(None)
+
+    def test_workload_postgres_configuration_fails_before_loading(self, monkeypatch):
+        monkeypatch.delenv("BENCH_SERVE_PG_URL", raising=False)
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve.load_workload",
+            lambda *_args: (_ for _ in ()).throw(AssertionError("must not load")),
+        )
+
+        with pytest.raises(ValueError, match="BENCH_SERVE_PG_URL"):
+            asyncio.run(
+                run_bench_serve_workload(
+                    url="http://server",
+                    workload_path="unused.json",
+                    output_format="postgres",
+                )
+            )
+
+    def test_prompt_postgres_configuration_fails_before_connecting(self, monkeypatch):
+        monkeypatch.delenv("BENCH_SERVE_PG_URL", raising=False)
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve.auto_detect_runtime",
+            lambda *_args: (_ for _ in ()).throw(AssertionError("must not connect")),
+        )
+
+        with pytest.raises(ValueError, match="BENCH_SERVE_PG_URL"):
+            asyncio.run(run_bench_serve(fmt="postgres"))
+
+    def test_missing_postgres_dependency_has_install_guidance(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def import_without_psycopg(name, *args, **kwargs):
+            if name == "psycopg" or name.startswith("psycopg."):
+                raise ImportError("psycopg unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_psycopg)
+
+        with pytest.raises(RuntimeError, match=r"vllm-mlx\[postgres\]"):
+            _load_psycopg()
+
     def test_sqlite_identifier_validation_rejects_unsafe_names(self):
-        with pytest.raises(ValueError, match="invalid SQLite table identifier"):
+        with pytest.raises(ValueError, match="invalid SQL table identifier"):
             _validate_sql_identifier("bench; DROP TABLE bench_serve", kind="table")
 
-        with pytest.raises(ValueError, match="invalid SQLite column identifier"):
+        with pytest.raises(ValueError, match="invalid SQL column identifier"):
             _validate_sql_identifier("case-id", kind="column")
+
+    def test_postgres_rejects_unsafe_table_before_connecting(self, monkeypatch):
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve._load_psycopg",
+            lambda: (_ for _ in ()).throw(AssertionError("must not connect")),
+        )
+
+        with pytest.raises(ValueError, match="invalid SQL table identifier"):
+            write_postgres([], "postgresql://db/bench", "bench; DROP TABLE users")
+
+    def test_postgres_quotes_keyword_table_names(self, monkeypatch):
+        psycopg, Jsonb, cursor = self._fake_postgres()
+        monkeypatch.setattr(
+            "vllm_mlx.bench_serve._load_psycopg", lambda: (psycopg, Jsonb)
+        )
+
+        write_postgres([_make_sample_result()], "postgresql://db/bench", "user")
+
+        assert 'CREATE TABLE IF NOT EXISTS "user"' in cursor.executed[0]
+        assert 'INSERT INTO "user"' in cursor.batches[0][0]
+
+    def test_cli_accepts_postgres_output_options(self):
+        from vllm_mlx.cli import create_parser
+
+        args = create_parser().parse_args(
+            ["bench-serve", "--format", "postgres", "--pg-table", "benchmark_runs"]
+        )
+
+        assert args.format == "postgres"
+        assert args.pg_table == "benchmark_runs"
 
     def test_format_workload_payload_rejects_unknown_format(self):
         with pytest.raises(ValueError, match="Unsupported workload output format"):

--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -23,6 +23,7 @@ import itertools
 import json
 import logging
 import math
+import os
 import platform
 import re
 import sqlite3
@@ -45,6 +46,8 @@ from tabulate import tabulate as _tabulate
 _BUILTIN_DIR = Path(__file__).parent / "bench_serve_prompts"
 _BUILTIN_NAMES = {"short", "medium", "long", "thinking"}
 _SQL_IDENTIFIER_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+_POSTGRES_PROMPT_TABLE = "bench_serve_results"
+_POSTGRES_WORKLOAD_TABLE = "bench_serve_workload_results"
 
 
 @dataclass
@@ -1701,6 +1704,7 @@ async def run_bench_serve_workload(
     request_timeout_s: Optional[float] = 300.0,
     repetitions: int = 1,
     cache_policy: Optional[str] = None,
+    pg_table: Optional[str] = None,
 ) -> dict:
     """Run a declarative workload against a running server.
 
@@ -1710,6 +1714,13 @@ async def run_bench_serve_workload(
     """
     if repetitions < 1:
         raise ValueError("repetitions must be at least 1")
+
+    postgres_target = None
+    if output_format == "postgres":
+        table = pg_table or _POSTGRES_WORKLOAD_TABLE
+        connection_url = _resolve_postgres_url(output_path)
+        write_workload_postgres({"results": []}, connection_url, table)
+        postgres_target = (connection_url, table)
 
     workload = load_workload(workload_path)
     resolved_cache_policy = _normalize_cache_policy(
@@ -1807,6 +1818,12 @@ async def run_bench_serve_workload(
             raise ValueError("--output is required when --format sqlite")
         write_workload_sqlite(payload, output_path)
         print(f"Workload SQLite results written to {output_path}")
+        return payload
+    if output_format == "postgres":
+        assert postgres_target is not None
+        connection_url, table = postgres_target
+        write_workload_postgres(payload, connection_url, table)
+        print(f"Workload PostgreSQL results written to table {table}")
         return payload
 
     rendered = format_workload_payload(payload, output_format)
@@ -1993,7 +2010,83 @@ def _write_sqlite_rows(
 def _validate_sql_identifier(identifier: str, *, kind: str) -> None:
     """Reject unsafe SQL identifiers before string interpolation."""
     if not _SQL_IDENTIFIER_RE.fullmatch(identifier):
-        raise ValueError(f"invalid SQLite {kind} identifier: {identifier!r}")
+        raise ValueError(f"invalid SQL {kind} identifier: {identifier!r}")
+
+
+def _resolve_postgres_url(output_path: Optional[str]) -> str:
+    """Resolve a PostgreSQL connection URL without logging its contents."""
+    connection_url = output_path or os.environ.get("BENCH_SERVE_PG_URL")
+    if not connection_url:
+        raise ValueError(
+            "--output or BENCH_SERVE_PG_URL is required when --format postgres"
+        )
+    return connection_url
+
+
+def _load_psycopg():
+    """Load the optional PostgreSQL driver only when requested."""
+    try:
+        import psycopg
+        from psycopg.types.json import Jsonb
+    except ImportError as exc:
+        raise RuntimeError(
+            'PostgreSQL output requires psycopg; install "vllm-mlx[postgres]"'
+        ) from exc
+    return psycopg, Jsonb
+
+
+def _postgres_safe(value):
+    """Normalize non-finite values before binding SQL and JSONB parameters."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: _postgres_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_postgres_safe(item) for item in value]
+    return value
+
+
+def _write_postgres_rows(
+    connection_url: str,
+    *,
+    table: str,
+    schema: str,
+    columns: list[str],
+    rows: list[dict],
+    raw_rows: list[dict],
+) -> None:
+    """Append benchmark rows to PostgreSQL using parameterized values."""
+    _validate_sql_identifier(table, kind="table")
+    for column in [*columns, "raw_result"]:
+        _validate_sql_identifier(column, kind="column")
+    if len(rows) != len(raw_rows):
+        raise ValueError("PostgreSQL normalized and raw row counts must match")
+
+    psycopg, Jsonb = _load_psycopg()
+    quoted_table = f'"{table}"'
+    insert_columns = [*columns, "raw_result"]
+    placeholders = ", ".join("%s" for _ in insert_columns)
+    column_list = ", ".join(insert_columns)
+    values = [
+        [*(_postgres_safe(row.get(col)) for col in columns), Jsonb(_postgres_safe(raw))]
+        for row, raw in zip(rows, raw_rows)
+    ]
+    table_schema = (
+        "id BIGSERIAL PRIMARY KEY, "
+        "created_at TIMESTAMPTZ NOT NULL DEFAULT now(), "
+        f"{schema}, raw_result JSONB NOT NULL"
+    )
+
+    with psycopg.connect(connection_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"CREATE TABLE IF NOT EXISTS {quoted_table} ({table_schema})"
+            )
+            if values:
+                cursor.executemany(
+                    f"INSERT INTO {quoted_table} ({column_list}) VALUES ({placeholders})",
+                    values,
+                )
 
 
 def write_sqlite(results: list[BenchServeResult], output_path: str) -> None:
@@ -2004,6 +2097,22 @@ def write_sqlite(results: list[BenchServeResult], output_path: str) -> None:
         schema=_SQL_SCHEMA,
         columns=RESULT_COLUMNS,
         rows=rows,
+    )
+
+
+def write_postgres(
+    results: list[BenchServeResult],
+    connection_url: str,
+    table: str = _POSTGRES_PROMPT_TABLE,
+) -> None:
+    rows = [_result_to_dict(result) for result in results]
+    _write_postgres_rows(
+        connection_url,
+        table=table,
+        schema=_SQL_SCHEMA,
+        columns=RESULT_COLUMNS,
+        rows=rows,
+        raw_rows=rows,
     )
 
 
@@ -2181,6 +2290,23 @@ def write_workload_sqlite(payload: dict, output_path: str) -> None:
     )
 
 
+def write_workload_postgres(
+    payload: dict,
+    connection_url: str,
+    table: str = _POSTGRES_WORKLOAD_TABLE,
+) -> None:
+    raw_rows = payload.get("results") or []
+    rows = [_workload_record_to_row(record) for record in raw_rows]
+    _write_postgres_rows(
+        connection_url,
+        table=table,
+        schema=_WORKLOAD_SQL_SCHEMA,
+        columns=WORKLOAD_RESULT_COLUMNS,
+        rows=rows,
+        raw_rows=raw_rows,
+    )
+
+
 def format_workload_payload(payload: dict, fmt: str = "json") -> str:
     if fmt == "json":
         return format_workload_json(payload)
@@ -2219,6 +2345,7 @@ async def run_bench_serve(
     override_fields: Optional[dict] = None,
     system_prompt_file: Optional[str] = None,
     skip_preflight_token_count: bool = False,
+    pg_table: Optional[str] = None,
 ) -> list[BenchServeResult]:
     """Run the full bench-serve sweep against a running vllm-mlx server.
 
@@ -2239,7 +2366,7 @@ async def run_bench_serve(
         output_path: File path to write results to. If ``None``, prints to
             stdout.
         fmt: Output format — one of ``"table"``, ``"json"``, ``"csv"``,
-            ``"sql"``, or ``"sqlite"``.
+            ``"sql"``, ``"sqlite"``, or ``"postgres"``.
         do_validate: Whether to validate each response.
         scrape: Whether to scrape ``/metrics`` before and after each run.
         tag: Optional tag string stored in every result row.
@@ -2248,6 +2375,13 @@ async def run_bench_serve(
     Returns:
         List of :class:`BenchServeResult` instances.
     """
+    postgres_target = None
+    if fmt == "postgres":
+        table = pg_table or _POSTGRES_PROMPT_TABLE
+        connection_url = _resolve_postgres_url(output_path)
+        write_postgres([], connection_url, table)
+        postgres_target = (connection_url, table)
+
     # 1. Set defaults
     if prompt_sets is None:
         prompt_sets = ["short", "medium", "long"]
@@ -2598,6 +2732,12 @@ async def run_bench_serve(
                 raise ValueError("--output is required when --format sqlite")
             write_sqlite(results, output_path)
             print(f"\nSQLite results written to {output_path}")
+            return results
+        if fmt == "postgres":
+            assert postgres_target is not None
+            connection_url, table = postgres_target
+            write_postgres(results, connection_url, table)
+            print(f"\nPostgreSQL results written to table {table}")
             return results
 
         formatters = {

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -924,6 +924,7 @@ def bench_serve_command(args):
                 request_timeout_s=request_timeout_s,
                 repetitions=args.repetitions,
                 cache_policy=args.cache_policy,
+                pg_table=args.pg_table,
             )
         )
         return
@@ -986,6 +987,7 @@ def bench_serve_command(args):
             skip_preflight_token_count=(
                 args.skip_preflight_token_count or bool(args.system_prompt_file)
             ),
+            pg_table=args.pg_table,
         )
     )
 
@@ -2038,17 +2040,27 @@ Examples:
         "--output",
         type=str,
         default=None,
-        help="File path to write results to (default: stdout)",
+        help=(
+            "File path to write results to, or PostgreSQL connection URL when "
+            "--format postgres (default: stdout or BENCH_SERVE_PG_URL)"
+        ),
     )
     bench_serve_parser.add_argument(
         "--format",
         type=str,
         default="auto",
-        choices=["auto", "table", "json", "csv", "sql", "sqlite"],
+        choices=["auto", "table", "json", "csv", "sql", "sqlite", "postgres"],
         help=(
             "Output format (auto = table for prompt sweeps, json for workloads; "
-            "sqlite requires --output)"
+            "sqlite requires --output; postgres accepts --output or "
+            "BENCH_SERVE_PG_URL)"
         ),
+    )
+    bench_serve_parser.add_argument(
+        "--pg-table",
+        type=str,
+        default=None,
+        help="Custom PostgreSQL table name (lowercase letters, digits, underscores)",
     )
     bench_serve_parser.add_argument(
         "--validate",


### PR DESCRIPTION
## Summary

Add PostgreSQL as an optional `bench-serve` output backend for prompt sweeps and declarative workloads.

- accept connection URLs through `--output` or `BENCH_SERVE_PG_URL`
- create mode-specific tables with searchable columns and `raw_result` JSONB
- support validated custom table names through `--pg-table`
- fail before benchmark execution when PostgreSQL configuration or connectivity is invalid
- keep psycopg optional through the `vllm-mlx[postgres]` extra

Closes #475.

## Type of change

- New feature
- Documentation

## Surface touched

- CLI / serve command
- Build / packaging

## Test plan

```bash
pytest tests/test_bench_serve.py tests/test_dependency_floors.py -q
ruff check vllm_mlx/bench_serve.py vllm_mlx/cli.py tests/test_bench_serve.py --select E,F,W --ignore E402,E501,E731,F811,F841
black --check vllm_mlx/ tests/
```

The focused tests use a fake psycopg connection, so they do not require a PostgreSQL service. The final writer was also smoke-tested against PostgreSQL 16.

## Test results

- `pytest`: 110 passed, 2 skipped integration tests
- Ruff: passed
- Black: 223 files unchanged
- PostgreSQL 16 smoke validation: passed for both schemas, transactions, empty preflight, keyword table names, and non-finite numeric normalization

## Performance impact

N/A. PostgreSQL writes occur only when explicitly selected after benchmark measurement. A zero-row schema preflight runs before measurement to fail fast.

## Output parity

N/A. This change does not touch model generation or response handling.

## Risk notes

- Connection URLs may contain credentials, so application messages never print or log them.
- User-selected table names are restricted to lowercase unqualified identifiers and quoted before SQL interpolation.
- All row and JSONB values use psycopg parameter binding.
- Prompt sweeps and workloads use separate default tables because their schemas differ.
- Existing incompatible tables are not migrated automatically.
