### PR TITLE
Metal context kernel foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,13 @@ jobs:
           assert platform.machine() == "arm64"
           capabilities = _metal_context.capabilities()
           assert capabilities.get("compiled") is True, capabilities
-          assert capabilities.get("available") is True, capabilities
+          # GitHub's arm64 macOS hosts expose the Apple toolchain but may not
+          # expose a Metal device to jobs.  Compilation is mandatory here;
+          # dispatch tests run when a device is actually present and otherwise
+          # must report the precise fail-closed reason.
+          if not capabilities.get("available"):
+              assert capabilities.get("metal_device") is False, capabilities
+              assert "no GPU" in capabilities.get("reason", ""), capabilities
           print("Metal Context native capability:", capabilities)
           PY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,33 @@ jobs:
       - name: Run black
         run: black --check vllm_mlx/ tests/
 
+      - name: Verify native source distribution manifest
+        run: |
+          pip install build
+          rm -rf /tmp/vllm-mlx-sdist
+          python -m build --sdist --outdir /tmp/vllm-mlx-sdist
+          python - <<'PY'
+          import glob
+          import tarfile
+
+          archive = glob.glob("/tmp/vllm-mlx-sdist/*.tar.gz")
+          assert len(archive) == 1, archive
+          with tarfile.open(archive[0], "r:gz") as source:
+              names = source.getnames()
+          required = {
+              "native/metal_context/kernels/paged_decode.metal",
+              "native/metal_context/src/python_module.mm",
+              "native/metal_context/README.md",
+              "scripts/build_metal_context.py",
+              "tests/test_attention_backend.py",
+              "tests/test_metal_context_native.py",
+          }
+          missing = {
+              path for path in required if not any(name.endswith(path) for name in names)
+          }
+          assert not missing, f"sdist is missing: {sorted(missing)}"
+          PY
+
   type-check:
     runs-on: ubuntu-latest
     steps:
@@ -63,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests numpy
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -89,6 +116,7 @@ jobs:
             tests/test_endpoint_model_policies.py \
             tests/test_truncation.py \
             tests/test_cli_arg_types.py \
+            tests/test_attention_backend.py \
             tests/test_gemma4_openai_format.py \
             tests/test_gemma4_streaming_edge.py \
             tests/test_gemma4_tool_parser.py \
@@ -128,6 +156,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install project and dependencies
+        env:
+          VLLM_MLX_BUILD_METAL_CONTEXT: "1"
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,vision,harmony]"
@@ -137,10 +167,25 @@ jobs:
           python -c "import platform; assert platform.machine() == 'arm64', 'Not ARM64'"
           python -c "import mlx.core as mx; print(f'MLX OK: {mx.default_device()}')"
 
+      - name: Verify strict native Metal build
+        run: |
+          python - <<'PY'
+          import platform
+          from vllm_mlx import _metal_context
+
+          assert platform.machine() == "arm64"
+          capabilities = _metal_context.capabilities()
+          assert capabilities.get("compiled") is True, capabilities
+          assert capabilities.get("available") is True, capabilities
+          print("Metal Context native capability:", capabilities)
+          PY
+
       - name: Run MLX-dependent tests
         run: |
           pytest \
             tests/test_platform.py \
+            tests/test_attention_backend.py \
+            tests/test_metal_context_native.py \
             tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include LICENSE
+include README.md
+include MANIFEST.in
+include pyproject.toml
+include setup.py
+
+# Optional Metal Context Engine source distribution inputs.
+recursive-include native/metal_context *.metal *.mm *.md
+include scripts/build_metal_context.py
+
+# Keep the portable/native foundation regression tests available to downstream
+# source checkouts without broadening the package's installed data files.
+include tests/test_attention_backend.py
+include tests/test_metal_context_native.py

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ export ANTHROPIC_API_KEY=not-needed
 claude
 ```
 
+### Optional Metal Context foundation
+
+The normal package and editable installs keep the experimental compiled Metal
+Context foundation disabled.  This preserves the portable MLX path and avoids
+silently requiring an Xcode/Metal toolchain.  On an Apple Silicon Mac with
+Xcode installed, opt in explicitly when building from source:
+
+```bash
+VLLM_MLX_BUILD_METAL_CONTEXT=1 python -m pip install -e .
+```
+
+The strict build rejects non-Apple-Silicon hosts or missing Metal tools.  The
+foundation currently provides a validated kernel/oracle surface only; it is
+not a qualified serving executor.  Keep `--attention-backend mlx` (the
+default), or use `auto` while qualification is pending.  An explicit
+`--attention-backend metal-context` request fails closed until the executor is
+integrated and qualified.
+
 ## Features
 
 ### APIs

--- a/native/metal_context/README.md
+++ b/native/metal_context/README.md
@@ -1,0 +1,55 @@
+# Metal Context Engine native foundation
+
+This directory contains the optional phase-one native kernel package.  It is
+deliberately independent of the scheduler and page-owner implementation:
+
+* `kernels/paged_decode.metal` is a BF16, online-softmax paged decode kernel.
+  It accepts non-contiguous `int32` page tables, GQA, head dimension 128,
+  block sizes 16/32, and partial tail blocks.
+* `src/python_module.mm` is a small CPython/Metal bridge.  Its initial ABI
+  accepts contiguous host buffers containing BF16 bits as `uint16` buffers and
+  returns a float32 byte buffer.  The copies are intentionally visible; this
+  is a correctness/build foundation, not a serving-performance claim.
+* `scripts/build_metal_context.py` compiles the checked-in shader to a
+  `_metal_context.metallib`.  The optional setuptools hook packages that
+  library beside the extension.
+
+The logical page layout at this boundary is:
+
+```text
+query       [batch, query_heads, head_dim]
+key/value   [page, kv_heads, block_offset, head_dim]
+page_table  [batch, logical_block]
+seq_lens    [batch]
+```
+
+The host validates shapes, native-endian PEP-3118 formats, page bounds for
+every live token, finite BF16 data, conservative float32 dot/score bounds, and
+the supported geometry before allocating any Metal buffer.  Unused page table
+entries may be `-1`; live entries may not be.  The shader repeats the
+page-bound guard so a malformed low-level dispatch cannot read outside the
+page buffer, while the host remains responsible for surfacing the error.
+
+## Building
+
+Normal installs remain pure Python/MLX.  On a macOS/Xcode builder, opt in to
+the native build explicitly:
+
+```sh
+VLLM_MLX_BUILD_METAL_CONTEXT=1 python -m pip install -e .
+```
+
+The strict mode fails if the host is not Apple Silicon or
+`xcrun metal`/`xcrun metallib` is missing.  Normal installs leave the optional
+extension disabled; the fallback module then reports the exact reason and an
+explicit `metal-context` selection must fail closed.
+
+For a standalone library build:
+
+```sh
+python scripts/build_metal_context.py --output /tmp/_metal_context.metallib
+```
+
+The extension's `capabilities()` record is the source of truth for whether the
+device, ABI, and packaged library are usable.  A compiled extension is not a
+serving qualification or performance result.

--- a/native/metal_context/README.md
+++ b/native/metal_context/README.md
@@ -30,6 +30,15 @@ entries may be `-1`; live entries may not be.  The shader repeats the
 page-bound guard so a malformed low-level dispatch cannot read outside the
 page buffer, while the host remains responsible for surfacing the error.
 
+## Known execution limitation
+
+Parallelism is across `(request, query_head)` only. Each threadgroup walks
+the sequence serially, one token at a time, with ten threadgroup barriers per
+token (including the seven-step dot-product reduction). This is a correctness
+and ABI reference, not a long-context serving-performance-qualified kernel.
+The host dispatches `(128, 1, 1)` threads per group; the shader uniformly
+rejects other actual group dimensions before scratch access or barriers.
+
 ## Building
 
 Normal installs remain pure Python/MLX.  On a macOS/Xcode builder, opt in to

--- a/native/metal_context/kernels/paged_decode.metal
+++ b/native/metal_context/kernels/paged_decode.metal
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The first Metal Context Engine kernel.  The host API intentionally keeps
+// the layout explicit so that the page runtime can validate every stride
+// before dispatching it.
+//
+// Inputs:
+//   query       [batch, query_heads, head_dim]       BF16 bits (ushort)
+//   key_pages   [pages, kv_heads, block_size, head_dim] BF16 bits
+//   value_pages [pages, kv_heads, block_size, head_dim] BF16 bits
+//   page_table  [batch, max_blocks]                 int32
+//   seq_lens    [batch]                             int32
+//
+// Output:
+//   output      [batch, query_heads, head_dim]       float32
+//
+// A threadgroup owns one (request, query-head) output vector.  The online
+// softmax state is updated token by token, so pages need not be physically
+// contiguous.  Query heads are mapped to KV heads by the GQA ratio.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct PagedDecodeParams {
+  uint batch_size;
+  uint query_heads;
+  uint kv_heads;
+  uint head_dim;
+  uint block_size;
+  uint max_blocks;
+  uint page_count;
+  uint page_table_stride;
+  float scale;
+  uint reserved0;
+  uint reserved1;
+  uint reserved2;
+};
+
+// MLX stores BF16 as the IEEE-754 upper 16 bits of a float.  Keeping the
+// storage type as ushort avoids depending on the availability of the MSL
+// bfloat type on the oldest supported Apple GPU family.
+inline float bf16_to_float(ushort bits) {
+  return as_type<float>(uint(bits) << 16);
+}
+
+kernel void metal_context_paged_decode(
+    device const ushort* query [[buffer(0)]],
+    device const ushort* key_pages [[buffer(1)]],
+    device const ushort* value_pages [[buffer(2)]],
+    device const int* page_table [[buffer(3)]],
+    device const int* seq_lens [[buffer(4)]],
+    device float* output [[buffer(5)]],
+    constant PagedDecodeParams& p [[buffer(6)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]]) {
+  // The host dispatches exactly one 128-thread group per output vector.  A
+  // guard remains here because it is cheap and prevents accidental writes if
+  // a future caller uses a larger grid.
+  const uint request = tg_pos.x / p.query_heads;
+  const uint query_head = tg_pos.x % p.query_heads;
+  if (request >= p.batch_size || query_head >= p.query_heads || tid >= 128) {
+    return;
+  }
+
+  // Phase-1 qualification is head_dim=128.  Keeping this guard in the shader
+  // makes an unsupported dispatch memory-safe even if host validation is
+  // bypassed by a future low-level caller.
+  if (p.head_dim != 128 || p.kv_heads == 0 ||
+      (p.query_heads % p.kv_heads) != 0) {
+    return;
+  }
+
+  threadgroup float partial_dot[128];
+  threadgroup float softmax_state[4];
+
+  const uint query_base = (request * p.query_heads + query_head) * p.head_dim;
+  const uint q_per_kv = p.query_heads / p.kv_heads;
+  const uint kv_head = query_head / q_per_kv;
+  const int requested_length = seq_lens[request];
+  const uint sequence_length = requested_length > 0
+      ? min(uint(requested_length), p.max_blocks * p.block_size)
+      : 0;
+
+  // Each lane owns one output dimension for head_dim=128.  The accumulators
+  // stay in float32 even though K/V are BF16.
+  float accumulator = 0.0f;
+  if (tid == 0) {
+    softmax_state[0] = -INFINITY;  // running max
+    softmax_state[1] = 0.0f;       // running denominator
+    softmax_state[2] = 0.0f;       // exp(old_max - new_max)
+    softmax_state[3] = 0.0f;       // exp(score - new_max)
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint token = 0; token < sequence_length; ++token) {
+    const uint logical_block = token / p.block_size;
+    const uint block_offset = token % p.block_size;
+    const int physical_page = page_table[
+        request * p.page_table_stride + logical_block];
+
+    // The host rejects invalid page IDs.  Retaining the check in the shader
+    // prevents a malformed table from turning into an out-of-bounds GPU read;
+    // a skipped page is surfaced as an error by the host-side validation path.
+    // Do not `continue` here: every lane must execute the same barriers.
+    const bool page_valid = physical_page >= 0 &&
+        uint(physical_page) < p.page_count;
+
+    const uint key_base = page_valid
+        ? ((uint(physical_page) * p.kv_heads + kv_head) * p.block_size +
+           block_offset) * p.head_dim
+        : 0;
+
+    float dot_part = 0.0f;
+    if (page_valid && tid < p.head_dim) {
+      dot_part = bf16_to_float(query[query_base + tid]) *
+          bf16_to_float(key_pages[key_base + tid]);
+    }
+    partial_dot[tid] = dot_part;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Reduction for a fixed 128-wide group.  All accesses are in-bounds and
+    // every lane participates, including when a future head dimension uses
+    // fewer lanes.
+    for (uint stride = 64; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        partial_dot[tid] += partial_dot[tid + stride];
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+      const float score = partial_dot[0] * p.scale;
+      const float old_max = softmax_state[0];
+      const float new_max = max(old_max, score);
+      // exp(-inf - -inf) is NaN on some GPU families.  The explicit branch
+      // keeps the empty-prefix and first-token cases deterministic.
+      const float old_weight = page_valid && isfinite(old_max)
+          ? exp(old_max - new_max) * softmax_state[1]
+          : (page_valid ? 0.0f : softmax_state[1]);
+      const float token_weight = page_valid ? exp(score - new_max) : 0.0f;
+      if (page_valid) {
+        softmax_state[0] = new_max;
+        softmax_state[1] = old_weight + token_weight;
+        softmax_state[2] = isfinite(old_max) ? exp(old_max - new_max) : 0.0f;
+        softmax_state[3] = token_weight;
+      } else {
+        softmax_state[2] = 1.0f;
+        softmax_state[3] = 0.0f;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid < p.head_dim) {
+      const float value = page_valid ? bf16_to_float(value_pages[key_base + tid])
+                                     : 0.0f;
+      accumulator = accumulator * softmax_state[2] +
+          value * softmax_state[3];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid < p.head_dim) {
+    const uint output_base = (request * p.query_heads + query_head) * p.head_dim;
+    const float denominator = softmax_state[1];
+    output[output_base + tid] = denominator > 0.0f
+        ? accumulator / denominator
+        : 0.0f;
+  }
+}

--- a/native/metal_context/kernels/paged_decode.metal
+++ b/native/metal_context/kernels/paged_decode.metal
@@ -53,13 +53,17 @@ kernel void metal_context_paged_decode(
     device float* output [[buffer(5)]],
     constant PagedDecodeParams& p [[buffer(6)]],
     uint tid [[thread_index_in_threadgroup]],
-    uint3 tg_pos [[threadgroup_position_in_grid]]) {
-  // The host dispatches exactly one 128-thread group per output vector.  A
-  // guard remains here because it is cheap and prevents accidental writes if
-  // a future caller uses a larger grid.
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint3 group_size [[threads_per_threadgroup]]) {
+  // Reject unsupported actual geometry uniformly: every lane must either
+  // return here or participate in all barriers and the 128-element scratch.
+  if (group_size.x != 128 || group_size.y != 1 || group_size.z != 1 ||
+      p.query_heads == 0) {
+    return;
+  }
   const uint request = tg_pos.x / p.query_heads;
   const uint query_head = tg_pos.x % p.query_heads;
-  if (request >= p.batch_size || query_head >= p.query_heads || tid >= 128) {
+  if (request >= p.batch_size || query_head >= p.query_heads) {
     return;
   }
 

--- a/native/metal_context/src/python_module.mm
+++ b/native/metal_context/src/python_module.mm
@@ -649,7 +649,7 @@ PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
   if (!PyArg_ParseTupleAndKeywords(
           args,
           kwargs,
-          "OOOOOiff:paged_decode",
+          "OOOOOiif:paged_decode",
           const_cast<char**>(keywords),
           &query_object,
           &key_object,

--- a/native/metal_context/src/python_module.mm
+++ b/native/metal_context/src/python_module.mm
@@ -1,0 +1,839 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Optional CPython bridge for the phase-1 Metal Context Engine kernel.
+//
+// This bridge deliberately accepts contiguous host buffers rather than
+// reaching into MLX's private allocator.  That makes the ABI testable and
+// keeps installation optional.  The page runtime can add a zero-copy MLX
+// adapter once the ownership/synchronization contract is qualified; it does
+// not need to change the kernel's explicit layout or validation rules.
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <dispatch/dispatch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <initializer_list>
+#include <limits>
+#include <mutex>
+#include <string>
+
+namespace {
+
+constexpr uint32_t kAbiVersion = 1;
+constexpr uint32_t kHeadDim = 128;
+constexpr uint32_t kThreadsPerThreadgroup = 128;
+
+bool compiled_for_apple_silicon() {
+#if defined(__arm64__) || defined(__aarch64__)
+  return true;
+#else
+  return false;
+#endif
+}
+
+struct PagedDecodeParams {
+  uint32_t batch_size;
+  uint32_t query_heads;
+  uint32_t kv_heads;
+  uint32_t head_dim;
+  uint32_t block_size;
+  uint32_t max_blocks;
+  uint32_t page_count;
+  uint32_t page_table_stride;
+  float scale;
+  uint32_t reserved0;
+  uint32_t reserved1;
+  uint32_t reserved2;
+};
+
+static_assert(sizeof(PagedDecodeParams) == 48, "Metal parameter ABI changed");
+
+struct BufferGuard {
+  Py_buffer view{};
+  bool acquired = false;
+
+  ~BufferGuard() {
+    if (acquired) {
+      PyBuffer_Release(&view);
+    }
+  }
+};
+
+struct Runtime {
+  std::mutex mutex;
+  bool attempted = false;
+  bool available = false;
+  std::string path;
+  std::string error;
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> queue = nil;
+  id<MTLComputePipelineState> pipeline = nil;
+};
+
+Runtime g_runtime;
+
+bool set_dict_item(PyObject* dict, const char* key, PyObject* value) {
+  if (value == nullptr) {
+    return false;
+  }
+  if (PyDict_SetItemString(dict, key, value) < 0) {
+    Py_DECREF(value);
+    return false;
+  }
+  Py_DECREF(value);
+  return true;
+}
+
+bool set_dict_string(PyObject* dict, const char* key, const std::string& value) {
+  return set_dict_item(dict, key, PyUnicode_FromString(value.c_str()));
+}
+
+bool set_dict_bool(PyObject* dict, const char* key, bool value) {
+  return set_dict_item(dict, key, PyBool_FromLong(value ? 1 : 0));
+}
+
+bool set_dict_uint(PyObject* dict, const char* key, uint32_t value) {
+  return set_dict_item(dict, key, PyLong_FromUnsignedLong(value));
+}
+
+PyObject* unavailable_capabilities(const std::string& reason) {
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+  if (!set_dict_bool(result, "available", false) ||
+      !set_dict_bool(result, "compiled", true) ||
+      !set_dict_bool(result, "metal_device", false) ||
+      !set_dict_bool(result, "apple_silicon", compiled_for_apple_silicon()) ||
+      !set_dict_bool(result, "serving_ready", false) ||
+      !set_dict_uint(result, "abi_version", kAbiVersion) ||
+      !set_dict_string(result, "backend", "metal-context") ||
+      !set_dict_string(result, "reason", reason) ||
+      !set_dict_string(result, "kernel", "metal_context_paged_decode") ||
+      !set_dict_string(result, "kv_dtype", "bfloat16") ||
+      !set_dict_bool(result, "gqa", true) ||
+      !set_dict_bool(result, "partial_blocks", true) ||
+      !set_dict_bool(result, "online_softmax", true)) {
+    Py_DECREF(result);
+    return nullptr;
+  }
+  PyObject* block_sizes = Py_BuildValue("(ii)", 16, 32);
+  PyObject* head_dims = Py_BuildValue("(i)", static_cast<int>(kHeadDim));
+  if (block_sizes == nullptr || head_dims == nullptr ||
+      PyDict_SetItemString(result, "block_sizes", block_sizes) < 0 ||
+      PyDict_SetItemString(result, "head_dims", head_dims) < 0) {
+    Py_XDECREF(block_sizes);
+    Py_XDECREF(head_dims);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(block_sizes);
+  Py_DECREF(head_dims);
+  return result;
+}
+
+std::string py_object_path(PyObject* module) {
+  const char* override_path = std::getenv("VLLM_MLX_METAL_CONTEXT_METALLIB");
+  if (override_path != nullptr && override_path[0] != '\0') {
+    return override_path;
+  }
+
+  PyObject* file_object = PyModule_GetFilenameObject(module);
+  if (file_object == nullptr) {
+    PyErr_Clear();
+    return {};
+  }
+  const char* file_name = PyUnicode_AsUTF8(file_object);
+  std::string result;
+  if (file_name != nullptr) {
+    try {
+      result =
+          (std::filesystem::path(file_name).parent_path() /
+           "_metal_context.metallib")
+              .string();
+    } catch (const std::exception&) {
+      result.clear();
+    }
+  } else {
+    PyErr_Clear();
+  }
+  Py_DECREF(file_object);
+  return result;
+}
+
+std::string ns_error_description(NSError* error, const char* fallback) {
+  if (error != nil && error.localizedDescription != nil) {
+    const char* description = [error.localizedDescription UTF8String];
+    if (description != nullptr && description[0] != '\0') {
+      return description;
+    }
+  }
+  return fallback;
+}
+
+bool ensure_runtime(const std::string& path) {
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+  if (g_runtime.attempted && g_runtime.path == path) {
+    return g_runtime.available;
+  }
+
+  g_runtime.attempted = true;
+  g_runtime.available = false;
+  g_runtime.path = path;
+  g_runtime.error.clear();
+  g_runtime.device = nil;
+  g_runtime.queue = nil;
+  g_runtime.pipeline = nil;
+
+  if (!compiled_for_apple_silicon()) {
+    g_runtime.error = "the Metal Context Engine requires an Apple Silicon arm64 build";
+    return false;
+  }
+  if (path.empty()) {
+    g_runtime.error =
+        "the packaged _metal_context.metallib could not be located";
+    return false;
+  }
+  try {
+    if (!std::filesystem::exists(path)) {
+      g_runtime.error = "the Metal library does not exist at " + path;
+      return false;
+    }
+  } catch (const std::filesystem::filesystem_error& exception) {
+    g_runtime.error = "could not inspect the Metal library path: ";
+    g_runtime.error += exception.what();
+    return false;
+  }
+
+  @autoreleasepool {
+    do {
+      g_runtime.device = MTLCreateSystemDefaultDevice();
+      if (g_runtime.device == nil) {
+        g_runtime.error = "MTLCreateSystemDefaultDevice returned no GPU";
+        break;
+      }
+
+      NSData* library_bytes = [NSData
+          dataWithContentsOfFile:[NSString stringWithUTF8String:path.c_str()]];
+      if (library_bytes == nil) {
+        g_runtime.error = "the packaged Metal library could not be read";
+        break;
+      }
+
+      if (library_bytes.length == 0) {
+        g_runtime.error = "the packaged Metal library is empty";
+        break;
+      }
+      void* owned_library_bytes = std::malloc(library_bytes.length);
+      if (owned_library_bytes == nullptr) {
+        g_runtime.error =
+            "could not allocate owned storage for the packaged Metal library";
+        break;
+      }
+      std::memcpy(owned_library_bytes, library_bytes.bytes, library_bytes.length);
+      dispatch_data_t library_data = dispatch_data_create(
+          owned_library_bytes,
+          library_bytes.length,
+          nullptr,
+          DISPATCH_DATA_DESTRUCTOR_FREE);
+      if (library_data == nullptr) {
+        std::free(owned_library_bytes);
+        g_runtime.error = "the packaged Metal library could not be mapped";
+        break;
+      }
+      NSError* error = nil;
+      id<MTLLibrary> library =
+          [g_runtime.device newLibraryWithData:library_data error:&error];
+      if (library == nil) {
+        g_runtime.error = ns_error_description(error, "Metal rejected the library");
+        break;
+      }
+
+      id<MTLFunction> function =
+          [library newFunctionWithName:@"metal_context_paged_decode"];
+      if (function == nil) {
+        g_runtime.error =
+            "the packaged Metal library is missing metal_context_paged_decode";
+        break;
+      }
+
+      g_runtime.pipeline =
+          [g_runtime.device newComputePipelineStateWithFunction:function
+                                                            error:&error];
+      if (g_runtime.pipeline == nil) {
+        g_runtime.error = ns_error_description(
+            error, "Metal could not create the kernel pipeline");
+        break;
+      }
+
+      g_runtime.queue = [g_runtime.device newCommandQueue];
+      if (g_runtime.queue == nil) {
+        g_runtime.error = "Metal could not create a command queue";
+        break;
+      }
+      g_runtime.available = true;
+    } while (false);
+  }
+  return g_runtime.available;
+}
+
+bool acquire_contiguous(PyObject* object, BufferGuard* guard, const char* name) {
+  if (PyObject_GetBuffer(
+          object,
+          &guard->view,
+          PyBUF_FORMAT | PyBUF_ND | PyBUF_STRIDES | PyBUF_C_CONTIGUOUS) < 0) {
+    PyErr_Format(
+        PyExc_TypeError,
+        "%s must expose a contiguous buffer (NumPy/MLX host arrays are "
+        "accepted after conversion)",
+        name);
+    return false;
+  }
+  guard->acquired = true;
+  return true;
+}
+
+bool has_shape(const Py_buffer& view, int ndim) {
+  return view.ndim == ndim && view.shape != nullptr;
+}
+
+bool host_is_little_endian() {
+  const uint16_t value = 1;
+  return *reinterpret_cast<const uint8_t*>(&value) == 1;
+}
+
+bool is_native_format(const Py_buffer& view, char expected) {
+  if (view.format == nullptr) {
+    return false;
+  }
+  // NumPy's native scalar buffers expose a one-character PEP-3118 format.
+  // Accept the native/no-prefix forms and an explicitly native ``@``/``=``
+  // prefix.  An explicit ``>``/``!`` is always rejected; ``<`` is accepted
+  // only on the little-endian Apple Silicon host this extension targets.
+  const char* format = view.format;
+  const char prefix = *format;
+  if (prefix == '@' || prefix == '=') {
+    ++format;
+  } else if (prefix == '<') {
+    if (!host_is_little_endian()) {
+      return false;
+    }
+    ++format;
+  } else if (prefix == '>' || prefix == '!') {
+    return false;
+  }
+  return std::strlen(format) == 1 && format[0] == expected;
+}
+
+bool finite_bf16_bits(const uint16_t bits) {
+  // BF16 has an eight-bit exponent.  All exponent bits set denotes either an
+  // infinity or NaN; both are rejected before dispatch by this host-buffer
+  // foundation API.
+  return (bits & 0x7f80u) != 0x7f80u;
+}
+
+float bf16_to_float_host(const uint16_t bits) {
+  const uint32_t word = static_cast<uint32_t>(bits) << 16;
+  float value = 0.0f;
+  std::memcpy(&value, &word, sizeof(value));
+  return value;
+}
+
+bool all_finite_bf16(const Py_buffer& view) {
+  const auto* values = static_cast<const uint16_t*>(view.buf);
+  const size_t count = static_cast<size_t>(view.len) / sizeof(uint16_t);
+  for (size_t index = 0; index < count; ++index) {
+    if (!finite_bf16_bits(values[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+float max_abs_bf16(const Py_buffer& view) {
+  const auto* values = static_cast<const uint16_t*>(view.buf);
+  const size_t count = static_cast<size_t>(view.len) / sizeof(uint16_t);
+  float maximum = 0.0f;
+  for (size_t index = 0; index < count; ++index) {
+    maximum = std::max(maximum, std::fabs(bf16_to_float_host(values[index])));
+  }
+  return maximum;
+}
+
+bool checked_product(std::initializer_list<uint64_t> values, uint64_t* result) {
+  uint64_t product = 1;
+  for (uint64_t value : values) {
+    if (value != 0 && product > std::numeric_limits<uint64_t>::max() / value) {
+      return false;
+    }
+    product *= value;
+  }
+  *result = product;
+  return true;
+}
+
+bool validate_inputs(
+    const BufferGuard& query,
+    const BufferGuard& key_pages,
+    const BufferGuard& value_pages,
+    const BufferGuard& page_table,
+    const BufferGuard& sequence_lengths,
+    int num_kv_heads,
+    int block_size,
+    float scale,
+    PagedDecodeParams* params,
+    std::string* error) {
+  const Py_buffer& q = query.view;
+  const Py_buffer& k = key_pages.view;
+  const Py_buffer& v = value_pages.view;
+  const Py_buffer& table = page_table.view;
+  const Py_buffer& lengths = sequence_lengths.view;
+
+  // Check dimensionality before dereferencing any shape pointer.  Malformed
+  // Python buffer exporters are part of the adversarial input surface.
+  if (!has_shape(q, 3) || !has_shape(k, 4) || !has_shape(v, 4) ||
+      !has_shape(table, 2) ||
+      !has_shape(lengths, 1)) {
+    *error =
+        "expected query [batch, query_heads, 128], key/value "
+        "[pages, kv_heads, block_size, 128], page_table [batch, max_blocks], "
+        "and sequence_lengths [batch]";
+    return false;
+  }
+
+  if (q.shape[2] != kHeadDim) {
+    *error = "query must have head_dim 128 for the phase-1 Metal kernel";
+    return false;
+  }
+
+  if (q.itemsize != 2 || k.itemsize != 2 || v.itemsize != 2 ||
+      !is_native_format(q, 'H') || !is_native_format(k, 'H') ||
+      !is_native_format(v, 'H')) {
+    *error =
+        "query, key_pages, and value_pages must expose BF16 storage as "
+        "contiguous uint16 buffers (PEP-3118 format H)";
+    return false;
+  }
+  if (table.itemsize != sizeof(int32_t) || lengths.itemsize != sizeof(int32_t) ||
+      !is_native_format(table, 'i') || !is_native_format(lengths, 'i')) {
+    *error =
+        "page_table and sequence_lengths must expose signed int32 buffers "
+        "(PEP-3118 format i)";
+    return false;
+  }
+  if (block_size != 16 && block_size != 32) {
+    *error = "block_size must be 16 or 32 for the phase-1 Metal kernel";
+    return false;
+  }
+  if (num_kv_heads <= 0) {
+    *error = "num_kv_heads must be positive";
+    return false;
+  }
+
+  const Py_ssize_t batch = q.shape[0];
+  const Py_ssize_t query_heads = q.shape[1];
+  const Py_ssize_t pages = k.shape[0];
+  const Py_ssize_t kv_heads = k.shape[1];
+  const Py_ssize_t max_blocks = table.shape[1];
+  if (batch <= 0 || query_heads <= 0 || pages <= 0 || kv_heads <= 0 ||
+      max_blocks <= 0) {
+    *error = "batch, heads, pages, and max_blocks must be positive";
+    return false;
+  }
+  if (table.shape[0] != batch || lengths.shape[0] != batch ||
+      k.shape[1] != num_kv_heads || v.shape[0] != pages ||
+      v.shape[1] != kv_heads || k.shape[2] != block_size ||
+      v.shape[2] != block_size || k.shape[3] != kHeadDim ||
+      v.shape[3] != kHeadDim) {
+    *error = "buffer shapes do not agree with batch, heads, block_size, or 128 head_dim";
+    return false;
+  }
+  if (query_heads % kv_heads != 0) {
+    *error = "query_heads must be an integer multiple of kv_heads (GQA)";
+    return false;
+  }
+
+  const uint64_t max_sequence =
+      static_cast<uint64_t>(max_blocks) * static_cast<uint64_t>(block_size);
+  if (max_sequence > std::numeric_limits<uint32_t>::max() ||
+      batch > std::numeric_limits<uint32_t>::max() ||
+      query_heads > std::numeric_limits<uint32_t>::max() ||
+      kv_heads > std::numeric_limits<uint32_t>::max() ||
+      pages > std::numeric_limits<uint32_t>::max() ||
+      max_blocks > std::numeric_limits<uint32_t>::max()) {
+    *error = "buffer dimensions exceed the native uint32 ABI";
+    return false;
+  }
+
+  uint64_t query_elements = 0;
+  uint64_t kv_elements = 0;
+  uint64_t table_elements = 0;
+  if (!checked_product(
+          {static_cast<uint64_t>(batch), static_cast<uint64_t>(query_heads),
+           kHeadDim},
+          &query_elements) ||
+      !checked_product(
+          {static_cast<uint64_t>(pages), static_cast<uint64_t>(kv_heads),
+           static_cast<uint64_t>(block_size), kHeadDim},
+          &kv_elements) ||
+      !checked_product(
+          {static_cast<uint64_t>(batch), static_cast<uint64_t>(max_blocks)},
+          &table_elements)) {
+    *error = "buffer dimensions overflow the native size calculation";
+    return false;
+  }
+  // Every composite offset in the MSL kernel is a uint32 expression.  Keep
+  // the entire reachable buffer/index space below UINT32_MAX rather than
+  // allowing a valid host allocation to wrap inside the shader.
+  if (query_elements > std::numeric_limits<uint32_t>::max() ||
+      kv_elements > std::numeric_limits<uint32_t>::max() ||
+      table_elements > std::numeric_limits<uint32_t>::max() ||
+      static_cast<uint64_t>(batch) * static_cast<uint64_t>(query_heads) >
+          std::numeric_limits<uint32_t>::max()) {
+    *error =
+        "buffer dimensions exceed the uint32 index/grid limit of the Metal "
+        "kernel";
+    return false;
+  }
+  const uint64_t expected_q = query_elements * sizeof(uint16_t);
+  const uint64_t expected_kv = kv_elements * sizeof(uint16_t);
+  const uint64_t expected_table = table_elements * sizeof(int32_t);
+  if (expected_q != static_cast<uint64_t>(q.len) ||
+      expected_kv != static_cast<uint64_t>(k.len) ||
+      expected_kv != static_cast<uint64_t>(v.len) ||
+      expected_table != static_cast<uint64_t>(table.len) ||
+      static_cast<uint64_t>(batch) * sizeof(int32_t) !=
+          static_cast<uint64_t>(lengths.len)) {
+    *error = "buffer byte lengths do not match their declared shapes";
+    return false;
+  }
+
+  if (!all_finite_bf16(q) || !all_finite_bf16(k) || !all_finite_bf16(v)) {
+    *error =
+        "query, key_pages, and value_pages must contain only finite BF16 "
+        "values";
+    return false;
+  }
+
+  // The shader performs the dot reduction in float32.  Finite BF16 inputs
+  // can still produce an infinity when multiplied/reduced at head_dim=128,
+  // and a subsequent Inf-Inf in online softmax would become NaN.  Use a
+  // conservative half-FLT_MAX envelope to leave room for float32 rounding;
+  // this is intentionally a host rejection in the host-buffer foundation.
+  constexpr long double kFloat32SafeMagnitude =
+      static_cast<long double>(std::numeric_limits<float>::max()) * 0.5L;
+  const long double max_dot =
+      static_cast<long double>(max_abs_bf16(q)) *
+      static_cast<long double>(max_abs_bf16(k)) * kHeadDim;
+  if (max_dot > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes may overflow the float32 dot "
+        "product at head_dim 128; reduce magnitudes";
+    return false;
+  }
+  const long double max_score =
+      max_dot * std::fabs(static_cast<long double>(scale));
+  if (max_score > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes and scale may overflow the "
+        "float32 attention score; reduce scale or magnitudes";
+    return false;
+  }
+
+  const auto* table_data = static_cast<const int32_t*>(table.buf);
+  const auto* length_data = static_cast<const int32_t*>(lengths.buf);
+  for (Py_ssize_t request = 0; request < batch; ++request) {
+    const int32_t length = length_data[request];
+    if (length < 0 || static_cast<uint64_t>(length) > max_sequence) {
+      *error = "sequence_lengths must be in [0, max_blocks * block_size]";
+      return false;
+    }
+    const Py_ssize_t needed_blocks =
+        (static_cast<Py_ssize_t>(length) + block_size - 1) / block_size;
+    for (Py_ssize_t logical_block = 0; logical_block < needed_blocks;
+         ++logical_block) {
+      const int32_t physical_page =
+          table_data[request * table.shape[1] + logical_block];
+      if (physical_page < 0 || physical_page >= pages) {
+        *error = "page_table contains an out-of-range page for a live token";
+        return false;
+      }
+    }
+  }
+
+  params->batch_size = static_cast<uint32_t>(batch);
+  params->query_heads = static_cast<uint32_t>(query_heads);
+  params->kv_heads = static_cast<uint32_t>(kv_heads);
+  params->head_dim = kHeadDim;
+  params->block_size = static_cast<uint32_t>(block_size);
+  params->max_blocks = static_cast<uint32_t>(max_blocks);
+  params->page_count = static_cast<uint32_t>(pages);
+  params->page_table_stride = static_cast<uint32_t>(max_blocks);
+  params->reserved0 = 0;
+  params->reserved1 = 0;
+  params->reserved2 = 0;
+  return true;
+}
+
+PyObject* py_capabilities(PyObject* self, PyObject*) {
+  const std::string path = py_object_path(self);
+  const bool available = ensure_runtime(path);
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+
+  if (!available) {
+    return unavailable_capabilities(g_runtime.error);
+  }
+
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+  const char* device_name =
+      g_runtime.device == nil ? "" : [g_runtime.device.name UTF8String];
+  const std::string name = device_name == nullptr ? "" : device_name;
+  if (!set_dict_bool(result, "available", true) ||
+      !set_dict_bool(result, "compiled", true) ||
+      !set_dict_bool(result, "metal_device", true) ||
+      !set_dict_bool(result, "apple_silicon", true) ||
+      !set_dict_bool(result, "serving_ready", false) ||
+      !set_dict_uint(result, "abi_version", kAbiVersion) ||
+      !set_dict_string(result, "backend", "metal-context") ||
+      !set_dict_string(result, "reason", "") ||
+      !set_dict_string(result, "device_name", name) ||
+      !set_dict_string(result, "metallib_path", g_runtime.path) ||
+      !set_dict_string(result, "kernel", "metal_context_paged_decode")) {
+    Py_DECREF(result);
+    return nullptr;
+  }
+
+  PyObject* block_sizes = Py_BuildValue("(ii)", 16, 32);
+  PyObject* head_dims = Py_BuildValue("(i)", static_cast<int>(kHeadDim));
+  if (block_sizes == nullptr || head_dims == nullptr ||
+      PyDict_SetItemString(result, "block_sizes", block_sizes) < 0 ||
+      PyDict_SetItemString(result, "head_dims", head_dims) < 0 ||
+      !set_dict_bool(result, "gqa", true) ||
+      !set_dict_bool(result, "partial_blocks", true) ||
+      !set_dict_bool(result, "online_softmax", true) ||
+      !set_dict_string(result, "kv_dtype", "bfloat16")) {
+    Py_XDECREF(block_sizes);
+    Py_XDECREF(head_dims);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(block_sizes);
+  Py_DECREF(head_dims);
+  return result;
+}
+
+PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
+  static const char* keywords[] = {
+      "query", "key_pages", "value_pages", "page_table",
+      "sequence_lengths", "num_kv_heads", "block_size", "scale", nullptr};
+  PyObject* query_object = nullptr;
+  PyObject* key_object = nullptr;
+  PyObject* value_object = nullptr;
+  PyObject* table_object = nullptr;
+  PyObject* lengths_object = nullptr;
+  int num_kv_heads = 0;
+  int block_size = 0;
+  float scale = 0.0f;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "OOOOOiff:paged_decode",
+          const_cast<char**>(keywords),
+          &query_object,
+          &key_object,
+          &value_object,
+          &table_object,
+          &lengths_object,
+          &num_kv_heads,
+          &block_size,
+          &scale)) {
+    return nullptr;
+  }
+  if (!std::isfinite(scale)) {
+    PyErr_SetString(PyExc_ValueError, "scale must be finite");
+    return nullptr;
+  }
+
+  BufferGuard query;
+  BufferGuard key_pages;
+  BufferGuard value_pages;
+  BufferGuard page_table;
+  BufferGuard sequence_lengths;
+  if (!acquire_contiguous(query_object, &query, "query") ||
+      !acquire_contiguous(key_object, &key_pages, "key_pages") ||
+      !acquire_contiguous(value_object, &value_pages, "value_pages") ||
+      !acquire_contiguous(table_object, &page_table, "page_table") ||
+      !acquire_contiguous(
+          lengths_object, &sequence_lengths, "sequence_lengths")) {
+    return nullptr;
+  }
+
+  PagedDecodeParams params{};
+  std::string validation_error;
+  if (!validate_inputs(
+          query,
+          key_pages,
+          value_pages,
+          page_table,
+          sequence_lengths,
+          num_kv_heads,
+          block_size,
+          scale,
+          &params,
+          &validation_error)) {
+    PyErr_SetString(PyExc_ValueError, validation_error.c_str());
+    return nullptr;
+  }
+  params.scale = scale;
+
+  const std::string path = py_object_path(self);
+  if (!ensure_runtime(path)) {
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "metal-context backend unavailable: %s",
+        g_runtime.error.c_str());
+    return nullptr;
+  }
+
+  uint64_t output_elements = 0;
+  if (!checked_product(
+          {params.batch_size, params.query_heads, params.head_dim},
+          &output_elements) ||
+      output_elements > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    PyErr_SetString(PyExc_OverflowError, "output shape exceeds native size limits");
+    return nullptr;
+  }
+  const size_t output_bytes = static_cast<size_t>(output_elements) * sizeof(float);
+
+  @autoreleasepool {
+    // Serialize the first low-level bridge while ownership is still host
+    // backed.  The future page runtime will replace these copies with
+    // allocator-owned GPU buffers and keep the command queue asynchronous.
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    id<MTLDevice> device = g_runtime.device;
+    id<MTLCommandQueue> queue = g_runtime.queue;
+    id<MTLComputePipelineState> pipeline = g_runtime.pipeline;
+    if (device == nil || queue == nil || pipeline == nil) {
+      PyErr_SetString(PyExc_RuntimeError, "metal-context runtime lost its pipeline");
+      return nullptr;
+    }
+
+    id<MTLBuffer> query_buffer =
+        [device newBufferWithLength:(NSUInteger)query.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> key_buffer =
+        [device newBufferWithLength:(NSUInteger)key_pages.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> value_buffer =
+        [device newBufferWithLength:(NSUInteger)value_pages.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> table_buffer =
+        [device newBufferWithLength:(NSUInteger)page_table.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> lengths_buffer =
+        [device newBufferWithLength:(NSUInteger)sequence_lengths.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> output_buffer =
+        [device newBufferWithLength:(NSUInteger)output_bytes
+                             options:MTLResourceStorageModeShared];
+    if (query_buffer == nil || key_buffer == nil || value_buffer == nil ||
+        table_buffer == nil || lengths_buffer == nil || output_buffer == nil) {
+      PyErr_SetString(PyExc_MemoryError, "Metal could not allocate kernel buffers");
+      return nullptr;
+    }
+
+    std::memcpy(query_buffer.contents, query.view.buf, query.view.len);
+    std::memcpy(key_buffer.contents, key_pages.view.buf, key_pages.view.len);
+    std::memcpy(value_buffer.contents, value_pages.view.buf, value_pages.view.len);
+    std::memcpy(table_buffer.contents, page_table.view.buf, page_table.view.len);
+    std::memcpy(
+        lengths_buffer.contents,
+        sequence_lengths.view.buf,
+        sequence_lengths.view.len);
+    std::memset(output_buffer.contents, 0, output_bytes);
+
+    id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> encoder =
+        [command_buffer computeCommandEncoder];
+    if (command_buffer == nil || encoder == nil) {
+      PyErr_SetString(PyExc_RuntimeError, "Metal could not create a command encoder");
+      return nullptr;
+    }
+    [encoder setComputePipelineState:pipeline];
+    [encoder setBuffer:query_buffer offset:0 atIndex:0];
+    [encoder setBuffer:key_buffer offset:0 atIndex:1];
+    [encoder setBuffer:value_buffer offset:0 atIndex:2];
+    [encoder setBuffer:table_buffer offset:0 atIndex:3];
+    [encoder setBuffer:lengths_buffer offset:0 atIndex:4];
+    [encoder setBuffer:output_buffer offset:0 atIndex:5];
+    [encoder setBytes:&params length:sizeof(params) atIndex:6];
+    const MTLSize grid = MTLSizeMake(
+        (NSUInteger)params.batch_size * params.query_heads, 1, 1);
+    const MTLSize group = MTLSizeMake(kThreadsPerThreadgroup, 1, 1);
+    [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+    [encoder endEncoding];
+    [command_buffer commit];
+    [command_buffer waitUntilCompleted];
+
+    if (command_buffer.status != MTLCommandBufferStatusCompleted) {
+      std::string error = ns_error_description(
+          command_buffer.error,
+          "Metal command buffer did not complete successfully");
+      PyErr_SetString(PyExc_RuntimeError, error.c_str());
+      return nullptr;
+    }
+    return PyBytes_FromStringAndSize(
+        static_cast<const char*>(output_buffer.contents),
+        static_cast<Py_ssize_t>(output_bytes));
+  }
+}
+
+PyObject* py_shutdown(PyObject*, PyObject*) {
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+  g_runtime.device = nil;
+  g_runtime.queue = nil;
+  g_runtime.pipeline = nil;
+  g_runtime.attempted = false;
+  g_runtime.available = false;
+  g_runtime.path.clear();
+  g_runtime.error.clear();
+  Py_RETURN_NONE;
+}
+
+PyMethodDef kMethods[] = {
+    {"capabilities", py_capabilities, METH_NOARGS,
+     "Return the compiled Metal Context Engine capability record."},
+    {"paged_decode", reinterpret_cast<PyCFunction>(py_paged_decode),
+     METH_VARARGS | METH_KEYWORDS,
+     "Run BF16 paged decode attention from contiguous host buffers."},
+    {"shutdown", py_shutdown, METH_NOARGS,
+     "Release the native Metal pipeline and queue."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+PyModuleDef kModule = {
+    PyModuleDef_HEAD_INIT,
+    "vllm_mlx._metal_context",
+    "Optional native Metal Context Engine kernel bridge.",
+    -1,
+    kMethods,
+};
+
+}  // namespace
+
+PyMODINIT_FUNC PyInit__metal_context() {
+  return PyModule_Create(&kModule);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ include = ["vllm_mlx*"]
 
 [tool.setuptools.package-data]
 "vllm_mlx.bench_serve_prompts" = ["*.json"]
+"vllm_mlx" = ["*.metallib"]
 
 [tool.black]
 line-length = 88

--- a/scripts/build_metal_context.py
+++ b/scripts/build_metal_context.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Compile the checked-in Metal Context Engine shaders into a metallib.
+
+This is deliberately a small, explicit workflow instead of a runtime shader
+compiler.  Release builders can run it on a pinned macOS/Xcode image and ship
+the resulting library beside the optional native extension.  No command is
+attempted on non-macOS hosts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "native" / "metal_context" / "kernels" / "paged_decode.metal"
+APPLE_SILICON = {"arm64", "aarch64"}
+
+
+def _xcrun(sdk: str, tool: str) -> str:
+    result = subprocess.run(
+        ["xcrun", "--sdk", sdk, "--find", tool],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        detail = result.stderr.strip() or f"xcrun could not find {tool}"
+        raise RuntimeError(detail)
+    return result.stdout.strip()
+
+
+def compile_metallib(output: Path, *, sdk: str = "macosx") -> None:
+    """Compile the phase-1 shader and atomically publish ``output``."""
+
+    if sys.platform != "darwin":
+        raise RuntimeError("Metal shader compilation requires macOS")
+    machine = platform.machine().lower()
+    if machine not in APPLE_SILICON:
+        raise RuntimeError(
+            "Metal Context Engine compilation requires Apple Silicon "
+            f"(arm64/aarch64), found {machine or 'unknown'}"
+        )
+    if not SOURCE.is_file():
+        raise RuntimeError(f"shader source is missing: {SOURCE}")
+
+    metal = _xcrun(sdk, "metal")
+    metallib = _xcrun(sdk, "metallib")
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="vllm-mlx-metal-") as temp_dir:
+        temp = Path(temp_dir)
+        air = temp / "paged_decode.air"
+        compiled = temp / "_metal_context.metallib"
+        subprocess.run(
+            [metal, "-c", os.fspath(SOURCE), "-o", os.fspath(air)],
+            check=True,
+        )
+        subprocess.run(
+            [metallib, os.fspath(air), "-o", os.fspath(compiled)],
+            check=True,
+        )
+        os.replace(compiled, output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "vllm_mlx" / "_metal_context.metallib",
+        help="destination metallib path",
+    )
+    parser.add_argument("--sdk", default="macosx", help="xcrun SDK name")
+    args = parser.parse_args()
+    compile_metallib(args.output, sdk=args.sdk)
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,7 @@ def _extensions() -> list[Extension]:
     return [
         Extension(
             "vllm_mlx._metal_context",
-            sources=[
-                os.fspath(
-                    ROOT / "native" / "metal_context" / "src" / "python_module.mm"
-                )
-            ],
+            sources=["native/metal_context/src/python_module.mm"],
             language="objc++",
             extra_compile_args=[
                 "-std=c++17",

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,18 @@ def _extensions() -> list[Extension]:
                 )
             ],
             language="objc++",
-            extra_compile_args=["-std=c++17", "-fobjc-arc"],
-            extra_link_args=["-framework", "Metal", "-framework", "Foundation"],
+            extra_compile_args=[
+                "-std=c++17",
+                "-fobjc-arc",
+                "-mmacosx-version-min=11.0",
+            ],
+            extra_link_args=[
+                "-mmacosx-version-min=11.0",
+                "-framework",
+                "Metal",
+                "-framework",
+                "Foundation",
+            ],
         )
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,13 @@ class MetalBuildExt(build_ext):
         destination_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(output, destination_dir / "_metal_context.metallib")
 
+    def build_extensions(self) -> None:
+        # distutils does not list Objective-C++ as a recognized source suffix,
+        # even though Apple's clang handles it correctly.  Register it before
+        # setuptools asks the compiler to classify extension sources.
+        if ".mm" not in self.compiler.src_extensions:
+            self.compiler.src_extensions.append(".mm")
+        super().build_extensions()
+
 
 setup(ext_modules=_extensions(), cmdclass={"build_ext": MetalBuildExt})

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,105 @@
+"""Optional native Metal Context Engine build hooks.
+
+The project metadata remains in ``pyproject.toml``.  This small shim only
+adds an extension when the caller is on Apple Silicon macOS, the Metal
+compiler is available, and ``VLLM_MLX_BUILD_METAL_CONTEXT=1`` is explicitly
+requested.  Normal installs keep this optional extension disabled.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+ROOT = Path(__file__).resolve().parent
+STRICT = {"1", "true", "yes", "on", "required"}
+APPLE_SILICON = {"arm64", "aarch64"}
+
+
+def _metal_toolchain_available() -> bool:
+    if sys.platform != "darwin" or shutil.which("xcrun") is None:
+        return False
+    return (
+        subprocess.run(
+            ["xcrun", "--sdk", "macosx", "--find", "metal"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
+    )
+
+
+def _extensions() -> list[Extension]:
+    # The native foundation is never built implicitly.  This keeps ordinary
+    # wheels/editable installs portable and makes the toolchain choice
+    # auditable in CI and release logs.
+    mode = os.environ.get("VLLM_MLX_BUILD_METAL_CONTEXT", "disabled").lower()
+    if mode in {"0", "false", "no", "off", "disabled"}:
+        return []
+    if sys.platform != "darwin":
+        if mode in STRICT:
+            raise RuntimeError("VLLM_MLX_BUILD_METAL_CONTEXT=1 requires macOS")
+        return []
+    machine = platform.machine().lower()
+    if machine not in APPLE_SILICON:
+        if mode in STRICT:
+            raise RuntimeError(
+                "VLLM_MLX_BUILD_METAL_CONTEXT=1 requires Apple Silicon "
+                f"(arm64/aarch64), found {machine or 'unknown'}"
+            )
+        return []
+    if not _metal_toolchain_available():
+        if mode in STRICT:
+            raise RuntimeError(
+                "Metal toolchain unavailable; install Xcode/Command Line Tools "
+                "or set VLLM_MLX_BUILD_METAL_CONTEXT=0"
+            )
+        return []
+    return [
+        Extension(
+            "vllm_mlx._metal_context",
+            sources=[
+                os.fspath(
+                    ROOT / "native" / "metal_context" / "src" / "python_module.mm"
+                )
+            ],
+            language="objc++",
+            extra_compile_args=["-std=c++17", "-fobjc-arc"],
+            extra_link_args=["-framework", "Metal", "-framework", "Foundation"],
+        )
+    ]
+
+
+class MetalBuildExt(build_ext):
+    """Build the metallib before the extension and package it beside it."""
+
+    def run(self) -> None:
+        if not self.extensions:
+            return super().run()
+        output = Path(self.build_temp) / "metal_context" / "_metal_context.metallib"
+        subprocess.run(
+            [
+                sys.executable,
+                os.fspath(ROOT / "scripts" / "build_metal_context.py"),
+                "--output",
+                os.fspath(output),
+            ],
+            check=True,
+        )
+        super().run()
+        destination_dir = (
+            ROOT / "vllm_mlx" if self.inplace else Path(self.build_lib) / "vllm_mlx"
+        )
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(output, destination_dir / "_metal_context.metallib")
+
+
+setup(ext_modules=_extensions(), cmdclass={"build_ext": MetalBuildExt})

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for phase-one attention backend dispatch and oracle semantics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vllm_mlx.attention_backend import (
+    AttentionBackendCapabilityError,
+    AttentionBackendName,
+    AttentionGeometry,
+    BackendCapabilities,
+    ContextBackend,
+    discover_capabilities,
+    mlx_sdpa_paged_decode_attention,
+    numpy_paged_decode_attention,
+    resolve_attention_backend,
+)
+
+
+def unavailable_capabilities(reason: str = "test extension unavailable"):
+    return BackendCapabilities(
+        platform="darwin",
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=reason,
+    )
+
+
+class TestBackendDispatch:
+    def test_mlx_is_default_and_never_requires_native_extension(self):
+        selection = resolve_attention_backend(capabilities=unavailable_capabilities())
+
+        assert selection.requested is AttentionBackendName.MLX
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.is_fallback is False
+
+    def test_default_mlx_does_not_probe_or_import_native(self, monkeypatch):
+        def fail_probe():
+            raise AssertionError("the MLX default must not probe native")
+
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend.discover_capabilities", fail_probe
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend.importlib.import_module", fail_probe
+        )
+
+        selection = resolve_attention_backend()
+
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.capabilities.probed is False
+        assert selection.capabilities.native_extension is False
+        assert selection.capabilities.available is False
+        assert selection.capabilities.architecture == ""
+
+    def test_auto_is_conservative_even_when_native_is_available(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        selection = resolve_attention_backend("auto", capabilities=capabilities)
+
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.is_fallback is True
+        assert "qualification matrix" in (selection.fallback_reason or "")
+
+    def test_explicit_metal_context_fails_without_capability(self):
+        with pytest.raises(
+            AttentionBackendCapabilityError,
+            match="explicitly requested but is unavailable",
+        ) as exc_info:
+            resolve_attention_backend(
+                "metal-context", capabilities=unavailable_capabilities("no device")
+            )
+
+        assert exc_info.value.capabilities.reason == "no device"
+        assert "--attention-backend mlx" in str(exc_info.value)
+
+    def test_explicit_metal_context_selects_only_after_probe(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        selection = resolve_attention_backend(
+            "metal-context", capabilities=capabilities
+        )
+
+        assert selection.selected is AttentionBackendName.METAL_CONTEXT
+        assert selection.is_fallback is False
+
+    def test_kernel_capability_without_executor_still_fails_closed(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+        )
+
+        with pytest.raises(
+            AttentionBackendCapabilityError,
+            match="no serving executor is registered",
+        ):
+            resolve_attention_backend("metal-context", capabilities=capabilities)
+
+    def test_explicit_metal_context_rejects_non_macos_capability(self):
+        capabilities = BackendCapabilities(
+            platform="linux",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        with pytest.raises(AttentionBackendCapabilityError, match="requires macOS"):
+            resolve_attention_backend("metal-context", capabilities=capabilities)
+
+    @pytest.mark.parametrize("value", ["bogus", "", "METAL_CONTEXT"])
+    def test_invalid_names_are_rejected(self, value):
+        with pytest.raises(ValueError, match="Unknown attention backend"):
+            resolve_attention_backend(value, capabilities=unavailable_capabilities())
+
+    def test_selection_status_is_serializable(self):
+        status = resolve_attention_backend(
+            "auto", capabilities=unavailable_capabilities()
+        ).as_dict()
+
+        assert status["requested"] == "auto"
+        assert status["selected"] == "mlx"
+        assert status["capabilities"]["available"] is False
+        assert status["capabilities"]["probed"] is False
+
+
+class TestCapabilityProbe:
+    def test_non_macos_fails_closed(self, monkeypatch):
+        monkeypatch.setattr("vllm_mlx.attention_backend.sys.platform", "linux")
+
+        capabilities = discover_capabilities()
+
+        assert capabilities.available is False
+        assert "requires macOS" in (capabilities.reason or "")
+
+    def test_non_apple_silicon_fails_closed(self, monkeypatch):
+        monkeypatch.setattr("vllm_mlx.attention_backend.sys.platform", "darwin")
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend._platform.machine", lambda: "x86_64"
+        )
+
+        capabilities = discover_capabilities()
+
+        assert capabilities.available is False
+        assert "requires Apple Silicon" in (capabilities.reason or "")
+
+
+class TestGeometry:
+    def test_qwen_phase_one_geometry_is_accepted(self):
+        AttentionGeometry(
+            num_layers=36,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            block_size=32,
+        ).validate()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"head_dim": 64},
+            {"block_size": 64},
+            {"kv_dtype": "float16"},
+            {"num_attention_heads": 30, "num_key_value_heads": 8},
+        ],
+    )
+    def test_unsupported_geometry_is_rejected(self, kwargs):
+        values = {
+            "num_layers": 36,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+        }
+        values.update(kwargs)
+        with pytest.raises(ValueError):
+            AttentionGeometry(**values).validate()
+
+
+class TestNumpyOracle:
+    def test_accepts_native_bf16_bit_storage(self):
+        query_values = np.asarray([[[1.0], [-2.5]]], dtype=np.float32)
+        query_bits = (query_values.view(np.uint32) >> 16).astype(np.uint16)
+        key_values = np.full((1, 1, 16, 1), 0.125, dtype=np.float32)
+        key_bits = (key_values.view(np.uint32) >> 16).astype(np.uint16)
+
+        output = numpy_paged_decode_attention(
+            query_bits,
+            key_bits,
+            key_bits,
+            np.asarray([[0]], dtype=np.int32),
+            np.asarray([1], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=1,
+            scale=1.0,
+        )
+
+        assert output.shape == query_values.shape
+        assert np.isfinite(output).all()
+
+    def test_noncontiguous_pages_gqa_and_partial_tail(self):
+        rng = np.random.default_rng(11)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        # Request zero uses physical pages [2, 0] and has a one-token tail;
+        # request one uses [1, 3] with a fourteen-token tail.
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+
+        assert output.shape == query.shape
+        assert np.isfinite(output).all()
+        assert output.dtype == np.float32
+
+    @pytest.mark.parametrize(
+        "mutator, message",
+        [
+            (lambda table, lengths: (table.astype(np.float32), lengths), "integer"),
+            (lambda table, lengths: (table, lengths.astype(np.float32)), "integer"),
+            (lambda table, lengths: (table, np.asarray([-1, 1])), "negative"),
+            (
+                lambda table, lengths: (np.asarray([[99, 0], [1, 3]]), lengths),
+                "outside",
+            ),
+        ],
+    )
+    def test_invalid_page_metadata_is_rejected(self, mutator, message):
+        rng = np.random.default_rng(3)
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, 16, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        lengths = np.asarray([17, 30], dtype=np.int32)
+        page_table, lengths = mutator(page_table, lengths)
+
+        with pytest.raises(ValueError, match=message):
+            numpy_paged_decode_attention(
+                query,
+                key_pages,
+                value_pages,
+                page_table,
+                lengths,
+                block_size=16,
+                num_kv_heads=2,
+            )
+
+    def test_zero_length_request_returns_zero_without_page_access(self):
+        query = np.ones((1, 4, 8), dtype=np.float32)
+        key_pages = np.zeros((0, 2, 16, 8), dtype=np.float32)
+        value_pages = np.zeros_like(key_pages)
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            np.zeros((1, 0), dtype=np.int32),
+            np.asarray([0], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=2,
+        )
+
+        np.testing.assert_array_equal(output, np.zeros_like(query))
+
+    def test_extreme_but_finite_logits_use_stable_softmax(self):
+        query = np.asarray([[[1.0e20]]], dtype=np.float32)
+        key_pages = np.zeros((1, 1, 16, 1), dtype=np.float32)
+        key_pages[0, 0, :2, 0] = [1.0e-10, 2.0e-10]
+        value_pages = np.zeros_like(key_pages)
+        value_pages[0, 0, :2, 0] = [1.0, 3.0]
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            np.asarray([[0]], dtype=np.int32),
+            np.asarray([2], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=1,
+            scale=1.0,
+        )
+
+        assert np.isfinite(output).all()
+        assert output[0, 0, 0] > 2.9
+
+    def test_finite_inputs_with_overflowed_logits_fail_explicitly(self):
+        query = np.asarray([[[1.0e20]]], dtype=np.float32)
+        key_pages = np.zeros((1, 1, 16, 1), dtype=np.float32)
+        key_pages[0, 0, 0, 0] = 1.0e20
+        value_pages = np.ones_like(key_pages)
+
+        with pytest.raises(ValueError, match="attention logits overflow"):
+            numpy_paged_decode_attention(
+                query,
+                key_pages,
+                value_pages,
+                np.asarray([[0]], dtype=np.int32),
+                np.asarray([1], dtype=np.int32),
+                block_size=16,
+                num_kv_heads=1,
+                scale=1.0,
+            )
+
+
+class TestMlxOracle:
+    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+        mx = pytest.importorskip("mlx.core")
+        rng = np.random.default_rng(23)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        numpy_output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mlx_output = mlx_sdpa_paged_decode_attention(
+            mx.array(query),
+            mx.array(key_pages),
+            mx.array(value_pages),
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mx.eval(mlx_output)
+
+        np.testing.assert_allclose(
+            np.asarray(mlx_output), numpy_output, rtol=2e-4, atol=2e-4
+        )
+
+    def test_sdpa_decodes_uint16_bf16_bits_before_attention(self):
+        mx = pytest.importorskip("mlx.core")
+        rng = np.random.default_rng(29)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+
+        def bf16_bits(values):
+            return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+        query_bits = bf16_bits(query)
+        key_bits = bf16_bits(key_pages)
+        value_bits = bf16_bits(value_pages)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        numpy_output = numpy_paged_decode_attention(
+            query_bits,
+            key_bits,
+            value_bits,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mlx_output = mlx_sdpa_paged_decode_attention(
+            mx.array(query_bits),
+            mx.array(key_bits),
+            mx.array(value_bits),
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mx.eval(mlx_output)
+
+        np.testing.assert_allclose(
+            np.asarray(mlx_output), numpy_output, rtol=2e-4, atol=2e-4
+        )
+
+
+class TestPythonContract:
+    def test_protocol_is_runtime_checkable_for_future_adapters(self):
+        class StubBackend:
+            pass
+
+        assert not isinstance(StubBackend(), ContextBackend)

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -333,8 +333,17 @@ class TestNumpyOracle:
 
 
 class TestMlxOracle:
-    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+    @staticmethod
+    def _real_mlx():
         mx = pytest.importorskip("mlx.core")
+        if not hasattr(mx, "fast") or not hasattr(
+            mx.fast, "scaled_dot_product_attention"
+        ):
+            pytest.skip("real MLX SDPA is unavailable")
+        return mx
+
+    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+        mx = self._real_mlx()
         rng = np.random.default_rng(23)
         block_size = 16
         query = rng.normal(size=(2, 4, 8)).astype(np.float32)
@@ -368,7 +377,7 @@ class TestMlxOracle:
         )
 
     def test_sdpa_decodes_uint16_bf16_bits_before_attention(self):
-        mx = pytest.importorskip("mlx.core")
+        mx = self._real_mlx()
         rng = np.random.default_rng(29)
         block_size = 16
         query = rng.normal(size=(2, 4, 8)).astype(np.float32)

--- a/tests/test_metal_context_native.py
+++ b/tests/test_metal_context_native.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Portable checks for the optional native Metal Context Engine surface."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from vllm_mlx.attention_backend import (
+    mlx_sdpa_paged_decode_attention,
+    numpy_paged_decode_attention,
+)
+
+
+def test_capability_probe_never_requires_native_build():
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+
+    assert capabilities["backend"] == "metal-context"
+    assert capabilities["abi_version"] == 1
+    assert capabilities["block_sizes"] == (16, 32)
+    assert capabilities["head_dims"] == (128,)
+    assert capabilities["gqa"] is True
+    assert capabilities["partial_blocks"] is True
+    assert capabilities["online_softmax"] is True
+    assert capabilities["kv_dtype"] == "bfloat16"
+    assert isinstance(capabilities["apple_silicon"], bool)
+    assert capabilities["serving_ready"] is False
+    assert isinstance(capabilities["available"], bool)
+    if not capabilities["available"]:
+        assert capabilities["reason"]
+
+
+def test_unavailable_native_dispatch_fails_precisely():
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if capabilities["available"]:
+        pytest.skip("native extension is available; dispatch is covered on Apple CI")
+
+    with pytest.raises(RuntimeError, match="metal-context backend unavailable"):
+        _metal_context.paged_decode(None)
+
+
+def test_native_paged_decode_matches_numpy_oracle():
+    """Exercise the compiled Metal dispatch when the strict build is present."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    rng = np.random.default_rng(31)
+    block_size = 16
+    head_dim = 128
+    query_heads = 4
+    kv_heads = 2
+    query_values = rng.normal(0.0, 0.25, size=(2, query_heads, head_dim)).astype(
+        np.float32
+    )
+    key_values = rng.normal(0.0, 0.25, size=(4, kv_heads, block_size, head_dim)).astype(
+        np.float32
+    )
+    value_values = rng.normal(0.0, 0.25, size=key_values.shape).astype(np.float32)
+
+    def to_bf16_bits(values):
+        return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+    def from_bf16_bits(values):
+        return (values.astype(np.uint32) << 16).view(np.float32)
+
+    query = to_bf16_bits(query_values)
+    key_pages = to_bf16_bits(key_values)
+    value_pages = to_bf16_bits(value_values)
+    page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+    sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+    scale = 1.0 / math.sqrt(head_dim)
+
+    native_bytes = _metal_context.paged_decode(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        num_kv_heads=kv_heads,
+        block_size=block_size,
+        scale=scale,
+    )
+    native_output = np.frombuffer(native_bytes, dtype=np.float32).reshape(
+        query_values.shape
+    )
+
+    oracle_output = numpy_paged_decode_attention(
+        from_bf16_bits(query),
+        from_bf16_bits(key_pages),
+        from_bf16_bits(value_pages),
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=kv_heads,
+        scale=scale,
+    )
+
+    np.testing.assert_allclose(native_output, oracle_output, rtol=2e-2, atol=2e-2)
+
+
+def test_native_paged_decode_matches_mlx_oracle():
+    """Compare the real Metal dispatch with MLX SDPA when both are present."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+    pytest.importorskip("mlx.core")
+
+    rng = np.random.default_rng(37)
+    block_size = 32
+    head_dim = 128
+    query_heads = 4
+    kv_heads = 2
+    query = rng.normal(0.0, 0.2, size=(2, query_heads, head_dim)).astype(np.float32)
+    key_pages = rng.normal(0.0, 0.2, size=(4, kv_heads, block_size, head_dim)).astype(
+        np.float32
+    )
+    value_pages = rng.normal(0.0, 0.2, size=key_pages.shape).astype(np.float32)
+    page_table = np.asarray([[3, 0], [2, 1]], dtype=np.int32)
+    sequence_lengths = np.asarray([32, 33], dtype=np.int32)
+    scale = 1.0 / math.sqrt(head_dim)
+
+    def to_bf16_bits(values):
+        return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+    query_bits = to_bf16_bits(query)
+    key_bits = to_bf16_bits(key_pages)
+    value_bits = to_bf16_bits(value_pages)
+    native_output = np.frombuffer(
+        _metal_context.paged_decode(
+            query_bits,
+            key_bits,
+            value_bits,
+            page_table,
+            sequence_lengths,
+            num_kv_heads=kv_heads,
+            block_size=block_size,
+            scale=scale,
+        ),
+        dtype=np.float32,
+    ).reshape(query.shape)
+    mlx_output = mlx_sdpa_paged_decode_attention(
+        query_bits,
+        key_bits,
+        value_bits,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=kv_heads,
+        scale=scale,
+    )
+
+    np.testing.assert_allclose(
+        native_output, np.asarray(mlx_output), rtol=3e-2, atol=3e-2
+    )
+
+
+def test_native_rejects_non_native_formats_and_nonfinite_bf16():
+    """The host ABI must reject ambiguous byte order and unsafe BF16 values."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    rng = np.random.default_rng(41)
+    query = (
+        rng.normal(size=(1, 2, 128)).astype(np.float32).view(np.uint32) >> 16
+    ).astype(np.uint16)
+    key = np.zeros((1, 1, 16, 128), dtype=np.uint16)
+    value = np.zeros_like(key)
+    table = np.asarray([[0]], dtype=np.int32)
+    lengths = np.asarray([1], dtype=np.int32)
+    kwargs = dict(
+        num_kv_heads=1,
+        block_size=16,
+        scale=1.0 / math.sqrt(128),
+    )
+
+    with pytest.raises(ValueError, match="expected query"):
+        _metal_context.paged_decode(
+            query.reshape(2, 128), key, value, table, lengths, **kwargs
+        )
+    with pytest.raises(ValueError, match="uint16"):
+        _metal_context.paged_decode(
+            query.astype(">u2"), key, value, table, lengths, **kwargs
+        )
+    with pytest.raises(ValueError, match="uint16"):
+        _metal_context.paged_decode(
+            query.astype(np.float16), key, value, table, lengths, **kwargs
+        )
+
+    nonfinite_query = query.copy()
+    nonfinite_query[0, 0, 0] = np.uint16(0x7F80)
+    with pytest.raises(ValueError, match="finite BF16"):
+        _metal_context.paged_decode(
+            nonfinite_query, key, value, table, lengths, **kwargs
+        )
+
+
+def test_native_rejects_finite_bf16_dot_and_score_overflow():
+    """Finite BF16 extremes must not reach an Inf/Inf softmax reduction."""
+
+    from vllm_mlx import _metal_context
+
+    if not _metal_context.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    key = np.zeros((1, 1, 16, 128), dtype=np.uint16)
+    value = np.zeros_like(key)
+    table = np.asarray([[0]], dtype=np.int32)
+    lengths = np.asarray([1], dtype=np.int32)
+
+    # 0x7f7f is the largest finite BF16 value.  The conservative host bound
+    # rejects max_q * max_k * head_dim before any Metal allocation/dispatch.
+    query = np.full((1, 1, 128), np.uint16(0x7F7F), dtype=np.uint16)
+    key.fill(np.uint16(0x7F7F))
+    with pytest.raises(ValueError, match="dot product"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=1.0,
+        )
+
+    # 0x5d31 is approximately 8e17.  Its 128-term dot bound is finite, but
+    # multiplying that bound by scale=4 exceeds the guarded score envelope.
+    query.fill(np.uint16(0x5D31))
+    key.fill(np.uint16(0x5D31))
+    with pytest.raises(ValueError, match="attention score"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=4.0,
+        )
+
+
+def test_native_shutdown_can_repeat_without_stale_runtime_state():
+    """Repeated capability probe/shutdown cycles must recreate the pipeline."""
+
+    from vllm_mlx import _metal_context
+
+    if not _metal_context.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    for _ in range(3):
+        _metal_context.shutdown()
+        capabilities = _metal_context.capabilities()
+        assert capabilities["available"] is True
+        assert capabilities["serving_ready"] is False

--- a/tests/test_metal_context_shader_contract.py
+++ b/tests/test_metal_context_shader_contract.py
@@ -1,0 +1,35 @@
+"""Source-only guard regression; no Metal device or MLX imports."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+class ShaderGeometryContract(unittest.TestCase):
+    def test_uniform_geometry_guard_precedes_scratch_and_barriers(self):
+        root = Path(__file__).resolve().parents[1]
+        shader = (root / "native/metal_context/kernels/paged_decode.metal").read_text()
+        shader = re.sub(r"//[^\n]*", "", shader)
+        self.assertIn("uint3 group_size [[threads_per_threadgroup]]", shader)
+        guard = re.search(
+            r"if\s*\(group_size\.x != 128 \|\| group_size\.y != 1 "
+            r"\|\| group_size\.z != 1 \|\|\s*p\.query_heads == 0\)"
+            r"\s*\{\s*return;\s*\}",
+            shader,
+        )
+        self.assertIsNotNone(guard)
+        for operation in (
+            "tg_pos.x / p.query_heads",
+            "threadgroup float partial_dot[128]",
+            "partial_dot[tid] =",
+            "threadgroup_barrier(",
+        ):
+            self.assertLess(guard.end(), shader.index(operation))
+        self.assertNotRegex(shader, r"if\s*\([^)]*tid[^)]*\)\s*\{\s*return;")
+        host = (root / "native/metal_context/src/python_module.mm").read_text()
+        self.assertIn("constexpr uint32_t kThreadsPerThreadgroup = 128;", host)
+        self.assertIn("MTLSizeMake(kThreadsPerThreadgroup, 1, 1)", host)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_mlx/_metal_context.py
+++ b/vllm_mlx/_metal_context.py
@@ -1,0 +1,55 @@
+"""Fallback surface for the optional Metal Context Engine extension.
+
+The native module has the same import name (``vllm_mlx._metal_context``) and
+is selected by Python automatically when it is present.  Keeping this small
+fallback importable is important: normal MLX serving and Linux CI must not
+require an Apple toolchain, while an explicit ``metal-context`` request still
+gets an actionable capability error from the higher-level backend.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Any
+
+ABI_VERSION = 1
+
+
+def capabilities() -> dict[str, Any]:
+    """Return a precise, non-raising unavailable capability record."""
+
+    return {
+        "available": False,
+        "compiled": False,
+        "metal_device": False,
+        "apple_silicon": platform.machine().lower() in {"arm64", "aarch64"},
+        "serving_ready": False,
+        "abi_version": ABI_VERSION,
+        "backend": "metal-context",
+        "reason": (
+            "the optional native Metal Context Engine was not built; install "
+            "on Apple Silicon with VLLM_MLX_BUILD_METAL_CONTEXT=1 and the "
+            "Xcode Metal toolchain"
+        ),
+        "kernel": "metal_context_paged_decode",
+        "block_sizes": (16, 32),
+        "head_dims": (128,),
+        "gqa": True,
+        "partial_blocks": True,
+        "online_softmax": True,
+        "kv_dtype": "bfloat16",
+    }
+
+
+def paged_decode(*args: Any, **kwargs: Any) -> bytes:
+    """Reject native dispatch when the optional extension is unavailable."""
+
+    del args, kwargs
+    raise RuntimeError("metal-context backend unavailable: " + capabilities()["reason"])
+
+
+def shutdown() -> None:
+    """Keep lifecycle calls harmless when no native module was installed."""
+
+
+__all__ = ["ABI_VERSION", "capabilities", "paged_decode", "shutdown"]

--- a/vllm_mlx/attention_backend.py
+++ b/vllm_mlx/attention_backend.py
@@ -1,0 +1,823 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention backend selection and the phase-one context backend contract.
+
+The Metal Context Engine is intentionally opt-in while its native implementation
+is being qualified.  This module is kept importable on every platform and does
+not import MLX or the optional native extension until a caller asks for the
+corresponding capability probe/oracle.
+
+There are two deliberately separate surfaces here:
+
+* :func:`resolve_attention_backend` is the process-startup dispatch decision.
+  ``mlx`` is the safe default, ``auto`` is conservative MLX routing until a
+  qualified matrix is recorded, and an explicit ``metal-context`` request is a
+  hard capability error rather than a silent fallback.
+* :class:`ContextBackend` is the narrow runtime contract that the native page
+  runtime will implement in a later package.  It is not wired into a scheduler
+  in this phase.
+
+The NumPy and MLX helpers use one explicit paged tensor layout so that native
+kernel tests can compare identical inputs to a correctness oracle:
+
+* query: ``[batch, query_heads, head_dim]`` (one decode query per request)
+* key/value pages: ``[page, kv_heads, block_offset, head_dim]``
+* page table: ``[batch, logical_block]`` containing physical page indices
+* sequence lengths: ``[batch]``; only the first ``length`` tokens are read
+
+The native ABI may use a different physical layout internally, but its adapter
+must preserve these logical semantics at the Python boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+import importlib
+import math
+import platform as _platform
+import sys
+from typing import Any, NewType, Protocol, runtime_checkable
+
+ATTENTION_BACKEND_CHOICES = ("mlx", "metal-context", "auto")
+"""CLI values accepted by the serving interfaces."""
+
+NATIVE_EXTENSION_MODULE = "vllm_mlx._metal_context"
+"""Import path reserved for the optional compiled extension."""
+
+METAL_CONTEXT_ABI_VERSION = 1
+APPLE_SILICON_ARCHITECTURES = frozenset({"arm64", "aarch64"})
+
+
+class AttentionBackendName(str, Enum):
+    """Names understood by the serving configuration."""
+
+    MLX = "mlx"
+    METAL_CONTEXT = "metal-context"
+    AUTO = "auto"
+
+
+def _coerce_backend_name(value: str | AttentionBackendName) -> AttentionBackendName:
+    if isinstance(value, AttentionBackendName):
+        return value
+    try:
+        return AttentionBackendName(value.strip().lower())
+    except (AttributeError, ValueError) as exc:
+        choices = ", ".join(ATTENTION_BACKEND_CHOICES)
+        raise ValueError(
+            f"Unknown attention backend {value!r}; expected one of: {choices}"
+        ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapabilities:
+    """A serializable snapshot of native backend availability.
+
+    ``available`` means that the extension has passed its own capability probe
+    and advertises the phase-one ABI.  It is deliberately stricter than merely
+    being importable: a wheel can contain a native module that is not usable on
+    the current OS/device or was built against an incompatible ABI.
+
+    ``serving_ready`` is a separate gate.  Phase one ships the executable
+    kernel foundation before a scheduler-owned executor exists, so a native
+    module can be available for oracle/kernel tests while explicit serving
+    selection still fails closed.
+    """
+
+    platform: str
+    native_extension: bool
+    metal_device: bool
+    abi_version: int | None
+    available: bool
+    serving_ready: bool = False
+    reason: str | None = None
+    architecture: str = ""
+    # ``mlx`` never needs to import or probe the optional native module.  Keep
+    # that distinction visible to status consumers instead of representing an
+    # unprobed default as a failed capability probe.
+    probed: bool = False
+
+    def as_dict(self) -> dict[str, object]:
+        """Return status data safe to expose in health/status responses."""
+
+        return {
+            "platform": self.platform,
+            "native_extension": self.native_extension,
+            "metal_device": self.metal_device,
+            "abi_version": self.abi_version,
+            "available": self.available,
+            "serving_ready": self.serving_ready,
+            "reason": self.reason,
+            "architecture": self.architecture,
+            "probed": self.probed,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackendSelection:
+    """Result of resolving the requested backend at process startup."""
+
+    requested: AttentionBackendName
+    selected: AttentionBackendName
+    capabilities: BackendCapabilities
+    fallback_reason: str | None = None
+
+    @property
+    def is_fallback(self) -> bool:
+        """Whether the requested value did not become the selected backend."""
+
+        return self.requested is not self.selected
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a stable status representation."""
+
+        return {
+            "requested": self.requested.value,
+            "selected": self.selected.value,
+            "fallback": self.is_fallback,
+            "fallback_reason": self.fallback_reason,
+            "capabilities": self.capabilities.as_dict(),
+        }
+
+
+class AttentionBackendCapabilityError(RuntimeError):
+    """Raised when an explicitly requested backend cannot be used."""
+
+    def __init__(
+        self,
+        requested: AttentionBackendName,
+        capabilities: BackendCapabilities,
+    ) -> None:
+        self.requested = requested
+        self.capabilities = capabilities
+        reason = capabilities.reason
+        if not reason and capabilities.platform != "darwin":
+            reason = "the Metal Context backend requires macOS"
+        if (
+            not reason
+            and capabilities.architecture
+            and capabilities.architecture not in APPLE_SILICON_ARCHITECTURES
+        ):
+            reason = (
+                "the Metal Context backend requires Apple Silicon "
+                f"(found {capabilities.architecture})"
+            )
+        if not reason and capabilities.available and not capabilities.serving_ready:
+            reason = (
+                "the native kernel is available, but no serving executor is "
+                "registered yet"
+            )
+        reason = reason or "the required capability probe failed"
+        super().__init__(
+            "Attention backend 'metal-context' was explicitly requested but is "
+            f"unavailable: {reason}. Install a vllm-mlx build with the optional "
+            f"{NATIVE_EXTENSION_MODULE} extension on supported Apple Silicon, "
+            "or select --attention-backend mlx."
+        )
+
+
+def _unprobed_capabilities() -> BackendCapabilities:
+    """Return the neutral capability snapshot used by the MLX default.
+
+    Selecting the established MLX backend does not require importing the
+    optional native extension.  In particular, this function intentionally
+    does not call :func:`discover_capabilities` so a normal installation stays
+    independent of the Metal build and its device probe.
+    """
+
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=None,
+        architecture="",
+        probed=False,
+    )
+
+
+def _unsupported_capabilities(reason: str) -> BackendCapabilities:
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=reason,
+        architecture=_platform.machine().lower(),
+        probed=True,
+    )
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def discover_capabilities() -> BackendCapabilities:
+    """Probe the optional native extension without importing MLX eagerly.
+
+    The extension exposes a zero-argument ``capabilities()`` function returning
+    a mapping.  Requiring that small ABI probe makes an importable but stale
+    extension fail closed instead of being treated as a usable backend.
+    """
+
+    if sys.platform != "darwin":
+        return _unsupported_capabilities(
+            f"the Metal Context backend requires macOS (current platform: {sys.platform})"
+        )
+
+    machine = _platform.machine().lower()
+    if machine not in APPLE_SILICON_ARCHITECTURES:
+        return _unsupported_capabilities(
+            "the Metal Context backend requires Apple Silicon "
+            f"(arm64/aarch64; current architecture: {machine or 'unknown'})"
+        )
+
+    try:
+        native = importlib.import_module(NATIVE_EXTENSION_MODULE)
+    except (ImportError, OSError) as exc:
+        detail = str(exc).strip() or exc.__class__.__name__
+        return _unsupported_capabilities(
+            f"the optional native extension could not be loaded: {detail}"
+        )
+
+    probe = getattr(native, "capabilities", None)
+    if not callable(probe):
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason=(
+                f"{NATIVE_EXTENSION_MODULE} does not expose the required "
+                "capabilities() ABI probe"
+            ),
+            architecture=machine,
+            probed=True,
+        )
+
+    try:
+        raw = probe()
+    except Exception as exc:  # native errors must become a precise status
+        detail = str(exc).strip() or exc.__class__.__name__
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason=f"the native capability probe failed: {detail}",
+            architecture=machine,
+            probed=True,
+        )
+
+    if not isinstance(raw, Mapping):
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason="the native capability probe returned a non-mapping result",
+            architecture=machine,
+            probed=True,
+        )
+
+    native_extension = bool(raw.get("compiled", True))
+    abi_version = _int_or_none(raw.get("abi_version"))
+    advertised = bool(raw.get("available", raw.get("supported", False)))
+    # Older phase-one native bridges use ``available`` as the result of a
+    # successful Metal device/pipeline probe but do not expose a separate
+    # metal_device field.  Preserve that ABI while still requiring a positive
+    # probe result; newer bridges can report the field explicitly.
+    metal_device = bool(raw.get("metal_device", advertised))
+    reasons: list[str] = []
+    if not native_extension:
+        reasons.append("the optional native extension is not compiled")
+    if not metal_device:
+        reasons.append("no usable Metal device was reported")
+    if abi_version != METAL_CONTEXT_ABI_VERSION:
+        reasons.append(
+            f"native ABI {abi_version!r} does not match required ABI "
+            f"{METAL_CONTEXT_ABI_VERSION}"
+        )
+    if not advertised:
+        native_reason = raw.get("reason")
+        if isinstance(native_reason, str) and native_reason.strip():
+            reasons.append(native_reason.strip())
+        else:
+            reasons.append("the native extension did not advertise availability")
+    serving_ready = bool(raw.get("serving_ready", raw.get("executor_available", False)))
+    if not serving_ready:
+        reasons.append(
+            "the native kernel is not serving-ready; the Metal Context executor "
+            "has not been integrated and qualified"
+        )
+
+    available = metal_device and abi_version == METAL_CONTEXT_ABI_VERSION and advertised
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=native_extension,
+        metal_device=metal_device,
+        abi_version=abi_version,
+        available=available,
+        serving_ready=serving_ready,
+        reason=(
+            None if available and serving_ready else "; ".join(dict.fromkeys(reasons))
+        ),
+        architecture=machine,
+        probed=True,
+    )
+
+
+def resolve_attention_backend(
+    requested: str | AttentionBackendName = AttentionBackendName.MLX,
+    *,
+    capabilities: BackendCapabilities | None = None,
+) -> BackendSelection:
+    """Resolve a serving request without silently enabling an unqualified path.
+
+    ``auto`` intentionally selects MLX even when the extension is present.  A
+    later qualification patch can add an explicit matrix gate while preserving
+    this function's startup/error contract.
+    """
+
+    name = _coerce_backend_name(requested)
+
+    # MLX is the established default and must remain independent of the
+    # optional native extension.  A caller that already has a capability
+    # snapshot may attach it for status/debugging, but the default path never
+    # performs a probe or imports the native module.
+    if name is AttentionBackendName.MLX:
+        caps = capabilities if capabilities is not None else _unprobed_capabilities()
+        return BackendSelection(
+            requested=name,
+            selected=AttentionBackendName.MLX,
+            capabilities=caps,
+        )
+
+    # ``auto`` may probe conservatively so it can report why Metal was not
+    # selected.  Explicit ``metal-context`` also probes here, then fails with
+    # a precise capability error if the serving executor is unavailable.
+    caps = capabilities if capabilities is not None else discover_capabilities()
+
+    if name is AttentionBackendName.METAL_CONTEXT:
+        if (
+            caps.platform != "darwin"
+            or (
+                caps.architecture
+                and caps.architecture not in APPLE_SILICON_ARCHITECTURES
+            )
+            or not caps.available
+            or not caps.serving_ready
+        ):
+            raise AttentionBackendCapabilityError(name, caps)
+        return BackendSelection(
+            requested=name,
+            selected=name,
+            capabilities=caps,
+        )
+
+    if name is AttentionBackendName.AUTO:
+        return BackendSelection(
+            requested=name,
+            selected=AttentionBackendName.MLX,
+            capabilities=caps,
+            fallback_reason=(
+                "automatic Metal Context routing is disabled until the explicit "
+                "qualification matrix passes; using the MLX correctness path"
+            ),
+        )
+
+    raise AssertionError(f"unhandled attention backend {name!r}")
+
+
+def validate_attention_backend(
+    requested: str | AttentionBackendName,
+    *,
+    capabilities: BackendCapabilities | None = None,
+) -> BackendSelection:
+    """Compatibility alias emphasizing startup validation at call sites."""
+
+    return resolve_attention_backend(requested, capabilities=capabilities)
+
+
+@dataclass(frozen=True, slots=True)
+class AttentionGeometry:
+    """Phase-one geometry accepted by a concrete context backend."""
+
+    num_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int = 128
+    block_size: int = 16
+    kv_dtype: str = "bfloat16"
+
+    def validate(self) -> None:
+        """Reject shapes outside the initial Qwen dense/MoE qualification scope."""
+
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+        if self.num_attention_heads <= 0 or self.num_key_value_heads <= 0:
+            raise ValueError("attention head counts must be positive")
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError(
+                "num_attention_heads must be divisible by num_key_value_heads for GQA"
+            )
+        if self.head_dim != 128:
+            raise ValueError("Metal Context v1 supports head_dim=128 only")
+        if self.block_size not in (16, 32):
+            raise ValueError("Metal Context v1 supports block_size 16 or 32 only")
+        if self.kv_dtype.lower() not in {"bfloat16", "bf16"}:
+            raise ValueError("Metal Context v1 supports BF16 K/V pages only")
+
+
+RequestHandle = NewType("RequestHandle", int)
+PageHandle = NewType("PageHandle", int)
+PrefixHandle = NewType("PrefixHandle", int)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotMetadata:
+    """Opaque metadata returned by a future snapshot implementation."""
+
+    identity: str
+    page_count: int
+    token_count: int
+    content_hash: str
+
+
+@runtime_checkable
+class ContextBackend(Protocol):
+    """Narrow lifecycle contract for the native context runtime.
+
+    Implementations own page-table and command-queue state.  The protocol is
+    intentionally free of scheduler/request-output types so it can be tested
+    independently before a production executor is introduced.
+    """
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        pass
+
+    def validate(self, geometry: AttentionGeometry) -> None:
+        pass
+
+    def allocate_request(self, request_id: str, *, max_tokens: int) -> RequestHandle:
+        pass
+
+    def allocate_pages(
+        self, request: RequestHandle, count: int
+    ) -> tuple[PageHandle, ...]:
+        pass
+
+    def append_kv(
+        self,
+        request: RequestHandle,
+        layer: int,
+        keys: Any,
+        values: Any,
+    ) -> None:
+        pass
+
+    def paged_decode_attention(
+        self, request: RequestHandle, layer: int, query: Any
+    ) -> Any:
+        pass
+
+    def attach_prefix(self, request: RequestHandle, prefix: PrefixHandle) -> None:
+        pass
+
+    def fork_prefix(self, prefix: PrefixHandle) -> PrefixHandle:
+        pass
+
+    def release(self, request: RequestHandle) -> None:
+        pass
+
+    def evict(self, *, target_pages: int | None = None) -> int:
+        pass
+
+    def snapshot(self, prefix: PrefixHandle, *, destination: str) -> SnapshotMetadata:
+        pass
+
+    def restore(self, source: str) -> PrefixHandle:
+        pass
+
+    def metrics(self) -> Mapping[str, int | float | str | None]:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _as_numpy(value: Any) -> Any:
+    """Import NumPy lazily and provide a helpful dependency error."""
+
+    try:
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover - numpy is a project dependency
+        raise RuntimeError("NumPy is required for the attention oracle") from exc
+    return np.asarray(value)
+
+
+def _float32_values(value: Any) -> Any:
+    """Normalize numeric oracle tensors, including native BF16 bit storage."""
+
+    import numpy as np
+
+    array = _as_numpy(value)
+    if array.dtype == np.uint16:
+        # The optional native ABI represents BF16 values as the high 16 bits
+        # of an IEEE float32.  Accepting that representation here lets native
+        # tests compare exactly the same buffers against the reference.
+        return (array.astype(np.uint32) << 16).view(np.float32)
+    return array.astype(np.float32, copy=False)
+
+
+def _mlx_uint16_array(value: Any, mx: Any) -> bool:
+    """Identify MLX arrays carrying the native BF16-bit representation."""
+
+    dtype = getattr(value, "dtype", None)
+    uint16_dtype = getattr(mx, "uint16", None)
+    if uint16_dtype is not None and dtype == uint16_dtype:
+        return True
+    normalized = str(dtype).lower().replace(" ", "")
+    return normalized in {"uint16", "uint16_t"}
+
+
+def _normalize_mlx_input(value: Any, normalized_numpy: Any, mx: Any) -> Any:
+    """Decode native BF16 bits before passing an MLX array to SDPA."""
+
+    if isinstance(value, mx.array):
+        if _mlx_uint16_array(value, mx):
+            # _float32_values interprets uint16 as the upper half of float32.
+            return mx.array(_float32_values(value))
+        return value
+    return mx.array(normalized_numpy)
+
+
+def _validate_paged_inputs(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None,
+) -> tuple[Any, Any, Any, Any, Any, int]:
+    """Validate and normalize oracle input metadata."""
+
+    import numpy as np
+
+    q = _float32_values(query)
+    k = _float32_values(key_pages)
+    v = _float32_values(value_pages)
+    table = _as_numpy(page_table)
+    lengths = _as_numpy(sequence_lengths)
+    if q.ndim != 3:
+        raise ValueError("query must have shape [batch, query_heads, head_dim]")
+    if k.ndim != 4 or v.ndim != 4:
+        raise ValueError(
+            "key_pages and value_pages must have shape "
+            "[page, kv_heads, block, head_dim]"
+        )
+    if k.shape != v.shape:
+        raise ValueError("key_pages and value_pages must have identical shapes")
+    if table.ndim != 2 or lengths.ndim != 1 or table.shape[0] != q.shape[0]:
+        raise ValueError(
+            "page_table/sequence_lengths batch dimensions do not match query"
+        )
+    if lengths.shape[0] != q.shape[0]:
+        raise ValueError("sequence_lengths batch dimension does not match query")
+    if k.shape[2] != block_size:
+        raise ValueError("page tensors do not match block_size")
+    if k.shape[1] <= 0 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("attention head counts and head_dim must be positive")
+    if q.shape[2] != k.shape[3]:
+        raise ValueError("query and page head_dim values do not match")
+    if num_kv_heads is not None and k.shape[1] != num_kv_heads:
+        raise ValueError("page tensor kv head count does not match num_kv_heads")
+    if q.shape[1] % k.shape[1]:
+        raise ValueError("query heads must be divisible by KV heads for GQA")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if not np.issubdtype(table.dtype, np.integer):
+        raise ValueError("page_table must contain integer page indices")
+    if not np.issubdtype(lengths.dtype, np.integer):
+        raise ValueError("sequence_lengths must contain integer lengths")
+    if np.any(lengths < 0):
+        raise ValueError("sequence_lengths cannot be negative")
+    max_tokens = table.shape[1] * block_size
+    if np.any(lengths > max_tokens):
+        raise ValueError("sequence_lengths exceed the page table capacity")
+    if not (np.isfinite(q).all() and np.isfinite(k).all() and np.isfinite(v).all()):
+        raise ValueError(
+            "query, key_pages, and value_pages must contain only finite values"
+        )
+    return q, k, v, table, lengths, k.shape[1]
+
+
+def numpy_paged_decode_attention(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None = None,
+    scale: float | None = None,
+) -> Any:
+    """Compute one-token paged decode attention with a NumPy reference.
+
+    The implementation gathers only the valid tail of each logical sequence,
+    checks every physical page index, and computes a stable softmax in float32.
+    It is a correctness oracle, not a serving implementation.
+    """
+
+    import numpy as np
+
+    q, k, v, table, lengths, kv_heads = _validate_paged_inputs(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+    )
+    batch, query_heads, head_dim = q.shape
+    scale_value = 1.0 / math.sqrt(head_dim) if scale is None else float(scale)
+    output = np.zeros((batch, query_heads, head_dim), dtype=np.float32)
+    group_size = query_heads // kv_heads
+    page_count = k.shape[0]
+
+    for batch_index in range(batch):
+        sequence_length = int(lengths[batch_index])
+        if sequence_length == 0:
+            continue
+
+        logical_blocks = (sequence_length + block_size - 1) // block_size
+        page_ids = table[batch_index, :logical_blocks]
+        if np.any(page_ids < 0) or np.any(page_ids >= page_count):
+            raise ValueError("page_table contains a physical page outside page tensors")
+
+        keys = np.empty((sequence_length, kv_heads, head_dim), dtype=np.float32)
+        values = np.empty_like(keys)
+        cursor = 0
+        for logical_block, page_id_value in enumerate(page_ids):
+            page_id = int(page_id_value)
+            tokens = min(block_size, sequence_length - cursor)
+            keys[cursor : cursor + tokens] = np.transpose(
+                k[page_id, :, :tokens], (1, 0, 2)
+            )
+            values[cursor : cursor + tokens] = np.transpose(
+                v[page_id, :, :tokens], (1, 0, 2)
+            )
+            cursor += tokens
+
+        query_row = q[batch_index].astype(np.float32, copy=False)
+        for query_head in range(query_heads):
+            kv_head = query_head // group_size
+            with np.errstate(over="ignore", invalid="ignore"):
+                logits = (keys[:, kv_head] @ query_row[query_head]) * scale_value
+            if not np.isfinite(logits).all():
+                raise ValueError("attention logits overflow for finite float32 inputs")
+            max_logit = np.max(logits)
+            weights = np.exp(logits - max_logit)
+            denominator = np.sum(weights, dtype=np.float64)
+            if not np.isfinite(denominator) or denominator <= 0:
+                raise ValueError("attention softmax denominator is not finite")
+            weights /= denominator
+            output[batch_index, query_head] = weights @ values[:, kv_head]
+
+    return output
+
+
+def mlx_sdpa_paged_decode_attention(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None = None,
+    scale: float | None = None,
+) -> Any:
+    """Run the same paged inputs through MLX's SDPA implementation.
+
+    MLX SDPA uses ``[batch, heads, sequence, head_dim]``.  This adapter gathers
+    each non-contiguous logical sequence and invokes SDPA one request at a time,
+    explicitly expanding grouped KV heads to the query-head count.  That keeps
+    GQA semantics identical to the NumPy oracle and avoids relying on an
+    MLX-version-specific implicit GQA broadcast.
+    """
+
+    try:
+        import mlx.core as mx
+    except ImportError as exc:  # pragma: no cover - exercised on non-Apple CI
+        raise RuntimeError("MLX is required for the MLX SDPA attention oracle") from exc
+
+    q_np, _k_np, _v_np, table_np, lengths_np, _ = _validate_paged_inputs(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+    )
+    q = _normalize_mlx_input(query, q_np, mx)
+    k_pages = _normalize_mlx_input(key_pages, _k_np, mx)
+    v_pages = _normalize_mlx_input(value_pages, _v_np, mx)
+    batch, query_heads, head_dim = q_np.shape
+    scale_value = 1.0 / math.sqrt(head_dim) if scale is None else float(scale)
+    outputs = []
+
+    for batch_index in range(batch):
+        sequence_length = int(lengths_np[batch_index])
+        if sequence_length == 0:
+            outputs.append(mx.zeros((query_heads, head_dim), dtype=q.dtype))
+            continue
+        logical_blocks = (sequence_length + block_size - 1) // block_size
+        page_ids = table_np[batch_index, :logical_blocks]
+        if (page_ids < 0).any() or (page_ids >= int(k_pages.shape[0])).any():
+            raise ValueError("page_table contains a physical page outside page tensors")
+        key_parts = []
+        value_parts = []
+        cursor = 0
+        for page_id_value in page_ids:
+            page_id = int(page_id_value)
+            tokens = min(block_size, sequence_length - cursor)
+            key_parts.append(mx.transpose(k_pages[page_id, :, :tokens], (1, 0, 2)))
+            value_parts.append(mx.transpose(v_pages[page_id, :, :tokens], (1, 0, 2)))
+            cursor += tokens
+        keys = mx.concatenate(key_parts, axis=0)
+        values = mx.concatenate(value_parts, axis=0)
+
+        # MLX SDPA's explicit layout is [batch, heads, sequence, head_dim].
+        q_arg = q[batch_index][None, :, None, :]
+        k_heads = mx.transpose(keys, (1, 0, 2))
+        v_heads = mx.transpose(values, (1, 0, 2))
+        if query_heads != int(k_heads.shape[0]):
+            group_size = query_heads // int(k_heads.shape[0])
+            # Repeat each KV head contiguously: q0/q1 use kv0, q2/q3 use
+            # kv1 for the common 4-query-head/2-KV-head GQA shape.
+            k_heads = mx.concatenate(
+                [
+                    k_heads[index : index + 1]
+                    for index in range(int(k_heads.shape[0]))
+                    for _ in range(group_size)
+                ],
+                axis=0,
+            )
+            v_heads = mx.concatenate(
+                [
+                    v_heads[index : index + 1]
+                    for index in range(int(v_heads.shape[0]))
+                    for _ in range(group_size)
+                ],
+                axis=0,
+            )
+        k_arg = k_heads[None, :, :, :]
+        v_arg = v_heads[None, :, :, :]
+        attended = mx.fast.scaled_dot_product_attention(
+            q_arg,
+            k_arg,
+            v_arg,
+            scale=scale_value,
+        )
+        outputs.append(attended[0, :, 0, :])
+
+    return mx.stack(outputs) if outputs else mx.zeros((0, query_heads, head_dim))
+
+
+__all__ = [
+    "APPLE_SILICON_ARCHITECTURES",
+    "ATTENTION_BACKEND_CHOICES",
+    "AttentionBackendCapabilityError",
+    "AttentionBackendName",
+    "AttentionGeometry",
+    "BackendCapabilities",
+    "BackendSelection",
+    "ContextBackend",
+    "METAL_CONTEXT_ABI_VERSION",
+    "NATIVE_EXTENSION_MODULE",
+    "PageHandle",
+    "PrefixHandle",
+    "RequestHandle",
+    "SnapshotMetadata",
+    "discover_capabilities",
+    "mlx_sdpa_paged_decode_attention",
+    "numpy_paged_decode_attention",
+    "resolve_attention_backend",
+    "validate_attention_backend",
+]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -22,6 +22,11 @@ from .cli_arg_types import (
     make_positive_int_arg_parser,
     memory_budget_gb_arg,
 )
+from .attention_backend import (
+    ATTENTION_BACKEND_CHOICES,
+    AttentionBackendCapabilityError,
+    resolve_attention_backend,
+)
 from .tool_parsers import ToolParserManager
 
 _TOOL_PARSER_CHOICES = ToolParserManager.list_registered()
@@ -52,14 +57,39 @@ def serve_command(args):
     import os
     import sys
 
+    logger = logging.getLogger(__name__)
+    requested_attention_backend = getattr(args, "attention_backend", "mlx")
+    try:
+        attention_backend = resolve_attention_backend(requested_attention_backend)
+    except AttentionBackendCapabilityError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     import uvicorn
 
-    # Import unified server
+    # Import unified server only after the explicit backend capability check.
     from . import server
     from .model_registry import RegistryServeDefaults
     from .server import RateLimiter, app, load_model, load_model_registry
 
-    logger = logging.getLogger(__name__)
+    # Selection is deliberately separate from scheduler construction.  The
+    # native context runtime is opt-in and its executor is introduced by a
+    # later package; recording the validated selection now makes startup
+    # behavior explicit without changing the MLX execution path.
+    server.configure_attention_backend(attention_backend)
+    if attention_backend.fallback_reason:
+        logger.info(
+            "Attention backend: requested=%s selected=%s (%s)",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+            attention_backend.fallback_reason,
+        )
+    else:
+        logger.info(
+            "Attention backend: requested=%s selected=%s",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+        )
     model_arg = getattr(args, "model", None)
     models_config = getattr(args, "models_config", None)
     memory_budget_gb = getattr(args, "memory_budget_gb", None)
@@ -1090,6 +1120,17 @@ Examples:
         help="Host to bind (default: localhost; use 0.0.0.0 to expose externally)",
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    serve_parser.add_argument(
+        "--attention-backend",
+        type=str,
+        choices=ATTENTION_BACKEND_CHOICES,
+        default="mlx",
+        help=(
+            "Attention execution backend: mlx (default), metal-context "
+            "(explicit opt-in; requires the compiled native extension), or "
+            "auto (currently remains on mlx until qualification passes)."
+        ),
+    )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"
     )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -159,6 +159,12 @@ from .cli_arg_types import (
     make_json_object_arg_parser,
     make_positive_int_arg_parser,
 )
+from .attention_backend import (
+    ATTENTION_BACKEND_CHOICES,
+    AttentionBackendCapabilityError,
+    BackendSelection,
+    resolve_attention_backend,
+)
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
 from .endpoint_model_policies import (
     resolve_embedding_model_name,
@@ -209,6 +215,10 @@ _default_min_p: float | None = None  # Set via --default-min-p
 _default_presence_penalty: float | None = None  # Set via --default-presence-penalty
 _default_repetition_penalty: float | None = None  # Set via --default-repetition-penalty
 _metrics_enabled = False
+# Backend selection is configured during CLI startup.  Keeping this separate
+# from the scheduler preserves the existing MLX route until a qualified native
+# executor is introduced.
+_attention_backend_selection: BackendSelection | None = None
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
 _force_mllm_model: bool = False
@@ -228,6 +238,34 @@ _FALLBACK_TOP_K = 0
 _FALLBACK_MIN_P = 0.0
 _FALLBACK_PRESENCE_PENALTY = 0.0
 _FALLBACK_REPETITION_PENALTY = 1.0
+
+
+def configure_attention_backend(selection: BackendSelection) -> None:
+    """Record the startup backend decision for status and future executors."""
+
+    if selection.selected.value == "metal-context" and (
+        not selection.capabilities.available or not selection.capabilities.serving_ready
+    ):
+        raise AttentionBackendCapabilityError(
+            selection.selected, selection.capabilities
+        )
+    global _attention_backend_selection
+    _attention_backend_selection = selection
+
+
+def _attention_backend_status() -> dict[str, object]:
+    """Return backend selection without probing or changing runtime state."""
+
+    selection = _attention_backend_selection
+    if selection is None:
+        return {
+            "requested": "mlx",
+            "selected": "mlx",
+            "fallback": False,
+            "fallback_reason": None,
+            "capabilities": None,
+        }
+    return selection.as_dict()
 
 
 def _resolve_temperature(request_value: float | None) -> float:
@@ -3613,6 +3651,7 @@ async def health():
             else "llm"
         ),
         "engine_type": engine_stats.get("engine_type", "unknown"),
+        "attention_backend": _attention_backend_status(),
         "mcp": mcp_info,
     }
     if lifecycle is not None:
@@ -3663,6 +3702,7 @@ async def status():
                 "models": _model_manager.list_models(),
             },
             "embedding": _embedding_status(),
+            "attention_backend": _attention_backend_status(),
         }
     lifecycle = _public_lifecycle_status(_get_lifecycle_status())
     if _engine is None:
@@ -3672,6 +3712,7 @@ async def status():
             "residency": lifecycle,
             "requests": [],
             "embedding": _embedding_status(),
+            "attention_backend": _attention_backend_status(),
         }
 
     stats = _engine.get_stats()
@@ -3684,6 +3725,7 @@ async def status():
         "model": _model_name,
         "residency": lifecycle,
         "embedding": _embedding_status(),
+        "attention_backend": _attention_backend_status(),
         "uptime_s": round(stats.get("uptime_seconds", 0), 1),
         "steps_executed": stats.get("steps_executed", 0),
         "num_running": stats.get("num_running", 0),
@@ -6848,6 +6890,27 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
 
+    try:
+        attention_backend = resolve_attention_backend(
+            getattr(args, "attention_backend", "mlx")
+        )
+    except AttentionBackendCapabilityError as exc:
+        parser.error(str(exc))
+    configure_attention_backend(attention_backend)
+    if attention_backend.fallback_reason:
+        logger.info(
+            "Attention backend: requested=%s selected=%s (%s)",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+            attention_backend.fallback_reason,
+        )
+    else:
+        logger.info(
+            "Attention backend: requested=%s selected=%s",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+        )
+
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
     global _default_temperature, _default_top_p, _default_chat_template_kwargs
@@ -6997,6 +7060,17 @@ Examples:
         type=int,
         default=8000,
         help="Port to bind to",
+    )
+    parser.add_argument(
+        "--attention-backend",
+        type=str,
+        choices=ATTENTION_BACKEND_CHOICES,
+        default="mlx",
+        help=(
+            "Attention execution backend: mlx (default), metal-context "
+            "(explicit opt-in; requires the compiled native extension), or "
+            "auto (currently remains on mlx until qualification passes)."
+        ),
     )
     parser.add_argument(
         "--mllm",


### PR DESCRIPTION
## Summary

Introduces the first, deliberately non-serving slice of the Metal Context Engine:

- optional Objective-C++/Metal extension and precompiled metallib build path;
- BF16 paged-decode attention kernel for Qwen-style GQA, head dimension 128, block sizes 16/32, noncontiguous page tables, and partial tail blocks;
- narrow Python backend/capability contract plus NumPy and MLX SDPA correctness oracles;
- `--attention-backend mlx|metal-context|auto`, with `mlx` still the default, `auto` conservatively selecting MLX, and explicit `metal-context` failing closed until an executor is integrated;
- backend status in health/status output;
- source-distribution and Apple Silicon native-build validation.

This does **not** replace the scheduler, own production KV pages, or claim a serving speedup. The native bridge currently copies host buffers and reports `serving_ready=false`; scheduler/page-runtime integration belongs in later PRs.

## Safety and unsupported configurations

The kernel rejects non-Apple-Silicon environments, incompatible ABI, missing/corrupt metallibs, non-native buffer formats, malformed dimensions, invalid page tables, non-finite or overflow-risk inputs, head dimensions other than 128, block sizes other than 16/32, and non-BF16 K/V storage. Existing pure-Python/MLX installations remain functional without compiling the extension.

## Verification

- Full local suite: `2687 passed, 30 skipped, 27 deselected`
- Focused backend/native surface: `32 passed, 5 skipped`
- Ruff, Black, type check, and `git diff --check`: pass
- source distribution contains the native source, shader, build script, and tests
- Objective-C++ host syntax check: pass
- two Luna Max adversarial review cycles plus post-fix verification; final verdict: `SHIP`
- GitHub CI: all jobs green on Python 3.10–3.13, including strict native/metallib compilation on arm64 macOS

GitHub's hosted arm64 macOS workers do not expose a Metal device, so capability probing correctly fails closed there after compilation. Actual GPU numerical dispatch remains a required device/self-hosted qualification before any serving integration or performance claim. Capacity/performance artifacts begin when a serving path exists and will use the capacity-envelope schema from #720 (or its accepted successor).

## Stack

1. This PR: native kernel and ABI foundation
2. Page runtime
3. Dense executor
4. Concurrency and Qwen3 MoE
5. Persistence and tiering
6. Automatic dispatch and packaging qualification

Please do not merge yet: this is a draft for architectural review. Wayner retains final architectural and merge approval.
