### PR TITLE
Add capacity envelope benchmark artifacts

### DIFF
--- a/docs/guides/capacity-envelope.md
+++ b/docs/guides/capacity-envelope.md
@@ -1,0 +1,44 @@
+# Capacity-envelope benchmarking
+
+`bench-serve --capacity-envelope` measures how much concurrent work a running
+OpenAI-compatible server can sustain under explicit latency and failure SLOs.
+It is an HTTP-only client: it does not load a model or change serving defaults.
+
+```bash
+vllm-mlx bench-serve --url http://localhost:8000 \
+  --capacity-envelope \
+  --capacity-concurrency 1,2,4,8,16 \
+  --capacity-prompt-tokens 256,2048 \
+  --capacity-output-tokens 128 \
+  --capacity-cache-modes cold,warm,prefix-hit,prefix-miss \
+  --capacity-max-p95-ttft-ms 1000 \
+  --capacity-max-p95-e2e-ms 10000 \
+  --output capacity.json
+```
+
+The versioned JSON artifact includes the canonical workload hash, runtime and
+host provenance, request samples, p50/p95/p99 cell summaries, successful-token
+throughput, request failures (including timeout and OOM classifications), cache
+actions, optional server telemetry, sustainable concurrency, and throughput per
+GiB. Missing telemetry is `null`/unavailable; it is never estimated as zero.
+
+## Measurement rules
+
+- A cell fails when any request exceeds the configured failure allowance.
+- Throughput uses successful completion tokens and measured batch wall time.
+- `chunk_gap_ms` measures content-SSE chunk gaps because an HTTP chunk is not
+  necessarily one token. Aggregate token throughput uses server `usage` counts.
+- Every cache case starts with a successful `DELETE /v1/cache`; the run aborts
+  if the server cannot verify that reset. Cold cells do not run a warmup request.
+- Warm cells exercise model-warm/no-prefix-hit behavior by warming a distinct
+  prompt. Prefix-hit cells warm the measured prompt; prefix-miss cells warm a
+  deterministic alternate prefix before measuring the requested prompt.
+- Memory and optional MTP/speculative/cache counters include their observation
+  source. Unsupported or inaccessible endpoints remain unavailable.
+- Optional A/B parity uses greedy generation only. It compares token IDs when
+  the server emits them and otherwise compares a decoded-output SHA-256 hash.
+
+Prompt-token targets are workload buckets, not tokenizer claims. Each sample
+records the server-reported prompt-token count as the authoritative observation.
+Only compare artifacts whose workload and provenance describe compatible model,
+quantization, software, cache, sampling, and hardware conditions.

--- a/docs/guides/capacity-envelope.md
+++ b/docs/guides/capacity-envelope.md
@@ -26,6 +26,9 @@ GiB. Missing telemetry is `null`/unavailable; it is never estimated as zero.
 
 - A cell fails when any request exceeds the configured failure allowance.
 - Throughput uses successful completion tokens and measured batch wall time.
+- A response that reaches the requested output limit is successful. A response
+  without authoritative OpenAI `usage` token counts fails instead of producing
+  zero-token throughput.
 - `chunk_gap_ms` measures content-SSE chunk gaps because an HTTP chunk is not
   necessarily one token. Aggregate token throughput uses server `usage` counts.
 - Every cache case starts with a successful `DELETE /v1/cache`; the run aborts
@@ -33,6 +36,8 @@ GiB. Missing telemetry is `null`/unavailable; it is never estimated as zero.
 - Warm cells exercise model-warm/no-prefix-hit behavior by warming a distinct
   prompt. Prefix-hit cells warm the measured prompt; prefix-miss cells warm a
   deterministic alternate prefix before measuring the requested prompt.
+- Prefix-hit/miss labels must be corroborated by server cache counters. Servers
+  without an engine cache report those cells unavailable rather than aborting.
 - Memory and optional MTP/speculative/cache counters include their observation
   source. Unsupported or inaccessible endpoints remain unavailable.
 - Optional A/B parity uses greedy generation only. It compares token IDs when

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -206,6 +206,8 @@ TTFT, TPOT, throughput, cache deltas, and Metal memory. Workload mode adds
 per-case quality checks, repeated samples for variance, and comparison-only
 product policy timeouts. Workload cases can embed `messages` directly or point
 `request_path` at an existing OpenAI-compatible request JSON.
+Capacity-envelope mode produces a versioned concurrency/SLO evidence artifact;
+see [Capacity-envelope benchmarking](../guides/capacity-envelope.md).
 
 ### Usage
 
@@ -221,6 +223,7 @@ vllm-mlx bench-serve --url http://localhost:8000 [options]
 | `--model` | API model id | Auto-detect |
 | `--prompts` | Comma-separated prompt sets or files for sweep mode | `short,medium,long` |
 | `--workload` | Declarative workload JSON for contract mode | None |
+| `--capacity-envelope` | Run the versioned capacity-envelope JSON benchmark | False |
 | `--concurrency` | Comma-separated concurrency levels for sweep mode | `1,4` |
 | `--max-tokens` | Max tokens for sweep mode | `256` |
 | `--repetitions` | Repetitions per sweep configuration or workload case | `3` |

--- a/tests/test_bench_serve_capacity.py
+++ b/tests/test_bench_serve_capacity.py
@@ -2,15 +2,23 @@
 """Regression tests for the versioned capacity-envelope evidence contract."""
 
 import pytest
+import httpx
 
 from vllm_mlx.bench_serve import (
     CapacityConfig,
     CapacityThresholds,
     _capacity_hardware_fingerprint,
+    _capacity_baseline_identity,
+    _capacity_cache_stats_are_empty,
     _capacity_memory_from_status,
+    _capacity_provenance,
+    _capacity_reset_state_verified,
     _capacity_telemetry_delta,
+    _run_capacity_request,
+    _verify_capacity_cache_mode,
     classify_capacity_error,
     compare_capacity_outputs,
+    parse_metrics_text,
     parse_sse_line,
     run_capacity_envelope,
     sha256_json,
@@ -66,6 +74,74 @@ def test_unavailable_observations_remain_null(monkeypatch):
     assert hardware["memory_gb"] is None
     assert _capacity_memory_from_status({}) == {"source": "unavailable"}
     assert _capacity_telemetry_delta({}, {})["available"] is False
+
+
+def test_telemetry_delta_never_invents_missing_series():
+    delta = _capacity_telemetry_delta(
+        {"telemetry": {"shared": 4.0, "gone": 9.0}},
+        {"telemetry": {"shared": 7.0, "new": 2.0}},
+    )
+    assert delta["values"] == {"shared": 3.0}
+    assert delta["missing_before"] == ["new"]
+    assert delta["missing_after"] == ["gone"]
+
+
+def test_actual_vllm_mlx_cache_metrics_are_retained():
+    parsed = parse_metrics_text("vllm_mlx_cache_hits 4\nvllm_mlx_cache_misses 2\n")
+    assert parsed["telemetry"] == {
+        "vllm_mlx_cache_hits": 4.0,
+        "vllm_mlx_cache_misses": 2.0,
+    }
+
+
+def test_cache_stats_distinguish_missing_from_explicit_no_cache():
+    assert _capacity_cache_stats_are_empty({}) is None
+    assert _capacity_cache_stats_are_empty({"engine_cache": None}) is True
+
+
+def test_explicit_no_cache_cannot_override_nonempty_post_reset_stats():
+    event = {
+        "ok": True,
+        "response": {"status": "cleared", "engine_cache": None},
+    }
+    assert _capacity_reset_state_verified(event, False) is False
+
+
+def test_prefix_cache_verification_requires_observed_counter_direction():
+    hit = _verify_capacity_cache_mode(
+        "prefix-hit",
+        {
+            "available": True,
+            "values": {
+                "vllm_prefix_cache_hits_total": 1.0,
+                "vllm_prefix_cache_misses_total": 0.0,
+            },
+        },
+    )
+    assert hit["status"] == "verified"
+    assert _verify_capacity_cache_mode("prefix-hit", {})["status"] == "unavailable"
+
+
+def test_capacity_provenance_preserves_nested_mtp_status(monkeypatch):
+    monkeypatch.setattr("vllm_mlx.bench_serve._capacity_source_commit", lambda: "abc")
+    provenance = _capacity_provenance(
+        url="http://localhost:8000",
+        model_id="model",
+        runtime={},
+        status={"mtp": {"enabled": True, "accepted_tokens": 12}},
+        hardware={},
+    )
+    assert provenance["runtime"]["mtp_enabled"] is True
+    assert provenance["runtime"]["mtp"]["accepted_tokens"] == 12
+    assert provenance["client"]["source_commit"] == "abc"
+
+
+def test_baseline_identity_requires_revision_and_quantization():
+    partial = {
+        "runtime": {"model_id": "model"},
+        "model": {"revision": None, "quantization": None},
+    }
+    assert _capacity_baseline_identity(partial, partial)["verified"] is False
 
 
 def test_sse_timing_inputs_are_explicitly_chunks_with_optional_token_ids():
@@ -141,6 +217,10 @@ async def test_cold_cell_requires_verified_reset(monkeypatch):
         lambda *args: _async_value({}),
     )
     monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_capacity_cache_stats",
+        lambda *args: _async_value(None),
+    )
+    monkeypatch.setattr(
         "vllm_mlx.bench_serve.clear_runtime_cache",
         lambda *args: _async_value({"ok": False, "status_code": 404, "error": ""}),
     )
@@ -174,6 +254,10 @@ async def test_cold_cell_never_warms_after_reset(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "vllm_mlx.bench_serve.scrape_metrics",
         lambda *args: _async_value({}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_capacity_cache_stats",
+        lambda *args: _async_value({"engine_cache": {"hits": 0, "entry_count": 0}}),
     )
     monkeypatch.setattr(
         "vllm_mlx.bench_serve._capacity_hardware_fingerprint",
@@ -219,5 +303,158 @@ async def test_cold_cell_never_warms_after_reset(monkeypatch, tmp_path):
     assert result["cells"][0]["cache_actions"][0]["warmup_requests"] == 0
 
 
+@pytest.mark.anyio
+async def test_unsupported_prefix_cache_is_unavailable_not_an_abort(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr("vllm_mlx.bench_serve.httpx.AsyncClient", _DummyClient)
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.auto_detect_runtime",
+        lambda *args: _async_value({"model_id": "test-model"}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_post_run_status",
+        lambda *args: _async_value({}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._capacity_hardware_fingerprint",
+        lambda: {"memory_gb": None, "source": {}},
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_capacity_cache_stats",
+        lambda *args: _async_value({"engine_cache": None}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.clear_runtime_cache",
+        lambda *args: _async_value(
+            {
+                "ok": True,
+                "status_code": 200,
+                "response": {"status": "cleared", "engine_cache": None},
+            }
+        ),
+    )
+    result = await run_capacity_envelope(
+        model="test-model",
+        output_path=str(tmp_path / "capacity.json"),
+        config=CapacityConfig(
+            concurrencies=(1,),
+            prompt_tokens=(8,),
+            output_tokens=(4,),
+            cache_modes=("prefix-hit",),
+            repetitions=1,
+        ),
+    )
+    assert result["cells"][0]["cache_verification"]["status"] == "unavailable"
+    assert result["cells"][0]["sustainable"] is False
+
+
 async def _async_value(value):
     return value
+
+
+@pytest.mark.anyio
+async def test_capacity_request_accepts_configured_length_completion(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.stream_chat_completion",
+        lambda **kwargs: _async_value(
+            {
+                "finish_reason": "length",
+                "content": "bounded output",
+                "tool_calls": [],
+                "usage_available": True,
+                "prompt_tokens": 8,
+                "completion_tokens": 4,
+                "ttft_ms": 1.0,
+                "tpot_ms": 2.0,
+                "e2e_latency_ms": 3.0,
+                "queue_time_ms": None,
+                "token_ids": [],
+            }
+        ),
+    )
+    sample = await _run_capacity_request(
+        object(),
+        "http://test",
+        messages=[{"role": "user", "content": "x"}],
+        model="test",
+        max_tokens=4,
+        extra_body=None,
+        request_timeout_s=1,
+    )
+    assert sample["error"] == ""
+    assert sample["validated"] is True
+    assert sample["chunk_gap_ms"] == 2.0
+
+
+@pytest.mark.anyio
+async def test_capacity_request_rejects_missing_usage(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.stream_chat_completion",
+        lambda **kwargs: _async_value(
+            {
+                "finish_reason": "stop",
+                "content": "output",
+                "tool_calls": [],
+                "usage_available": False,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "ttft_ms": 1.0,
+                "tpot_ms": 2.0,
+                "e2e_latency_ms": 3.0,
+                "queue_time_ms": None,
+                "token_ids": [],
+            }
+        ),
+    )
+    sample = await _run_capacity_request(
+        object(),
+        "http://test",
+        messages=[{"role": "user", "content": "x"}],
+        model="test",
+        max_tokens=4,
+        extra_body=None,
+        request_timeout_s=1,
+    )
+    assert sample["error"] == "token usage unavailable"
+    assert sample["validated"] is False
+
+
+@pytest.mark.anyio
+async def test_capacity_request_classifies_oom_from_http_response_body(monkeypatch):
+    request = httpx.Request("POST", "http://test/v1/chat/completions")
+    response = httpx.Response(500, request=request, text="Metal out of memory")
+
+    async def fail(**kwargs):
+        raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+    monkeypatch.setattr("vllm_mlx.bench_serve.stream_chat_completion", fail)
+    sample = await _run_capacity_request(
+        object(),
+        "http://test",
+        messages=[{"role": "user", "content": "x"}],
+        model="test",
+        max_tokens=4,
+        extra_body=None,
+        request_timeout_s=1,
+    )
+    assert sample["error_kind"] == "oom"
+
+
+@pytest.mark.anyio
+async def test_capacity_request_reads_streaming_http_error_body_before_classifying():
+    async def handler(request):
+        return httpx.Response(500, content=b"Metal out of memory")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await _run_capacity_request(
+            client,
+            "http://test",
+            messages=[{"role": "user", "content": "x"}],
+            model="test",
+            max_tokens=4,
+            extra_body=None,
+            request_timeout_s=1,
+        )
+    assert sample["error_kind"] == "oom"
+    assert "Metal out of memory" in sample["error"]

--- a/tests/test_bench_serve_capacity.py
+++ b/tests/test_bench_serve_capacity.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the versioned capacity-envelope evidence contract."""
+
+import pytest
+
+from vllm_mlx.bench_serve import (
+    CapacityConfig,
+    CapacityThresholds,
+    _capacity_hardware_fingerprint,
+    _capacity_memory_from_status,
+    _capacity_telemetry_delta,
+    classify_capacity_error,
+    compare_capacity_outputs,
+    parse_sse_line,
+    run_capacity_envelope,
+    sha256_json,
+    summarize_capacity_cell,
+    summarize_capacity_envelope,
+)
+
+
+def _sample(**overrides):
+    value = {
+        "error": "",
+        "error_kind": None,
+        "ttft_ms": 10.0,
+        "chunk_gap_ms": 2.0,
+        "e2e_latency_ms": 20.0,
+        "queue_time_ms": None,
+        "prompt_tokens": 16,
+        "completion_tokens": 8,
+        "correctness": {"status": "not_run"},
+        "memory": {"source": "unavailable"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_partial_failure_fails_cell_and_does_not_inflate_rps():
+    cell = summarize_capacity_cell(
+        prompt_tokens=16,
+        output_tokens=8,
+        cache_mode="warm",
+        concurrency=2,
+        samples=[_sample(), _sample(error="timed out", error_kind="timeout")],
+        batch_durations_ms=[1000.0],
+        thresholds=CapacityThresholds(),
+    )
+
+    assert cell["failure_count"] == 1
+    assert cell["timeout_count"] == 1
+    assert cell["requests_per_s"] == 1.0
+    assert cell["sustainable"] is False
+
+
+def test_unavailable_observations_remain_null(monkeypatch):
+    def unavailable(*args, **kwargs):
+        raise OSError("unavailable")
+
+    monkeypatch.setattr("subprocess.run", unavailable)
+
+    hardware = _capacity_hardware_fingerprint()
+    assert hardware["gpu_cores"] is None
+    assert hardware["bandwidth_gbs"] is None
+    assert hardware["chip"] is None
+    assert hardware["memory_gb"] is None
+    assert _capacity_memory_from_status({}) == {"source": "unavailable"}
+    assert _capacity_telemetry_delta({}, {})["available"] is False
+
+
+def test_sse_timing_inputs_are_explicitly_chunks_with_optional_token_ids():
+    parsed = parse_sse_line(
+        'data: {"choices":[{"delta":{"content":"several tokens"},'
+        '"logprobs":{"content":[{"token_id":7},{"token_id":8}]}}],'
+        '"metrics":{"queue_time_ms":3.5}}'
+    )
+
+    assert parsed["content"] == "several tokens"
+    assert parsed["token_ids"] == [7, 8]
+    assert parsed["queue_time_ms"] == 3.5
+
+
+def test_workload_hash_is_order_stable_and_output_parity_prefers_token_ids():
+    assert sha256_json({"b": 2, "a": 1}) == sha256_json({"a": 1, "b": 2})
+    comparison = compare_capacity_outputs(
+        {"token_ids": [1, 2], "content": "ignored"},
+        {"token_ids": [1, 2], "content": "different"},
+    )
+    assert comparison["status"] == "match"
+    assert comparison["method"] == "token_ids"
+
+
+def test_envelope_reports_throughput_per_gib_not_concurrency_per_gib():
+    config = CapacityConfig(
+        concurrencies=(1,),
+        prompt_tokens=(16,),
+        output_tokens=(8,),
+        cache_modes=("warm",),
+    )
+    summary = summarize_capacity_envelope(
+        [{"concurrency": 1, "sustainable": True, "output_throughput_tps": 64.0}],
+        config=config,
+        memory_gb=16.0,
+    )
+    assert summary["throughput_per_gib"] == 4.0
+    assert summary["sustainable_concurrency_per_gib"] == 0.0625
+
+
+@pytest.mark.parametrize(
+    ("message", "kind"),
+    [
+        ("request timeout", "timeout"),
+        ("Metal out of memory", "oom"),
+        ("HTTP 500", "error"),
+    ],
+)
+def test_error_classification(message, kind):
+    assert classify_capacity_error(message) == kind
+
+
+class _DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+@pytest.mark.anyio
+async def test_cold_cell_requires_verified_reset(monkeypatch):
+    monkeypatch.setattr("vllm_mlx.bench_serve.httpx.AsyncClient", _DummyClient)
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.auto_detect_runtime",
+        lambda *args: _async_value({"model_id": "test-model"}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_post_run_status",
+        lambda *args: _async_value({}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.clear_runtime_cache",
+        lambda *args: _async_value({"ok": False, "status_code": 404, "error": ""}),
+    )
+
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        await run_capacity_envelope(
+            model="test-model",
+            config=CapacityConfig(
+                concurrencies=(1,),
+                prompt_tokens=(8,),
+                output_tokens=(4,),
+                cache_modes=("cold",),
+                repetitions=1,
+                warmup=3,
+            ),
+        )
+
+
+@pytest.mark.anyio
+async def test_cold_cell_never_warms_after_reset(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr("vllm_mlx.bench_serve.httpx.AsyncClient", _DummyClient)
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.auto_detect_runtime",
+        lambda *args: _async_value({"model_id": "test-model"}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._fetch_post_run_status",
+        lambda *args: _async_value({}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.scrape_metrics",
+        lambda *args: _async_value({}),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve._capacity_hardware_fingerprint",
+        lambda: {"memory_gb": None},
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.bench_serve.clear_runtime_cache",
+        lambda *args: _async_value(
+            {
+                "ok": True,
+                "status_code": 200,
+                "response": {
+                    "status": "cleared",
+                    "engine_cache": {"prefix_cache": True},
+                },
+            }
+        ),
+    )
+
+    async def fake_request(*args, **kwargs):
+        calls.append(kwargs)
+        return _sample(
+            finish_reason="stop",
+            content="ok",
+            telemetry_delta={"available": False, "values": None},
+        )
+
+    monkeypatch.setattr("vllm_mlx.bench_serve._run_capacity_request", fake_request)
+    result = await run_capacity_envelope(
+        model="test-model",
+        output_path=str(tmp_path / "capacity.json"),
+        config=CapacityConfig(
+            concurrencies=(2,),
+            prompt_tokens=(8,),
+            output_tokens=(4,),
+            cache_modes=("cold",),
+            repetitions=1,
+            warmup=3,
+        ),
+    )
+
+    assert len(calls) == 2
+    assert result["cells"][0]["cache_actions"][0]["warmup_requests"] == 0
+
+
+async def _async_value(value):
+    return value

--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -235,6 +235,9 @@ def classify_sustainable_capacity(
         reasons.append("correctness failure")
     if summary.get("correctness_unavailable_count", 0):
         reasons.append("correctness unavailable")
+    cache_status = summary.get("cache_verification", {}).get("status")
+    if cache_status != "verified":
+        reasons.append(f"cache state {cache_status or 'unavailable'}")
 
     for field_name, limit, label in (
         ("ttft_ms", thresholds.max_p95_ttft_ms, "p95 TTFT"),
@@ -262,6 +265,7 @@ def summarize_capacity_cell(
     thresholds: CapacityThresholds,
     telemetry_delta: Optional[dict] = None,
     cache_actions: Optional[list[dict]] = None,
+    cache_verification: Optional[dict] = None,
 ) -> dict:
     """Aggregate request samples into one classified capacity cell."""
     errors = [sample for sample in samples if sample.get("error")]
@@ -305,6 +309,8 @@ def summarize_capacity_cell(
         ),
         "telemetry_delta": telemetry_delta or {},
         "cache_actions": cache_actions or [],
+        "cache_verification": cache_verification
+        or {"status": "unavailable", "source": None},
         "memory": {
             "active_gb": _metric_stats(
                 [
@@ -339,6 +345,14 @@ def summarize_capacity_cell(
                 "unavailable",
             ),
         },
+        "mtp_status": next(
+            (
+                sample.get("mtp_status")
+                for sample in reversed(valid)
+                if sample.get("mtp_status") is not None
+            ),
+            None,
+        ),
     }
     sustainable, reasons = classify_sustainable_capacity(summary, thresholds)
     summary["sustainable"] = sustainable
@@ -848,6 +862,7 @@ def parse_metrics_text(text: str) -> dict:
             "mtp" in lower_name
             or "spec" in lower_name
             or "prefix_cache" in lower_name
+            or lower_name.startswith("vllm_mlx_cache_")
             or "queue" in lower_name
         ):
             try:
@@ -1024,6 +1039,52 @@ async def clear_runtime_cache(client: httpx.AsyncClient, base_url: str) -> dict:
     except Exception as exc:
         event["error"] = str(exc)
     return event
+
+
+async def _fetch_capacity_cache_stats(
+    client: httpx.AsyncClient, base_url: str
+) -> Optional[dict]:
+    try:
+        response = await client.get(f"{base_url}/v1/cache/stats")
+        response.raise_for_status()
+        data = response.json()
+        return data if isinstance(data, dict) else None
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+def _capacity_cache_stats_are_empty(stats: Optional[dict]) -> Optional[bool]:
+    if stats is None:
+        return None
+    if "engine_cache" not in stats:
+        return None
+    engine = stats.get("engine_cache")
+    if engine is None:
+        return True
+    if not isinstance(engine, dict) or "error" in engine:
+        return None
+    activity_keys = {
+        "hits",
+        "misses",
+        "tokens_saved",
+        "entry_count",
+        "current_memory_bytes",
+        "current_memory_mb",
+        "dropped_entries",
+    }
+    observed: list[float] = []
+
+    def _walk(value: Any) -> None:
+        if not isinstance(value, dict):
+            return
+        for key, nested in value.items():
+            if key in activity_keys and isinstance(nested, (int, float)):
+                observed.append(float(nested))
+            elif isinstance(nested, dict):
+                _walk(nested)
+
+    _walk(engine)
+    return all(value == 0 for value in observed) if observed else None
 
 
 def _normalize_cache_policy(value: Optional[str]) -> str:
@@ -1316,6 +1377,8 @@ async def stream_chat_completion(
         async with client.stream(
             "POST", f"{base_url}/v1/chat/completions", json=body
         ) as response:
+            if getattr(response, "status_code", 200) >= 400:
+                await response.aread()
             response.raise_for_status()
             async for raw_line in response.aiter_lines():
                 parsed = parse_sse_line(raw_line)
@@ -1376,6 +1439,11 @@ async def stream_chat_completion(
 
     return {
         **metrics,
+        "usage_available": bool(
+            isinstance(usage, dict)
+            and "prompt_tokens" in usage
+            and "completion_tokens" in usage
+        ),
         "completion_tokens": completion_tokens,
         "prompt_tokens": prompt_tokens,
         "finish_reason": finish_reason,
@@ -2095,7 +2163,7 @@ async def run_bench_serve_workload(
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         runtime = await auto_detect_runtime(client, url)
-        hardware = _capacity_hardware_fingerprint()
+        hardware = detect_hardware_fingerprint()
         model_id = model or runtime.get("model_id", "")
         if not model_id:
             raise ValueError("could not determine model ID; pass --model")
@@ -3044,25 +3112,70 @@ def _capacity_telemetry_delta(before: dict, after: dict) -> dict:
     after_values = after.get("telemetry") or {}
     if not before_values or not after_values:
         return {"available": False, "source": "/metrics", "values": None}
+    shared_keys = sorted(set(before_values) & set(after_values))
+    if not shared_keys:
+        return {"available": False, "source": "/metrics", "values": None}
     delta: dict[str, float] = {}
-    for key in sorted(set(before_values) | set(after_values)):
-        value = float(after_values.get(key, 0.0)) - float(before_values.get(key, 0.0))
+    for key in shared_keys:
+        value = float(after_values[key]) - float(before_values[key])
         if value:
             delta[key] = value
-    return {"available": True, "source": "/metrics", "values": delta}
+    return {
+        "available": True,
+        "source": "/metrics",
+        "values": delta,
+        "missing_before": sorted(set(after_values) - set(before_values)),
+        "missing_after": sorted(set(before_values) - set(after_values)),
+    }
 
 
-def _verified_capacity_cache_reset(event: dict) -> bool:
+def _verified_capacity_cache_reset(
+    event: dict, *, require_engine_cache: bool = False
+) -> bool:
     """Require the vllm-mlx cache endpoint's explicit engine acknowledgement."""
     response = event.get("response") or {}
+    if "engine_cache" not in response:
+        return False
     engine_cache = response.get("engine_cache")
-    return bool(
-        event.get("ok")
-        and response.get("status") == "cleared"
-        and isinstance(engine_cache, dict)
-        and engine_cache
-        and "error" not in engine_cache
-    )
+    acknowledged = bool(event.get("ok") and response.get("status") == "cleared")
+    if not acknowledged or (isinstance(engine_cache, dict) and "error" in engine_cache):
+        return False
+    if require_engine_cache:
+        return isinstance(engine_cache, dict) and bool(engine_cache)
+    return True
+
+
+def _capacity_reset_state_verified(
+    event: dict, post_reset_empty: Optional[bool]
+) -> bool:
+    if not _verified_capacity_cache_reset(event):
+        return False
+    engine_cache = (event.get("response") or {}).get("engine_cache")
+    if post_reset_empty is False:
+        return False
+    if engine_cache is not None and post_reset_empty is not True:
+        return False
+    return True
+
+
+def _verify_capacity_cache_mode(cache_mode: str, telemetry: dict) -> dict:
+    if cache_mode not in {"prefix-hit", "prefix-miss"}:
+        return {"status": "verified", "source": "controlled reset/warmup"}
+    if not telemetry.get("available"):
+        return {"status": "unavailable", "source": "/metrics"}
+    values = telemetry.get("values") or {}
+    hits = sum(value for key, value in values.items() if "cache_hits" in key)
+    misses = sum(value for key, value in values.items() if "cache_misses" in key)
+    if cache_mode == "prefix-hit":
+        verified = hits > 0
+    else:
+        verified = misses > 0 and hits == 0
+    return {
+        "status": "verified" if verified else "mismatch",
+        "source": "/metrics",
+        "cache_hits": hits,
+        "cache_misses": misses,
+    }
 
 
 def _capacity_hardware_fingerprint() -> dict:
@@ -3102,18 +3215,20 @@ def _capacity_hardware_fingerprint() -> dict:
 def _capacity_provenance(
     *,
     url: str,
-    model_id: str,
+    model_id: Optional[str],
     runtime: dict,
     status: dict,
     hardware: dict,
 ) -> dict:
     """Collect explicit provenance, leaving unknown values as null."""
+    mtp = status.get("mtp") if isinstance(status.get("mtp"), dict) else None
     return {
         "client": {
             "package": "vllm-mlx",
             "package_version": _capacity_package_version("vllm-mlx"),
             "python_version": platform.python_version(),
             "platform": platform.platform(),
+            "source_commit": _capacity_source_commit(),
         },
         "server": {
             "url": url,
@@ -3125,7 +3240,8 @@ def _capacity_provenance(
             "model_id": model_id,
             "model_type": runtime.get("model_type") or None,
             "engine_type": runtime.get("engine_type") or None,
-            "mtp_enabled": runtime.get("mtp_enabled"),
+            "mtp": mtp,
+            "mtp_enabled": mtp.get("enabled") if mtp else None,
             "specprefill": runtime.get("specprefill"),
             "kv_quant": runtime.get("kv_quant") or None,
             "cache_type": runtime.get("cache_type") or None,
@@ -3141,6 +3257,22 @@ def _capacity_provenance(
             for name in ("mlx", "mlx-lm", "mlx-vlm")
         },
     }
+
+
+def _capacity_source_commit() -> Optional[str]:
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parent.parent,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
 
 
 def compare_capacity_outputs(candidate: dict, baseline: dict) -> dict:
@@ -3223,17 +3355,23 @@ async def _run_capacity_request(
         )
         error = ""
     except Exception as exc:
+        response = getattr(exc, "response", None)
+        try:
+            response_text = response.text if response is not None else ""
+        except httpx.ResponseNotRead:
+            response_text = ""
         result = {
             "ttft_ms": None,
             "tpot_ms": None,
             "e2e_latency_ms": None,
             "queue_time_ms": None,
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "usage_available": False,
             "content": "",
             "token_ids": [],
         }
-        error = str(exc)
+        error = " — ".join(part for part in (str(exc), response_text) if part)
     sample = {
         **result,
         "error": error,
@@ -3243,12 +3381,13 @@ async def _run_capacity_request(
     if error:
         sample["validated"] = False
     else:
-        valid, reason = validate_response(
-            result.get("finish_reason"),
-            result.get("content", ""),
-            200,
-            tool_calls=result.get("tool_calls") or [],
-        )
+        finish_reason = result.get("finish_reason")
+        has_output = bool(result.get("content") or result.get("tool_calls"))
+        valid = finish_reason in {"stop", "length", "tool_calls"} and has_output
+        reason = "" if valid else "invalid or empty capacity response"
+        if not result.get("usage_available"):
+            valid = False
+            reason = "token usage unavailable"
         sample["validated"] = valid
         if not valid:
             sample["error"] = reason
@@ -3309,7 +3448,7 @@ async def run_capacity_envelope(
             baseline_status = await _fetch_post_run_status(client, baseline_url)
             baseline_provenance = _capacity_provenance(
                 url=baseline_url,
-                model_id=baseline_runtime.get("model_id") or model_id,
+                model_id=baseline_runtime.get("model_id"),
                 runtime=baseline_runtime,
                 status=baseline_status,
                 hardware={"scope": "not_collected"},
@@ -3329,7 +3468,16 @@ async def run_capacity_envelope(
             "config": config.to_dict(),
             "request_template": {
                 "role": "user",
-                "generator": "capacity envelope repeated-token-v1",
+                "generator": "capacity-envelope-token-bucket-v2",
+                "extra_body": request_extra,
+                "baseline_enabled": baseline_url is not None,
+            },
+            "prompt_material_sha256": {
+                f"{tokens}:{variant}": sha256_json(
+                    build_capacity_messages(tokens, variant=variant)
+                )
+                for tokens in config.prompt_tokens
+                for variant in ("base", "warm", "miss")
             },
         }
         workload_hash = sha256_json(workload_descriptor)
@@ -3343,6 +3491,7 @@ async def run_capacity_envelope(
                         telemetry_values: dict[str, float] = {}
                         telemetry_available = True
                         cache_actions: list[dict] = []
+                        cache_mode_available = True
                         for repetition in range(config.repetitions):
                             measured_variant = (
                                 "miss" if cache_mode == "prefix-miss" else "base"
@@ -3361,8 +3510,16 @@ async def run_capacity_envelope(
                                 "warmup_requests": 0,
                             }
                             reset = await clear_runtime_cache(client, url)
+                            post_reset_stats = await _fetch_capacity_cache_stats(
+                                client, url
+                            )
+                            post_reset_empty = _capacity_cache_stats_are_empty(
+                                post_reset_stats
+                            )
                             actions["reset_before_measured"] = True
                             actions["reset_event"] = reset
+                            actions["post_reset_stats"] = post_reset_stats
+                            actions["post_reset_empty"] = post_reset_empty
                             cache_events.append(
                                 {
                                     "prompt_tokens": prompt_tokens,
@@ -3373,11 +3530,23 @@ async def run_capacity_envelope(
                                     "event": reset,
                                 }
                             )
-                            if not _verified_capacity_cache_reset(reset):
+                            if not _capacity_reset_state_verified(
+                                reset, post_reset_empty
+                            ):
                                 raise RuntimeError(
                                     f"{cache_mode} cache state could not be verified: "
                                     f"{reset.get('error') or reset.get('status_code')}"
                                 )
+                            if cache_mode in {
+                                "prefix-hit",
+                                "prefix-miss",
+                            } and not _verified_capacity_cache_reset(
+                                reset, require_engine_cache=True
+                            ):
+                                actions["availability"] = "unsupported"
+                                cache_actions.append(actions)
+                                cache_mode_available = False
+                                continue
                             warmup_count = 0 if cache_mode == "cold" else config.warmup
                             if cache_mode in {"warm", "prefix-hit", "prefix-miss"}:
                                 warmup_count = max(1, warmup_count)
@@ -3436,19 +3605,31 @@ async def run_capacity_envelope(
                                         "timing_semantics": "content_chunk_gap",
                                         "memory": batch_memory,
                                         "telemetry_delta": batch_telemetry,
+                                        "mtp_status": (
+                                            status_after.get("mtp")
+                                            if isinstance(status_after.get("mtp"), dict)
+                                            else None
+                                        ),
                                     }
                                 )
                             if baseline_url and batch:
-                                baseline_sample = await _run_capacity_request(
-                                    client,
-                                    baseline_url,
-                                    messages=measured_messages,
-                                    model=model_id,
-                                    max_tokens=output_tokens,
-                                    extra_body=request_extra,
-                                    request_timeout_s=config.request_timeout_s,
+                                baseline_batch = await asyncio.gather(
+                                    *[
+                                        _run_capacity_request(
+                                            client,
+                                            baseline_url,
+                                            messages=measured_messages,
+                                            model=model_id,
+                                            max_tokens=output_tokens,
+                                            extra_body=request_extra,
+                                            request_timeout_s=config.request_timeout_s,
+                                        )
+                                        for _ in batch
+                                    ]
                                 )
-                                for sample in batch:
+                                for sample, baseline_sample in zip(
+                                    batch, baseline_batch
+                                ):
                                     if (
                                         not baseline_identity["verified"]
                                         or sample.get("error")
@@ -3479,6 +3660,20 @@ async def run_capacity_envelope(
                                         telemetry_values.get(key, 0.0) + value
                                     )
 
+                        cell_telemetry = {
+                            "available": telemetry_available,
+                            "source": "/metrics",
+                            "values": telemetry_values if telemetry_available else None,
+                        }
+                        cache_verification = (
+                            _verify_capacity_cache_mode(cache_mode, cell_telemetry)
+                            if cache_mode_available
+                            else {
+                                "status": "unavailable",
+                                "source": "DELETE /v1/cache",
+                                "reason": "engine cache unsupported",
+                            }
+                        )
                         cell = summarize_capacity_cell(
                             prompt_tokens=prompt_tokens,
                             output_tokens=output_tokens,
@@ -3487,14 +3682,9 @@ async def run_capacity_envelope(
                             samples=cell_samples,
                             batch_durations_ms=batch_durations_ms,
                             thresholds=config.thresholds,
-                            telemetry_delta={
-                                "available": telemetry_available,
-                                "source": "/metrics",
-                                "values": (
-                                    telemetry_values if telemetry_available else None
-                                ),
-                            },
+                            telemetry_delta=cell_telemetry,
                             cache_actions=cache_actions,
+                            cache_verification=cache_verification,
                         )
                         cells.append(cell)
                         print(

--- a/vllm_mlx/bench_serve.py
+++ b/vllm_mlx/bench_serve.py
@@ -18,6 +18,8 @@ It is a pure HTTP client that talks to a running OpenAI-compatible server.
 import asyncio
 import csv as csv_mod
 import dataclasses as _dataclasses
+import hashlib
+import importlib.metadata
 import io
 import itertools
 import json
@@ -70,6 +72,319 @@ class Workload:
     description: str
     defaults: dict
     cases: list[WorkloadCase]
+
+
+# ---------------------------------------------------------------------------
+# Versioned capacity-envelope contract
+# ---------------------------------------------------------------------------
+
+# This is intentionally separate from ``BenchServeResult``.  The existing
+# prompt-sweep output is a useful compatibility surface; capacity envelopes
+# need a richer, versioned artifact with explicit provenance and failure
+# classification.
+CAPACITY_ENVELOPE_KIND = "vllm-mlx-capacity-envelope"
+CAPACITY_ENVELOPE_SCHEMA_VERSION = 1
+CAPACITY_CACHE_MODES = ("cold", "warm", "prefix-hit", "prefix-miss")
+DEFAULT_CAPACITY_CONCURRENCIES = (1, 2, 4, 8, 16, 32)
+DEFAULT_CAPACITY_PROMPT_TOKENS = (256, 2048, 8192, 32768)
+DEFAULT_CAPACITY_OUTPUT_TOKENS = (128, 512)
+
+
+@dataclass(frozen=True)
+class CapacityThresholds:
+    """Tail-latency and failure limits for sustainable capacity."""
+
+    max_p95_ttft_ms: Optional[float] = None
+    max_p95_chunk_gap_ms: Optional[float] = None
+    max_p95_e2e_ms: Optional[float] = None
+    max_failure_rate: float = 0.0
+    max_ooms: int = 0
+    max_timeouts: int = 0
+
+
+@dataclass(frozen=True)
+class CapacityConfig:
+    """Declarative, JSON-serializable capacity sweep configuration."""
+
+    concurrencies: tuple[int, ...] = DEFAULT_CAPACITY_CONCURRENCIES
+    prompt_tokens: tuple[int, ...] = DEFAULT_CAPACITY_PROMPT_TOKENS
+    output_tokens: tuple[int, ...] = DEFAULT_CAPACITY_OUTPUT_TOKENS
+    cache_modes: tuple[str, ...] = CAPACITY_CACHE_MODES
+    repetitions: int = 3
+    warmup: int = 1
+    request_timeout_s: Optional[float] = 300.0
+    thresholds: CapacityThresholds = CapacityThresholds()
+    extra_body: Optional[dict] = None
+
+    def __post_init__(self) -> None:
+        for name in ("concurrencies", "prompt_tokens", "output_tokens"):
+            values = getattr(self, name)
+            if not values or any(int(value) < 1 for value in values):
+                raise ValueError(f"{name} must contain positive integers")
+        if not self.cache_modes or any(
+            mode not in CAPACITY_CACHE_MODES for mode in self.cache_modes
+        ):
+            raise ValueError(
+                f"cache_modes must contain only: {', '.join(CAPACITY_CACHE_MODES)}"
+            )
+        if self.repetitions < 1:
+            raise ValueError("repetitions must be at least 1")
+        if self.warmup < 0:
+            raise ValueError("warmup must be non-negative")
+        if self.request_timeout_s is not None and self.request_timeout_s <= 0:
+            raise ValueError("request_timeout_s must be positive or None")
+        if not isinstance(self.thresholds, CapacityThresholds):
+            raise ValueError("thresholds must be a CapacityThresholds instance")
+        if self.extra_body is not None and not isinstance(self.extra_body, dict):
+            raise ValueError("extra_body must be an object")
+
+    def to_dict(self) -> dict:
+        """Return a stable JSON-compatible representation of the config."""
+        thresholds = _dataclasses.asdict(self.thresholds)
+        return {
+            "concurrencies": list(self.concurrencies),
+            "prompt_tokens": list(self.prompt_tokens),
+            "output_tokens": list(self.output_tokens),
+            "cache_modes": list(self.cache_modes),
+            "repetitions": self.repetitions,
+            "warmup": self.warmup,
+            "request_timeout_s": self.request_timeout_s,
+            "thresholds": thresholds,
+            "extra_body": self.extra_body or {},
+        }
+
+
+def _canonical_json(value: Any) -> str:
+    """Serialize JSON deterministically for reproducible artifact hashes."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: Any) -> str:
+    """Return the SHA-256 of a canonical JSON value."""
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def build_capacity_messages(
+    target_prompt_tokens: int, *, variant: str = "base"
+) -> list[dict]:
+    """Build a deterministic approximate-length HTTP prompt.
+
+    Tokenizers differ across model families, so ``target_prompt_tokens`` is a
+    requested workload size, not a claim about the resulting token count. The
+    server-reported ``usage.prompt_tokens`` is authoritative in each sample.
+    ``variant`` lets the prefix-miss case use a distinct prompt while keeping
+    the requested size constant.
+    """
+    marker = variant
+    prefix = f"capacity envelope {marker}: "
+    content = prefix + ("x " * max(1, target_prompt_tokens - 4)).strip()
+    return [{"role": "user", "content": content}]
+
+
+def classify_capacity_error(error: str) -> str:
+    """Classify transport/server failures without guessing at other errors."""
+    normalized = (error or "").lower()
+    if "timeout" in normalized or "timed out" in normalized:
+        return "timeout"
+    if any(
+        marker in normalized
+        for marker in (
+            "out of memory",
+            "out-of-memory",
+            "oom",
+            "memoryerror",
+            "metal resource",
+        )
+    ):
+        return "oom"
+    return "error"
+
+
+def _metric_stats(records: list[dict], key: str) -> Optional[dict]:
+    values = [
+        float(record[key])
+        for record in records
+        if record.get(key) is not None and isinstance(record.get(key), (int, float))
+    ]
+    return compute_summary_stats(values) if values else None
+
+
+def classify_sustainable_capacity(
+    summary: dict, thresholds: CapacityThresholds
+) -> tuple[bool, list[str]]:
+    """Apply explicit SLOs to one capacity cell summary.
+
+    Missing latency telemetry cannot pass a configured latency SLO.  When no
+    SLO is configured for a metric, unavailable telemetry remains unavailable
+    and does not get replaced with a fabricated zero.
+    """
+    reasons: list[str] = []
+    if summary.get("sample_count", 0) == 0:
+        reasons.append("no samples")
+    if summary.get("failure_rate", 0.0) > thresholds.max_failure_rate:
+        reasons.append(
+            f"failure_rate {summary['failure_rate']:.4f} > {thresholds.max_failure_rate:.4f}"
+        )
+    if summary.get("oom_count", 0) > thresholds.max_ooms:
+        reasons.append(f"oom_count {summary['oom_count']} > {thresholds.max_ooms}")
+    if summary.get("timeout_count", 0) > thresholds.max_timeouts:
+        reasons.append(
+            f"timeout_count {summary['timeout_count']} > {thresholds.max_timeouts}"
+        )
+    if summary.get("correctness_failure_count", 0):
+        reasons.append("correctness failure")
+    if summary.get("correctness_unavailable_count", 0):
+        reasons.append("correctness unavailable")
+
+    for field_name, limit, label in (
+        ("ttft_ms", thresholds.max_p95_ttft_ms, "p95 TTFT"),
+        ("chunk_gap_ms", thresholds.max_p95_chunk_gap_ms, "p95 chunk gap"),
+        ("e2e_latency_ms", thresholds.max_p95_e2e_ms, "p95 end-to-end latency"),
+    ):
+        if limit is None:
+            continue
+        stats = summary.get(field_name)
+        if not stats:
+            reasons.append(f"{label} unavailable")
+        elif stats.get("p95", 0.0) > limit:
+            reasons.append(f"{label} {stats['p95']:.3f} > {limit:.3f} ms")
+    return (not reasons, reasons)
+
+
+def summarize_capacity_cell(
+    *,
+    prompt_tokens: int,
+    output_tokens: int,
+    cache_mode: str,
+    concurrency: int,
+    samples: list[dict],
+    batch_durations_ms: list[float],
+    thresholds: CapacityThresholds,
+    telemetry_delta: Optional[dict] = None,
+    cache_actions: Optional[list[dict]] = None,
+) -> dict:
+    """Aggregate request samples into one classified capacity cell."""
+    errors = [sample for sample in samples if sample.get("error")]
+    valid = [sample for sample in samples if not sample.get("error")]
+    completion_tokens = sum(
+        int(sample.get("completion_tokens", 0) or 0) for sample in valid
+    )
+    duration_s = sum(batch_durations_ms) / 1000.0
+    summary = {
+        "prompt_tokens_target": prompt_tokens,
+        "output_tokens_target": output_tokens,
+        "cache_mode": cache_mode,
+        "concurrency": concurrency,
+        "sample_count": len(samples),
+        "failure_count": len(errors),
+        "failure_rate": len(errors) / len(samples) if samples else 0.0,
+        "timeout_count": sum(
+            sample.get("error_kind") == "timeout" for sample in samples
+        ),
+        "oom_count": sum(sample.get("error_kind") == "oom" for sample in samples),
+        "correctness_failure_count": sum(
+            sample.get("correctness", {}).get("status") == "mismatch"
+            for sample in samples
+        ),
+        "correctness_unavailable_count": sum(
+            sample.get("correctness", {}).get("status") == "unavailable"
+            for sample in samples
+        ),
+        "ttft_ms": _metric_stats(valid, "ttft_ms"),
+        "chunk_gap_ms": _metric_stats(valid, "chunk_gap_ms"),
+        "e2e_latency_ms": _metric_stats(valid, "e2e_latency_ms"),
+        "queue_time_ms": _metric_stats(valid, "queue_time_ms"),
+        "prompt_tokens": _metric_stats(valid, "prompt_tokens"),
+        "completion_tokens": _metric_stats(valid, "completion_tokens"),
+        "output_throughput_tps": completion_tokens / duration_s if duration_s else None,
+        # Throughput is based on successful requests only.  A failed request
+        # must not inflate the apparent capacity of a cell.
+        "requests_per_s": len(valid) / duration_s if duration_s else None,
+        "batch_duration_ms": (
+            compute_summary_stats(batch_durations_ms) if batch_durations_ms else None
+        ),
+        "telemetry_delta": telemetry_delta or {},
+        "cache_actions": cache_actions or [],
+        "memory": {
+            "active_gb": _metric_stats(
+                [
+                    sample["memory"]
+                    for sample in valid
+                    if sample.get("memory", {}).get("active_gb") is not None
+                ],
+                "active_gb",
+            ),
+            "peak_gb": _metric_stats(
+                [
+                    sample["memory"]
+                    for sample in valid
+                    if sample.get("memory", {}).get("peak_gb") is not None
+                ],
+                "peak_gb",
+            ),
+            "cache_gb": _metric_stats(
+                [
+                    sample["memory"]
+                    for sample in valid
+                    if sample.get("memory", {}).get("cache_gb") is not None
+                ],
+                "cache_gb",
+            ),
+            "source": next(
+                (
+                    sample.get("memory", {}).get("source")
+                    for sample in valid
+                    if sample.get("memory", {}).get("source")
+                ),
+                "unavailable",
+            ),
+        },
+    }
+    sustainable, reasons = classify_sustainable_capacity(summary, thresholds)
+    summary["sustainable"] = sustainable
+    summary["sustainability_reasons"] = reasons
+    return summary
+
+
+def summarize_capacity_envelope(
+    cells: list[dict], *, config: CapacityConfig, memory_gb: Optional[float]
+) -> dict:
+    """Return global and per-concurrency sustainable-capacity classifications."""
+    by_concurrency: dict[int, list[dict]] = {}
+    for cell in cells:
+        by_concurrency.setdefault(int(cell["concurrency"]), []).append(cell)
+    sustainable_concurrencies = sorted(
+        concurrency
+        for concurrency, rows in by_concurrency.items()
+        if rows and all(row.get("sustainable", False) for row in rows)
+    )
+    highest = max(sustainable_concurrencies, default=None)
+    sustainable_throughputs = [
+        float(row["output_throughput_tps"])
+        for row in cells
+        if row.get("sustainable") and row.get("output_throughput_tps") is not None
+    ]
+    peak_throughput = max(sustainable_throughputs, default=None)
+    return {
+        "sustainable_concurrencies": sustainable_concurrencies,
+        "highest_concurrency": highest,
+        "peak_sustainable_output_throughput_tps": peak_throughput,
+        "throughput_per_gib": (
+            peak_throughput / memory_gb
+            if peak_throughput is not None and memory_gb is not None and memory_gb > 0
+            else None
+        ),
+        "sustainable_concurrency_per_gib": (
+            highest / memory_gb
+            if highest is not None and memory_gb is not None and memory_gb > 0
+            else None
+        ),
+        "evaluated_concurrencies": sorted(by_concurrency),
+        "note": (
+            "A concurrency is sustainable only when every prompt-length, output-length, "
+            "and cache-mode cell at that concurrency passes the configured SLOs."
+        ),
+    }
 
 
 def load_prompt_set(name_or_path: str) -> list[list[dict]]:
@@ -514,10 +829,37 @@ def parse_metrics_text(text: str) -> dict:
         m = re.search(pattern, text, re.MULTILINE)
         return int(m.group(1)) if m else 0
 
+    # Keep the historical counters above stable, while also retaining
+    # optional telemetry relevant to a capacity envelope.  Labels are part
+    # of the key so reason-specific MTP/speculative counters are not merged.
+    telemetry: dict[str, float] = {}
+    metric_pattern = re.compile(
+        r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
+    )
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        match = metric_pattern.match(line)
+        if not match:
+            continue
+        name, labels, value = match.groups()
+        lower_name = name.lower()
+        if (
+            "mtp" in lower_name
+            or "spec" in lower_name
+            or "prefix_cache" in lower_name
+            or "queue" in lower_name
+        ):
+            try:
+                telemetry[f"{name}{labels or ''}"] = float(value)
+            except ValueError:
+                continue
+
     return {
         "cache_hits": _extract("vllm_prefix_cache_hits_total"),
         "cache_misses": _extract("vllm_prefix_cache_misses_total"),
         "tokens_saved": _extract("vllm_prefix_cache_tokens_saved_total"),
+        "telemetry": telemetry,
     }
 
 
@@ -739,11 +1081,33 @@ def parse_sse_line(line: str) -> Optional[dict]:
         return None
 
     choices = chunk.get("choices") or []
-    delta = choices[0].get("delta", {}) if choices else {}
+    choice = choices[0] if choices else {}
+    delta = choice.get("delta", {}) if choices else {}
     content = delta.get("content", "") or ""
-    finish_reason = choices[0].get("finish_reason") if choices else None
+    finish_reason = choice.get("finish_reason") if choices else None
     usage = chunk.get("usage")
     tool_calls_delta = delta.get("tool_calls")
+
+    # Different OpenAI-compatible servers expose optional queue timing and
+    # token IDs in slightly different locations.  Preserve only values that
+    # are actually emitted; the capacity report uses null when unavailable.
+    queue_time_ms = chunk.get("queue_time_ms")
+    if queue_time_ms is None:
+        queue_time_ms = choice.get("queue_time_ms")
+    if queue_time_ms is None:
+        queue_time_ms = (chunk.get("metrics") or {}).get("queue_time_ms")
+    token_ids = choice.get("token_ids") or delta.get("token_ids") or []
+    if not token_ids:
+        logprobs = choice.get("logprobs") or {}
+        token_ids = logprobs.get("token_ids") or []
+        if not token_ids:
+            token_ids = [
+                item.get("token_id")
+                for item in (logprobs.get("content") or [])
+                if item.get("token_id") is not None
+            ]
+    if not isinstance(token_ids, list):
+        token_ids = [token_ids]
 
     return {
         "id": chunk.get("id"),
@@ -751,6 +1115,8 @@ def parse_sse_line(line: str) -> Optional[dict]:
         "finish_reason": finish_reason,
         "usage": usage,
         "tool_calls_delta": tool_calls_delta,
+        "queue_time_ms": float(queue_time_ms) if queue_time_ms is not None else None,
+        "token_ids": token_ids,
     }
 
 
@@ -942,9 +1308,11 @@ async def stream_chat_completion(
     usage: Optional[dict] = None
     request_id: Optional[str] = None
     tool_calls_acc: dict[int, dict] = {}
+    queue_time_ms: Optional[float] = None
+    token_ids: list[int] = []
 
     async def _consume_stream() -> None:
-        nonlocal finish_reason, request_id, t_first_token, usage
+        nonlocal finish_reason, request_id, t_first_token, usage, queue_time_ms
         async with client.stream(
             "POST", f"{base_url}/v1/chat/completions", json=body
         ) as response:
@@ -957,6 +1325,10 @@ async def stream_chat_completion(
                     request_id = parsed["id"]
                 if parsed.get("usage"):
                     usage = parsed["usage"]
+                if parsed.get("queue_time_ms") is not None:
+                    queue_time_ms = parsed["queue_time_ms"]
+                if parsed.get("token_ids"):
+                    token_ids.extend(parsed["token_ids"])
                 if parsed.get("finish_reason"):
                     finish_reason = parsed["finish_reason"]
                 tc_delta = parsed.get("tool_calls_delta")
@@ -1009,6 +1381,8 @@ async def stream_chat_completion(
         "finish_reason": finish_reason,
         "content": "".join(content_parts),
         "tool_calls": finalize_tool_calls(tool_calls_acc),
+        "queue_time_ms": queue_time_ms,
+        "token_ids": token_ids,
     }
 
 
@@ -1721,7 +2095,7 @@ async def run_bench_serve_workload(
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         runtime = await auto_detect_runtime(client, url)
-        hardware = detect_hardware_fingerprint()
+        hardware = _capacity_hardware_fingerprint()
         model_id = model or runtime.get("model_id", "")
         if not model_id:
             raise ValueError("could not determine model ID; pass --model")
@@ -2618,3 +2992,551 @@ async def run_bench_serve(
             print(output)
 
         return results
+
+
+# ---------------------------------------------------------------------------
+# Versioned capacity-envelope runner
+# ---------------------------------------------------------------------------
+
+
+def _capacity_package_version(package: str) -> Optional[str]:
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _capacity_memory_from_status(status: dict) -> dict:
+    """Extract memory only when the status endpoint actually reports it."""
+    metal = status.get("metal") or {}
+    aliases = {
+        "active_gb": ("active_memory_gb", "active_gb"),
+        "peak_gb": ("peak_memory_gb", "peak_gb"),
+        "cache_gb": ("cache_memory_gb", "cache_gb"),
+    }
+    memory: dict[str, Any] = {"source": "unavailable"}
+    for output_name, keys in aliases.items():
+        value = next((metal[key] for key in keys if key in metal), None)
+        if value is not None:
+            try:
+                memory[output_name] = float(value)
+            except (TypeError, ValueError):
+                memory[output_name] = None
+    if any(memory.get(name) is not None for name in aliases):
+        memory["source"] = "/v1/status"
+    else:
+        for output_name, keys in aliases.items():
+            value = next((status[key] for key in keys if key in status), None)
+            if value is not None:
+                try:
+                    memory[output_name] = float(value)
+                except (TypeError, ValueError):
+                    memory[output_name] = None
+        if any(memory.get(name) is not None for name in aliases):
+            memory["source"] = "/v1/status"
+    return memory
+
+
+def _capacity_telemetry_delta(before: dict, after: dict) -> dict:
+    if not before or not after:
+        return {"available": False, "source": "/metrics", "values": None}
+    before_values = before.get("telemetry") or {}
+    after_values = after.get("telemetry") or {}
+    if not before_values or not after_values:
+        return {"available": False, "source": "/metrics", "values": None}
+    delta: dict[str, float] = {}
+    for key in sorted(set(before_values) | set(after_values)):
+        value = float(after_values.get(key, 0.0)) - float(before_values.get(key, 0.0))
+        if value:
+            delta[key] = value
+    return {"available": True, "source": "/metrics", "values": delta}
+
+
+def _verified_capacity_cache_reset(event: dict) -> bool:
+    """Require the vllm-mlx cache endpoint's explicit engine acknowledgement."""
+    response = event.get("response") or {}
+    engine_cache = response.get("engine_cache")
+    return bool(
+        event.get("ok")
+        and response.get("status") == "cleared"
+        and isinstance(engine_cache, dict)
+        and engine_cache
+        and "error" not in engine_cache
+    )
+
+
+def _capacity_hardware_fingerprint() -> dict:
+    """Collect host facts without exposing estimated profile values."""
+    import subprocess
+
+    def _sysctl(name: str) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip() or None
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    chip = _sysctl("machdep.cpu.brand_string")
+    memory_bytes = _sysctl("hw.memsize")
+    memory_gb = float(memory_bytes) / (1024**3) if memory_bytes else None
+    return {
+        "chip": chip,
+        "memory_gb": memory_gb,
+        "os_version": platform.platform(),
+        "gpu_cores": None,
+        "bandwidth_gbs": None,
+        "source": {
+            "chip": "sysctl" if chip else "unavailable",
+            "memory_gb": "sysctl" if memory_gb is not None else "unavailable",
+            "gpu_cores": "unavailable",
+            "bandwidth_gbs": "unavailable",
+        },
+    }
+
+
+def _capacity_provenance(
+    *,
+    url: str,
+    model_id: str,
+    runtime: dict,
+    status: dict,
+    hardware: dict,
+) -> dict:
+    """Collect explicit provenance, leaving unknown values as null."""
+    return {
+        "client": {
+            "package": "vllm-mlx",
+            "package_version": _capacity_package_version("vllm-mlx"),
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "server": {
+            "url": url,
+            "version": status.get("version") or status.get("server_version"),
+            "commit": status.get("commit") or status.get("server_commit"),
+        },
+        "hardware": hardware,
+        "runtime": {
+            "model_id": model_id,
+            "model_type": runtime.get("model_type") or None,
+            "engine_type": runtime.get("engine_type") or None,
+            "mtp_enabled": runtime.get("mtp_enabled"),
+            "specprefill": runtime.get("specprefill"),
+            "kv_quant": runtime.get("kv_quant") or None,
+            "cache_type": runtime.get("cache_type") or None,
+        },
+        "model": {
+            "revision": status.get("model_revision") or status.get("revision"),
+            "quantization": status.get("quantization") or status.get("quant"),
+            "context_limit": status.get("context_limit") or status.get("max_model_len"),
+        },
+        "feature_flags": status.get("feature_flags") or status.get("features") or None,
+        "library_versions": {
+            name: _capacity_package_version(name)
+            for name in ("mlx", "mlx-lm", "mlx-vlm")
+        },
+    }
+
+
+def compare_capacity_outputs(candidate: dict, baseline: dict) -> dict:
+    """Compare deterministic A/B outputs using IDs, then decoded text hash."""
+    candidate_ids = candidate.get("token_ids") or []
+    baseline_ids = baseline.get("token_ids") or []
+    if candidate_ids and baseline_ids:
+        candidate_hash = sha256_json(candidate_ids)
+        baseline_hash = sha256_json(baseline_ids)
+        return {
+            "status": "match" if candidate_hash == baseline_hash else "mismatch",
+            "method": "token_ids",
+            "candidate_hash": candidate_hash,
+            "baseline_hash": baseline_hash,
+        }
+    candidate_hash = hashlib.sha256(
+        str(candidate.get("content") or "").encode("utf-8")
+    ).hexdigest()
+    baseline_hash = hashlib.sha256(
+        str(baseline.get("content") or "").encode("utf-8")
+    ).hexdigest()
+    return {
+        "status": "match" if candidate_hash == baseline_hash else "mismatch",
+        "method": "decoded_output_sha256",
+        "candidate_hash": candidate_hash,
+        "baseline_hash": baseline_hash,
+    }
+
+
+def _capacity_baseline_identity(candidate: dict, baseline: dict) -> dict:
+    fields = ("model_id", "revision", "quantization")
+    candidate_values = {
+        "model_id": candidate.get("runtime", {}).get("model_id"),
+        "revision": candidate.get("model", {}).get("revision"),
+        "quantization": candidate.get("model", {}).get("quantization"),
+    }
+    baseline_values = {
+        "model_id": baseline.get("runtime", {}).get("model_id"),
+        "revision": baseline.get("model", {}).get("revision"),
+        "quantization": baseline.get("model", {}).get("quantization"),
+    }
+    missing = [
+        field
+        for field in fields
+        if candidate_values[field] is None or baseline_values[field] is None
+    ]
+    mismatched = [
+        field
+        for field in fields
+        if field not in missing and candidate_values[field] != baseline_values[field]
+    ]
+    return {
+        "verified": not missing and not mismatched,
+        "missing_fields": missing,
+        "mismatched_fields": mismatched,
+        "candidate": candidate_values,
+        "baseline": baseline_values,
+    }
+
+
+async def _run_capacity_request(
+    client: httpx.AsyncClient,
+    base_url: str,
+    *,
+    messages: list[dict],
+    model: str,
+    max_tokens: int,
+    extra_body: Optional[dict],
+    request_timeout_s: Optional[float],
+) -> dict:
+    try:
+        result = await stream_chat_completion(
+            client=client,
+            base_url=base_url,
+            messages=messages,
+            model=model,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
+            timeout_s=request_timeout_s,
+        )
+        error = ""
+    except Exception as exc:
+        result = {
+            "ttft_ms": None,
+            "tpot_ms": None,
+            "e2e_latency_ms": None,
+            "queue_time_ms": None,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "content": "",
+            "token_ids": [],
+        }
+        error = str(exc)
+    sample = {
+        **result,
+        "error": error,
+        "error_kind": classify_capacity_error(error) if error else None,
+    }
+    sample["chunk_gap_ms"] = sample.pop("tpot_ms", None)
+    if error:
+        sample["validated"] = False
+    else:
+        valid, reason = validate_response(
+            result.get("finish_reason"),
+            result.get("content", ""),
+            200,
+            tool_calls=result.get("tool_calls") or [],
+        )
+        sample["validated"] = valid
+        if not valid:
+            sample["error"] = reason
+            sample["error_kind"] = "error"
+    return sample
+
+
+async def run_capacity_envelope(
+    *,
+    url: str = "http://127.0.0.1:8080",
+    model: Optional[str] = None,
+    config: Optional[CapacityConfig] = None,
+    output_path: Optional[str] = None,
+    baseline_url: Optional[str] = None,
+) -> dict:
+    """Run a versioned capacity sweep against one or two HTTP servers.
+
+    This function only uses OpenAI-compatible HTTP endpoints.  It never
+    imports MLX model internals and does not change server behavior beyond the
+    existing optional ``DELETE /v1/cache`` endpoint used for explicit cold
+    cells.
+    """
+    config = config or CapacityConfig()
+    run_id = str(uuid.uuid4())[:8]
+    started_at = datetime.now(timezone.utc).isoformat()
+    timeout = (
+        httpx.Timeout(config.request_timeout_s) if config.request_timeout_s else None
+    )
+    samples: list[dict] = []
+    cells: list[dict] = []
+    cache_events: list[dict] = []
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        runtime = await auto_detect_runtime(client, url)
+        hardware = _capacity_hardware_fingerprint()
+        is_local_server = any(
+            marker in url for marker in ("127.0.0.1", "localhost", "[::1]")
+        )
+        hardware["scope"] = "client_host"
+        if not is_local_server:
+            hardware["memory_gb"] = None
+            hardware["source"]["memory_gb"] = "unavailable for remote server"
+        model_id = model or runtime.get("model_id", "")
+        if not model_id:
+            raise ValueError("could not determine model ID; pass --model")
+        status = await _fetch_post_run_status(client, url)
+        provenance = _capacity_provenance(
+            url=url,
+            model_id=model_id,
+            runtime=runtime,
+            status=status,
+            hardware=hardware,
+        )
+        baseline_provenance = None
+        baseline_identity = None
+        if baseline_url:
+            baseline_runtime = await auto_detect_runtime(client, baseline_url)
+            baseline_status = await _fetch_post_run_status(client, baseline_url)
+            baseline_provenance = _capacity_provenance(
+                url=baseline_url,
+                model_id=baseline_runtime.get("model_id") or model_id,
+                runtime=baseline_runtime,
+                status=baseline_status,
+                hardware={"scope": "not_collected"},
+            )
+            baseline_identity = _capacity_baseline_identity(
+                provenance, baseline_provenance
+            )
+        request_extra = dict(config.extra_body or {})
+        if baseline_url and "temperature" not in request_extra:
+            # A/B comparisons must be deterministic unless the caller
+            # explicitly chooses another sampling policy.
+            request_extra["temperature"] = 0.0
+        if baseline_url and float(request_extra.get("temperature", 0.0)) != 0.0:
+            raise ValueError("baseline parity requires deterministic temperature=0")
+        workload_descriptor = {
+            "schema_version": CAPACITY_ENVELOPE_SCHEMA_VERSION,
+            "config": config.to_dict(),
+            "request_template": {
+                "role": "user",
+                "generator": "capacity envelope repeated-token-v1",
+            },
+        }
+        workload_hash = sha256_json(workload_descriptor)
+
+        for prompt_tokens in config.prompt_tokens:
+            for output_tokens in config.output_tokens:
+                for cache_mode in config.cache_modes:
+                    for concurrency in config.concurrencies:
+                        cell_samples: list[dict] = []
+                        batch_durations_ms: list[float] = []
+                        telemetry_values: dict[str, float] = {}
+                        telemetry_available = True
+                        cache_actions: list[dict] = []
+                        for repetition in range(config.repetitions):
+                            measured_variant = (
+                                "miss" if cache_mode == "prefix-miss" else "base"
+                            )
+                            measured_messages = build_capacity_messages(
+                                prompt_tokens, variant=measured_variant
+                            )
+                            warmup_variant = "warm" if cache_mode == "warm" else "base"
+                            warmup_messages = build_capacity_messages(
+                                prompt_tokens, variant=warmup_variant
+                            )
+                            actions: dict[str, Any] = {
+                                "mode": cache_mode,
+                                "repetition": repetition,
+                                "reset_before_measured": False,
+                                "warmup_requests": 0,
+                            }
+                            reset = await clear_runtime_cache(client, url)
+                            actions["reset_before_measured"] = True
+                            actions["reset_event"] = reset
+                            cache_events.append(
+                                {
+                                    "prompt_tokens": prompt_tokens,
+                                    "output_tokens": output_tokens,
+                                    "cache_mode": cache_mode,
+                                    "concurrency": concurrency,
+                                    "repetition": repetition,
+                                    "event": reset,
+                                }
+                            )
+                            if not _verified_capacity_cache_reset(reset):
+                                raise RuntimeError(
+                                    f"{cache_mode} cache state could not be verified: "
+                                    f"{reset.get('error') or reset.get('status_code')}"
+                                )
+                            warmup_count = 0 if cache_mode == "cold" else config.warmup
+                            if cache_mode in {"warm", "prefix-hit", "prefix-miss"}:
+                                warmup_count = max(1, warmup_count)
+                            for _ in range(warmup_count):
+                                warmup_sample = await _run_capacity_request(
+                                    client,
+                                    url,
+                                    messages=warmup_messages,
+                                    model=model_id,
+                                    max_tokens=output_tokens,
+                                    extra_body=request_extra,
+                                    request_timeout_s=config.request_timeout_s,
+                                )
+                                if warmup_sample.get("error"):
+                                    raise RuntimeError(
+                                        f"{cache_mode} warmup failed: "
+                                        f"{warmup_sample['error']}"
+                                    )
+                            actions["warmup_requests"] = warmup_count
+                            cache_actions.append(actions)
+
+                            metrics_before = await scrape_metrics(client, url)
+                            started = time.perf_counter()
+                            batch = await asyncio.gather(
+                                *[
+                                    _run_capacity_request(
+                                        client,
+                                        url,
+                                        messages=measured_messages,
+                                        model=model_id,
+                                        max_tokens=output_tokens,
+                                        extra_body=request_extra,
+                                        request_timeout_s=config.request_timeout_s,
+                                    )
+                                    for _ in range(concurrency)
+                                ]
+                            )
+                            batch_duration_ms = (time.perf_counter() - started) * 1000.0
+                            metrics_after = await scrape_metrics(client, url)
+                            status_after = await _fetch_post_run_status(client, url)
+                            batch_telemetry = _capacity_telemetry_delta(
+                                metrics_before, metrics_after
+                            )
+                            batch_memory = _capacity_memory_from_status(status_after)
+                            batch_durations_ms.append(batch_duration_ms)
+                            for sample in batch:
+                                sample.update(
+                                    {
+                                        "prompt_tokens_target": prompt_tokens,
+                                        "output_tokens_target": output_tokens,
+                                        "cache_mode": cache_mode,
+                                        "concurrency": concurrency,
+                                        "repetition": repetition,
+                                        "batch_duration_ms": batch_duration_ms,
+                                        "cache_state": actions,
+                                        "timing_semantics": "content_chunk_gap",
+                                        "memory": batch_memory,
+                                        "telemetry_delta": batch_telemetry,
+                                    }
+                                )
+                            if baseline_url and batch:
+                                baseline_sample = await _run_capacity_request(
+                                    client,
+                                    baseline_url,
+                                    messages=measured_messages,
+                                    model=model_id,
+                                    max_tokens=output_tokens,
+                                    extra_body=request_extra,
+                                    request_timeout_s=config.request_timeout_s,
+                                )
+                                for sample in batch:
+                                    if (
+                                        not baseline_identity["verified"]
+                                        or sample.get("error")
+                                        or baseline_sample.get("error")
+                                    ):
+                                        sample["correctness"] = {
+                                            "status": "unavailable",
+                                            "reason": "baseline identity unverified",
+                                        }
+                                    else:
+                                        sample["correctness"] = (
+                                            compare_capacity_outputs(
+                                                sample, baseline_sample
+                                            )
+                                        )
+                            else:
+                                for sample in batch:
+                                    sample["correctness"] = {"status": "not_run"}
+                            cell_samples.extend(batch)
+                            samples.extend(batch)
+                            if not batch_telemetry.get("available"):
+                                telemetry_available = False
+                            else:
+                                for key, value in (
+                                    batch_telemetry.get("values") or {}
+                                ).items():
+                                    telemetry_values[key] = (
+                                        telemetry_values.get(key, 0.0) + value
+                                    )
+
+                        cell = summarize_capacity_cell(
+                            prompt_tokens=prompt_tokens,
+                            output_tokens=output_tokens,
+                            cache_mode=cache_mode,
+                            concurrency=concurrency,
+                            samples=cell_samples,
+                            batch_durations_ms=batch_durations_ms,
+                            thresholds=config.thresholds,
+                            telemetry_delta={
+                                "available": telemetry_available,
+                                "source": "/metrics",
+                                "values": (
+                                    telemetry_values if telemetry_available else None
+                                ),
+                            },
+                            cache_actions=cache_actions,
+                        )
+                        cells.append(cell)
+                        print(
+                            f"  prompt={prompt_tokens} output={output_tokens} "
+                            f"cache={cache_mode} concurrency={concurrency}: "
+                            f"{'PASS' if cell['sustainable'] else 'FAIL'}"
+                        )
+
+    finished_at = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "kind": CAPACITY_ENVELOPE_KIND,
+        "schema_version": CAPACITY_ENVELOPE_SCHEMA_VERSION,
+        "run_id": run_id,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "workload_hash": workload_hash,
+        "provenance_hash": sha256_json(provenance),
+        "workload": workload_descriptor,
+        "provenance": provenance,
+        "baseline_provenance": baseline_provenance,
+        "baseline_identity": baseline_identity,
+        "summary": summarize_capacity_envelope(
+            cells,
+            config=config,
+            memory_gb=hardware.get("memory_gb"),
+        ),
+        "measurement": {
+            "ttft_ms": "first content chunk from request start",
+            "chunk_gap_ms": "mean gap between content chunks; not token TPOT",
+            "queue_time_ms": "server-reported only; null when absent",
+            "output_throughput_tps": "successful completion tokens / batch wall time",
+            "memory": "null when /v1/status does not report the field",
+            "memory_scope": "post-batch /v1/status snapshot; not a per-cell peak",
+        },
+        "cache_events": cache_events,
+        "cells": cells,
+        "samples": samples,
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if output_path:
+        Path(output_path).expanduser().write_text(rendered + "\n")
+        print(f"Capacity envelope written to {output_path}")
+    else:
+        print(rendered)
+    return payload

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -945,7 +945,68 @@ def bench_serve_command(args):
     """Run serving benchmark."""
     import asyncio
 
-    from .bench_serve import run_bench_serve, run_bench_serve_workload
+    from .bench_serve import (
+        CapacityConfig,
+        CapacityThresholds,
+        run_bench_serve,
+        run_bench_serve_workload,
+        run_capacity_envelope,
+    )
+
+    if args.capacity_envelope:
+
+        def _positive_csv(value: str, option: str) -> tuple[int, ...]:
+            try:
+                parsed = tuple(
+                    int(item.strip()) for item in value.split(",") if item.strip()
+                )
+            except ValueError as exc:
+                raise ValueError(f"{option} must be comma-separated integers") from exc
+            if not parsed or any(item < 1 for item in parsed):
+                raise ValueError(f"{option} must contain positive integers")
+            return parsed
+
+        cache_modes = tuple(
+            item.strip().lower()
+            for item in args.capacity_cache_modes.split(",")
+            if item.strip()
+        )
+        config = CapacityConfig(
+            concurrencies=_positive_csv(
+                args.capacity_concurrency, "--capacity-concurrency"
+            ),
+            prompt_tokens=_positive_csv(
+                args.capacity_prompt_tokens, "--capacity-prompt-tokens"
+            ),
+            output_tokens=_positive_csv(
+                args.capacity_output_tokens, "--capacity-output-tokens"
+            ),
+            cache_modes=cache_modes,
+            repetitions=args.capacity_repetitions,
+            warmup=args.capacity_warmup,
+            request_timeout_s=(
+                None if args.request_timeout_s <= 0 else args.request_timeout_s
+            ),
+            thresholds=CapacityThresholds(
+                max_p95_ttft_ms=args.capacity_max_p95_ttft_ms,
+                max_p95_chunk_gap_ms=args.capacity_max_p95_chunk_gap_ms,
+                max_p95_e2e_ms=args.capacity_max_p95_e2e_ms,
+                max_failure_rate=args.capacity_max_failure_rate,
+                max_ooms=args.capacity_max_ooms,
+                max_timeouts=args.capacity_max_timeouts,
+            ),
+            extra_body={"temperature": 0.0},
+        )
+        asyncio.run(
+            run_capacity_envelope(
+                url=args.url,
+                model=args.model,
+                config=config,
+                output_path=args.output,
+                baseline_url=args.capacity_baseline_url,
+            )
+        )
+        return
 
     if args.workload:
         sweep_only_warnings = []
@@ -2035,6 +2096,93 @@ Examples:
             "runs contract-style cases with per-case quality checks and "
             "comparison-only policy timeouts instead of the prompt sweep."
         ),
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-envelope",
+        action="store_true",
+        help=(
+            "Run the versioned capacity-envelope sweep. This is an HTTP-only "
+            "mode and writes a JSON artifact; legacy prompt/workload modes "
+            "remain unchanged."
+        ),
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-concurrency",
+        type=str,
+        default="1,2,4,8,16,32",
+        help="Capacity concurrency levels (default: 1,2,4,8,16,32)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-prompt-tokens",
+        type=str,
+        default="256,2048,8192,32768",
+        help="Requested prompt sizes (default: 256,2048,8192,32768)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-output-tokens",
+        type=str,
+        default="128,512",
+        help="Requested output limits (default: 128,512)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-cache-modes",
+        type=str,
+        default="cold,warm,prefix-hit,prefix-miss",
+        help="Cache-state cases (default: cold,warm,prefix-hit,prefix-miss)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-repetitions",
+        type=int,
+        default=3,
+        help="Measured repetitions per capacity cell (default: 3)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-warmup",
+        type=int,
+        default=1,
+        help="Warmup requests before measured capacity batches (default: 1)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-baseline-url",
+        type=str,
+        default=None,
+        help="Optional HTTP baseline URL for greedy output parity checks",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-p95-ttft-ms",
+        type=float,
+        default=None,
+        help="Optional p95 TTFT SLO for sustainable capacity",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-p95-chunk-gap-ms",
+        type=float,
+        default=None,
+        help="Optional p95 content-chunk-gap SLO for sustainable capacity",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-p95-e2e-ms",
+        type=float,
+        default=None,
+        help="Optional p95 end-to-end latency SLO for sustainable capacity",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-failure-rate",
+        type=float,
+        default=0.0,
+        help="Maximum allowed request failure rate (default: 0)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-ooms",
+        type=int,
+        default=0,
+        help="Maximum allowed OOM-classified failures (default: 0)",
+    )
+    bench_serve_parser.add_argument(
+        "--capacity-max-timeouts",
+        type=int,
+        default=0,
+        help="Maximum allowed timeout failures (default: 0)",
     )
     bench_serve_parser.add_argument(
         "--prompts",


### PR DESCRIPTION
## Summary

Adds an HTTP-only capacity-envelope mode to `vllm-mlx bench-serve` for measuring sustainable serving capacity on Apple Silicon.

The new mode produces a versioned JSON evidence artifact across configurable concurrency, prompt-size, output-size, and cache-state sweeps. It does not change model loading, scheduling, generation behavior, or serving defaults.

## What it measures

- p50/p95/p99 TTFT, content-chunk gap, and end-to-end latency
- Successful completion-token throughput and requests per second
- Request failures, timeouts, OOMs, and validation failures
- Cold, model-warm, prefix-hit, and prefix-miss behavior
- Sustainable concurrency under configurable SLOs
- Sustainable concurrency/GiB and throughput/GiB
- Server-reported memory and optional MTP, speculative-decoding, queue, and cache telemetry

## Evidence integrity

The artifact:

- Fails closed when authoritative token usage is unavailable
- Does not count failed requests toward successful throughput
- Treats output-limit completions as valid benchmark results
- Represents unavailable telemetry as unavailable rather than zero
- Verifies cache reset state and observed prefix hit/miss behavior
- Records model, runtime, software, hardware, source-commit, and workload provenance
- Includes deterministic workload and provenance hashes
- Labels SSE timing as `chunk_gap_ms`, not token TPOT
- Optionally performs greedy A/B output checks when baseline model identity can be verified

## Usage

```bash
vllm-mlx bench-serve \
  --url http://localhost:8000 \
  --capacity-envelope \
  --capacity-concurrency 1,2,4,8,16 \
  --capacity-prompt-tokens 256,2048 \
  --capacity-output-tokens 128 \
  --capacity-cache-modes cold,warm,prefix-hit,prefix-miss \
  --capacity-max-p95-ttft-ms 1000 \
  --capacity-max-p95-e2e-ms 10000 \
  --output capacity.json
```

## Compatibility

The capacity-envelope schema and runner are additive. Existing prompt-sweep and declarative-workload behavior remains unchanged.

## Verification

- Focused benchmark tests: 121 passed, 2 skipped
- Complete suite: 2,677 passed, 25 skipped, 27 standard deselections
- Black, Ruff, and `git diff --check`: passed
- Independent adversarial review: no remaining P0/P1 findings

## Scope

This PR contains benchmarking and evidence-generation work only. It does not include serving optimizations, Metal kernels, scheduler changes, or competitive benchmark claims.
