### PR TITLE
docs: fix broken star history chart in READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -301,7 +301,7 @@ Apache 2.0. Ver [LICENSE](LICENSE).
 
 ## Historia de stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.dera.page/#waybarrios/vllm-mlx&Date)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -301,7 +301,7 @@ Apache 2.0. Voir [LICENSE](LICENSE).
 
 ## Historique des stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.dera.page/#waybarrios/vllm-mlx&Date)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Apache 2.0. See [LICENSE](LICENSE).
 
 ## Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.dera.page/#waybarrios/vllm-mlx&Date)
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -295,7 +295,7 @@ Apache 2.0。详见 [LICENSE](LICENSE)。
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.com/#waybarrios/vllm-mlx&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=waybarrios/vllm-mlx&type=Date)](https://star-history.dera.page/#waybarrios/vllm-mlx&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README files no longer renders, which breaks the repository landing page for all language versions. This change updates the chart and its link so the stargazer history displays again for everyone who visits the project.