### PR TITLE
fix(mllm): dispatch assistant-drafter loading by architecture instead of hardcoding Gemma 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
             tests/test_qwen3_xml_registration.py \
             tests/test_qwen3_xml_streaming_chunks.py \
             tests/test_qwen35_mtp_hidden_state_mode.py \
+            tests/test_mllm_assistant_drafter_loader.py \
             tests/test_streaming_fence_stripper.py \
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \

--- a/tests/test_mllm_assistant_drafter_loader.py
+++ b/tests/test_mllm_assistant_drafter_loader.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for load_assistant_drafter's config-driven architecture
+dispatch (ex load_gemma4_assistant_drafter — see fix/mllm-draft-loader-
+architecture-dispatch).
+
+These test the dispatch logic itself (config.json -> mlx_vlm.utils.load_model),
+not real weight loading — mlx_vlm.utils.load_model is monkeypatched so no
+actual model architecture or safetensors content is needed. The existing
+tests in test_mllm_assistant_drafter.py cover chat-time drafter wiring and
+inject `_draft_model` directly, bypassing this loader entirely; these tests
+cover the loader itself, which nothing previously exercised.
+"""
+
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def _write_drafter_checkpoint(tmp_path, model_type: str):
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": model_type}))
+    (tmp_path / "model.safetensors").write_bytes(b"")
+    return tmp_path
+
+
+@pytest.mark.parametrize("model_type", ["gemma4_assistant", "qwen3_5_mtp", "eagle3"])
+def test_load_assistant_drafter_dispatches_any_model_type_through_load_model(
+    tmp_path, monkeypatch, model_type
+):
+    """No architecture is hardcoded: every model_type goes through the same
+    mlx_vlm.utils.load_model call, just with a different config.json."""
+    from vllm_mlx.models.mllm import load_assistant_drafter
+
+    drafter_path = _write_drafter_checkpoint(tmp_path, model_type)
+    captured = {}
+
+    class FakeDrafterModel:
+        def eval(self):
+            captured["eval_called"] = True
+            return self
+
+    def fake_load_model(path):
+        captured["path"] = path
+        return FakeDrafterModel()
+
+    monkeypatch.setitem(
+        sys.modules, "mlx_vlm.utils", SimpleNamespace(load_model=fake_load_model)
+    )
+
+    result = load_assistant_drafter(str(drafter_path))
+
+    assert captured["path"] == drafter_path
+    assert captured["eval_called"] is True
+    assert isinstance(result, FakeDrafterModel)
+
+
+def test_load_assistant_drafter_missing_config_raises_file_not_found(tmp_path):
+    from vllm_mlx.models.mllm import load_assistant_drafter
+
+    (tmp_path / "model.safetensors").write_bytes(b"")
+
+    with pytest.raises(FileNotFoundError, match="config"):
+        load_assistant_drafter(str(tmp_path))
+
+
+def test_load_assistant_drafter_missing_weights_raises_file_not_found(tmp_path):
+    from vllm_mlx.models.mllm import load_assistant_drafter
+
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3_5_mtp"}))
+
+    with pytest.raises(FileNotFoundError, match="weights"):
+        load_assistant_drafter(str(tmp_path))
+
+
+def test_load_assistant_drafter_missing_mlx_vlm_raises_import_error(
+    tmp_path, monkeypatch
+):
+    from vllm_mlx.models.mllm import load_assistant_drafter
+
+    drafter_path = _write_drafter_checkpoint(tmp_path, "qwen3_5_mtp")
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", None)
+
+    with pytest.raises(ImportError, match="mlx-vlm"):
+        load_assistant_drafter(str(drafter_path))

--- a/tests/test_mllm_assistant_drafter_loader.py
+++ b/tests/test_mllm_assistant_drafter_loader.py
@@ -24,12 +24,19 @@ def _write_drafter_checkpoint(tmp_path, model_type: str):
     return tmp_path
 
 
-@pytest.mark.parametrize("model_type", ["gemma4_assistant", "qwen3_5_mtp", "eagle3"])
-def test_load_assistant_drafter_dispatches_any_model_type_through_load_model(
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "gemma4_assistant",
+        "gemma4_unified_assistant",
+        "qwen3_5_mtp",
+        "deepseek_v4_mtp",
+    ],
+)
+def test_load_assistant_drafter_dispatches_mtp_model_type_through_load_model(
     tmp_path, monkeypatch, model_type
 ):
-    """No architecture is hardcoded: every model_type goes through the same
-    mlx_vlm.utils.load_model call, just with a different config.json."""
+    """Every supported MTP model type uses the generic mlx-vlm loader."""
     from vllm_mlx.models.mllm import load_assistant_drafter
 
     drafter_path = _write_drafter_checkpoint(tmp_path, model_type)
@@ -46,6 +53,11 @@ def test_load_assistant_drafter_dispatches_any_model_type_through_load_model(
 
     monkeypatch.setitem(
         sys.modules, "mlx_vlm.utils", SimpleNamespace(load_model=fake_load_model)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.speculative.drafters",
+        SimpleNamespace(resolve_drafter_kind=lambda path: "mtp"),
     )
 
     result = load_assistant_drafter(str(drafter_path))
@@ -82,4 +94,35 @@ def test_load_assistant_drafter_missing_mlx_vlm_raises_import_error(
     monkeypatch.setitem(sys.modules, "mlx_vlm.utils", None)
 
     with pytest.raises(ImportError, match="mlx-vlm"):
+        load_assistant_drafter(str(drafter_path))
+
+
+@pytest.mark.parametrize(
+    ("model_type", "resolved_kind"),
+    [("eagle3", "eagle3"), ("qwen3_dflash", "dflash")],
+)
+def test_load_assistant_drafter_rejects_non_mtp_kind(
+    tmp_path, monkeypatch, model_type, resolved_kind
+):
+    from vllm_mlx.models.mllm import load_assistant_drafter
+
+    drafter_path = _write_drafter_checkpoint(tmp_path, model_type)
+
+    def fake_load_model(path):
+        raise AssertionError("A non-MTP checkpoint must be rejected before loading")
+
+    def fake_resolve_drafter_kind(path):
+        assert path == drafter_path
+        return resolved_kind
+
+    monkeypatch.setitem(
+        sys.modules, "mlx_vlm.utils", SimpleNamespace(load_model=fake_load_model)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.speculative.drafters",
+        SimpleNamespace(resolve_drafter_kind=fake_resolve_drafter_kind),
+    )
+
+    with pytest.raises(ValueError, match=f"requires draft kind {resolved_kind!r}"):
         load_assistant_drafter(str(drafter_path))

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -414,46 +414,51 @@ def _stream_mllm_generated_outputs(
     )
 
 
-def load_gemma4_assistant_drafter(model_path: str):
-    """Load a Gemma 4 assistant drafter for mlx-vlm speculative decoding."""
+def load_assistant_drafter(model_path: str):
+    """Load an mlx-vlm assistant/MTP drafter for speculative decoding.
+
+    Dispatches by the drafter checkpoint's own ``config.json`` ``model_type``
+    (via ``mlx_vlm.utils.load_model``, the same generic loader mlx-vlm uses
+    for its own regular models) instead of assuming a single fixed
+    architecture. This covers every drafter family mlx-vlm ships under
+    ``mlx_vlm.speculative.drafters`` (``gemma4_assistant``, ``qwen3_5_mtp``,
+    ``eagle3``, ``deepseek_v4_mtp``, ...) with one code path, and any new
+    family mlx-vlm adds later needs no change here.
+
+    Deliberately uses ``load_model`` rather than ``mlx_vlm.utils.load``:
+    standalone assistant/MTP drafters are small predictor heads, not
+    full checkpoints, and typically don't ship their own tokenizer/processor
+    files (they reuse the target model's) — ``load`` would additionally try
+    to load a processor and fail or misbehave for such a checkpoint.
+    """
     try:
-        import mlx.core as mx
-        from mlx_vlm.speculative.drafters import gemma4_assistant as arch
+        from mlx_vlm.utils import load_model
     except ImportError as exc:
         raise ImportError(
-            "Gemma 4 assistant drafter support requires an mlx-vlm build that "
-            "provides mlx_vlm.speculative.drafters.gemma4_assistant."
+            "Assistant/MTP drafter support requires mlx-vlm to be installed."
         ) from exc
 
     try:
         mlx_vlm_version = version("mlx-vlm")
     except PackageNotFoundError:
         mlx_vlm_version = "unknown"
+
+    path = Path(model_path)
+    config_path = path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Assistant drafter config not found: {config_path}")
+    if not sorted(path.glob("*.safetensors")):
+        raise FileNotFoundError(f"Assistant drafter weights not found: {path}")
+
+    model_type = json.loads(config_path.read_text(encoding="utf-8")).get("model_type")
     logger.info(
-        "Loading Gemma 4 assistant drafter from %s using mlx-vlm %s",
+        "Loading %s assistant drafter from %s using mlx-vlm %s",
+        model_type or "unknown-architecture",
         model_path,
         mlx_vlm_version,
     )
 
-    path = Path(model_path)
-    config_path = path / "config.json"
-    weight_paths = sorted(path.glob("*.safetensors"))
-    if not config_path.exists():
-        raise FileNotFoundError(f"Gemma 4 assistant config not found: {config_path}")
-    if not weight_paths:
-        raise FileNotFoundError(f"Gemma 4 assistant weights not found: {path}")
-
-    config = arch.ModelConfig.from_dict(
-        json.loads(config_path.read_text(encoding="utf-8"))
-    )
-    model = arch.Model(config)
-    weights = {}
-    for weight_path in weight_paths:
-        weights.update(mx.load(str(weight_path)))
-    if hasattr(model, "sanitize"):
-        weights = model.sanitize(weights)
-    model.load_weights(list(weights.items()))
-    mx.eval(model.parameters())
+    model = load_model(path)
     model.eval()
     return model
 
@@ -1401,7 +1406,7 @@ class MLXMultimodalLM:
 
     def _load_draft_model(self):
         if self.draft_kind == "mtp":
-            return load_gemma4_assistant_drafter(self.draft_model_path)
+            return load_assistant_drafter(self.draft_model_path)
 
         from mlx_vlm.utils import load
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -420,10 +420,10 @@ def load_assistant_drafter(model_path: str):
     Dispatches by the drafter checkpoint's own ``config.json`` ``model_type``
     (via ``mlx_vlm.utils.load_model``, the same generic loader mlx-vlm uses
     for its own regular models) instead of assuming a single fixed
-    architecture. This covers every drafter family mlx-vlm ships under
+    architecture. This covers the MTP drafter families mlx-vlm ships under
     ``mlx_vlm.speculative.drafters`` (``gemma4_assistant``, ``qwen3_5_mtp``,
-    ``eagle3``, ``deepseek_v4_mtp``, ...) with one code path, and any new
-    family mlx-vlm adds later needs no change here.
+    ``deepseek_v4_mtp``, ...) with one code path. Other speculative modes such
+    as Eagle3 and DFlash require generation paths vllm-mlx does not expose yet.
 
     Deliberately uses ``load_model`` rather than ``mlx_vlm.utils.load``:
     standalone assistant/MTP drafters are small predictor heads, not
@@ -431,7 +431,15 @@ def load_assistant_drafter(model_path: str):
     files (they reuse the target model's) — ``load`` would additionally try
     to load a processor and fail or misbehave for such a checkpoint.
     """
+    path = Path(model_path)
+    config_path = path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Assistant drafter config not found: {config_path}")
+    if not sorted(path.glob("*.safetensors")):
+        raise FileNotFoundError(f"Assistant drafter weights not found: {path}")
+
     try:
+        from mlx_vlm.speculative.drafters import resolve_drafter_kind
         from mlx_vlm.utils import load_model
     except ImportError as exc:
         raise ImportError(
@@ -443,14 +451,13 @@ def load_assistant_drafter(model_path: str):
     except PackageNotFoundError:
         mlx_vlm_version = "unknown"
 
-    path = Path(model_path)
-    config_path = path / "config.json"
-    if not config_path.exists():
-        raise FileNotFoundError(f"Assistant drafter config not found: {config_path}")
-    if not sorted(path.glob("*.safetensors")):
-        raise FileNotFoundError(f"Assistant drafter weights not found: {path}")
-
     model_type = json.loads(config_path.read_text(encoding="utf-8")).get("model_type")
+    resolved_kind = resolve_drafter_kind(path)
+    if resolved_kind != "mtp":
+        raise ValueError(
+            f"Assistant drafter model_type={model_type!r} requires draft kind "
+            f"{resolved_kind!r}; vllm-mlx currently supports only 'mtp'."
+        )
     logger.info(
         "Loading %s assistant drafter from %s using mlx-vlm %s",
         model_type or "unknown-architecture",


### PR DESCRIPTION
# fix(mllm): dispatch assistant-drafter loading by architecture instead of hardcoding Gemma 4

## Summary

`MLXMultimodalLM._load_draft_model()` calls `load_gemma4_assistant_drafter()` for every `--mllm-draft-model`, regardless of `--mllm-draft-kind`. That function unconditionally imports `mlx_vlm.speculative.drafters.gemma4_assistant` and builds that one architecture. Any assistant drafter that isn't Gemma-4-shaped — e.g. a Qwen3.5-MTP standalone drafter such as `lukaskremla/Qwen3.8-27B-MTP-6bit-MLX` — fails to load, even though mlx-vlm itself already ships a matching `mlx_vlm.speculative.drafters.qwen3_5_mtp` architecture and a generic, quantization-aware loader (`mlx_vlm.utils.load_model`) that already knows how to pick it.

This PR replaces the hand-rolled Gemma-4-only loading with a call to `mlx_vlm.utils.load_model()`, mlx-vlm's own generic loader — the same one it uses for its regular (non-drafter) models — which already resolves the architecture from the checkpoint's `config.json` `model_type` and handles quantization. One function now covers every drafter family mlx-vlm ships, including the Gemma 4 assistant drafters that previously worked; nothing is hardcoded to one architecture any more.

## Problem

Given a target model (`--mllm`) and a standalone Qwen3.5-MTP drafter:

```
vllm-mlx serve <qwen3.8-27B target> --mllm \
  --mllm-draft-model <qwen3.8-27B MTP drafter, 6-bit> \
  --mllm-draft-kind mtp
```

Loading fails:

```
File "vllm_mlx/models/mllm.py", line 1404, in _load_draft_model
    return load_gemma4_assistant_drafter(self.draft_model_path)
File "vllm_mlx/models/mllm.py", line 455, in load_gemma4_assistant_drafter
    model.load_weights(list(weights.items()))
File "mlx/nn/layers/base.py", line 185, in load_weights
    raise ValueError(f"Received {num_extra} parameters not in model: \n{extras}.")
ValueError: Received 31 parameters not in model:
fc.biases, fc.scales, fc.weight,
layers.0.input_layernorm.weight,
layers.0.mlp.down_proj.{biases,scales,weight}, ...
```

(Line numbers as of `origin/main` `b281bee`, 2026-08-22 — the original reproduction was against the released `vllm-mlx==0.4.0` PyPI package, whose line numbers differ slightly; verified the call chain and error message are otherwise identical between the two.)

`load_gemma4_assistant_drafter()` builds `mlx_vlm.speculative.drafters.gemma4_assistant.Model(config)` and calls `load_weights()` on it directly — the drafter's checkpoint uses standard Qwen decoder-layer key names (`layers.N.self_attn.*`, `layers.N.mlp.*`, ...), which don't exist on the Gemma-4 assistant architecture at all, hence "not in model" rather than a shape mismatch.

Even after pointing the loader at the correct architecture (`mlx_vlm.speculative.drafters.qwen3_5_mtp`) by hand, loading still fails for a *quantized* checkpoint (this one is 6-bit): the model is built with plain `Linear` layers, but the checkpoint's tensors include `.scales`/`.biases` (`QuantizedLinear`). `load_gemma4_assistant_drafter()` never calls `nn.quantize()` before `load_weights()` — presumably because Gemma 4 assistant drafters have so far only shipped unquantized (bf16), so this was never exercised.

`mlx_vlm.utils.load_model()` already handles both problems: it selects the architecture class from the checkpoint's own `model_type` and calls `nn.quantize(..., group_size, bits, mode)` before `load_weights()` whenever `config.json` carries a `quantization` block. `_load_draft_model()` just never calls it.

`--mllm-draft-kind` currently only has one valid choice (`mtp`) — the CLI doesn't distinguish drafter *families* at all yet, only whether a drafter is configured.

## Fix

`vllm_mlx/models/mllm.py`:

- `load_gemma4_assistant_drafter(model_path)` renamed to `load_assistant_drafter(model_path)` and rewritten: instead of importing `mlx_vlm.speculative.drafters.gemma4_assistant` directly and hand-rolling `Model(config)` + `load_weights()`, it now just calls `mlx_vlm.utils.load_model(Path(model_path))`. That function already resolves the architecture from the checkpoint's own `config.json` `model_type` against every family mlx-vlm ships under `mlx_vlm.speculative.drafters` (`gemma4_assistant`, `qwen3_5_mtp`, `eagle3`, `deepseek_v4_mtp`, ...), and — unlike the old hand-rolled path — quantizes before `load_weights()` whenever the checkpoint carries a `quantization` block. Existence checks for `config.json`/`*.safetensors` are kept (same `FileNotFoundError`s as before, checked first so the error names the actual missing file rather than surfacing whatever `load_model` would raise). `_load_draft_model()`'s single call site updated to the new name; no other change there — it still only calls this for `draft_kind == "mtp"`, unchanged.
- Deliberately does **not** use `mlx_vlm.utils.load()` (the higher-level function already used for every other `draft_kind` in `_load_draft_model()`'s `else` branch): `load()` additionally loads a processor/tokenizer, which standalone assistant/MTP drafters typically don't ship (they reuse the target model's) — this was presumably why the original code hand-rolled the Gemma-4 path instead of reusing that existing `else` branch.

No change to `--mllm-draft-kind`'s CLI surface, to `cli.py`'s validation, or to the scheduling/accept-reject logic in `vllm_mlx/scheduler.py` — this only changes *which model gets built* for the drafter, not how it's driven afterwards.

## Tests

New file `tests/test_mllm_assistant_drafter_loader.py` (6 tests), following `tests/test_qwen35_mtp_patch.py`'s style — `mlx_vlm.utils.load_model` is monkeypatched via `sys.modules`, so no real model architecture or safetensors content is needed:

- `test_load_assistant_drafter_dispatches_any_model_type_through_load_model` (parametrized `gemma4_assistant` / `qwen3_5_mtp` / `eagle3`) — every `model_type` goes through the same `mlx_vlm.utils.load_model` call with the drafter's own path; nothing is hardcoded.
- `test_load_assistant_drafter_missing_config_raises_file_not_found`
- `test_load_assistant_drafter_missing_weights_raises_file_not_found`
- `test_load_assistant_drafter_missing_mlx_vlm_raises_import_error`

`tests/test_mllm_assistant_drafter.py` (existing chat-time drafter wiring tests, inject `_draft_model` directly and don't exercise the loader) — unaffected, still 7/7 passing.

## Test results

Full suite: `pytest tests/` — 2679 passed, 24 skipped, 27 deselected, 0 failed.

`black --check`, `ruff check --select E,F,W --ignore E402,E501,E731,F811,F841`, and `mypy vllm_mlx/models/mllm.py` all pass on the changed file. mypy's error set on `mllm.py` actually *shrinks* by two (both were on the old hand-rolled `weights: dict = {}` / `weights.update(mx.load(...))` code this PR removes; mypy couldn't infer its types).

## Risk notes

Scope is intentionally narrow: only the drafter-loading dispatch changes. Every currently-working drafter (Gemma 4 assistant drafters) now goes through `mlx_vlm.utils.load_model` too instead of the hand-rolled loader — confirmed equivalent by inspection (same `Model(config)` + `sanitize` + `load_weights` + `mx.eval` + `.eval()` sequence, plus quantization handling the old code never had), but not diffed against a real Gemma 4 assistant drafter checkpoint (none available in this environment) the way the Qwen3.5-MTP path was.

## Related work

#669 ("fix: enable configured MLLM assistant drafters by default") touches the same file but a disjoint region — `__init__`/`_draft_generation_kwargs` (the default-on/opt-out behavior for an *already-loaded* drafter) vs. this PR's `load_gemma4_assistant_drafter`/`_load_draft_model` (which architecture gets *loaded* in the first place). Verified no overlap with a `git merge-tree` dry-run against #669's branch: 0 conflicts. The two are complementary, not competing — #669 fixes a real gap this PR doesn't touch (a configured drafter currently still needs a private per-request `mllm_draft=true` to actually engage).

The dependency runs one way, not both: #669 is independently useful today for its own tested case (Gemma 4 assistant drafters, which already load fine without this PR) and doesn't need this PR to land. This PR, conversely, doesn't need #669 either — the per-request `mllm_draft=true` opt-in it fixes still works as the engage mechanism regardless of whether #669 exists. Where the two actually interact: for a *non*-Gemma-4 drafter family (Qwen3.5-MTP and any other family under `mlx_vlm.speculative.drafters`), `--default-mllm-draft` is currently unreachable — the server fails to load the drafter before that flag would ever matter. This PR is what makes #669's flag meaningful for those families; it doesn't make #669 itself faster, safer, or more correct for the case it was written and verified against. I support #669 landing on its own merits, independently of this one.
