### PR TITLE
fix(reasoning): GLM-4.7 injects <think> in the prompt — stream thinking as reasoning_content, not content

### DIFF
--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -1291,13 +1291,34 @@ class TestGlm4Parser:
 
     # Streaming tests
 
-    def test_streaming_no_tags_emits_content(self, parser):
-        """GLM-4 streaming without tags should emit content (not reasoning)."""
+    def test_streaming_no_tags_emits_reasoning(self, parser):
+        """GLM-4.7 injects <think> in the prompt, so tag-less streaming
+        output is implicit reasoning (thinking-disabled requests bypass
+        the parser server-side and are not affected)."""
         parser.reset_state()
         result = parser.extract_reasoning_streaming("", "Hello", "Hello")
         assert result is not None
-        assert result.content == "Hello"
-        assert result.reasoning is None
+        assert result.reasoning == "Hello"
+        assert result.content is None
+
+    def test_streaming_implicit_close_splits_reasoning_and_content(self, parser):
+        """Only </think> in output (GLM-4.7 shape): reasoning before the
+        tag, content after — nothing leaks across."""
+        parser.reset_state()
+        tokens = ["thinking a", "bout it", "</think>", "the answer"]
+        accumulated = ""
+        reasoning_parts, content_parts = [], []
+        for token in tokens:
+            prev = accumulated
+            accumulated += token
+            result = parser.extract_reasoning_streaming(prev, accumulated, token)
+            if result:
+                if result.reasoning:
+                    reasoning_parts.append(result.reasoning)
+                if result.content:
+                    content_parts.append(result.content)
+        assert "".join(reasoning_parts) == "thinking about it"
+        assert "".join(content_parts) == "the answer"
 
     def test_streaming_with_thinking(self, parser):
         """Test streaming with think tags."""
@@ -1327,16 +1348,16 @@ class TestGlm4Parser:
 
         tokens = ["<|begin_of_box|>", "Paris", "<|end_of_box|>"]
         accumulated = ""
-        content_parts = []
+        parts = []
 
         for token in tokens:
             prev = accumulated
             accumulated += token
             result = parser.extract_reasoning_streaming(prev, accumulated, token)
-            if result and result.content:
-                content_parts.append(result.content)
+            if result:
+                parts.append((result.reasoning or "") + (result.content or ""))
 
-        full = "".join(content_parts)
+        full = "".join(parts)
         assert "Paris" in full
         assert "<|begin_of_box|>" not in full
         assert "<|end_of_box|>" not in full

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -3,15 +3,11 @@
 Reasoning parser for GLM-4 models (GLM-4.5-Air, GLM-4.6V, GLM-4.7, etc.).
 
 GLM-4 uses <think>...</think> tags for reasoning content, same as Qwen3.
-However, unlike Qwen3, GLM-4 does NOT inject <think> in the prompt —
-the model decides autonomously whether to reason.
-
-This means:
-- Output without tags = normal response (no reasoning)
-- Output with tags = reasoning + content
-
-This is the opposite of Qwen3 where no tags = pure reasoning (because
-<think> was injected in the prompt and the model hit max_tokens).
+GLM-4.7's chat template injects <think> in the prompt when thinking is
+enabled (and a pre-closed </think> when disabled), so model output with
+thinking on carries only the closing tag — implicit reasoning mode, like
+Qwen3. Thinking-disabled requests bypass reasoning parsing server-side
+(``_thinking_disabled``), so no-tag output is not misclassified.
 
 GLM-4.6V also wraps responses in <|begin_of_box|>...<|end_of_box|> container
 tags which must be stripped before returning content.
@@ -70,38 +66,24 @@ class Glm4ReasoningParser(BaseThinkingReasoningParser):
         """
         Extract reasoning from streaming delta.
 
-        Overrides base class pre_think behavior: when no tags have been seen,
-        emit delta as content (not reasoning). GLM-4 doesn't inject <think>
-        in the prompt, so early tokens without tags are normal content.
+        GLM-4.7's chat template injects ``<think>`` at the end of the
+        generation prompt when thinking is enabled (and a pre-closed
+        ``</think>`` when disabled), so with thinking on the model output
+        contains only the CLOSING tag — the base class's implicit-reasoning
+        mode (default to reasoning until ``</think>``) is exactly right.
+        Thinking-disabled requests never reach this parser: the server
+        bypasses reasoning parsing via ``_thinking_disabled``, so plain
+        content is not at risk of being swallowed into reasoning.
 
-        Once <think> is seen, delegates to base class state machine.
+        (An earlier version assumed GLM-4 never injects ``<think>`` and
+        emitted pre-tag deltas as content; on GLM-4.7 that streamed the
+        entire thinking block into ``content``.)
         """
         # Strip GLM-4.6V box container tags (special tokens, always whole)
         delta_text = delta_text.replace(_BOX_START, "").replace(_BOX_END, "")
         if not delta_text:
             return None
 
-        start_tok = self.start_token
-        end_tok = self.end_token
-
-        # In pre_think phase: check if we should treat as content
-        if self._phase == "pre_think":
-            # If start tag appeared, transition to thinking via base class
-            if start_tok in current_text:
-                return super().extract_reasoning_streaming(
-                    previous_text, current_text, delta_text
-                )
-
-            # If end tag appeared without start (implicit mode from agent)
-            if end_tok in current_text:
-                return super().extract_reasoning_streaming(
-                    previous_text, current_text, delta_text
-                )
-
-            # No tags yet — GLM-4 doesn't inject <think>, so this is content
-            return DeltaMessage(content=delta_text)
-
-        # In thinking or content phase, delegate to base class
         return super().extract_reasoning_streaming(
             previous_text, current_text, delta_text
         )

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -151,7 +151,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
             if start_tok in current_text:
                 self._phase = "thinking"
                 idx = delta_text.find(start_tok)
-                after = delta_text[idx + len(start_tok) :] if idx >= 0 else delta_text
+                if idx >= 0:
+                    after = delta_text[idx + len(start_tok) :]
+                else:
+                    # Tag straddles the previous|delta boundary: drop the
+                    # tag remnant at the head of this delta.
+                    tag_end = current_text.find(start_tok) + len(start_tok)
+                    after = delta_text[max(0, tag_end - len(previous_text)) :]
 
                 if end_tok in after:
                     self._phase = "content"
@@ -178,8 +184,11 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     reasoning = delta_text[:idx]
                     content = delta_text[idx + len(end_tok) :]
                 else:
+                    # Tag straddles the previous|delta boundary: drop the
+                    # tag remnant at the head of this delta.
+                    tag_end = current_text.find(end_tok) + len(end_tok)
                     reasoning = None
-                    content = delta_text
+                    content = delta_text[max(0, tag_end - len(previous_text)) :]
                 return self._transition_to_content(reasoning, content)
 
             # No tags — default to reasoning (implicit mode assumption).
@@ -214,8 +223,11 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     reasoning = delta_text[:idx]
                     content = delta_text[idx + len(end_tok) :]
                 else:
-                    reasoning = delta_text
-                    content = None
+                    # Tag straddles the previous|delta boundary: drop the
+                    # tag remnant at the head of this delta.
+                    tag_end = current_text.find(end_tok) + len(end_tok)
+                    reasoning = None
+                    content = delta_text[max(0, tag_end - len(previous_text)) :]
                 return self._transition_to_content(reasoning, content)
             return DeltaMessage(reasoning=delta_text)
 


### PR DESCRIPTION
## Summary

With `--reasoning-parser glm4`, **GLM-4.7's entire thinking block streams into `content`** instead of `reasoning_content`. Non-streaming responses are unaffected, which makes the bug easy to miss — it only shows up for streaming clients (observed via an agent frontend rendering thinking text as the visible reply).

## Root cause

GLM-4.7's chat template **injects `<think>` at the end of the generation prompt** when thinking is enabled, and a pre-closed `</think>` when disabled:

```
>>> tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
'...<|assistant|><think>'                        # thinking enabled (default)
'...<|assistant|></think>'                       # enable_thinking=False
```

So with thinking enabled, model output contains **only the closing tag** — but `Glm4ReasoningParser.extract_reasoning_streaming` was built on the opposite assumption ("GLM-4 does NOT inject `<think>` in the prompt") and emits pre-tag deltas as content. Result: every thinking token streams as `content` until `</think>` arrives, at which point only the final pre-tag fragment lands in `reasoning_content`.

The non-streaming path works because `extract_reasoning` sees the closing tag in the full text and takes the only-closing-tag branch.

## Fix

- **`glm4_parser.py`**: drop the content-assuming `pre_think` override and delegate to the base class, whose implicit-reasoning mode (default to reasoning until `</think>`) matches GLM-4.7's template. GLM-4.6V box-tag stripping is retained. Thinking-disabled requests are not misrouted: the server already bypasses reasoning parsing for them (`_thinking_disabled`), which also covers the template's pre-closed `</think>` variant.
- **`think_parser.py`**: fix a latent boundary bug in the `idx == -1` branches (start/end tag completed across a delta boundary): the tag remnant at the head of the delta leaked into content/reasoning (e.g. `ink>` prefixed to content). Now the remnant is dropped by computing the straddle offset from `current_text`/`previous_text`. Remaining cosmetic edge: the tag's head characters from the *prior* delta stay in reasoning; full fix needs tail-holdback buffering, which isn't needed while the tags are single special tokens (they are for GLM/Qwen — the straddle only occurs for models whose tags tokenize into pieces).
- **Tests**: encode the GLM-4.7 contract — tag-less streaming deltas are implicit reasoning; a stream with only `</think>` splits cleanly with nothing leaking across; box-tag stripping asserted on the combined stream.

## Verification

- `pytest tests/test_reasoning_parser.py tests/test_streaming_think_router.py tests/test_thinking_processor.py tests/test_thinking_aware_processor.py` — 174 passed.
- Live on `mlx-community/GLM-4.7-4bit` (M3 Ultra, `--tool-call-parser glm47 --reasoning-parser glm4`), streaming: thinking default → clean separation (806-char reasoning, 20-char content); tools present → clean; `enable_thinking: false` → content only, no reasoning; tool-call turn → reasoning separated, `tool_calls` delta emitted correctly.
- Parser-level replay of the GLM-4.7 output shape at 1/5/7-char chunk sizes: content exactly matches the post-`</think>` text at every granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
