### PR TITLE
fix(engine): allow RotatingKVCache snapshots in system-prompt cache

### DIFF
--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -249,16 +249,18 @@ class SimpleEngine(BaseEngine):
             "evictions": 0,
         }
         # True only when the model's prompt cache can be snapshotted and
-        # restored for the manual system-prefix cache branch. Plain KV caches
-        # and hybrid ``ArraysCache`` entries are safe when their state
-        # containers are copied at snapshot/restore boundaries. Sliding-window
-        # cache classes such as ``RotatingKVCache`` remain disabled because
-        # their extra cursor metadata is not captured by ``.state`` alone.
+        # restored for the manual system-prefix cache branch. Plain KV caches,
+        # hybrid ``ArraysCache`` entries, and ``RotatingKVCache`` are safe when
+        # their state and metadata are captured/restored at boundaries.
         self._supports_system_kv_cache: bool = False
 
     @staticmethod
     def _clone_cache_state(value: Any) -> Any:
-        """Copy cache state containers without duplicating immutable MLX arrays."""
+        """Copy cache state containers without duplicating immutable MLX arrays.
+
+        Also handles meta_state containers (e.g. RotatingKVCache metadata) so
+        that sliding-window caches can be snapshotted and restored safely.
+        """
         if isinstance(value, tuple):
             return tuple(SimpleEngine._clone_cache_state(v) for v in value)
         if isinstance(value, list):
@@ -266,9 +268,17 @@ class SimpleEngine(BaseEngine):
         return value
 
     @classmethod
+    def _cache_entry_snapshot(cls, cache_entry: Any) -> Any:
+        """Capture both value state and cursor metadata for a cache entry."""
+        state = cls._clone_cache_state(cache_entry.state)
+        if hasattr(cache_entry, "meta_state"):
+            return (state, cache_entry.meta_state)
+        return state
+
+    @classmethod
     def _snapshot_prompt_cache(cls, prompt_cache: list[Any]) -> list[Any]:
         """Capture cache states without aliasing mutable state containers."""
-        return [cls._clone_cache_state(c.state) for c in prompt_cache]
+        return [cls._cache_entry_snapshot(c) for c in prompt_cache]
 
     @classmethod
     def _restore_prompt_cache(
@@ -276,7 +286,13 @@ class SimpleEngine(BaseEngine):
     ) -> None:
         """Restore cache states without letting decode mutate the saved snapshot."""
         for i, saved_state in enumerate(snapshot):
-            prompt_cache[i].state = cls._clone_cache_state(saved_state)
+            cache_entry = prompt_cache[i]
+            if isinstance(saved_state, tuple) and len(saved_state) == 2:
+                value_state, meta_state = saved_state
+                cache_entry.state = cls._clone_cache_state(value_state)
+                cache_entry.meta_state = meta_state
+            else:
+                cache_entry.state = cls._clone_cache_state(saved_state)
 
     @staticmethod
     def _iter_cache_state_arrays(value: Any):
@@ -295,12 +311,12 @@ class SimpleEngine(BaseEngine):
     @staticmethod
     def _cache_class_is_system_snapshot_safe(cache_entry: Any) -> bool:
         try:
-            from mlx_lm.models.cache import ArraysCache, KVCache
+            from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
 
-            return isinstance(cache_entry, (KVCache, ArraysCache))
+            return isinstance(cache_entry, (KVCache, ArraysCache, RotatingKVCache))
         except Exception:
             cache_type = type(cache_entry).__name__
-            return cache_type in {"KVCache", "ArraysCache"}
+            return cache_type in {"KVCache", "ArraysCache", "RotatingKVCache"}
 
     @classmethod
     def _probe_system_kv_cache_support(cls, model: Any, route: str) -> bool:


### PR DESCRIPTION
## Problem

The system-prefix KV cache probe explicitly disables `RotatingKVCache` from snapshots because its extra cursor metadata (`meta_state`) is not captured by `.state` alone:

```python
# Current code (v0.4.1)
return cache_type in {"KVCache", "ArraysCache"}
```

This forces a **full re-prefill on every turn** for Gemma 4 models, which use `RotatingKVCache` for their sliding-window attention layers. On a 31B model this wastes ~1-3s per turn of unnecessary GPU work re-prefilling the system prompt + tool definitions.

## Fix

Capture `meta_state` alongside array state at snapshot boundaries, and restore it when replaying cached prefixes:

1. `_cache_entry_snapshot()` — captures both `state` and `meta_state` as a tuple
2. `_restore_prompt_cache()` — unpacks the tuple and restores both fields
3. `_cache_class_is_system_snapshot_safe()` — adds `RotatingKVCache` to the allowed class set

## Impact

- **Gemma 4 users** (all sizes: e4b, 12B, 31B) get system-prompt KV caching
- **Agent workloads** see faster turn transitions (~1-3s saved per turn on 31B)
- **GPU efficiency** improves — no redundant re-prefill of static prefixes

## Testing

Tested against `mlx-community/gemma-4-31b-it-4bit` and `mlx-community/gemma-4-e4b-it-4bit` via the Nix overlay at [funkymonkeymonk/nix](https://github.com/funkymonkeymonk/nix). The patch eliminates the "System KV cache SKIP (text route): ... has controls/features the cache branch cannot honor ([non_kv_cache_class])" log line and replaces it with cache HIT/MISS lines.