### PR TITLE
Report MLLM prefix caches in registry memory budgets

### DIFF
--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -126,8 +126,13 @@ together with the prefix-cache setting:
 ```
 Registry memory budget: 68.0 GB of model weights; Metal allocation ceiling
 64.0 GB (50% of 128.0 GB, from serve default); prefix-cache maximum
-20.0 GB per continuous-batching engine (--cache-memory-mb, 2 of 3 entries)
+20.0 GB per memory-aware prefix-cache engine (--cache-memory-mb, 2 of 3 entries)
 ```
+
+The entry count follows the cache path each model will use. With
+`--use-paged-cache`, text engines use the paged cache and are excluded from this
+count. MLLM engines still construct a memory-aware prefix cache, so their
+per-engine `--cache-memory-mb` maximum remains included.
 
 When the weights budget alone does not fit below the ceiling, startup warns:
 

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -155,6 +155,10 @@ per-engine `--cache-memory-mb` maximum remains included. For an unresolved
 remote model ID, set `mllm: true` on the registry entry so the startup report
 can include its cache without relying on a model-name heuristic.
 
+If an entry enables continuous batching while the global serve default leaves
+it disabled, the report uses the same scheduler defaults as the engine,
+including the default 20% memory-aware cache limit.
+
 When the weights budget alone does not fit below the ceiling, startup warns:
 
 ```

--- a/docs/guides/model-registry.md
+++ b/docs/guides/model-registry.md
@@ -132,7 +132,9 @@ Registry memory budget: 68.0 GB of model weights; Metal allocation ceiling
 The entry count follows the cache path each model will use. With
 `--use-paged-cache`, text engines use the paged cache and are excluded from this
 count. MLLM engines still construct a memory-aware prefix cache, so their
-per-engine `--cache-memory-mb` maximum remains included.
+per-engine `--cache-memory-mb` maximum remains included. For an unresolved
+remote model ID, set `mllm: true` on the registry entry so the startup report
+can include its cache without relying on a model-name heuristic.
 
 When the weights budget alone does not fit below the ceiling, startup warns:
 
@@ -168,9 +170,10 @@ Notes on how the check is computed:
   allocated lazily, and simple-mode entries never receive it at all. Subtracting
   it once would understate capacity with one resident model and overstate it
   with several, so it is reported next to the ceiling rather than folded into
-  it. It is reported only when it can actually bind — that is, for
-  continuous-batching entries using the memory-aware prefix cache (not
-  `--use-paged-cache`).
+  it. It is reported only when it can actually bind: for continuous-batching
+  entries using the memory-aware prefix cache. Text entries using
+  `--use-paged-cache` are excluded, while MLLM entries remain included because
+  they still construct the memory-aware prefix cache.
 - A separate warning fires when `--cache-memory-mb` alone is at or above the
   ceiling, which is a configuration error in its own right.
 - On hosts where MLX cannot report a Metal working-set size, the check reports

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -159,3 +159,13 @@ def test_start_mllm_forwards_ssd_cache_fields(monkeypatch):
     )
     assert captured["config_kwargs"]["ssd_cache_dir"] == "/tmp/ssd-kv"
     assert captured["config_kwargs"]["ssd_cache_max_gb"] == 42.0
+
+
+def test_start_mllm_forwards_prefix_cache_memory_percent(monkeypatch):
+    """The MLLM prefix cache must receive the configured percentage limit."""
+    captured = _run_start_mllm(
+        monkeypatch,
+        _base_scheduler_config(cache_memory_percent=0.35),
+    )
+
+    assert captured["config_kwargs"]["prefix_cache_memory_percent"] == 0.35

--- a/tests/test_mllm_ssd_spill.py
+++ b/tests/test_mllm_ssd_spill.py
@@ -22,9 +22,11 @@ def _install_fakes(monkeypatch, prefix_cache_obj):
 
     set_calls = []
     tier_instances = []
+    generator_kwargs = []
 
     class FakeGenerator:
         def __init__(self, *a, **kw):
+            generator_kwargs.append(kw)
             self.prefix_cache = prefix_cache_obj
             self.language_model = SimpleNamespace(mtp=None)
 
@@ -66,7 +68,7 @@ def _install_fakes(monkeypatch, prefix_cache_obj):
     fake_ssd.SSDCacheConfig = FakeTierConfig
     monkeypatch.setitem(sys.modules, "vllm_mlx.ssd_cache", fake_ssd)
 
-    return set_calls, tier_instances
+    return set_calls, tier_instances, generator_kwargs
 
 
 def _bare_scheduler(config):
@@ -83,7 +85,7 @@ def _bare_scheduler(config):
 
 def test_ssd_tier_attached_when_dir_set(monkeypatch, tmp_path):
     prefix_cache = SimpleNamespace()
-    set_calls, tiers = _install_fakes(monkeypatch, prefix_cache)
+    set_calls, tiers, _ = _install_fakes(monkeypatch, prefix_cache)
 
     cfg = MLLMSchedulerConfig(ssd_cache_dir=str(tmp_path), ssd_cache_max_gb=7.0)
     sched = _bare_scheduler(cfg)
@@ -100,7 +102,7 @@ def test_ssd_tier_attached_when_dir_set(monkeypatch, tmp_path):
 
 def test_no_tier_when_dir_unset(monkeypatch):
     prefix_cache = SimpleNamespace()
-    set_calls, tiers = _install_fakes(monkeypatch, prefix_cache)
+    set_calls, tiers, _ = _install_fakes(monkeypatch, prefix_cache)
 
     cfg = MLLMSchedulerConfig(ssd_cache_dir=None)
     sched = _bare_scheduler(cfg)
@@ -113,7 +115,7 @@ def test_no_tier_when_dir_unset(monkeypatch):
 
 def test_no_tier_when_prefix_cache_absent(monkeypatch, tmp_path):
     # Prefix caching disabled → generator.prefix_cache is None → no SSD tier.
-    set_calls, tiers = _install_fakes(monkeypatch, None)
+    set_calls, tiers, _ = _install_fakes(monkeypatch, None)
 
     cfg = MLLMSchedulerConfig(ssd_cache_dir=str(tmp_path))
     sched = _bare_scheduler(cfg)
@@ -121,3 +123,14 @@ def test_no_tier_when_prefix_cache_absent(monkeypatch, tmp_path):
 
     assert tiers == []
     assert sched._ssd_tier is None
+
+
+def test_prefix_cache_uses_configured_memory_percent(monkeypatch):
+    _, _, generator_kwargs = _install_fakes(monkeypatch, SimpleNamespace())
+    cfg = MLLMSchedulerConfig(prefix_cache_memory_percent=0.35)
+    sched = _bare_scheduler(cfg)
+
+    sched._ensure_batch_generator()
+
+    prefix_cache_config = generator_kwargs[0]["prefix_cache_config"]
+    assert prefix_cache_config.max_memory_percent == 0.35

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -386,6 +386,7 @@ def test_cache_limit_ignored_for_simple_mode_entries(tmp_path):
 
     assert report.continuous_batching_entries == 0
     assert report.total_entries == 1
+    assert report.memory_aware_prefix_cache_entries == 0
     assert report.per_engine_cache_limit_bytes is None
     assert report.per_engine_cache_percent is None
 
@@ -407,6 +408,87 @@ def test_cache_limit_ignored_when_paged_cache_supersedes_it(tmp_path):
     )
 
     assert report.continuous_batching_entries == 1
+    assert report.memory_aware_prefix_cache_entries == 0
+    assert report.per_engine_cache_limit_bytes is None
+
+
+def test_cache_limit_applies_to_auto_detected_mllm_with_paged_cache(tmp_path, caplog):
+    """MLLM still constructs MemoryAwarePrefixCache under --use-paged-cache."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"text": 8, "vision": 8})
+    vision_path = Path(registry["vision"].source)
+    (vision_path / "config.json").write_text('{"vision_config": {}}')
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(
+                cache_memory_mb=20480, use_paged_cache=True
+            ),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 2
+    assert report.memory_aware_prefix_cache_entries == 1
+    assert report.per_engine_cache_limit_bytes == 20 * GB
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.model_registry"):
+        log_memory_budget_report(report)
+
+    assert "20.0 GB per memory-aware prefix-cache engine" in caplog.text
+    assert "1 of 2 entries" in caplog.text
+
+
+@pytest.mark.parametrize("force_source", ["entry", "serve_default"])
+def test_cache_limit_applies_to_forced_mllm_with_paged_cache(tmp_path, force_source):
+    """Both MLLM override sources select the same cache path as BatchedEngine."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 8})
+    defaults = _defaults_with(
+        continuous_batching=True,
+        force_mllm=force_source == "serve_default",
+        scheduler_config=SchedulerConfig(cache_memory_mb=20480, use_paged_cache=True),
+    )
+    if force_source == "entry":
+        registry["alpha"] = dataclasses.replace(registry["alpha"], force_mllm=True)
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        defaults,
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.memory_aware_prefix_cache_entries == 1
+    assert report.per_engine_cache_limit_bytes == 20 * GB
+
+
+def test_entry_mllm_false_overrides_serve_default_for_cache_report(tmp_path):
+    """The report must use the same per-entry override precedence as loading."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 8})
+    registry["alpha"] = dataclasses.replace(registry["alpha"], force_mllm=False)
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(
+            continuous_batching=True,
+            force_mllm=True,
+            scheduler_config=SchedulerConfig(
+                cache_memory_mb=20480, use_paged_cache=True
+            ),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.memory_aware_prefix_cache_entries == 0
     assert report.per_engine_cache_limit_bytes is None
 
 
@@ -635,7 +717,7 @@ def test_log_memory_budget_report_reports_ceiling_and_cache(tmp_path, caplog):
 
     assert "Registry memory budget: 40.0 GB" in caplog.text
     assert "Metal allocation ceiling 64.0 GB" in caplog.text
-    assert "20.0 GB per continuous-batching engine" in caplog.text
+    assert "20.0 GB per memory-aware prefix-cache engine" in caplog.text
     assert "2 of 2 entries" in caplog.text
 
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -443,6 +443,31 @@ def test_cache_limit_applies_to_auto_detected_mllm_with_paged_cache(tmp_path, ca
     assert "1 of 2 entries" in caplog.text
 
 
+def test_cache_percent_applies_to_mllm_with_paged_cache(tmp_path):
+    """The report uses the percentage forwarded to the MLLM prefix cache."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"vision": 8})
+    vision_path = Path(registry["vision"].source)
+    (vision_path / "config.json").write_text('{"vision_config": {}}')
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(
+                cache_memory_percent=0.35, use_paged_cache=True
+            ),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.memory_aware_prefix_cache_entries == 1
+    assert report.per_engine_cache_limit_bytes is None
+    assert report.per_engine_cache_percent == pytest.approx(0.35)
+
+
 @pytest.mark.parametrize("force_source", ["entry", "serve_default"])
 def test_cache_limit_applies_to_forced_mllm_with_paged_cache(tmp_path, force_source):
     """Both MLLM override sources select the same cache path as BatchedEngine."""
@@ -490,6 +515,43 @@ def test_entry_mllm_false_overrides_serve_default_for_cache_report(tmp_path):
 
     assert report.memory_aware_prefix_cache_entries == 0
     assert report.per_engine_cache_limit_bytes is None
+
+
+@pytest.mark.parametrize(
+    ("force_mllm", "expected_entries"),
+    [(None, 0), (True, 1)],
+)
+def test_unresolved_remote_mllm_requires_explicit_declaration(
+    tmp_path, monkeypatch, force_mllm, expected_entries
+):
+    """Remote name heuristics are not authoritative for capacity warnings."""
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    monkeypatch.chdir(tmp_path)
+    registry = {
+        "remote": RegisteredModel(
+            name="remote",
+            source="example/VL-text-model",
+            force_mllm=force_mllm,
+            estimated_memory_bytes=8 * GB,
+        )
+    }
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults_with(
+            continuous_batching=True,
+            scheduler_config=SchedulerConfig(
+                cache_memory_mb=20480, use_paged_cache=True
+            ),
+        ),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.memory_aware_prefix_cache_entries == expected_entries
+    expected_limit = 20 * GB if force_mllm else None
+    assert report.per_engine_cache_limit_bytes == expected_limit
 
 
 def test_cache_limit_above_ceiling_warns_without_negative_numbers(tmp_path, caplog):

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -689,6 +689,28 @@ def test_cache_percent_applies_to_mllm_with_paged_cache(tmp_path):
     assert report.per_engine_cache_percent == pytest.approx(0.35)
 
 
+def test_entry_batching_override_reports_default_scheduler_cache(tmp_path):
+    """Entry-level batching uses SchedulerConfig defaults when CLI batching is off."""
+    registry = _registry(tmp_path, {"vision": 8})
+    registry["vision"] = dataclasses.replace(
+        registry["vision"], continuous_batching=True
+    )
+    vision_path = Path(registry["vision"].source)
+    (vision_path / "config.json").write_text('{"vision_config": {}}')
+
+    report = build_memory_budget_report(
+        _manager_config(budget_gb=10),
+        registry,
+        _defaults(),
+        device_working_set_bytes=128 * GB,
+    )
+
+    assert report.continuous_batching_entries == 1
+    assert report.memory_aware_prefix_cache_entries == 1
+    assert report.per_engine_cache_limit_bytes is None
+    assert report.per_engine_cache_percent == pytest.approx(0.20)
+
+
 @pytest.mark.parametrize("force_source", ["entry", "serve_default"])
 def test_cache_limit_applies_to_forced_mllm_with_paged_cache(tmp_path, force_source):
     """Both MLLM override sources select the same cache path as BatchedEngine."""

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -363,6 +363,9 @@ class BatchedEngine(BaseEngine):
         prefix_cache_memory_mb = getattr(
             self._scheduler_config, "cache_memory_mb", None
         )
+        prefix_cache_memory_percent = getattr(
+            self._scheduler_config, "cache_memory_percent", 0.20
+        )
         enable_mtp = (
             self._scheduler_config.enable_mtp if self._scheduler_config else False
         )
@@ -401,6 +404,7 @@ class BatchedEngine(BaseEngine):
             enable_prefix_cache=enable_prefix_cache,
             use_memory_aware_cache=use_memory_aware_cache,
             prefix_cache_memory_mb=prefix_cache_memory_mb,
+            prefix_cache_memory_percent=prefix_cache_memory_percent,
             enable_mtp=enable_mtp,
             mtp_num_draft_tokens=mtp_num_draft,
             kv_cache_quantization=kv_quant,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -77,6 +77,8 @@ class MLLMSchedulerConfig:
     use_memory_aware_cache: bool = True
     # Memory limit for prefix cache (None = auto-detect)
     prefix_cache_memory_mb: Optional[int] = None
+    # Fraction of available memory used when no explicit MB limit is configured
+    prefix_cache_memory_percent: float = 0.20
     # KV cache quantization for prefix cache store/fetch
     kv_cache_quantization: bool = False
     kv_cache_quantization_bits: int = 8
@@ -307,6 +309,7 @@ class MLLMScheduler:
             if self.config.enable_prefix_cache and self.config.use_memory_aware_cache:
                 prefix_cache_config = MemoryCacheConfig(
                     max_memory_mb=self.config.prefix_cache_memory_mb,
+                    max_memory_percent=self.config.prefix_cache_memory_percent,
                     kv_quantize=self.config.kv_cache_quantization,
                     kv_bits=self.config.kv_cache_quantization_bits,
                     kv_group_size=self.config.kv_cache_quantization_group_size,

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -292,10 +292,10 @@ class MemoryBudgetReport:
 
     The prefix-cache limit is deliberately *not* folded into that comparison.
     ``cache_memory_mb`` is a per-engine maximum — it is cloned into each
-    resident continuous-batching engine and allocated lazily, and simple-mode
-    entries never receive it at all — so it is neither a single process-wide
-    reservation nor a bound that can be subtracted once. It is reported
-    alongside the ceiling instead, with its own conflict check.
+    applicable resident continuous-batching engine and allocated lazily, and
+    simple-mode entries never receive it at all — so it is neither a single
+    process-wide reservation nor a bound that can be subtracted once. It is
+    reported alongside the ceiling instead, with its own conflict check.
     """
 
     budget_bytes: int
@@ -304,6 +304,7 @@ class MemoryBudgetReport:
     gpu_memory_utilization_source: str | None
     per_engine_cache_limit_bytes: int | None
     per_engine_cache_percent: float | None
+    memory_aware_prefix_cache_entries: int
     continuous_batching_entries: int
     total_entries: int
 
@@ -337,6 +338,16 @@ class MemoryBudgetReport:
         return self.per_engine_cache_limit_bytes >= ceiling
 
 
+def _registry_entry_uses_mllm_path(
+    entry: RegisteredModel, defaults: RegistryServeDefaults
+) -> bool:
+    """Match the MLLM selection performed when BatchedEngine is constructed."""
+    force_mllm = (
+        entry.force_mllm if entry.force_mllm is not None else defaults.force_mllm
+    )
+    return bool(force_mllm) or is_mllm_model(entry.source)
+
+
 def build_memory_budget_report(
     manager_config: RegistryManagerConfig,
     registry: dict[str, RegisteredModel],
@@ -361,6 +372,8 @@ def build_memory_budget_report(
     # even constructed with a gpu_memory_utilization — so a simple-mode entry's
     # override is inert and must not be treated as a ceiling candidate.
     candidates: list[tuple[float, int, str]] = []
+    memory_aware_prefix_cache_entries = 0
+    scheduler_config = defaults.scheduler_config
     for name in sorted(registry):
         entry = registry[name]
         entry_continuous_batching = (
@@ -370,6 +383,18 @@ def build_memory_budget_report(
         )
         if not entry_continuous_batching:
             continue
+
+        if (
+            scheduler_config is not None
+            and getattr(scheduler_config, "enable_prefix_cache", False)
+            and getattr(scheduler_config, "use_memory_aware_cache", False)
+        ):
+            uses_mllm_path = _registry_entry_uses_mllm_path(entry, defaults)
+            if uses_mllm_path or not getattr(
+                scheduler_config, "use_paged_cache", False
+            ):
+                memory_aware_prefix_cache_entries += 1
+
         if entry.gpu_memory_utilization is not None:
             # Rank 1: an override is only attributable to the entry declaring it.
             candidates.append(
@@ -386,17 +411,14 @@ def build_memory_budget_report(
     if candidates:
         utilization, _, utilization_source = min(candidates)
 
-    # cache_memory_mb only binds for continuous-batching engines, and only when
-    # the memory-aware prefix cache is the one actually in use.
-    scheduler_config = defaults.scheduler_config
+    # cache_memory_mb only binds for continuous-batching engines that actually
+    # construct the memory-aware prefix cache. Text engines select the paged
+    # cache when requested, but MLLM engines do not implement that cache and
+    # continue to construct MemoryAwarePrefixCache.
     per_engine_cache_limit_bytes: int | None = None
     per_engine_cache_percent: float | None = None
     cache_applies = (
-        scheduler_config is not None
-        and continuous_batching_entries > 0
-        and getattr(scheduler_config, "enable_prefix_cache", False)
-        and not getattr(scheduler_config, "use_paged_cache", False)
-        and getattr(scheduler_config, "use_memory_aware_cache", False)
+        scheduler_config is not None and memory_aware_prefix_cache_entries > 0
     )
     if cache_applies:
         cache_memory_mb = getattr(scheduler_config, "cache_memory_mb", None)
@@ -414,6 +436,7 @@ def build_memory_budget_report(
         gpu_memory_utilization_source=utilization_source,
         per_engine_cache_limit_bytes=per_engine_cache_limit_bytes,
         per_engine_cache_percent=per_engine_cache_percent,
+        memory_aware_prefix_cache_entries=memory_aware_prefix_cache_entries,
         continuous_batching_entries=continuous_batching_entries,
         total_entries=len(registry),
     )
@@ -440,16 +463,19 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
         )
         return
 
-    engines = f"{report.continuous_batching_entries} of {report.total_entries} entries"
+    engines = (
+        f"{report.memory_aware_prefix_cache_entries} of "
+        f"{report.total_entries} entries"
+    )
     if report.per_engine_cache_limit_bytes is not None:
         cache_desc = (
             f"{report.per_engine_cache_limit_bytes / gb:.1f} GB per "
-            f"continuous-batching engine (--cache-memory-mb, {engines})"
+            f"memory-aware prefix-cache engine (--cache-memory-mb, {engines})"
         )
     elif report.per_engine_cache_percent is not None:
         cache_desc = (
             f"~{report.per_engine_cache_percent * 100:.0f}% of available RAM per "
-            f"continuous-batching engine (--cache-memory-percent, {engines}); "
+            f"memory-aware prefix-cache engine (--cache-memory-percent, {engines}); "
             "scales at runtime"
         )
     else:
@@ -483,10 +509,11 @@ def log_memory_budget_report(report: MemoryBudgetReport) -> None:
 
     if report.cache_limit_exceeds_ceiling:
         logger.warning(
-            "--cache-memory-mb (%.1f GB per continuous-batching engine) is at or "
+            "--cache-memory-mb (%.1f GB per memory-aware prefix-cache engine) is "
+            "at or "
             "above the Metal allocation ceiling (%.1f GB) on its own, leaving no "
             "room for model weights. Note this is a per-engine maximum: it is "
-            "cloned into every resident continuous-batching engine, so the "
+            "cloned into every applicable resident continuous-batching engine, so the "
             "aggregate grows with the number of resident models.",
             (report.per_engine_cache_limit_bytes or 0) / gb,
             ceiling / gb,

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -414,6 +414,11 @@ def build_memory_budget_report(
     candidates: list[tuple[float, int, str]] = []
     memory_aware_prefix_cache_entries = 0
     scheduler_config = defaults.scheduler_config
+    if scheduler_config is None:
+        # A registry entry can enable continuous batching while the global CLI
+        # flag is off. BatchedEngine supplies SchedulerConfig defaults in that
+        # case, so the startup report must account for the same default cache.
+        scheduler_config = SchedulerConfig()
     for name in sorted(registry):
         entry = registry[name]
         entry_continuous_batching = (

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -341,11 +341,21 @@ class MemoryBudgetReport:
 def _registry_entry_uses_mllm_path(
     entry: RegisteredModel, defaults: RegistryServeDefaults
 ) -> bool:
-    """Match the MLLM selection performed when BatchedEngine is constructed."""
+    """Classify explicit or locally verifiable MLLM registry entries."""
     force_mllm = (
         entry.force_mllm if entry.force_mllm is not None else defaults.force_mllm
     )
-    return bool(force_mllm) or is_mllm_model(entry.source)
+    if force_mllm:
+        return True
+
+    # Remote IDs are unresolved when this startup report is built. Their names
+    # are only a heuristic and can disagree with the downloaded config that the
+    # engine later treats as authoritative. Require an explicit declaration for
+    # remote entries so capacity warnings cannot be false positives.
+    if not Path(entry.source).exists():
+        return False
+
+    return is_mllm_model(entry.source)
 
 
 def build_memory_budget_report(


### PR DESCRIPTION
## Summary

Fixes #712 by making the registry startup memory report match the prefix-cache path used by each engine.

Text engines using `--use-paged-cache` remain excluded from memory-aware cache attribution. MLLM engines are included because they continue to construct `MemoryAwarePrefixCache` even when paged cache is enabled.

## What changed

- Count memory-aware prefix-cache consumers per registry entry.
- Preserve per-entry and serve-default `mllm` precedence.
- Detect local MLLM sources from their authoritative `config.json`.
- Require `mllm: true` for unresolved remote IDs instead of using model-name heuristics for capacity warnings.
- Report the per-engine cache limit and applicable entry count.
- Propagate `--cache-memory-percent` through `BatchedEngine` and `MLLMSchedulerConfig` into the MLLM `MemoryCacheConfig`.
- Apply runtime scheduler defaults when an entry enables continuous batching while the global default is disabled.
- Document text, MLLM, paged-cache, and unresolved remote behavior.

The cache maximum remains informational. It is not subtracted from the process-wide model-weight budget because it is a lazy, per-engine maximum whose aggregate depends on model residency.

## Validation

CI passed on the final branch head:

- Ruff and Black
- mypy
- Linux tests on Python 3.10, 3.11, 3.12, and 3.13
- focused Python 3.14 tests
- Apple Silicon tests on Python 3.11 and 3.13
- EngineCore stream-affinity regression tests

The focused regression coverage includes local MLLM detection, explicit remote MLLM declaration, paged text exclusion, cache percentage propagation, entry/default override precedence, entry-level batching defaults, and operator-facing report output.

CI run: https://github.com/waybarrios/vllm-mlx/actions/runs/33978815366

## Runtime impact

The runtime change is limited to honoring the configured cache-memory percentage on the existing MLLM memory-aware prefix cache. Model execution, scheduling order, tokenization, and generated output are unchanged.

Closes #712
