### PR TITLE
Link the public documentation site from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ See [Installation Guide](docs/getting-started/installation.md) for full options.
 
 ## Documentation
 
+Browse the complete documentation at [vllm-mlx.is-a.dev](https://vllm-mlx.is-a.dev/).
+
 - **Getting started**: [Installation](docs/getting-started/installation.md) · [Quick Start](docs/getting-started/quickstart.md)
 - **Servers & APIs**: [OpenAI server](docs/guides/server.md) · [Anthropic Messages API](docs/guides/server.md#anthropic-messages-api) · [Python API](docs/guides/python-api.md)
 - **Features**: [Multimodal](docs/guides/multimodal.md) · [Audio](docs/guides/audio.md) · [Embeddings](docs/guides/embeddings.md) · [Reasoning](docs/guides/reasoning.md) · [MCP & Tool Calling](docs/guides/mcp-tools.md) · [Tool Parsers](docs/guides/tool-calling.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,8 @@ audio = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/waybarrios/vllm-mlx"
-Documentation = "https://github.com/waybarrios/vllm-mlx/tree/main/docs"
+Homepage = "https://vllm-mlx.is-a.dev/"
+Documentation = "https://vllm-mlx.is-a.dev/"
 Repository = "https://github.com/waybarrios/vllm-mlx"
 Issues = "https://github.com/waybarrios/vllm-mlx/issues"
 "Release Notes" = "https://github.com/waybarrios/vllm-mlx/releases"


### PR DESCRIPTION
## Summary

Link the public documentation site from the README displayed on GitHub and from the package metadata.

- Add `https://vllm-mlx.is-a.dev/` to the README Documentation section.
- Use the documentation site as the project homepage.
- Replace the old GitHub docs-directory URL with the deployed documentation site.
- Keep repository, issue, and release links unchanged.

## Type of change

- Documentation

## Surface touched

- Build / packaging
- Docs only

## Test plan

- Parse `pyproject.toml` with Python's `tomllib`.
- Verify `https://vllm-mlx.is-a.dev/` is reachable.
- Run `git diff --check`.
- Confirm the branch is based on the latest `main`.

## Test results

- `pyproject.toml` parsed successfully.
- The documentation site returned HTTP 200.
- The diff check passed.
- The branch matches the latest `origin/main`.

## Performance impact

N/A, docs and package metadata only.

## Output parity

N/A, runtime behavior is unchanged.

## Risk notes

Low risk. This only changes public project links in the README and package metadata.
