### PR TITLE
feat: add native Metal context page runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,13 @@ jobs:
           assert platform.machine() == "arm64"
           capabilities = _metal_context.capabilities()
           assert capabilities.get("compiled") is True, capabilities
-          assert capabilities.get("available") is True, capabilities
+          # GitHub's arm64 macOS hosts expose the Apple toolchain but may not
+          # expose a Metal device to jobs.  Compilation is mandatory here;
+          # dispatch tests run when a device is actually present and otherwise
+          # must report the precise fail-closed reason.
+          if not capabilities.get("available"):
+              assert capabilities.get("metal_device") is False, capabilities
+              assert "no GPU" in capabilities.get("reason", ""), capabilities
           print("Metal Context native capability:", capabilities)
           PY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,19 @@ jobs:
           required = {
               "native/metal_context/kernels/paged_decode.metal",
               "native/metal_context/src/python_module.mm",
+              "native/metal_context/src/page_runtime.hpp",
+              "native/metal_context/src/page_runtime.mm",
+              "native/metal_context/src/page_runtime_python.mm",
+              "native/metal_context/tests/page_runtime_offset_test.mm",
+              "native/metal_context/tests/page_runtime_fork_stress_test.mm",
+              "native/metal_context/tests/page_runtime_concurrency_test.mm",
               "native/metal_context/README.md",
               "scripts/build_metal_context.py",
+              "docs/metal-context-page-runtime.md",
               "tests/test_attention_backend.py",
               "tests/test_metal_context_native.py",
+              "tests/test_metal_context_page_runtime.py",
+              "vllm_mlx/metal_context_runtime.py",
           }
           missing = {
               path for path in required if not any(name.endswith(path) for name in names)
@@ -186,12 +195,54 @@ jobs:
           print("Metal Context native capability:", capabilities)
           PY
 
+      - name: Verify native page-runtime metadata offset helper
+        run: |
+          SDK=$(xcrun --sdk macosx --show-sdk-path)
+          xcrun --sdk macosx clang++ \
+            -std=c++17 -fobjc-arc -mmacosx-version-min=11.0 \
+            -isysroot "$SDK" \
+            -Inative/metal_context/src \
+            native/metal_context/src/page_runtime.mm \
+            native/metal_context/tests/page_runtime_offset_test.mm \
+            -framework Metal -framework Foundation \
+            -o /tmp/vllm-mlx-page-runtime-offset-test
+          /tmp/vllm-mlx-page-runtime-offset-test
+
+      - name: Run native prefix fork ASAN stress harness
+        run: |
+          SDK=$(xcrun --sdk macosx --show-sdk-path)
+          xcrun --sdk macosx clang++ \
+            -std=c++17 -fobjc-arc -fsanitize=address \
+            -fno-omit-frame-pointer -mmacosx-version-min=11.0 \
+            -isysroot "$SDK" \
+            -Inative/metal_context/src \
+            native/metal_context/src/page_runtime.mm \
+            native/metal_context/tests/page_runtime_fork_stress_test.mm \
+            -framework Metal -framework Foundation \
+            -o /tmp/vllm-mlx-page-runtime-fork-stress
+          ASAN_OPTIONS=detect_leaks=0 /tmp/vllm-mlx-page-runtime-fork-stress
+
+      - name: Run native PageRuntime lock-order ASAN stress harness
+        run: |
+          SDK=$(xcrun --sdk macosx --show-sdk-path)
+          xcrun --sdk macosx clang++ \
+            -std=c++17 -fobjc-arc -fsanitize=address \
+            -fno-omit-frame-pointer -mmacosx-version-min=11.0 \
+            -isysroot "$SDK" \
+            -Inative/metal_context/src \
+            native/metal_context/src/page_runtime.mm \
+            native/metal_context/tests/page_runtime_concurrency_test.mm \
+            -framework Metal -framework Foundation \
+            -o /tmp/vllm-mlx-page-runtime-concurrency
+          ASAN_OPTIONS=detect_leaks=0 /tmp/vllm-mlx-page-runtime-concurrency
+
       - name: Run MLX-dependent tests
         run: |
           pytest \
             tests/test_platform.py \
             tests/test_attention_backend.py \
             tests/test_metal_context_native.py \
+            tests/test_metal_context_page_runtime.py \
             tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,33 @@ jobs:
       - name: Run black
         run: black --check vllm_mlx/ tests/
 
+      - name: Verify native source distribution manifest
+        run: |
+          pip install build
+          rm -rf /tmp/vllm-mlx-sdist
+          python -m build --sdist --outdir /tmp/vllm-mlx-sdist
+          python - <<'PY'
+          import glob
+          import tarfile
+
+          archive = glob.glob("/tmp/vllm-mlx-sdist/*.tar.gz")
+          assert len(archive) == 1, archive
+          with tarfile.open(archive[0], "r:gz") as source:
+              names = source.getnames()
+          required = {
+              "native/metal_context/kernels/paged_decode.metal",
+              "native/metal_context/src/python_module.mm",
+              "native/metal_context/README.md",
+              "scripts/build_metal_context.py",
+              "tests/test_attention_backend.py",
+              "tests/test_metal_context_native.py",
+          }
+          missing = {
+              path for path in required if not any(name.endswith(path) for name in names)
+          }
+          assert not missing, f"sdist is missing: {sorted(missing)}"
+          PY
+
   type-check:
     runs-on: ubuntu-latest
     steps:
@@ -63,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests
+          pip install pytest anyio pytest-cov pydantic fastapi jsonschema httpx psutil transformers requests numpy
 
       - name: Run unit tests (no MLX required)
         run: |
@@ -89,6 +116,7 @@ jobs:
             tests/test_endpoint_model_policies.py \
             tests/test_truncation.py \
             tests/test_cli_arg_types.py \
+            tests/test_attention_backend.py \
             tests/test_gemma4_openai_format.py \
             tests/test_gemma4_streaming_edge.py \
             tests/test_gemma4_tool_parser.py \
@@ -128,6 +156,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install project and dependencies
+        env:
+          VLLM_MLX_BUILD_METAL_CONTEXT: "1"
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,vision,harmony]"
@@ -137,10 +167,25 @@ jobs:
           python -c "import platform; assert platform.machine() == 'arm64', 'Not ARM64'"
           python -c "import mlx.core as mx; print(f'MLX OK: {mx.default_device()}')"
 
+      - name: Verify strict native Metal build
+        run: |
+          python - <<'PY'
+          import platform
+          from vllm_mlx import _metal_context
+
+          assert platform.machine() == "arm64"
+          capabilities = _metal_context.capabilities()
+          assert capabilities.get("compiled") is True, capabilities
+          assert capabilities.get("available") is True, capabilities
+          print("Metal Context native capability:", capabilities)
+          PY
+
       - name: Run MLX-dependent tests
         run: |
           pytest \
             tests/test_platform.py \
+            tests/test_attention_backend.py \
+            tests/test_metal_context_native.py \
             tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,10 +5,13 @@ include pyproject.toml
 include setup.py
 
 # Optional Metal Context Engine source distribution inputs.
-recursive-include native/metal_context *.metal *.mm *.md
+recursive-include native/metal_context *.metal *.mm *.hpp *.md
 include scripts/build_metal_context.py
 
 # Keep the portable/native foundation regression tests available to downstream
 # source checkouts without broadening the package's installed data files.
 include tests/test_attention_backend.py
 include tests/test_metal_context_native.py
+include tests/test_metal_context_page_runtime.py
+include docs/metal-context-page-runtime.md
+include vllm_mlx/metal_context_runtime.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include LICENSE
+include README.md
+include MANIFEST.in
+include pyproject.toml
+include setup.py
+
+# Optional Metal Context Engine source distribution inputs.
+recursive-include native/metal_context *.metal *.mm *.md
+include scripts/build_metal_context.py
+
+# Keep the portable/native foundation regression tests available to downstream
+# source checkouts without broadening the package's installed data files.
+include tests/test_attention_backend.py
+include tests/test_metal_context_native.py

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ export ANTHROPIC_API_KEY=not-needed
 claude
 ```
 
+### Optional Metal Context foundation
+
+The normal package and editable installs keep the experimental compiled Metal
+Context foundation disabled.  This preserves the portable MLX path and avoids
+silently requiring an Xcode/Metal toolchain.  On an Apple Silicon Mac with
+Xcode installed, opt in explicitly when building from source:
+
+```bash
+VLLM_MLX_BUILD_METAL_CONTEXT=1 python -m pip install -e .
+```
+
+The strict build rejects non-Apple-Silicon hosts or missing Metal tools.  The
+foundation currently provides a validated kernel/oracle surface only; it is
+not a qualified serving executor.  Keep `--attention-backend mlx` (the
+default), or use `auto` while qualification is pending.  An explicit
+`--attention-backend metal-context` request fails closed until the executor is
+integrated and qualified.
+
 ## Features
 
 ### APIs

--- a/docs/metal-context-page-runtime.md
+++ b/docs/metal-context-page-runtime.md
@@ -1,0 +1,52 @@
+# Metal Context page runtime
+
+This package adds the ownership layer below the future serving executor. It is
+not a scheduler and it is not enabled by `--attention-backend` yet.
+
+`vllm_mlx.metal_context_runtime.MetalContextPageRuntime` owns a preallocated
+BF16 KV page pool with one physical page layout shared across layers:
+
+```text
+[page, layer, kv_head, block_offset, head_dim]
+```
+
+The lifecycle boundary is deliberately small:
+
+- allocate request handles and physical pages;
+- append `[tokens, kv_heads, head_dim]` keys/values;
+- attach and fork immutable prefix page chains;
+- copy a shared page before a request writes to it;
+- release references and evict only unreferenced pages;
+- dispatch the phase-one native paged-decode kernel or the explicit NumPy
+  correctness mode;
+- maintain GPU-ready page tables/sequence lengths incrementally on lifecycle
+  mutations, so steady-state decode performs no CPU page-chain traversal;
+- report ownership, dispatch, preallocation/copy, metadata-byte, and bounded
+  attention-validation metrics (`dispatches`/`dispatch_failures`, with
+  truthful `native_*` and `oracle_*` aliases); and
+- tear down deterministically.
+
+Native execution is selected explicitly with `execution="native"`. It requires
+the compiled `_metal_context` extension's `PageRuntime` type, a matching ABI,
+and a usable Metal device. In this mode the Python class is only an adapter:
+allocation, KV ownership, prefix references, copy-on-write, eviction, metrics,
+decode, and teardown remain owned by the compiled runtime. Missing or stale
+capabilities raise `MetalContextCapabilityError`. Native dispatch failures are
+propagated; the runtime never silently switches to the NumPy oracle.
+`execution="numpy"` is a portable test mode and is not a serving fallback.
+
+Persistence is intentionally not part of this package. `snapshot()` and
+`restore()` raise `NotImplementedError` until the separate persistence/tiering
+package adds versioned identities, checksummed pages, tenant namespaces, and
+atomic manifests. No Python objects are serialized here.
+
+Prefix creation is only allowed after every supported layer has the same
+non-zero populated length. If `token_count` is supplied, it must equal that
+complete length in both NumPy and native modes; partial layer/page-chain
+prefixes are intentionally rejected until they have an explicit immutable
+ownership contract.
+
+The page runtime is currently not wired into the scheduler or serving
+defaults. Its focused lifecycle tests are in
+`tests/test_metal_context_page_runtime.py` and compare decode results with the
+shared NumPy/MLX oracle contract.

--- a/native/metal_context/README.md
+++ b/native/metal_context/README.md
@@ -1,0 +1,55 @@
+# Metal Context Engine native foundation
+
+This directory contains the optional phase-one native kernel package.  It is
+deliberately independent of the scheduler and page-owner implementation:
+
+* `kernels/paged_decode.metal` is a BF16, online-softmax paged decode kernel.
+  It accepts non-contiguous `int32` page tables, GQA, head dimension 128,
+  block sizes 16/32, and partial tail blocks.
+* `src/python_module.mm` is a small CPython/Metal bridge.  Its initial ABI
+  accepts contiguous host buffers containing BF16 bits as `uint16` buffers and
+  returns a float32 byte buffer.  The copies are intentionally visible; this
+  is a correctness/build foundation, not a serving-performance claim.
+* `scripts/build_metal_context.py` compiles the checked-in shader to a
+  `_metal_context.metallib`.  The optional setuptools hook packages that
+  library beside the extension.
+
+The logical page layout at this boundary is:
+
+```text
+query       [batch, query_heads, head_dim]
+key/value   [page, kv_heads, block_offset, head_dim]
+page_table  [batch, logical_block]
+seq_lens    [batch]
+```
+
+The host validates shapes, native-endian PEP-3118 formats, page bounds for
+every live token, finite BF16 data, conservative float32 dot/score bounds, and
+the supported geometry before allocating any Metal buffer.  Unused page table
+entries may be `-1`; live entries may not be.  The shader repeats the
+page-bound guard so a malformed low-level dispatch cannot read outside the
+page buffer, while the host remains responsible for surfacing the error.
+
+## Building
+
+Normal installs remain pure Python/MLX.  On a macOS/Xcode builder, opt in to
+the native build explicitly:
+
+```sh
+VLLM_MLX_BUILD_METAL_CONTEXT=1 python -m pip install -e .
+```
+
+The strict mode fails if the host is not Apple Silicon or
+`xcrun metal`/`xcrun metallib` is missing.  Normal installs leave the optional
+extension disabled; the fallback module then reports the exact reason and an
+explicit `metal-context` selection must fail closed.
+
+For a standalone library build:
+
+```sh
+python scripts/build_metal_context.py --output /tmp/_metal_context.metallib
+```
+
+The extension's `capabilities()` record is the source of truth for whether the
+device, ABI, and packaged library are usable.  A compiled extension is not a
+serving qualification or performance result.

--- a/native/metal_context/kernels/paged_decode.metal
+++ b/native/metal_context/kernels/paged_decode.metal
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The first Metal Context Engine kernel.  The host API intentionally keeps
+// the layout explicit so that the page runtime can validate every stride
+// before dispatching it.
+//
+// Inputs:
+//   query       [batch, query_heads, head_dim]       BF16 bits (ushort)
+//   key_pages   [pages, kv_heads, block_size, head_dim] BF16 bits
+//   value_pages [pages, kv_heads, block_size, head_dim] BF16 bits
+//   page_table  [batch, max_blocks]                 int32
+//   seq_lens    [batch]                             int32
+//
+// Output:
+//   output      [batch, query_heads, head_dim]       float32
+//
+// A threadgroup owns one (request, query-head) output vector.  The online
+// softmax state is updated token by token, so pages need not be physically
+// contiguous.  Query heads are mapped to KV heads by the GQA ratio.
+
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct PagedDecodeParams {
+  uint batch_size;
+  uint query_heads;
+  uint kv_heads;
+  uint head_dim;
+  uint block_size;
+  uint max_blocks;
+  uint page_count;
+  uint page_table_stride;
+  float scale;
+  uint reserved0;
+  uint reserved1;
+  uint reserved2;
+};
+
+// MLX stores BF16 as the IEEE-754 upper 16 bits of a float.  Keeping the
+// storage type as ushort avoids depending on the availability of the MSL
+// bfloat type on the oldest supported Apple GPU family.
+inline float bf16_to_float(ushort bits) {
+  return as_type<float>(uint(bits) << 16);
+}
+
+kernel void metal_context_paged_decode(
+    device const ushort* query [[buffer(0)]],
+    device const ushort* key_pages [[buffer(1)]],
+    device const ushort* value_pages [[buffer(2)]],
+    device const int* page_table [[buffer(3)]],
+    device const int* seq_lens [[buffer(4)]],
+    device float* output [[buffer(5)]],
+    constant PagedDecodeParams& p [[buffer(6)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint3 tg_pos [[threadgroup_position_in_grid]]) {
+  // The host dispatches exactly one 128-thread group per output vector.  A
+  // guard remains here because it is cheap and prevents accidental writes if
+  // a future caller uses a larger grid.
+  const uint request = tg_pos.x / p.query_heads;
+  const uint query_head = tg_pos.x % p.query_heads;
+  if (request >= p.batch_size || query_head >= p.query_heads || tid >= 128) {
+    return;
+  }
+
+  // Phase-1 qualification is head_dim=128.  Keeping this guard in the shader
+  // makes an unsupported dispatch memory-safe even if host validation is
+  // bypassed by a future low-level caller.
+  if (p.head_dim != 128 || p.kv_heads == 0 ||
+      (p.query_heads % p.kv_heads) != 0) {
+    return;
+  }
+
+  threadgroup float partial_dot[128];
+  threadgroup float softmax_state[4];
+
+  const uint query_base = (request * p.query_heads + query_head) * p.head_dim;
+  const uint q_per_kv = p.query_heads / p.kv_heads;
+  const uint kv_head = query_head / q_per_kv;
+  const int requested_length = seq_lens[request];
+  const uint sequence_length = requested_length > 0
+      ? min(uint(requested_length), p.max_blocks * p.block_size)
+      : 0;
+
+  // Each lane owns one output dimension for head_dim=128.  The accumulators
+  // stay in float32 even though K/V are BF16.
+  float accumulator = 0.0f;
+  if (tid == 0) {
+    softmax_state[0] = -INFINITY;  // running max
+    softmax_state[1] = 0.0f;       // running denominator
+    softmax_state[2] = 0.0f;       // exp(old_max - new_max)
+    softmax_state[3] = 0.0f;       // exp(score - new_max)
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint token = 0; token < sequence_length; ++token) {
+    const uint logical_block = token / p.block_size;
+    const uint block_offset = token % p.block_size;
+    const int physical_page = page_table[
+        request * p.page_table_stride + logical_block];
+
+    // The host rejects invalid page IDs.  Retaining the check in the shader
+    // prevents a malformed table from turning into an out-of-bounds GPU read;
+    // a skipped page is surfaced as an error by the host-side validation path.
+    // Do not `continue` here: every lane must execute the same barriers.
+    const bool page_valid = physical_page >= 0 &&
+        uint(physical_page) < p.page_count;
+
+    const uint key_base = page_valid
+        ? ((uint(physical_page) * p.kv_heads + kv_head) * p.block_size +
+           block_offset) * p.head_dim
+        : 0;
+
+    float dot_part = 0.0f;
+    if (page_valid && tid < p.head_dim) {
+      dot_part = bf16_to_float(query[query_base + tid]) *
+          bf16_to_float(key_pages[key_base + tid]);
+    }
+    partial_dot[tid] = dot_part;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Reduction for a fixed 128-wide group.  All accesses are in-bounds and
+    // every lane participates, including when a future head dimension uses
+    // fewer lanes.
+    for (uint stride = 64; stride > 0; stride >>= 1) {
+      if (tid < stride) {
+        partial_dot[tid] += partial_dot[tid + stride];
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+      const float score = partial_dot[0] * p.scale;
+      const float old_max = softmax_state[0];
+      const float new_max = max(old_max, score);
+      // exp(-inf - -inf) is NaN on some GPU families.  The explicit branch
+      // keeps the empty-prefix and first-token cases deterministic.
+      const float old_weight = page_valid && isfinite(old_max)
+          ? exp(old_max - new_max) * softmax_state[1]
+          : (page_valid ? 0.0f : softmax_state[1]);
+      const float token_weight = page_valid ? exp(score - new_max) : 0.0f;
+      if (page_valid) {
+        softmax_state[0] = new_max;
+        softmax_state[1] = old_weight + token_weight;
+        softmax_state[2] = isfinite(old_max) ? exp(old_max - new_max) : 0.0f;
+        softmax_state[3] = token_weight;
+      } else {
+        softmax_state[2] = 1.0f;
+        softmax_state[3] = 0.0f;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid < p.head_dim) {
+      const float value = page_valid ? bf16_to_float(value_pages[key_base + tid])
+                                     : 0.0f;
+      accumulator = accumulator * softmax_state[2] +
+          value * softmax_state[3];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid < p.head_dim) {
+    const uint output_base = (request * p.query_heads + query_head) * p.head_dim;
+    const float denominator = softmax_state[1];
+    output[output_base + tid] = denominator > 0.0f
+        ? accumulator / denominator
+        : 0.0f;
+  }
+}

--- a/native/metal_context/src/page_runtime.hpp
+++ b/native/metal_context/src/page_runtime.hpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ownership runtime for the optional Metal Context Engine.
+//
+// This header intentionally contains no Python or Objective-C types.  The
+// CPython bridge in page_runtime_python.mm owns the Python ABI while this
+// class owns request/page lifetime, page-table state, and the preallocated
+// per-layer KV storage.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace metal_context {
+
+struct PageRuntimeMetrics {
+  uint64_t resident_pages = 0;
+  uint64_t referenced_pages = 0;
+  uint64_t shared_pages = 0;
+  uint64_t evictable_pages = 0;
+  uint64_t free_pages = 0;
+  uint64_t requests = 0;
+  uint64_t prefixes = 0;
+  uint64_t page_allocations = 0;
+  uint64_t request_allocations = 0;
+  uint64_t prefix_allocations = 0;
+  uint64_t cow_events = 0;
+  uint64_t evictions = 0;
+  uint64_t releases = 0;
+  uint64_t cancellations = 0;
+  uint64_t append_tokens = 0;
+  uint64_t dispatches = 0;
+  uint64_t dispatch_failures = 0;
+  uint64_t native_dispatches = 0;
+  uint64_t native_failures = 0;
+  uint64_t buffer_allocations = 0;
+  uint64_t decode_buffer_allocations = 0;
+  uint64_t query_copies = 0;
+  uint64_t output_copies = 0;
+  uint64_t metadata_copies = 0;
+  uint64_t metadata_bytes = 0;
+  uint64_t kv_copy_bytes = 0;
+  uint64_t kv_pool_copies = 0;
+  uint64_t attention_validation_bytes = 0;
+  uint64_t decode_page_resolution_checks = 0;
+  uint64_t snapshot_failures = 0;
+  uint64_t restore_failures = 0;
+  uint64_t max_pages = 0;
+  uint64_t max_blocks_per_request = 0;
+  uint64_t block_size = 0;
+  bool shutdown = false;
+  uint64_t bytes_per_layer = 0;
+  uint64_t kv_bytes = 0;
+};
+
+class PageRuntime {
+ public:
+  // A bridge-side mutation transaction.  Native state is committed only
+  // after the CPython caller has built its return object; rollback is
+  // allocation-free and generation-safe.  The token is intentionally opaque
+  // to Python and must not outlive its PageRuntime owner.
+  class MutationToken {
+   public:
+    MutationToken();
+    ~MutationToken();
+    MutationToken(const MutationToken&) = delete;
+    MutationToken& operator=(const MutationToken&) = delete;
+    MutationToken(MutationToken&&) noexcept;
+    MutationToken& operator=(MutationToken&&) noexcept;
+
+   public:
+    // Definition is private to the native translation unit; the public
+    // declaration only lets PageRuntime's implementation carry the opaque
+    // transaction state through its helpers.
+    struct State;
+
+   private:
+    std::unique_ptr<State> state_;
+    friend class PageRuntime;
+  };
+
+  PageRuntime(
+      uint32_t num_layers,
+      uint32_t num_attention_heads,
+      uint32_t num_key_value_heads,
+      uint32_t head_dim,
+      uint32_t block_size,
+      uint32_t max_pages,
+      uint32_t max_blocks_per_request,
+      uint32_t max_requests);
+  ~PageRuntime();
+
+  PageRuntime(const PageRuntime&) = delete;
+  PageRuntime& operator=(const PageRuntime&) = delete;
+  PageRuntime(PageRuntime&&) = delete;
+  PageRuntime& operator=(PageRuntime&&) = delete;
+
+  // All methods return false and populate error on stale handles, invalid
+  // shapes, exhausted capacity, or a shut-down runtime.  The Python bridge
+  // converts these errors to the narrow exception types documented by the
+  // public backend protocol.
+  bool allocate_request(
+      const std::string& request_id,
+      uint32_t max_tokens,
+      uint64_t* handle,
+      std::string* error);
+  bool allocate_request(
+      const std::string& request_id,
+      uint32_t max_tokens,
+      uint64_t* handle,
+      MutationToken* mutation,
+      std::string* error);
+  bool allocate_pages(
+      uint64_t request,
+      uint32_t count,
+      std::vector<uint64_t>* handles,
+      std::string* error);
+  bool allocate_pages(
+      uint64_t request,
+      uint32_t count,
+      std::vector<uint64_t>* handles,
+      MutationToken* mutation,
+      std::string* error);
+  bool append_kv(
+      uint64_t request,
+      uint32_t layer,
+      const uint16_t* keys,
+      const uint16_t* values,
+      uint32_t tokens,
+      std::string* error);
+
+  bool create_prefix(uint64_t request, uint64_t* prefix, std::string* error);
+  bool create_prefix(
+      uint64_t request,
+      uint64_t* prefix,
+      MutationToken* mutation,
+      std::string* error);
+  bool fork_prefix(uint64_t prefix, uint64_t* forked, std::string* error);
+  bool fork_prefix(
+      uint64_t prefix,
+      uint64_t* forked,
+      MutationToken* mutation,
+      std::string* error);
+  bool attach_prefix(uint64_t request, uint64_t prefix, std::string* error);
+  bool release_prefix(uint64_t prefix, std::string* error);
+  bool release_request(uint64_t request, bool cancelled, std::string* error);
+
+  // Persistence is intentionally deferred to the next PR-stack package.  The
+  // explicit failure methods keep the contract fail-closed while exposing
+  // truthful counters to status/metrics callers.
+  bool snapshot(
+      uint64_t prefix,
+      const std::string& destination,
+      std::string* error);
+  bool restore(
+      const std::string& source,
+      uint64_t* prefix,
+      std::string* error);
+
+  // Evict at most target_pages resident pages with no request/prefix
+  // references.  A null target means evict every currently evictable page.
+  uint32_t evict(uint32_t target_pages, bool has_target, std::string* error);
+  uint32_t evict(
+      uint32_t target_pages,
+      bool has_target,
+      MutationToken* mutation,
+      std::string* error);
+
+  bool page_table(
+      uint64_t request,
+      uint32_t layer,
+      std::vector<int32_t>* table,
+      std::string* error) const;
+  bool request_pages(
+      uint64_t request,
+      std::vector<uint64_t>* pages,
+      std::string* error) const;
+  bool sequence_length(uint64_t request, uint32_t* length, std::string* error)
+      const;
+
+  // Dispatch the phase-one kernel using a consistent snapshot of the runtime
+  // owned pages and metadata.  The kernel bridge remains synchronous in this
+  // package; scheduler-owned asynchronous queues are a later package.
+  bool paged_decode(
+      uint64_t request,
+      uint32_t layer,
+      const uint16_t* query,
+      size_t query_elements,
+      float scale,
+      std::vector<float>* output,
+      std::string* error);
+  bool paged_decode(
+      uint64_t request,
+      uint32_t layer,
+      const uint16_t* query,
+      size_t query_elements,
+      float scale,
+      std::vector<float>* output,
+      MutationToken* mutation,
+      std::string* error);
+
+  // Commit/rollback are noexcept by contract: rollback is used from a C API
+  // failure path after CPython allocation failure and performs no allocation.
+  void commit(MutationToken* mutation) noexcept;
+  void rollback(MutationToken* mutation) noexcept;
+
+  PageRuntimeMetrics metrics(std::string* error) const;
+  void shutdown();
+  bool is_shutdown() const;
+
+  uint32_t num_layers() const;
+  uint32_t num_attention_heads() const;
+  uint32_t num_key_value_heads() const;
+  uint32_t head_dim() const;
+  uint32_t block_size() const;
+  uint32_t max_pages() const;
+  uint32_t max_blocks_per_request() const;
+  uint32_t max_requests() const;
+
+  // The Python bridge supplies the packaged metallib location after module
+  // initialization.  Keeping it on the runtime avoids a process-global
+  // environment mutation and makes multiple extension copies deterministic.
+  void set_metallib_path(const std::string& path);
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+// Shared host-side ABI helper used by the native dispatch path and its
+// allocation-free offset harness.  It returns the byte offset of one layer's
+// sequence length within the [request, layer] int32 metadata buffer.
+uint64_t page_runtime_sequence_buffer_offset(
+    uint32_t request_slot,
+    uint32_t num_layers,
+    uint32_t layer);
+
+}  // namespace metal_context

--- a/native/metal_context/src/page_runtime.mm
+++ b/native/metal_context/src/page_runtime.mm
@@ -1,0 +1,2928 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Native ownership runtime for the Metal Context Engine.
+
+#include "page_runtime.hpp"
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <dispatch/dispatch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <initializer_list>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace metal_context {
+namespace {
+
+constexpr uint32_t kSupportedHeadDim = 128;
+constexpr uint32_t kMinBlockSize = 16;
+constexpr uint32_t kMaxBlockSize = 32;
+constexpr uint32_t kThreadsPerThreadgroup = 128;
+constexpr uint64_t kMaximumMetadataBytes = UINT64_C(256) * 1024 * 1024;
+
+struct PagedDecodeParams {
+  uint32_t batch_size;
+  uint32_t query_heads;
+  uint32_t kv_heads;
+  uint32_t head_dim;
+  uint32_t block_size;
+  uint32_t max_blocks;
+  uint32_t page_count;
+  uint32_t page_table_stride;
+  float scale;
+  uint32_t reserved0;
+  uint32_t reserved1;
+  uint32_t reserved2;
+};
+
+static_assert(sizeof(PagedDecodeParams) == 48, "Metal parameter ABI changed");
+
+uint64_t checked_product(
+    std::initializer_list<uint64_t> values,
+    const char* what) {
+  uint64_t result = 1;
+  for (uint64_t value : values) {
+    if (value != 0 &&
+        result > std::numeric_limits<uint64_t>::max() / value) {
+      throw std::invalid_argument(std::string(what) + " overflows uint64");
+    }
+    result *= value;
+  }
+  return result;
+}
+
+uint64_t make_handle(uint32_t generation, uint32_t slot) {
+  return (static_cast<uint64_t>(generation) << 32) | slot;
+}
+
+uint32_t handle_slot(uint64_t handle) {
+  return static_cast<uint32_t>(handle & UINT64_C(0xffffffff));
+}
+
+uint32_t handle_generation(uint64_t handle) {
+  return static_cast<uint32_t>(handle >> 32);
+}
+
+uint32_t next_generation(uint32_t generation) {
+  ++generation;
+  return generation == 0 ? 1 : generation;
+}
+
+uint32_t validated_page_count(uint32_t value) {
+  if (value == 0) {
+    throw std::invalid_argument("max_pages must be positive");
+  }
+  // Page tables and the Metal shader use signed int32 page IDs.
+  if (value > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
+    throw std::invalid_argument("max_pages must not exceed INT32_MAX");
+  }
+  return value;
+}
+
+uint32_t validated_block_capacity(uint32_t value, uint32_t block_size) {
+  if (value == 0) {
+    throw std::invalid_argument("max_blocks_per_request must be positive");
+  }
+  if (block_size == 0 ||
+      value > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) /
+          block_size) {
+    throw std::invalid_argument(
+        "max_blocks_per_request * block_size exceeds the int32 sequence limit");
+  }
+  return value;
+}
+
+uint32_t validated_request_capacity(uint32_t value) {
+  if (value == 0) {
+    throw std::invalid_argument("max_requests must be positive");
+  }
+  return value;
+}
+
+uint64_t validated_metadata_elements(
+    uint32_t request_capacity,
+    uint32_t per_request_elements,
+    const char* what) {
+  const uint64_t elements = checked_product(
+      {request_capacity, per_request_elements}, what);
+  if (elements > kMaximumMetadataBytes / sizeof(int32_t)) {
+    throw std::invalid_argument(
+        std::string(what) + " exceeds the 256 MiB qualified metadata limit");
+  }
+  return elements;
+}
+
+bool finite_bf16(uint16_t bits) {
+  return (bits & 0x7f80u) != 0x7f80u;
+}
+
+float bf16_to_float(uint16_t bits) {
+  const uint32_t word = static_cast<uint32_t>(bits) << 16;
+  float value = 0.0f;
+  std::memcpy(&value, &word, sizeof(value));
+  return value;
+}
+
+bool all_finite_bf16(const uint16_t* values, size_t count) {
+  if (values == nullptr) {
+    return false;
+  }
+  for (size_t index = 0; index < count; ++index) {
+    if (!finite_bf16(values[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+float max_abs_bf16(const uint16_t* values, size_t count) {
+  float maximum = 0.0f;
+  for (size_t index = 0; index < count; ++index) {
+    maximum = std::max(maximum, std::fabs(bf16_to_float(values[index])));
+  }
+  return maximum;
+}
+
+bool validate_attention_envelope(
+    const uint16_t* query,
+    size_t query_elements,
+    uint32_t sequence_length,
+    float max_key,
+    float max_value,
+    uint32_t head_dim,
+    float scale,
+    std::string* error) {
+  if (!std::isfinite(scale)) {
+    *error = "scale must be finite";
+    return false;
+  }
+  if (!all_finite_bf16(query, query_elements) ||
+      !std::isfinite(max_key) || !std::isfinite(max_value)) {
+    *error = "query and live KV metadata must contain only finite BF16 values";
+    return false;
+  }
+  const float max_query = max_abs_bf16(query, query_elements);
+  // Keep the same conservative half-FLT_MAX envelope as the foundation
+  // bridge.  Finite BF16 products can still overflow a float32 reduction;
+  // rejecting them here prevents Inf-Inf/NaN states in online softmax.
+  constexpr long double kFloat32SafeMagnitude =
+      static_cast<long double>(std::numeric_limits<float>::max()) * 0.5L;
+  const long double max_dot =
+      static_cast<long double>(max_query) *
+      static_cast<long double>(max_key) *
+      static_cast<long double>(head_dim);
+  if (max_dot > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes may overflow the float32 dot "
+        "product at head_dim 128; reduce magnitudes";
+    return false;
+  }
+  const long double max_score =
+      max_dot * std::fabs(static_cast<long double>(scale));
+  if (max_score > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes and scale may overflow the "
+        "float32 attention score; reduce scale or magnitudes";
+    return false;
+  }
+  // Online softmax keeps the final value as a normalized weighted average,
+  // but the shader still forms a running value numerator.  Bound the
+  // worst-case finite accumulation so an extreme BF16 V cannot turn that
+  // intermediate into Inf before normalization.  The request maxima are
+  // maintained on append/prefix operations, so this check is O(1) in the
+  // context length.
+  const long double max_value_accumulation =
+      static_cast<long double>(max_value) * sequence_length;
+  if (max_value_accumulation > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 value magnitudes and sequence length may overflow the "
+        "float32 value accumulation; reduce values or context length";
+    return false;
+  }
+  return true;
+}
+
+std::string metallib_path() {
+  const char* override_path =
+      std::getenv("VLLM_MLX_METAL_CONTEXT_METALLIB");
+  if (override_path != nullptr && override_path[0] != '\0') {
+    return override_path;
+  }
+  // The Python bridge normally supplies the package path through the same
+  // environment override during tests.  Keep the fallback explicit instead
+  // of compiling or loading shader source at runtime.
+  return {};
+}
+
+struct KernelRuntime {
+  std::mutex mutex;
+  uint64_t active_runtimes = 0;
+  bool attempted = false;
+  bool available = false;
+  std::string path;
+  std::string error;
+  id<MTLDevice> device = nil;
+  id<MTLComputePipelineState> pipeline = nil;
+};
+
+KernelRuntime g_kernel;
+
+void reset_kernel_unlocked() {
+  g_kernel.device = nil;
+  g_kernel.pipeline = nil;
+  g_kernel.attempted = false;
+  g_kernel.available = false;
+  g_kernel.path.clear();
+  g_kernel.error.clear();
+}
+
+void retain_kernel_runtime() {
+  std::lock_guard<std::mutex> lock(g_kernel.mutex);
+  ++g_kernel.active_runtimes;
+}
+
+void release_kernel_runtime() {
+  std::lock_guard<std::mutex> lock(g_kernel.mutex);
+  if (g_kernel.active_runtimes == 0) {
+    return;
+  }
+  --g_kernel.active_runtimes;
+  if (g_kernel.active_runtimes == 0) {
+    // Each dispatch retains its pipeline locally, and a runtime drains its
+    // active leases before calling this function.  The final reference can
+    // therefore release the shared pipeline without a process-wide dispatch
+    // mutex.
+    reset_kernel_unlocked();
+  }
+}
+
+void shutdown_kernel_if_unused_impl() {
+  std::lock_guard<std::mutex> lock(g_kernel.mutex);
+  if (g_kernel.active_runtimes == 0) {
+    reset_kernel_unlocked();
+  }
+}
+
+bool compiled_for_apple_silicon() {
+#if defined(__arm64__) || defined(__aarch64__)
+  return true;
+#else
+  return false;
+#endif
+}
+
+std::string metal_error(NSError* error, const char* fallback) {
+  if (error != nil && error.localizedDescription != nil) {
+    const char* description = [error.localizedDescription UTF8String];
+    if (description != nullptr && description[0] != '\0') {
+      return description;
+    }
+  }
+  return fallback;
+}
+
+bool ensure_kernel(const std::string& path) {
+  std::lock_guard<std::mutex> lock(g_kernel.mutex);
+  if (g_kernel.attempted && g_kernel.path == path) {
+    return g_kernel.available;
+  }
+  if (g_kernel.active_runtimes != 0 && g_kernel.attempted &&
+      g_kernel.path != path) {
+    g_kernel.error =
+        "native Metal Context runtimes must share one metallib path while "
+        "dispatches are active";
+    return false;
+  }
+  g_kernel.attempted = true;
+  g_kernel.available = false;
+  g_kernel.path = path;
+  g_kernel.error.clear();
+  g_kernel.device = nil;
+  g_kernel.pipeline = nil;
+
+  if (!compiled_for_apple_silicon()) {
+    g_kernel.error =
+        "the Metal Context Engine requires an Apple Silicon arm64 build";
+    return false;
+  }
+  if (path.empty()) {
+    g_kernel.error =
+        "the packaged _metal_context.metallib could not be located; set "
+        "VLLM_MLX_METAL_CONTEXT_METALLIB for an explicit path";
+    return false;
+  }
+  try {
+    if (!std::filesystem::exists(path)) {
+      g_kernel.error = "the Metal library does not exist at " + path;
+      return false;
+    }
+  } catch (const std::filesystem::filesystem_error& exception) {
+    g_kernel.error = "could not inspect the Metal library path: ";
+    g_kernel.error += exception.what();
+    return false;
+  }
+
+  @autoreleasepool {
+    do {
+      g_kernel.device = MTLCreateSystemDefaultDevice();
+      if (g_kernel.device == nil) {
+        g_kernel.error = "MTLCreateSystemDefaultDevice returned no GPU";
+        break;
+      }
+      NSData* bytes = [NSData
+          dataWithContentsOfFile:[NSString stringWithUTF8String:path.c_str()]];
+      if (bytes == nil || bytes.length == 0) {
+        g_kernel.error = "the packaged Metal library could not be read";
+        break;
+      }
+      void* owned_bytes = std::malloc(bytes.length);
+      if (owned_bytes == nullptr) {
+        g_kernel.error = "could not allocate Metal library storage";
+        break;
+      }
+      std::memcpy(owned_bytes, bytes.bytes, bytes.length);
+      dispatch_data_t library_data = dispatch_data_create(
+          owned_bytes,
+          bytes.length,
+          nullptr,
+          DISPATCH_DATA_DESTRUCTOR_FREE);
+      if (library_data == nullptr) {
+        std::free(owned_bytes);
+        g_kernel.error = "could not map the Metal library data";
+        break;
+      }
+      NSError* error = nil;
+      id<MTLLibrary> library =
+          [g_kernel.device newLibraryWithData:library_data error:&error];
+      if (library == nil) {
+        g_kernel.error = metal_error(error, "Metal rejected the library");
+        break;
+      }
+      id<MTLFunction> function =
+          [library newFunctionWithName:@"metal_context_paged_decode"];
+      if (function == nil) {
+        g_kernel.error =
+            "the packaged Metal library is missing "
+            "metal_context_paged_decode";
+        break;
+      }
+      g_kernel.pipeline = [g_kernel.device
+          newComputePipelineStateWithFunction:function
+                                          error:&error];
+      if (g_kernel.pipeline == nil) {
+        g_kernel.error =
+            metal_error(error, "Metal could not create the kernel pipeline");
+        break;
+      }
+      g_kernel.available = true;
+    } while (false);
+  }
+  return g_kernel.available;
+}
+
+bool dispatch_kernel(
+    id<MTLCommandQueue> queue,
+    id<MTLBuffer> query_buffer,
+    NSUInteger query_offset,
+    id<MTLBuffer> kv_buffer,
+    NSUInteger key_offset,
+    NSUInteger value_offset,
+    id<MTLBuffer> page_table_buffer,
+    NSUInteger page_table_offset,
+    id<MTLBuffer> sequence_lengths_buffer,
+    NSUInteger sequence_lengths_offset,
+    id<MTLBuffer> output_buffer,
+    NSUInteger output_offset,
+    const uint16_t* query,
+    size_t query_elements,
+    uint32_t batch_size,
+    uint32_t query_heads,
+    uint32_t kv_heads,
+    uint32_t head_dim,
+    uint32_t block_size,
+    uint32_t max_blocks,
+    uint32_t page_count,
+    float scale,
+    const std::string& path,
+    std::vector<float>* output,
+    std::string* error,
+    uint64_t* query_copies,
+    uint64_t* output_copies) {
+  if (queue == nil || query_buffer == nil || kv_buffer == nil ||
+      page_table_buffer == nil || sequence_lengths_buffer == nil ||
+      output_buffer == nil || query == nullptr || output == nullptr ||
+      error == nullptr) {
+    if (error != nullptr) {
+      *error = "paged decode received a null runtime buffer";
+    }
+    return false;
+  }
+  if (head_dim != kSupportedHeadDim ||
+      (block_size != kMinBlockSize && block_size != kMaxBlockSize) ||
+      kv_heads == 0 || query_heads == 0 || query_heads % kv_heads != 0 ||
+      batch_size == 0 || max_blocks == 0 || page_count == 0 ||
+      !std::isfinite(scale)) {
+    *error = "paged decode geometry is outside the Metal Context v1 ABI";
+    return false;
+  }
+  const uint64_t expected_query =
+      checked_product({batch_size, query_heads, head_dim}, "query size");
+  if (expected_query > std::numeric_limits<uint32_t>::max() ||
+      query_elements != expected_query) {
+    *error = "query element count does not match the runtime geometry";
+    return false;
+  }
+  const uint64_t output_elements = expected_query;
+  if (output_elements > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    *error = "paged decode output exceeds native size limits";
+    return false;
+  }
+
+  if (!ensure_kernel(path)) {
+    std::lock_guard<std::mutex> lock(g_kernel.mutex);
+    *error = "native Metal Context kernel unavailable: " + g_kernel.error;
+    return false;
+  }
+  id<MTLComputePipelineState> pipeline = nil;
+  {
+    // Retain the pipeline locally, but release the global lock before command
+    // encoding.  Independent PageRuntime queues must not serialize on the
+    // process-wide lifecycle mutex.
+    std::lock_guard<std::mutex> lock(g_kernel.mutex);
+    if (!g_kernel.available || g_kernel.pipeline == nil) {
+      *error = "native Metal Context kernel lost its pipeline";
+      return false;
+    }
+    pipeline = g_kernel.pipeline;
+  }
+
+  @autoreleasepool {
+    const size_t query_bytes =
+        static_cast<size_t>(expected_query) * sizeof(uint16_t);
+    const size_t output_bytes =
+        static_cast<size_t>(output_elements) * sizeof(float);
+    const size_t page_table_bytes = checked_product(
+        {max_blocks, sizeof(int32_t)}, "page table dispatch range");
+    const size_t sequence_bytes = sizeof(int32_t);
+    const auto buffer_range_valid = [](id<MTLBuffer> buffer,
+                                       NSUInteger offset,
+                                       size_t bytes) {
+      return buffer != nil && buffer.contents != nullptr &&
+          bytes <= std::numeric_limits<NSUInteger>::max() &&
+          offset <= buffer.length &&
+          static_cast<NSUInteger>(bytes) <= buffer.length - offset;
+    };
+    const size_t kv_bytes = checked_product(
+        {static_cast<uint64_t>(page_count), static_cast<uint64_t>(block_size),
+         static_cast<uint64_t>(kv_heads), static_cast<uint64_t>(head_dim),
+         sizeof(uint16_t)},
+        "KV dispatch range");
+    if (!buffer_range_valid(query_buffer, query_offset, query_bytes) ||
+        !buffer_range_valid(output_buffer, output_offset, output_bytes) ||
+        !buffer_range_valid(kv_buffer, key_offset, kv_bytes) ||
+        !buffer_range_valid(kv_buffer, value_offset, kv_bytes) ||
+        !buffer_range_valid(
+            page_table_buffer, page_table_offset, page_table_bytes) ||
+        !buffer_range_valid(
+            sequence_lengths_buffer, sequence_lengths_offset, sequence_bytes)) {
+      *error = "paged decode runtime buffer range is outside its allocation";
+      return false;
+    }
+    std::memcpy(
+        static_cast<uint8_t*>(query_buffer.contents) + query_offset,
+        query,
+        query_bytes);
+    if (query_copies != nullptr) {
+      ++*query_copies;
+    }
+    std::memset(
+        static_cast<uint8_t*>(output_buffer.contents) + output_offset,
+        0,
+        output_bytes);
+
+    PagedDecodeParams params{};
+    params.batch_size = batch_size;
+    params.query_heads = query_heads;
+    params.kv_heads = kv_heads;
+    params.head_dim = head_dim;
+    params.block_size = block_size;
+    params.max_blocks = max_blocks;
+    params.page_count = page_count;
+    params.page_table_stride = max_blocks;
+    params.scale = scale;
+    id<MTLCommandBuffer> command = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> encoder =
+        command == nil ? nil : [command computeCommandEncoder];
+    if (command == nil || encoder == nil) {
+      *error = "Metal could not create the paged decode command encoder";
+      return false;
+    }
+    [encoder setComputePipelineState:pipeline];
+    [encoder setBuffer:query_buffer offset:query_offset atIndex:0];
+    [encoder setBuffer:kv_buffer offset:key_offset atIndex:1];
+    [encoder setBuffer:kv_buffer offset:value_offset atIndex:2];
+    [encoder setBuffer:page_table_buffer offset:page_table_offset atIndex:3];
+    [encoder setBuffer:sequence_lengths_buffer
+              offset:sequence_lengths_offset
+            atIndex:4];
+    [encoder setBuffer:output_buffer offset:output_offset atIndex:5];
+    [encoder setBytes:&params length:sizeof(params) atIndex:6];
+    const MTLSize grid =
+        MTLSizeMake(static_cast<NSUInteger>(batch_size) * query_heads, 1, 1);
+    const MTLSize group = MTLSizeMake(kThreadsPerThreadgroup, 1, 1);
+    [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+    [encoder endEncoding];
+    [command commit];
+    [command waitUntilCompleted];
+    if (command.status != MTLCommandBufferStatusCompleted) {
+      *error = metal_error(
+          command.error, "Metal paged decode command did not complete");
+      return false;
+    }
+    output->resize(static_cast<size_t>(output_elements));
+    std::memcpy(
+        output->data(),
+        static_cast<const uint8_t*>(output_buffer.contents) + output_offset,
+        output_bytes);
+    if (output_copies != nullptr) {
+      ++*output_copies;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+// Export only the guarded module-shutdown hook.  The kernel object and its
+// mutex remain translation-unit private; callers cannot tear down resources
+// without passing through the active PageRuntime reference count.
+void shutdown_kernel_if_unused() {
+  shutdown_kernel_if_unused_impl();
+}
+
+uint64_t page_runtime_sequence_buffer_offset(
+    uint32_t request_slot,
+    uint32_t num_layers,
+    uint32_t layer) {
+  if (num_layers == 0 || layer >= num_layers) {
+    throw std::invalid_argument(
+        "sequence buffer layer is outside the configured layer count");
+  }
+  const uint64_t request_base = checked_product(
+      {request_slot, num_layers}, "sequence buffer request offset");
+  return checked_product(
+      {request_base + layer, sizeof(int32_t)},
+      "sequence buffer byte offset");
+}
+
+id<MTLBuffer> allocate_runtime_buffer(
+    id<MTLDevice> device,
+    uint64_t bytes,
+    uint64_t* allocation_counter) {
+  if (device == nil) {
+    return nil;
+  }
+  if (bytes > std::numeric_limits<NSUInteger>::max()) {
+    throw std::invalid_argument(
+        "native Metal buffer length exceeds NSUInteger capacity");
+  }
+  id<MTLBuffer> buffer = [device
+      newBufferWithLength:static_cast<NSUInteger>(bytes)
+                   options:MTLResourceStorageModeShared];
+  if (buffer != nil && allocation_counter != nullptr) {
+    ++*allocation_counter;
+  }
+  return buffer;
+}
+
+struct MutationPageSnapshot {
+  uint32_t page = 0;
+  bool allocated = false;
+  uint32_t generation = 0;
+  uint32_t references = 0;
+  uint64_t last_used = 0;
+};
+
+struct PageRuntime::MutationToken::State {
+  enum class Kind : uint8_t {
+    kNone,
+    kRequest,
+    kPages,
+    kPrefix,
+    kEviction,
+    kDecode,
+  };
+
+  Kind kind = Kind::kNone;
+  bool armed = false;
+  bool prefix_was_new = false;
+  bool has_request_sequence = false;
+  uint32_t request_slot = 0;
+  uint32_t prefix_slot = 0;
+  uint32_t first_block = 0;
+  uint32_t prior_request_generation = 0;
+  uint32_t new_generation = 0;
+  uint32_t prior_prefix_generation = 0;
+  uint32_t prior_request_sequence_length = 0;
+  uint32_t prior_page_table_length = 0;
+  uint64_t old_clock = 0;
+  uint64_t old_page_allocations = 0;
+  uint64_t old_eviction_count = 0;
+  uint64_t old_prefix_allocations = 0;
+  uint64_t old_request_allocations = 0;
+  uint64_t old_metadata_copies = 0;
+  uint64_t old_metadata_bytes = 0;
+  uint64_t old_dispatches = 0;
+  uint64_t old_dispatch_failures = 0;
+  uint64_t old_native_dispatches = 0;
+  uint64_t old_native_failures = 0;
+  uint64_t old_query_copies = 0;
+  uint64_t old_output_copies = 0;
+  uint64_t old_attention_validation_bytes = 0;
+  std::vector<int32_t> prior_request_pages;
+  std::vector<int32_t> prior_layer_lengths;
+  std::vector<int32_t> prefix_pages;
+  std::vector<MutationPageSnapshot> page_snapshots;
+
+  void reset() noexcept {
+    kind = Kind::kNone;
+    armed = false;
+    prefix_was_new = false;
+    has_request_sequence = false;
+    request_slot = 0;
+    prefix_slot = 0;
+    first_block = 0;
+    prior_request_generation = 0;
+    new_generation = 0;
+    prior_prefix_generation = 0;
+    prior_request_sequence_length = 0;
+    prior_page_table_length = 0;
+    old_clock = 0;
+    old_page_allocations = 0;
+    old_eviction_count = 0;
+    old_prefix_allocations = 0;
+    old_request_allocations = 0;
+    old_metadata_copies = 0;
+    old_metadata_bytes = 0;
+    old_dispatches = 0;
+    old_dispatch_failures = 0;
+    old_native_dispatches = 0;
+    old_native_failures = 0;
+    old_query_copies = 0;
+    old_output_copies = 0;
+    old_attention_validation_bytes = 0;
+    prior_request_pages.clear();
+    prior_layer_lengths.clear();
+    prefix_pages.clear();
+    page_snapshots.clear();
+  }
+};
+
+PageRuntime::MutationToken::MutationToken()
+    : state_(std::make_unique<State>()) {}
+
+PageRuntime::MutationToken::~MutationToken() = default;
+
+PageRuntime::MutationToken::MutationToken(MutationToken&&) noexcept = default;
+
+PageRuntime::MutationToken& PageRuntime::MutationToken::operator=(
+    MutationToken&&) noexcept = default;
+
+struct PageRuntime::Impl {
+  struct LayerStorage {
+    id<MTLBuffer> buffer = nil;
+    std::vector<uint16_t> host;
+    uint16_t* data() {
+      return buffer == nil ? host.data() : static_cast<uint16_t*>(buffer.contents);
+    }
+    const uint16_t* data() const {
+      return buffer == nil ? host.data()
+                           : static_cast<const uint16_t*>(buffer.contents);
+    }
+  };
+
+  struct PageMeta {
+    bool allocated = false;
+    uint32_t generation = 0;
+    uint32_t references = 0;
+    uint64_t last_used = 0;
+  };
+
+  struct RequestMeta {
+    bool live = false;
+    uint32_t generation = 0;
+    std::string id;
+    uint32_t max_tokens = 0;
+    uint32_t sequence_length = 0;
+    uint32_t page_table_length = 0;
+    std::vector<uint32_t> layer_lengths;
+    std::vector<float> layer_max_key;
+    std::vector<float> layer_max_value;
+    std::vector<int32_t> pages;
+  };
+
+  struct PrefixMeta {
+    bool live = false;
+    uint32_t generation = 0;
+    uint32_t token_count = 0;
+    std::vector<float> layer_max_key;
+    std::vector<float> layer_max_value;
+    std::vector<int32_t> pages;
+  };
+
+  struct DispatchResult {
+    bool validation_failed = false;
+    bool dispatch_attempted = false;
+    bool dispatched = false;
+    uint64_t validation_bytes = 0;
+    uint64_t query_copies = 0;
+    uint64_t output_copies = 0;
+  };
+
+  static_assert(
+      std::is_nothrow_move_assignable<RequestMeta>::value,
+      "request replacement must publish without throwing");
+  static_assert(
+      std::is_nothrow_move_constructible<PrefixMeta>::value,
+      "prefix replacement must publish without throwing");
+
+  const uint32_t num_layers;
+  const uint32_t num_attention_heads;
+  const uint32_t num_key_value_heads;
+  const uint32_t head_dim;
+  const uint32_t block_size;
+  const uint32_t max_pages;
+  const uint32_t max_blocks_per_request;
+  const uint32_t max_requests;
+  const uint64_t page_elements;
+  const uint64_t bytes_per_layer;
+  const uint64_t query_elements;
+  const uint64_t query_bytes_per_slot;
+  const uint64_t output_bytes_per_slot;
+
+  mutable std::mutex mutex;
+  // Lock order is strict: ``Impl::mutex`` is acquired before a
+  // ``slot_mutexes[slot]`` lock.  Code that has released ``Impl::mutex`` may
+  // keep a slot lock across synchronous dispatch, but it must release the
+  // slot lock before reacquiring ``Impl::mutex``.  In particular, dispatch
+  // completion records metrics only after the slot lock is dropped.  No
+  // helper called while holding a slot lock may acquire the runtime mutex.
+  bool stopped = false;
+  bool stopping = false;
+  uint32_t active_dispatches = 0;
+  std::condition_variable dispatch_cv;
+  uint64_t clock = 0;
+  uint64_t page_allocations = 0;
+  uint64_t request_allocations = 0;
+  uint64_t prefix_allocations = 0;
+  uint64_t cow_events = 0;
+  uint64_t eviction_count = 0;
+  uint64_t release_count = 0;
+  uint64_t cancellation_count = 0;
+  uint64_t append_tokens = 0;
+  uint64_t dispatches = 0;
+  uint64_t dispatch_failures = 0;
+  uint64_t native_dispatches = 0;
+  uint64_t native_failures = 0;
+  // Keep process-wide kernel teardown ordered with every live PageRuntime,
+  // including host-only runtimes that never dispatch a shader.
+  bool kernel_reference = false;
+
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> command_queue = nil;
+  std::vector<LayerStorage> layers;
+  std::vector<int32_t> page_table;
+  std::vector<int32_t> layer_sequence_lengths;
+  id<MTLBuffer> page_table_buffer = nil;
+  id<MTLBuffer> sequence_lengths_buffer = nil;
+  id<MTLBuffer> query_scratch_buffer = nil;
+  id<MTLBuffer> output_scratch_buffer = nil;
+  std::vector<std::mutex> slot_mutexes;
+  std::vector<PageMeta> pages;
+  std::vector<RequestMeta> requests;
+  std::vector<PrefixMeta> prefixes;
+  std::string library_path;
+  uint64_t buffer_allocations = 0;
+  uint64_t decode_buffer_allocations = 0;
+  uint64_t query_copies = 0;
+  uint64_t output_copies = 0;
+  uint64_t metadata_copies = 0;
+  uint64_t metadata_bytes = 0;
+  uint64_t kv_copy_bytes = 0;
+  uint64_t kv_pool_copies = 0;
+  uint64_t attention_validation_bytes = 0;
+  uint64_t decode_page_resolution_checks = 0;
+  uint64_t snapshot_failures = 0;
+  uint64_t restore_failures = 0;
+
+  Impl(
+      uint32_t layers_count,
+      uint32_t attention_heads,
+      uint32_t kv_heads,
+      uint32_t dimension,
+      uint32_t block,
+      uint32_t page_count,
+      uint32_t block_capacity,
+      uint32_t request_capacity)
+      : num_layers(layers_count),
+        num_attention_heads(attention_heads),
+        num_key_value_heads(kv_heads),
+        head_dim(dimension),
+        block_size(block),
+        max_pages(validated_page_count(page_count)),
+        max_blocks_per_request(validated_block_capacity(block_capacity, block)),
+        max_requests(validated_request_capacity(request_capacity)),
+        page_elements(checked_product(
+            {kv_heads, block, dimension}, "page element count")),
+        // One native allocation contains a key plane followed by a value
+        // plane.  ``page_elements`` is the element count of one plane.
+        bytes_per_layer(checked_product(
+            {2, validated_page_count(page_count), kv_heads, block, dimension,
+             sizeof(uint16_t)},
+            "per-layer KV allocation")),
+        query_elements(checked_product(
+            {attention_heads, dimension}, "query element count")),
+        query_bytes_per_slot(
+            checked_product({query_elements, sizeof(uint16_t)}, "query scratch")),
+        output_bytes_per_slot(checked_product(
+            {query_elements, sizeof(float)}, "output scratch")),
+        page_table(
+            validated_metadata_elements(
+                validated_request_capacity(request_capacity),
+                validated_block_capacity(block_capacity, block),
+                "page table"),
+            -1),
+        layer_sequence_lengths(validated_metadata_elements(
+            validated_request_capacity(request_capacity),
+            layers_count,
+            "layer sequence lengths"), 0),
+        slot_mutexes(validated_request_capacity(request_capacity)),
+        pages(validated_page_count(page_count)),
+        requests(validated_request_capacity(request_capacity)),
+        prefixes() {
+    if (num_layers == 0 || num_attention_heads == 0 ||
+        num_key_value_heads == 0) {
+      throw std::invalid_argument("layer and head counts must be positive");
+    }
+    if (num_attention_heads % num_key_value_heads != 0) {
+      throw std::invalid_argument(
+          "num_attention_heads must be divisible by num_key_value_heads for GQA");
+    }
+    if (head_dim != kSupportedHeadDim) {
+      throw std::invalid_argument("Metal Context v1 supports head_dim=128 only");
+    }
+    if (block_size != kMinBlockSize && block_size != kMaxBlockSize) {
+      throw std::invalid_argument("Metal Context v1 supports block_size 16 or 32 only");
+    }
+    if (page_elements > std::numeric_limits<size_t>::max() ||
+        bytes_per_layer > std::numeric_limits<size_t>::max()) {
+      throw std::invalid_argument("page runtime allocation exceeds native size limits");
+    }
+    const uint64_t all_page_elements = checked_product(
+        {max_pages, page_elements}, "all-page shader index space");
+    const uint64_t page_table_elements = checked_product(
+        {max_requests, max_blocks_per_request}, "page-table index space");
+    if (page_elements > std::numeric_limits<uint32_t>::max() ||
+        all_page_elements > std::numeric_limits<uint32_t>::max() ||
+        page_table_elements > std::numeric_limits<uint32_t>::max() ||
+        query_elements > std::numeric_limits<uint32_t>::max()) {
+      throw std::invalid_argument(
+          "page or query index space exceeds the uint32 shader limit");
+    }
+    const uint64_t query_scratch_bytes = checked_product(
+        {max_requests, query_bytes_per_slot}, "query scratch allocation");
+    const uint64_t output_scratch_bytes = checked_product(
+        {max_requests, output_bytes_per_slot}, "output scratch allocation");
+    if (query_scratch_bytes > kMaximumMetadataBytes ||
+        output_scratch_bytes > kMaximumMetadataBytes ||
+        query_scratch_bytes > kMaximumMetadataBytes - output_scratch_bytes) {
+      throw std::invalid_argument(
+          "combined decode scratch allocation exceeds the 256 MiB qualified "
+          "metadata limit");
+    }
+    // Do not let a missing/typoed capacity silently attempt a multi-hundred
+    // gigabyte allocation during process startup.  Real qualification runs
+    // can choose a larger explicit capacity in a later resource policy.
+    constexpr uint64_t kMaximumLayerBytes = UINT64_C(64) * 1024 * 1024 * 1024;
+    if (bytes_per_layer > kMaximumLayerBytes) {
+      throw std::invalid_argument(
+          "per-layer KV allocation exceeds the 64 GiB native safety limit");
+    }
+
+    requests.resize(max_requests);
+    @autoreleasepool {
+      device = MTLCreateSystemDefaultDevice();
+      layers.resize(num_layers);
+      for (LayerStorage& layer : layers) {
+        if (device != nil) {
+          layer.buffer = allocate_runtime_buffer(
+              device, bytes_per_layer, &buffer_allocations);
+          if (layer.buffer == nil) {
+            throw std::runtime_error(
+                "Metal could not allocate the preallocated per-layer KV buffer");
+          }
+          std::memset(layer.buffer.contents, 0, static_cast<size_t>(bytes_per_layer));
+        } else {
+          layer.host.resize(
+              static_cast<size_t>(bytes_per_layer / sizeof(uint16_t)),
+              static_cast<uint16_t>(0));
+        }
+      }
+      const uint64_t page_table_bytes = checked_product(
+          {max_requests, max_blocks_per_request, sizeof(int32_t)},
+          "page table bytes");
+      const uint64_t sequence_bytes =
+          checked_product(
+              {max_requests, num_layers, sizeof(int32_t)},
+              "sequence length bytes");
+      if (device != nil) {
+        command_queue = [device newCommandQueue];
+        if (command_queue == nil) {
+          throw std::runtime_error("Metal could not create a runtime command queue");
+        }
+        page_table_buffer = allocate_runtime_buffer(
+            device, page_table_bytes, &buffer_allocations);
+        sequence_lengths_buffer = allocate_runtime_buffer(
+            device, sequence_bytes, &buffer_allocations);
+        query_scratch_buffer = allocate_runtime_buffer(
+            device, query_scratch_bytes, &buffer_allocations);
+        output_scratch_buffer = allocate_runtime_buffer(
+            device, output_scratch_bytes, &buffer_allocations);
+        if (page_table_buffer == nil || sequence_lengths_buffer == nil ||
+            query_scratch_buffer == nil || output_scratch_buffer == nil) {
+          throw std::runtime_error(
+              "Metal could not allocate the preallocated runtime buffers");
+        }
+        std::memset(
+            page_table_buffer.contents, 0xff, static_cast<size_t>(page_table_bytes));
+        std::memset(
+            sequence_lengths_buffer.contents,
+            0,
+            static_cast<size_t>(sequence_bytes));
+        std::memset(
+            query_scratch_buffer.contents,
+            0,
+            static_cast<size_t>(query_scratch_bytes));
+        std::memset(
+            output_scratch_buffer.contents,
+            0,
+            static_cast<size_t>(output_scratch_bytes));
+      }
+    }
+    retain_kernel_runtime();
+    kernel_reference = true;
+  }
+
+  // Destruction is also a teardown entry point (for example, a constructor
+  // replacement from the Python bridge).  Drain every synchronous decode
+  // lease before releasing the buffers those leases reference.  Keep the
+  // kernel release outside the runtime mutex, matching PageRuntime::shutdown.
+  void shutdown_and_wait() {
+    bool release_kernel = false;
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      if (stopped) {
+        return;
+      }
+      if (stopping) {
+        dispatch_cv.wait(lock, [this] { return stopped; });
+        return;
+      }
+      stopping = true;
+      dispatch_cv.wait(lock, [this] { return active_dispatches == 0; });
+      release_kernel = shutdown_unlocked();
+      dispatch_cv.notify_all();
+    }
+    if (release_kernel) {
+      release_kernel_runtime();
+    }
+  }
+
+  ~Impl() { shutdown_and_wait(); }
+
+  bool shutdown_unlocked() {
+    if (stopped) {
+      return false;
+    }
+    stopped = true;
+    stopping = false;
+    // Clear references before releasing Objective-C resources so a future
+    // destructor cannot observe a half-torn-down page table.
+    for (RequestMeta& request : requests) {
+      request.live = false;
+      request.pages.clear();
+      request.layer_lengths.clear();
+      request.layer_max_key.clear();
+      request.layer_max_value.clear();
+      request.sequence_length = 0;
+      request.page_table_length = 0;
+    }
+    for (PrefixMeta& prefix : prefixes) {
+      prefix.live = false;
+      prefix.pages.clear();
+      prefix.layer_max_key.clear();
+      prefix.layer_max_value.clear();
+      prefix.token_count = 0;
+    }
+    for (PageMeta& page : pages) {
+      page.references = 0;
+      page.allocated = false;
+    }
+    page_table.clear();
+    layer_sequence_lengths.clear();
+    layers.clear();
+    command_queue = nil;
+    page_table_buffer = nil;
+    sequence_lengths_buffer = nil;
+    query_scratch_buffer = nil;
+    output_scratch_buffer = nil;
+    device = nil;
+    const bool release_kernel = kernel_reference;
+    kernel_reference = false;
+    return release_kernel;
+  }
+
+  bool check_running(std::string* error) const {
+    if (stopped || stopping) {
+      if (error != nullptr) {
+        *error = "page runtime is shut down";
+      }
+      return false;
+    }
+    return true;
+  }
+
+  void finish_dispatch(const DispatchResult& result) {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (active_dispatches > 0) {
+      --active_dispatches;
+    }
+    if (result.validation_bytes != 0) {
+      attention_validation_bytes += result.validation_bytes;
+    }
+    if (result.dispatched) {
+      ++dispatches;
+      native_dispatches = dispatches;
+    } else if (result.validation_failed || result.dispatch_attempted) {
+      ++dispatch_failures;
+      native_failures = dispatch_failures;
+    }
+    query_copies += result.query_copies;
+    output_copies += result.output_copies;
+    dispatch_cv.notify_all();
+  }
+
+  using MutationState = PageRuntime::MutationToken::State;
+
+  static MutationPageSnapshot snapshot_page(
+      uint32_t page,
+      const PageMeta& meta) {
+    return MutationPageSnapshot{
+        page,
+        meta.allocated,
+        meta.generation,
+        meta.references,
+        meta.last_used};
+  }
+
+  void save_metadata_counters(MutationState& state) const {
+    state.old_metadata_copies = metadata_copies;
+    state.old_metadata_bytes = metadata_bytes;
+  }
+
+  bool prepare_request_undo_unlocked(
+      uint32_t slot,
+      MutationState& state,
+      std::string* error) {
+    (void)error;
+    state.reset();
+    state.kind = MutationState::Kind::kRequest;
+    state.request_slot = slot;
+    const RequestMeta& request = requests[slot];
+    state.prior_request_generation = request.generation;
+    state.new_generation = next_generation(request.generation);
+    state.old_request_allocations = request_allocations;
+    save_metadata_counters(state);
+    state.prior_request_pages.assign(
+        page_table.begin() +
+            static_cast<size_t>(slot) * max_blocks_per_request,
+        page_table.begin() +
+            static_cast<size_t>(slot + 1) * max_blocks_per_request);
+    state.prior_layer_lengths.assign(
+        layer_sequence_lengths.begin() +
+            static_cast<size_t>(slot) * num_layers,
+        layer_sequence_lengths.begin() +
+            static_cast<size_t>(slot + 1) * num_layers);
+    state.armed = true;
+    return true;
+  }
+
+  bool prepare_pages_undo_unlocked(
+      uint32_t slot,
+      uint32_t first_block,
+      uint32_t count,
+      MutationState& state,
+      std::string* error) {
+    (void)error;
+    state.reset();
+    state.kind = MutationState::Kind::kPages;
+    state.request_slot = slot;
+    state.first_block = first_block;
+    const RequestMeta& request = requests[slot];
+    state.prior_request_generation = request.generation;
+    state.prior_page_table_length = request.page_table_length;
+    state.old_clock = clock;
+    state.old_page_allocations = page_allocations;
+    state.old_eviction_count = eviction_count;
+    save_metadata_counters(state);
+    state.prior_request_pages.assign(
+        request.pages.begin() + first_block,
+        request.pages.begin() + first_block + count);
+    state.page_snapshots.reserve(count);
+    std::vector<uint32_t> reserved;
+    reserved.reserve(count);
+    for (uint32_t index = 0; index < count; ++index) {
+      const uint32_t page = find_allocation_candidate_unlocked(reserved);
+      if (page == max_pages) {
+        state.reset();
+        if (error != nullptr) {
+          *error =
+              "page capacity exhausted: every resident page is still referenced";
+        }
+        return false;
+      }
+      reserved.push_back(page);
+      state.page_snapshots.push_back(snapshot_page(page, pages[page]));
+    }
+    state.armed = true;
+    return true;
+  }
+
+  bool prepare_prefix_undo_unlocked(
+      uint32_t prefix_slot,
+      bool prefix_was_new,
+      uint32_t prior_generation,
+      uint32_t new_generation,
+      bool has_request_sequence,
+      uint32_t request_slot,
+      uint32_t prior_request_sequence_length,
+      const std::vector<int32_t>& pages_to_reference,
+      MutationState& state) {
+    state.reset();
+    state.kind = MutationState::Kind::kPrefix;
+    state.prefix_slot = prefix_slot;
+    state.prefix_was_new = prefix_was_new;
+    state.prior_prefix_generation = prior_generation;
+    state.new_generation = new_generation;
+    state.has_request_sequence = has_request_sequence;
+    state.request_slot = request_slot;
+    state.prior_request_sequence_length = prior_request_sequence_length;
+    state.old_clock = clock;
+    state.old_prefix_allocations = prefix_allocations;
+    state.prefix_pages = pages_to_reference;
+    state.page_snapshots.reserve(state.prefix_pages.size());
+    for (int32_t page_value : state.prefix_pages) {
+      if (page_value < 0 || static_cast<uint32_t>(page_value) >= pages.size()) {
+        state.reset();
+        return false;
+      }
+      const uint32_t page = static_cast<uint32_t>(page_value);
+      state.page_snapshots.push_back(snapshot_page(page, pages[page]));
+    }
+    state.armed = true;
+    return true;
+  }
+
+  void prepare_eviction_undo_unlocked(
+      uint32_t target,
+      MutationState& state) {
+    state.reset();
+    state.kind = MutationState::Kind::kEviction;
+    state.old_clock = clock;
+    state.old_eviction_count = eviction_count;
+    state.page_snapshots.reserve(std::min(target, max_pages));
+    state.armed = true;
+  }
+
+  void prepare_decode_undo_unlocked(MutationState& state) {
+    state.reset();
+    state.kind = MutationState::Kind::kDecode;
+    state.old_dispatches = dispatches;
+    state.old_dispatch_failures = dispatch_failures;
+    state.old_native_dispatches = native_dispatches;
+    state.old_native_failures = native_failures;
+    state.old_query_copies = query_copies;
+    state.old_output_copies = output_copies;
+    state.old_attention_validation_bytes = attention_validation_bytes;
+    state.armed = true;
+  }
+
+  bool resolve_request(
+      uint64_t handle,
+      uint32_t* slot,
+      RequestMeta** request,
+      std::string* error) {
+    if (!check_running(error)) {
+      return false;
+    }
+    const uint32_t index = handle_slot(handle);
+    if (index >= requests.size() || handle_generation(handle) == 0) {
+      if (error != nullptr) {
+        *error = "invalid request handle";
+      }
+      return false;
+    }
+    RequestMeta& candidate = requests[index];
+    if (!candidate.live || candidate.generation != handle_generation(handle)) {
+      if (error != nullptr) {
+        *error = "stale or released request handle";
+      }
+      return false;
+    }
+    if (slot != nullptr) {
+      *slot = index;
+    }
+    if (request != nullptr) {
+      *request = &candidate;
+    }
+    return true;
+  }
+
+  bool resolve_prefix(
+      uint64_t handle,
+      uint32_t* slot,
+      PrefixMeta** prefix,
+      std::string* error) {
+    if (!check_running(error)) {
+      return false;
+    }
+    const uint32_t index = handle_slot(handle);
+    if (index >= prefixes.size() || handle_generation(handle) == 0) {
+      if (error != nullptr) {
+        *error = "invalid prefix handle";
+      }
+      return false;
+    }
+    PrefixMeta& candidate = prefixes[index];
+    if (!candidate.live || candidate.generation != handle_generation(handle)) {
+      if (error != nullptr) {
+        *error = "stale or released prefix handle";
+      }
+      return false;
+    }
+    if (slot != nullptr) {
+      *slot = index;
+    }
+    if (prefix != nullptr) {
+      *prefix = &candidate;
+    }
+    return true;
+  }
+
+  bool resolve_page(uint32_t page, std::string* error) const {
+    if (page >= pages.size() || !pages[page].allocated) {
+      if (error != nullptr) {
+        *error = "page is not resident";
+      }
+      return false;
+    }
+    return true;
+  }
+
+  void touch(uint32_t page) {
+    pages[page].last_used = ++clock;
+  }
+
+  void sync_table_range(
+      uint32_t request_slot,
+      uint32_t first_block,
+      uint32_t block_count) {
+    if (block_count == 0 || page_table_buffer == nil) {
+      return;
+    }
+    if (first_block > max_blocks_per_request ||
+        block_count > max_blocks_per_request - first_block) {
+      throw std::out_of_range("page-table metadata range is outside capacity");
+    }
+    const size_t offset =
+        (static_cast<size_t>(request_slot) * max_blocks_per_request +
+         first_block) *
+        sizeof(int32_t);
+    const size_t bytes = static_cast<size_t>(block_count) * sizeof(int32_t);
+    std::memcpy(
+        static_cast<uint8_t*>(page_table_buffer.contents) + offset,
+        page_table.data() +
+            static_cast<size_t>(request_slot) * max_blocks_per_request +
+            first_block,
+        bytes);
+    ++metadata_copies;
+    metadata_bytes += bytes;
+  }
+
+  void sync_table(uint32_t request_slot) {
+    sync_table_range(request_slot, 0, max_blocks_per_request);
+  }
+
+  void sync_length_layer(uint32_t request_slot, uint32_t layer) {
+    if (layer >= num_layers) {
+      throw std::out_of_range("sequence-length metadata layer is out of range");
+    }
+    const size_t index = static_cast<size_t>(request_slot) * num_layers + layer;
+    const auto& lengths = requests[request_slot].layer_lengths;
+    const int32_t length =
+        layer < lengths.size() ? static_cast<int32_t>(lengths[layer]) : 0;
+    layer_sequence_lengths[index] = length;
+    if (sequence_lengths_buffer != nil) {
+      static_cast<int32_t*>(sequence_lengths_buffer.contents)[index] = length;
+      ++metadata_copies;
+      metadata_bytes += sizeof(int32_t);
+    }
+  }
+
+  void sync_length(uint32_t request_slot) {
+    for (uint32_t layer = 0; layer < num_layers; ++layer) {
+      sync_length_layer(request_slot, layer);
+    }
+  }
+
+  // Every KV data movement goes through this helper so instrumentation cannot
+  // silently miss a future COW or host-ingress bulk copy.  This is deliberately
+  // separate from kv_pool_copies: the latter is reserved for a forbidden
+  // capacity-sized snapshot of the whole preallocated pool and must remain
+  // zero on the decode path.
+  void copy_kv_bytes(void* destination, const void* source, size_t bytes) {
+    std::memcpy(destination, source, bytes);
+    kv_copy_bytes += bytes;
+  }
+
+  uint32_t find_evictable_page_unlocked() const {
+    uint32_t candidate = max_pages;
+    uint64_t candidate_tick = std::numeric_limits<uint64_t>::max();
+    for (uint32_t page = 0; page < max_pages; ++page) {
+      const PageMeta& meta = pages[page];
+      if (meta.allocated && meta.references == 0 &&
+          meta.last_used <= candidate_tick) {
+        candidate = page;
+        candidate_tick = meta.last_used;
+      }
+    }
+    return candidate;
+  }
+
+  uint32_t find_allocation_candidate_unlocked(
+      const std::vector<uint32_t>& reserved) const {
+    for (uint32_t page = 0; page < max_pages; ++page) {
+      if (!pages[page].allocated &&
+          std::find(reserved.begin(), reserved.end(), page) == reserved.end()) {
+        return page;
+      }
+    }
+    uint32_t candidate = max_pages;
+    uint64_t candidate_tick = std::numeric_limits<uint64_t>::max();
+    for (uint32_t page = 0; page < max_pages; ++page) {
+      const PageMeta& meta = pages[page];
+      if (meta.allocated && meta.references == 0 &&
+          std::find(reserved.begin(), reserved.end(), page) == reserved.end() &&
+          meta.last_used <= candidate_tick) {
+        candidate = page;
+        candidate_tick = meta.last_used;
+      }
+    }
+    return candidate;
+  }
+
+  uint32_t evict_one_unlocked() {
+    const uint32_t candidate = find_evictable_page_unlocked();
+    if (candidate == max_pages) {
+      return max_pages;
+    }
+    // Every live request/prefix page-table entry owns one reference.  A zero
+    // reference therefore proves that no GPU-ready table can still point at
+    // this page; the next owner publishes its replacement entry through
+    // sync_table_range before decode can observe it.
+    pages[candidate].allocated = false;
+    pages[candidate].references = 0;
+    pages[candidate].last_used = 0;
+    pages[candidate].generation = next_generation(pages[candidate].generation);
+    ++eviction_count;
+    return candidate;
+  }
+
+  uint32_t allocate_physical_page_unlocked(std::string* error) {
+    for (;;) {
+      for (uint32_t page = 0; page < max_pages; ++page) {
+        if (!pages[page].allocated) {
+          PageMeta& meta = pages[page];
+          meta.allocated = true;
+          meta.references = 0;
+          meta.generation = next_generation(meta.generation);
+          touch(page);
+          ++page_allocations;
+          return page;
+        }
+      }
+      if (evict_one_unlocked() == max_pages) {
+        if (error != nullptr) {
+          *error =
+              "page capacity exhausted: every resident page is still referenced";
+        }
+        return max_pages;
+      }
+    }
+  }
+
+  bool can_reserve_physical_pages_unlocked(
+      uint32_t needed,
+      std::string* error) const {
+    uint64_t available = 0;
+    for (const PageMeta& page : pages) {
+      if (!page.allocated || page.references == 0) {
+        ++available;
+      }
+    }
+    if (available < needed) {
+      if (error != nullptr) {
+        *error =
+            "page capacity exhausted: every resident page is still referenced";
+      }
+      return false;
+    }
+    return true;
+  }
+
+  void increment_page(uint32_t page) {
+    ++pages[page].references;
+    touch(page);
+  }
+
+  void decrement_page(uint32_t page) {
+    if (pages[page].references == 0) {
+      return;
+    }
+    --pages[page].references;
+    touch(page);
+  }
+
+  bool cow_page_unlocked(
+      RequestMeta& request,
+      uint32_t request_slot,
+      uint32_t logical_block,
+      std::string* error) {
+    const int32_t old_value = request.pages[logical_block];
+    if (old_value < 0 || !resolve_page(static_cast<uint32_t>(old_value), error)) {
+      return false;
+    }
+    const uint32_t old_page = static_cast<uint32_t>(old_value);
+    if (pages[old_page].references <= 1) {
+      touch(old_page);
+      return true;
+    }
+    const uint32_t new_page = allocate_physical_page_unlocked(error);
+    if (new_page == max_pages) {
+      return false;
+    }
+    const size_t source_offset =
+        static_cast<size_t>(old_page) * static_cast<size_t>(page_elements);
+    const size_t destination_offset =
+        static_cast<size_t>(new_page) * static_cast<size_t>(page_elements);
+    const size_t bytes = static_cast<size_t>(page_elements) * sizeof(uint16_t);
+    const size_t value_plane =
+        static_cast<size_t>(max_pages) * static_cast<size_t>(page_elements);
+    for (LayerStorage& layer : layers) {
+      copy_kv_bytes(
+          layer.data() + destination_offset,
+          layer.data() + source_offset,
+          bytes);
+      copy_kv_bytes(
+          layer.data() + value_plane + destination_offset,
+          layer.data() + value_plane + source_offset,
+          bytes);
+    }
+    decrement_page(old_page);
+    increment_page(new_page);
+    request.pages[logical_block] = static_cast<int32_t>(new_page);
+    page_table[static_cast<size_t>(request_slot) * max_blocks_per_request +
+               logical_block] = static_cast<int32_t>(new_page);
+    sync_table_range(request_slot, logical_block, 1);
+    ++cow_events;
+    return true;
+  }
+
+  bool ensure_request_page_unlocked(
+      RequestMeta& request,
+      uint32_t request_slot,
+      uint32_t logical_block,
+      std::string* error) {
+    if (logical_block >= max_blocks_per_request) {
+      if (error != nullptr) {
+        *error = "logical block exceeds the request page-table capacity";
+      }
+      return false;
+    }
+    int32_t& page_entry = request.pages[logical_block];
+    if (page_entry < 0) {
+      const uint32_t page = allocate_physical_page_unlocked(error);
+      if (page == max_pages) {
+        return false;
+      }
+      page_entry = static_cast<int32_t>(page);
+      increment_page(page);
+      page_table[static_cast<size_t>(request_slot) * max_blocks_per_request +
+                 logical_block] = page_entry;
+      request.page_table_length =
+          std::max(request.page_table_length, logical_block + 1);
+      sync_table_range(request_slot, logical_block, 1);
+      return true;
+    }
+    return resolve_page(static_cast<uint32_t>(page_entry), error);
+  }
+
+};
+
+PageRuntime::PageRuntime(
+    uint32_t num_layers,
+    uint32_t num_attention_heads,
+    uint32_t num_key_value_heads,
+    uint32_t head_dim,
+    uint32_t block_size,
+    uint32_t max_pages,
+    uint32_t max_blocks_per_request,
+    uint32_t max_requests)
+    : impl_(std::make_unique<Impl>(
+          num_layers,
+          num_attention_heads,
+          num_key_value_heads,
+          head_dim,
+          block_size,
+          max_pages,
+          max_blocks_per_request,
+          max_requests)) {}
+
+PageRuntime::~PageRuntime() = default;
+
+void PageRuntime::commit(MutationToken* mutation) noexcept {
+  if (mutation != nullptr && mutation->state_ != nullptr) {
+    mutation->state_->reset();
+  }
+}
+
+void PageRuntime::rollback(MutationToken* mutation) noexcept {
+  if (mutation == nullptr || mutation->state_ == nullptr ||
+      !mutation->state_->armed) {
+    return;
+  }
+  MutationToken::State& state = *mutation->state_;
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  auto restore_page_snapshots = [&] {
+    for (const MutationPageSnapshot& snapshot : state.page_snapshots) {
+      if (snapshot.page >= impl_->pages.size()) {
+        continue;
+      }
+      auto& page = impl_->pages[snapshot.page];
+      page.allocated = snapshot.allocated;
+      page.generation = snapshot.generation;
+      page.references = snapshot.references;
+      page.last_used = snapshot.last_used;
+    }
+  };
+  switch (state.kind) {
+    case MutationToken::State::Kind::kRequest: {
+      if (state.request_slot < impl_->requests.size()) {
+        auto& request = impl_->requests[state.request_slot];
+        if (request.live && request.generation == state.new_generation) {
+          request.live = false;
+          request.generation = state.prior_request_generation;
+          request.id.clear();
+          request.max_tokens = 0;
+          request.sequence_length = 0;
+          request.page_table_length = 0;
+          request.layer_lengths.clear();
+          request.layer_max_key.clear();
+          request.layer_max_value.clear();
+          request.pages.clear();
+          const size_t table_base =
+              static_cast<size_t>(state.request_slot) *
+              impl_->max_blocks_per_request;
+          if (state.prior_request_pages.size() ==
+              impl_->max_blocks_per_request) {
+            std::copy(
+                state.prior_request_pages.begin(),
+                state.prior_request_pages.end(),
+                impl_->page_table.begin() + table_base);
+            if (impl_->page_table_buffer != nil) {
+              std::memcpy(
+                  static_cast<uint8_t*>(impl_->page_table_buffer.contents) +
+                      table_base * sizeof(int32_t),
+                  state.prior_request_pages.data(),
+                  state.prior_request_pages.size() * sizeof(int32_t));
+            }
+          }
+          const size_t length_base =
+              static_cast<size_t>(state.request_slot) * impl_->num_layers;
+          if (state.prior_layer_lengths.size() == impl_->num_layers) {
+            std::copy(
+                state.prior_layer_lengths.begin(),
+                state.prior_layer_lengths.end(),
+                impl_->layer_sequence_lengths.begin() + length_base);
+            if (impl_->sequence_lengths_buffer != nil) {
+              std::memcpy(
+                  static_cast<uint8_t*>(
+                      impl_->sequence_lengths_buffer.contents) +
+                      length_base * sizeof(int32_t),
+                  state.prior_layer_lengths.data(),
+                  state.prior_layer_lengths.size() * sizeof(int32_t));
+            }
+          }
+          impl_->request_allocations = state.old_request_allocations;
+          impl_->metadata_copies = state.old_metadata_copies;
+          impl_->metadata_bytes = state.old_metadata_bytes;
+        }
+      }
+      break;
+    }
+    case MutationToken::State::Kind::kPages: {
+      if (state.request_slot < impl_->requests.size()) {
+        auto& request = impl_->requests[state.request_slot];
+        if (request.live && request.generation == state.prior_request_generation) {
+          for (size_t index = 0; index < state.prior_request_pages.size();
+               ++index) {
+            const size_t block = state.first_block + index;
+            if (block < request.pages.size()) {
+              request.pages[block] = state.prior_request_pages[index];
+              impl_->page_table[
+                  static_cast<size_t>(state.request_slot) *
+                      impl_->max_blocks_per_request +
+                  block] = state.prior_request_pages[index];
+            }
+          }
+          request.page_table_length = state.prior_page_table_length;
+          if (impl_->page_table_buffer != nil &&
+              !state.prior_request_pages.empty()) {
+            const size_t offset =
+                (static_cast<size_t>(state.request_slot) *
+                     impl_->max_blocks_per_request +
+                 state.first_block) *
+                sizeof(int32_t);
+            std::memcpy(
+                static_cast<uint8_t*>(impl_->page_table_buffer.contents) +
+                    offset,
+                state.prior_request_pages.data(),
+                state.prior_request_pages.size() * sizeof(int32_t));
+          }
+        }
+      }
+      restore_page_snapshots();
+      impl_->clock = state.old_clock;
+      impl_->page_allocations = state.old_page_allocations;
+      impl_->eviction_count = state.old_eviction_count;
+      impl_->metadata_copies = state.old_metadata_copies;
+      impl_->metadata_bytes = state.old_metadata_bytes;
+      break;
+    }
+    case MutationToken::State::Kind::kPrefix: {
+      std::unique_lock<std::mutex> slot_lock;
+      if (state.has_request_sequence &&
+          state.request_slot < impl_->requests.size()) {
+        slot_lock = std::unique_lock<std::mutex>(
+            impl_->slot_mutexes[state.request_slot]);
+      }
+      if (state.prefix_was_new) {
+        if (state.prefix_slot + 1 == impl_->prefixes.size()) {
+          impl_->prefixes.pop_back();
+        }
+      } else if (state.prefix_slot < impl_->prefixes.size()) {
+        auto& prefix = impl_->prefixes[state.prefix_slot];
+        prefix.live = false;
+        prefix.generation = state.prior_prefix_generation;
+        prefix.token_count = 0;
+        prefix.pages.clear();
+        prefix.layer_max_key.clear();
+        prefix.layer_max_value.clear();
+      }
+      if (state.has_request_sequence &&
+          state.request_slot < impl_->requests.size()) {
+        impl_->requests[state.request_slot].sequence_length =
+            state.prior_request_sequence_length;
+      }
+      restore_page_snapshots();
+      impl_->clock = state.old_clock;
+      impl_->prefix_allocations = state.old_prefix_allocations;
+      break;
+    }
+    case MutationToken::State::Kind::kEviction:
+      restore_page_snapshots();
+      impl_->clock = state.old_clock;
+      impl_->eviction_count = state.old_eviction_count;
+      break;
+    case MutationToken::State::Kind::kDecode:
+      impl_->dispatches = state.old_dispatches;
+      impl_->dispatch_failures = state.old_dispatch_failures;
+      impl_->native_dispatches = state.old_native_dispatches;
+      impl_->native_failures = state.old_native_failures;
+      impl_->query_copies = state.old_query_copies;
+      impl_->output_copies = state.old_output_copies;
+      impl_->attention_validation_bytes = state.old_attention_validation_bytes;
+      break;
+    case MutationToken::State::Kind::kNone:
+      break;
+  }
+  state.reset();
+}
+
+bool PageRuntime::allocate_request(
+    const std::string& request_id,
+    uint32_t max_tokens,
+    uint64_t* handle,
+    std::string* error) {
+  return allocate_request(request_id, max_tokens, handle, nullptr, error);
+}
+
+bool PageRuntime::allocate_request(
+    const std::string& request_id,
+    uint32_t max_tokens,
+    uint64_t* handle,
+    MutationToken* mutation,
+    std::string* error) {
+  if (handle == nullptr) {
+    if (error != nullptr) {
+      *error = "request handle output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return false;
+  }
+  if (request_id.empty()) {
+    if (error != nullptr) {
+      *error = "request_id must be a non-empty string";
+    }
+    return false;
+  }
+  for (const auto& candidate : impl_->requests) {
+    if (candidate.live && candidate.id == request_id) {
+      if (error != nullptr) {
+        *error = "request_id is already active";
+      }
+      return false;
+    }
+  }
+  const uint64_t capacity = static_cast<uint64_t>(impl_->max_blocks_per_request) *
+      impl_->block_size;
+  if (max_tokens > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
+    if (error != nullptr) {
+      *error = "max_tokens must not exceed INT32_MAX";
+    }
+    return false;
+  }
+  if (max_tokens == 0 || static_cast<uint64_t>(max_tokens) > capacity) {
+    if (error != nullptr) {
+      *error = "max_tokens must be in [1, max_blocks_per_request * block_size]";
+    }
+    return false;
+  }
+  for (uint32_t slot = 0; slot < impl_->max_requests; ++slot) {
+    auto& request = impl_->requests[slot];
+    if (request.live) {
+      continue;
+    }
+    if (mutation != nullptr) {
+      if (mutation->state_ == nullptr || mutation->state_->armed) {
+        if (error != nullptr) {
+          *error = "mutation token is already armed or invalid";
+        }
+        return false;
+      }
+      if (!impl_->prepare_request_undo_unlocked(
+              slot, *mutation->state_, error)) {
+        return false;
+      }
+    }
+    // Build all potentially-allocating state before publishing ``live``.
+    // A bad_alloc here must leave this slot indistinguishable from its prior
+    // released state so a later request cannot observe a half-initialized
+    // generation or page table.
+    Impl::RequestMeta replacement;
+    replacement.live = true;
+    replacement.generation = next_generation(request.generation);
+    replacement.id = request_id;
+    replacement.max_tokens = max_tokens;
+    replacement.sequence_length = 0;
+    replacement.page_table_length = 0;
+    replacement.layer_lengths.assign(impl_->num_layers, 0);
+    replacement.layer_max_key.assign(impl_->num_layers, 0.0f);
+    replacement.layer_max_value.assign(impl_->num_layers, 0.0f);
+    replacement.pages.assign(impl_->max_blocks_per_request, -1);
+    request = std::move(replacement);
+    std::fill(
+        impl_->page_table.begin() +
+            static_cast<size_t>(slot) * impl_->max_blocks_per_request,
+        impl_->page_table.begin() +
+            static_cast<size_t>(slot + 1) * impl_->max_blocks_per_request,
+        -1);
+    impl_->sync_table(slot);
+    impl_->sync_length(slot);
+    *handle = make_handle(request.generation, slot);
+    ++impl_->request_allocations;
+    return true;
+  }
+  if (error != nullptr) {
+    *error = "request capacity exhausted";
+  }
+  return false;
+}
+
+bool PageRuntime::allocate_pages(
+    uint64_t request_handle,
+    uint32_t count,
+    std::vector<uint64_t>* handles,
+    std::string* error) {
+  return allocate_pages(request_handle, count, handles, nullptr, error);
+}
+
+bool PageRuntime::allocate_pages(
+    uint64_t request_handle,
+    uint32_t count,
+    std::vector<uint64_t>* handles,
+    MutationToken* mutation,
+    std::string* error) {
+  if (handles == nullptr) {
+    if (error != nullptr) {
+      *error = "page handle output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t request_slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!impl_->resolve_request(request_handle, &request_slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[request_slot]);
+  if (count == 0) {
+    handles->clear();
+    return true;
+  }
+  uint32_t first_empty = impl_->max_blocks_per_request;
+  for (uint32_t block = 0; block < impl_->max_blocks_per_request; ++block) {
+    if (request->pages[block] < 0) {
+      first_empty = block;
+      break;
+    }
+  }
+  const uint32_t request_page_capacity =
+      (request->max_tokens + impl_->block_size - 1) / impl_->block_size;
+  if (first_empty == impl_->max_blocks_per_request ||
+      first_empty >= request_page_capacity ||
+      count > request_page_capacity - first_empty) {
+    if (error != nullptr) {
+      *error =
+          "requested pages exceed the request max_tokens capacity (" +
+          std::to_string(request_page_capacity) + " pages)";
+    }
+    return false;
+  }
+  // Allocate transactionally: if capacity cannot satisfy the whole request,
+  // leave both metadata and refcounts unchanged.
+  uint32_t unallocated = 0;
+  for (const auto& page : impl_->pages) {
+    if (!page.allocated) {
+      ++unallocated;
+    }
+  }
+  if (unallocated < count) {
+    // Count evictable pages separately so referenced pages can never be
+    // accidentally reclaimed to satisfy an allocation.
+    uint32_t evictable = 0;
+    for (const auto& page : impl_->pages) {
+      if (page.allocated && page.references == 0) {
+        ++evictable;
+      }
+    }
+    if (unallocated + evictable < count) {
+      if (error != nullptr) {
+        *error =
+            "page capacity exhausted: every resident page is still referenced";
+      }
+      return false;
+    }
+  }
+  handles->clear();
+  handles->reserve(count);
+  if (mutation != nullptr) {
+    if (mutation->state_ == nullptr || mutation->state_->armed) {
+      if (error != nullptr) {
+        *error = "mutation token is already armed or invalid";
+      }
+      return false;
+    }
+    if (!impl_->prepare_pages_undo_unlocked(
+            request_slot, first_empty, count, *mutation->state_, error)) {
+      return false;
+    }
+  }
+  for (uint32_t offset = 0; offset < count; ++offset) {
+    const uint32_t block = first_empty + offset;
+    const uint32_t page = impl_->allocate_physical_page_unlocked(error);
+    if (page == impl_->max_pages) {
+      handles->clear();
+      return false;
+    }
+    request->pages[block] = static_cast<int32_t>(page);
+    impl_->increment_page(page);
+    impl_->page_table[static_cast<size_t>(request_slot) *
+                          impl_->max_blocks_per_request +
+                      block] = static_cast<int32_t>(page);
+    request->page_table_length =
+        std::max(request->page_table_length, block + 1);
+    handles->push_back(make_handle(
+        impl_->pages[page].generation, page));
+  }
+  impl_->sync_table_range(request_slot, first_empty, count);
+  return true;
+}
+
+bool PageRuntime::append_kv(
+    uint64_t request_handle,
+    uint32_t layer,
+    const uint16_t* keys,
+    const uint16_t* values,
+    uint32_t tokens,
+    std::string* error) {
+  if (keys == nullptr || values == nullptr) {
+    if (error != nullptr) {
+      *error = "keys and values must not be null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t request_slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!impl_->resolve_request(request_handle, &request_slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[request_slot]);
+  if (layer >= impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "layer index is outside the configured layer count";
+    }
+    return false;
+  }
+  const uint64_t elements = checked_product(
+      {tokens, impl_->num_key_value_heads, impl_->head_dim}, "KV append size");
+  if (elements > std::numeric_limits<size_t>::max()) {
+    if (error != nullptr) {
+      *error = "KV append exceeds native size limits";
+    }
+    return false;
+  }
+  const uint32_t current = request->layer_lengths[layer];
+  if (tokens == 0) {
+    return true;
+  }
+  const size_t append_elements = static_cast<size_t>(elements);
+  if (!all_finite_bf16(keys, append_elements) ||
+      !all_finite_bf16(values, append_elements)) {
+    if (error != nullptr) {
+      *error = "keys and values must contain only finite BF16 values";
+    }
+    return false;
+  }
+  const float append_max_key = max_abs_bf16(keys, append_elements);
+  const float append_max_value = max_abs_bf16(values, append_elements);
+  if (static_cast<uint64_t>(current) + tokens > request->max_tokens) {
+    if (error != nullptr) {
+      *error = "KV append exceeds the request max_tokens limit";
+    }
+    return false;
+  }
+  const uint32_t end = current + tokens;
+  const uint32_t first_block = current / impl_->block_size;
+  const uint32_t last_block = (end - 1) / impl_->block_size;
+  uint32_t pages_needed = 0;
+  for (uint32_t block = first_block; block <= last_block; ++block) {
+    const int32_t page = request->pages[block];
+    if (page < 0) {
+      ++pages_needed;
+    } else if (!impl_->resolve_page(static_cast<uint32_t>(page), error)) {
+      return false;
+    } else if (impl_->pages[static_cast<uint32_t>(page)].references > 1) {
+      ++pages_needed;
+    }
+  }
+  // No page table, refcount, or LRU mutation occurs before this preflight.
+  // Therefore an OOM during a multi-block append cannot leave a partial COW
+  // or an evicted page behind.
+  if (!impl_->can_reserve_physical_pages_unlocked(pages_needed, error)) {
+    return false;
+  }
+  for (uint32_t block = first_block; block <= last_block; ++block) {
+    if (!impl_->ensure_request_page_unlocked(*request, request_slot, block, error)) {
+      return false;
+    }
+    // A shared partial prefix page is copied before the first write.  Full
+    // pages at an exact block boundary remain read-only and shared.
+    if (!impl_->cow_page_unlocked(*request, request_slot, block, error)) {
+      return false;
+    }
+  }
+
+  const size_t page_stride = static_cast<size_t>(impl_->page_elements);
+  uint32_t cursor = 0;
+  while (cursor < tokens) {
+    const uint32_t absolute = current + cursor;
+    const uint32_t logical_block = absolute / impl_->block_size;
+    const uint32_t block_offset = absolute % impl_->block_size;
+    const uint32_t copy_tokens = std::min(
+        tokens - cursor, impl_->block_size - block_offset);
+    const int32_t page_value = request->pages[logical_block];
+    if (page_value < 0 ||
+        !impl_->resolve_page(static_cast<uint32_t>(page_value), error)) {
+      return false;
+    }
+    const uint32_t page = static_cast<uint32_t>(page_value);
+    impl_->touch(page);
+    const size_t destination =
+        static_cast<size_t>(page) * page_stride +
+        static_cast<size_t>(block_offset) * impl_->num_key_value_heads *
+            impl_->head_dim;
+    const size_t source =
+        static_cast<size_t>(cursor) * impl_->num_key_value_heads *
+        impl_->head_dim;
+    const size_t bytes = static_cast<size_t>(copy_tokens) *
+        impl_->num_key_value_heads * impl_->head_dim * sizeof(uint16_t);
+    // K and V occupy separate preallocated planes in each layer buffer.
+    impl_->copy_kv_bytes(
+        impl_->layers[layer].data() + destination, keys + source, bytes);
+    const size_t value_plane = static_cast<size_t>(impl_->max_pages) * page_stride;
+    impl_->copy_kv_bytes(
+        impl_->layers[layer].data() + value_plane + destination,
+        values + source,
+        bytes);
+    cursor += copy_tokens;
+  }
+  request->layer_lengths[layer] = end;
+  request->layer_max_key[layer] =
+      std::max(request->layer_max_key[layer], append_max_key);
+  request->layer_max_value[layer] =
+      std::max(request->layer_max_value[layer], append_max_value);
+  request->sequence_length = *std::max_element(
+      request->layer_lengths.begin(), request->layer_lengths.end());
+  impl_->append_tokens += tokens;
+  impl_->sync_length_layer(request_slot, layer);
+  return true;
+}
+
+bool PageRuntime::create_prefix(
+    uint64_t request_handle,
+    uint64_t* prefix_handle,
+    std::string* error) {
+  return create_prefix(request_handle, prefix_handle, nullptr, error);
+}
+
+bool PageRuntime::create_prefix(
+    uint64_t request_handle,
+    uint64_t* prefix_handle,
+    MutationToken* mutation,
+    std::string* error) {
+  if (prefix_handle == nullptr) {
+    if (error != nullptr) {
+      *error = "prefix handle output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t request_slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!impl_->resolve_request(request_handle, &request_slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[request_slot]);
+  if (request->layer_lengths.empty() || request->layer_lengths[0] == 0 ||
+      std::any_of(
+          request->layer_lengths.begin() + 1,
+          request->layer_lengths.end(),
+          [&](uint32_t length) { return length != request->layer_lengths[0]; })) {
+    if (error != nullptr) {
+      *error =
+          "prefix creation requires all layers to have equal, non-zero lengths";
+    }
+    return false;
+  }
+  const uint32_t token_count = request->layer_lengths[0];
+  if (request->layer_max_key.size() != impl_->num_layers ||
+      request->layer_max_value.size() != impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "request attention range metadata is not initialized";
+    }
+    return false;
+  }
+  const uint32_t blocks =
+      (token_count + impl_->block_size - 1) / impl_->block_size;
+  if (blocks > request->page_table_length ||
+      blocks > request->pages.size()) {
+    if (error != nullptr) {
+      *error = "request page table is shorter than the prefix sequence";
+    }
+    return false;
+  }
+  uint32_t prefix_slot = 0;
+  for (; prefix_slot < impl_->prefixes.size(); ++prefix_slot) {
+    if (!impl_->prefixes[prefix_slot].live) {
+      break;
+    }
+  }
+  const uint32_t prior_generation =
+      prefix_slot < impl_->prefixes.size()
+          ? impl_->prefixes[prefix_slot].generation
+          : 0;
+
+  // Prepare every vector before publishing the prefix slot.  This keeps a
+  // bad_alloc from leaving a live prefix with only part of its metadata.
+  Impl::PrefixMeta replacement;
+  replacement.live = true;
+  replacement.generation = next_generation(prior_generation);
+  replacement.token_count = token_count;
+  replacement.layer_max_key = request->layer_max_key;
+  replacement.layer_max_value = request->layer_max_value;
+  replacement.pages.assign(
+      request->pages.begin(), request->pages.begin() + blocks);
+  for (int32_t page : replacement.pages) {
+    if (page < 0 || !impl_->resolve_page(static_cast<uint32_t>(page), error)) {
+      return false;
+    }
+  }
+
+  if (mutation != nullptr) {
+    if (mutation->state_ == nullptr || mutation->state_->armed) {
+      if (error != nullptr) {
+        *error = "mutation token is already armed or invalid";
+      }
+      return false;
+    }
+    if (!impl_->prepare_prefix_undo_unlocked(
+            prefix_slot,
+            prefix_slot == impl_->prefixes.size(),
+            prior_generation,
+            replacement.generation,
+            true,
+            request_slot,
+            request->sequence_length,
+            replacement.pages,
+            *mutation->state_)) {
+      if (error != nullptr) {
+        *error = "could not prepare prefix rollback state";
+      }
+      return false;
+    }
+  }
+
+  if (prefix_slot == impl_->prefixes.size()) {
+    impl_->prefixes.emplace_back(std::move(replacement));
+  } else {
+    auto& prefix = impl_->prefixes[prefix_slot];
+    prefix.live = replacement.live;
+    prefix.generation = replacement.generation;
+    prefix.token_count = replacement.token_count;
+    prefix.layer_max_key.swap(replacement.layer_max_key);
+    prefix.layer_max_value.swap(replacement.layer_max_value);
+    prefix.pages.swap(replacement.pages);
+  }
+  const auto& prefix = impl_->prefixes[prefix_slot];
+  for (int32_t page : prefix.pages) {
+    impl_->increment_page(static_cast<uint32_t>(page));
+  }
+  request->sequence_length = token_count;
+  *prefix_handle = make_handle(prefix.generation, prefix_slot);
+  ++impl_->prefix_allocations;
+  return true;
+}
+
+bool PageRuntime::fork_prefix(
+    uint64_t prefix_handle,
+    uint64_t* forked_handle,
+    std::string* error) {
+  return fork_prefix(prefix_handle, forked_handle, nullptr, error);
+}
+
+bool PageRuntime::fork_prefix(
+    uint64_t prefix_handle,
+    uint64_t* forked_handle,
+    MutationToken* mutation,
+    std::string* error) {
+  if (forked_handle == nullptr) {
+    if (error != nullptr) {
+      *error = "forked prefix output is null";
+    }
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  Impl::PrefixMeta* source = nullptr;
+  if (!impl_->resolve_prefix(prefix_handle, nullptr, &source, error)) {
+    return false;
+  }
+  if (source->layer_max_key.size() != impl_->num_layers ||
+      source->layer_max_value.size() != impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "prefix attention range metadata is not initialized";
+    }
+    return false;
+  }
+  // ``prefixes`` is a growable vector.  Copy the source payload before any
+  // emplace_back so a reallocation cannot invalidate the source pointer.
+  const uint32_t source_token_count = source->token_count;
+  std::vector<float> source_max_key = source->layer_max_key;
+  std::vector<float> source_max_value = source->layer_max_value;
+  std::vector<int32_t> source_pages = source->pages;
+  uint32_t slot = 0;
+  for (; slot < impl_->prefixes.size(); ++slot) {
+    if (!impl_->prefixes[slot].live) {
+      break;
+    }
+  }
+  const uint32_t prior_generation =
+      slot < impl_->prefixes.size() ? impl_->prefixes[slot].generation : 0;
+  Impl::PrefixMeta replacement;
+  replacement.live = true;
+  replacement.generation = next_generation(prior_generation);
+  replacement.token_count = source_token_count;
+  replacement.layer_max_key = std::move(source_max_key);
+  replacement.layer_max_value = std::move(source_max_value);
+  replacement.pages = std::move(source_pages);
+  for (int32_t page : replacement.pages) {
+    if (page < 0 || !impl_->resolve_page(static_cast<uint32_t>(page), error)) {
+      return false;
+    }
+  }
+
+  if (mutation != nullptr) {
+    if (mutation->state_ == nullptr || mutation->state_->armed) {
+      if (error != nullptr) {
+        *error = "mutation token is already armed or invalid";
+      }
+      return false;
+    }
+    if (!impl_->prepare_prefix_undo_unlocked(
+            slot,
+            slot == impl_->prefixes.size(),
+            prior_generation,
+            replacement.generation,
+            false,
+            0,
+            0,
+            replacement.pages,
+            *mutation->state_)) {
+      if (error != nullptr) {
+        *error = "could not prepare prefix rollback state";
+      }
+      return false;
+    }
+  }
+
+  if (slot == impl_->prefixes.size()) {
+    impl_->prefixes.emplace_back(std::move(replacement));
+  } else {
+    auto& destination = impl_->prefixes[slot];
+    destination.live = replacement.live;
+    destination.generation = replacement.generation;
+    destination.token_count = replacement.token_count;
+    destination.layer_max_key.swap(replacement.layer_max_key);
+    destination.layer_max_value.swap(replacement.layer_max_value);
+    destination.pages.swap(replacement.pages);
+  }
+  const auto& destination = impl_->prefixes[slot];
+  for (int32_t page : destination.pages) {
+    impl_->increment_page(static_cast<uint32_t>(page));
+  }
+  *forked_handle = make_handle(destination.generation, slot);
+  ++impl_->prefix_allocations;
+  return true;
+}
+
+bool PageRuntime::attach_prefix(
+    uint64_t request_handle,
+    uint64_t prefix_handle,
+    std::string* error) {
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t request_slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!impl_->resolve_request(request_handle, &request_slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[request_slot]);
+  Impl::PrefixMeta* prefix = nullptr;
+  if (!impl_->resolve_prefix(prefix_handle, nullptr, &prefix, error)) {
+    return false;
+  }
+  if (request->sequence_length != 0 ||
+      std::any_of(
+          request->pages.begin(), request->pages.end(),
+          [](int32_t page) { return page >= 0; })) {
+    if (error != nullptr) {
+      *error = "a prefix can only attach to an empty request";
+    }
+    return false;
+  }
+  if (prefix->token_count > request->max_tokens) {
+    if (error != nullptr) {
+      *error = "prefix token count exceeds the request max_tokens limit";
+    }
+    return false;
+  }
+  if (prefix->pages.size() > request->pages.size()) {
+    if (error != nullptr) {
+      *error = "prefix page count exceeds the request page-table capacity";
+    }
+    return false;
+  }
+  if (prefix->layer_max_key.size() != impl_->num_layers ||
+      prefix->layer_max_value.size() != impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "prefix attention range metadata is not initialized";
+    }
+    return false;
+  }
+  if (request->layer_lengths.size() != impl_->num_layers ||
+      request->layer_max_key.size() != impl_->num_layers ||
+      request->layer_max_value.size() != impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "request attention range metadata is not initialized";
+    }
+    return false;
+  }
+  for (size_t index = 0; index < prefix->pages.size(); ++index) {
+    const int32_t page = prefix->pages[index];
+    if (page < 0 || !impl_->resolve_page(static_cast<uint32_t>(page), error)) {
+      return false;
+    }
+  }
+  for (size_t index = 0; index < prefix->pages.size(); ++index) {
+    const int32_t page = prefix->pages[index];
+    request->pages[index] = page;
+    impl_->increment_page(static_cast<uint32_t>(page));
+    impl_->page_table[static_cast<size_t>(request_slot) *
+                          impl_->max_blocks_per_request +
+                      index] = page;
+  }
+  request->sequence_length = prefix->token_count;
+  request->page_table_length = static_cast<uint32_t>(prefix->pages.size());
+  std::fill(
+      request->layer_lengths.begin(), request->layer_lengths.end(),
+      request->sequence_length);
+  std::copy(
+      prefix->layer_max_key.begin(),
+      prefix->layer_max_key.end(),
+      request->layer_max_key.begin());
+  std::copy(
+      prefix->layer_max_value.begin(),
+      prefix->layer_max_value.end(),
+      request->layer_max_value.begin());
+  impl_->sync_table_range(
+      request_slot, 0, static_cast<uint32_t>(prefix->pages.size()));
+  impl_->sync_length(request_slot);
+  return true;
+}
+
+bool PageRuntime::release_prefix(uint64_t prefix_handle, std::string* error) {
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return false;
+  }
+  const uint32_t prefix_slot = handle_slot(prefix_handle);
+  const uint32_t prefix_generation = handle_generation(prefix_handle);
+  if (prefix_slot < impl_->prefixes.size() && prefix_generation != 0) {
+    const auto& prior = impl_->prefixes[prefix_slot];
+    if (!prior.live && prior.generation == prefix_generation) {
+      // Releasing the exact same handle twice is deliberately idempotent.
+      // A reused slot has a different generation and still fails below.
+      return true;
+    }
+  }
+  Impl::PrefixMeta* prefix = nullptr;
+  if (!impl_->resolve_prefix(prefix_handle, nullptr, &prefix, error)) {
+    return false;
+  }
+  for (int32_t page : prefix->pages) {
+    if (page >= 0 && static_cast<uint32_t>(page) < impl_->pages.size()) {
+      impl_->decrement_page(static_cast<uint32_t>(page));
+    }
+  }
+  prefix->live = false;
+  prefix->pages.clear();
+  prefix->layer_max_key.clear();
+  prefix->layer_max_value.clear();
+  prefix->token_count = 0;
+  return true;
+}
+
+bool PageRuntime::release_request(
+    uint64_t request_handle,
+    bool cancelled,
+    std::string* error) {
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return false;
+  }
+  const uint32_t prior_slot = handle_slot(request_handle);
+  const uint32_t request_generation = handle_generation(request_handle);
+  if (prior_slot < impl_->requests.size() && request_generation != 0) {
+    const auto& prior = impl_->requests[prior_slot];
+    if (!prior.live && prior.generation == request_generation) {
+      // Releasing/cancelling an already released handle is a safe no-op.  A
+      // stale handle from a later slot reuse has a different generation and
+      // is rejected by resolve_request below.
+      return true;
+    }
+  }
+  uint32_t request_slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!impl_->resolve_request(request_handle, &request_slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[request_slot]);
+  for (int32_t page : request->pages) {
+    if (page >= 0 && static_cast<uint32_t>(page) < impl_->pages.size()) {
+      impl_->decrement_page(static_cast<uint32_t>(page));
+    }
+  }
+  request->live = false;
+  request->id.clear();
+    request->max_tokens = 0;
+    request->sequence_length = 0;
+    request->page_table_length = 0;
+  request->layer_lengths.clear();
+  request->layer_max_key.clear();
+  request->layer_max_value.clear();
+  request->pages.clear();
+  std::fill(
+      impl_->page_table.begin() +
+          static_cast<size_t>(request_slot) * impl_->max_blocks_per_request,
+      impl_->page_table.begin() +
+          static_cast<size_t>(request_slot + 1) * impl_->max_blocks_per_request,
+      -1);
+  impl_->sync_table(request_slot);
+  impl_->sync_length(request_slot);
+  if (cancelled) {
+    ++impl_->cancellation_count;
+  } else {
+    ++impl_->release_count;
+  }
+  return true;
+}
+
+bool PageRuntime::snapshot(
+    uint64_t prefix_handle,
+    const std::string& destination,
+    std::string* error) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return false;
+  }
+  (void)prefix_handle;
+  (void)destination;
+  ++impl_->snapshot_failures;
+  if (error != nullptr) {
+    *error =
+        "Metal Context page-runtime snapshots are deferred to the persistence "
+        "package; no page bytes are written by this backend";
+  }
+  return false;
+}
+
+bool PageRuntime::restore(
+    const std::string& source,
+    uint64_t* prefix_handle,
+    std::string* error) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return false;
+  }
+  (void)source;
+  if (prefix_handle != nullptr) {
+    *prefix_handle = 0;
+  }
+  ++impl_->restore_failures;
+  if (error != nullptr) {
+    *error =
+        "Metal Context page-runtime restore is deferred to the persistence "
+        "package; arbitrary Python objects are never deserialized";
+  }
+  return false;
+}
+
+uint32_t PageRuntime::evict(
+    uint32_t target_pages,
+    bool has_target,
+    std::string* error) {
+  return evict(target_pages, has_target, nullptr, error);
+}
+
+uint32_t PageRuntime::evict(
+    uint32_t target_pages,
+    bool has_target,
+    MutationToken* mutation,
+    std::string* error) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  if (!impl_->check_running(error)) {
+    return 0;
+  }
+  const uint32_t target = has_target ? target_pages : impl_->max_pages;
+  if (mutation != nullptr) {
+    if (mutation->state_ == nullptr || mutation->state_->armed) {
+      if (error != nullptr) {
+        *error = "mutation token is already armed or invalid";
+      }
+      return 0;
+    }
+    impl_->prepare_eviction_undo_unlocked(target, *mutation->state_);
+  }
+  uint32_t evicted = 0;
+  while (evicted < target) {
+    const uint32_t candidate = impl_->find_evictable_page_unlocked();
+    if (candidate == impl_->max_pages) {
+      break;
+    }
+    if (mutation != nullptr) {
+      mutation->state_->page_snapshots.push_back(
+          Impl::snapshot_page(candidate, impl_->pages[candidate]));
+    }
+    if (impl_->evict_one_unlocked() == impl_->max_pages) {
+      break;
+    }
+    ++evicted;
+  }
+  return evicted;
+}
+
+bool PageRuntime::page_table(
+    uint64_t request_handle,
+    uint32_t layer,
+    std::vector<int32_t>* table,
+    std::string* error) const {
+  if (table == nullptr) {
+    if (error != nullptr) {
+      *error = "page-table output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!const_cast<Impl*>(impl_.get())->resolve_request(
+          request_handle, &slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[slot]);
+  if (layer >= impl_->num_layers) {
+    if (error != nullptr) {
+      *error = "layer index is outside the configured layer count";
+    }
+    return false;
+  }
+  const uint32_t length = request->layer_lengths[layer];
+  const uint32_t blocks =
+      (length + impl_->block_size - 1) / impl_->block_size;
+  if (blocks > request->page_table_length ||
+      blocks > request->pages.size()) {
+    if (error != nullptr) {
+      *error = "request page table is shorter than its layer sequence";
+    }
+    return false;
+  }
+  table->assign(
+      impl_->page_table.begin() +
+          static_cast<size_t>(slot) * impl_->max_blocks_per_request,
+      impl_->page_table.begin() +
+          static_cast<size_t>(slot) * impl_->max_blocks_per_request + blocks);
+  return true;
+}
+
+bool PageRuntime::request_pages(
+    uint64_t request_handle,
+    std::vector<uint64_t>* pages,
+    std::string* error) const {
+  if (pages == nullptr) {
+    if (error != nullptr) {
+      *error = "request-pages output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!const_cast<Impl*>(impl_.get())->resolve_request(
+          request_handle, &slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[slot]);
+  pages->clear();
+  for (int32_t page : request->pages) {
+    if (page < 0) {
+      break;
+    }
+    if (!impl_->resolve_page(static_cast<uint32_t>(page), error)) {
+      return false;
+    }
+    pages->push_back(make_handle(
+        impl_->pages[static_cast<uint32_t>(page)].generation,
+        static_cast<uint32_t>(page)));
+  }
+  return true;
+}
+
+bool PageRuntime::sequence_length(
+    uint64_t request_handle,
+    uint32_t* length,
+    std::string* error) const {
+  if (length == nullptr) {
+    if (error != nullptr) {
+      *error = "sequence-length output is null";
+    }
+    return false;
+  }
+  std::unique_lock<std::mutex> lock(impl_->mutex);
+  uint32_t slot = 0;
+  Impl::RequestMeta* request = nullptr;
+  if (!const_cast<Impl*>(impl_.get())->resolve_request(
+          request_handle, &slot, &request, error)) {
+    return false;
+  }
+  std::unique_lock<std::mutex> slot_lock(impl_->slot_mutexes[slot]);
+  *length = request->sequence_length;
+  return true;
+}
+
+bool PageRuntime::paged_decode(
+    uint64_t request_handle,
+    uint32_t layer,
+    const uint16_t* query,
+    size_t query_elements,
+    float scale,
+    std::vector<float>* output,
+    std::string* error) {
+  return paged_decode(
+      request_handle,
+      layer,
+      query,
+      query_elements,
+      scale,
+      output,
+      nullptr,
+      error);
+}
+
+bool PageRuntime::paged_decode(
+    uint64_t request_handle,
+    uint32_t layer,
+    const uint16_t* query,
+    size_t query_elements,
+    float scale,
+    std::vector<float>* output,
+    MutationToken* mutation,
+    std::string* error) {
+  if (query == nullptr || output == nullptr || error == nullptr) {
+    if (error != nullptr) {
+      *error = "paged decode query/output must not be null";
+    }
+    return false;
+  }
+  uint32_t slot = 0;
+  uint32_t length = 0;
+  float max_key = 0.0f;
+  float max_value = 0.0f;
+  Impl::RequestMeta* request = nullptr;
+  std::unique_lock<std::mutex> slot_lock;
+  std::string path;
+  Impl::DispatchResult dispatch_result;
+  {
+    std::unique_lock<std::mutex> lock(impl_->mutex);
+    if (!const_cast<Impl*>(impl_.get())->resolve_request(
+            request_handle, &slot, &request, error)) {
+      return false;
+    }
+    if (layer >= impl_->num_layers) {
+      *error = "layer index is outside the configured layer count";
+      return false;
+    }
+    // A slot owns its query/output scratch ranges and its live page table.
+    // Hold that slot lock across validation and dispatch so append/COW/release
+    // cannot mutate the shared KV pages while the GPU is reading them.  The
+    // runtime mutex is released before the slot lock is used; the dispatch
+    // lease drops the slot lock before it records any result under the runtime
+    // mutex, preserving the documented Impl -> slot lock order.
+    slot_lock = std::unique_lock<std::mutex>(impl_->slot_mutexes[slot]);
+    if (request->layer_lengths.size() != impl_->num_layers ||
+        request->layer_max_key.size() != impl_->num_layers ||
+        request->layer_max_value.size() != impl_->num_layers) {
+      *error = "request layer metadata is not initialized";
+      return false;
+    }
+    if (query_elements != impl_->query_elements) {
+      *error = "query element count does not match the runtime geometry";
+      return false;
+    }
+    length = request->layer_lengths[layer];
+    max_key = request->layer_max_key[layer];
+    max_value = request->layer_max_value[layer];
+    const uint32_t blocks =
+        (length + impl_->block_size - 1) / impl_->block_size;
+    if (blocks > request->page_table_length ||
+        blocks > request->pages.size()) {
+      *error = "request page table is shorter than its sequence length";
+      return false;
+    }
+    // Page-table and sequence-length buffers are kept GPU-ready by every
+    // lifecycle mutation.  Do not walk or touch the logical page chain here:
+    // steady-state decode CPU work is O(query) plus constant metadata.
+    path = impl_->library_path;
+    // Register the in-flight operation before releasing the runtime mutex.
+    // Shutdown marks the runtime as stopping and waits for this lease, so it
+    // cannot release the shared kernel while the preallocated buffers are in
+    // use.
+    if (mutation != nullptr) {
+      if (mutation->state_ == nullptr || mutation->state_->armed) {
+        *error = "mutation token is already armed or invalid";
+        return false;
+      }
+      impl_->prepare_decode_undo_unlocked(*mutation->state_);
+    }
+    ++impl_->active_dispatches;
+  }
+  struct DispatchLease {
+    Impl* impl;
+    std::unique_lock<std::mutex>* slot_lock;
+    Impl::DispatchResult* result;
+    ~DispatchLease() noexcept {
+      // Mutators take the runtime mutex before a slot mutex.  Release the
+      // slot first so they cannot wait on this lease while finish_dispatch()
+      // waits on the runtime mutex.
+      if (slot_lock != nullptr && slot_lock->owns_lock()) {
+        slot_lock->unlock();
+      }
+      if (impl != nullptr) {
+        impl->finish_dispatch(*result);
+      }
+    }
+  } dispatch_lease{impl_.get(), &slot_lock, &dispatch_result};
+  dispatch_result.validation_bytes = query_elements * sizeof(uint16_t);
+  dispatch_result.validation_failed = true;
+  if (!validate_attention_envelope(
+          query,
+          query_elements,
+          length,
+          max_key,
+          max_value,
+          impl_->head_dim,
+          scale,
+          error)) {
+    return false;
+  }
+  dispatch_result.validation_failed = false;
+  dispatch_result.dispatch_attempted = true;
+  if (path.empty()) {
+    path = metallib_path();
+  }
+  dispatch_result.dispatched = dispatch_kernel(
+      impl_->command_queue,
+      impl_->query_scratch_buffer,
+      static_cast<NSUInteger>(
+          static_cast<uint64_t>(slot) * impl_->query_bytes_per_slot),
+      impl_->layers[layer].buffer,
+      0,
+      static_cast<NSUInteger>(checked_product(
+          {impl_->max_pages, impl_->page_elements, sizeof(uint16_t)},
+          "value buffer offset")),
+      impl_->page_table_buffer,
+      static_cast<NSUInteger>(checked_product(
+          {slot, impl_->max_blocks_per_request, sizeof(int32_t)},
+          "page-table buffer offset")),
+      impl_->sequence_lengths_buffer,
+      static_cast<NSUInteger>(page_runtime_sequence_buffer_offset(
+          slot, impl_->num_layers, layer)),
+      impl_->output_scratch_buffer,
+      static_cast<NSUInteger>(
+          static_cast<uint64_t>(slot) * impl_->output_bytes_per_slot),
+      query,
+      query_elements,
+      1,
+      impl_->num_attention_heads,
+      impl_->num_key_value_heads,
+      impl_->head_dim,
+      impl_->block_size,
+      impl_->max_blocks_per_request,
+      impl_->max_pages,
+      scale,
+      path,
+      output,
+      error,
+      &dispatch_result.query_copies,
+      &dispatch_result.output_copies);
+  return dispatch_result.dispatched;
+}
+
+PageRuntimeMetrics PageRuntime::metrics(std::string* error) const {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  PageRuntimeMetrics result;
+  (void)error;
+  result.shutdown = impl_->stopped;
+  result.max_pages = impl_->max_pages;
+  result.max_blocks_per_request = impl_->max_blocks_per_request;
+  result.block_size = impl_->block_size;
+  // The configured page capacity remains available for diagnostics, but the
+  // backing storage has been released after shutdown; report resident bytes,
+  // rather than stale allocation capacity, in the post-shutdown snapshot.
+  result.bytes_per_layer = impl_->stopped ? 0 : impl_->bytes_per_layer;
+  result.kv_bytes = result.bytes_per_layer * impl_->num_layers;
+  result.page_allocations = impl_->page_allocations;
+  result.request_allocations = impl_->request_allocations;
+  result.prefix_allocations = impl_->prefix_allocations;
+  result.cow_events = impl_->cow_events;
+  result.evictions = impl_->eviction_count;
+  result.releases = impl_->release_count;
+  result.cancellations = impl_->cancellation_count;
+  result.append_tokens = impl_->append_tokens;
+  result.dispatches = impl_->dispatches;
+  result.dispatch_failures = impl_->dispatch_failures;
+  result.native_dispatches = impl_->native_dispatches;
+  result.native_failures = impl_->native_failures;
+  result.buffer_allocations = impl_->buffer_allocations;
+  result.decode_buffer_allocations = impl_->decode_buffer_allocations;
+  result.query_copies = impl_->query_copies;
+  result.output_copies = impl_->output_copies;
+  result.metadata_copies = impl_->metadata_copies;
+  result.metadata_bytes = impl_->metadata_bytes;
+  result.kv_copy_bytes = impl_->kv_copy_bytes;
+  result.kv_pool_copies = impl_->kv_pool_copies;
+  result.attention_validation_bytes = impl_->attention_validation_bytes;
+  result.decode_page_resolution_checks =
+      impl_->decode_page_resolution_checks;
+  result.snapshot_failures = impl_->snapshot_failures;
+  result.restore_failures = impl_->restore_failures;
+  for (const auto& page : impl_->pages) {
+    if (!page.allocated) {
+      ++result.free_pages;
+    } else {
+      ++result.resident_pages;
+      if (page.references > 0) {
+        ++result.referenced_pages;
+      } else {
+        ++result.evictable_pages;
+      }
+      if (page.references > 1) {
+        ++result.shared_pages;
+      }
+    }
+  }
+  for (const auto& request : impl_->requests) {
+    if (request.live) {
+      ++result.requests;
+    }
+  }
+  for (const auto& prefix : impl_->prefixes) {
+    if (prefix.live) {
+      ++result.prefixes;
+    }
+  }
+  return result;
+}
+
+void PageRuntime::shutdown() {
+  impl_->shutdown_and_wait();
+}
+
+bool PageRuntime::is_shutdown() const {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  return impl_->stopped;
+}
+
+uint32_t PageRuntime::num_layers() const { return impl_->num_layers; }
+uint32_t PageRuntime::num_attention_heads() const {
+  return impl_->num_attention_heads;
+}
+uint32_t PageRuntime::num_key_value_heads() const {
+  return impl_->num_key_value_heads;
+}
+uint32_t PageRuntime::head_dim() const { return impl_->head_dim; }
+uint32_t PageRuntime::block_size() const { return impl_->block_size; }
+uint32_t PageRuntime::max_pages() const { return impl_->max_pages; }
+uint32_t PageRuntime::max_blocks_per_request() const {
+  return impl_->max_blocks_per_request;
+}
+uint32_t PageRuntime::max_requests() const { return impl_->max_requests; }
+
+void PageRuntime::set_metallib_path(const std::string& path) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  impl_->library_path = path;
+}
+
+}  // namespace metal_context

--- a/native/metal_context/src/page_runtime_python.mm
+++ b/native/metal_context/src/page_runtime_python.mm
@@ -1,0 +1,1414 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CPython ABI for the native page ownership runtime.
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "page_runtime.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <condition_variable>
+#include <mutex>
+#include <new>
+#include <string>
+#include <vector>
+
+namespace {
+
+using metal_context::PageRuntime;
+
+struct BufferGuard {
+  Py_buffer view{};
+  bool acquired = false;
+  ~BufferGuard() {
+    if (acquired) {
+      PyBuffer_Release(&view);
+    }
+  }
+};
+
+struct PageRuntimeObject {
+  PyObject_HEAD
+  PageRuntime* runtime = nullptr;
+  std::mutex lifecycle_mutex;
+  std::condition_variable lifecycle_cv;
+  uint32_t active_calls = 0;
+};
+
+bool acquire_buffer(PyObject* object, BufferGuard* guard, const char* name) {
+  if (PyObject_GetBuffer(
+          object,
+          &guard->view,
+          PyBUF_FORMAT | PyBUF_ND | PyBUF_STRIDES | PyBUF_C_CONTIGUOUS) < 0) {
+    PyErr_Format(
+        PyExc_TypeError,
+        "%s must expose a contiguous buffer (NumPy arrays are accepted)",
+        name);
+    return false;
+  }
+  guard->acquired = true;
+  return true;
+}
+
+bool host_is_little_endian() {
+  const uint16_t value = 1;
+  return *reinterpret_cast<const uint8_t*>(&value) == 1;
+}
+
+bool is_native_uint16_buffer(const Py_buffer& view) {
+  if (view.itemsize != sizeof(uint16_t) || view.format == nullptr) {
+    return false;
+  }
+  const char* format = view.format;
+  if (*format == '@' || *format == '=') {
+    ++format;
+  } else if (*format == '<') {
+    if (!host_is_little_endian()) {
+      return false;
+    }
+    ++format;
+  } else if (*format == '>' || *format == '!') {
+    return false;
+  }
+  return std::strlen(format) == 1 && format[0] == 'H';
+}
+
+bool finite_bf16(const Py_buffer& view) {
+  const auto* data = static_cast<const uint16_t*>(view.buf);
+  const size_t count = static_cast<size_t>(view.len) / sizeof(uint16_t);
+  for (size_t index = 0; index < count; ++index) {
+    if ((data[index] & 0x7f80u) == 0x7f80u) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool runtime_error(const std::string& error) {
+  PyErr_SetString(PyExc_RuntimeError, error.c_str());
+  return false;
+}
+
+bool value_error(const std::string& error) {
+  PyErr_SetString(PyExc_ValueError, error.c_str());
+  return false;
+}
+
+bool lifecycle_error(const std::string& error) {
+  if (error.find("capacity exhausted") != std::string::npos) {
+    PyErr_SetString(PyExc_MemoryError, error.c_str());
+    return false;
+  }
+  return value_error(error);
+}
+
+bool not_implemented_error(const std::string& error) {
+  PyErr_SetString(PyExc_NotImplementedError, error.c_str());
+  return false;
+}
+
+// No C++ exception may cross a CPython ``PyCFunction`` ABI boundary.  Keep
+// this mapping in one place and use the scope macros below around every
+// bridge method that touches the native runtime (including vector/dict
+// construction that can throw bad_alloc).
+void set_native_exception(const std::bad_alloc& exception) {
+  PyErr_SetString(
+      PyExc_MemoryError,
+      exception.what()[0] == '\0' ? "native page runtime allocation failed"
+                                  : exception.what());
+}
+
+void set_native_exception(const std::exception& exception) {
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      exception.what()[0] == '\0' ? "native page runtime operation failed"
+                                  : exception.what());
+}
+
+void set_unknown_native_exception() {
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      "unknown native page runtime exception");
+}
+
+#define PAGE_RUNTIME_PY_TRY try {
+#define PAGE_RUNTIME_PY_CATCH                                                 \
+  } catch (const std::bad_alloc& exception) {                                 \
+    set_native_exception(exception);                                           \
+    return nullptr;                                                            \
+  } catch (const std::exception& exception) {                                  \
+    set_native_exception(exception);                                           \
+    return nullptr;                                                            \
+  } catch (...) {                                                              \
+    set_unknown_native_exception();                                            \
+    return nullptr;                                                            \
+  }
+
+// A decode call releases the GIL while Metal waits synchronously.  Keep a
+// lifecycle lease on the Python object's native pointer so __init__ and
+// deallocation cannot delete the PageRuntime until the call has reacquired
+// the GIL and left this scope.
+class RuntimeCallLease {
+ public:
+  explicit RuntimeCallLease(PageRuntimeObject* owner) : owner_(owner) {}
+
+  bool acquire() {
+    std::unique_lock<std::mutex> lock(owner_->lifecycle_mutex);
+    if (owner_->runtime == nullptr || owner_->runtime->is_shutdown()) {
+      PyErr_SetString(PyExc_RuntimeError, "page runtime is shut down");
+      return false;
+    }
+    runtime_ = owner_->runtime;
+    ++owner_->active_calls;
+    acquired_ = true;
+    return true;
+  }
+
+  PageRuntime* get() const { return runtime_; }
+
+  ~RuntimeCallLease() noexcept {
+    if (!acquired_) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(owner_->lifecycle_mutex);
+    if (owner_->active_calls > 0) {
+      --owner_->active_calls;
+    }
+    owner_->lifecycle_cv.notify_all();
+  }
+
+ private:
+  PageRuntimeObject* owner_;
+  PageRuntime* runtime_ = nullptr;
+  bool acquired_ = false;
+};
+
+// Native mutators are deliberately kept uncommitted until the bridge has
+// successfully constructed the Python object it returns.  CPython allocators
+// can fail after the native operation has changed page ownership, so the
+// guard rolls the operation back on every NULL return (including a caught
+// bad_alloc).  PageRuntime::rollback is allocation-free and generation-safe.
+class NativeMutationGuard {
+ public:
+  explicit NativeMutationGuard(PageRuntime* runtime) : runtime_(runtime) {}
+
+  PageRuntime::MutationToken* token() { return &token_; }
+
+  void commit() noexcept {
+    if (!committed_) {
+      runtime_->commit(&token_);
+      committed_ = true;
+    }
+  }
+
+  void rollback() noexcept {
+    if (!committed_) {
+      runtime_->rollback(&token_);
+      committed_ = true;
+    }
+  }
+
+  ~NativeMutationGuard() noexcept { rollback(); }
+
+ private:
+  PageRuntime* runtime_;
+  PageRuntime::MutationToken token_;
+  bool committed_ = false;
+};
+
+bool require_runtime(PageRuntimeObject* self) {
+  if (self->runtime == nullptr || self->runtime->is_shutdown()) {
+    PyErr_SetString(PyExc_RuntimeError, "page runtime is shut down");
+    return false;
+  }
+  return true;
+}
+
+std::string packaged_metallib_path() {
+  const char* override_path =
+      std::getenv("VLLM_MLX_METAL_CONTEXT_METALLIB");
+  if (override_path != nullptr && override_path[0] != '\0') {
+    return override_path;
+  }
+  PyObject* module = PyImport_AddModule("vllm_mlx._metal_context");
+  if (module == nullptr) {
+    PyErr_Clear();
+    return {};
+  }
+  PyObject* file_object = PyModule_GetFilenameObject(module);
+  if (file_object == nullptr) {
+    PyErr_Clear();
+    return {};
+  }
+  const char* file_name = PyUnicode_AsUTF8(file_object);
+  std::string result;
+  if (file_name != nullptr) {
+    try {
+      result = (std::filesystem::path(file_name).parent_path() /
+                "_metal_context.metallib")
+                   .string();
+    } catch (const std::exception&) {
+      result.clear();
+    }
+  } else {
+    PyErr_Clear();
+  }
+  Py_DECREF(file_object);
+  return result;
+}
+
+bool py_uint64(PyObject* object, uint64_t* result, const char* name) {
+  if (!PyLong_Check(object)) {
+    PyErr_Format(PyExc_TypeError, "%s must be an integer handle", name);
+    return false;
+  }
+  unsigned long long value = PyLong_AsUnsignedLongLong(object);
+  if (value == ULLONG_MAX && PyErr_Occurred()) {
+    return false;
+  }
+  *result = static_cast<uint64_t>(value);
+  return true;
+}
+
+bool result_fault_requested(const char* operation, const char* stage) {
+  const char* configured =
+      std::getenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT");
+  if (configured == nullptr || configured[0] == '\0') {
+    return false;
+  }
+  return std::strcmp(configured, "all") == 0 ||
+      std::strcmp(configured, operation) == 0 ||
+      std::strcmp(configured, stage) == 0 ||
+      (std::strstr(configured, operation) != nullptr &&
+       std::strstr(configured, stage) != nullptr);
+}
+
+bool fail_result_allocation(const char* operation, const char* stage) {
+  if (!result_fault_requested(operation, stage)) {
+    return false;
+  }
+  PyErr_NoMemory();
+  return true;
+}
+
+PyObject* result_u64(const char* operation, uint64_t value) {
+  if (fail_result_allocation(operation, "long")) {
+    return nullptr;
+  }
+  return PyLong_FromUnsignedLongLong(value);
+}
+
+PyObject* result_u32(const char* operation, uint32_t value) {
+  if (fail_result_allocation(operation, "long")) {
+    return nullptr;
+  }
+  return PyLong_FromUnsignedLong(value);
+}
+
+PyObject* result_bytes(
+    const char* operation,
+    const char* data,
+    Py_ssize_t size) {
+  if (fail_result_allocation(operation, "bytes")) {
+    return nullptr;
+  }
+  return PyBytes_FromStringAndSize(data, size);
+}
+
+PyObject* tuple_from_u64(
+    const std::vector<uint64_t>& values,
+    const char* operation) {
+  if (fail_result_allocation(operation, "tuple")) {
+    return nullptr;
+  }
+  PyObject* result = PyTuple_New(static_cast<Py_ssize_t>(values.size()));
+  if (result == nullptr) {
+    return nullptr;
+  }
+  for (size_t index = 0; index < values.size(); ++index) {
+    if (fail_result_allocation(operation, "tuple_item")) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyObject* value = PyLong_FromUnsignedLongLong(values[index]);
+    if (value == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(result, static_cast<Py_ssize_t>(index), value);
+  }
+  return result;
+}
+
+PyObject* tuple_from_i32(
+    const std::vector<int32_t>& values,
+    const char* operation) {
+  if (fail_result_allocation(operation, "tuple")) {
+    return nullptr;
+  }
+  PyObject* result = PyTuple_New(static_cast<Py_ssize_t>(values.size()));
+  if (result == nullptr) {
+    return nullptr;
+  }
+  for (size_t index = 0; index < values.size(); ++index) {
+    if (fail_result_allocation(operation, "tuple_item")) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyObject* value = PyLong_FromLong(values[index]);
+    if (value == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(result, static_cast<Py_ssize_t>(index), value);
+  }
+  return result;
+}
+
+int page_runtime_init(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  static const char* keywords[] = {
+      "num_layers",
+      "num_attention_heads",
+      "num_key_value_heads",
+      "head_dim",
+      "block_size",
+      "max_pages",
+      "max_blocks_per_request",
+      "max_requests",
+      nullptr};
+  unsigned int num_layers = 0;
+  unsigned int num_attention_heads = 0;
+  unsigned int num_key_value_heads = 0;
+  unsigned int head_dim = 128;
+  unsigned int block_size = 16;
+  unsigned int max_pages = 64;
+  unsigned int max_blocks_per_request = 1024;
+  unsigned int max_requests = 64;
+
+  // ``num_kv_heads`` is a short alias useful to adapters that already expose
+  // the attention geometry under that spelling.  Normalize it to the public
+  // canonical keyword, then remove the alias: PyArg_ParseTupleAndKeywords
+  // rejects unknown keys even when the canonical value has been supplied.
+  PyObject* normalized_kwargs = kwargs;
+  if (kwargs != nullptr &&
+      PyDict_GetItemString(kwargs, "num_key_value_heads") == nullptr) {
+    PyObject* alias = PyDict_GetItemString(kwargs, "num_kv_heads");
+    if (alias != nullptr) {
+      normalized_kwargs = PyDict_Copy(kwargs);
+      if (normalized_kwargs == nullptr ||
+          PyDict_SetItemString(
+              normalized_kwargs, "num_key_value_heads", alias) < 0) {
+        Py_XDECREF(normalized_kwargs == kwargs ? nullptr : normalized_kwargs);
+        return -1;
+      }
+      if (PyDict_DelItemString(normalized_kwargs, "num_kv_heads") < 0) {
+        Py_DECREF(normalized_kwargs);
+        return -1;
+      }
+    }
+  }
+  const int parsed = PyArg_ParseTupleAndKeywords(
+      args,
+      normalized_kwargs,
+      "III|IIIII:PageRuntime",
+      const_cast<char**>(keywords),
+      &num_layers,
+      &num_attention_heads,
+      &num_key_value_heads,
+      &head_dim,
+      &block_size,
+      &max_pages,
+      &max_blocks_per_request,
+      &max_requests);
+  if (normalized_kwargs != kwargs) {
+    Py_DECREF(normalized_kwargs);
+  }
+  if (!parsed) {
+    return -1;
+  }
+  try {
+    std::unique_ptr<PageRuntime> replacement = std::make_unique<PageRuntime>(
+        num_layers,
+        num_attention_heads,
+        num_key_value_heads,
+        head_dim,
+        block_size,
+        max_pages,
+        max_blocks_per_request,
+        max_requests);
+    replacement->set_metallib_path(packaged_metallib_path());
+    PageRuntime* prior = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(self->lifecycle_mutex);
+      std::exception_ptr wait_failure;
+      Py_BEGIN_ALLOW_THREADS
+      try {
+        self->lifecycle_cv.wait(
+            lock, [self] { return self->active_calls == 0; });
+      } catch (...) {
+        wait_failure = std::current_exception();
+      }
+      Py_END_ALLOW_THREADS
+      if (wait_failure) {
+        std::rethrow_exception(wait_failure);
+      }
+      prior = self->runtime;
+      self->runtime = replacement.release();
+    }
+    delete prior;
+  } catch (const std::bad_alloc&) {
+    PyErr_SetString(PyExc_MemoryError, "could not allocate the native page runtime");
+    return -1;
+  } catch (const std::invalid_argument& exception) {
+    PyErr_SetString(PyExc_ValueError, exception.what());
+    return -1;
+  } catch (const std::exception& exception) {
+    set_native_exception(exception);
+    return -1;
+  } catch (...) {
+    set_unknown_native_exception();
+    return -1;
+  }
+  return 0;
+}
+
+PyObject* page_runtime_new(PyTypeObject* type, PyObject*, PyObject*) {
+  PAGE_RUNTIME_PY_TRY
+  auto* self = reinterpret_cast<PageRuntimeObject*>(type->tp_alloc(type, 0));
+  if (self == nullptr) {
+    return nullptr;
+  }
+  try {
+    // Default-initialize the C++ members without value-initializing the
+    // PyObject_HEAD fields that tp_alloc already populated.
+    new (self) PageRuntimeObject;
+  } catch (...) {
+    type->tp_free(reinterpret_cast<PyObject*>(self));
+    throw;
+  }
+  return reinterpret_cast<PyObject*>(self);
+  PAGE_RUNTIME_PY_CATCH
+}
+
+void page_runtime_dealloc(PageRuntimeObject* self) {
+  PageRuntime* prior = nullptr;
+  try {
+    {
+      std::unique_lock<std::mutex> lock(self->lifecycle_mutex);
+      std::exception_ptr wait_failure;
+      Py_BEGIN_ALLOW_THREADS
+      try {
+        self->lifecycle_cv.wait(
+            lock, [self] { return self->active_calls == 0; });
+      } catch (...) {
+        wait_failure = std::current_exception();
+      }
+      Py_END_ALLOW_THREADS
+      if (wait_failure) {
+        std::rethrow_exception(wait_failure);
+      }
+      prior = self->runtime;
+      self->runtime = nullptr;
+    }
+    delete prior;
+  } catch (const std::bad_alloc& exception) {
+    set_native_exception(exception);
+    PyErr_WriteUnraisable(reinterpret_cast<PyObject*>(self));
+  } catch (const std::exception& exception) {
+    PyErr_SetString(PyExc_RuntimeError, exception.what());
+    PyErr_WriteUnraisable(reinterpret_cast<PyObject*>(self));
+  } catch (...) {
+    set_unknown_native_exception();
+    PyErr_WriteUnraisable(reinterpret_cast<PyObject*>(self));
+  }
+  self->~PageRuntimeObject();
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject*>(self));
+}
+
+PyObject* page_runtime_allocate_request(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request_id", "max_tokens", nullptr};
+  const char* request_id = nullptr;
+  unsigned int max_tokens = 0;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "sI:allocate_request",
+          const_cast<char**>(keywords),
+          &request_id,
+          &max_tokens) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t handle = 0;
+  std::string error;
+  NativeMutationGuard mutation(self->runtime);
+  if (!self->runtime->allocate_request(
+          request_id, max_tokens, &handle, mutation.token(), &error)) {
+    lifecycle_error(error);
+    return nullptr;
+  }
+  PyObject* result = result_u64("allocate_request", handle);
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_allocate_pages(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request", "count", nullptr};
+  PyObject* request_object = nullptr;
+  unsigned int count = 0;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "OI:allocate_pages",
+          const_cast<char**>(keywords),
+          &request_object,
+          &count) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  std::vector<uint64_t> handles;
+  std::string error;
+  NativeMutationGuard mutation(self->runtime);
+  if (!self->runtime->allocate_pages(
+          request, count, &handles, mutation.token(), &error)) {
+    lifecycle_error(error);
+    return nullptr;
+  }
+  PyObject* result = tuple_from_u64(handles, "allocate_pages");
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_append_kv(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request", "layer", "keys", "values", nullptr};
+  PyObject* request_object = nullptr;
+  unsigned int layer = 0;
+  PyObject* keys_object = nullptr;
+  PyObject* values_object = nullptr;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "OIOO:append_kv",
+          const_cast<char**>(keywords),
+          &request_object,
+          &layer,
+          &keys_object,
+          &values_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  BufferGuard keys;
+  BufferGuard values;
+  if (!acquire_buffer(keys_object, &keys, "keys") ||
+      !acquire_buffer(values_object, &values, "values")) {
+    return nullptr;
+  }
+  if (keys.view.ndim != 3 || values.view.ndim != 3 ||
+      keys.view.shape == nullptr || values.view.shape == nullptr ||
+      !is_native_uint16_buffer(keys.view) ||
+      !is_native_uint16_buffer(values.view)) {
+    value_error(
+        "keys and values must be contiguous uint16 BF16 buffers with shape "
+        "[tokens, kv_heads, 128]");
+    return nullptr;
+  }
+  if (keys.view.shape[0] != values.view.shape[0] ||
+      keys.view.shape[1] != values.view.shape[1] ||
+      keys.view.shape[1] <= 0 ||
+      keys.view.shape[1] != self->runtime->num_key_value_heads() ||
+      static_cast<uint64_t>(keys.view.shape[0]) >
+          std::numeric_limits<uint32_t>::max() ||
+      keys.view.shape[2] != 128 || values.view.shape[2] != 128 ||
+      static_cast<uint64_t>(keys.view.len) !=
+          static_cast<uint64_t>(keys.view.shape[0]) * keys.view.shape[1] * 128 *
+              sizeof(uint16_t) ||
+      static_cast<uint64_t>(values.view.len) !=
+          static_cast<uint64_t>(values.view.shape[0]) * values.view.shape[1] * 128 *
+              sizeof(uint16_t)) {
+    value_error("keys and values shapes/byte lengths do not agree");
+    return nullptr;
+  }
+  if (!finite_bf16(keys.view) || !finite_bf16(values.view)) {
+    value_error("keys and values must contain finite BF16 values");
+    return nullptr;
+  }
+  std::string error;
+  if (!self->runtime->append_kv(
+          request,
+          layer,
+          static_cast<const uint16_t*>(keys.view.buf),
+          static_cast<const uint16_t*>(values.view.buf),
+          static_cast<uint32_t>(keys.view.shape[0]),
+          &error)) {
+    lifecycle_error(error);
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_create_prefix(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* request_object = nullptr;
+  if (!PyArg_ParseTuple(args, "O:create_prefix", &request_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  uint64_t prefix = 0;
+  std::string error;
+  NativeMutationGuard mutation(self->runtime);
+  if (!self->runtime->create_prefix(
+          request, &prefix, mutation.token(), &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  PyObject* result = result_u64("create_prefix", prefix);
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_fork_prefix(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* prefix_object = nullptr;
+  if (!PyArg_ParseTuple(args, "O:fork_prefix", &prefix_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t prefix = 0;
+  if (!py_uint64(prefix_object, &prefix, "prefix")) {
+    return nullptr;
+  }
+  uint64_t forked = 0;
+  std::string error;
+  NativeMutationGuard mutation(self->runtime);
+  if (!self->runtime->fork_prefix(
+          prefix, &forked, mutation.token(), &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  PyObject* result = result_u64("fork_prefix", forked);
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_attach_prefix(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* request_object = nullptr;
+  PyObject* prefix_object = nullptr;
+  if (!PyArg_ParseTuple(args, "OO:attach_prefix", &request_object, &prefix_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  uint64_t prefix = 0;
+  if (!py_uint64(request_object, &request, "request") ||
+      !py_uint64(prefix_object, &prefix, "prefix")) {
+    return nullptr;
+  }
+  std::string error;
+  if (!self->runtime->attach_prefix(request, prefix, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_release_prefix(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* prefix_object = nullptr;
+  if (!PyArg_ParseTuple(args, "O:release_prefix", &prefix_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t prefix = 0;
+  if (!py_uint64(prefix_object, &prefix, "prefix")) {
+    return nullptr;
+  }
+  std::string error;
+  if (!self->runtime->release_prefix(prefix, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_release(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs,
+    bool cancelled) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request", nullptr};
+  PyObject* request_object = nullptr;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "O:release",
+          const_cast<char**>(keywords),
+          &request_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  std::string error;
+  if (!self->runtime->release_request(request, cancelled, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_snapshot(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"prefix", "destination", nullptr};
+  PyObject* prefix_object = nullptr;
+  const char* destination = nullptr;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "Os:snapshot",
+          const_cast<char**>(keywords),
+          &prefix_object,
+          &destination) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t prefix = 0;
+  if (!py_uint64(prefix_object, &prefix, "prefix")) {
+    return nullptr;
+  }
+  std::string error;
+  if (!self->runtime->snapshot(prefix, destination, &error)) {
+    if (error.find("deferred") != std::string::npos) {
+      not_implemented_error(error);
+    } else {
+      runtime_error(error);
+    }
+    return nullptr;
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_restore(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"source", nullptr};
+  const char* source = nullptr;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "s:restore",
+          const_cast<char**>(keywords),
+          &source) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t prefix = 0;
+  std::string error;
+  if (!self->runtime->restore(source, &prefix, &error)) {
+    if (error.find("deferred") != std::string::npos) {
+      not_implemented_error(error);
+    } else {
+      runtime_error(error);
+    }
+    return nullptr;
+  }
+  return result_u64("restore", prefix);
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_release_request(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  return page_runtime_release(self, args, kwargs, false);
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_cancel(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  return page_runtime_release(self, args, kwargs, true);
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_evict(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"target_pages", nullptr};
+  PyObject* target_object = Py_None;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "|O:evict",
+          const_cast<char**>(keywords),
+          &target_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  bool has_target = target_object != Py_None;
+  unsigned int target = 0;
+  if (has_target) {
+    if (!PyLong_Check(target_object)) {
+      PyErr_SetString(PyExc_TypeError, "target_pages must be a non-negative integer");
+      return nullptr;
+    }
+    unsigned long value = PyLong_AsUnsignedLong(target_object);
+    if (value == ULONG_MAX && PyErr_Occurred()) {
+      return nullptr;
+    }
+    if (value > std::numeric_limits<unsigned int>::max()) {
+      PyErr_SetString(PyExc_OverflowError, "target_pages is too large");
+      return nullptr;
+    }
+    target = static_cast<unsigned int>(value);
+  }
+  std::string error;
+  NativeMutationGuard mutation(self->runtime);
+  const uint32_t evicted =
+      self->runtime->evict(target, has_target, mutation.token(), &error);
+  if (!error.empty()) {
+    runtime_error(error);
+    return nullptr;
+  }
+  PyObject* result = result_u32("evict", evicted);
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_page_table(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request", "layer", nullptr};
+  PyObject* request_object = nullptr;
+  unsigned int layer = 0;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "O|I:page_table",
+          const_cast<char**>(keywords),
+          &request_object,
+          &layer) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  std::vector<int32_t> table;
+  std::string error;
+  if (!self->runtime->page_table(request, layer, &table, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  return tuple_from_i32(table, "page_table");
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_request_pages(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* request_object = nullptr;
+  if (!PyArg_ParseTuple(args, "O:request_pages", &request_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  std::vector<uint64_t> pages;
+  std::string error;
+  if (!self->runtime->request_pages(request, &pages, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  return tuple_from_u64(pages, "request_pages");
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_sequence_length(
+    PageRuntimeObject* self,
+    PyObject* args) {
+  PAGE_RUNTIME_PY_TRY
+  PyObject* request_object = nullptr;
+  if (!PyArg_ParseTuple(args, "O:sequence_length", &request_object) ||
+      !require_runtime(self)) {
+    return nullptr;
+  }
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  uint32_t length = 0;
+  std::string error;
+  if (!self->runtime->sequence_length(request, &length, &error)) {
+    value_error(error);
+    return nullptr;
+  }
+  return result_u32("sequence_length", length);
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_paged_decode(
+    PageRuntimeObject* self,
+    PyObject* args,
+    PyObject* kwargs) {
+  PAGE_RUNTIME_PY_TRY
+  static const char* keywords[] = {"request", "layer", "query", "scale", nullptr};
+  PyObject* request_object = nullptr;
+  unsigned int layer = 0;
+  PyObject* query_object = nullptr;
+  float scale = 1.0f / std::sqrt(128.0f);
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "OIO|f:paged_decode",
+          const_cast<char**>(keywords),
+          &request_object,
+          &layer,
+          &query_object,
+          &scale)) {
+    return nullptr;
+  }
+  RuntimeCallLease runtime_lease(self);
+  if (!runtime_lease.acquire()) {
+    return nullptr;
+  }
+  PageRuntime* runtime = runtime_lease.get();
+  uint64_t request = 0;
+  if (!py_uint64(request_object, &request, "request")) {
+    return nullptr;
+  }
+  BufferGuard query;
+  if (!acquire_buffer(query_object, &query, "query")) {
+    return nullptr;
+  }
+  if (query.view.ndim != 2 || query.view.shape == nullptr ||
+      !is_native_uint16_buffer(query.view) ||
+      query.view.shape[0] != runtime->num_attention_heads() ||
+      query.view.shape[1] != 128 ||
+      static_cast<uint64_t>(query.view.len) !=
+          static_cast<uint64_t>(query.view.shape[0]) * 128 * sizeof(uint16_t) ||
+      !finite_bf16(query.view)) {
+    value_error(
+        "query must be a contiguous finite uint16 BF16 buffer with shape "
+        "[query_heads, 128]");
+    return nullptr;
+  }
+  if (!std::isfinite(scale)) {
+    value_error("scale must be finite");
+    return nullptr;
+  }
+  std::vector<float> output;
+  std::string error;
+  bool dispatched = false;
+  NativeMutationGuard mutation(runtime);
+  // Validation and buffer acquisition above require the GIL.  The compiled
+  // runtime owns its lifecycle/dispatch locks, so release the GIL while the
+  // synchronous Metal command is in flight and allow independent requests to
+  // overlap at the Python adapter boundary.
+  std::exception_ptr no_gil_failure;
+  Py_BEGIN_ALLOW_THREADS
+  try {
+    dispatched = runtime->paged_decode(
+        request,
+        layer,
+        static_cast<const uint16_t*>(query.view.buf),
+        static_cast<size_t>(query.view.shape[0]) * 128,
+        scale,
+        &output,
+        mutation.token(),
+        &error);
+  } catch (...) {
+    // No C++ exception may cross CPython's GIL-release macros.  Translate
+    // only after Py_END_ALLOW_THREADS has restored the thread state.
+    no_gil_failure = std::current_exception();
+  }
+  Py_END_ALLOW_THREADS
+  if (no_gil_failure) {
+    std::rethrow_exception(no_gil_failure);
+  }
+  if (!dispatched) {
+    // Failure counters are part of the observable runtime contract.  Keep
+    // that native failure mutation even though no Python result is built.
+    mutation.commit();
+    if (error.find("finite BF16") != std::string::npos ||
+        error.find("overflow") != std::string::npos ||
+        error.find("value accumulation") != std::string::npos ||
+        error == "scale must be finite") {
+      value_error(error);
+    } else {
+      runtime_error(error);
+    }
+    return nullptr;
+  }
+  PyObject* result = result_bytes(
+      "paged_decode",
+      reinterpret_cast<const char*>(output.data()),
+      static_cast<Py_ssize_t>(output.size() * sizeof(float)));
+  if (result == nullptr) {
+    return nullptr;
+  }
+  mutation.commit();
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_metrics(PageRuntimeObject* self, PyObject*) {
+  PAGE_RUNTIME_PY_TRY
+  if (self->runtime == nullptr) {
+    PyErr_SetString(PyExc_RuntimeError, "page runtime is not initialized");
+    return nullptr;
+  }
+  std::string error;
+  const auto metrics = self->runtime->metrics(&error);
+  if (!error.empty()) {
+    runtime_error(error);
+    return nullptr;
+  }
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+#define SET_METRIC(name, value)                                                   \
+  do {                                                                             \
+    PyObject* metric_value = PyLong_FromUnsignedLongLong(value);                  \
+    if (metric_value == nullptr || PyDict_SetItemString(result, name, metric_value) < 0) { \
+      Py_XDECREF(metric_value);                                                   \
+      Py_DECREF(result);                                                           \
+      return nullptr;                                                             \
+    }                                                                              \
+    Py_DECREF(metric_value);                                                       \
+  } while (false)
+  SET_METRIC("resident_pages", metrics.resident_pages);
+  SET_METRIC("referenced_pages", metrics.referenced_pages);
+  SET_METRIC("shared_pages", metrics.shared_pages);
+  SET_METRIC("evictable_pages", metrics.evictable_pages);
+  SET_METRIC("free_pages", metrics.free_pages);
+  SET_METRIC("requests", metrics.requests);
+  SET_METRIC("prefixes", metrics.prefixes);
+  SET_METRIC("page_allocations", metrics.page_allocations);
+  SET_METRIC("request_allocations", metrics.request_allocations);
+  SET_METRIC("prefix_allocations", metrics.prefix_allocations);
+  SET_METRIC("cow_events", metrics.cow_events);
+  SET_METRIC("evictions", metrics.evictions);
+  SET_METRIC("releases", metrics.releases);
+  SET_METRIC("cancellations", metrics.cancellations);
+  SET_METRIC("append_tokens", metrics.append_tokens);
+  SET_METRIC("dispatches", metrics.dispatches);
+  SET_METRIC("dispatch_failures", metrics.dispatch_failures);
+  SET_METRIC("native_dispatches", metrics.native_dispatches);
+  SET_METRIC("native_failures", metrics.native_failures);
+  SET_METRIC("buffer_allocations", metrics.buffer_allocations);
+  SET_METRIC("decode_buffer_allocations", metrics.decode_buffer_allocations);
+  SET_METRIC("query_copies", metrics.query_copies);
+  SET_METRIC("output_copies", metrics.output_copies);
+  SET_METRIC("metadata_copies", metrics.metadata_copies);
+  SET_METRIC("metadata_bytes", metrics.metadata_bytes);
+  SET_METRIC("kv_copy_bytes", metrics.kv_copy_bytes);
+  SET_METRIC("kv_pool_copies", metrics.kv_pool_copies);
+  SET_METRIC("attention_validation_bytes", metrics.attention_validation_bytes);
+  SET_METRIC(
+      "decode_page_resolution_checks",
+      metrics.decode_page_resolution_checks);
+  SET_METRIC("snapshot_failures", metrics.snapshot_failures);
+  SET_METRIC("restore_failures", metrics.restore_failures);
+  // Keep mode-qualified aliases aligned with the adapter/oracle metric
+  // contract.  These are native counts, not a second dispatch counter.
+  SET_METRIC("max_pages", metrics.max_pages);
+  SET_METRIC("max_blocks_per_request", metrics.max_blocks_per_request);
+  SET_METRIC("block_size", metrics.block_size);
+  SET_METRIC("bytes_per_layer", metrics.bytes_per_layer);
+  SET_METRIC("kv_bytes", metrics.kv_bytes);
+#undef SET_METRIC
+  PyObject* kv_dtype = PyUnicode_FromString("bfloat16");
+  if (kv_dtype == nullptr || PyDict_SetItemString(result, "kv_dtype", kv_dtype) < 0) {
+    Py_XDECREF(kv_dtype);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(kv_dtype);
+  PyObject* shutdown = PyBool_FromLong(metrics.shutdown ? 1 : 0);
+  if (shutdown == nullptr ||
+      PyDict_SetItemString(result, "shutdown", shutdown) < 0) {
+    Py_XDECREF(shutdown);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(shutdown);
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_shutdown(PageRuntimeObject* self, PyObject*) {
+  PAGE_RUNTIME_PY_TRY
+  if (self->runtime != nullptr) {
+    self->runtime->shutdown();
+  }
+  Py_RETURN_NONE;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyObject* page_runtime_geometry(PageRuntimeObject* self, PyObject*) {
+  PAGE_RUNTIME_PY_TRY
+  if (!require_runtime(self)) {
+    return nullptr;
+  }
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+  const struct Entry {
+    const char* name;
+    uint32_t value;
+  } entries[] = {
+      {"num_layers", self->runtime->num_layers()},
+      {"num_attention_heads", self->runtime->num_attention_heads()},
+      {"num_key_value_heads", self->runtime->num_key_value_heads()},
+      {"head_dim", self->runtime->head_dim()},
+      {"block_size", self->runtime->block_size()},
+      {"max_pages", self->runtime->max_pages()},
+      {"max_blocks_per_request", self->runtime->max_blocks_per_request()},
+      {"max_requests", self->runtime->max_requests()},
+  };
+  for (const auto& entry : entries) {
+    PyObject* value = PyLong_FromUnsignedLong(entry.value);
+    if (value == nullptr || PyDict_SetItemString(result, entry.name, value) < 0) {
+      Py_XDECREF(value);
+      Py_DECREF(result);
+      return nullptr;
+    }
+    Py_DECREF(value);
+  }
+  return result;
+  PAGE_RUNTIME_PY_CATCH
+}
+
+PyMethodDef page_runtime_methods[] = {
+    {"allocate_request",
+     _PyCFunction_CAST(page_runtime_allocate_request),
+     METH_VARARGS | METH_KEYWORDS,
+     "Allocate a request slot and return an opaque request handle."},
+    {"allocate_pages",
+     _PyCFunction_CAST(page_runtime_allocate_pages),
+     METH_VARARGS | METH_KEYWORDS,
+     "Allocate contiguous logical pages for a request."},
+    {"append_kv",
+     _PyCFunction_CAST(page_runtime_append_kv),
+     METH_VARARGS | METH_KEYWORDS,
+     "Append contiguous BF16 K/V tokens to one layer."},
+    {"create_prefix",
+     _PyCFunction_CAST(page_runtime_create_prefix),
+     METH_VARARGS,
+     "Create a shared read-only prefix handle from a request."},
+    {"fork_prefix",
+     _PyCFunction_CAST(page_runtime_fork_prefix),
+     METH_VARARGS,
+     "Fork a prefix handle while retaining page references."},
+    {"attach_prefix",
+     _PyCFunction_CAST(page_runtime_attach_prefix),
+     METH_VARARGS,
+     "Attach a shared prefix to an empty request."},
+    {"release_prefix",
+     _PyCFunction_CAST(page_runtime_release_prefix),
+     METH_VARARGS,
+     "Release a prefix handle."},
+    {"snapshot",
+     _PyCFunction_CAST(page_runtime_snapshot),
+     METH_VARARGS | METH_KEYWORDS,
+     "Fail closed until the persistent context-store package is available."},
+    {"restore",
+     _PyCFunction_CAST(page_runtime_restore),
+     METH_VARARGS | METH_KEYWORDS,
+     "Fail closed until the persistent context-store package is available."},
+    {"release",
+     _PyCFunction_CAST(page_runtime_release_request),
+     METH_VARARGS | METH_KEYWORDS,
+     "Release a request and its page references."},
+    {"cancel",
+     _PyCFunction_CAST(page_runtime_cancel),
+     METH_VARARGS | METH_KEYWORDS,
+     "Cancel and release a request."},
+    {"release_request",
+     _PyCFunction_CAST(page_runtime_release_request),
+     METH_VARARGS | METH_KEYWORDS,
+     "Release a request and its page references."},
+    {"evict",
+     _PyCFunction_CAST(page_runtime_evict),
+     METH_VARARGS | METH_KEYWORDS,
+     "Evict unreferenced pages by LRU order."},
+    {"page_table",
+     _PyCFunction_CAST(page_runtime_page_table),
+     METH_VARARGS | METH_KEYWORDS,
+     "Return the request's physical page table."},
+    {"request_pages",
+     _PyCFunction_CAST(page_runtime_request_pages),
+     METH_VARARGS,
+     "Return opaque handles for resident request pages."},
+    {"sequence_length",
+     _PyCFunction_CAST(page_runtime_sequence_length),
+     METH_VARARGS,
+     "Return the request sequence length."},
+    {"paged_decode",
+     _PyCFunction_CAST(page_runtime_paged_decode),
+     METH_VARARGS | METH_KEYWORDS,
+     "Dispatch the BF16 paged decode kernel for one request/layer."},
+    {"paged_decode_attention",
+     _PyCFunction_CAST(page_runtime_paged_decode),
+     METH_VARARGS | METH_KEYWORDS,
+     "Alias for paged_decode."},
+    {"metrics",
+     _PyCFunction_CAST(page_runtime_metrics),
+     METH_NOARGS,
+     "Return page ownership and lifecycle metrics."},
+    {"geometry",
+     _PyCFunction_CAST(page_runtime_geometry),
+     METH_NOARGS,
+     "Return the validated runtime geometry."},
+    {"shutdown",
+     _PyCFunction_CAST(page_runtime_shutdown),
+     METH_NOARGS,
+     "Deterministically release all runtime resources."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+// Keep the type object zero-initialized in C++ and initialize its Python
+// object header through the public setters below.  This avoids a
+// ``-Wmissing-field-initializers`` warning while remaining valid across the
+// supported CPython versions (3.10+).
+PyTypeObject page_runtime_type = {};
+
+}  // namespace
+
+namespace metal_context {
+
+int add_page_runtime_type(PyObject* module) {
+  try {
+    if (page_runtime_type.tp_name == nullptr) {
+      PyObject* type_object = reinterpret_cast<PyObject*>(&page_runtime_type);
+      Py_SET_REFCNT(type_object, 1);
+      Py_SET_TYPE(type_object, &PyType_Type);
+      Py_SET_SIZE(reinterpret_cast<PyVarObject*>(type_object), 0);
+    }
+    page_runtime_type.tp_name = "vllm_mlx._metal_context.PageRuntime";
+    page_runtime_type.tp_basicsize = sizeof(PageRuntimeObject);
+    page_runtime_type.tp_dealloc = reinterpret_cast<destructor>(page_runtime_dealloc);
+    page_runtime_type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    page_runtime_type.tp_doc = "Native Metal Context Engine page ownership runtime.";
+    page_runtime_type.tp_methods = page_runtime_methods;
+    page_runtime_type.tp_init = reinterpret_cast<initproc>(page_runtime_init);
+    page_runtime_type.tp_new = page_runtime_new;
+    if (PyType_Ready(&page_runtime_type) < 0) {
+      return -1;
+    }
+    Py_INCREF(&page_runtime_type);
+    if (PyModule_AddObject(
+            module,
+            "PageRuntime",
+            reinterpret_cast<PyObject*>(&page_runtime_type)) < 0) {
+      Py_DECREF(&page_runtime_type);
+      return -1;
+    }
+  } catch (const std::bad_alloc& exception) {
+    set_native_exception(exception);
+    return -1;
+  } catch (const std::exception& exception) {
+    set_native_exception(exception);
+    return -1;
+  } catch (...) {
+    set_unknown_native_exception();
+    return -1;
+  }
+  return 0;
+}
+
+}  // namespace metal_context
+
+#undef PAGE_RUNTIME_PY_TRY
+#undef PAGE_RUNTIME_PY_CATCH

--- a/native/metal_context/src/python_module.mm
+++ b/native/metal_context/src/python_module.mm
@@ -17,14 +17,26 @@
 
 #include <algorithm>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <initializer_list>
 #include <limits>
 #include <mutex>
 #include <string>
+
+namespace metal_context {
+// Defined in page_runtime_python.mm.  Keep the existing kernel bridge's
+// module definition as the single extension entry point while registering
+// the optional page-runtime type from its companion translation unit.
+int add_page_runtime_type(PyObject* module);
+// Keep module-level shutdown from resetting shared kernel state while a
+// native PageRuntime instance is still alive in another adapter.
+void shutdown_kernel_if_unused();
+}
 
 namespace {
 
@@ -70,6 +82,9 @@ struct BufferGuard {
 
 struct Runtime {
   std::mutex mutex;
+  std::condition_variable dispatch_cv;
+  uint32_t active_dispatches = 0;
+  bool stopping = false;
   bool attempted = false;
   bool available = false;
   std::string path;
@@ -80,6 +95,78 @@ struct Runtime {
 };
 
 Runtime g_runtime;
+
+class LegacyDispatchLease {
+ public:
+  explicit LegacyDispatchLease(Runtime* runtime) : runtime_(runtime) {}
+
+  bool acquire() {
+    std::unique_lock<std::mutex> lock(runtime_->mutex);
+    if (runtime_->stopping || runtime_->device == nil ||
+        runtime_->queue == nil || runtime_->pipeline == nil) {
+      return false;
+    }
+    ++runtime_->active_dispatches;
+    acquired_ = true;
+    return true;
+  }
+
+  ~LegacyDispatchLease() noexcept {
+    if (!acquired_) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(runtime_->mutex);
+    if (runtime_->active_dispatches > 0) {
+      --runtime_->active_dispatches;
+    }
+    runtime_->dispatch_cv.notify_all();
+  }
+
+ private:
+  Runtime* runtime_;
+  bool acquired_ = false;
+};
+
+// All exported legacy callbacks are C ABI entry points.  Keep native
+// allocation/Objective-C++ failures inside this translation unit and convert
+// them to Python exceptions rather than allowing C++ unwinding through
+// CPython.
+void set_native_exception(const std::bad_alloc& exception) {
+  const char* message = exception.what();
+  PyErr_SetString(
+      PyExc_MemoryError,
+      message == nullptr || message[0] == '\0'
+          ? "native Metal Context allocation failed"
+          : message);
+}
+
+void set_native_exception(const std::exception& exception) {
+  const char* message = exception.what();
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      message == nullptr || message[0] == '\0'
+          ? "native Metal Context operation failed"
+          : message);
+}
+
+void set_unknown_native_exception() {
+  PyErr_SetString(
+      PyExc_RuntimeError,
+      "unknown native Metal Context exception");
+}
+
+#define METAL_CONTEXT_PY_TRY try {
+#define METAL_CONTEXT_PY_CATCH                                                  \
+  } catch (const std::bad_alloc& exception) {                                  \
+    set_native_exception(exception);                                            \
+    return nullptr;                                                             \
+  } catch (const std::exception& exception) {                                   \
+    set_native_exception(exception);                                             \
+    return nullptr;                                                             \
+  } catch (...) {                                                               \
+    set_unknown_native_exception();                                              \
+    return nullptr;                                                             \
+  }
 
 bool set_dict_item(PyObject* dict, const char* key, PyObject* value) {
   if (value == nullptr) {
@@ -184,6 +271,13 @@ bool ensure_runtime(const std::string& path) {
   std::lock_guard<std::mutex> lock(g_runtime.mutex);
   if (g_runtime.attempted && g_runtime.path == path) {
     return g_runtime.available;
+  }
+  if (g_runtime.active_dispatches != 0 && g_runtime.attempted &&
+      g_runtime.path != path) {
+    g_runtime.error =
+        "native Metal Context callbacks must share one metallib path while "
+        "dispatches are active";
+    return false;
   }
 
   g_runtime.attempted = true;
@@ -534,6 +628,8 @@ bool validate_inputs(
   const long double max_dot =
       static_cast<long double>(max_abs_bf16(q)) *
       static_cast<long double>(max_abs_bf16(k)) * kHeadDim;
+  const long double max_value =
+      static_cast<long double>(max_abs_bf16(v));
   if (max_dot > kFloat32SafeMagnitude) {
     *error =
         "finite BF16 query/key magnitudes may overflow the float32 dot "
@@ -551,12 +647,15 @@ bool validate_inputs(
 
   const auto* table_data = static_cast<const int32_t*>(table.buf);
   const auto* length_data = static_cast<const int32_t*>(lengths.buf);
+  uint64_t max_sequence_length = 0;
   for (Py_ssize_t request = 0; request < batch; ++request) {
     const int32_t length = length_data[request];
     if (length < 0 || static_cast<uint64_t>(length) > max_sequence) {
       *error = "sequence_lengths must be in [0, max_blocks * block_size]";
       return false;
     }
+    max_sequence_length = std::max(
+        max_sequence_length, static_cast<uint64_t>(length));
     const Py_ssize_t needed_blocks =
         (static_cast<Py_ssize_t>(length) + block_size - 1) / block_size;
     for (Py_ssize_t logical_block = 0; logical_block < needed_blocks;
@@ -568,6 +667,14 @@ bool validate_inputs(
         return false;
       }
     }
+  }
+  const long double max_value_accumulation =
+      max_value * static_cast<long double>(max_sequence_length);
+  if (max_value_accumulation > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 value magnitudes and sequence length may overflow the "
+        "float32 value accumulation; reduce values or context length";
+    return false;
   }
 
   params->batch_size = static_cast<uint32_t>(batch);
@@ -585,6 +692,7 @@ bool validate_inputs(
 }
 
 PyObject* py_capabilities(PyObject* self, PyObject*) {
+  METAL_CONTEXT_PY_TRY
   const std::string path = py_object_path(self);
   const bool available = ensure_runtime(path);
   std::lock_guard<std::mutex> lock(g_runtime.mutex);
@@ -632,9 +740,11 @@ PyObject* py_capabilities(PyObject* self, PyObject*) {
   Py_DECREF(block_sizes);
   Py_DECREF(head_dims);
   return result;
+  METAL_CONTEXT_PY_CATCH
 }
 
 PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
+  METAL_CONTEXT_PY_TRY
   static const char* keywords[] = {
       "query", "key_pages", "value_pages", "page_table",
       "sequence_lengths", "num_kv_heads", "block_size", "scale", nullptr};
@@ -718,14 +828,23 @@ PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
   }
   const size_t output_bytes = static_cast<size_t>(output_elements) * sizeof(float);
 
-  @autoreleasepool {
-    // Serialize the first low-level bridge while ownership is still host
-    // backed.  The future page runtime will replace these copies with
-    // allocator-owned GPU buffers and keep the command queue asynchronous.
+  LegacyDispatchLease dispatch_lease(&g_runtime);
+  if (!dispatch_lease.acquire()) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "metal-context runtime is shutting down or lost its pipeline");
+    return nullptr;
+  }
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> queue = nil;
+  id<MTLComputePipelineState> pipeline = nil;
+  {
     std::lock_guard<std::mutex> lock(g_runtime.mutex);
-    id<MTLDevice> device = g_runtime.device;
-    id<MTLCommandQueue> queue = g_runtime.queue;
-    id<MTLComputePipelineState> pipeline = g_runtime.pipeline;
+    device = g_runtime.device;
+    queue = g_runtime.queue;
+    pipeline = g_runtime.pipeline;
+  }
+  @autoreleasepool {
     if (device == nil || queue == nil || pipeline == nil) {
       PyErr_SetString(PyExc_RuntimeError, "metal-context runtime lost its pipeline");
       return nullptr;
@@ -785,8 +904,21 @@ PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
     const MTLSize group = MTLSizeMake(kThreadsPerThreadgroup, 1, 1);
     [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
     [encoder endEncoding];
-    [command_buffer commit];
-    [command_buffer waitUntilCompleted];
+    // Keep Python available to unrelated requests while this synchronous
+    // command waits.  The lease above pins the global Metal objects until the
+    // command has completed and the GIL is reacquired.
+    std::exception_ptr no_gil_failure;
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      [command_buffer commit];
+      [command_buffer waitUntilCompleted];
+    } catch (...) {
+      no_gil_failure = std::current_exception();
+    }
+    Py_END_ALLOW_THREADS
+    if (no_gil_failure) {
+      std::rethrow_exception(no_gil_failure);
+    }
 
     if (command_buffer.status != MTLCommandBufferStatusCompleted) {
       std::string error = ns_error_description(
@@ -799,24 +931,52 @@ PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
         static_cast<const char*>(output_buffer.contents),
         static_cast<Py_ssize_t>(output_bytes));
   }
+  METAL_CONTEXT_PY_CATCH
 }
 
 PyObject* py_shutdown(PyObject*, PyObject*) {
-  std::lock_guard<std::mutex> lock(g_runtime.mutex);
-  g_runtime.device = nil;
-  g_runtime.queue = nil;
-  g_runtime.pipeline = nil;
-  g_runtime.attempted = false;
-  g_runtime.available = false;
-  g_runtime.path.clear();
-  g_runtime.error.clear();
+  METAL_CONTEXT_PY_TRY
+  {
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    g_runtime.stopping = true;
+  }
+  // A dispatch lease is released after its command wait reacquires the GIL.
+  // Do not hold the GIL while waiting here or shutdown would deadlock with a
+  // concurrent py_paged_decode that is already inside Py_BEGIN_ALLOW_THREADS.
+  std::exception_ptr no_gil_failure;
+  Py_BEGIN_ALLOW_THREADS
+  try {
+    std::unique_lock<std::mutex> lock(g_runtime.mutex);
+    g_runtime.dispatch_cv.wait(
+        lock, [] { return g_runtime.active_dispatches == 0; });
+  } catch (...) {
+    no_gil_failure = std::current_exception();
+  }
+  Py_END_ALLOW_THREADS
+  if (no_gil_failure) {
+    std::rethrow_exception(no_gil_failure);
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    g_runtime.device = nil;
+    g_runtime.queue = nil;
+    g_runtime.pipeline = nil;
+    g_runtime.attempted = false;
+    g_runtime.available = false;
+    g_runtime.path.clear();
+    g_runtime.error.clear();
+    g_runtime.stopping = false;
+    g_runtime.dispatch_cv.notify_all();
+  }
+  metal_context::shutdown_kernel_if_unused();
   Py_RETURN_NONE;
+  METAL_CONTEXT_PY_CATCH
 }
 
 PyMethodDef kMethods[] = {
     {"capabilities", py_capabilities, METH_NOARGS,
      "Return the compiled Metal Context Engine capability record."},
-    {"paged_decode", reinterpret_cast<PyCFunction>(py_paged_decode),
+    {"paged_decode", _PyCFunction_CAST(py_paged_decode),
      METH_VARARGS | METH_KEYWORDS,
      "Run BF16 paged decode attention from contiguous host buffers."},
     {"shutdown", py_shutdown, METH_NOARGS,
@@ -830,10 +990,27 @@ PyModuleDef kModule = {
     "Optional native Metal Context Engine kernel bridge.",
     -1,
     kMethods,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
 };
 
 }  // namespace
 
 PyMODINIT_FUNC PyInit__metal_context() {
-  return PyModule_Create(&kModule);
+  METAL_CONTEXT_PY_TRY
+  PyObject* module = PyModule_Create(&kModule);
+  if (module == nullptr) {
+    return nullptr;
+  }
+  if (metal_context::add_page_runtime_type(module) < 0) {
+    Py_DECREF(module);
+    return nullptr;
+  }
+  return module;
+  METAL_CONTEXT_PY_CATCH
 }
+
+#undef METAL_CONTEXT_PY_TRY
+#undef METAL_CONTEXT_PY_CATCH

--- a/native/metal_context/src/python_module.mm
+++ b/native/metal_context/src/python_module.mm
@@ -649,7 +649,7 @@ PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
   if (!PyArg_ParseTupleAndKeywords(
           args,
           kwargs,
-          "OOOOOiff:paged_decode",
+          "OOOOOiif:paged_decode",
           const_cast<char**>(keywords),
           &query_object,
           &key_object,

--- a/native/metal_context/src/python_module.mm
+++ b/native/metal_context/src/python_module.mm
@@ -1,0 +1,839 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Optional CPython bridge for the phase-1 Metal Context Engine kernel.
+//
+// This bridge deliberately accepts contiguous host buffers rather than
+// reaching into MLX's private allocator.  That makes the ABI testable and
+// keeps installation optional.  The page runtime can add a zero-copy MLX
+// adapter once the ownership/synchronization contract is qualified; it does
+// not need to change the kernel's explicit layout or validation rules.
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include <dispatch/dispatch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <initializer_list>
+#include <limits>
+#include <mutex>
+#include <string>
+
+namespace {
+
+constexpr uint32_t kAbiVersion = 1;
+constexpr uint32_t kHeadDim = 128;
+constexpr uint32_t kThreadsPerThreadgroup = 128;
+
+bool compiled_for_apple_silicon() {
+#if defined(__arm64__) || defined(__aarch64__)
+  return true;
+#else
+  return false;
+#endif
+}
+
+struct PagedDecodeParams {
+  uint32_t batch_size;
+  uint32_t query_heads;
+  uint32_t kv_heads;
+  uint32_t head_dim;
+  uint32_t block_size;
+  uint32_t max_blocks;
+  uint32_t page_count;
+  uint32_t page_table_stride;
+  float scale;
+  uint32_t reserved0;
+  uint32_t reserved1;
+  uint32_t reserved2;
+};
+
+static_assert(sizeof(PagedDecodeParams) == 48, "Metal parameter ABI changed");
+
+struct BufferGuard {
+  Py_buffer view{};
+  bool acquired = false;
+
+  ~BufferGuard() {
+    if (acquired) {
+      PyBuffer_Release(&view);
+    }
+  }
+};
+
+struct Runtime {
+  std::mutex mutex;
+  bool attempted = false;
+  bool available = false;
+  std::string path;
+  std::string error;
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> queue = nil;
+  id<MTLComputePipelineState> pipeline = nil;
+};
+
+Runtime g_runtime;
+
+bool set_dict_item(PyObject* dict, const char* key, PyObject* value) {
+  if (value == nullptr) {
+    return false;
+  }
+  if (PyDict_SetItemString(dict, key, value) < 0) {
+    Py_DECREF(value);
+    return false;
+  }
+  Py_DECREF(value);
+  return true;
+}
+
+bool set_dict_string(PyObject* dict, const char* key, const std::string& value) {
+  return set_dict_item(dict, key, PyUnicode_FromString(value.c_str()));
+}
+
+bool set_dict_bool(PyObject* dict, const char* key, bool value) {
+  return set_dict_item(dict, key, PyBool_FromLong(value ? 1 : 0));
+}
+
+bool set_dict_uint(PyObject* dict, const char* key, uint32_t value) {
+  return set_dict_item(dict, key, PyLong_FromUnsignedLong(value));
+}
+
+PyObject* unavailable_capabilities(const std::string& reason) {
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+  if (!set_dict_bool(result, "available", false) ||
+      !set_dict_bool(result, "compiled", true) ||
+      !set_dict_bool(result, "metal_device", false) ||
+      !set_dict_bool(result, "apple_silicon", compiled_for_apple_silicon()) ||
+      !set_dict_bool(result, "serving_ready", false) ||
+      !set_dict_uint(result, "abi_version", kAbiVersion) ||
+      !set_dict_string(result, "backend", "metal-context") ||
+      !set_dict_string(result, "reason", reason) ||
+      !set_dict_string(result, "kernel", "metal_context_paged_decode") ||
+      !set_dict_string(result, "kv_dtype", "bfloat16") ||
+      !set_dict_bool(result, "gqa", true) ||
+      !set_dict_bool(result, "partial_blocks", true) ||
+      !set_dict_bool(result, "online_softmax", true)) {
+    Py_DECREF(result);
+    return nullptr;
+  }
+  PyObject* block_sizes = Py_BuildValue("(ii)", 16, 32);
+  PyObject* head_dims = Py_BuildValue("(i)", static_cast<int>(kHeadDim));
+  if (block_sizes == nullptr || head_dims == nullptr ||
+      PyDict_SetItemString(result, "block_sizes", block_sizes) < 0 ||
+      PyDict_SetItemString(result, "head_dims", head_dims) < 0) {
+    Py_XDECREF(block_sizes);
+    Py_XDECREF(head_dims);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(block_sizes);
+  Py_DECREF(head_dims);
+  return result;
+}
+
+std::string py_object_path(PyObject* module) {
+  const char* override_path = std::getenv("VLLM_MLX_METAL_CONTEXT_METALLIB");
+  if (override_path != nullptr && override_path[0] != '\0') {
+    return override_path;
+  }
+
+  PyObject* file_object = PyModule_GetFilenameObject(module);
+  if (file_object == nullptr) {
+    PyErr_Clear();
+    return {};
+  }
+  const char* file_name = PyUnicode_AsUTF8(file_object);
+  std::string result;
+  if (file_name != nullptr) {
+    try {
+      result =
+          (std::filesystem::path(file_name).parent_path() /
+           "_metal_context.metallib")
+              .string();
+    } catch (const std::exception&) {
+      result.clear();
+    }
+  } else {
+    PyErr_Clear();
+  }
+  Py_DECREF(file_object);
+  return result;
+}
+
+std::string ns_error_description(NSError* error, const char* fallback) {
+  if (error != nil && error.localizedDescription != nil) {
+    const char* description = [error.localizedDescription UTF8String];
+    if (description != nullptr && description[0] != '\0') {
+      return description;
+    }
+  }
+  return fallback;
+}
+
+bool ensure_runtime(const std::string& path) {
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+  if (g_runtime.attempted && g_runtime.path == path) {
+    return g_runtime.available;
+  }
+
+  g_runtime.attempted = true;
+  g_runtime.available = false;
+  g_runtime.path = path;
+  g_runtime.error.clear();
+  g_runtime.device = nil;
+  g_runtime.queue = nil;
+  g_runtime.pipeline = nil;
+
+  if (!compiled_for_apple_silicon()) {
+    g_runtime.error = "the Metal Context Engine requires an Apple Silicon arm64 build";
+    return false;
+  }
+  if (path.empty()) {
+    g_runtime.error =
+        "the packaged _metal_context.metallib could not be located";
+    return false;
+  }
+  try {
+    if (!std::filesystem::exists(path)) {
+      g_runtime.error = "the Metal library does not exist at " + path;
+      return false;
+    }
+  } catch (const std::filesystem::filesystem_error& exception) {
+    g_runtime.error = "could not inspect the Metal library path: ";
+    g_runtime.error += exception.what();
+    return false;
+  }
+
+  @autoreleasepool {
+    do {
+      g_runtime.device = MTLCreateSystemDefaultDevice();
+      if (g_runtime.device == nil) {
+        g_runtime.error = "MTLCreateSystemDefaultDevice returned no GPU";
+        break;
+      }
+
+      NSData* library_bytes = [NSData
+          dataWithContentsOfFile:[NSString stringWithUTF8String:path.c_str()]];
+      if (library_bytes == nil) {
+        g_runtime.error = "the packaged Metal library could not be read";
+        break;
+      }
+
+      if (library_bytes.length == 0) {
+        g_runtime.error = "the packaged Metal library is empty";
+        break;
+      }
+      void* owned_library_bytes = std::malloc(library_bytes.length);
+      if (owned_library_bytes == nullptr) {
+        g_runtime.error =
+            "could not allocate owned storage for the packaged Metal library";
+        break;
+      }
+      std::memcpy(owned_library_bytes, library_bytes.bytes, library_bytes.length);
+      dispatch_data_t library_data = dispatch_data_create(
+          owned_library_bytes,
+          library_bytes.length,
+          nullptr,
+          DISPATCH_DATA_DESTRUCTOR_FREE);
+      if (library_data == nullptr) {
+        std::free(owned_library_bytes);
+        g_runtime.error = "the packaged Metal library could not be mapped";
+        break;
+      }
+      NSError* error = nil;
+      id<MTLLibrary> library =
+          [g_runtime.device newLibraryWithData:library_data error:&error];
+      if (library == nil) {
+        g_runtime.error = ns_error_description(error, "Metal rejected the library");
+        break;
+      }
+
+      id<MTLFunction> function =
+          [library newFunctionWithName:@"metal_context_paged_decode"];
+      if (function == nil) {
+        g_runtime.error =
+            "the packaged Metal library is missing metal_context_paged_decode";
+        break;
+      }
+
+      g_runtime.pipeline =
+          [g_runtime.device newComputePipelineStateWithFunction:function
+                                                            error:&error];
+      if (g_runtime.pipeline == nil) {
+        g_runtime.error = ns_error_description(
+            error, "Metal could not create the kernel pipeline");
+        break;
+      }
+
+      g_runtime.queue = [g_runtime.device newCommandQueue];
+      if (g_runtime.queue == nil) {
+        g_runtime.error = "Metal could not create a command queue";
+        break;
+      }
+      g_runtime.available = true;
+    } while (false);
+  }
+  return g_runtime.available;
+}
+
+bool acquire_contiguous(PyObject* object, BufferGuard* guard, const char* name) {
+  if (PyObject_GetBuffer(
+          object,
+          &guard->view,
+          PyBUF_FORMAT | PyBUF_ND | PyBUF_STRIDES | PyBUF_C_CONTIGUOUS) < 0) {
+    PyErr_Format(
+        PyExc_TypeError,
+        "%s must expose a contiguous buffer (NumPy/MLX host arrays are "
+        "accepted after conversion)",
+        name);
+    return false;
+  }
+  guard->acquired = true;
+  return true;
+}
+
+bool has_shape(const Py_buffer& view, int ndim) {
+  return view.ndim == ndim && view.shape != nullptr;
+}
+
+bool host_is_little_endian() {
+  const uint16_t value = 1;
+  return *reinterpret_cast<const uint8_t*>(&value) == 1;
+}
+
+bool is_native_format(const Py_buffer& view, char expected) {
+  if (view.format == nullptr) {
+    return false;
+  }
+  // NumPy's native scalar buffers expose a one-character PEP-3118 format.
+  // Accept the native/no-prefix forms and an explicitly native ``@``/``=``
+  // prefix.  An explicit ``>``/``!`` is always rejected; ``<`` is accepted
+  // only on the little-endian Apple Silicon host this extension targets.
+  const char* format = view.format;
+  const char prefix = *format;
+  if (prefix == '@' || prefix == '=') {
+    ++format;
+  } else if (prefix == '<') {
+    if (!host_is_little_endian()) {
+      return false;
+    }
+    ++format;
+  } else if (prefix == '>' || prefix == '!') {
+    return false;
+  }
+  return std::strlen(format) == 1 && format[0] == expected;
+}
+
+bool finite_bf16_bits(const uint16_t bits) {
+  // BF16 has an eight-bit exponent.  All exponent bits set denotes either an
+  // infinity or NaN; both are rejected before dispatch by this host-buffer
+  // foundation API.
+  return (bits & 0x7f80u) != 0x7f80u;
+}
+
+float bf16_to_float_host(const uint16_t bits) {
+  const uint32_t word = static_cast<uint32_t>(bits) << 16;
+  float value = 0.0f;
+  std::memcpy(&value, &word, sizeof(value));
+  return value;
+}
+
+bool all_finite_bf16(const Py_buffer& view) {
+  const auto* values = static_cast<const uint16_t*>(view.buf);
+  const size_t count = static_cast<size_t>(view.len) / sizeof(uint16_t);
+  for (size_t index = 0; index < count; ++index) {
+    if (!finite_bf16_bits(values[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+float max_abs_bf16(const Py_buffer& view) {
+  const auto* values = static_cast<const uint16_t*>(view.buf);
+  const size_t count = static_cast<size_t>(view.len) / sizeof(uint16_t);
+  float maximum = 0.0f;
+  for (size_t index = 0; index < count; ++index) {
+    maximum = std::max(maximum, std::fabs(bf16_to_float_host(values[index])));
+  }
+  return maximum;
+}
+
+bool checked_product(std::initializer_list<uint64_t> values, uint64_t* result) {
+  uint64_t product = 1;
+  for (uint64_t value : values) {
+    if (value != 0 && product > std::numeric_limits<uint64_t>::max() / value) {
+      return false;
+    }
+    product *= value;
+  }
+  *result = product;
+  return true;
+}
+
+bool validate_inputs(
+    const BufferGuard& query,
+    const BufferGuard& key_pages,
+    const BufferGuard& value_pages,
+    const BufferGuard& page_table,
+    const BufferGuard& sequence_lengths,
+    int num_kv_heads,
+    int block_size,
+    float scale,
+    PagedDecodeParams* params,
+    std::string* error) {
+  const Py_buffer& q = query.view;
+  const Py_buffer& k = key_pages.view;
+  const Py_buffer& v = value_pages.view;
+  const Py_buffer& table = page_table.view;
+  const Py_buffer& lengths = sequence_lengths.view;
+
+  // Check dimensionality before dereferencing any shape pointer.  Malformed
+  // Python buffer exporters are part of the adversarial input surface.
+  if (!has_shape(q, 3) || !has_shape(k, 4) || !has_shape(v, 4) ||
+      !has_shape(table, 2) ||
+      !has_shape(lengths, 1)) {
+    *error =
+        "expected query [batch, query_heads, 128], key/value "
+        "[pages, kv_heads, block_size, 128], page_table [batch, max_blocks], "
+        "and sequence_lengths [batch]";
+    return false;
+  }
+
+  if (q.shape[2] != kHeadDim) {
+    *error = "query must have head_dim 128 for the phase-1 Metal kernel";
+    return false;
+  }
+
+  if (q.itemsize != 2 || k.itemsize != 2 || v.itemsize != 2 ||
+      !is_native_format(q, 'H') || !is_native_format(k, 'H') ||
+      !is_native_format(v, 'H')) {
+    *error =
+        "query, key_pages, and value_pages must expose BF16 storage as "
+        "contiguous uint16 buffers (PEP-3118 format H)";
+    return false;
+  }
+  if (table.itemsize != sizeof(int32_t) || lengths.itemsize != sizeof(int32_t) ||
+      !is_native_format(table, 'i') || !is_native_format(lengths, 'i')) {
+    *error =
+        "page_table and sequence_lengths must expose signed int32 buffers "
+        "(PEP-3118 format i)";
+    return false;
+  }
+  if (block_size != 16 && block_size != 32) {
+    *error = "block_size must be 16 or 32 for the phase-1 Metal kernel";
+    return false;
+  }
+  if (num_kv_heads <= 0) {
+    *error = "num_kv_heads must be positive";
+    return false;
+  }
+
+  const Py_ssize_t batch = q.shape[0];
+  const Py_ssize_t query_heads = q.shape[1];
+  const Py_ssize_t pages = k.shape[0];
+  const Py_ssize_t kv_heads = k.shape[1];
+  const Py_ssize_t max_blocks = table.shape[1];
+  if (batch <= 0 || query_heads <= 0 || pages <= 0 || kv_heads <= 0 ||
+      max_blocks <= 0) {
+    *error = "batch, heads, pages, and max_blocks must be positive";
+    return false;
+  }
+  if (table.shape[0] != batch || lengths.shape[0] != batch ||
+      k.shape[1] != num_kv_heads || v.shape[0] != pages ||
+      v.shape[1] != kv_heads || k.shape[2] != block_size ||
+      v.shape[2] != block_size || k.shape[3] != kHeadDim ||
+      v.shape[3] != kHeadDim) {
+    *error = "buffer shapes do not agree with batch, heads, block_size, or 128 head_dim";
+    return false;
+  }
+  if (query_heads % kv_heads != 0) {
+    *error = "query_heads must be an integer multiple of kv_heads (GQA)";
+    return false;
+  }
+
+  const uint64_t max_sequence =
+      static_cast<uint64_t>(max_blocks) * static_cast<uint64_t>(block_size);
+  if (max_sequence > std::numeric_limits<uint32_t>::max() ||
+      batch > std::numeric_limits<uint32_t>::max() ||
+      query_heads > std::numeric_limits<uint32_t>::max() ||
+      kv_heads > std::numeric_limits<uint32_t>::max() ||
+      pages > std::numeric_limits<uint32_t>::max() ||
+      max_blocks > std::numeric_limits<uint32_t>::max()) {
+    *error = "buffer dimensions exceed the native uint32 ABI";
+    return false;
+  }
+
+  uint64_t query_elements = 0;
+  uint64_t kv_elements = 0;
+  uint64_t table_elements = 0;
+  if (!checked_product(
+          {static_cast<uint64_t>(batch), static_cast<uint64_t>(query_heads),
+           kHeadDim},
+          &query_elements) ||
+      !checked_product(
+          {static_cast<uint64_t>(pages), static_cast<uint64_t>(kv_heads),
+           static_cast<uint64_t>(block_size), kHeadDim},
+          &kv_elements) ||
+      !checked_product(
+          {static_cast<uint64_t>(batch), static_cast<uint64_t>(max_blocks)},
+          &table_elements)) {
+    *error = "buffer dimensions overflow the native size calculation";
+    return false;
+  }
+  // Every composite offset in the MSL kernel is a uint32 expression.  Keep
+  // the entire reachable buffer/index space below UINT32_MAX rather than
+  // allowing a valid host allocation to wrap inside the shader.
+  if (query_elements > std::numeric_limits<uint32_t>::max() ||
+      kv_elements > std::numeric_limits<uint32_t>::max() ||
+      table_elements > std::numeric_limits<uint32_t>::max() ||
+      static_cast<uint64_t>(batch) * static_cast<uint64_t>(query_heads) >
+          std::numeric_limits<uint32_t>::max()) {
+    *error =
+        "buffer dimensions exceed the uint32 index/grid limit of the Metal "
+        "kernel";
+    return false;
+  }
+  const uint64_t expected_q = query_elements * sizeof(uint16_t);
+  const uint64_t expected_kv = kv_elements * sizeof(uint16_t);
+  const uint64_t expected_table = table_elements * sizeof(int32_t);
+  if (expected_q != static_cast<uint64_t>(q.len) ||
+      expected_kv != static_cast<uint64_t>(k.len) ||
+      expected_kv != static_cast<uint64_t>(v.len) ||
+      expected_table != static_cast<uint64_t>(table.len) ||
+      static_cast<uint64_t>(batch) * sizeof(int32_t) !=
+          static_cast<uint64_t>(lengths.len)) {
+    *error = "buffer byte lengths do not match their declared shapes";
+    return false;
+  }
+
+  if (!all_finite_bf16(q) || !all_finite_bf16(k) || !all_finite_bf16(v)) {
+    *error =
+        "query, key_pages, and value_pages must contain only finite BF16 "
+        "values";
+    return false;
+  }
+
+  // The shader performs the dot reduction in float32.  Finite BF16 inputs
+  // can still produce an infinity when multiplied/reduced at head_dim=128,
+  // and a subsequent Inf-Inf in online softmax would become NaN.  Use a
+  // conservative half-FLT_MAX envelope to leave room for float32 rounding;
+  // this is intentionally a host rejection in the host-buffer foundation.
+  constexpr long double kFloat32SafeMagnitude =
+      static_cast<long double>(std::numeric_limits<float>::max()) * 0.5L;
+  const long double max_dot =
+      static_cast<long double>(max_abs_bf16(q)) *
+      static_cast<long double>(max_abs_bf16(k)) * kHeadDim;
+  if (max_dot > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes may overflow the float32 dot "
+        "product at head_dim 128; reduce magnitudes";
+    return false;
+  }
+  const long double max_score =
+      max_dot * std::fabs(static_cast<long double>(scale));
+  if (max_score > kFloat32SafeMagnitude) {
+    *error =
+        "finite BF16 query/key magnitudes and scale may overflow the "
+        "float32 attention score; reduce scale or magnitudes";
+    return false;
+  }
+
+  const auto* table_data = static_cast<const int32_t*>(table.buf);
+  const auto* length_data = static_cast<const int32_t*>(lengths.buf);
+  for (Py_ssize_t request = 0; request < batch; ++request) {
+    const int32_t length = length_data[request];
+    if (length < 0 || static_cast<uint64_t>(length) > max_sequence) {
+      *error = "sequence_lengths must be in [0, max_blocks * block_size]";
+      return false;
+    }
+    const Py_ssize_t needed_blocks =
+        (static_cast<Py_ssize_t>(length) + block_size - 1) / block_size;
+    for (Py_ssize_t logical_block = 0; logical_block < needed_blocks;
+         ++logical_block) {
+      const int32_t physical_page =
+          table_data[request * table.shape[1] + logical_block];
+      if (physical_page < 0 || physical_page >= pages) {
+        *error = "page_table contains an out-of-range page for a live token";
+        return false;
+      }
+    }
+  }
+
+  params->batch_size = static_cast<uint32_t>(batch);
+  params->query_heads = static_cast<uint32_t>(query_heads);
+  params->kv_heads = static_cast<uint32_t>(kv_heads);
+  params->head_dim = kHeadDim;
+  params->block_size = static_cast<uint32_t>(block_size);
+  params->max_blocks = static_cast<uint32_t>(max_blocks);
+  params->page_count = static_cast<uint32_t>(pages);
+  params->page_table_stride = static_cast<uint32_t>(max_blocks);
+  params->reserved0 = 0;
+  params->reserved1 = 0;
+  params->reserved2 = 0;
+  return true;
+}
+
+PyObject* py_capabilities(PyObject* self, PyObject*) {
+  const std::string path = py_object_path(self);
+  const bool available = ensure_runtime(path);
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+
+  if (!available) {
+    return unavailable_capabilities(g_runtime.error);
+  }
+
+  PyObject* result = PyDict_New();
+  if (result == nullptr) {
+    return nullptr;
+  }
+  const char* device_name =
+      g_runtime.device == nil ? "" : [g_runtime.device.name UTF8String];
+  const std::string name = device_name == nullptr ? "" : device_name;
+  if (!set_dict_bool(result, "available", true) ||
+      !set_dict_bool(result, "compiled", true) ||
+      !set_dict_bool(result, "metal_device", true) ||
+      !set_dict_bool(result, "apple_silicon", true) ||
+      !set_dict_bool(result, "serving_ready", false) ||
+      !set_dict_uint(result, "abi_version", kAbiVersion) ||
+      !set_dict_string(result, "backend", "metal-context") ||
+      !set_dict_string(result, "reason", "") ||
+      !set_dict_string(result, "device_name", name) ||
+      !set_dict_string(result, "metallib_path", g_runtime.path) ||
+      !set_dict_string(result, "kernel", "metal_context_paged_decode")) {
+    Py_DECREF(result);
+    return nullptr;
+  }
+
+  PyObject* block_sizes = Py_BuildValue("(ii)", 16, 32);
+  PyObject* head_dims = Py_BuildValue("(i)", static_cast<int>(kHeadDim));
+  if (block_sizes == nullptr || head_dims == nullptr ||
+      PyDict_SetItemString(result, "block_sizes", block_sizes) < 0 ||
+      PyDict_SetItemString(result, "head_dims", head_dims) < 0 ||
+      !set_dict_bool(result, "gqa", true) ||
+      !set_dict_bool(result, "partial_blocks", true) ||
+      !set_dict_bool(result, "online_softmax", true) ||
+      !set_dict_string(result, "kv_dtype", "bfloat16")) {
+    Py_XDECREF(block_sizes);
+    Py_XDECREF(head_dims);
+    Py_DECREF(result);
+    return nullptr;
+  }
+  Py_DECREF(block_sizes);
+  Py_DECREF(head_dims);
+  return result;
+}
+
+PyObject* py_paged_decode(PyObject* self, PyObject* args, PyObject* kwargs) {
+  static const char* keywords[] = {
+      "query", "key_pages", "value_pages", "page_table",
+      "sequence_lengths", "num_kv_heads", "block_size", "scale", nullptr};
+  PyObject* query_object = nullptr;
+  PyObject* key_object = nullptr;
+  PyObject* value_object = nullptr;
+  PyObject* table_object = nullptr;
+  PyObject* lengths_object = nullptr;
+  int num_kv_heads = 0;
+  int block_size = 0;
+  float scale = 0.0f;
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "OOOOOiff:paged_decode",
+          const_cast<char**>(keywords),
+          &query_object,
+          &key_object,
+          &value_object,
+          &table_object,
+          &lengths_object,
+          &num_kv_heads,
+          &block_size,
+          &scale)) {
+    return nullptr;
+  }
+  if (!std::isfinite(scale)) {
+    PyErr_SetString(PyExc_ValueError, "scale must be finite");
+    return nullptr;
+  }
+
+  BufferGuard query;
+  BufferGuard key_pages;
+  BufferGuard value_pages;
+  BufferGuard page_table;
+  BufferGuard sequence_lengths;
+  if (!acquire_contiguous(query_object, &query, "query") ||
+      !acquire_contiguous(key_object, &key_pages, "key_pages") ||
+      !acquire_contiguous(value_object, &value_pages, "value_pages") ||
+      !acquire_contiguous(table_object, &page_table, "page_table") ||
+      !acquire_contiguous(
+          lengths_object, &sequence_lengths, "sequence_lengths")) {
+    return nullptr;
+  }
+
+  PagedDecodeParams params{};
+  std::string validation_error;
+  if (!validate_inputs(
+          query,
+          key_pages,
+          value_pages,
+          page_table,
+          sequence_lengths,
+          num_kv_heads,
+          block_size,
+          scale,
+          &params,
+          &validation_error)) {
+    PyErr_SetString(PyExc_ValueError, validation_error.c_str());
+    return nullptr;
+  }
+  params.scale = scale;
+
+  const std::string path = py_object_path(self);
+  if (!ensure_runtime(path)) {
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    PyErr_Format(
+        PyExc_RuntimeError,
+        "metal-context backend unavailable: %s",
+        g_runtime.error.c_str());
+    return nullptr;
+  }
+
+  uint64_t output_elements = 0;
+  if (!checked_product(
+          {params.batch_size, params.query_heads, params.head_dim},
+          &output_elements) ||
+      output_elements > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    PyErr_SetString(PyExc_OverflowError, "output shape exceeds native size limits");
+    return nullptr;
+  }
+  const size_t output_bytes = static_cast<size_t>(output_elements) * sizeof(float);
+
+  @autoreleasepool {
+    // Serialize the first low-level bridge while ownership is still host
+    // backed.  The future page runtime will replace these copies with
+    // allocator-owned GPU buffers and keep the command queue asynchronous.
+    std::lock_guard<std::mutex> lock(g_runtime.mutex);
+    id<MTLDevice> device = g_runtime.device;
+    id<MTLCommandQueue> queue = g_runtime.queue;
+    id<MTLComputePipelineState> pipeline = g_runtime.pipeline;
+    if (device == nil || queue == nil || pipeline == nil) {
+      PyErr_SetString(PyExc_RuntimeError, "metal-context runtime lost its pipeline");
+      return nullptr;
+    }
+
+    id<MTLBuffer> query_buffer =
+        [device newBufferWithLength:(NSUInteger)query.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> key_buffer =
+        [device newBufferWithLength:(NSUInteger)key_pages.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> value_buffer =
+        [device newBufferWithLength:(NSUInteger)value_pages.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> table_buffer =
+        [device newBufferWithLength:(NSUInteger)page_table.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> lengths_buffer =
+        [device newBufferWithLength:(NSUInteger)sequence_lengths.view.len
+                             options:MTLResourceStorageModeShared];
+    id<MTLBuffer> output_buffer =
+        [device newBufferWithLength:(NSUInteger)output_bytes
+                             options:MTLResourceStorageModeShared];
+    if (query_buffer == nil || key_buffer == nil || value_buffer == nil ||
+        table_buffer == nil || lengths_buffer == nil || output_buffer == nil) {
+      PyErr_SetString(PyExc_MemoryError, "Metal could not allocate kernel buffers");
+      return nullptr;
+    }
+
+    std::memcpy(query_buffer.contents, query.view.buf, query.view.len);
+    std::memcpy(key_buffer.contents, key_pages.view.buf, key_pages.view.len);
+    std::memcpy(value_buffer.contents, value_pages.view.buf, value_pages.view.len);
+    std::memcpy(table_buffer.contents, page_table.view.buf, page_table.view.len);
+    std::memcpy(
+        lengths_buffer.contents,
+        sequence_lengths.view.buf,
+        sequence_lengths.view.len);
+    std::memset(output_buffer.contents, 0, output_bytes);
+
+    id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+    id<MTLComputeCommandEncoder> encoder =
+        [command_buffer computeCommandEncoder];
+    if (command_buffer == nil || encoder == nil) {
+      PyErr_SetString(PyExc_RuntimeError, "Metal could not create a command encoder");
+      return nullptr;
+    }
+    [encoder setComputePipelineState:pipeline];
+    [encoder setBuffer:query_buffer offset:0 atIndex:0];
+    [encoder setBuffer:key_buffer offset:0 atIndex:1];
+    [encoder setBuffer:value_buffer offset:0 atIndex:2];
+    [encoder setBuffer:table_buffer offset:0 atIndex:3];
+    [encoder setBuffer:lengths_buffer offset:0 atIndex:4];
+    [encoder setBuffer:output_buffer offset:0 atIndex:5];
+    [encoder setBytes:&params length:sizeof(params) atIndex:6];
+    const MTLSize grid = MTLSizeMake(
+        (NSUInteger)params.batch_size * params.query_heads, 1, 1);
+    const MTLSize group = MTLSizeMake(kThreadsPerThreadgroup, 1, 1);
+    [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+    [encoder endEncoding];
+    [command_buffer commit];
+    [command_buffer waitUntilCompleted];
+
+    if (command_buffer.status != MTLCommandBufferStatusCompleted) {
+      std::string error = ns_error_description(
+          command_buffer.error,
+          "Metal command buffer did not complete successfully");
+      PyErr_SetString(PyExc_RuntimeError, error.c_str());
+      return nullptr;
+    }
+    return PyBytes_FromStringAndSize(
+        static_cast<const char*>(output_buffer.contents),
+        static_cast<Py_ssize_t>(output_bytes));
+  }
+}
+
+PyObject* py_shutdown(PyObject*, PyObject*) {
+  std::lock_guard<std::mutex> lock(g_runtime.mutex);
+  g_runtime.device = nil;
+  g_runtime.queue = nil;
+  g_runtime.pipeline = nil;
+  g_runtime.attempted = false;
+  g_runtime.available = false;
+  g_runtime.path.clear();
+  g_runtime.error.clear();
+  Py_RETURN_NONE;
+}
+
+PyMethodDef kMethods[] = {
+    {"capabilities", py_capabilities, METH_NOARGS,
+     "Return the compiled Metal Context Engine capability record."},
+    {"paged_decode", reinterpret_cast<PyCFunction>(py_paged_decode),
+     METH_VARARGS | METH_KEYWORDS,
+     "Run BF16 paged decode attention from contiguous host buffers."},
+    {"shutdown", py_shutdown, METH_NOARGS,
+     "Release the native Metal pipeline and queue."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+PyModuleDef kModule = {
+    PyModuleDef_HEAD_INIT,
+    "vllm_mlx._metal_context",
+    "Optional native Metal Context Engine kernel bridge.",
+    -1,
+    kMethods,
+};
+
+}  // namespace
+
+PyMODINIT_FUNC PyInit__metal_context() {
+  return PyModule_Create(&kModule);
+}

--- a/native/metal_context/tests/page_runtime_concurrency_test.mm
+++ b/native/metal_context/tests/page_runtime_concurrency_test.mm
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Deterministic host/ASAN regression for the PageRuntime lock contract.
+
+#include "page_runtime.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+int main() {
+  using metal_context::PageRuntime;
+
+  PageRuntime runtime(
+      /*num_layers=*/4,
+      /*num_attention_heads=*/1,
+      /*num_key_value_heads=*/1,
+      /*head_dim=*/128,
+      /*block_size=*/16,
+      /*max_pages=*/8,
+      /*max_blocks_per_request=*/4,
+      /*max_requests=*/1);
+  std::string error;
+  uint64_t request = 0;
+  if (!runtime.allocate_request("lock-order", 64, &request, &error)) {
+    std::fprintf(stderr, "allocate_request failed: %s\n", error.c_str());
+    return 1;
+  }
+
+  std::vector<uint16_t> kv(128, 0);
+  std::vector<uint16_t> query(128, 0);
+  constexpr uint32_t kWorkers = 4;
+  constexpr uint32_t kIterations = 8;
+  std::atomic<uint32_t> ready{0};
+  std::atomic<bool> start{false};
+  std::atomic<uint32_t> completed{0};
+  std::atomic<uint32_t> failures{0};
+  std::mutex completion_mutex;
+  std::condition_variable completion_cv;
+  std::vector<std::thread> workers;
+  workers.reserve(kWorkers);
+
+  for (uint32_t layer = 0; layer < kWorkers; ++layer) {
+    workers.emplace_back([&, layer] {
+      try {
+        ready.fetch_add(1, std::memory_order_release);
+        while (!start.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+          std::string append_error;
+          if (!runtime.append_kv(
+                  request,
+                  layer,
+                  kv.data(),
+                  kv.data(),
+                  1,
+                  &append_error)) {
+            ++failures;
+          }
+          std::vector<float> output;
+          std::string decode_error;
+          // A host-only build is expected to fail closed before dispatch;
+          // the lock/lifecycle assertion is that this call always returns.
+          (void)runtime.paged_decode(
+              request,
+              layer,
+              query.data(),
+              query.size(),
+              1.0f,
+              &output,
+              &decode_error);
+        }
+      } catch (...) {
+        ++failures;
+      }
+      completed.fetch_add(1, std::memory_order_release);
+      completion_cv.notify_one();
+    });
+  }
+
+  while (ready.load(std::memory_order_acquire) != kWorkers) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+  {
+    std::unique_lock<std::mutex> lock(completion_mutex);
+    if (!completion_cv.wait_for(
+            lock,
+            std::chrono::seconds(5),
+            [&] {
+              return completed.load(std::memory_order_acquire) == kWorkers;
+            })) {
+      std::fprintf(stderr, "PageRuntime lock-order regression timed out\n");
+      std::_Exit(2);
+    }
+  }
+  for (std::thread& worker : workers) {
+    worker.join();
+  }
+  if (failures.load(std::memory_order_acquire) != 0) {
+    std::fprintf(stderr, "PageRuntime concurrency worker failed\n");
+    return 1;
+  }
+
+  if (!runtime.release_request(request, false, &error)) {
+    std::fprintf(stderr, "release_request failed: %s\n", error.c_str());
+    return 1;
+  }
+  runtime.shutdown();
+  return 0;
+}

--- a/native/metal_context/tests/page_runtime_fork_stress_test.mm
+++ b/native/metal_context/tests/page_runtime_fork_stress_test.mm
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "page_runtime.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+int main() {
+  metal_context::PageRuntime runtime(
+      1, 1, 1, 128, 16, 2, 1, 1);
+  std::string error;
+  uint64_t request = 0;
+  assert(runtime.allocate_request("fork-stress", 16, &request, &error));
+  std::vector<uint64_t> pages;
+  assert(runtime.allocate_pages(request, 1, &pages, &error));
+  const uint16_t zero[128] = {};
+  assert(runtime.append_kv(request, 0, zero, zero, 1, &error));
+
+  uint64_t source = 0;
+  assert(runtime.create_prefix(request, &source, &error));
+  std::vector<uint64_t> forks;
+  forks.reserve(4096);
+  for (int index = 0; index < 4096; ++index) {
+    uint64_t forked = 0;
+    // Keeping every fork live forces repeated PrefixMeta vector growth.  The
+    // source pointer must remain valid across each reallocation.
+    assert(runtime.fork_prefix(source, &forked, &error));
+    forks.push_back(forked);
+  }
+  for (uint64_t forked : forks) {
+    assert(runtime.release_prefix(forked, &error));
+  }
+  assert(runtime.release_prefix(source, &error));
+  assert(runtime.release_request(request, false, &error));
+  runtime.shutdown();
+  return 0;
+}

--- a/native/metal_context/tests/page_runtime_offset_test.mm
+++ b/native/metal_context/tests/page_runtime_offset_test.mm
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "page_runtime.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
+int main() {
+  using metal_context::page_runtime_sequence_buffer_offset;
+
+  // The layout is [request slot][layer], not request*layer.  These cases
+  // cover both nonzero dimensions and the layer-zero rows that the old
+  // multiplication formula collapsed onto offset zero.
+  assert(page_runtime_sequence_buffer_offset(0, 2, 0) == 0);
+  assert(page_runtime_sequence_buffer_offset(0, 2, 1) == sizeof(int32_t));
+  assert(page_runtime_sequence_buffer_offset(1, 2, 0) == 2 * sizeof(int32_t));
+  assert(page_runtime_sequence_buffer_offset(1, 2, 1) == 3 * sizeof(int32_t));
+  assert(page_runtime_sequence_buffer_offset(7, 4, 3) == 31 * sizeof(int32_t));
+
+  bool rejected = false;
+  try {
+    (void)page_runtime_sequence_buffer_offset(0, 2, 2);
+  } catch (const std::invalid_argument&) {
+    rejected = true;
+  }
+  assert(rejected);
+  return 0;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ include = ["vllm_mlx*"]
 
 [tool.setuptools.package-data]
 "vllm_mlx.bench_serve_prompts" = ["*.json"]
+"vllm_mlx" = ["*.metallib"]
 
 [tool.black]
 line-length = 88

--- a/scripts/build_metal_context.py
+++ b/scripts/build_metal_context.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Compile the checked-in Metal Context Engine shaders into a metallib.
+
+This is deliberately a small, explicit workflow instead of a runtime shader
+compiler.  Release builders can run it on a pinned macOS/Xcode image and ship
+the resulting library beside the optional native extension.  No command is
+attempted on non-macOS hosts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "native" / "metal_context" / "kernels" / "paged_decode.metal"
+APPLE_SILICON = {"arm64", "aarch64"}
+
+
+def _xcrun(sdk: str, tool: str) -> str:
+    result = subprocess.run(
+        ["xcrun", "--sdk", sdk, "--find", tool],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        detail = result.stderr.strip() or f"xcrun could not find {tool}"
+        raise RuntimeError(detail)
+    return result.stdout.strip()
+
+
+def compile_metallib(output: Path, *, sdk: str = "macosx") -> None:
+    """Compile the phase-1 shader and atomically publish ``output``."""
+
+    if sys.platform != "darwin":
+        raise RuntimeError("Metal shader compilation requires macOS")
+    machine = platform.machine().lower()
+    if machine not in APPLE_SILICON:
+        raise RuntimeError(
+            "Metal Context Engine compilation requires Apple Silicon "
+            f"(arm64/aarch64), found {machine or 'unknown'}"
+        )
+    if not SOURCE.is_file():
+        raise RuntimeError(f"shader source is missing: {SOURCE}")
+
+    metal = _xcrun(sdk, "metal")
+    metallib = _xcrun(sdk, "metallib")
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="vllm-mlx-metal-") as temp_dir:
+        temp = Path(temp_dir)
+        air = temp / "paged_decode.air"
+        compiled = temp / "_metal_context.metallib"
+        subprocess.run(
+            [metal, "-c", os.fspath(SOURCE), "-o", os.fspath(air)],
+            check=True,
+        )
+        subprocess.run(
+            [metallib, os.fspath(air), "-o", os.fspath(compiled)],
+            check=True,
+        )
+        os.replace(compiled, output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "vllm_mlx" / "_metal_context.metallib",
+        help="destination metallib path",
+    )
+    parser.add_argument("--sdk", default="macosx", help="xcrun SDK name")
+    args = parser.parse_args()
+    compile_metallib(args.output, sdk=args.sdk)
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,11 @@ def _extensions() -> list[Extension]:
     return [
         Extension(
             "vllm_mlx._metal_context",
-            sources=["native/metal_context/src/python_module.mm"],
+            sources=[
+                "native/metal_context/src/python_module.mm",
+                "native/metal_context/src/page_runtime.mm",
+                "native/metal_context/src/page_runtime_python.mm",
+            ],
             language="objc++",
             extra_compile_args=[
                 "-std=c++17",

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,7 @@ def _extensions() -> list[Extension]:
     return [
         Extension(
             "vllm_mlx._metal_context",
-            sources=[
-                os.fspath(
-                    ROOT / "native" / "metal_context" / "src" / "python_module.mm"
-                )
-            ],
+            sources=["native/metal_context/src/python_module.mm"],
             language="objc++",
             extra_compile_args=[
                 "-std=c++17",

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,18 @@ def _extensions() -> list[Extension]:
                 )
             ],
             language="objc++",
-            extra_compile_args=["-std=c++17", "-fobjc-arc"],
-            extra_link_args=["-framework", "Metal", "-framework", "Foundation"],
+            extra_compile_args=[
+                "-std=c++17",
+                "-fobjc-arc",
+                "-mmacosx-version-min=11.0",
+            ],
+            extra_link_args=[
+                "-mmacosx-version-min=11.0",
+                "-framework",
+                "Metal",
+                "-framework",
+                "Foundation",
+            ],
         )
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,13 @@ class MetalBuildExt(build_ext):
         destination_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(output, destination_dir / "_metal_context.metallib")
 
+    def build_extensions(self) -> None:
+        # distutils does not list Objective-C++ as a recognized source suffix,
+        # even though Apple's clang handles it correctly.  Register it before
+        # setuptools asks the compiler to classify extension sources.
+        if ".mm" not in self.compiler.src_extensions:
+            self.compiler.src_extensions.append(".mm")
+        super().build_extensions()
+
 
 setup(ext_modules=_extensions(), cmdclass={"build_ext": MetalBuildExt})

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,105 @@
+"""Optional native Metal Context Engine build hooks.
+
+The project metadata remains in ``pyproject.toml``.  This small shim only
+adds an extension when the caller is on Apple Silicon macOS, the Metal
+compiler is available, and ``VLLM_MLX_BUILD_METAL_CONTEXT=1`` is explicitly
+requested.  Normal installs keep this optional extension disabled.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+ROOT = Path(__file__).resolve().parent
+STRICT = {"1", "true", "yes", "on", "required"}
+APPLE_SILICON = {"arm64", "aarch64"}
+
+
+def _metal_toolchain_available() -> bool:
+    if sys.platform != "darwin" or shutil.which("xcrun") is None:
+        return False
+    return (
+        subprocess.run(
+            ["xcrun", "--sdk", "macosx", "--find", "metal"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode
+        == 0
+    )
+
+
+def _extensions() -> list[Extension]:
+    # The native foundation is never built implicitly.  This keeps ordinary
+    # wheels/editable installs portable and makes the toolchain choice
+    # auditable in CI and release logs.
+    mode = os.environ.get("VLLM_MLX_BUILD_METAL_CONTEXT", "disabled").lower()
+    if mode in {"0", "false", "no", "off", "disabled"}:
+        return []
+    if sys.platform != "darwin":
+        if mode in STRICT:
+            raise RuntimeError("VLLM_MLX_BUILD_METAL_CONTEXT=1 requires macOS")
+        return []
+    machine = platform.machine().lower()
+    if machine not in APPLE_SILICON:
+        if mode in STRICT:
+            raise RuntimeError(
+                "VLLM_MLX_BUILD_METAL_CONTEXT=1 requires Apple Silicon "
+                f"(arm64/aarch64), found {machine or 'unknown'}"
+            )
+        return []
+    if not _metal_toolchain_available():
+        if mode in STRICT:
+            raise RuntimeError(
+                "Metal toolchain unavailable; install Xcode/Command Line Tools "
+                "or set VLLM_MLX_BUILD_METAL_CONTEXT=0"
+            )
+        return []
+    return [
+        Extension(
+            "vllm_mlx._metal_context",
+            sources=[
+                os.fspath(
+                    ROOT / "native" / "metal_context" / "src" / "python_module.mm"
+                )
+            ],
+            language="objc++",
+            extra_compile_args=["-std=c++17", "-fobjc-arc"],
+            extra_link_args=["-framework", "Metal", "-framework", "Foundation"],
+        )
+    ]
+
+
+class MetalBuildExt(build_ext):
+    """Build the metallib before the extension and package it beside it."""
+
+    def run(self) -> None:
+        if not self.extensions:
+            return super().run()
+        output = Path(self.build_temp) / "metal_context" / "_metal_context.metallib"
+        subprocess.run(
+            [
+                sys.executable,
+                os.fspath(ROOT / "scripts" / "build_metal_context.py"),
+                "--output",
+                os.fspath(output),
+            ],
+            check=True,
+        )
+        super().run()
+        destination_dir = (
+            ROOT / "vllm_mlx" if self.inplace else Path(self.build_lib) / "vllm_mlx"
+        )
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(output, destination_dir / "_metal_context.metallib")
+
+
+setup(ext_modules=_extensions(), cmdclass={"build_ext": MetalBuildExt})

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for phase-one attention backend dispatch and oracle semantics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vllm_mlx.attention_backend import (
+    AttentionBackendCapabilityError,
+    AttentionBackendName,
+    AttentionGeometry,
+    BackendCapabilities,
+    ContextBackend,
+    discover_capabilities,
+    mlx_sdpa_paged_decode_attention,
+    numpy_paged_decode_attention,
+    resolve_attention_backend,
+)
+
+
+def unavailable_capabilities(reason: str = "test extension unavailable"):
+    return BackendCapabilities(
+        platform="darwin",
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=reason,
+    )
+
+
+class TestBackendDispatch:
+    def test_mlx_is_default_and_never_requires_native_extension(self):
+        selection = resolve_attention_backend(capabilities=unavailable_capabilities())
+
+        assert selection.requested is AttentionBackendName.MLX
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.is_fallback is False
+
+    def test_default_mlx_does_not_probe_or_import_native(self, monkeypatch):
+        def fail_probe():
+            raise AssertionError("the MLX default must not probe native")
+
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend.discover_capabilities", fail_probe
+        )
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend.importlib.import_module", fail_probe
+        )
+
+        selection = resolve_attention_backend()
+
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.capabilities.probed is False
+        assert selection.capabilities.native_extension is False
+        assert selection.capabilities.available is False
+        assert selection.capabilities.architecture == ""
+
+    def test_auto_is_conservative_even_when_native_is_available(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        selection = resolve_attention_backend("auto", capabilities=capabilities)
+
+        assert selection.selected is AttentionBackendName.MLX
+        assert selection.is_fallback is True
+        assert "qualification matrix" in (selection.fallback_reason or "")
+
+    def test_explicit_metal_context_fails_without_capability(self):
+        with pytest.raises(
+            AttentionBackendCapabilityError,
+            match="explicitly requested but is unavailable",
+        ) as exc_info:
+            resolve_attention_backend(
+                "metal-context", capabilities=unavailable_capabilities("no device")
+            )
+
+        assert exc_info.value.capabilities.reason == "no device"
+        assert "--attention-backend mlx" in str(exc_info.value)
+
+    def test_explicit_metal_context_selects_only_after_probe(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        selection = resolve_attention_backend(
+            "metal-context", capabilities=capabilities
+        )
+
+        assert selection.selected is AttentionBackendName.METAL_CONTEXT
+        assert selection.is_fallback is False
+
+    def test_kernel_capability_without_executor_still_fails_closed(self):
+        capabilities = BackendCapabilities(
+            platform="darwin",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+        )
+
+        with pytest.raises(
+            AttentionBackendCapabilityError,
+            match="no serving executor is registered",
+        ):
+            resolve_attention_backend("metal-context", capabilities=capabilities)
+
+    def test_explicit_metal_context_rejects_non_macos_capability(self):
+        capabilities = BackendCapabilities(
+            platform="linux",
+            native_extension=True,
+            metal_device=True,
+            abi_version=1,
+            available=True,
+            serving_ready=True,
+        )
+
+        with pytest.raises(AttentionBackendCapabilityError, match="requires macOS"):
+            resolve_attention_backend("metal-context", capabilities=capabilities)
+
+    @pytest.mark.parametrize("value", ["bogus", "", "METAL_CONTEXT"])
+    def test_invalid_names_are_rejected(self, value):
+        with pytest.raises(ValueError, match="Unknown attention backend"):
+            resolve_attention_backend(value, capabilities=unavailable_capabilities())
+
+    def test_selection_status_is_serializable(self):
+        status = resolve_attention_backend(
+            "auto", capabilities=unavailable_capabilities()
+        ).as_dict()
+
+        assert status["requested"] == "auto"
+        assert status["selected"] == "mlx"
+        assert status["capabilities"]["available"] is False
+        assert status["capabilities"]["probed"] is False
+
+
+class TestCapabilityProbe:
+    def test_non_macos_fails_closed(self, monkeypatch):
+        monkeypatch.setattr("vllm_mlx.attention_backend.sys.platform", "linux")
+
+        capabilities = discover_capabilities()
+
+        assert capabilities.available is False
+        assert "requires macOS" in (capabilities.reason or "")
+
+    def test_non_apple_silicon_fails_closed(self, monkeypatch):
+        monkeypatch.setattr("vllm_mlx.attention_backend.sys.platform", "darwin")
+        monkeypatch.setattr(
+            "vllm_mlx.attention_backend._platform.machine", lambda: "x86_64"
+        )
+
+        capabilities = discover_capabilities()
+
+        assert capabilities.available is False
+        assert "requires Apple Silicon" in (capabilities.reason or "")
+
+
+class TestGeometry:
+    def test_qwen_phase_one_geometry_is_accepted(self):
+        AttentionGeometry(
+            num_layers=36,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            block_size=32,
+        ).validate()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"head_dim": 64},
+            {"block_size": 64},
+            {"kv_dtype": "float16"},
+            {"num_attention_heads": 30, "num_key_value_heads": 8},
+        ],
+    )
+    def test_unsupported_geometry_is_rejected(self, kwargs):
+        values = {
+            "num_layers": 36,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+        }
+        values.update(kwargs)
+        with pytest.raises(ValueError):
+            AttentionGeometry(**values).validate()
+
+
+class TestNumpyOracle:
+    def test_accepts_native_bf16_bit_storage(self):
+        query_values = np.asarray([[[1.0], [-2.5]]], dtype=np.float32)
+        query_bits = (query_values.view(np.uint32) >> 16).astype(np.uint16)
+        key_values = np.full((1, 1, 16, 1), 0.125, dtype=np.float32)
+        key_bits = (key_values.view(np.uint32) >> 16).astype(np.uint16)
+
+        output = numpy_paged_decode_attention(
+            query_bits,
+            key_bits,
+            key_bits,
+            np.asarray([[0]], dtype=np.int32),
+            np.asarray([1], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=1,
+            scale=1.0,
+        )
+
+        assert output.shape == query_values.shape
+        assert np.isfinite(output).all()
+
+    def test_noncontiguous_pages_gqa_and_partial_tail(self):
+        rng = np.random.default_rng(11)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        # Request zero uses physical pages [2, 0] and has a one-token tail;
+        # request one uses [1, 3] with a fourteen-token tail.
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+
+        assert output.shape == query.shape
+        assert np.isfinite(output).all()
+        assert output.dtype == np.float32
+
+    @pytest.mark.parametrize(
+        "mutator, message",
+        [
+            (lambda table, lengths: (table.astype(np.float32), lengths), "integer"),
+            (lambda table, lengths: (table, lengths.astype(np.float32)), "integer"),
+            (lambda table, lengths: (table, np.asarray([-1, 1])), "negative"),
+            (
+                lambda table, lengths: (np.asarray([[99, 0], [1, 3]]), lengths),
+                "outside",
+            ),
+        ],
+    )
+    def test_invalid_page_metadata_is_rejected(self, mutator, message):
+        rng = np.random.default_rng(3)
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, 16, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        lengths = np.asarray([17, 30], dtype=np.int32)
+        page_table, lengths = mutator(page_table, lengths)
+
+        with pytest.raises(ValueError, match=message):
+            numpy_paged_decode_attention(
+                query,
+                key_pages,
+                value_pages,
+                page_table,
+                lengths,
+                block_size=16,
+                num_kv_heads=2,
+            )
+
+    def test_zero_length_request_returns_zero_without_page_access(self):
+        query = np.ones((1, 4, 8), dtype=np.float32)
+        key_pages = np.zeros((0, 2, 16, 8), dtype=np.float32)
+        value_pages = np.zeros_like(key_pages)
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            np.zeros((1, 0), dtype=np.int32),
+            np.asarray([0], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=2,
+        )
+
+        np.testing.assert_array_equal(output, np.zeros_like(query))
+
+    def test_extreme_but_finite_logits_use_stable_softmax(self):
+        query = np.asarray([[[1.0e20]]], dtype=np.float32)
+        key_pages = np.zeros((1, 1, 16, 1), dtype=np.float32)
+        key_pages[0, 0, :2, 0] = [1.0e-10, 2.0e-10]
+        value_pages = np.zeros_like(key_pages)
+        value_pages[0, 0, :2, 0] = [1.0, 3.0]
+
+        output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            np.asarray([[0]], dtype=np.int32),
+            np.asarray([2], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=1,
+            scale=1.0,
+        )
+
+        assert np.isfinite(output).all()
+        assert output[0, 0, 0] > 2.9
+
+    def test_finite_inputs_with_overflowed_logits_fail_explicitly(self):
+        query = np.asarray([[[1.0e20]]], dtype=np.float32)
+        key_pages = np.zeros((1, 1, 16, 1), dtype=np.float32)
+        key_pages[0, 0, 0, 0] = 1.0e20
+        value_pages = np.ones_like(key_pages)
+
+        with pytest.raises(ValueError, match="attention logits overflow"):
+            numpy_paged_decode_attention(
+                query,
+                key_pages,
+                value_pages,
+                np.asarray([[0]], dtype=np.int32),
+                np.asarray([1], dtype=np.int32),
+                block_size=16,
+                num_kv_heads=1,
+                scale=1.0,
+            )
+
+
+class TestMlxOracle:
+    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+        mx = pytest.importorskip("mlx.core")
+        rng = np.random.default_rng(23)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        numpy_output = numpy_paged_decode_attention(
+            query,
+            key_pages,
+            value_pages,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mlx_output = mlx_sdpa_paged_decode_attention(
+            mx.array(query),
+            mx.array(key_pages),
+            mx.array(value_pages),
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mx.eval(mlx_output)
+
+        np.testing.assert_allclose(
+            np.asarray(mlx_output), numpy_output, rtol=2e-4, atol=2e-4
+        )
+
+    def test_sdpa_decodes_uint16_bf16_bits_before_attention(self):
+        mx = pytest.importorskip("mlx.core")
+        rng = np.random.default_rng(29)
+        block_size = 16
+        query = rng.normal(size=(2, 4, 8)).astype(np.float32)
+        key_pages = rng.normal(size=(4, 2, block_size, 8)).astype(np.float32)
+        value_pages = rng.normal(size=key_pages.shape).astype(np.float32)
+
+        def bf16_bits(values):
+            return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+        query_bits = bf16_bits(query)
+        key_bits = bf16_bits(key_pages)
+        value_bits = bf16_bits(value_pages)
+        page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+        sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+
+        numpy_output = numpy_paged_decode_attention(
+            query_bits,
+            key_bits,
+            value_bits,
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mlx_output = mlx_sdpa_paged_decode_attention(
+            mx.array(query_bits),
+            mx.array(key_bits),
+            mx.array(value_bits),
+            page_table,
+            sequence_lengths,
+            block_size=block_size,
+            num_kv_heads=2,
+        )
+        mx.eval(mlx_output)
+
+        np.testing.assert_allclose(
+            np.asarray(mlx_output), numpy_output, rtol=2e-4, atol=2e-4
+        )
+
+
+class TestPythonContract:
+    def test_protocol_is_runtime_checkable_for_future_adapters(self):
+        class StubBackend:
+            pass
+
+        assert not isinstance(StubBackend(), ContextBackend)

--- a/tests/test_attention_backend.py
+++ b/tests/test_attention_backend.py
@@ -333,8 +333,17 @@ class TestNumpyOracle:
 
 
 class TestMlxOracle:
-    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+    @staticmethod
+    def _real_mlx():
         mx = pytest.importorskip("mlx.core")
+        if not hasattr(mx, "fast") or not hasattr(
+            mx.fast, "scaled_dot_product_attention"
+        ):
+            pytest.skip("real MLX SDPA is unavailable")
+        return mx
+
+    def test_sdpa_matches_numpy_for_gqa_and_noncontiguous_pages(self):
+        mx = self._real_mlx()
         rng = np.random.default_rng(23)
         block_size = 16
         query = rng.normal(size=(2, 4, 8)).astype(np.float32)
@@ -368,7 +377,7 @@ class TestMlxOracle:
         )
 
     def test_sdpa_decodes_uint16_bf16_bits_before_attention(self):
-        mx = pytest.importorskip("mlx.core")
+        mx = self._real_mlx()
         rng = np.random.default_rng(29)
         block_size = 16
         query = rng.normal(size=(2, 4, 8)).astype(np.float32)

--- a/tests/test_metal_context_native.py
+++ b/tests/test_metal_context_native.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -34,12 +35,74 @@ def test_capability_probe_never_requires_native_build():
         assert capabilities["reason"]
 
 
+def test_page_runtime_decode_has_no_hidden_pool_snapshot_or_dispatch_allocations():
+    """Keep the allocation-free steady-state contract mechanically visible."""
+
+    source = (
+        Path(__file__).parents[1]
+        / "native"
+        / "metal_context"
+        / "src"
+        / "page_runtime.mm"
+    ).read_text(encoding="utf-8")
+    dispatch_start = source.index("bool dispatch_kernel(")
+    dispatch_end = source.index("}  // namespace", dispatch_start)
+    dispatch_source = source[dispatch_start:dispatch_end]
+    assert "newBufferWithLength" not in dispatch_source
+    assert "copy_decode_snapshot" not in source
+    # Exactly one allocation site remains in the PageRuntime TU: the central
+    # wrapper used by constructor-time preallocation.
+    assert source.count("newBufferWithLength") == 1
+    assert "std::vector<uint16_t> snapshot" not in source
+    envelope_start = source.index("bool validate_attention_envelope(")
+    envelope_end = source.index("std::string metallib_path(", envelope_start)
+    envelope_source = source[envelope_start:envelope_end]
+    assert "for (uint32_t token" not in envelope_source
+    assert "max_value_accumulation" in envelope_source
+    decode_start = source.index("bool PageRuntime::paged_decode(")
+    decode_end = source.index("PageRuntimeMetrics PageRuntime::metrics(", decode_start)
+    decode_source = source[decode_start:decode_end]
+    assert "resolve_page" not in decode_source
+    assert "for (" not in decode_source
+    assert "decode_page_resolution_checks" in source
+    assert "finish_dispatch(*result)" in decode_source
+    assert "sync_table_range" in source
+    bridge = (
+        Path(__file__).parents[1]
+        / "native"
+        / "metal_context"
+        / "src"
+        / "page_runtime_python.mm"
+    ).read_text(encoding="utf-8")
+    assert "RuntimeCallLease" in bridge
+    assert "Py_BEGIN_ALLOW_THREADS" in bridge
+    assert "lifecycle_cv.wait" in bridge
+    assert bridge.count("try {") >= 3
+    assert bridge.count("current_exception") >= 3
+    legacy_bridge = (
+        Path(__file__).parents[1]
+        / "native"
+        / "metal_context"
+        / "src"
+        / "python_module.mm"
+    ).read_text(encoding="utf-8")
+    assert "LegacyDispatchLease" in legacy_bridge
+    assert legacy_bridge.count("Py_BEGIN_ALLOW_THREADS") >= 1
+    assert legacy_bridge.count("try {") >= 2
+    assert legacy_bridge.count("current_exception") >= 2
+
+
 def test_unavailable_native_dispatch_fails_precisely():
     from vllm_mlx import _metal_context
 
     capabilities = _metal_context.capabilities()
     if capabilities["available"]:
         pytest.skip("native extension is available; dispatch is covered on Apple CI")
+    if capabilities.get("compiled"):
+        # A compiled extension without a Metal device is still covered by the
+        # host-storage PageRuntime lifecycle tests below.  This test targets
+        # the pure-Python fail-closed dispatch surface only.
+        pytest.skip("compiled native dispatch is unavailable without a Metal device")
 
     with pytest.raises(RuntimeError, match="metal-context backend unavailable"):
         _metal_context.paged_decode(None)
@@ -256,6 +319,50 @@ def test_native_rejects_finite_bf16_dot_and_score_overflow():
             scale=4.0,
         )
 
+    # Value accumulation is a separate envelope from QK score safety.  Two
+    # finite maximum-BF16 values must not be allowed to overflow the running
+    # numerator even when the attention scores themselves are all zero.
+    query.fill(np.uint16(0))
+    key.fill(np.uint16(0))
+    value.fill(np.uint16(0x7F7F))
+    lengths[0] = 2
+    with pytest.raises(ValueError, match="value accumulation"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=1.0,
+        )
+
+
+def test_legacy_foundation_rejects_value_accumulation_before_dispatch():
+    """The raw foundation bridge shares the native V safety envelope."""
+
+    from vllm_mlx import _metal_context
+
+    if not _metal_context.capabilities().get("compiled"):
+        pytest.skip("compiled native foundation bridge is unavailable")
+    query = np.zeros((1, 1, 128), dtype=np.uint16)
+    key = np.zeros((1, 1, 16, 128), dtype=np.uint16)
+    value = np.full_like(key, np.uint16(0x7F7F))
+    table = np.asarray([[0]], dtype=np.int32)
+    lengths = np.asarray([2], dtype=np.int32)
+    with pytest.raises(ValueError, match="value accumulation"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=1.0,
+        )
+
 
 def test_native_shutdown_can_repeat_without_stale_runtime_state():
     """Repeated capability probe/shutdown cycles must recreate the pipeline."""
@@ -270,3 +377,485 @@ def test_native_shutdown_can_repeat_without_stale_runtime_state():
         capabilities = _metal_context.capabilities()
         assert capabilities["available"] is True
         assert capabilities["serving_ready"] is False
+
+
+def _compiled_page_runtime():
+    """Return the compiled ownership type without requiring a Metal device."""
+
+    from vllm_mlx import _metal_context
+
+    page_runtime = getattr(_metal_context, "PageRuntime", None)
+    if page_runtime is None:
+        pytest.skip("compiled native PageRuntime extension is unavailable")
+    return _metal_context, page_runtime
+
+
+def _native_zero_kv(tokens: int, kv_heads: int = 1) -> np.ndarray:
+    return np.zeros((tokens, kv_heads, 128), dtype=np.uint16)
+
+
+def test_compiled_page_runtime_host_lifecycle_runs_without_gpu():
+    """Exercise ownership/prefix teardown; no dispatch or GPU is required."""
+
+    native, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(
+        num_layers=2,
+        num_attention_heads=4,
+        num_kv_heads=2,
+        head_dim=128,
+        block_size=16,
+        max_pages=4,
+        max_blocks_per_request=2,
+        max_requests=4,
+    )
+    assert runtime.geometry()["num_key_value_heads"] == 2
+    request = runtime.allocate_request("host-lifecycle", max_tokens=32)
+    assert len(runtime.allocate_pages(request, 2)) == 2
+    keys = _native_zero_kv(17, 2)
+    runtime.append_kv(request, 0, keys, keys)
+    runtime.append_kv(request, 1, keys, keys)
+    prefix = runtime.create_prefix(request)
+    branch = runtime.allocate_request("host-branch", max_tokens=32)
+    runtime.attach_prefix(branch, prefix)
+
+    metrics = runtime.metrics()
+    assert metrics["append_tokens"] == 34
+    assert metrics["max_pages"] == 4
+    assert metrics["kv_dtype"] == "bfloat16"
+    assert metrics["shared_pages"] == 2
+    assert metrics["dispatches"] == 0
+    assert metrics["dispatch_failures"] == 0
+
+    # Release is idempotent for the same generation, and post-shutdown
+    # diagnostics retain truthful capacity/counter values.
+    runtime.release(branch)
+    runtime.release(branch)
+    runtime.release(request)
+    runtime.release_prefix(prefix)
+    runtime.shutdown()
+    runtime.shutdown()
+    after = runtime.metrics()
+    assert after["shutdown"] is True
+    assert after["resident_pages"] == 0
+    assert after["free_pages"] == 4
+    assert after["requests"] == 0
+    assert after["prefixes"] == 0
+    assert after["kv_bytes"] == 0
+    assert after["append_tokens"] == 34
+    native.shutdown()
+
+
+def test_compiled_page_runtime_result_allocation_rolls_back_request(
+    monkeypatch,
+):
+    """A failed PyLong result must not publish a request slot or generation."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 2, 2, 2)
+    before = runtime.metrics()
+    monkeypatch.setenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT", "allocate_request")
+    with pytest.raises(MemoryError):
+        runtime.allocate_request("result-fault-request", max_tokens=16)
+    monkeypatch.delenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT")
+    assert runtime.metrics() == before
+
+    # The rolled-back slot and generation are immediately reusable.
+    request = runtime.allocate_request("result-fault-request", max_tokens=16)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+@pytest.mark.parametrize("fault_value", ["allocate_pages", "tuple_item"])
+def test_compiled_page_runtime_result_allocation_rolls_back_pages(
+    monkeypatch,
+    fault_value,
+):
+    """Tuple construction, including a partial-item failure, is transactional."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 4, 2, 1)
+    request = runtime.allocate_request("result-fault-pages", max_tokens=32)
+    before = (
+        runtime.metrics(),
+        runtime.request_pages(request),
+        runtime.page_table(request),
+    )
+    monkeypatch.setenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT", fault_value)
+    with pytest.raises(MemoryError):
+        runtime.allocate_pages(request, 2)
+    monkeypatch.delenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT")
+    assert (
+        runtime.metrics(),
+        runtime.request_pages(request),
+        runtime.page_table(request),
+    ) == before
+
+    pages = runtime.allocate_pages(request, 2)
+    assert len(pages) == 2
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_result_allocation_rolls_back_prefixes(
+    monkeypatch,
+):
+    """Prefix creation/forking restore refs, sequence length, and counters."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(2, 1, 1, 128, 16, 4, 2, 3)
+    request = runtime.allocate_request("result-fault-prefix", max_tokens=32)
+    runtime.allocate_pages(request, 2)
+    one = _native_zero_kv(1)
+    runtime.append_kv(request, 0, one, one)
+    runtime.append_kv(request, 1, one, one)
+
+    before_create = (
+        runtime.metrics(),
+        runtime.page_table(request, layer=0),
+        runtime.sequence_length(request),
+    )
+    monkeypatch.setenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT", "create_prefix")
+    with pytest.raises(MemoryError):
+        runtime.create_prefix(request)
+    monkeypatch.delenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT")
+    assert (
+        runtime.metrics(),
+        runtime.page_table(request, layer=0),
+        runtime.sequence_length(request),
+    ) == before_create
+
+    prefix = runtime.create_prefix(request)
+    before_fork = runtime.metrics()
+    monkeypatch.setenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT", "fork_prefix")
+    with pytest.raises(MemoryError):
+        runtime.fork_prefix(prefix)
+    monkeypatch.delenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT")
+    assert runtime.metrics() == before_fork
+    forked = runtime.fork_prefix(prefix)
+    runtime.release_prefix(forked)
+    runtime.release_prefix(prefix)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_result_allocation_rolls_back_eviction(
+    monkeypatch,
+):
+    """A failed eviction PyLong restores page metadata and LRU counters."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 2, 1, 1)
+    request = runtime.allocate_request("result-fault-evict", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    runtime.release(request)
+    before = runtime.metrics()
+    monkeypatch.setenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT", "evict")
+    with pytest.raises(MemoryError):
+        runtime.evict(1)
+    monkeypatch.delenv("VLLM_MLX_METAL_CONTEXT_TEST_FAIL_RESULT")
+    assert runtime.metrics() == before
+    assert runtime.evict(1) == 1
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_snapshot_restore_fail_closed_with_native_metrics():
+    """Persistence is deferred, but native failure counters remain truthful."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 2, 1, 1)
+    request = runtime.allocate_request("snapshot-metrics", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    one = _native_zero_kv(1)
+    runtime.append_kv(request, 0, one, one)
+    prefix = runtime.create_prefix(request)
+
+    with pytest.raises(NotImplementedError, match="snapshots are deferred"):
+        runtime.snapshot(prefix=prefix, destination="/tmp/not-written")
+    with pytest.raises(NotImplementedError, match="restore is deferred"):
+        runtime.restore(source="/tmp/not-read")
+    metrics = runtime.metrics()
+    assert metrics["snapshot_failures"] == 1
+    assert metrics["restore_failures"] == 1
+    runtime.release_prefix(prefix)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_rejects_int32_capacity_overflow():
+    """Page IDs and sequence lengths are int32 at the native/Metal ABI."""
+
+    _, page_runtime = _compiled_page_runtime()
+    with pytest.raises(ValueError, match="INT32_MAX"):
+        page_runtime(1, 1, 1, 128, 16, 2**31, 1, 1)
+    with pytest.raises(ValueError, match="int32"):
+        page_runtime(1, 1, 1, 128, 16, 1, 2**27, 1)
+    with pytest.raises(ValueError, match="256 MiB"):
+        page_runtime(1, 1, 1, 128, 16, 1, 1024, 70_000)
+
+    runtime = page_runtime(1, 1, 1, 128, 16, 1, 1, 1)
+    with pytest.raises(ValueError, match="INT32_MAX"):
+        runtime.allocate_request("too-long", 2**31)
+    # A failed replacement constructor must not discard the previously valid
+    # runtime owned by this Python object.
+    with pytest.raises(ValueError, match="INT32_MAX"):
+        runtime.__init__(1, 1, 1, 128, 16, 2**31, 1, 1)
+    handle = runtime.allocate_request("still-live", max_tokens=16)
+    runtime.release(handle)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_page_allocation_respects_request_max_tokens():
+    """Native page reservation must match the NumPy request capacity rule."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 4, 4, 1)
+    request = runtime.allocate_request("one-page", max_tokens=17)
+    runtime.allocate_pages(request, 1)
+    with pytest.raises(ValueError, match=r"max_tokens capacity \(2 pages\)"):
+        runtime.allocate_pages(request, 2)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_prefix_and_append_oom_are_transactional():
+    """A multi-block COW append must not partially mutate ownership state."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(2, 1, 1, 128, 16, 2, 2, 3)
+    base = runtime.allocate_request("oom-base", max_tokens=32)
+    runtime.allocate_pages(base, 1)
+    one = _native_zero_kv(1)
+    runtime.append_kv(base, 0, one, one)
+    runtime.append_kv(base, 1, one, one)
+    prefix = runtime.create_prefix(base)
+    branch = runtime.allocate_request("oom-branch", max_tokens=32)
+    runtime.attach_prefix(branch, prefix)
+    before_table = runtime.page_table(branch)
+    before_metrics = runtime.metrics()
+
+    many = _native_zero_kv(17)
+    with pytest.raises(MemoryError, match="capacity exhausted"):
+        runtime.append_kv(branch, 0, many, many)
+
+    assert runtime.page_table(branch) == before_table
+    assert runtime.metrics() == before_metrics
+    assert runtime.metrics()["dispatch_failures"] == 0
+    runtime.release(branch)
+    runtime.release(base)
+    runtime.release_prefix(prefix)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_prefix_fork_growth_is_safe_without_gpu():
+    """Forking live prefixes must survive repeated PrefixMeta reallocations."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 2, 1, 1)
+    request = runtime.allocate_request("fork-growth", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    one = _native_zero_kv(1)
+    runtime.append_kv(request, 0, one, one)
+    prefix = runtime.create_prefix(request)
+
+    forks = [runtime.fork_prefix(prefix) for _ in range(512)]
+    assert runtime.metrics()["prefixes"] == len(forks) + 1
+    for forked in forks:
+        runtime.release_prefix(forked)
+    runtime.release_prefix(prefix)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_value_accumulation_guard_rejects_extreme_v():
+    """Finite BF16 V must not overflow a multi-token shader accumulator."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 2, 2, 1)
+    request = runtime.allocate_request("value-guard", max_tokens=32)
+    runtime.allocate_pages(request, 2)
+    keys = _native_zero_kv(2)
+    values = np.full((2, 1, 128), np.uint16(0x7F7F), dtype=np.uint16)
+    runtime.append_kv(request, 0, keys, values)
+    query = np.zeros((1, 128), dtype=np.uint16)
+    with pytest.raises(ValueError, match="value accumulation"):
+        runtime.paged_decode(request, 0, query)
+    assert runtime.metrics()["dispatch_failures"] == 1
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_append_rejects_nonfinite_kv_transactionally():
+    """Nonfinite ingress must not change lengths, pages, or range metadata."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 1, 1, 1)
+    request = runtime.allocate_request("append-finite", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    one = _native_zero_kv(1)
+    runtime.append_kv(request, 0, one, one)
+    before = runtime.metrics()
+    bad = np.full((1, 1, 128), np.uint16(0x7F80), dtype=np.uint16)
+    with pytest.raises(ValueError, match="finite BF16"):
+        runtime.append_kv(request, 0, bad, one)
+    assert runtime.sequence_length(request) == 1
+    assert runtime.metrics() == before
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_attention_validation_bytes_ignore_context_length():
+    """Decode validation accounts for Q bytes, not every historical KV token."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 3, 2, 2)
+    short = runtime.allocate_request("validation-short", max_tokens=16)
+    long = runtime.allocate_request("validation-long", max_tokens=32)
+    runtime.allocate_pages(short, 1)
+    runtime.allocate_pages(long, 2)
+    one = _native_zero_kv(1)
+    many = _native_zero_kv(32)
+    runtime.append_kv(short, 0, one, one)
+    runtime.append_kv(long, 0, many, many)
+    query = np.zeros((1, 128), dtype=np.uint16)
+    before = runtime.metrics()["attention_validation_bytes"]
+    before_page_checks = runtime.metrics()["decode_page_resolution_checks"]
+    for request in (short, long):
+        try:
+            runtime.paged_decode(request, 0, query)
+        except RuntimeError:
+            # A host-only build validates metadata, then fails closed before
+            # pipeline dispatch because no Metal device is present.
+            pass
+    after = runtime.metrics()["attention_validation_bytes"]
+    assert after - before == 2 * query.nbytes
+    assert runtime.metrics()["decode_page_resolution_checks"] - before_page_checks == 0
+    runtime.release(short)
+    runtime.release(long)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_numerical_guard_counts_failed_dispatch_without_gpu():
+    """Finite BF16 extremes fail before Metal pipeline lookup/dispatch."""
+
+    _, page_runtime = _compiled_page_runtime()
+    runtime = page_runtime(1, 1, 1, 128, 16, 1, 1, 1)
+    request = runtime.allocate_request("numerical-guard", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    extreme = np.full((1, 1, 128), np.uint16(0x7F7F), dtype=np.uint16)
+    runtime.append_kv(request, 0, extreme, extreme)
+    query = np.full((1, 128), np.uint16(0x7F7F), dtype=np.uint16)
+    with pytest.raises(ValueError, match="dot product"):
+        runtime.paged_decode(request, 0, query, scale=1.0)
+
+    moderate = np.full((1, 1, 128), np.uint16(0x5D31), dtype=np.uint16)
+    runtime.release(request)
+    request = runtime.allocate_request("score-guard", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    runtime.append_kv(request, 0, moderate, moderate)
+    query.fill(np.uint16(0x5D31))
+    with pytest.raises(ValueError, match="attention score"):
+        runtime.paged_decode(request, 0, query, scale=4.0)
+    metrics = runtime.metrics()
+    assert metrics["dispatches"] == 0
+    assert metrics["dispatch_failures"] == 2
+    assert metrics["native_dispatches"] == 0
+    assert metrics["native_failures"] == metrics["dispatch_failures"]
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_reuses_decode_buffers_without_kv_pool_copies():
+    """Warm decode must use preallocated scratch and live metadata only."""
+
+    native, page_runtime = _compiled_page_runtime()
+    if not native.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    runtime = page_runtime(1, 1, 1, 128, 16, 4, 2, 2)
+    request = runtime.allocate_request("steady-state", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    zeros = np.zeros((1, 1, 128), dtype=np.uint16)
+    runtime.append_kv(request, 0, zeros, zeros)
+    query = np.zeros((1, 128), dtype=np.uint16)
+
+    runtime.paged_decode(request, 0, query)
+    warm = runtime.metrics()
+    assert warm["buffer_allocations"] > 0
+    assert warm["decode_buffer_allocations"] == 0
+    assert warm["kv_pool_copies"] == 0
+    assert warm["kv_copy_bytes"] > 0
+
+    for _ in range(3):
+        runtime.paged_decode(request, 0, query)
+    after = runtime.metrics()
+    assert after["buffer_allocations"] == warm["buffer_allocations"]
+    assert after["decode_buffer_allocations"] == 0
+    assert after["kv_pool_copies"] == 0
+    assert after["kv_copy_bytes"] == warm["kv_copy_bytes"]
+    assert after["metadata_copies"] == warm["metadata_copies"]
+    assert after["query_copies"] - warm["query_copies"] == 3
+    assert after["output_copies"] - warm["output_copies"] == 3
+    assert after["dispatches"] - warm["dispatches"] == 3
+    assert after["native_dispatches"] == after["dispatches"]
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_multi_slot_layer_lengths_use_distinct_offsets():
+    """GPU decode must address sequence metadata as [slot, layer]."""
+
+    native, page_runtime = _compiled_page_runtime()
+    if not native.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    runtime = page_runtime(2, 1, 1, 128, 16, 4, 1, 2)
+    first = runtime.allocate_request("offset-first", max_tokens=16)
+    second = runtime.allocate_request("offset-second", max_tokens=16)
+    runtime.allocate_pages(first, 1)
+    runtime.allocate_pages(second, 1)
+
+    def bf16_bits(value: float) -> np.uint16:
+        word = np.asarray([value], dtype=np.float32).view(np.uint32)[0]
+        return np.uint16(word >> 16)
+
+    def kv(token_count: int) -> tuple[np.ndarray, np.ndarray]:
+        keys = np.zeros((token_count, 1, 128), dtype=np.uint16)
+        values = np.empty_like(keys)
+        for token in range(token_count):
+            values[token, 0, :] = bf16_bits(float(token + 1))
+        return keys, values
+
+    expected_lengths = (
+        (first, 0, 1),
+        (first, 1, 2),
+        (second, 0, 3),
+        (second, 1, 4),
+    )
+    for request, layer, token_count in expected_lengths:
+        keys, values = kv(token_count)
+        runtime.append_kv(request, layer, keys, values)
+
+    query = np.zeros((1, 128), dtype=np.uint16)
+    for request, layer, token_count in expected_lengths:
+        output = np.frombuffer(
+            runtime.paged_decode(request, layer, query), dtype=np.float32
+        ).reshape(1, 128)
+        expected = np.mean(np.arange(1, token_count + 1, dtype=np.float32))
+        np.testing.assert_allclose(output, expected, rtol=2e-2, atol=2e-2)
+
+    runtime.release(first)
+    runtime.release(second)
+    runtime.shutdown()
+
+
+def test_compiled_page_runtime_shared_teardown_preserves_other_instances():
+    """Module shutdown must not reset resources held by another runtime."""
+
+    native, page_runtime = _compiled_page_runtime()
+    first = page_runtime(1, 1, 1, 128, 16, 1, 1, 1)
+    second = page_runtime(1, 1, 1, 128, 16, 1, 1, 1)
+    first.shutdown()
+    native.shutdown()
+    request = second.allocate_request("survives-module-shutdown", max_tokens=16)
+    second.allocate_pages(request, 1)
+    second.release(request)
+    second.shutdown()

--- a/tests/test_metal_context_native.py
+++ b/tests/test_metal_context_native.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Portable checks for the optional native Metal Context Engine surface."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from vllm_mlx.attention_backend import (
+    mlx_sdpa_paged_decode_attention,
+    numpy_paged_decode_attention,
+)
+
+
+def test_capability_probe_never_requires_native_build():
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+
+    assert capabilities["backend"] == "metal-context"
+    assert capabilities["abi_version"] == 1
+    assert capabilities["block_sizes"] == (16, 32)
+    assert capabilities["head_dims"] == (128,)
+    assert capabilities["gqa"] is True
+    assert capabilities["partial_blocks"] is True
+    assert capabilities["online_softmax"] is True
+    assert capabilities["kv_dtype"] == "bfloat16"
+    assert isinstance(capabilities["apple_silicon"], bool)
+    assert capabilities["serving_ready"] is False
+    assert isinstance(capabilities["available"], bool)
+    if not capabilities["available"]:
+        assert capabilities["reason"]
+
+
+def test_unavailable_native_dispatch_fails_precisely():
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if capabilities["available"]:
+        pytest.skip("native extension is available; dispatch is covered on Apple CI")
+
+    with pytest.raises(RuntimeError, match="metal-context backend unavailable"):
+        _metal_context.paged_decode(None)
+
+
+def test_native_paged_decode_matches_numpy_oracle():
+    """Exercise the compiled Metal dispatch when the strict build is present."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    rng = np.random.default_rng(31)
+    block_size = 16
+    head_dim = 128
+    query_heads = 4
+    kv_heads = 2
+    query_values = rng.normal(0.0, 0.25, size=(2, query_heads, head_dim)).astype(
+        np.float32
+    )
+    key_values = rng.normal(0.0, 0.25, size=(4, kv_heads, block_size, head_dim)).astype(
+        np.float32
+    )
+    value_values = rng.normal(0.0, 0.25, size=key_values.shape).astype(np.float32)
+
+    def to_bf16_bits(values):
+        return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+    def from_bf16_bits(values):
+        return (values.astype(np.uint32) << 16).view(np.float32)
+
+    query = to_bf16_bits(query_values)
+    key_pages = to_bf16_bits(key_values)
+    value_pages = to_bf16_bits(value_values)
+    page_table = np.asarray([[2, 0], [1, 3]], dtype=np.int32)
+    sequence_lengths = np.asarray([17, 30], dtype=np.int32)
+    scale = 1.0 / math.sqrt(head_dim)
+
+    native_bytes = _metal_context.paged_decode(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        num_kv_heads=kv_heads,
+        block_size=block_size,
+        scale=scale,
+    )
+    native_output = np.frombuffer(native_bytes, dtype=np.float32).reshape(
+        query_values.shape
+    )
+
+    oracle_output = numpy_paged_decode_attention(
+        from_bf16_bits(query),
+        from_bf16_bits(key_pages),
+        from_bf16_bits(value_pages),
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=kv_heads,
+        scale=scale,
+    )
+
+    np.testing.assert_allclose(native_output, oracle_output, rtol=2e-2, atol=2e-2)
+
+
+def test_native_paged_decode_matches_mlx_oracle():
+    """Compare the real Metal dispatch with MLX SDPA when both are present."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+    pytest.importorskip("mlx.core")
+
+    rng = np.random.default_rng(37)
+    block_size = 32
+    head_dim = 128
+    query_heads = 4
+    kv_heads = 2
+    query = rng.normal(0.0, 0.2, size=(2, query_heads, head_dim)).astype(np.float32)
+    key_pages = rng.normal(0.0, 0.2, size=(4, kv_heads, block_size, head_dim)).astype(
+        np.float32
+    )
+    value_pages = rng.normal(0.0, 0.2, size=key_pages.shape).astype(np.float32)
+    page_table = np.asarray([[3, 0], [2, 1]], dtype=np.int32)
+    sequence_lengths = np.asarray([32, 33], dtype=np.int32)
+    scale = 1.0 / math.sqrt(head_dim)
+
+    def to_bf16_bits(values):
+        return (values.view(np.uint32) >> 16).astype(np.uint16)
+
+    query_bits = to_bf16_bits(query)
+    key_bits = to_bf16_bits(key_pages)
+    value_bits = to_bf16_bits(value_pages)
+    native_output = np.frombuffer(
+        _metal_context.paged_decode(
+            query_bits,
+            key_bits,
+            value_bits,
+            page_table,
+            sequence_lengths,
+            num_kv_heads=kv_heads,
+            block_size=block_size,
+            scale=scale,
+        ),
+        dtype=np.float32,
+    ).reshape(query.shape)
+    mlx_output = mlx_sdpa_paged_decode_attention(
+        query_bits,
+        key_bits,
+        value_bits,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=kv_heads,
+        scale=scale,
+    )
+
+    np.testing.assert_allclose(
+        native_output, np.asarray(mlx_output), rtol=3e-2, atol=3e-2
+    )
+
+
+def test_native_rejects_non_native_formats_and_nonfinite_bf16():
+    """The host ABI must reject ambiguous byte order and unsafe BF16 values."""
+
+    from vllm_mlx import _metal_context
+
+    capabilities = _metal_context.capabilities()
+    if not capabilities["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    rng = np.random.default_rng(41)
+    query = (
+        rng.normal(size=(1, 2, 128)).astype(np.float32).view(np.uint32) >> 16
+    ).astype(np.uint16)
+    key = np.zeros((1, 1, 16, 128), dtype=np.uint16)
+    value = np.zeros_like(key)
+    table = np.asarray([[0]], dtype=np.int32)
+    lengths = np.asarray([1], dtype=np.int32)
+    kwargs = dict(
+        num_kv_heads=1,
+        block_size=16,
+        scale=1.0 / math.sqrt(128),
+    )
+
+    with pytest.raises(ValueError, match="expected query"):
+        _metal_context.paged_decode(
+            query.reshape(2, 128), key, value, table, lengths, **kwargs
+        )
+    with pytest.raises(ValueError, match="uint16"):
+        _metal_context.paged_decode(
+            query.astype(">u2"), key, value, table, lengths, **kwargs
+        )
+    with pytest.raises(ValueError, match="uint16"):
+        _metal_context.paged_decode(
+            query.astype(np.float16), key, value, table, lengths, **kwargs
+        )
+
+    nonfinite_query = query.copy()
+    nonfinite_query[0, 0, 0] = np.uint16(0x7F80)
+    with pytest.raises(ValueError, match="finite BF16"):
+        _metal_context.paged_decode(
+            nonfinite_query, key, value, table, lengths, **kwargs
+        )
+
+
+def test_native_rejects_finite_bf16_dot_and_score_overflow():
+    """Finite BF16 extremes must not reach an Inf/Inf softmax reduction."""
+
+    from vllm_mlx import _metal_context
+
+    if not _metal_context.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    key = np.zeros((1, 1, 16, 128), dtype=np.uint16)
+    value = np.zeros_like(key)
+    table = np.asarray([[0]], dtype=np.int32)
+    lengths = np.asarray([1], dtype=np.int32)
+
+    # 0x7f7f is the largest finite BF16 value.  The conservative host bound
+    # rejects max_q * max_k * head_dim before any Metal allocation/dispatch.
+    query = np.full((1, 1, 128), np.uint16(0x7F7F), dtype=np.uint16)
+    key.fill(np.uint16(0x7F7F))
+    with pytest.raises(ValueError, match="dot product"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=1.0,
+        )
+
+    # 0x5d31 is approximately 8e17.  Its 128-term dot bound is finite, but
+    # multiplying that bound by scale=4 exceeds the guarded score envelope.
+    query.fill(np.uint16(0x5D31))
+    key.fill(np.uint16(0x5D31))
+    with pytest.raises(ValueError, match="attention score"):
+        _metal_context.paged_decode(
+            query,
+            key,
+            value,
+            table,
+            lengths,
+            num_kv_heads=1,
+            block_size=16,
+            scale=4.0,
+        )
+
+
+def test_native_shutdown_can_repeat_without_stale_runtime_state():
+    """Repeated capability probe/shutdown cycles must recreate the pipeline."""
+
+    from vllm_mlx import _metal_context
+
+    if not _metal_context.capabilities()["available"]:
+        pytest.skip("strict native Metal build is unavailable")
+
+    for _ in range(3):
+        _metal_context.shutdown()
+        capabilities = _metal_context.capabilities()
+        assert capabilities["available"] is True
+        assert capabilities["serving_ready"] is False

--- a/tests/test_metal_context_page_runtime.py
+++ b/tests/test_metal_context_page_runtime.py
@@ -1,0 +1,1262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lifecycle and ownership tests for the phase-two page runtime."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import types
+
+import numpy as np
+import pytest
+
+from vllm_mlx.attention_backend import (
+    AttentionGeometry,
+    ContextBackend,
+    PrefixHandle,
+    RequestHandle,
+    numpy_paged_decode_attention,
+)
+from vllm_mlx.metal_context_runtime import (
+    MetalContextCapabilityError,
+    MetalContextPageRuntime,
+    MetalContextRuntimeError,
+)
+
+
+@pytest.fixture
+def geometry() -> AttentionGeometry:
+    return AttentionGeometry(
+        num_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        block_size=16,
+    )
+
+
+def _values(
+    tokens: int,
+    *,
+    kv_heads: int = 2,
+    head_dim: int = 128,
+    seed: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    keys = rng.normal(0.0, 0.2, size=(tokens, kv_heads, head_dim)).astype(np.float32)
+    values = rng.normal(0.0, 0.2, size=keys.shape).astype(np.float32)
+    return keys, values
+
+
+def _as_bf16(values: np.ndarray) -> np.ndarray:
+    return (
+        (values.view(np.uint32) >> np.uint32(16)).astype(np.uint16).astype(np.uint32)
+        << 16
+    ).view(np.float32)
+
+
+def _runtime(
+    geometry: AttentionGeometry, *, max_pages: int = 8
+) -> MetalContextPageRuntime:
+    return MetalContextPageRuntime(geometry, max_pages=max_pages, execution="numpy")
+
+
+def test_runtime_implements_protocol_and_preallocates_no_resident_pages(geometry):
+    runtime = _runtime(geometry, max_pages=4)
+
+    assert isinstance(runtime, ContextBackend)
+    metrics = runtime.metrics()
+    assert metrics["resident_pages"] == 0
+    assert metrics["free_pages"] == 4
+    assert metrics["execution"] == "numpy"
+    runtime.shutdown()
+
+
+def test_allocation_append_decode_and_model_oracle_match(geometry):
+    runtime = _runtime(geometry, max_pages=4)
+    request = runtime.allocate_request("request-a", max_tokens=32)
+    pages = runtime.allocate_pages(request, 2)
+    keys, values = _values(17, seed=7)
+
+    runtime.append_kv(request, 0, keys, values)
+    assert len(pages) == 2
+    table = runtime.page_table(request)
+    np.testing.assert_array_equal(table, np.asarray([[0, 1]], dtype=np.int32))
+
+    query = np.random.default_rng(8).normal(0.0, 0.2, size=(4, 128)).astype(np.float32)
+    output = runtime.paged_decode_attention(request, 0, query)
+
+    # Reconstruct the same page layout from the runtime's public diagnostic
+    # metadata and the known source values.  The runtime's NumPy execution
+    # path is required to call the shared foundation oracle, not a second
+    # attention implementation.
+    key_pages = np.zeros((2, 2, 16, 128), dtype=np.float32)
+    value_pages = np.zeros_like(key_pages)
+    key_pages[0, :, :16] = np.transpose(_as_bf16(keys[:16]), (1, 0, 2))
+    key_pages[1, :, :1] = np.transpose(_as_bf16(keys[16:]), (1, 0, 2))
+    value_pages[0, :, :16] = np.transpose(_as_bf16(values[:16]), (1, 0, 2))
+    value_pages[1, :, :1] = np.transpose(_as_bf16(values[16:]), (1, 0, 2))
+    expected = numpy_paged_decode_attention(
+        query[None],
+        key_pages,
+        value_pages,
+        table,
+        np.asarray([17], dtype=np.int32),
+        block_size=16,
+        num_kv_heads=2,
+    )[0]
+    np.testing.assert_allclose(output, expected, rtol=4e-4, atol=4e-4)
+    metrics = runtime.metrics()
+    assert metrics["append_tokens"] == 17
+    assert metrics["dispatches"] == 1
+    assert metrics["oracle_dispatches"] == 1
+    assert metrics["native_dispatches"] == 0
+    assert metrics["dispatch_failures"] == metrics["native_failures"] == 0
+    assert metrics["oracle_failures"] == 0
+
+
+def test_query_rank_and_zero_length_decode_are_deterministic(geometry):
+    runtime = _runtime(geometry, max_pages=1)
+    request = runtime.allocate_request("empty", max_tokens=16)
+    query = np.ones((4, 128), dtype=np.float32)
+
+    squeezed = runtime.paged_decode_attention(request, 0, query)
+    batched = runtime.paged_decode_attention(request, 0, query[None])
+    np.testing.assert_array_equal(squeezed, np.zeros((4, 128), dtype=np.float32))
+    np.testing.assert_array_equal(batched, np.zeros((1, 4, 128), dtype=np.float32))
+    runtime.shutdown()
+
+
+def test_prefix_attach_fork_and_copy_on_write_preserve_immutable_pages(geometry):
+    runtime = _runtime(geometry, max_pages=6)
+    base = runtime.allocate_request("base", max_tokens=32)
+    runtime.allocate_pages(base, 2)
+    keys, values = _values(17, seed=12)
+    runtime.append_kv(base, 0, keys, values)
+    runtime.append_kv(base, 1, keys, values)
+    prefix = runtime.create_prefix(base, token_count=17)
+    forked = runtime.fork_prefix(prefix)
+
+    first = runtime.allocate_request("first", max_tokens=32)
+    second = runtime.allocate_request("second", max_tokens=32)
+    runtime.attach_prefix(first, prefix)
+    runtime.attach_prefix(second, forked)
+    before = runtime.page_table(first).copy()
+    assert runtime.page_refcounts()[:2] == (5, 5)
+
+    new_keys, new_values = _values(1, seed=13)
+    runtime.append_kv(first, 0, new_keys, new_values)
+
+    after = runtime.page_table(first)
+    np.testing.assert_array_equal(after[0, 0], before[0, 0])
+    assert after[0, 1] != before[0, 1]
+    np.testing.assert_array_equal(runtime.page_table(second), before)
+    np.testing.assert_array_equal(runtime.page_table(base), before)
+    assert runtime.metrics()["cow_events"] == 1
+    shared_pages = runtime.metrics()["shared_pages"]
+    assert isinstance(shared_pages, int) and shared_pages >= 1
+
+    runtime.release(first)
+    runtime.release(second)
+    runtime.release(base)
+    runtime.release_prefix(prefix)
+    runtime.release_prefix(forked)
+    assert runtime.evict() == 3
+    assert runtime.metrics()["free_pages"] == 6
+    runtime.shutdown()
+
+
+def test_prefix_requires_equal_nonzero_population_for_every_layer(geometry):
+    runtime = _runtime(geometry, max_pages=3)
+    request = runtime.allocate_request("incomplete", max_tokens=32)
+    runtime.allocate_pages(request, 2)
+    keys, values = _values(1, seed=14)
+    runtime.append_kv(request, 0, keys, values)
+
+    with pytest.raises(ValueError, match="equal, non-zero"):
+        runtime.create_prefix(request)
+
+    keys2, values2 = _values(2, seed=15)
+    runtime.append_kv(request, 1, keys2, values2)
+    with pytest.raises(ValueError, match="equal, non-zero"):
+        runtime.create_prefix(request)
+
+    runtime.append_kv(request, 0, keys2[1:], values2[1:])
+    prefix = runtime.create_prefix(request)
+    runtime.release_prefix(prefix)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+@pytest.mark.parametrize("execution", ["numpy", "native"])
+def test_prefix_token_count_must_be_the_complete_length_in_both_modes(
+    geometry, execution
+):
+    native_module = _native_module() if execution == "native" else None
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=2,
+        execution=execution,
+        native_module=native_module,
+    )
+    request = runtime.allocate_request(f"complete-prefix-{execution}", max_tokens=32)
+    runtime.allocate_pages(request, 2)
+    keys, values = _values(17, seed=31)
+    runtime.append_kv(request, 0, keys, values)
+    runtime.append_kv(request, 1, keys, values)
+
+    with pytest.raises(ValueError, match="fully populated"):
+        runtime.create_prefix(request, token_count=1)
+    prefix = runtime.create_prefix(request, token_count=17)
+    runtime.release_prefix(prefix)
+    runtime.release(request)
+    runtime.shutdown()
+
+
+@pytest.mark.parametrize("execution", ["numpy", "native"])
+def test_page_allocation_honors_request_max_tokens_in_both_modes(geometry, execution):
+    native_module = _native_module() if execution == "native" else None
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=4,
+        execution=execution,
+        native_module=native_module,
+    )
+    request = runtime.allocate_request(f"page-capacity-{execution}", max_tokens=1)
+
+    with pytest.raises(ValueError, match="request max_tokens capacity"):
+        runtime.allocate_pages(request, 2)
+    assert len(runtime.allocate_pages(request, 1)) == 1
+    with pytest.raises(ValueError, match="request max_tokens capacity"):
+        runtime.allocate_pages(request, 1)
+
+    runtime.release(request)
+    runtime.shutdown()
+
+
+def test_shared_tail_cow_oom_is_atomic_and_does_not_mutate_prefix(geometry):
+    runtime = _runtime(geometry, max_pages=1)
+    base = runtime.allocate_request("base", max_tokens=16)
+    runtime.allocate_pages(base, 1)
+    keys, values = _values(1, seed=17)
+    runtime.append_kv(base, 0, keys, values)
+    runtime.append_kv(base, 1, keys, values)
+    prefix = runtime.create_prefix(base, token_count=1)
+    branch = runtime.allocate_request("branch", max_tokens=16)
+    runtime.attach_prefix(branch, prefix)
+    before = runtime.page_table(branch)
+
+    with pytest.raises(MemoryError, match="out of pages"):
+        runtime.append_kv(branch, 0, keys, values)
+
+    np.testing.assert_array_equal(runtime.page_table(branch), before)
+    np.testing.assert_array_equal(runtime.page_table(base), before)
+    assert runtime.metrics()["cow_events"] == 0
+    assert runtime.metrics()["oom_events"] == 0
+    runtime.shutdown()
+
+
+def test_append_missing_page_plus_cow_oom_is_fully_transactional(geometry):
+    """A failed 17-token append cannot leak a reserved tail page."""
+
+    runtime = _runtime(geometry, max_pages=2)
+    base = runtime.allocate_request("transaction-base", max_tokens=32)
+    runtime.allocate_pages(base, 1)
+    one_key, one_value = _values(1, seed=18)
+    runtime.append_kv(base, 0, one_key, one_value)
+    runtime.append_kv(base, 1, one_key, one_value)
+    prefix = runtime.create_prefix(base)
+    branch = runtime.allocate_request("transaction-branch", max_tokens=32)
+    runtime.attach_prefix(branch, prefix)
+
+    before_table = runtime.page_table(branch)
+    before_refs = runtime.page_refcounts()
+    before_metrics = dict(runtime.metrics())
+    many_keys, many_values = _values(17, seed=19)
+
+    with pytest.raises(MemoryError, match="out of pages"):
+        runtime.append_kv(branch, 0, many_keys, many_values)
+
+    np.testing.assert_array_equal(runtime.page_table(branch), before_table)
+    assert runtime.page_refcounts() == before_refs
+    assert dict(runtime.metrics()) == before_metrics
+
+    runtime.release(branch)
+    runtime.release(base)
+    runtime.release_prefix(prefix)
+    runtime.shutdown()
+
+
+def test_eviction_skips_referenced_pages_and_recovers_capacity(geometry):
+    runtime = _runtime(geometry, max_pages=2)
+    first = runtime.allocate_request("first", max_tokens=16)
+    second = runtime.allocate_request("second", max_tokens=16)
+    runtime.allocate_pages(first, 1)
+    runtime.allocate_pages(second, 1)
+    assert runtime.evict() == 0
+
+    runtime.release(first)
+    assert runtime.evict(target_pages=1) == 1
+    assert runtime.metrics()["free_pages"] == 1
+
+    third = runtime.allocate_request("third", max_tokens=32)
+    runtime.allocate_pages(third, 1)
+    with pytest.raises(MemoryError, match="out of pages"):
+        runtime.allocate_pages(third, 1)
+    runtime.release(second)
+    runtime.release(third)
+    assert runtime.evict() == 2
+    runtime.shutdown()
+
+
+def test_release_and_shutdown_are_idempotent_and_teardown_is_deterministic(geometry):
+    runtime = _runtime(geometry, max_pages=1)
+    request = runtime.allocate_request("cancelled", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    runtime.release(request)
+    runtime.release(request)
+    assert runtime.metrics()["released_requests"] == 1
+    assert runtime.metrics()["release_calls"] == 2
+
+    runtime.shutdown()
+    runtime.shutdown()
+    assert runtime.metrics()["shutdown"] is True
+    assert runtime.metrics()["free_pages"] == 1
+    with pytest.raises(MetalContextRuntimeError, match="shut down"):
+        runtime.allocate_request("late", max_tokens=16)
+
+
+def test_oracle_mutable_state_is_serialized_across_concurrent_layers(geometry):
+    runtime = _runtime(geometry, max_pages=4)
+    request = runtime.allocate_request("concurrent", max_tokens=32)
+    keys, values = _values(8, seed=44)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        append_futures = [
+            executor.submit(runtime.append_kv, request, layer, keys, values)
+            for layer in (0, 1)
+        ]
+        metric_futures = [executor.submit(runtime.metrics) for _ in range(2)]
+        for future in append_futures:
+            future.result()
+        for metric_future in metric_futures:
+            metric_future.result()
+
+    assert runtime.page_table(request).shape == (1, 1)
+    assert runtime.metrics()["append_tokens"] == 16
+    runtime.shutdown()
+
+
+@pytest.mark.parametrize("execution", ["numpy", "native"])
+def test_snapshot_and_restore_fail_closed_until_persistence_package(
+    geometry, execution
+):
+    native_module = _native_module() if execution == "native" else None
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=1,
+        execution=execution,
+        native_module=native_module,
+    )
+    request = runtime.allocate_request(f"persist-{execution}", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    keys, values = _values(1)
+    runtime.append_kv(request, 0, keys, values)
+    runtime.append_kv(request, 1, keys, values)
+    prefix = runtime.create_prefix(request, token_count=1)
+
+    with pytest.raises(NotImplementedError, match="snapshots are deferred"):
+        runtime.snapshot(prefix, destination="/tmp/not-written")
+    with pytest.raises(NotImplementedError, match="restore is deferred"):
+        runtime.restore("/tmp/not-read")
+    assert runtime.metrics()["snapshot_failures"] == 1
+    assert runtime.metrics()["restore_failures"] == 1
+    runtime.shutdown()
+    assert runtime.metrics()["snapshot_failures"] == 1
+    assert runtime.metrics()["restore_failures"] == 1
+
+
+def test_unsupported_geometry_and_request_metadata_are_rejected():
+    with pytest.raises(ValueError, match="head_dim=128"):
+        MetalContextPageRuntime(
+            AttentionGeometry(1, 2, 1, head_dim=64),
+            max_pages=1,
+            execution="numpy",
+        )
+
+    runtime = MetalContextPageRuntime(
+        AttentionGeometry(1, 2, 1), max_pages=1, execution="numpy"
+    )
+    with pytest.raises(ValueError, match="request_id"):
+        runtime.allocate_request("", max_tokens=16)
+    with pytest.raises(ValueError, match="max_tokens"):
+        runtime.allocate_request("bad", max_tokens=0)
+    with pytest.raises(ValueError, match="INT32_MAX"):
+        runtime.allocate_request("too-long", max_tokens=2**31)
+    request = runtime.allocate_request("ok", max_tokens=16)
+    assert runtime.allocate_pages(request, 0) == ()
+    with pytest.raises(ValueError, match="already active"):
+        runtime.allocate_request("ok", max_tokens=16)
+    runtime.shutdown()
+
+
+def test_numpy_constructor_rejects_native_int32_capacity_overflow():
+    geometry = AttentionGeometry(1, 1, 1, block_size=16)
+    with pytest.raises(ValueError, match="max_pages.*INT32_MAX"):
+        MetalContextPageRuntime(
+            geometry,
+            max_pages=2**31,
+            execution="numpy",
+        )
+    with pytest.raises(ValueError, match="int32 sequence limit"):
+        MetalContextPageRuntime(
+            geometry,
+            max_pages=1,
+            max_blocks_per_request=2**31,
+            execution="numpy",
+        )
+
+
+class _FakeNativePageRuntime:
+    """Small executable model of the compiled PageRuntime Python ABI."""
+
+    instances: list["_FakeNativePageRuntime"] = []
+    # Only the blocking test subclass materializes these synchronization
+    # primitives; annotations let the shared instance registry remain typed.
+    decode_entered: threading.Event
+    decode_release: threading.Event
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls: list[tuple[str, object]] = []
+        self.next_request = 100
+        self.next_prefix = 200
+        self.layer_lengths: dict[int, list[int]] = {}
+        self.request_ids: dict[int, str] = {}
+        self.max_tokens: dict[int, int] = {}
+        self.pages: dict[int, tuple[int, ...]] = {}
+        self.prefixes: dict[int, int] = {}
+        self.attachments: dict[int, int] = {}
+        self.released: set[int] = set()
+        self.failures: dict[str, int] = {}
+        self.post_failures: dict[str, int] = {}
+        self.shutdown_called = False
+        self.shutdown_state = False
+        self.dispatches = 0
+        self.dispatch_failures = 0
+        self.counters: dict[str, int] = {
+            "page_allocations": 0,
+            "request_allocations": 0,
+            "prefix_allocations": 0,
+            "prefix_attaches": 0,
+            "prefix_forks": 0,
+            "prefix_tokens_attached": 0,
+            "cow_events": 0,
+            "evictions": 0,
+            "pages_freed": 0,
+            "releases": 0,
+            "release_calls": 0,
+            "released_requests": 0,
+            "cancellations": 0,
+            "append_tokens": 0,
+            "oom_events": 0,
+            "snapshot_failures": 0,
+            "restore_failures": 0,
+        }
+        self.__class__.instances.append(self)
+
+    def fail_next(self, operation: str) -> None:
+        self.failures[operation] = self.failures.get(operation, 0) + 1
+
+    def fail_after_mutation(self, operation: str) -> None:
+        """Inject a fault after mutation while honoring native atomicity."""
+
+        self.post_failures[operation] = self.post_failures.get(operation, 0) + 1
+
+    def _maybe_fail(self, operation: str) -> None:
+        remaining = self.failures.get(operation, 0)
+        if remaining:
+            self.failures[operation] = remaining - 1
+            raise MemoryError(f"injected {operation} failure")
+
+    def _maybe_fail_after(self, operation: str) -> None:
+        remaining = self.post_failures.get(operation, 0)
+        if remaining:
+            self.post_failures[operation] = remaining - 1
+            raise MemoryError(f"injected post-mutation {operation} failure")
+
+    def allocate_request(self, *, request_id, max_tokens):
+        self._maybe_fail("allocate_request")
+        self.calls.append(("allocate_request", (request_id, max_tokens)))
+        handle = self.next_request
+        self.next_request += 1
+        if request_id in self.request_ids.values():
+            raise ValueError("request_id is already active")
+        self.request_ids[handle] = request_id
+        self.max_tokens[handle] = max_tokens
+        self.layer_lengths[handle] = [0] * self.kwargs["num_layers"]
+        self.pages[handle] = ()
+        self.counters["request_allocations"] += 1
+        try:
+            self._maybe_fail_after("allocate_request")
+        except BaseException:
+            self.request_ids.pop(handle, None)
+            self.max_tokens.pop(handle, None)
+            self.layer_lengths.pop(handle, None)
+            self.pages.pop(handle, None)
+            self.next_request -= 1
+            self.counters["request_allocations"] -= 1
+            raise
+        return handle
+
+    def allocate_pages(self, *, request, count):
+        self._maybe_fail("allocate_pages")
+        self.calls.append(("allocate_pages", (request, count)))
+        old = self.pages[request]
+        capacity = (
+            self.max_tokens[request] + self.kwargs["block_size"] - 1
+        ) // self.kwargs["block_size"]
+        if len(old) + count > capacity:
+            raise ValueError("requested pages exceed the request max_tokens capacity")
+        pages = old + tuple(range(len(old), len(old) + count))
+        self.pages[request] = pages
+        self.counters["page_allocations"] += count
+        try:
+            self._maybe_fail_after("allocate_pages")
+        except BaseException:
+            self.pages[request] = old
+            self.counters["page_allocations"] -= count
+            raise
+        return pages
+
+    def append_kv(self, *, request, layer, keys, values):
+        self._maybe_fail("append_kv")
+        self.calls.append(("append_kv", (request, layer, keys.copy(), values.copy())))
+        token_count = int(keys.shape[0])
+        self.layer_lengths[request][layer] += token_count
+        self.counters["append_tokens"] += token_count
+
+    def sequence_length(self, request):
+        self._maybe_fail("sequence_length")
+        self.calls.append(("sequence_length", request))
+        lengths = self.layer_lengths[request]
+        if (
+            not lengths
+            or not lengths[0]
+            or any(length != lengths[0] for length in lengths)
+        ):
+            raise ValueError(
+                "prefix creation requires all layers to have equal, non-zero lengths"
+            )
+        return lengths[0]
+
+    def create_prefix(self, request):
+        self._maybe_fail("create_prefix")
+        self.calls.append(("create_prefix", request))
+        prefix = self.next_prefix
+        self.next_prefix += 1
+        self.prefixes[prefix] = request
+        self.counters["prefix_allocations"] += 1
+        try:
+            self._maybe_fail_after("create_prefix")
+        except BaseException:
+            self.prefixes.pop(prefix, None)
+            self.next_prefix -= 1
+            self.counters["prefix_allocations"] -= 1
+            raise
+        return prefix
+
+    def fork_prefix(self, prefix):
+        self._maybe_fail("fork_prefix")
+        self.calls.append(("fork_prefix", prefix))
+        forked = self.next_prefix
+        self.next_prefix += 1
+        self.prefixes[forked] = self.prefixes[prefix]
+        self.counters["prefix_allocations"] += 1
+        self.counters["prefix_forks"] += 1
+        try:
+            self._maybe_fail_after("fork_prefix")
+        except BaseException:
+            self.prefixes.pop(forked, None)
+            self.next_prefix -= 1
+            self.counters["prefix_allocations"] -= 1
+            self.counters["prefix_forks"] -= 1
+            raise
+        return forked
+
+    def attach_prefix(self, request, prefix):
+        self._maybe_fail("attach_prefix")
+        self.calls.append(("attach_prefix", (request, prefix)))
+        source_request = self.prefixes[prefix]
+        old_pages = self.pages[request]
+        old_lengths = list(self.layer_lengths[request])
+        old_attachment = self.attachments.get(request)
+        self.pages[request] = self.pages[source_request]
+        self.layer_lengths[request] = list(self.layer_lengths[source_request])
+        self.attachments[request] = prefix
+        self.counters["prefix_attaches"] += 1
+        self.counters["prefix_tokens_attached"] += self.layer_lengths[request][0]
+        try:
+            self._maybe_fail_after("attach_prefix")
+        except BaseException:
+            attached_tokens = self.layer_lengths[request][0]
+            self.pages[request] = old_pages
+            self.layer_lengths[request] = old_lengths
+            if old_attachment is None:
+                self.attachments.pop(request, None)
+            else:
+                self.attachments[request] = old_attachment
+            self.counters["prefix_attaches"] -= 1
+            self.counters["prefix_tokens_attached"] -= attached_tokens
+            raise
+
+    def release_prefix(self, prefix):
+        self._maybe_fail("release_prefix")
+        self.calls.append(("release_prefix", prefix))
+        prior = self.prefixes.pop(prefix, None)
+        if prior is None:
+            return
+        try:
+            self._maybe_fail_after("release_prefix")
+        except BaseException:
+            self.prefixes[prefix] = prior
+            raise
+
+    def release(self, *, request):
+        self._maybe_fail("release")
+        self.calls.append(("release", request))
+        if request in self.released:
+            return
+        old_pages = self.pages[request]
+        old_lengths = list(self.layer_lengths[request])
+        old_attachment = self.attachments.get(request)
+        self.counters["release_calls"] += 1
+        self.counters["releases"] += 1
+        self.counters["released_requests"] += 1
+        self.released.add(request)
+        self.pages[request] = ()
+        self.layer_lengths[request] = [0] * self.kwargs["num_layers"]
+        self.attachments.pop(request, None)
+        try:
+            self._maybe_fail_after("release")
+        except BaseException:
+            self.released.discard(request)
+            self.pages[request] = old_pages
+            self.layer_lengths[request] = old_lengths
+            if old_attachment is not None:
+                self.attachments[request] = old_attachment
+            self.counters["release_calls"] -= 1
+            self.counters["releases"] -= 1
+            self.counters["released_requests"] -= 1
+            raise
+
+    def cancel(self, *, request):
+        self._maybe_fail("cancel")
+        self.calls.append(("cancel", request))
+        if request in self.released:
+            return
+        old_pages = self.pages[request]
+        old_lengths = list(self.layer_lengths[request])
+        old_attachment = self.attachments.get(request)
+        self.counters["release_calls"] += 1
+        self.counters["cancellations"] += 1
+        self.counters["released_requests"] += 1
+        self.released.add(request)
+        self.pages[request] = ()
+        self.layer_lengths[request] = [0] * self.kwargs["num_layers"]
+        self.attachments.pop(request, None)
+        try:
+            self._maybe_fail_after("cancel")
+        except BaseException:
+            self.released.discard(request)
+            self.pages[request] = old_pages
+            self.layer_lengths[request] = old_lengths
+            if old_attachment is not None:
+                self.attachments[request] = old_attachment
+            self.counters["release_calls"] -= 1
+            self.counters["cancellations"] -= 1
+            self.counters["released_requests"] -= 1
+            raise
+
+    def evict(self, **kwargs):
+        self.calls.append(("evict", kwargs))
+        return 0
+
+    def snapshot(self, *, prefix, destination):
+        self._maybe_fail("snapshot")
+        self.counters["snapshot_failures"] += 1
+        raise NotImplementedError("snapshots are deferred")
+
+    def restore(self, *, source):
+        self._maybe_fail("restore")
+        self.counters["restore_failures"] += 1
+        raise NotImplementedError("restore is deferred")
+
+    def page_table(self, request, layer=0):
+        self._maybe_fail("page_table")
+        self.calls.append(("page_table", (request, layer)))
+        token_count = self.layer_lengths[request][layer]
+        blocks = (token_count + self.kwargs["block_size"] - 1) // self.kwargs[
+            "block_size"
+        ]
+        return self.pages[request][:blocks]
+
+    def paged_decode(self, *, request, layer, query, scale):
+        self.calls.append(("paged_decode", (request, layer, query.copy(), scale)))
+        self.dispatches += 1
+        return np.zeros((4, 128), dtype=np.float32).tobytes()
+
+    def metrics(self):
+        if self.shutdown_state:
+            resident = 0
+            requests = 0
+            prefixes = 0
+            free_pages = self.kwargs["max_pages"]
+        else:
+            live_requests = [
+                handle for handle in self.layer_lengths if handle not in self.released
+            ]
+            resident = len(
+                {page for handle in live_requests for page in self.pages[handle]}
+            )
+            requests = len(live_requests)
+            prefixes = len(self.prefixes)
+            free_pages = self.kwargs["max_pages"] - resident
+        return {
+            "resident_pages": resident,
+            "referenced_pages": resident,
+            "shared_pages": 0,
+            "evictions": self.counters["evictions"],
+            "pages_freed": self.counters["pages_freed"],
+            "free_pages": free_pages,
+            "requests": requests,
+            "prefixes": prefixes,
+            "page_allocations": self.counters["page_allocations"],
+            "request_allocations": self.counters["request_allocations"],
+            "prefix_allocations": self.counters["prefix_allocations"],
+            "prefix_attaches": self.counters["prefix_attaches"],
+            "prefix_forks": self.counters["prefix_forks"],
+            "prefix_tokens_attached": self.counters["prefix_tokens_attached"],
+            "cow_events": self.counters["cow_events"],
+            "releases": self.counters["releases"],
+            "release_calls": self.counters["release_calls"],
+            "released_requests": self.counters["released_requests"],
+            "cancellations": self.counters["cancellations"],
+            "append_tokens": self.counters["append_tokens"],
+            "oom_events": self.counters["oom_events"],
+            "dispatches": self.dispatches,
+            "dispatch_failures": self.dispatch_failures,
+            "snapshot_failures": self.counters["snapshot_failures"],
+            "restore_failures": self.counters["restore_failures"],
+            "max_pages": self.kwargs["max_pages"],
+            "max_blocks_per_request": self.kwargs["max_blocks_per_request"],
+            "block_size": self.kwargs["block_size"],
+            "shutdown": self.shutdown_state,
+        }
+
+    def shutdown(self):
+        self.shutdown_called = True
+        self.shutdown_state = True
+
+
+def _native_module(page_runtime_type=_FakeNativePageRuntime):
+    return types.SimpleNamespace(
+        capabilities=lambda: {
+            "available": True,
+            "compiled": True,
+            "metal_device": True,
+            "abi_version": 1,
+            "serving_ready": False,
+        },
+        PageRuntime=page_runtime_type,
+    )
+
+
+def _native_state(native: _FakeNativePageRuntime) -> dict[str, object]:
+    return {
+        "request_ids": dict(native.request_ids),
+        "max_tokens": dict(native.max_tokens),
+        "next_request": native.next_request,
+        "next_prefix": native.next_prefix,
+        "layer_lengths": {
+            handle: list(lengths) for handle, lengths in native.layer_lengths.items()
+        },
+        "pages": dict(native.pages),
+        "prefixes": dict(native.prefixes),
+        "attachments": dict(native.attachments),
+        "released": set(native.released),
+        "counters": dict(native.counters),
+        "shutdown": native.shutdown_state,
+    }
+
+
+def _adapter_native_state(runtime: MetalContextPageRuntime) -> dict[str, object]:
+    # Native lifecycle state belongs to the compiled runtime.  The adapter's
+    # only mutable native-side field is its local shutdown guard.
+    return {"shutdown": runtime._shutdown}
+
+
+def _native_prefix_fixture(
+    geometry: AttentionGeometry,
+) -> tuple[
+    MetalContextPageRuntime,
+    _FakeNativePageRuntime,
+    RequestHandle,
+    PrefixHandle,
+]:
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=2,
+        execution="native",
+        native_module=_native_module(),
+    )
+    native = _FakeNativePageRuntime.instances[-1]
+    request = runtime.allocate_request("failure-base", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    keys, values = _values(1)
+    runtime.append_kv(request, 0, keys, values)
+    runtime.append_kv(request, 1, keys, values)
+    prefix = runtime.create_prefix(request)
+    return runtime, native, request, prefix
+
+
+def test_native_page_table_truncates_reserved_tail_and_preserves_prefix_lengths(
+    geometry,
+):
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=2,
+        execution="native",
+        native_module=_native_module(),
+    )
+    native = _FakeNativePageRuntime.instances[-1]
+    request = runtime.allocate_request("layer-table", max_tokens=32)
+    runtime.allocate_pages(request, 2)
+    keys, values = _values(1, seed=51)
+    runtime.append_kv(request, 0, keys, values)
+
+    # Native allocation reserves two physical pages, but only layer zero has
+    # a populated token.  The adapter must use its authoritative per-layer
+    # lengths rather than exposing the native allocation watermark.
+    np.testing.assert_array_equal(
+        runtime.page_table(request, layer=0), np.asarray([[0]], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        runtime.page_table(request, layer=1), np.empty((1, 0), dtype=np.int32)
+    )
+
+    runtime.append_kv(request, 1, keys, values)
+    prefix = runtime.create_prefix(request)
+    branch = runtime.allocate_request("layer-table-branch", max_tokens=32)
+    runtime.attach_prefix(branch, prefix)
+    for layer in range(geometry.num_layers):
+        np.testing.assert_array_equal(
+            runtime.page_table(branch, layer=layer),
+            np.asarray([[0]], dtype=np.int32),
+        )
+    assert native.layer_lengths[int(branch)] == [1, 1]
+    runtime.release(branch)
+    runtime.release(request)
+    runtime.release_prefix(prefix)
+    runtime.shutdown()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "allocate_request",
+        "allocate_pages",
+        "create_prefix",
+        "fork_prefix",
+        "attach_prefix",
+        "release_prefix",
+        "release",
+        "cancel",
+    ],
+)
+def test_native_memory_errors_leave_adapter_and_native_ownership_converged(
+    geometry, operation
+):
+    if operation == "allocate_request":
+        runtime = MetalContextPageRuntime(
+            geometry,
+            max_pages=2,
+            execution="native",
+            native_module=_native_module(),
+        )
+        native = _FakeNativePageRuntime.instances[-1]
+        before_native = _native_state(native)
+        before_adapter = _adapter_native_state(runtime)
+        native.fail_after_mutation(operation)
+        with pytest.raises(MemoryError, match="injected"):
+            runtime.allocate_request("failure-request", max_tokens=16)
+    elif operation == "allocate_pages":
+        runtime = MetalContextPageRuntime(
+            geometry,
+            max_pages=2,
+            execution="native",
+            native_module=_native_module(),
+        )
+        native = _FakeNativePageRuntime.instances[-1]
+        request = runtime.allocate_request("failure-pages", max_tokens=16)
+        before_native = _native_state(native)
+        before_adapter = _adapter_native_state(runtime)
+        native.fail_after_mutation(operation)
+        with pytest.raises(MemoryError, match="injected"):
+            runtime.allocate_pages(request, 1)
+    elif operation in {"create_prefix", "fork_prefix", "release_prefix"}:
+        runtime, native, _request, prefix = _native_prefix_fixture(geometry)
+        if operation == "fork_prefix":
+            before_native = _native_state(native)
+            before_adapter = _adapter_native_state(runtime)
+            native.fail_after_mutation(operation)
+            with pytest.raises(MemoryError, match="injected"):
+                runtime.fork_prefix(prefix)
+        else:
+            before_native = _native_state(native)
+            before_adapter = _adapter_native_state(runtime)
+            native.fail_after_mutation(operation)
+            with pytest.raises(MemoryError, match="injected"):
+                (
+                    runtime.release_prefix(prefix)
+                    if operation == "release_prefix"
+                    else runtime.create_prefix(_request)
+                )
+    else:
+        runtime, native, request, prefix = _native_prefix_fixture(geometry)
+        if operation == "attach_prefix":
+            branch = runtime.allocate_request("failure-branch", max_tokens=16)
+            before_native = _native_state(native)
+            before_adapter = _adapter_native_state(runtime)
+            native.fail_after_mutation(operation)
+            with pytest.raises(MemoryError, match="injected"):
+                runtime.attach_prefix(branch, prefix)
+        else:
+            before_native = _native_state(native)
+            before_adapter = _adapter_native_state(runtime)
+            native.fail_after_mutation(operation)
+            with pytest.raises(MemoryError, match="injected"):
+                (
+                    runtime.cancel(request)
+                    if operation == "cancel"
+                    else runtime.release(request)
+                )
+
+    assert _native_state(native) == before_native
+    after_adapter = _adapter_native_state(runtime)
+    assert after_adapter == before_adapter
+    runtime.shutdown()
+
+
+def test_native_execution_requires_capabilities_and_never_silently_falls_back(
+    geometry,
+):
+    unavailable = types.SimpleNamespace(
+        capabilities=lambda: {
+            "available": False,
+            "compiled": True,
+            "metal_device": False,
+            "abi_version": 1,
+            "reason": "test GPU unavailable",
+        }
+    )
+    with pytest.raises(MetalContextCapabilityError, match="test GPU unavailable"):
+        MetalContextPageRuntime(
+            geometry, max_pages=2, execution="native", native_module=unavailable
+        )
+
+    runtime = MetalContextPageRuntime(
+        geometry, max_pages=2, execution="native", native_module=_native_module()
+    )
+    native = _FakeNativePageRuntime.instances[-1]
+    request = runtime.allocate_request("native", max_tokens=16)
+    with pytest.raises(ValueError, match="already active"):
+        runtime.allocate_request("native", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    keys, values = _values(1)
+    runtime.append_kv(request, 0, keys, values)
+    runtime.append_kv(request, 1, keys, values)
+    prefix = runtime.create_prefix(request)
+    forked = runtime.fork_prefix(prefix)
+    runtime.attach_prefix(runtime.allocate_request("branch", max_tokens=16), prefix)
+    output = runtime.paged_decode_attention(request, 0, np.ones((4, 128), np.float32))
+    assert output.shape == (4, 128)
+    assert not hasattr(runtime, "_keys")
+    assert not hasattr(runtime, "_values")
+    for shadow_name in (
+        "_native_handle_request_ids",
+        "_native_request_max_tokens",
+        "_native_request_page_counts",
+        "_native_request_layer_lengths",
+        "_native_released_requests",
+        "_native_released_prefixes",
+        "_native_prefix_handles",
+        "_native_prefix_token_counts",
+        "_native_metrics_cache",
+        "_requests",
+        "_prefixes",
+        "_released_requests",
+        "_released_prefixes",
+        "_request_ids",
+        "_next_request",
+        "_next_prefix",
+        "_clock",
+        "_counters",
+    ):
+        assert not hasattr(runtime, shadow_name)
+    call_names = [name for name, _ in native.calls]
+    assert call_names == [
+        "allocate_request",
+        "allocate_request",
+        "allocate_pages",
+        "append_kv",
+        "append_kv",
+        "sequence_length",
+        "create_prefix",
+        "fork_prefix",
+        "allocate_request",
+        "attach_prefix",
+        "paged_decode",
+    ]
+    runtime.release(request)
+    runtime.release(request)
+    cancelled = runtime.allocate_request("cancelled", max_tokens=16)
+    runtime.cancel(cancelled)
+    runtime.cancel(cancelled)
+    runtime.release_prefix(prefix)
+    runtime.release_prefix(prefix)
+    metrics = runtime.metrics()
+    assert metrics["resident_pages"] == 1
+    assert metrics["dispatches"] == 1
+    assert metrics["native_dispatches"] == 1
+    assert metrics["oracle_dispatches"] == 0
+    assert metrics["dispatch_failures"] == metrics["native_failures"] == 0
+    assert metrics["pages_allocated"] == 1
+    assert metrics["append_tokens"] == 2
+    assert metrics["prefix_attaches"] == 1
+    assert metrics["prefix_forks"] == 1
+    assert metrics["prefix_tokens_attached"] == 1
+    assert metrics["release_calls"] == 2
+    assert metrics["released_requests"] == 2
+    assert metrics["cancellations"] == 1
+    assert metrics["oom_events"] == 0
+    runtime.shutdown()
+    assert native.shutdown_called is True
+    shutdown_metrics = runtime.metrics()
+    assert shutdown_metrics["resident_pages"] == 0
+    assert shutdown_metrics["referenced_pages"] == 0
+    assert shutdown_metrics["requests"] == 0
+    assert shutdown_metrics["prefixes"] == 0
+    assert shutdown_metrics["free_pages"] == 2
+    assert shutdown_metrics["pages_allocated"] == 1
+    assert shutdown_metrics["append_tokens"] == 2
+    assert shutdown_metrics["prefix_attaches"] == 1
+    assert shutdown_metrics["prefix_forks"] == 1
+    assert shutdown_metrics["release_calls"] == 2
+    assert shutdown_metrics["released_requests"] == 2
+    assert shutdown_metrics["cancellations"] == 1
+
+
+def test_native_decodes_can_overlap_without_python_lifecycle_lock(geometry):
+    class OverlapPageRuntime(_FakeNativePageRuntime):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.decode_barrier = threading.Barrier(2)
+
+        def paged_decode(self, **kwargs):
+            self.decode_barrier.wait(timeout=2)
+            return super().paged_decode(**kwargs)
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=2,
+        execution="native",
+        native_module=_native_module(OverlapPageRuntime),
+    )
+    first = runtime.allocate_request("overlap-first", max_tokens=16)
+    second = runtime.allocate_request("overlap-second", max_tokens=16)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(
+                runtime.paged_decode_attention,
+                request,
+                0,
+                np.ones((4, 128), dtype=np.float32),
+            )
+            for request in (first, second)
+        ]
+        outputs = [future.result(timeout=3) for future in futures]
+
+    assert all(output.shape == (4, 128) for output in outputs)
+    assert runtime.metrics()["dispatches"] == 2
+    runtime.shutdown()
+
+
+def test_native_decode_does_not_block_lifecycle_metrics(geometry):
+    class BlockingPageRuntime(_FakeNativePageRuntime):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.decode_entered = threading.Event()
+            self.decode_release = threading.Event()
+
+        def paged_decode(self, **kwargs):
+            self.decode_entered.set()
+            if not self.decode_release.wait(timeout=3):
+                raise RuntimeError("test decode release timed out")
+            return super().paged_decode(**kwargs)
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=1,
+        execution="native",
+        native_module=_native_module(BlockingPageRuntime),
+    )
+    native = _FakeNativePageRuntime.instances[-1]
+    request = runtime.allocate_request("lifecycle-during-decode", max_tokens=16)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        decode = executor.submit(
+            runtime.paged_decode_attention,
+            request,
+            0,
+            np.ones((4, 128), dtype=np.float32),
+        )
+        assert native.decode_entered.wait(timeout=2)
+        metrics = executor.submit(runtime.metrics).result(timeout=1)
+        assert metrics["requests"] == 1
+        native.decode_release.set()
+        assert decode.result(timeout=2).shape == (4, 128)
+    runtime.shutdown()
+
+
+def test_native_dispatch_error_is_reported_without_oracle_fallback(geometry):
+    class FailingPageRuntime(_FakeNativePageRuntime):
+        def paged_decode(self, **kwargs):
+            self.dispatch_failures += 1
+            raise RuntimeError("kernel command failed")
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=1,
+        execution="native",
+        native_module=_native_module(FailingPageRuntime),
+    )
+    request = runtime.allocate_request("native-error", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    keys, values = _values(1)
+    runtime.append_kv(request, 0, keys, values)
+    with pytest.raises(RuntimeError, match="kernel command failed"):
+        runtime.paged_decode_attention(request, 0, np.ones((4, 128), np.float32))
+    metrics = runtime.metrics()
+    assert metrics["dispatches"] == 0
+    assert metrics["native_dispatches"] == 0
+    assert metrics["dispatch_failures"] == 1
+    assert metrics["native_failures"] == 1
+    assert metrics["oracle_dispatches"] == 0
+    runtime.shutdown()
+
+
+def test_native_capacity_failures_report_oom_events(geometry):
+    class OOMPageRuntime(_FakeNativePageRuntime):
+        def allocate_pages(self, **kwargs):
+            self.counters["oom_events"] += 1
+            raise MemoryError("capacity exhausted")
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=1,
+        execution="native",
+        native_module=_native_module(OOMPageRuntime),
+    )
+    request = runtime.allocate_request("native-oom", max_tokens=16)
+    with pytest.raises(MemoryError, match="capacity exhausted"):
+        runtime.allocate_pages(request, 1)
+    assert runtime.metrics()["oom_events"] == 1
+    assert runtime.metrics()["pages_allocated"] == 0
+    runtime.shutdown()
+
+
+def test_native_metrics_preserve_authoritative_snapshot_restore_counters(geometry):
+    class MetricsPageRuntime(_FakeNativePageRuntime):
+        def metrics(self):
+            result = super().metrics()
+            result.update({"snapshot_failures": 7, "restore_failures": 9})
+            return result
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=1,
+        execution="native",
+        native_module=_native_module(MetricsPageRuntime),
+    )
+    assert runtime.metrics()["snapshot_failures"] == 7
+    assert runtime.metrics()["restore_failures"] == 9
+    runtime.shutdown()
+
+
+def test_actual_compiled_page_runtime_is_used_when_available(geometry):
+    native = pytest.importorskip("vllm_mlx._metal_context")
+    capabilities = native.capabilities()
+    if not capabilities.get("available") or not hasattr(native, "PageRuntime"):
+        pytest.skip("compiled native PageRuntime is unavailable")
+
+    runtime = MetalContextPageRuntime(
+        geometry,
+        max_pages=2,
+        max_requests=2,
+        execution="native",
+        native_module=native,
+    )
+    assert isinstance(runtime._native_runtime, native.PageRuntime)
+    request = runtime.allocate_request("compiled", max_tokens=16)
+    runtime.allocate_pages(request, 1)
+    keys, values = _values(1, seed=55)
+    runtime.append_kv(request, 0, keys, values)
+    runtime.append_kv(request, 1, keys, values)
+    prefix = runtime.create_prefix(request)
+    runtime.release(request)
+    runtime.release(request)
+    runtime.release_prefix(prefix)
+    runtime.shutdown()
+    runtime.shutdown()
+
+
+def test_randomized_page_layouts_match_reference_oracle(geometry):
+    """Exercise varied sequence lengths and GQA against the shared oracle."""
+
+    rng = np.random.default_rng(99)
+    for iteration in range(12):
+        runtime = _runtime(geometry, max_pages=5)
+        request = runtime.allocate_request(str(iteration), max_tokens=64)
+        runtime.allocate_pages(request, 4)
+        length = int(rng.integers(1, 65))
+        keys, values = _values(length, seed=100 + iteration)
+        runtime.append_kv(request, 0, keys, values)
+        query = rng.normal(0.0, 0.2, size=(4, 128)).astype(np.float32)
+        output = runtime.paged_decode_attention(request, 0, query)
+
+        # Use a packed logical page view as a second independent model of the
+        # append layout; the runtime page IDs may be physical/non-contiguous in
+        # later allocation strategies, while the page-table contract remains
+        # the only source of lookup order.
+        pages = runtime.page_table(request)
+        key_storage = np.zeros((5, 2, 16, 128), dtype=np.float32)
+        value_storage = np.zeros_like(key_storage)
+        for logical, page_id in enumerate(pages[0]):
+            start = logical * 16
+            end = min(start + 16, length)
+            key_storage[page_id, :, : end - start] = np.transpose(
+                _as_bf16(keys[start:end]), (1, 0, 2)
+            )
+            value_storage[page_id, :, : end - start] = np.transpose(
+                _as_bf16(values[start:end]), (1, 0, 2)
+            )
+        expected = numpy_paged_decode_attention(
+            query[None],
+            key_storage,
+            value_storage,
+            pages,
+            np.asarray([length], dtype=np.int32),
+            block_size=16,
+            num_kv_heads=2,
+        )[0]
+        np.testing.assert_allclose(output, expected, rtol=4e-4, atol=4e-4)
+        runtime.shutdown()

--- a/vllm_mlx/_metal_context.py
+++ b/vllm_mlx/_metal_context.py
@@ -1,0 +1,55 @@
+"""Fallback surface for the optional Metal Context Engine extension.
+
+The native module has the same import name (``vllm_mlx._metal_context``) and
+is selected by Python automatically when it is present.  Keeping this small
+fallback importable is important: normal MLX serving and Linux CI must not
+require an Apple toolchain, while an explicit ``metal-context`` request still
+gets an actionable capability error from the higher-level backend.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Any
+
+ABI_VERSION = 1
+
+
+def capabilities() -> dict[str, Any]:
+    """Return a precise, non-raising unavailable capability record."""
+
+    return {
+        "available": False,
+        "compiled": False,
+        "metal_device": False,
+        "apple_silicon": platform.machine().lower() in {"arm64", "aarch64"},
+        "serving_ready": False,
+        "abi_version": ABI_VERSION,
+        "backend": "metal-context",
+        "reason": (
+            "the optional native Metal Context Engine was not built; install "
+            "on Apple Silicon with VLLM_MLX_BUILD_METAL_CONTEXT=1 and the "
+            "Xcode Metal toolchain"
+        ),
+        "kernel": "metal_context_paged_decode",
+        "block_sizes": (16, 32),
+        "head_dims": (128,),
+        "gqa": True,
+        "partial_blocks": True,
+        "online_softmax": True,
+        "kv_dtype": "bfloat16",
+    }
+
+
+def paged_decode(*args: Any, **kwargs: Any) -> bytes:
+    """Reject native dispatch when the optional extension is unavailable."""
+
+    del args, kwargs
+    raise RuntimeError("metal-context backend unavailable: " + capabilities()["reason"])
+
+
+def shutdown() -> None:
+    """Keep lifecycle calls harmless when no native module was installed."""
+
+
+__all__ = ["ABI_VERSION", "capabilities", "paged_decode", "shutdown"]

--- a/vllm_mlx/attention_backend.py
+++ b/vllm_mlx/attention_backend.py
@@ -1,0 +1,823 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention backend selection and the phase-one context backend contract.
+
+The Metal Context Engine is intentionally opt-in while its native implementation
+is being qualified.  This module is kept importable on every platform and does
+not import MLX or the optional native extension until a caller asks for the
+corresponding capability probe/oracle.
+
+There are two deliberately separate surfaces here:
+
+* :func:`resolve_attention_backend` is the process-startup dispatch decision.
+  ``mlx`` is the safe default, ``auto`` is conservative MLX routing until a
+  qualified matrix is recorded, and an explicit ``metal-context`` request is a
+  hard capability error rather than a silent fallback.
+* :class:`ContextBackend` is the narrow runtime contract that the native page
+  runtime will implement in a later package.  It is not wired into a scheduler
+  in this phase.
+
+The NumPy and MLX helpers use one explicit paged tensor layout so that native
+kernel tests can compare identical inputs to a correctness oracle:
+
+* query: ``[batch, query_heads, head_dim]`` (one decode query per request)
+* key/value pages: ``[page, kv_heads, block_offset, head_dim]``
+* page table: ``[batch, logical_block]`` containing physical page indices
+* sequence lengths: ``[batch]``; only the first ``length`` tokens are read
+
+The native ABI may use a different physical layout internally, but its adapter
+must preserve these logical semantics at the Python boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+import importlib
+import math
+import platform as _platform
+import sys
+from typing import Any, NewType, Protocol, runtime_checkable
+
+ATTENTION_BACKEND_CHOICES = ("mlx", "metal-context", "auto")
+"""CLI values accepted by the serving interfaces."""
+
+NATIVE_EXTENSION_MODULE = "vllm_mlx._metal_context"
+"""Import path reserved for the optional compiled extension."""
+
+METAL_CONTEXT_ABI_VERSION = 1
+APPLE_SILICON_ARCHITECTURES = frozenset({"arm64", "aarch64"})
+
+
+class AttentionBackendName(str, Enum):
+    """Names understood by the serving configuration."""
+
+    MLX = "mlx"
+    METAL_CONTEXT = "metal-context"
+    AUTO = "auto"
+
+
+def _coerce_backend_name(value: str | AttentionBackendName) -> AttentionBackendName:
+    if isinstance(value, AttentionBackendName):
+        return value
+    try:
+        return AttentionBackendName(value.strip().lower())
+    except (AttributeError, ValueError) as exc:
+        choices = ", ".join(ATTENTION_BACKEND_CHOICES)
+        raise ValueError(
+            f"Unknown attention backend {value!r}; expected one of: {choices}"
+        ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapabilities:
+    """A serializable snapshot of native backend availability.
+
+    ``available`` means that the extension has passed its own capability probe
+    and advertises the phase-one ABI.  It is deliberately stricter than merely
+    being importable: a wheel can contain a native module that is not usable on
+    the current OS/device or was built against an incompatible ABI.
+
+    ``serving_ready`` is a separate gate.  Phase one ships the executable
+    kernel foundation before a scheduler-owned executor exists, so a native
+    module can be available for oracle/kernel tests while explicit serving
+    selection still fails closed.
+    """
+
+    platform: str
+    native_extension: bool
+    metal_device: bool
+    abi_version: int | None
+    available: bool
+    serving_ready: bool = False
+    reason: str | None = None
+    architecture: str = ""
+    # ``mlx`` never needs to import or probe the optional native module.  Keep
+    # that distinction visible to status consumers instead of representing an
+    # unprobed default as a failed capability probe.
+    probed: bool = False
+
+    def as_dict(self) -> dict[str, object]:
+        """Return status data safe to expose in health/status responses."""
+
+        return {
+            "platform": self.platform,
+            "native_extension": self.native_extension,
+            "metal_device": self.metal_device,
+            "abi_version": self.abi_version,
+            "available": self.available,
+            "serving_ready": self.serving_ready,
+            "reason": self.reason,
+            "architecture": self.architecture,
+            "probed": self.probed,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackendSelection:
+    """Result of resolving the requested backend at process startup."""
+
+    requested: AttentionBackendName
+    selected: AttentionBackendName
+    capabilities: BackendCapabilities
+    fallback_reason: str | None = None
+
+    @property
+    def is_fallback(self) -> bool:
+        """Whether the requested value did not become the selected backend."""
+
+        return self.requested is not self.selected
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a stable status representation."""
+
+        return {
+            "requested": self.requested.value,
+            "selected": self.selected.value,
+            "fallback": self.is_fallback,
+            "fallback_reason": self.fallback_reason,
+            "capabilities": self.capabilities.as_dict(),
+        }
+
+
+class AttentionBackendCapabilityError(RuntimeError):
+    """Raised when an explicitly requested backend cannot be used."""
+
+    def __init__(
+        self,
+        requested: AttentionBackendName,
+        capabilities: BackendCapabilities,
+    ) -> None:
+        self.requested = requested
+        self.capabilities = capabilities
+        reason = capabilities.reason
+        if not reason and capabilities.platform != "darwin":
+            reason = "the Metal Context backend requires macOS"
+        if (
+            not reason
+            and capabilities.architecture
+            and capabilities.architecture not in APPLE_SILICON_ARCHITECTURES
+        ):
+            reason = (
+                "the Metal Context backend requires Apple Silicon "
+                f"(found {capabilities.architecture})"
+            )
+        if not reason and capabilities.available and not capabilities.serving_ready:
+            reason = (
+                "the native kernel is available, but no serving executor is "
+                "registered yet"
+            )
+        reason = reason or "the required capability probe failed"
+        super().__init__(
+            "Attention backend 'metal-context' was explicitly requested but is "
+            f"unavailable: {reason}. Install a vllm-mlx build with the optional "
+            f"{NATIVE_EXTENSION_MODULE} extension on supported Apple Silicon, "
+            "or select --attention-backend mlx."
+        )
+
+
+def _unprobed_capabilities() -> BackendCapabilities:
+    """Return the neutral capability snapshot used by the MLX default.
+
+    Selecting the established MLX backend does not require importing the
+    optional native extension.  In particular, this function intentionally
+    does not call :func:`discover_capabilities` so a normal installation stays
+    independent of the Metal build and its device probe.
+    """
+
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=None,
+        architecture="",
+        probed=False,
+    )
+
+
+def _unsupported_capabilities(reason: str) -> BackendCapabilities:
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        reason=reason,
+        architecture=_platform.machine().lower(),
+        probed=True,
+    )
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def discover_capabilities() -> BackendCapabilities:
+    """Probe the optional native extension without importing MLX eagerly.
+
+    The extension exposes a zero-argument ``capabilities()`` function returning
+    a mapping.  Requiring that small ABI probe makes an importable but stale
+    extension fail closed instead of being treated as a usable backend.
+    """
+
+    if sys.platform != "darwin":
+        return _unsupported_capabilities(
+            f"the Metal Context backend requires macOS (current platform: {sys.platform})"
+        )
+
+    machine = _platform.machine().lower()
+    if machine not in APPLE_SILICON_ARCHITECTURES:
+        return _unsupported_capabilities(
+            "the Metal Context backend requires Apple Silicon "
+            f"(arm64/aarch64; current architecture: {machine or 'unknown'})"
+        )
+
+    try:
+        native = importlib.import_module(NATIVE_EXTENSION_MODULE)
+    except (ImportError, OSError) as exc:
+        detail = str(exc).strip() or exc.__class__.__name__
+        return _unsupported_capabilities(
+            f"the optional native extension could not be loaded: {detail}"
+        )
+
+    probe = getattr(native, "capabilities", None)
+    if not callable(probe):
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason=(
+                f"{NATIVE_EXTENSION_MODULE} does not expose the required "
+                "capabilities() ABI probe"
+            ),
+            architecture=machine,
+            probed=True,
+        )
+
+    try:
+        raw = probe()
+    except Exception as exc:  # native errors must become a precise status
+        detail = str(exc).strip() or exc.__class__.__name__
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason=f"the native capability probe failed: {detail}",
+            architecture=machine,
+            probed=True,
+        )
+
+    if not isinstance(raw, Mapping):
+        return BackendCapabilities(
+            platform=sys.platform,
+            native_extension=True,
+            metal_device=False,
+            abi_version=None,
+            available=False,
+            reason="the native capability probe returned a non-mapping result",
+            architecture=machine,
+            probed=True,
+        )
+
+    native_extension = bool(raw.get("compiled", True))
+    abi_version = _int_or_none(raw.get("abi_version"))
+    advertised = bool(raw.get("available", raw.get("supported", False)))
+    # Older phase-one native bridges use ``available`` as the result of a
+    # successful Metal device/pipeline probe but do not expose a separate
+    # metal_device field.  Preserve that ABI while still requiring a positive
+    # probe result; newer bridges can report the field explicitly.
+    metal_device = bool(raw.get("metal_device", advertised))
+    reasons: list[str] = []
+    if not native_extension:
+        reasons.append("the optional native extension is not compiled")
+    if not metal_device:
+        reasons.append("no usable Metal device was reported")
+    if abi_version != METAL_CONTEXT_ABI_VERSION:
+        reasons.append(
+            f"native ABI {abi_version!r} does not match required ABI "
+            f"{METAL_CONTEXT_ABI_VERSION}"
+        )
+    if not advertised:
+        native_reason = raw.get("reason")
+        if isinstance(native_reason, str) and native_reason.strip():
+            reasons.append(native_reason.strip())
+        else:
+            reasons.append("the native extension did not advertise availability")
+    serving_ready = bool(raw.get("serving_ready", raw.get("executor_available", False)))
+    if not serving_ready:
+        reasons.append(
+            "the native kernel is not serving-ready; the Metal Context executor "
+            "has not been integrated and qualified"
+        )
+
+    available = metal_device and abi_version == METAL_CONTEXT_ABI_VERSION and advertised
+    return BackendCapabilities(
+        platform=sys.platform,
+        native_extension=native_extension,
+        metal_device=metal_device,
+        abi_version=abi_version,
+        available=available,
+        serving_ready=serving_ready,
+        reason=(
+            None if available and serving_ready else "; ".join(dict.fromkeys(reasons))
+        ),
+        architecture=machine,
+        probed=True,
+    )
+
+
+def resolve_attention_backend(
+    requested: str | AttentionBackendName = AttentionBackendName.MLX,
+    *,
+    capabilities: BackendCapabilities | None = None,
+) -> BackendSelection:
+    """Resolve a serving request without silently enabling an unqualified path.
+
+    ``auto`` intentionally selects MLX even when the extension is present.  A
+    later qualification patch can add an explicit matrix gate while preserving
+    this function's startup/error contract.
+    """
+
+    name = _coerce_backend_name(requested)
+
+    # MLX is the established default and must remain independent of the
+    # optional native extension.  A caller that already has a capability
+    # snapshot may attach it for status/debugging, but the default path never
+    # performs a probe or imports the native module.
+    if name is AttentionBackendName.MLX:
+        caps = capabilities if capabilities is not None else _unprobed_capabilities()
+        return BackendSelection(
+            requested=name,
+            selected=AttentionBackendName.MLX,
+            capabilities=caps,
+        )
+
+    # ``auto`` may probe conservatively so it can report why Metal was not
+    # selected.  Explicit ``metal-context`` also probes here, then fails with
+    # a precise capability error if the serving executor is unavailable.
+    caps = capabilities if capabilities is not None else discover_capabilities()
+
+    if name is AttentionBackendName.METAL_CONTEXT:
+        if (
+            caps.platform != "darwin"
+            or (
+                caps.architecture
+                and caps.architecture not in APPLE_SILICON_ARCHITECTURES
+            )
+            or not caps.available
+            or not caps.serving_ready
+        ):
+            raise AttentionBackendCapabilityError(name, caps)
+        return BackendSelection(
+            requested=name,
+            selected=name,
+            capabilities=caps,
+        )
+
+    if name is AttentionBackendName.AUTO:
+        return BackendSelection(
+            requested=name,
+            selected=AttentionBackendName.MLX,
+            capabilities=caps,
+            fallback_reason=(
+                "automatic Metal Context routing is disabled until the explicit "
+                "qualification matrix passes; using the MLX correctness path"
+            ),
+        )
+
+    raise AssertionError(f"unhandled attention backend {name!r}")
+
+
+def validate_attention_backend(
+    requested: str | AttentionBackendName,
+    *,
+    capabilities: BackendCapabilities | None = None,
+) -> BackendSelection:
+    """Compatibility alias emphasizing startup validation at call sites."""
+
+    return resolve_attention_backend(requested, capabilities=capabilities)
+
+
+@dataclass(frozen=True, slots=True)
+class AttentionGeometry:
+    """Phase-one geometry accepted by a concrete context backend."""
+
+    num_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int = 128
+    block_size: int = 16
+    kv_dtype: str = "bfloat16"
+
+    def validate(self) -> None:
+        """Reject shapes outside the initial Qwen dense/MoE qualification scope."""
+
+        if self.num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+        if self.num_attention_heads <= 0 or self.num_key_value_heads <= 0:
+            raise ValueError("attention head counts must be positive")
+        if self.num_attention_heads % self.num_key_value_heads:
+            raise ValueError(
+                "num_attention_heads must be divisible by num_key_value_heads for GQA"
+            )
+        if self.head_dim != 128:
+            raise ValueError("Metal Context v1 supports head_dim=128 only")
+        if self.block_size not in (16, 32):
+            raise ValueError("Metal Context v1 supports block_size 16 or 32 only")
+        if self.kv_dtype.lower() not in {"bfloat16", "bf16"}:
+            raise ValueError("Metal Context v1 supports BF16 K/V pages only")
+
+
+RequestHandle = NewType("RequestHandle", int)
+PageHandle = NewType("PageHandle", int)
+PrefixHandle = NewType("PrefixHandle", int)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotMetadata:
+    """Opaque metadata returned by a future snapshot implementation."""
+
+    identity: str
+    page_count: int
+    token_count: int
+    content_hash: str
+
+
+@runtime_checkable
+class ContextBackend(Protocol):
+    """Narrow lifecycle contract for the native context runtime.
+
+    Implementations own page-table and command-queue state.  The protocol is
+    intentionally free of scheduler/request-output types so it can be tested
+    independently before a production executor is introduced.
+    """
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        pass
+
+    def validate(self, geometry: AttentionGeometry) -> None:
+        pass
+
+    def allocate_request(self, request_id: str, *, max_tokens: int) -> RequestHandle:
+        pass
+
+    def allocate_pages(
+        self, request: RequestHandle, count: int
+    ) -> tuple[PageHandle, ...]:
+        pass
+
+    def append_kv(
+        self,
+        request: RequestHandle,
+        layer: int,
+        keys: Any,
+        values: Any,
+    ) -> None:
+        pass
+
+    def paged_decode_attention(
+        self, request: RequestHandle, layer: int, query: Any
+    ) -> Any:
+        pass
+
+    def attach_prefix(self, request: RequestHandle, prefix: PrefixHandle) -> None:
+        pass
+
+    def fork_prefix(self, prefix: PrefixHandle) -> PrefixHandle:
+        pass
+
+    def release(self, request: RequestHandle) -> None:
+        pass
+
+    def evict(self, *, target_pages: int | None = None) -> int:
+        pass
+
+    def snapshot(self, prefix: PrefixHandle, *, destination: str) -> SnapshotMetadata:
+        pass
+
+    def restore(self, source: str) -> PrefixHandle:
+        pass
+
+    def metrics(self) -> Mapping[str, int | float | str | None]:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _as_numpy(value: Any) -> Any:
+    """Import NumPy lazily and provide a helpful dependency error."""
+
+    try:
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover - numpy is a project dependency
+        raise RuntimeError("NumPy is required for the attention oracle") from exc
+    return np.asarray(value)
+
+
+def _float32_values(value: Any) -> Any:
+    """Normalize numeric oracle tensors, including native BF16 bit storage."""
+
+    import numpy as np
+
+    array = _as_numpy(value)
+    if array.dtype == np.uint16:
+        # The optional native ABI represents BF16 values as the high 16 bits
+        # of an IEEE float32.  Accepting that representation here lets native
+        # tests compare exactly the same buffers against the reference.
+        return (array.astype(np.uint32) << 16).view(np.float32)
+    return array.astype(np.float32, copy=False)
+
+
+def _mlx_uint16_array(value: Any, mx: Any) -> bool:
+    """Identify MLX arrays carrying the native BF16-bit representation."""
+
+    dtype = getattr(value, "dtype", None)
+    uint16_dtype = getattr(mx, "uint16", None)
+    if uint16_dtype is not None and dtype == uint16_dtype:
+        return True
+    normalized = str(dtype).lower().replace(" ", "")
+    return normalized in {"uint16", "uint16_t"}
+
+
+def _normalize_mlx_input(value: Any, normalized_numpy: Any, mx: Any) -> Any:
+    """Decode native BF16 bits before passing an MLX array to SDPA."""
+
+    if isinstance(value, mx.array):
+        if _mlx_uint16_array(value, mx):
+            # _float32_values interprets uint16 as the upper half of float32.
+            return mx.array(_float32_values(value))
+        return value
+    return mx.array(normalized_numpy)
+
+
+def _validate_paged_inputs(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None,
+) -> tuple[Any, Any, Any, Any, Any, int]:
+    """Validate and normalize oracle input metadata."""
+
+    import numpy as np
+
+    q = _float32_values(query)
+    k = _float32_values(key_pages)
+    v = _float32_values(value_pages)
+    table = _as_numpy(page_table)
+    lengths = _as_numpy(sequence_lengths)
+    if q.ndim != 3:
+        raise ValueError("query must have shape [batch, query_heads, head_dim]")
+    if k.ndim != 4 or v.ndim != 4:
+        raise ValueError(
+            "key_pages and value_pages must have shape "
+            "[page, kv_heads, block, head_dim]"
+        )
+    if k.shape != v.shape:
+        raise ValueError("key_pages and value_pages must have identical shapes")
+    if table.ndim != 2 or lengths.ndim != 1 or table.shape[0] != q.shape[0]:
+        raise ValueError(
+            "page_table/sequence_lengths batch dimensions do not match query"
+        )
+    if lengths.shape[0] != q.shape[0]:
+        raise ValueError("sequence_lengths batch dimension does not match query")
+    if k.shape[2] != block_size:
+        raise ValueError("page tensors do not match block_size")
+    if k.shape[1] <= 0 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("attention head counts and head_dim must be positive")
+    if q.shape[2] != k.shape[3]:
+        raise ValueError("query and page head_dim values do not match")
+    if num_kv_heads is not None and k.shape[1] != num_kv_heads:
+        raise ValueError("page tensor kv head count does not match num_kv_heads")
+    if q.shape[1] % k.shape[1]:
+        raise ValueError("query heads must be divisible by KV heads for GQA")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if not np.issubdtype(table.dtype, np.integer):
+        raise ValueError("page_table must contain integer page indices")
+    if not np.issubdtype(lengths.dtype, np.integer):
+        raise ValueError("sequence_lengths must contain integer lengths")
+    if np.any(lengths < 0):
+        raise ValueError("sequence_lengths cannot be negative")
+    max_tokens = table.shape[1] * block_size
+    if np.any(lengths > max_tokens):
+        raise ValueError("sequence_lengths exceed the page table capacity")
+    if not (np.isfinite(q).all() and np.isfinite(k).all() and np.isfinite(v).all()):
+        raise ValueError(
+            "query, key_pages, and value_pages must contain only finite values"
+        )
+    return q, k, v, table, lengths, k.shape[1]
+
+
+def numpy_paged_decode_attention(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None = None,
+    scale: float | None = None,
+) -> Any:
+    """Compute one-token paged decode attention with a NumPy reference.
+
+    The implementation gathers only the valid tail of each logical sequence,
+    checks every physical page index, and computes a stable softmax in float32.
+    It is a correctness oracle, not a serving implementation.
+    """
+
+    import numpy as np
+
+    q, k, v, table, lengths, kv_heads = _validate_paged_inputs(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+    )
+    batch, query_heads, head_dim = q.shape
+    scale_value = 1.0 / math.sqrt(head_dim) if scale is None else float(scale)
+    output = np.zeros((batch, query_heads, head_dim), dtype=np.float32)
+    group_size = query_heads // kv_heads
+    page_count = k.shape[0]
+
+    for batch_index in range(batch):
+        sequence_length = int(lengths[batch_index])
+        if sequence_length == 0:
+            continue
+
+        logical_blocks = (sequence_length + block_size - 1) // block_size
+        page_ids = table[batch_index, :logical_blocks]
+        if np.any(page_ids < 0) or np.any(page_ids >= page_count):
+            raise ValueError("page_table contains a physical page outside page tensors")
+
+        keys = np.empty((sequence_length, kv_heads, head_dim), dtype=np.float32)
+        values = np.empty_like(keys)
+        cursor = 0
+        for logical_block, page_id_value in enumerate(page_ids):
+            page_id = int(page_id_value)
+            tokens = min(block_size, sequence_length - cursor)
+            keys[cursor : cursor + tokens] = np.transpose(
+                k[page_id, :, :tokens], (1, 0, 2)
+            )
+            values[cursor : cursor + tokens] = np.transpose(
+                v[page_id, :, :tokens], (1, 0, 2)
+            )
+            cursor += tokens
+
+        query_row = q[batch_index].astype(np.float32, copy=False)
+        for query_head in range(query_heads):
+            kv_head = query_head // group_size
+            with np.errstate(over="ignore", invalid="ignore"):
+                logits = (keys[:, kv_head] @ query_row[query_head]) * scale_value
+            if not np.isfinite(logits).all():
+                raise ValueError("attention logits overflow for finite float32 inputs")
+            max_logit = np.max(logits)
+            weights = np.exp(logits - max_logit)
+            denominator = np.sum(weights, dtype=np.float64)
+            if not np.isfinite(denominator) or denominator <= 0:
+                raise ValueError("attention softmax denominator is not finite")
+            weights /= denominator
+            output[batch_index, query_head] = weights @ values[:, kv_head]
+
+    return output
+
+
+def mlx_sdpa_paged_decode_attention(
+    query: Any,
+    key_pages: Any,
+    value_pages: Any,
+    page_table: Any,
+    sequence_lengths: Any,
+    *,
+    block_size: int,
+    num_kv_heads: int | None = None,
+    scale: float | None = None,
+) -> Any:
+    """Run the same paged inputs through MLX's SDPA implementation.
+
+    MLX SDPA uses ``[batch, heads, sequence, head_dim]``.  This adapter gathers
+    each non-contiguous logical sequence and invokes SDPA one request at a time,
+    explicitly expanding grouped KV heads to the query-head count.  That keeps
+    GQA semantics identical to the NumPy oracle and avoids relying on an
+    MLX-version-specific implicit GQA broadcast.
+    """
+
+    try:
+        import mlx.core as mx
+    except ImportError as exc:  # pragma: no cover - exercised on non-Apple CI
+        raise RuntimeError("MLX is required for the MLX SDPA attention oracle") from exc
+
+    q_np, _k_np, _v_np, table_np, lengths_np, _ = _validate_paged_inputs(
+        query,
+        key_pages,
+        value_pages,
+        page_table,
+        sequence_lengths,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+    )
+    q = _normalize_mlx_input(query, q_np, mx)
+    k_pages = _normalize_mlx_input(key_pages, _k_np, mx)
+    v_pages = _normalize_mlx_input(value_pages, _v_np, mx)
+    batch, query_heads, head_dim = q_np.shape
+    scale_value = 1.0 / math.sqrt(head_dim) if scale is None else float(scale)
+    outputs = []
+
+    for batch_index in range(batch):
+        sequence_length = int(lengths_np[batch_index])
+        if sequence_length == 0:
+            outputs.append(mx.zeros((query_heads, head_dim), dtype=q.dtype))
+            continue
+        logical_blocks = (sequence_length + block_size - 1) // block_size
+        page_ids = table_np[batch_index, :logical_blocks]
+        if (page_ids < 0).any() or (page_ids >= int(k_pages.shape[0])).any():
+            raise ValueError("page_table contains a physical page outside page tensors")
+        key_parts = []
+        value_parts = []
+        cursor = 0
+        for page_id_value in page_ids:
+            page_id = int(page_id_value)
+            tokens = min(block_size, sequence_length - cursor)
+            key_parts.append(mx.transpose(k_pages[page_id, :, :tokens], (1, 0, 2)))
+            value_parts.append(mx.transpose(v_pages[page_id, :, :tokens], (1, 0, 2)))
+            cursor += tokens
+        keys = mx.concatenate(key_parts, axis=0)
+        values = mx.concatenate(value_parts, axis=0)
+
+        # MLX SDPA's explicit layout is [batch, heads, sequence, head_dim].
+        q_arg = q[batch_index][None, :, None, :]
+        k_heads = mx.transpose(keys, (1, 0, 2))
+        v_heads = mx.transpose(values, (1, 0, 2))
+        if query_heads != int(k_heads.shape[0]):
+            group_size = query_heads // int(k_heads.shape[0])
+            # Repeat each KV head contiguously: q0/q1 use kv0, q2/q3 use
+            # kv1 for the common 4-query-head/2-KV-head GQA shape.
+            k_heads = mx.concatenate(
+                [
+                    k_heads[index : index + 1]
+                    for index in range(int(k_heads.shape[0]))
+                    for _ in range(group_size)
+                ],
+                axis=0,
+            )
+            v_heads = mx.concatenate(
+                [
+                    v_heads[index : index + 1]
+                    for index in range(int(v_heads.shape[0]))
+                    for _ in range(group_size)
+                ],
+                axis=0,
+            )
+        k_arg = k_heads[None, :, :, :]
+        v_arg = v_heads[None, :, :, :]
+        attended = mx.fast.scaled_dot_product_attention(
+            q_arg,
+            k_arg,
+            v_arg,
+            scale=scale_value,
+        )
+        outputs.append(attended[0, :, 0, :])
+
+    return mx.stack(outputs) if outputs else mx.zeros((0, query_heads, head_dim))
+
+
+__all__ = [
+    "APPLE_SILICON_ARCHITECTURES",
+    "ATTENTION_BACKEND_CHOICES",
+    "AttentionBackendCapabilityError",
+    "AttentionBackendName",
+    "AttentionGeometry",
+    "BackendCapabilities",
+    "BackendSelection",
+    "ContextBackend",
+    "METAL_CONTEXT_ABI_VERSION",
+    "NATIVE_EXTENSION_MODULE",
+    "PageHandle",
+    "PrefixHandle",
+    "RequestHandle",
+    "SnapshotMetadata",
+    "discover_capabilities",
+    "mlx_sdpa_paged_decode_attention",
+    "numpy_paged_decode_attention",
+    "resolve_attention_backend",
+    "validate_attention_backend",
+]

--- a/vllm_mlx/attention_backend.py
+++ b/vllm_mlx/attention_backend.py
@@ -486,6 +486,11 @@ class ContextBackend(Protocol):
     ) -> None:
         pass
 
+    def create_prefix(
+        self, request: RequestHandle, *, token_count: int | None = None
+    ) -> PrefixHandle:
+        pass
+
     def paged_decode_attention(
         self, request: RequestHandle, layer: int, query: Any
     ) -> Any:
@@ -497,7 +502,13 @@ class ContextBackend(Protocol):
     def fork_prefix(self, prefix: PrefixHandle) -> PrefixHandle:
         pass
 
+    def release_prefix(self, prefix: PrefixHandle) -> None:
+        pass
+
     def release(self, request: RequestHandle) -> None:
+        pass
+
+    def cancel(self, request: RequestHandle) -> None:
         pass
 
     def evict(self, *, target_pages: int | None = None) -> int:
@@ -690,9 +701,9 @@ def numpy_paged_decode_attention(
                 logits = (keys[:, kv_head] @ query_row[query_head]) * scale_value
             if not np.isfinite(logits).all():
                 raise ValueError("attention logits overflow for finite float32 inputs")
-            max_logit = np.max(logits)
+            max_logit: np.float32 = np.max(logits)
             weights = np.exp(logits - max_logit)
-            denominator = np.sum(weights, dtype=np.float64)
+            denominator: np.float64 = np.sum(weights, dtype=np.float64)
             if not np.isfinite(denominator) or denominator <= 0:
                 raise ValueError("attention softmax denominator is not finite")
             weights /= denominator

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -22,6 +22,11 @@ from .cli_arg_types import (
     make_positive_int_arg_parser,
     memory_budget_gb_arg,
 )
+from .attention_backend import (
+    ATTENTION_BACKEND_CHOICES,
+    AttentionBackendCapabilityError,
+    resolve_attention_backend,
+)
 from .tool_parsers import ToolParserManager
 
 _TOOL_PARSER_CHOICES = ToolParserManager.list_registered()
@@ -52,14 +57,39 @@ def serve_command(args):
     import os
     import sys
 
+    logger = logging.getLogger(__name__)
+    requested_attention_backend = getattr(args, "attention_backend", "mlx")
+    try:
+        attention_backend = resolve_attention_backend(requested_attention_backend)
+    except AttentionBackendCapabilityError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     import uvicorn
 
-    # Import unified server
+    # Import unified server only after the explicit backend capability check.
     from . import server
     from .model_registry import RegistryServeDefaults
     from .server import RateLimiter, app, load_model, load_model_registry
 
-    logger = logging.getLogger(__name__)
+    # Selection is deliberately separate from scheduler construction.  The
+    # native context runtime is opt-in and its executor is introduced by a
+    # later package; recording the validated selection now makes startup
+    # behavior explicit without changing the MLX execution path.
+    server.configure_attention_backend(attention_backend)
+    if attention_backend.fallback_reason:
+        logger.info(
+            "Attention backend: requested=%s selected=%s (%s)",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+            attention_backend.fallback_reason,
+        )
+    else:
+        logger.info(
+            "Attention backend: requested=%s selected=%s",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+        )
     model_arg = getattr(args, "model", None)
     models_config = getattr(args, "models_config", None)
     memory_budget_gb = getattr(args, "memory_budget_gb", None)
@@ -1090,6 +1120,17 @@ Examples:
         help="Host to bind (default: localhost; use 0.0.0.0 to expose externally)",
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    serve_parser.add_argument(
+        "--attention-backend",
+        type=str,
+        choices=ATTENTION_BACKEND_CHOICES,
+        default="mlx",
+        help=(
+            "Attention execution backend: mlx (default), metal-context "
+            "(explicit opt-in; requires the compiled native extension), or "
+            "auto (currently remains on mlx until qualification passes)."
+        ),
+    )
     serve_parser.add_argument(
         "--max-num-seqs", type=int, default=256, help="Max concurrent sequences"
     )

--- a/vllm_mlx/metal_context_runtime.py
+++ b/vllm_mlx/metal_context_runtime.py
@@ -1,0 +1,1402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase-two page ownership runtime for the optional Metal Context Engine.
+
+This module is deliberately below the scheduler boundary.  It owns physical
+KV pages, request page tables, prefix references, copy-on-write, and the
+low-level decode call, but it does not know about HTTP requests, sampling, or
+continuous batching.
+
+The runtime has two explicit execution modes:
+
+``native``
+    Require the optional :mod:`vllm_mlx._metal_context` extension and dispatch
+    its compiled paged-decode kernel.  A missing capability or a native
+    dispatch error is surfaced to the caller; there is no implicit fallback.
+
+``numpy``
+    Use the checked-in NumPy oracle for lifecycle and ownership tests on
+    machines without Metal.  This mode is intentionally explicit and is not a
+    serving fallback.
+
+In native mode this class is an adapter around the compiled
+``_metal_context.PageRuntime``.  It does not allocate a second Python KV pool
+or maintain a parallel native page table.
+
+The page storage uses the native foundation's logical layout, one physical
+page shared by all layers:
+
+``[page, layer, kv_head, block_offset, head_dim]`` (BF16 bits as ``uint16``)
+
+``append_kv`` accepts ``[tokens, kv_heads, head_dim]`` values.  Prefixes are
+immutable views of page chains.  If a request writes into a page referenced by
+another request or prefix, the complete page is copied before the write.
+Persistence/snapshot support is intentionally not implemented in this
+package; that is the next PR-stack package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import wraps
+import importlib
+import math
+import platform
+import threading
+from typing import (
+    Any,
+    Callable,
+    Concatenate,
+    Literal,
+    Mapping,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+    cast,
+)
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .attention_backend import (
+    AttentionGeometry,
+    BackendCapabilities,
+    ContextBackend,
+    METAL_CONTEXT_ABI_VERSION,
+    NATIVE_EXTENSION_MODULE,
+    PageHandle,
+    PrefixHandle,
+    RequestHandle,
+    SnapshotMetadata,
+    numpy_paged_decode_attention,
+)
+
+ExecutionMode = Literal["native", "numpy"]
+_INT32_MAX = int(np.iinfo(np.int32).max)
+_P = ParamSpec("_P")
+_Self = TypeVar("_Self", bound="_LockOwner")
+_Return = TypeVar("_Return")
+
+
+class _LockOwner(Protocol):
+    _lock: threading.RLock
+
+
+def _locked(
+    method: Callable[Concatenate[_Self, _P], _Return],
+) -> Callable[Concatenate[_Self, _P], _Return]:
+    """Serialize all mutable page-runtime operations with the instance lock."""
+
+    def wrapper(self: _Self, *args: _P.args, **kwargs: _P.kwargs) -> _Return:
+        with self._lock:
+            return method(self, *args, **kwargs)
+
+    # ``functools.wraps`` preserves the public method metadata, while the
+    # typeshed wrapper protocol cannot express the ParamSpec-preserving
+    # decorator result precisely on every supported Python version.
+    wrapped = wraps(method)(wrapper)
+    return cast(Callable[Concatenate[_Self, _P], _Return], wrapped)
+
+
+class MetalContextRuntimeError(RuntimeError):
+    """Base error for page-runtime lifecycle failures."""
+
+
+class MetalContextCapabilityError(MetalContextRuntimeError):
+    """Raised when explicit native execution cannot be used."""
+
+
+@dataclass(slots=True)
+class _PageState:
+    refcount: int = 0
+    last_used: int = 0
+
+
+@dataclass(slots=True)
+class _RequestState:
+    request_id: str
+    max_tokens: int
+    pages: list[int] = field(default_factory=list)
+    layer_lengths: list[int] = field(default_factory=list)
+
+    @property
+    def length(self) -> int:
+        return max(self.layer_lengths, default=0)
+
+
+@dataclass(slots=True, frozen=True)
+class _PrefixState:
+    pages: tuple[int, ...]
+    token_count: int
+
+
+def _native_capabilities(
+    native_module: Any,
+    *,
+    execution: ExecutionMode,
+) -> BackendCapabilities:
+    """Validate and normalize the small native capability ABI."""
+
+    probe = getattr(native_module, "capabilities", None)
+    if not callable(probe):
+        raise MetalContextCapabilityError(
+            f"{NATIVE_EXTENSION_MODULE} does not expose capabilities()"
+        )
+    try:
+        raw = probe()
+    except Exception as exc:  # pragma: no cover - native-only failures
+        detail = str(exc).strip() or exc.__class__.__name__
+        raise MetalContextCapabilityError(
+            f"the native capability probe failed: {detail}"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise MetalContextCapabilityError(
+            "the native capability probe returned a non-mapping result"
+        )
+
+    abi = raw.get("abi_version")
+    abi_version = abi if isinstance(abi, int) and not isinstance(abi, bool) else None
+    advertised = bool(raw.get("available", False))
+    metal_device = bool(raw.get("metal_device", advertised))
+    compiled = bool(raw.get("compiled", True))
+    reasons: list[str] = []
+    if not compiled:
+        reasons.append("the optional native extension is not compiled")
+    if not metal_device:
+        reasons.append("no usable Metal device was reported")
+    if abi_version != METAL_CONTEXT_ABI_VERSION:
+        reasons.append(
+            f"native ABI {abi_version!r} does not match required ABI "
+            f"{METAL_CONTEXT_ABI_VERSION}"
+        )
+    if not advertised:
+        reason = raw.get("reason")
+        if isinstance(reason, str) and reason.strip():
+            reasons.append(reason.strip())
+        else:
+            reasons.append("the native extension did not advertise availability")
+
+    if execution == "native" and (
+        not compiled
+        or not advertised
+        or not metal_device
+        or abi_version != METAL_CONTEXT_ABI_VERSION
+    ):
+        detail = "; ".join(dict.fromkeys(reasons))
+        raise MetalContextCapabilityError(
+            "the Metal Context page runtime was explicitly configured for native "
+            f"execution but is unavailable: {detail}"
+        )
+
+    reason_value = raw.get("reason")
+    reason = (
+        reason_value.strip()
+        if isinstance(reason_value, str) and reason_value.strip()
+        else None
+    )
+    if reasons and not advertised:
+        reason = "; ".join(dict.fromkeys(reasons))
+    return BackendCapabilities(
+        platform="darwin",
+        native_extension=compiled,
+        metal_device=metal_device,
+        abi_version=abi_version,
+        available=(
+            advertised
+            and compiled
+            and metal_device
+            and abi_version == METAL_CONTEXT_ABI_VERSION
+        ),
+        # The foundation intentionally reports serving_ready=False until the
+        # scheduler executor is qualified.  This page runtime is a component,
+        # not a claim that production serving is ready.
+        serving_ready=bool(raw.get("serving_ready", False)),
+        reason=reason,
+        architecture=platform.machine().lower(),
+        probed=True,
+    )
+
+
+def _oracle_capabilities() -> BackendCapabilities:
+    return BackendCapabilities(
+        platform=platform.system().lower(),
+        native_extension=False,
+        metal_device=False,
+        abi_version=None,
+        available=False,
+        serving_ready=False,
+        reason="explicit NumPy oracle execution; native dispatch is disabled",
+        architecture=platform.machine().lower(),
+        probed=False,
+    )
+
+
+def _bf16_bits(value: Any, *, name: str) -> NDArray[np.uint16]:
+    """Convert finite values to the native BF16 upper-bit representation."""
+
+    array = np.asarray(value)
+    if array.dtype.kind == "u" and array.dtype.itemsize == 2:
+        if array.dtype.byteorder not in ("=", "<", "|"):
+            raise ValueError(f"{name} must use native-endian uint16 BF16 storage")
+        result: NDArray[np.uint16] = np.ascontiguousarray(array)
+        exponent_all_ones = (result & np.uint16(0x7F80)) == np.uint16(0x7F80)
+        if bool(np.any(exponent_all_ones)):
+            raise ValueError(f"{name} must contain only finite BF16 values")
+        return result
+
+    try:
+        float_values = np.asarray(array, dtype=np.float32)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must be numeric BF16-compatible data") from exc
+    if not bool(np.isfinite(float_values).all()):
+        raise ValueError(f"{name} must contain only finite values")
+    # Truncation matches the native foundation's documented conversion.  It is
+    # deterministic and avoids a hidden float16/float32 storage mode.
+    result = np.ascontiguousarray(
+        (float_values.view(np.uint32) >> np.uint32(16)).astype(np.uint16)
+    )
+    return result
+
+
+def _query_bits(
+    value: Any, *, expected_heads: int, head_dim: int
+) -> tuple[np.ndarray, bool]:
+    array = _bf16_bits(value, name="query")
+    if array.ndim == 2:
+        if array.shape != (expected_heads, head_dim):
+            raise ValueError(
+                "query must have shape [query_heads, 128] or " "[1, query_heads, 128]"
+            )
+        return array[None, ...], True
+    if array.ndim == 3 and array.shape == (1, expected_heads, head_dim):
+        return array, False
+    raise ValueError(
+        "query must have shape [query_heads, 128] or [1, query_heads, 128]"
+    )
+
+
+class MetalContextPageRuntime(ContextBackend):
+    """Own phase-two physical KV pages and dispatch phase-one attention.
+
+    Args:
+        geometry: Supported Qwen dense/MoE attention geometry.
+        max_pages: Number of preallocated physical pages.
+        execution: ``"native"`` requires the compiled extension.  ``"numpy"``
+            is an explicit oracle mode for portable lifecycle tests.
+        native_module: Optional injected module implementing the foundation
+            ``capabilities()``, ``paged_decode()``, and ``shutdown()`` ABI.
+
+    The class is intentionally not connected to a scheduler.  Requests are
+    opaque integer handles and are never serialized to disk.
+    """
+
+    # These fields are deliberately only materialized by the NumPy oracle.
+    # Class annotations keep the oracle-only methods type-checkable without
+    # creating a second lifecycle authority on native instances.
+    _keys: np.ndarray
+    _values: np.ndarray
+    _pages: list[_PageState]
+    _free_pages: set[int]
+    _requests: dict[int, _RequestState]
+    _prefixes: dict[int, _PrefixState]
+    _released_requests: set[int]
+    _released_prefixes: set[int]
+    _next_request: int
+    _next_prefix: int
+    _clock: int
+    _request_ids: set[str]
+    _counters: dict[str, int | float]
+
+    def __init__(
+        self,
+        geometry: AttentionGeometry,
+        *,
+        max_pages: int,
+        execution: ExecutionMode = "native",
+        native_module: Any | None = None,
+        max_blocks_per_request: int | None = None,
+        max_requests: int = 64,
+    ) -> None:
+        geometry.validate()
+        if execution not in ("native", "numpy"):
+            raise ValueError("execution must be 'native' or 'numpy'")
+        if (
+            not isinstance(max_pages, int)
+            or isinstance(max_pages, bool)
+            or max_pages <= 0
+        ):
+            raise ValueError("max_pages must be a positive integer")
+        if max_pages > _INT32_MAX:
+            raise ValueError("max_pages must not exceed INT32_MAX")
+        if max_blocks_per_request is None:
+            max_blocks_per_request = max_pages
+        if (
+            not isinstance(max_blocks_per_request, int)
+            or isinstance(max_blocks_per_request, bool)
+            or max_blocks_per_request <= 0
+        ):
+            raise ValueError("max_blocks_per_request must be a positive integer")
+        if max_blocks_per_request > _INT32_MAX // geometry.block_size:
+            raise ValueError(
+                "max_blocks_per_request * block_size exceeds the int32 sequence "
+                "limit"
+            )
+        if (
+            not isinstance(max_requests, int)
+            or isinstance(max_requests, bool)
+            or max_requests <= 0
+        ):
+            raise ValueError("max_requests must be a positive integer")
+
+        self.geometry = geometry
+        self.max_pages = max_pages
+        self.max_blocks_per_request = max_blocks_per_request
+        self.max_requests = max_requests
+        self.execution: ExecutionMode = execution
+        self._lock = threading.RLock()
+        self._native_module = native_module
+        self._native_runtime: Any | None = None
+        if execution == "native":
+            if native_module is None:
+                try:
+                    native_module = importlib.import_module(NATIVE_EXTENSION_MODULE)
+                except (ImportError, OSError) as exc:
+                    detail = str(exc).strip() or exc.__class__.__name__
+                    raise MetalContextCapabilityError(
+                        "the Metal Context page runtime was explicitly configured "
+                        f"for native execution but {NATIVE_EXTENSION_MODULE} "
+                        f"could not be loaded: {detail}"
+                    ) from exc
+            self._native_module = native_module
+            self._capabilities = _native_capabilities(
+                native_module, execution=execution
+            )
+            page_runtime_type = getattr(native_module, "PageRuntime", None)
+            if not callable(page_runtime_type):
+                raise MetalContextCapabilityError(
+                    f"{NATIVE_EXTENSION_MODULE} does not expose PageRuntime"
+                )
+            try:
+                self._native_runtime = page_runtime_type(
+                    num_layers=geometry.num_layers,
+                    num_attention_heads=geometry.num_attention_heads,
+                    num_key_value_heads=geometry.num_key_value_heads,
+                    head_dim=geometry.head_dim,
+                    block_size=geometry.block_size,
+                    max_pages=max_pages,
+                    max_blocks_per_request=max_blocks_per_request,
+                    max_requests=max_requests,
+                )
+            except (MemoryError, ValueError, RuntimeError):
+                raise
+            except Exception as exc:  # pragma: no cover - native-only failures
+                detail = str(exc).strip() or exc.__class__.__name__
+                raise MetalContextRuntimeError(
+                    f"could not construct the native page runtime: {detail}"
+                ) from exc
+        else:
+            self._capabilities = _oracle_capabilities()
+
+        self._shutdown = False
+        if execution == "numpy":
+            # The arrays are intentionally page-major and layer-major to make
+            # the page table passed to the oracle a direct physical index.
+            # Native mode never creates these parallel Python-owned buffers.
+            storage_shape = (
+                max_pages,
+                geometry.num_layers,
+                geometry.num_key_value_heads,
+                geometry.block_size,
+                geometry.head_dim,
+            )
+            try:
+                self._keys = np.zeros(storage_shape, dtype=np.uint16)
+                self._values = np.zeros(storage_shape, dtype=np.uint16)
+            except (MemoryError, ValueError) as exc:
+                raise MemoryError(
+                    "Metal Context page runtime could not allocate its preallocated "
+                    f"KV storage for {max_pages} pages"
+                ) from exc
+
+            self._pages = [_PageState() for _ in range(max_pages)]
+            self._free_pages: set[int] = set(range(max_pages))
+            self._requests: dict[int, _RequestState] = {}
+            self._prefixes: dict[int, _PrefixState] = {}
+            self._released_requests: set[int] = set()
+            self._released_prefixes: set[int] = set()
+            self._next_request = 1
+            self._next_prefix = 1
+            self._clock = 0
+            self._request_ids: set[str] = set()
+            self._counters: dict[str, int | float] = {
+                "pages_allocated": 0,
+                "pages_freed": 0,
+                "append_tokens": 0,
+                # ``dispatches``/``dispatch_failures`` are the stable totals
+                # for this backend.  The mode-specific fields make the
+                # source of the total explicit and are kept in parity with
+                # native metrics.
+                "dispatches": 0,
+                "dispatch_failures": 0,
+                "native_dispatches": 0,
+                "native_failures": 0,
+                "oracle_dispatches": 0,
+                "oracle_failures": 0,
+                "evictions": 0,
+                "cow_events": 0,
+                "oom_events": 0,
+                "release_calls": 0,
+                "released_requests": 0,
+                "cancellations": 0,
+                "prefix_attaches": 0,
+                "prefix_forks": 0,
+                "prefix_tokens_attached": 0,
+                "attention_validation_bytes": 0,
+                "metadata_bytes": 0,
+                "decode_page_resolution_checks": 0,
+                "snapshot_failures": 0,
+                "restore_failures": 0,
+            }
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        return self._capabilities
+
+    @_locked
+    def validate(self, geometry: AttentionGeometry) -> None:
+        geometry.validate()
+        if geometry != self.geometry:
+            raise ValueError(
+                "page runtime geometry does not match its preallocated storage"
+            )
+
+    def _ensure_open(self) -> None:
+        if self._shutdown:
+            raise MetalContextRuntimeError("Metal Context page runtime is shut down")
+
+    @staticmethod
+    def _handle(value: Any, *, name: str) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise KeyError(f"unknown {name} handle {value!r}")
+        return int(value)
+
+    def _request(self, request: RequestHandle) -> tuple[int, _RequestState]:
+        request_id = self._handle(request, name="request")
+        state = self._requests.get(request_id)
+        if state is None:
+            if request_id in self._released_requests:
+                raise KeyError(f"request handle {request_id} was released")
+            raise KeyError(f"unknown request handle {request_id}")
+        return request_id, state
+
+    def _prefix(self, prefix: PrefixHandle) -> tuple[int, _PrefixState]:
+        prefix_id = self._handle(prefix, name="prefix")
+        state = self._prefixes.get(prefix_id)
+        if state is None:
+            if prefix_id in self._released_prefixes:
+                raise KeyError(f"prefix handle {prefix_id} was released")
+            raise KeyError(f"unknown prefix handle {prefix_id}")
+        return prefix_id, state
+
+    def _native_request_id(self, request: RequestHandle) -> int:
+        """Validate only the immutable Python representation of a handle.
+
+        Generation/slot liveness is owned by the compiled runtime.  Keeping a
+        second Python request map here would create a stale ownership authority.
+        """
+
+        return self._handle(request, name="request")
+
+    def _native_prefix_id(self, prefix: PrefixHandle) -> int:
+        """Validate only the immutable Python representation of a handle."""
+
+        return self._handle(prefix, name="prefix")
+
+    def _touch(self, page_id: int) -> None:
+        self._clock += 1
+        self._pages[page_id].last_used = self._clock
+
+    def _plan_page_ids(self, count: int, *, record_oom: bool = True) -> tuple[int, ...]:
+        if count < 0:
+            raise ValueError("page count cannot be negative")
+        free = sorted(self._free_pages)
+        if count <= len(free):
+            return tuple(free[:count])
+        evictable = sorted(
+            (
+                state.last_used,
+                page_id,
+            )
+            for page_id, state in enumerate(self._pages)
+            if state.refcount == 0 and page_id not in self._free_pages
+        )
+        needed = count - len(free)
+        if needed > len(evictable):
+            if record_oom:
+                self._counters["oom_events"] += 1
+            raise MemoryError(
+                "Metal Context page runtime is out of pages: "
+                f"requested {count}, available {len(free) + len(evictable)}"
+            )
+        return tuple(free + [page_id for _, page_id in evictable[:needed]])
+
+    def _reserve_pages(
+        self,
+        count: int,
+        *,
+        page_ids: tuple[int, ...] | None = None,
+        record_oom: bool = True,
+    ) -> tuple[int, ...]:
+        selected = (
+            self._plan_page_ids(count, record_oom=record_oom)
+            if page_ids is None
+            else page_ids
+        )
+        if len(selected) != count:
+            raise MetalContextRuntimeError("page reservation plan has wrong size")
+        # Deterministic allocation makes page-table and COW tests reproducible.
+        for page_id in selected:
+            if page_id not in self._free_pages:
+                if self._pages[page_id].refcount != 0:
+                    raise MetalContextRuntimeError(
+                        "page reservation selected a referenced page"
+                    )
+                self._counters["evictions"] += 1
+                self._counters["pages_freed"] += 1
+            else:
+                self._free_pages.remove(page_id)
+            self._pages[page_id] = _PageState(refcount=1, last_used=0)
+            self._keys[page_id].fill(0)
+            self._values[page_id].fill(0)
+            self._touch(page_id)
+        self._counters["pages_allocated"] += count
+        return selected
+
+    @_locked
+    def allocate_request(self, request_id: str, *, max_tokens: int) -> RequestHandle:
+        self._ensure_open()
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise ValueError("request_id must be a non-empty string")
+        if self.execution == "numpy" and request_id in self._request_ids:
+            raise ValueError(f"request_id {request_id!r} is already active")
+        if (
+            not isinstance(max_tokens, int)
+            or isinstance(max_tokens, bool)
+            or max_tokens <= 0
+        ):
+            raise ValueError("max_tokens must be a positive integer")
+        if max_tokens > _INT32_MAX:
+            raise ValueError("max_tokens must not exceed INT32_MAX")
+        capacity = self.max_blocks_per_request * self.geometry.block_size
+        if max_tokens > capacity:
+            raise ValueError(
+                "max_tokens must be no greater than the configured page-table "
+                f"capacity ({capacity})"
+            )
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            handle = self._native_runtime.allocate_request(
+                request_id=request_id, max_tokens=max_tokens
+            )
+            # The compiled runtime publishes a valid generation/slot handle
+            # atomically.  No Python lifecycle entry is created after this
+            # call, so there is no adapter state that can diverge on OOM.
+            handle_id = self._handle(handle, name="request")
+            return RequestHandle(handle_id)
+        if len(self._requests) >= self.max_requests:
+            raise MemoryError("request capacity exhausted")
+        handle = self._next_request
+        self._next_request += 1
+        self._requests[handle] = _RequestState(
+            request_id=request_id,
+            max_tokens=max_tokens,
+            layer_lengths=[0] * self.geometry.num_layers,
+        )
+        self._request_ids.add(request_id)
+        return RequestHandle(handle)
+
+    @_locked
+    def allocate_pages(
+        self, request: RequestHandle, count: int
+    ) -> tuple[PageHandle, ...]:
+        self._ensure_open()
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+                raise ValueError("page count must be a non-negative integer")
+            request_id = self._native_request_id(request)
+            if count == 0:
+                return ()
+            pages = self._native_runtime.allocate_pages(request=request_id, count=count)
+            if len(pages) != count:
+                raise MetalContextRuntimeError(
+                    "native page runtime returned an unexpected page count"
+                )
+            if not isinstance(pages, tuple) or not all(
+                isinstance(page, int) and not isinstance(page, bool) and page >= 0
+                for page in pages
+            ):
+                raise MetalContextRuntimeError(
+                    "native page runtime returned malformed page handles"
+                )
+            # The compiled bridge returns an immutable tuple.  Reuse it
+            # directly so no Python lifecycle bookkeeping follows mutation.
+            typed_pages: tuple[PageHandle, ...] = pages
+            return typed_pages
+        _, state = self._request(request)
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError("page count must be a non-negative integer")
+        if count == 0:
+            return ()
+        capacity = math.ceil(state.max_tokens / self.geometry.block_size)
+        if len(state.pages) + count > capacity:
+            raise ValueError(
+                "requested pages exceed the request max_tokens capacity "
+                f"({capacity} pages)"
+            )
+        page_ids = self._reserve_pages(count)
+        state.pages.extend(page_ids)
+        return tuple(PageHandle(page_id) for page_id in page_ids)
+
+    def _normalize_kv_arrays(
+        self, layer: int, keys: Any, values: Any
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if not isinstance(layer, int) or isinstance(layer, bool):
+            raise ValueError("layer must be an integer")
+        if layer < 0 or layer >= self.geometry.num_layers:
+            raise ValueError(f"layer must be in [0, {self.geometry.num_layers})")
+        key_bits = _bf16_bits(keys, name="keys")
+        value_bits = _bf16_bits(values, name="values")
+        expected_tail = (
+            self.geometry.num_key_value_heads,
+            self.geometry.head_dim,
+        )
+        if key_bits.ndim != 3 or key_bits.shape[1:] != expected_tail:
+            raise ValueError("keys must have shape [tokens, num_key_value_heads, 128]")
+        if value_bits.shape != key_bits.shape:
+            raise ValueError("keys and values must have identical shapes")
+        return key_bits, value_bits
+
+    def _normalize_append(
+        self, request: _RequestState, layer: int, keys: Any, values: Any
+    ) -> tuple[np.ndarray, np.ndarray]:
+        key_bits, value_bits = self._normalize_kv_arrays(layer, keys, values)
+        if request.layer_lengths[layer] + key_bits.shape[0] > request.max_tokens:
+            raise ValueError("append would exceed request max_tokens")
+        return key_bits, value_bits
+
+    def _cow_for_range(
+        self, request: _RequestState, start: int, token_count: int
+    ) -> None:
+        if token_count == 0:
+            return
+        first_page = start // self.geometry.block_size
+        last_page = (start + token_count - 1) // self.geometry.block_size
+        if last_page >= len(request.pages):
+            missing = last_page + 1 - len(request.pages)
+            capacity = math.ceil(request.max_tokens / self.geometry.block_size)
+            if len(request.pages) + missing > capacity:
+                raise MemoryError(
+                    "Metal Context page runtime has no page capacity for append"
+                )
+        else:
+            missing = 0
+        shared_positions = [
+            position
+            for position in range(first_page, min(last_page + 1, len(request.pages)))
+            if self._pages[request.pages[position]].refcount > 1
+        ]
+        needed = missing + len(shared_positions)
+        if needed == 0:
+            return
+        # Plan every missing and COW page before mutating free lists,
+        # references, page tables, data, or metrics.  This is important for a
+        # request that needs one new page and one COW page when only one free
+        # page remains.
+        planned = self._plan_page_ids(needed, record_oom=False)
+        missing_ids = planned[:missing]
+        cow_ids = planned[missing:]
+        staged_copies = [
+            (
+                np.array(self._keys[request.pages[position]], copy=True),
+                np.array(self._values[request.pages[position]], copy=True),
+            )
+            for position in shared_positions
+        ]
+        self._reserve_pages(needed, page_ids=planned, record_oom=False)
+        new_pages = list(request.pages) + list(missing_ids)
+        for position, new_page_id, (key_copy, value_copy) in zip(
+            shared_positions, cow_ids, staged_copies
+        ):
+            old_page_id = request.pages[position]
+            self._keys[new_page_id] = key_copy
+            self._values[new_page_id] = value_copy
+            new_pages[position] = new_page_id
+            self._pages[old_page_id].refcount -= 1
+            self._touch(new_page_id)
+        request.pages[:] = new_pages
+        self._counters["cow_events"] += len(shared_positions)
+
+    @_locked
+    def append_kv(
+        self,
+        request: RequestHandle,
+        layer: int,
+        keys: Any,
+        values: Any,
+    ) -> None:
+        self._ensure_open()
+        if self.execution == "native":
+            key_bits, value_bits = self._normalize_kv_arrays(layer, keys, values)
+            assert self._native_runtime is not None
+            request_id = self._native_request_id(request)
+            self._native_runtime.append_kv(
+                request=request_id,
+                layer=layer,
+                keys=key_bits,
+                values=value_bits,
+            )
+            return
+        _, state = self._request(request)
+        key_bits, value_bits = self._normalize_append(state, layer, keys, values)
+        start = state.layer_lengths[layer]
+        token_count = int(key_bits.shape[0])
+        first_page = start // self.geometry.block_size
+        last_page = (
+            (start + token_count - 1) // self.geometry.block_size
+            if token_count
+            else first_page
+        )
+        existing_positions = range(first_page, min(last_page + 1, len(state.pages)))
+        missing = max(0, last_page + 1 - len(state.pages)) if token_count else 0
+        shared = [
+            position
+            for position in existing_positions
+            if self._pages[state.pages[position]].refcount > 1
+        ]
+        needed = missing + len(shared)
+        capacity = math.ceil(state.max_tokens / self.geometry.block_size)
+        if len(state.pages) + missing > capacity:
+            raise MemoryError(
+                "Metal Context page runtime has no page capacity for append"
+            )
+        # Preflight all page capacity before changing any ownership, data, or
+        # metrics.  In particular, a shared one-token prefix followed by a
+        # 17-token append needs both a new tail page and a COW page.
+        planned = self._plan_page_ids(needed, record_oom=False)
+        affected = {state.pages[position] for position in existing_positions}
+        affected.update(planned)
+        page_state_snapshot = {
+            page_id: _PageState(
+                refcount=self._pages[page_id].refcount,
+                last_used=self._pages[page_id].last_used,
+            )
+            for page_id in affected
+        }
+        data_snapshot = {
+            page_id: (
+                np.array(self._keys[page_id], copy=True),
+                np.array(self._values[page_id], copy=True),
+            )
+            for page_id in affected
+        }
+        free_snapshot = set(self._free_pages)
+        counters_snapshot = dict(self._counters)
+        clock_snapshot = self._clock
+        pages_snapshot = list(state.pages)
+        lengths_snapshot = list(state.layer_lengths)
+        try:
+            self._cow_for_range(state, start, token_count)
+
+            remaining = token_count
+            cursor = 0
+            while remaining:
+                token_position = start + cursor
+                page_position = token_position // self.geometry.block_size
+                page_offset = token_position % self.geometry.block_size
+                tokens = min(remaining, self.geometry.block_size - page_offset)
+                page_id = state.pages[page_position]
+                self._keys[page_id, layer, :, page_offset : page_offset + tokens, :] = (
+                    np.transpose(key_bits[cursor : cursor + tokens], (1, 0, 2))
+                )
+                self._values[
+                    page_id, layer, :, page_offset : page_offset + tokens, :
+                ] = np.transpose(value_bits[cursor : cursor + tokens], (1, 0, 2))
+                self._touch(page_id)
+                cursor += tokens
+                remaining -= tokens
+            state.layer_lengths[layer] += token_count
+            self._counters["append_tokens"] += token_count
+        except BaseException:
+            # Restore every observable part of the failed append, including
+            # evictions, refcounts, page-table ownership, storage bytes, and
+            # counters.  The preflight makes this path rare; it is retained so
+            # an unexpected buffer/assignment failure cannot expose a partial
+            # request state.
+            state.pages[:] = pages_snapshot
+            state.layer_lengths[:] = lengths_snapshot
+            self._free_pages = free_snapshot
+            self._clock = clock_snapshot
+            self._counters.clear()
+            self._counters.update(counters_snapshot)
+            for page_id, page_state in page_state_snapshot.items():
+                self._pages[page_id] = page_state
+                self._keys[page_id] = data_snapshot[page_id][0]
+                self._values[page_id] = data_snapshot[page_id][1]
+            raise
+
+    def _page_table(self, state: _RequestState, token_count: int) -> NDArray[np.int32]:
+        blocks = math.ceil(token_count / self.geometry.block_size)
+        if blocks > len(state.pages):
+            raise ValueError(
+                "request page table is shorter than its KV sequence; allocate_pages "
+                "before decoding"
+            )
+        table: NDArray[np.int32] = np.full((1, blocks), -1, dtype=np.int32)
+        if blocks:
+            table[0, :blocks] = np.asarray(state.pages[:blocks], dtype=np.int32)
+        return table
+
+    def paged_decode_attention(
+        self, request: RequestHandle, layer: int, query: Any
+    ) -> Any:
+        if not isinstance(layer, int) or isinstance(layer, bool):
+            raise ValueError("layer must be an integer")
+        if layer < 0 or layer >= self.geometry.num_layers:
+            raise ValueError(f"layer must be in [0, {self.geometry.num_layers})")
+        query_bits, squeeze = _query_bits(
+            query,
+            expected_heads=self.geometry.num_attention_heads,
+            head_dim=self.geometry.head_dim,
+        )
+        if self.execution == "native":
+            return self._paged_decode_native(
+                request, layer, query_bits, squeeze=squeeze
+            )
+        with self._lock:
+            self._ensure_open()
+            _, state = self._request(request)
+            token_count = state.layer_lengths[layer]
+            if token_count == 0:
+                output: NDArray[np.float32] = np.zeros(
+                    (1, self.geometry.num_attention_heads, self.geometry.head_dim),
+                    dtype=np.float32,
+                )
+                return output[0] if squeeze else output
+
+            table = self._page_table(state, token_count)
+            lengths = np.asarray([token_count], dtype=np.int32)
+            key_pages = np.ascontiguousarray(self._keys[:, layer])
+            value_pages = np.ascontiguousarray(self._values[:, layer])
+            scale = 1.0 / math.sqrt(self.geometry.head_dim)
+
+            try:
+                output = numpy_paged_decode_attention(
+                    query_bits,
+                    key_pages,
+                    value_pages,
+                    table,
+                    lengths,
+                    block_size=self.geometry.block_size,
+                    num_kv_heads=self.geometry.num_key_value_heads,
+                    scale=scale,
+                )
+            except Exception:
+                self._counters["oracle_failures"] += 1
+                self._counters["dispatch_failures"] += 1
+                raise
+            self._counters["oracle_dispatches"] += 1
+            self._counters["dispatches"] += 1
+            # Decode is a read reference and therefore makes the page recently
+            # used, but it never changes ownership or page contents.
+            for page_id in state.pages[
+                : math.ceil(token_count / self.geometry.block_size)
+            ]:
+                self._touch(page_id)
+            return output[0] if squeeze else output
+
+    def _paged_decode_native(
+        self,
+        request: RequestHandle,
+        layer: int,
+        query_bits: np.ndarray,
+        *,
+        squeeze: bool,
+    ) -> Any:
+        """Dispatch native decode outside the Python lifecycle lock.
+
+        The compiled runtime owns its own request/page/dispatch locks and
+        tracks in-flight dispatches through shutdown.  Python only protects
+        the short handle validation/capture section; holding ``self._lock``
+        across the native call would serialize otherwise independent requests.
+        """
+
+        with self._lock:
+            self._ensure_open()
+            assert self._native_runtime is not None
+            request_id = self._native_request_id(request)
+            native_runtime = self._native_runtime
+
+        raw_output = native_runtime.paged_decode(
+            request=request_id,
+            layer=layer,
+            query=query_bits[0],
+            scale=1.0 / math.sqrt(self.geometry.head_dim),
+        )
+        expected = (
+            self.geometry.num_attention_heads
+            * self.geometry.head_dim
+            * np.dtype(np.float32).itemsize
+        )
+        if not isinstance(raw_output, (bytes, bytearray, memoryview)):
+            raise MetalContextRuntimeError(
+                "native page runtime paged_decode returned a non-bytes result"
+            )
+        if len(raw_output) != expected:
+            raise MetalContextRuntimeError(
+                "native page runtime paged_decode returned an unexpected "
+                f"output length: expected {expected}, got {len(raw_output)}"
+            )
+        output = np.frombuffer(raw_output, dtype=np.float32).reshape(
+            (1, self.geometry.num_attention_heads, self.geometry.head_dim)
+        )
+        return output[0] if squeeze else output
+
+    @_locked
+    def create_prefix(
+        self, request: RequestHandle, *, token_count: int | None = None
+    ) -> PrefixHandle:
+        """Create an immutable shared prefix view from a live request."""
+
+        self._ensure_open()
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            request_id = self._native_request_id(request)
+            if token_count is not None and (
+                not isinstance(token_count, int)
+                or isinstance(token_count, bool)
+                or token_count <= 0
+            ):
+                raise ValueError(
+                    "token_count must equal the request's fully populated "
+                    "positive sequence length"
+                )
+            native_length = int(self._native_runtime.sequence_length(request_id))
+            if token_count is not None and token_count != native_length:
+                raise ValueError(
+                    "token_count must equal the request's fully populated "
+                    "sequence length"
+                )
+            prefix = self._native_runtime.create_prefix(request_id)
+            prefix_id = self._handle(prefix, name="prefix")
+            return PrefixHandle(prefix_id)
+        _, state = self._request(request)
+        if (
+            not state.layer_lengths
+            or state.layer_lengths[0] == 0
+            or len(set(state.layer_lengths)) > 1
+        ):
+            raise ValueError(
+                "prefix creation requires all layers to have equal, non-zero "
+                "populated lengths"
+            )
+        if token_count is None:
+            token_count = state.length
+        if (
+            not isinstance(token_count, int)
+            or isinstance(token_count, bool)
+            or token_count <= 0
+        ):
+            raise ValueError(
+                "token_count must equal the request's fully populated "
+                "positive sequence length"
+            )
+        if token_count != state.length:
+            raise ValueError(
+                "token_count must equal the request's fully populated "
+                "sequence length"
+            )
+        blocks = math.ceil(token_count / self.geometry.block_size)
+        if blocks > len(state.pages):
+            raise ValueError("request has no pages for the requested prefix")
+        pages = tuple(state.pages[:blocks])
+        for page_id in pages:
+            self._pages[page_id].refcount += 1
+            self._touch(page_id)
+        prefix_id = self._next_prefix
+        self._next_prefix += 1
+        self._prefixes[prefix_id] = _PrefixState(pages=pages, token_count=token_count)
+        return PrefixHandle(prefix_id)
+
+    @_locked
+    def attach_prefix(self, request: RequestHandle, prefix: PrefixHandle) -> None:
+        self._ensure_open()
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            request_id = self._native_request_id(request)
+            prefix_id = self._native_prefix_id(prefix)
+            self._native_runtime.attach_prefix(request_id, prefix_id)
+            return
+        _, request_state = self._request(request)
+        _, prefix_state = self._prefix(prefix)
+        if request_state.pages or any(request_state.layer_lengths):
+            raise ValueError("prefixes can only be attached to an empty request")
+        required_blocks = len(prefix_state.pages)
+        capacity = math.ceil(request_state.max_tokens / self.geometry.block_size)
+        if required_blocks > capacity:
+            raise ValueError("prefix exceeds request max_tokens capacity")
+        for page_id in prefix_state.pages:
+            self._pages[page_id].refcount += 1
+            self._touch(page_id)
+        request_state.pages.extend(prefix_state.pages)
+        request_state.layer_lengths[:] = [
+            prefix_state.token_count
+        ] * self.geometry.num_layers
+        self._counters["prefix_attaches"] += 1
+        self._counters["prefix_tokens_attached"] += prefix_state.token_count
+
+    @_locked
+    def fork_prefix(self, prefix: PrefixHandle) -> PrefixHandle:
+        self._ensure_open()
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            prefix_id = self._native_prefix_id(prefix)
+            forked = self._native_runtime.fork_prefix(prefix_id)
+            forked_id = self._handle(forked, name="prefix")
+            return PrefixHandle(forked_id)
+        _, prefix_state = self._prefix(prefix)
+        for page_id in prefix_state.pages:
+            self._pages[page_id].refcount += 1
+            self._touch(page_id)
+        prefix_id = self._next_prefix
+        self._next_prefix += 1
+        self._prefixes[prefix_id] = _PrefixState(
+            pages=prefix_state.pages,
+            token_count=prefix_state.token_count,
+        )
+        self._counters["prefix_forks"] += 1
+        return PrefixHandle(prefix_id)
+
+    @_locked
+    def release_prefix(self, prefix: PrefixHandle) -> None:
+        """Release a prefix handle; repeated release is an idempotent no-op."""
+
+        if self.execution == "native":
+            self._ensure_open()
+            prefix_id = self._handle(prefix, name="prefix")
+            assert self._native_runtime is not None
+            self._native_runtime.release_prefix(prefix_id)
+            return
+        prefix_id = self._handle(prefix, name="prefix")
+        if prefix_id in self._released_prefixes:
+            return
+        state = self._prefixes.pop(prefix_id, None)
+        if state is None:
+            raise KeyError(f"unknown prefix handle {prefix_id}")
+        for page_id in state.pages:
+            self._pages[page_id].refcount -= 1
+            if self._pages[page_id].refcount < 0:  # pragma: no cover - invariant guard
+                raise MetalContextRuntimeError("page reference count became negative")
+        self._released_prefixes.add(prefix_id)
+
+    @_locked
+    def release(self, request: RequestHandle) -> None:
+        """Release a request and its page references exactly once."""
+
+        request_id = self._handle(request, name="request")
+        if self.execution == "native":
+            self._ensure_open()
+            assert self._native_runtime is not None
+            self._native_runtime.release(request=request_id)
+            return
+        self._counters["release_calls"] += 1
+        if request_id in self._released_requests:
+            return
+        state = self._requests.pop(request_id, None)
+        if state is None:
+            raise KeyError(f"unknown request handle {request_id}")
+        for page_id in state.pages:
+            self._pages[page_id].refcount -= 1
+            if self._pages[page_id].refcount < 0:  # pragma: no cover - invariant guard
+                raise MetalContextRuntimeError("page reference count became negative")
+        self._released_requests.add(request_id)
+        self._request_ids.discard(state.request_id)
+        self._counters["released_requests"] += 1
+
+    @_locked
+    def cancel(self, request: RequestHandle) -> None:
+        """Cancel and release a request, preserving idempotent ownership."""
+
+        request_id = self._handle(request, name="request")
+        if self.execution == "native":
+            self._ensure_open()
+            assert self._native_runtime is not None
+            cancel = getattr(self._native_runtime, "cancel", None)
+            if not callable(cancel):
+                raise MetalContextRuntimeError(
+                    "native page runtime does not expose cancel"
+                )
+            cancel(request=request_id)
+            return
+        if request_id in self._released_requests:
+            return
+        self._counters["cancellations"] += 1
+        self.release(RequestHandle(request_id))
+
+    @_locked
+    def evict(self, *, target_pages: int | None = None) -> int:
+        """Evict unreferenced pages in LRU order and return the count."""
+
+        self._ensure_open()
+        if target_pages is not None and (
+            not isinstance(target_pages, int)
+            or isinstance(target_pages, bool)
+            or target_pages < 0
+        ):
+            raise ValueError("target_pages must be a non-negative integer or None")
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            if target_pages is None:
+                evicted = int(self._native_runtime.evict())
+            else:
+                evicted = int(self._native_runtime.evict(target_pages=target_pages))
+            return evicted
+        candidates = sorted(
+            (
+                state.last_used,
+                page_id,
+            )
+            for page_id, state in enumerate(self._pages)
+            if state.refcount == 0 and page_id not in self._free_pages
+        )
+        limit = len(candidates) if target_pages is None else target_pages
+        evicted = 0
+        for _, page_id in candidates[:limit]:
+            self._keys[page_id].fill(0)
+            self._values[page_id].fill(0)
+            self._pages[page_id] = _PageState()
+            self._free_pages.add(page_id)
+            evicted += 1
+        self._counters["evictions"] += evicted
+        self._counters["pages_freed"] += evicted
+        return evicted
+
+    @_locked
+    def snapshot(self, prefix: PrefixHandle, *, destination: str) -> SnapshotMetadata:
+        if self.execution == "native":
+            prefix_id = self._native_prefix_id(prefix)
+            assert self._native_runtime is not None
+            # The native bridge owns the authoritative failure counter and
+            # fail-closed persistence error for the native execution mode.
+            native_snapshot = getattr(self._native_runtime, "snapshot", None)
+            if callable(native_snapshot):
+                native_snapshot(prefix=prefix_id, destination=destination)
+            else:
+                raise NotImplementedError(
+                    "Metal Context page-runtime snapshots are deferred to the "
+                    "persistence package; no page bytes are written by this "
+                    "backend"
+                )
+            raise AssertionError("native snapshot unexpectedly returned")
+        del prefix, destination
+        self._counters["snapshot_failures"] += 1
+        raise NotImplementedError(
+            "Metal Context page-runtime snapshots are deferred to the persistence "
+            "package; no page bytes are written by this backend"
+        )
+
+    @_locked
+    def restore(self, source: str) -> PrefixHandle:
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            native_restore = getattr(self._native_runtime, "restore", None)
+            if callable(native_restore):
+                native_restore(source=source)
+            else:
+                raise NotImplementedError(
+                    "Metal Context page-runtime restore is deferred to the "
+                    "persistence package; arbitrary Python objects are never "
+                    "deserialized"
+                )
+            raise AssertionError("native restore unexpectedly returned")
+        del source
+        self._counters["restore_failures"] += 1
+        raise NotImplementedError(
+            "Metal Context page-runtime restore is deferred to the persistence "
+            "package; arbitrary Python objects are never deserialized"
+        )
+
+    @_locked
+    def metrics(self) -> Mapping[str, int | float | str | None]:
+        """Return stable ownership/dispatch metrics without exposing objects."""
+
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            # Native metrics remain the sole ownership/counter authority.  The
+            # adapter only adds stable aliases required by ContextBackend; it
+            # never merges a second Python counter set into these values.
+            raw = self._native_runtime.metrics()
+            native_result: dict[str, int | float | str | None] = dict(raw)
+
+            def native_count(name: str, fallback: int = 0) -> int:
+                value = native_result.get(name, fallback)
+                if not isinstance(value, int) or isinstance(value, bool):
+                    return fallback
+                return value
+
+            dispatches = max(
+                native_count("dispatches"), native_count("native_dispatches")
+            )
+            failures = max(
+                native_count("dispatch_failures"), native_count("native_failures")
+            )
+            evictions = native_count("evictions")
+            releases = native_count("releases")
+            cancellations = native_count("cancellations")
+            native_result.update(
+                {
+                    "backend": "metal-context",
+                    "execution": "native",
+                    "abi_version": self.capabilities.abi_version,
+                    "capability_reason": self.capabilities.reason,
+                    "block_size": native_count("block_size", self.geometry.block_size),
+                    "head_dim": self.geometry.head_dim,
+                    "native_available": self.capabilities.available,
+                    "dispatches": dispatches,
+                    "dispatch_failures": failures,
+                    "native_dispatches": dispatches,
+                    "native_failures": failures,
+                    "oracle_dispatches": 0,
+                    "oracle_failures": 0,
+                    "pages_allocated": native_count(
+                        "pages_allocated", native_count("page_allocations")
+                    ),
+                    "pages_freed": native_count("pages_freed", evictions),
+                    "append_tokens": native_count("append_tokens"),
+                    "evictions": evictions,
+                    "cow_events": native_count("cow_events"),
+                    "oom_events": native_count("oom_events"),
+                    "release_calls": native_count(
+                        "release_calls", releases + cancellations
+                    ),
+                    "released_requests": native_count(
+                        "released_requests", releases + cancellations
+                    ),
+                    "cancellations": cancellations,
+                    "prefix_attaches": native_count("prefix_attaches"),
+                    "prefix_forks": native_count("prefix_forks"),
+                    "prefix_tokens_attached": native_count("prefix_tokens_attached"),
+                    "snapshot_failures": native_count("snapshot_failures"),
+                    "restore_failures": native_count("restore_failures"),
+                    "max_pages": native_count("max_pages", self.max_pages),
+                    "max_blocks_per_request": native_count(
+                        "max_blocks_per_request", self.max_blocks_per_request
+                    ),
+                }
+            )
+            return native_result
+
+        resident = self.max_pages - len(self._free_pages)
+        referenced = sum(state.refcount > 0 for state in self._pages)
+        shared = sum(state.refcount > 1 for state in self._pages)
+        oracle_result: dict[str, int | float | str | None] = {
+            "backend": "metal-context",
+            "execution": self.execution,
+            "abi_version": self.capabilities.abi_version,
+            "capability_reason": self.capabilities.reason,
+            "resident_pages": resident,
+            "referenced_pages": referenced,
+            "shared_pages": shared,
+            "free_pages": len(self._free_pages),
+            "requests": len(self._requests),
+            "prefixes": len(self._prefixes),
+            "max_pages": self.max_pages,
+            "block_size": self.geometry.block_size,
+            "kv_dtype": self.geometry.kv_dtype,
+            "head_dim": self.geometry.head_dim,
+            "native_available": self.capabilities.available,
+            "shutdown": self._shutdown,
+        }
+        oracle_result.update(self._counters)
+        return oracle_result
+
+    @_locked
+    def shutdown(self) -> None:
+        """Release all ownership and native resources; safe to repeat."""
+
+        if self._shutdown:
+            return
+        if self.execution == "native":
+            assert self._native_runtime is not None
+            self._native_runtime.shutdown()
+            self._shutdown = True
+            return
+        # Mark handles released through the normal reference path before
+        # dropping tables, so a caller cannot accidentally reuse ownership.
+        for request_id in tuple(self._requests):
+            self.release(RequestHandle(request_id))
+        for prefix_id in tuple(self._prefixes):
+            self.release_prefix(PrefixHandle(prefix_id))
+        self._keys.fill(0)
+        self._values.fill(0)
+        self._free_pages = set(range(self.max_pages))
+        self._shutdown = True
+
+    @_locked
+    def page_table(
+        self, request: RequestHandle, *, layer: int = 0
+    ) -> NDArray[np.int32]:
+        """Return a copy of a request's logical page table for diagnostics/tests."""
+
+        self._ensure_open()
+        if not isinstance(layer, int) or isinstance(layer, bool):
+            raise ValueError("layer must be an integer")
+        if layer < 0 or layer >= self.geometry.num_layers:
+            raise ValueError(f"layer must be in [0, {self.geometry.num_layers})")
+        if self.execution == "native":
+            request_id = self._native_request_id(request)
+            assert self._native_runtime is not None
+            # The compiled runtime owns per-layer sequence lengths and returns
+            # the already-truncated logical page chain for this layer.  Do not
+            # reconstruct a second page-table authority in Python.
+            raw = cast(
+                NDArray[np.int32],
+                np.asarray(
+                    self._native_runtime.page_table(request_id, layer),
+                    dtype=np.int32,
+                ),
+            )
+            if raw.ndim != 1:
+                raw = cast(NDArray[np.int32], raw.reshape(-1))
+            native_result = cast(NDArray[np.int32], raw.reshape(1, raw.size).copy())
+            return native_result
+        _, state = self._request(request)
+        oracle_result = cast(
+            NDArray[np.int32],
+            self._page_table(state, state.layer_lengths[layer]).copy(),
+        )
+        return oracle_result
+
+    @_locked
+    def page_refcounts(self) -> tuple[int, ...]:
+        """Return physical-page reference counts without exposing page storage."""
+
+        if self.execution == "native":
+            raise NotImplementedError(
+                "native page references are opaque; use metrics() for ownership"
+            )
+        return tuple(state.refcount for state in self._pages)
+
+    def __enter__(self) -> "MetalContextPageRuntime":
+        self._ensure_open()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.shutdown()
+
+
+__all__ = [
+    "ExecutionMode",
+    "MetalContextCapabilityError",
+    "MetalContextPageRuntime",
+    "MetalContextRuntimeError",
+]

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -159,6 +159,12 @@ from .cli_arg_types import (
     make_json_object_arg_parser,
     make_positive_int_arg_parser,
 )
+from .attention_backend import (
+    ATTENTION_BACKEND_CHOICES,
+    AttentionBackendCapabilityError,
+    BackendSelection,
+    resolve_attention_backend,
+)
 from .engine import BaseEngine, BatchedEngine, GenerationOutput, SimpleEngine
 from .endpoint_model_policies import (
     resolve_embedding_model_name,
@@ -209,6 +215,10 @@ _default_min_p: float | None = None  # Set via --default-min-p
 _default_presence_penalty: float | None = None  # Set via --default-presence-penalty
 _default_repetition_penalty: float | None = None  # Set via --default-repetition-penalty
 _metrics_enabled = False
+# Backend selection is configured during CLI startup.  Keeping this separate
+# from the scheduler preserves the existing MLX route until a qualified native
+# executor is introduced.
+_attention_backend_selection: BackendSelection | None = None
 _max_audio_upload_bytes: int = DEFAULT_MAX_AUDIO_UPLOAD_BYTES
 _max_tts_input_chars: int = DEFAULT_MAX_TTS_INPUT_CHARS
 _force_mllm_model: bool = False
@@ -228,6 +238,34 @@ _FALLBACK_TOP_K = 0
 _FALLBACK_MIN_P = 0.0
 _FALLBACK_PRESENCE_PENALTY = 0.0
 _FALLBACK_REPETITION_PENALTY = 1.0
+
+
+def configure_attention_backend(selection: BackendSelection) -> None:
+    """Record the startup backend decision for status and future executors."""
+
+    if selection.selected.value == "metal-context" and (
+        not selection.capabilities.available or not selection.capabilities.serving_ready
+    ):
+        raise AttentionBackendCapabilityError(
+            selection.selected, selection.capabilities
+        )
+    global _attention_backend_selection
+    _attention_backend_selection = selection
+
+
+def _attention_backend_status() -> dict[str, object]:
+    """Return backend selection without probing or changing runtime state."""
+
+    selection = _attention_backend_selection
+    if selection is None:
+        return {
+            "requested": "mlx",
+            "selected": "mlx",
+            "fallback": False,
+            "fallback_reason": None,
+            "capabilities": None,
+        }
+    return selection.as_dict()
 
 
 def _resolve_temperature(request_value: float | None) -> float:
@@ -3613,6 +3651,7 @@ async def health():
             else "llm"
         ),
         "engine_type": engine_stats.get("engine_type", "unknown"),
+        "attention_backend": _attention_backend_status(),
         "mcp": mcp_info,
     }
     if lifecycle is not None:
@@ -3663,6 +3702,7 @@ async def status():
                 "models": _model_manager.list_models(),
             },
             "embedding": _embedding_status(),
+            "attention_backend": _attention_backend_status(),
         }
     lifecycle = _public_lifecycle_status(_get_lifecycle_status())
     if _engine is None:
@@ -3672,6 +3712,7 @@ async def status():
             "residency": lifecycle,
             "requests": [],
             "embedding": _embedding_status(),
+            "attention_backend": _attention_backend_status(),
         }
 
     stats = _engine.get_stats()
@@ -3684,6 +3725,7 @@ async def status():
         "model": _model_name,
         "residency": lifecycle,
         "embedding": _embedding_status(),
+        "attention_backend": _attention_backend_status(),
         "uptime_s": round(stats.get("uptime_seconds", 0), 1),
         "steps_executed": stats.get("steps_executed", 0),
         "num_running": stats.get("num_running", 0),
@@ -6848,6 +6890,27 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
 
+    try:
+        attention_backend = resolve_attention_backend(
+            getattr(args, "attention_backend", "mlx")
+        )
+    except AttentionBackendCapabilityError as exc:
+        parser.error(str(exc))
+    configure_attention_backend(attention_backend)
+    if attention_backend.fallback_reason:
+        logger.info(
+            "Attention backend: requested=%s selected=%s (%s)",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+            attention_backend.fallback_reason,
+        )
+    else:
+        logger.info(
+            "Attention backend: requested=%s selected=%s",
+            attention_backend.requested.value,
+            attention_backend.selected.value,
+        )
+
     # Set global configuration
     global _api_key, _default_timeout, _rate_limiter, _metrics_enabled
     global _default_temperature, _default_top_p, _default_chat_template_kwargs
@@ -6997,6 +7060,17 @@ Examples:
         type=int,
         default=8000,
         help="Port to bind to",
+    )
+    parser.add_argument(
+        "--attention-backend",
+        type=str,
+        choices=ATTENTION_BACKEND_CHOICES,
+        default="mlx",
+        help=(
+            "Attention execution backend: mlx (default), metal-context "
+            "(explicit opt-in; requires the compiled native extension), or "
+            "auto (currently remains on mlx until qualification passes)."
+        ),
     )
     parser.add_argument(
         "--mllm",


### PR DESCRIPTION
## Summary

This is PR 2 of the Metal Context Engine stack and is stacked on #721. It adds the native KV page ownership/runtime layer below the future scheduler integration. Once #721 lands, this PR diff will reduce to the page-runtime commit.

- preallocates BF16 per-layer KV storage and device-visible page/sequence tables
- adds request/page allocation, append, prefix attach/fork, copy-on-write, release, cancellation, eviction, metrics, and deterministic teardown
- delegates native mode to the compiled PageRuntime as the single ownership authority; NumPy remains an explicit correctness oracle only
- keeps decode free of capacity-sized KV copies, per-dispatch Metal buffer allocations, and host context traversal
- adds transactional OOM and CPython result-allocation rollback, generation-safe handles, numerical envelope guards, and concurrency-safe lifecycle handling
- does not wire the runtime into the scheduler, change serving defaults, add persistence, or make performance claims

## Verification

- independent adversarial review: SHIP
- focused backend/native/page-runtime tests: 83 passed, 9 skipped
- complete upstream suite: 2738 passed, 34 skipped, 27 deselected
- strict scoped mypy: passed
- Ruff, Black, and git diff --check: passed
- native extension and harnesses: -Wall -Wextra -Wpedantic -Werror compile/link passed
- ASAN offset, prefix-fork, and concurrency/deadlock harnesses: passed
- source-distribution contents: verified

## Qualification boundary

This host had no usable Metal compiler/GPU, so actual shader dispatch remains covered by the Apple CI jobs and still requires qualified-device performance/numerical evidence before scheduler integration or any production/default-routing claim. The runtime remains unconnected to serving and opt-in development work only.

Do not merge before #721. Wayner retains architectural and merge approval.