### PR TITLE
Fix MLX prefix cache thread ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
         run: |
           python -c "import platform; assert platform.machine() == 'arm64', 'Not ARM64'"
           python -c "import mlx.core as mx; print(f'MLX OK: {mx.default_device()}')"
+          python -m pip show mlx mlx-lm
 
       - name: Run MLX-dependent tests
         run: |

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -108,7 +108,8 @@ class TestBatchedEngineCacheRestore:
         engine._is_mllm = True
         return engine
 
-    def test_load_cache_from_disk_bootstraps_mllm_batch_generator(self):
+    @pytest.mark.anyio
+    async def test_load_cache_from_disk_bootstraps_mllm_batch_generator(self):
         engine = self._make_mllm_engine()
 
         prefix_cache = MagicMock()
@@ -122,7 +123,7 @@ class TestBatchedEngineCacheRestore:
         scheduler._ensure_batch_generator.side_effect = ensure_batch_generator
         engine._mllm_scheduler = scheduler
 
-        loaded = engine.load_cache_from_disk("/tmp/cache")
+        loaded = await engine.load_cache_from_disk("/tmp/cache")
 
         assert loaded == 2
         scheduler._ensure_batch_generator.assert_called_once_with()

--- a/tests/test_batched_engine_owner_thread.py
+++ b/tests/test_batched_engine_owner_thread.py
@@ -78,6 +78,25 @@ def _bare_engine_core(monkeypatch, worker=None):
     return engine
 
 
+def _run_executors_deterministically(monkeypatch):
+    """Drive executor callbacks synchronously while retaining worker identity."""
+    loop = asyncio.get_running_loop()
+
+    def run_in_executor(executor, operation, *args):
+        future = loop.create_future()
+        try:
+            if executor is None:
+                result = operation(*args)
+            else:
+                result = executor.submit(operation, *args).result(timeout=5)
+            future.set_result(result)
+        except BaseException as exc:
+            future.set_exception(exc)
+        return future
+
+    monkeypatch.setattr(loop, "run_in_executor", run_in_executor)
+
+
 def test_generation_worker_is_one_reused_thread():
     """The worker has to be stable: it owns the loaded model for the process."""
     from vllm_mlx.engine.batched import BatchedEngine
@@ -281,6 +300,42 @@ async def test_supplied_worker_outlives_the_engine_loop(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_engine_core_stop_cleanup_stays_on_supplied_worker(monkeypatch):
+    """Cancellation, its safety net, and repeated stop keep one owner."""
+    worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="engine-core")
+    core = _bare_engine_core(monkeypatch, worker=worker)
+    core._running = False
+    core._task = None
+    core._request_event = None
+    close_threads: list[int] = []
+
+    class StopScheduler(_FakeScheduler):
+        def has_requests(self):
+            return False
+
+        def _close_batch_generator(self):
+            close_threads.append(threading.get_ident())
+
+    core.scheduler = StopScheduler(core)
+    _run_executors_deterministically(monkeypatch)
+
+    try:
+        await core.start()
+        await asyncio.sleep(0)
+        loop_task = core._task
+
+        await core.stop()
+        await core.stop()
+
+        owner_thread = worker.submit(threading.get_ident).result()
+    finally:
+        worker.shutdown(wait=True)
+
+    assert loop_task is not None and loop_task.cancelled()
+    assert close_threads == [owner_thread, owner_thread, owner_thread]
+
+
+@pytest.mark.anyio
 async def test_loop_still_cleans_up_a_worker_it_created(monkeypatch):
     """Without a supplied worker the loop owns its pool and must retire it."""
     core = _bare_engine_core(monkeypatch, worker=None)
@@ -349,13 +404,14 @@ async def test_supplied_model_worker_is_not_replaced_by_stream_fallback(monkeypa
 async def test_cache_io_uses_the_model_generation_worker(operation, expected):
     """Persisted MLX cache state must stay on the model owner thread."""
     from vllm_mlx.engine.batched import BatchedEngine
+    from vllm_mlx.engine_core import AsyncEngineCore, EngineCore
 
     engine = object.__new__(BatchedEngine)
     engine._generation_executor = None
     engine._mllm_scheduler = None
     operation_threads: list[int] = []
 
-    class FakeAsyncEngine:
+    class FakeScheduler:
         def load_cache_from_disk(self, cache_dir):
             operation_threads.append(threading.get_ident())
             return 1
@@ -364,8 +420,13 @@ async def test_cache_io_uses_the_model_generation_worker(operation, expected):
             operation_threads.append(threading.get_ident())
             return True
 
-    engine._engine = FakeAsyncEngine()
     worker = engine._generation_worker()
+    core = object.__new__(EngineCore)
+    core.scheduler = FakeScheduler()
+    core._external_generation_worker = worker
+    async_engine = object.__new__(AsyncEngineCore)
+    async_engine.engine = core
+    engine._engine = async_engine
 
     try:
         result = await getattr(engine, operation)("cache")
@@ -376,6 +437,42 @@ async def test_cache_io_uses_the_model_generation_worker(operation, expected):
 
     assert result == expected
     assert operation_threads == list(owner_threads)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [("load_cache_from_disk", 1), ("save_cache_to_disk", True)],
+)
+async def test_mllm_cache_io_stays_on_the_model_event_loop(operation, expected):
+    """MLLM cache state follows MLLMScheduler instead of the text worker."""
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    engine = object.__new__(BatchedEngine)
+    engine._generation_executor = None
+    engine._engine = None
+    operation_threads: list[int] = []
+
+    class FakePrefixCache:
+        def load_from_disk(self, cache_dir):
+            operation_threads.append(threading.get_ident())
+            return 1
+
+        def save_to_disk(self, cache_dir):
+            operation_threads.append(threading.get_ident())
+            return True
+
+    prefix_cache = FakePrefixCache()
+    engine._mllm_scheduler = SimpleNamespace(
+        batch_generator=SimpleNamespace(prefix_cache=prefix_cache),
+        _ensure_batch_generator=lambda: None,
+    )
+
+    result = await getattr(engine, operation)("cache")
+
+    assert result == expected
+    assert operation_threads == [threading.get_ident()]
+    assert engine._generation_executor is None
 
 
 @pytest.mark.anyio
@@ -403,11 +500,56 @@ async def test_stop_retires_the_generation_worker():
 
 
 @pytest.mark.anyio
-async def test_stop_retires_generation_worker_when_engine_cleanup_fails():
+async def test_stop_closes_core_on_generation_worker_and_is_repeatable(monkeypatch):
+    """Deep reset runs on the model owner before that worker is retired."""
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    close_threads: list[int] = []
+
+    class FakeCore:
+        def close(self):
+            close_threads.append(threading.get_ident())
+
+    class FakeAsyncEngine:
+        engine = FakeCore()
+
+        async def stop(self):
+            pass
+
+    engine = object.__new__(BatchedEngine)
+    engine._generation_executor = None
+    engine._engine = FakeAsyncEngine()
+    engine._mllm_scheduler = None
+    engine._model = object()
+    engine._tokenizer = object()
+    engine._processor = None
+    engine._mllm_instance = None
+    engine._loaded = True
+    worker = engine._generation_worker()
+    owner_thread = worker.submit(threading.get_ident).result()
+    _run_executors_deterministically(monkeypatch)
+
+    await engine.stop()
+    await engine.stop()
+
+    assert close_threads == [owner_thread]
+    assert engine._generation_executor is None
+
+
+@pytest.mark.anyio
+async def test_stop_retires_generation_worker_when_engine_cleanup_fails(monkeypatch):
     """A cleanup error must not leave the model-owning executor alive."""
     from vllm_mlx.engine.batched import BatchedEngine
 
+    close_threads: list[int] = []
+
+    class FakeCore:
+        def close(self):
+            close_threads.append(threading.get_ident())
+
     class FailingAsyncEngine:
+        engine = FakeCore()
+
         async def stop(self):
             raise RuntimeError("engine cleanup failed")
 
@@ -421,10 +563,13 @@ async def test_stop_retires_generation_worker_when_engine_cleanup_fails():
     engine._mllm_instance = None
     engine._loaded = True
     worker = engine._generation_worker()
+    owner_thread = worker.submit(threading.get_ident).result()
+    _run_executors_deterministically(monkeypatch)
 
     with pytest.raises(RuntimeError, match="engine cleanup failed"):
         await engine.stop()
 
+    assert close_threads == [owner_thread]
     assert engine._generation_executor is None
     with pytest.raises(RuntimeError, match="cannot schedule new futures"):
         worker.submit(lambda: None)

--- a/tests/test_engine_core_thread_streams.py
+++ b/tests/test_engine_core_thread_streams.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
@@ -25,6 +26,10 @@ async def test_engine_core_runs_all_scheduler_steps_on_one_worker_thread(monkeyp
     engine._output_collectors = {}
     engine._stream_states = {}
     engine._finished_events = {}
+    engine._worker = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="test-engine"
+    )
+    engine._worker_stream_bound = False
 
     main_thread = threading.get_ident()
     bind_threads: list[int] = []
@@ -58,13 +63,54 @@ async def test_engine_core_runs_all_scheduler_steps_on_one_worker_thread(monkeyp
 
     monkeypatch.setattr("vllm_mlx.engine_core.bind_generation_streams", bind_streams)
 
-    await asyncio.wait_for(engine._engine_loop(), timeout=2)
+    try:
+        await asyncio.wait_for(engine._engine_loop(), timeout=2)
+    finally:
+        engine._worker.shutdown(wait=True)
 
     assert scheduler.step_threads
     assert len(set(scheduler.step_threads)) == 1
     assert scheduler.step_threads[0] != main_thread
     assert bind_threads == [scheduler.step_threads[0]]
     assert scheduler.close_threads == [scheduler.step_threads[0]]
+
+
+@pytest.mark.anyio
+async def test_engine_core_cache_io_uses_generation_worker(monkeypatch, tmp_path):
+    """Prefix-cache persistence must share the generation worker thread."""
+    from vllm_mlx.engine_core import EngineCore
+
+    engine = object.__new__(EngineCore)
+    engine._worker = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="test-engine"
+    )
+    engine._worker_stream_bound = False
+    bind_threads: list[int] = []
+    operation_threads: list[int] = []
+
+    class FakeScheduler:
+        def save_cache_to_disk(self, cache_dir):
+            operation_threads.append(threading.get_ident())
+            return True
+
+        def load_cache_from_disk(self, cache_dir):
+            operation_threads.append(threading.get_ident())
+            return 1
+
+    engine.scheduler = FakeScheduler()
+    monkeypatch.setattr(
+        "vllm_mlx.engine_core.bind_generation_streams",
+        lambda: bind_threads.append(threading.get_ident()),
+    )
+
+    try:
+        assert await engine.load_cache_from_disk(str(tmp_path)) == 1
+        assert await engine.save_cache_to_disk(str(tmp_path))
+    finally:
+        engine._worker.shutdown(wait=True)
+
+    assert len(set(operation_threads)) == 1
+    assert bind_threads == [operation_threads[0]]
 
 
 @pytest.mark.anyio

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1198,17 +1198,17 @@ class BatchedEngine(BaseEngine):
             return result
         return False
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
+    async def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk for persistence across restarts."""
         if self._mllm_scheduler and self._mllm_scheduler.batch_generator:
             pc = self._mllm_scheduler.batch_generator.prefix_cache
             if pc is not None:
                 return pc.save_to_disk(cache_dir)
         if self._engine:
-            return self._engine.save_cache_to_disk(cache_dir)
+            return await self._engine.save_cache_to_disk(cache_dir)
         return False
 
-    def load_cache_from_disk(self, cache_dir: str) -> int:
+    async def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk. Returns number of entries loaded."""
         if self._mllm_scheduler:
             self._mllm_scheduler._ensure_batch_generator()
@@ -1216,7 +1216,7 @@ class BatchedEngine(BaseEngine):
             if pc is not None:
                 return pc.load_from_disk(cache_dir)
         if self._engine:
-            return self._engine.load_cache_from_disk(cache_dir)
+            return await self._engine.load_cache_from_disk(cache_dir)
         return 0
 
     def clear_prefix_cache(self) -> None:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -29,6 +29,7 @@ from .base import (
     GenerationOutput,
     cleanup_startup_cancellation,
     run_blocking_startup_work,
+    suspend_cancellation,
 )
 from .chat_template_safety import normalize_messages_for_chat_template
 
@@ -666,8 +667,31 @@ class BatchedEngine(BaseEngine):
                 await self._mllm_scheduler.stop()
 
             if self._engine:
-                await self._engine.stop()
-                self._engine.engine.close()
+                engine = self._engine
+                try:
+                    await engine.stop()
+                except BaseException:
+                    # Preserve cancellation or the primary stop error while
+                    # still releasing registry and cache state on its owner.
+                    with suspend_cancellation():
+                        try:
+                            await self._run_on_generation_worker(engine.engine.close)
+                        except BaseException as cleanup_error:
+                            if isinstance(
+                                cleanup_error, (KeyboardInterrupt, SystemExit)
+                            ):
+                                raise
+                            logger.error(
+                                "BatchedEngine core cleanup failed after stop error",
+                                exc_info=(
+                                    type(cleanup_error),
+                                    cleanup_error,
+                                    cleanup_error.__traceback__,
+                                ),
+                            )
+                    raise
+                else:
+                    await self._run_on_generation_worker(engine.engine.close)
         finally:
             self._mllm_scheduler = None
             self._engine = None

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -110,6 +110,10 @@ class EngineCore:
         self._task: Optional[asyncio.Task] = None
         self._start_time: Optional[float] = None
         self._steps_executed = 0
+        # MLX streams are thread-local. Keep one executor for the complete
+        # engine lifetime so generation and cache persistence share ownership.
+        self._worker: Optional[ThreadPoolExecutor] = None
+        self._worker_stream_bound = False
 
         logger.debug(f"Engine {self._engine_id} initialized")
 
@@ -120,6 +124,10 @@ class EngineCore:
 
         self._running = True
         self._start_time = time.time()
+        self._worker = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="engine-core"
+        )
+        self._worker_stream_bound = False
         self._task = asyncio.create_task(self._engine_loop())
         logger.info("Engine started")
 
@@ -133,10 +141,24 @@ class EngineCore:
             except asyncio.CancelledError:
                 pass
             self._task = None
-        # Safety net: close batch generator if _engine_loop didn't get a
-        # chance to clean up (e.g. it was never started).  The call is
-        # idempotent — _close_batch_generator checks for None.
-        self.scheduler._close_batch_generator()
+        # Safety net: close the batch generator on the owner thread if the
+        # engine loop did not get a chance to clean it up (e.g. never started).
+        # The call is idempotent — _close_batch_generator checks for None.
+        if self._worker is not None:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                self._worker,
+                lambda: (
+                    bind_generation_streams(),
+                    self.scheduler._close_batch_generator(),
+                ),
+            )
+        else:
+            self.scheduler._close_batch_generator()
+        if self._worker is not None:
+            self._worker.shutdown(wait=True)
+            self._worker = None
+            self._worker_stream_bound = False
         logger.info("Engine stopped")
 
     def is_running(self) -> bool:
@@ -151,17 +173,14 @@ class EngineCore:
         """
 
         loop = asyncio.get_running_loop()
-        worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="engine-core")
-        worker_stream_bound = False
         model_thread_stream_bound = False
         use_worker_thread = True
         stream_thread_fallback_used = False
 
         def _bind_worker_streams_once() -> None:
-            nonlocal worker_stream_bound
-            if not worker_stream_bound:
+            if not self._worker_stream_bound:
                 bind_generation_streams()
-                worker_stream_bound = True
+                self._worker_stream_bound = True
 
         def _bind_model_streams_once() -> None:
             nonlocal model_thread_stream_bound
@@ -244,7 +263,7 @@ class EngineCore:
                         if use_worker_thread:
                             try:
                                 output = await loop.run_in_executor(
-                                    worker, _step_on_worker
+                                    self._worker, _step_on_worker
                                 )
                             except Exception as e:
                                 if (
@@ -252,7 +271,7 @@ class EngineCore:
                                     and not stream_thread_fallback_used
                                 ):
                                     await loop.run_in_executor(
-                                        worker, _recover_stream_thread_error_on_worker
+                                        self._worker, _recover_stream_thread_error_on_worker
                                     )
                                     use_worker_thread = False
                                     stream_thread_fallback_used = True
@@ -303,7 +322,7 @@ class EngineCore:
                             if output.finished_request_ids:
                                 if use_worker_thread:
                                     await loop.run_in_executor(
-                                        worker, _clear_cache_on_worker
+                                        self._worker, _clear_cache_on_worker
                                     )
                                 else:
                                     mx.clear_cache()
@@ -325,13 +344,27 @@ class EngineCore:
                     logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
                     await asyncio.sleep(0.1)
         finally:
-            try:
-                if use_worker_thread:
-                    await loop.run_in_executor(worker, _close_batch_generator_on_worker)
-                else:
-                    self.scheduler._close_batch_generator()
-            finally:
-                worker.shutdown(wait=True)
+            if use_worker_thread:
+                await loop.run_in_executor(
+                    self._worker, _close_batch_generator_on_worker
+                )
+            else:
+                self.scheduler._close_batch_generator()
+
+    async def _run_on_worker(self, operation):
+        """Run an MLX operation on the engine-owned stream thread."""
+        worker = self._worker
+        if worker is None:
+            raise RuntimeError("engine worker is not running")
+        loop = asyncio.get_running_loop()
+
+        def run():
+            if not self._worker_stream_bound:
+                bind_generation_streams()
+                self._worker_stream_bound = True
+            return operation()
+
+        return await loop.run_in_executor(worker, run)
 
     async def add_request(
         self,
@@ -627,13 +660,17 @@ class EngineCore:
         """Get prefix cache statistics."""
         return self.scheduler.get_cache_stats()
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
+    async def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk."""
-        return self.scheduler.save_cache_to_disk(cache_dir)
+        return await self._run_on_worker(
+            lambda: self.scheduler.save_cache_to_disk(cache_dir)
+        )
 
-    def load_cache_from_disk(self, cache_dir: str) -> int:
+    async def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk."""
-        return self.scheduler.load_cache_from_disk(cache_dir)
+        return await self._run_on_worker(
+            lambda: self.scheduler.load_cache_from_disk(cache_dir)
+        )
 
     def clear_runtime_caches(self) -> Dict[str, Any] | None:
         """Clear scheduler-managed runtime caches."""
@@ -781,13 +818,13 @@ class AsyncEngineCore:
         """Get prefix cache statistics."""
         return self.engine.get_cache_stats()
 
-    def save_cache_to_disk(self, cache_dir: str) -> bool:
+    async def save_cache_to_disk(self, cache_dir: str) -> bool:
         """Save prefix cache to disk."""
-        return self.engine.save_cache_to_disk(cache_dir)
+        return await self.engine.save_cache_to_disk(cache_dir)
 
-    def load_cache_from_disk(self, cache_dir: str) -> int:
+    async def load_cache_from_disk(self, cache_dir: str) -> int:
         """Load prefix cache from disk."""
-        return self.engine.load_cache_from_disk(cache_dir)
+        return await self.engine.load_cache_from_disk(cache_dir)
 
     def clear_runtime_caches(self) -> Dict[str, Any] | None:
         """Clear scheduler-managed runtime caches."""

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -23,6 +23,7 @@ import mlx.core as mx
 
 from .request import Request, RequestOutput, SamplingParams
 from .scheduler import Scheduler, SchedulerConfig
+from .engine.base import suspend_cancellation
 from .output_collector import RequestOutputCollector, RequestStreamState
 from .model_registry import get_registry
 from .mlx_streams import bind_generation_streams
@@ -181,10 +182,18 @@ class EngineCore:
             self._task = None
             # Safety nets for a loop that never started or whose cleanup
             # raised. Both operations are idempotent.
-            try:
-                self.scheduler._close_batch_generator()
-            finally:
-                await asyncio.to_thread(self.scheduler.close_ssd_tier)
+            with suspend_cancellation():
+                try:
+                    worker = getattr(self, "_external_generation_worker", None)
+                    if worker is None:
+                        self.scheduler._close_batch_generator()
+                    else:
+                        loop = asyncio.get_running_loop()
+                        await loop.run_in_executor(
+                            worker, self.scheduler._close_batch_generator
+                        )
+                finally:
+                    await asyncio.to_thread(self.scheduler.close_ssd_tier)
         logger.info("Engine stopped")
 
     def is_running(self) -> bool:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -41,6 +41,7 @@ import argparse
 import asyncio
 import copy
 from dataclasses import dataclass
+import inspect
 import json
 import logging
 import os
@@ -1227,7 +1228,7 @@ def _invalidate_tool_parser_cache(reason: str | None = None) -> None:
     _tool_parser_instance = None
 
 
-def _load_prefix_cache_from_disk(engine: BaseEngine | None = None) -> None:
+async def _load_prefix_cache_from_disk(engine: BaseEngine | None = None) -> None:
     """Load prefix cache from disk during startup."""
     target_engine = engine or _engine
     if target_engine is None:
@@ -1236,7 +1237,11 @@ def _load_prefix_cache_from_disk(engine: BaseEngine | None = None) -> None:
     try:
         d = _get_cache_dir()
         logger.info(f"[lifespan] Loading prefix cache from {d}")
-        loaded = target_engine.load_cache_from_disk(d)
+        load_cache = target_engine.load_cache_from_disk
+        if inspect.iscoroutinefunction(load_cache):
+            loaded = await load_cache(d)
+        else:
+            loaded = await asyncio.to_thread(load_cache, d)
         if loaded > 0:
             logger.info(f"[lifespan] Loaded {loaded} prefix cache entries")
         else:
@@ -1248,7 +1253,7 @@ def _load_prefix_cache_from_disk(engine: BaseEngine | None = None) -> None:
         )
 
 
-def _save_prefix_cache_to_disk(engine: BaseEngine | None = None) -> None:
+async def _save_prefix_cache_to_disk(engine: BaseEngine | None = None) -> None:
     """Save prefix cache to disk during shutdown."""
     target_engine = engine or _engine
     if target_engine is None:
@@ -1257,7 +1262,11 @@ def _save_prefix_cache_to_disk(engine: BaseEngine | None = None) -> None:
     try:
         d = _get_cache_dir()
         logger.info(f"[lifespan] Saving prefix cache to {d}")
-        saved = target_engine.save_cache_to_disk(d)
+        save_cache = target_engine.save_cache_to_disk
+        if inspect.iscoroutinefunction(save_cache):
+            saved = await save_cache(d)
+        else:
+            saved = await asyncio.to_thread(save_cache, d)
         if saved:
             logger.info(f"[lifespan] Saved prefix cache to {d}")
         else:
@@ -1327,13 +1336,16 @@ async def _engine_factory(spec: ModelSpec) -> BaseEngine:
 
 
 async def _run_blocking_engine_cache_io(io_fn, engine: BaseEngine) -> None:
-    """Run blocking cache persistence off the event loop.
+    """Run cache persistence through the engine's owned execution context.
 
     If the caller is canceled while waiting, finish the in-flight thread before
     propagating cancellation so engine state cannot keep mutating in the
     background after lifecycle cleanup has started.
     """
-    task = asyncio.create_task(asyncio.to_thread(io_fn, engine))
+    if inspect.iscoroutinefunction(io_fn):
+        task = asyncio.create_task(io_fn(engine))
+    else:
+        task = asyncio.create_task(asyncio.to_thread(io_fn, engine))
     try:
         await asyncio.shield(task)
     except asyncio.CancelledError:
@@ -1487,7 +1499,7 @@ async def lifespan(app: FastAPI):
             and _engine is not None
             and hasattr(_engine, "load_cache_from_disk")
         ):
-            _load_prefix_cache_from_disk()
+            await _load_prefix_cache_from_disk()
 
         # Warm up prefix cache with user-provided prompts (AFTER disk cache load,
         # so any already-persisted entries are preserved and warm-up only fills
@@ -1543,7 +1555,7 @@ async def lifespan(app: FastAPI):
             and _engine is not None
             and hasattr(_engine, "save_cache_to_disk")
         ):
-            _save_prefix_cache_to_disk()
+            await _save_prefix_cache_to_disk()
 
         # Shutdown: Close MCP connections and stop engine
         if _lifecycle_task is not None:


### PR DESCRIPTION
## Summary

Persisted prefix-cache load/save currently runs outside the single worker used by MLX generation. Because MLX streams are thread-local, a cache created or loaded on another thread can produce:

`There is no Stream(gpu, N) in current thread`

This patch keeps the generation executor on `EngineCore` for its full lifetime and routes text-engine cache persistence and cleanup through that same executor.

## Changes

- Make the `EngineCore` worker executor engine-owned rather than local to `_engine_loop`.
- Bind MLX generation streams once on that worker.
- Run scheduler steps, cache load/save, and worker cleanup on the same single-thread executor.
- Make cache persistence awaitable through `EngineCore`, `AsyncEngineCore`, and `BatchedEngine`.
- Await server lifecycle cache hooks.
- Preserve non-blocking compatibility for legacy synchronous cache hooks.
- Add regression coverage proving cache load/save and generation use one worker thread.

## Validation

Upstream regression tests:

```text
14 passed, 80 deselected
```

Selected coverage includes worker execution, cache persistence, batched-engine restore, lifecycle save/restore, cancellation, and compatibility paths.

In a separate local Bacon AI evaluation using LFM2.5 1.2B MLX on an M4 MacBook Air, 20 fresh server starts produced:

- 20/20 stateful Responses passes
- 0 stream/thread fallbacks
- 0 cache-save failures
- 0 cache-load failures
- 54.25 ms early continuation median
- 59.07 ms late continuation median

The evaluation is external to this repository and is provided as supporting evidence, not as a replacement for upstream tests.

I have limited experience contributing patches upstream, and I used Codex to help inspect the issue, implement the change, and run the local evaluation. I reviewed the resulting diff and am submitting it for maintainer review, especially around lifecycle ordering and multimodal behavior.
