### PR TITLE
fix(mllm): isolate media prefix caches

### DIFF
--- a/tests/test_mllm_cache.py
+++ b/tests/test_mllm_cache.py
@@ -144,10 +144,10 @@ class TestImageHashing:
             path2 = f2.name
 
         try:
-            # Order shouldn't matter (sorted internally)
+            # Order changes the visual input and therefore the KV state.
             hash_a = compute_images_hash([path1, path2])
             hash_b = compute_images_hash([path2, path1])
-            assert hash_a == hash_b
+            assert hash_a != hash_b
         finally:
             os.unlink(path1)
             os.unlink(path2)
@@ -421,9 +421,10 @@ class TestMLLMCacheManager:
             cache, hit = cache_manager.fetch_cache(images, prompt)
             assert hit is True
 
-            # Fetch same images in different order - should still hit (sorted internally)
+            # Reversed media order must not reuse the previous KV state.
             cache, hit = cache_manager.fetch_cache([img2, img1], prompt)
-            assert hit is True
+            assert cache is None
+            assert hit is False
         finally:
             os.unlink(img1)
             os.unlink(img2)

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -852,6 +852,99 @@ if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 
 
+class TestMLLMPrefixCacheMediaIsolation:
+    def test_process_prompts_does_not_fetch_prefix_cache_for_media(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FakeCache:
+            def merge(self, caches):
+                return self
+
+        prefix_cache = SimpleNamespace(fetch=MagicMock())
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_, **__: [FakeCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = prefix_cache
+        generator._think_suffix_len = 0
+        generator.prefill_step_size = 512
+        generator.language_model = object()
+        generator.model = MagicMock()
+        generator.sampler = MagicMock()
+        generator._preprocess_request = lambda req: None
+        vision_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator._run_vision_encoding = vision_prefill
+
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="media-prefix",
+            prompt="describe",
+            images=["image-a.png"],
+        )
+        request.input_ids = mx.array([[10, 20, 30]])
+        request.is_text_only = False
+
+        MLLMBatchGenerator._process_prompts(generator, [request])
+
+        prefix_cache.fetch.assert_not_called()
+        vision_prefill.assert_called_once()
+
+    def test_maybe_store_prefix_cache_skips_media(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+
+        media_request = MLLMBatchRequest(
+            uid=1,
+            request_id="media",
+            prompt="describe",
+            images=["image-a.png"],
+        )
+        media_request.input_ids = mx.array([[1, 2, 3]])
+        media_request.is_text_only = False
+
+        text_request = MLLMBatchRequest(uid=2, request_id="text", prompt="hello")
+        text_request.input_ids = mx.array([[1, 2, 3]])
+        text_request.is_text_only = True
+
+        batch = SimpleNamespace(
+            requests=[media_request, text_request],
+            num_tokens=[1, 1],
+            extract_cache=MagicMock(return_value=[object()]),
+        )
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = object()
+        generator._think_suffix_len = 0
+        generator._store_prefix_snapshot = MagicMock(return_value=True)
+
+        generator._maybe_store_prefix_cache(batch, [0, 1])
+
+        batch.extract_cache.assert_called_once_with(1)
+        generator._store_prefix_snapshot.assert_called_once()
+        assert generator._store_prefix_snapshot.call_args.args[3] == "text"
+
+
 class TestMLLMBatchGeneratorMTPGuards:
     def test_process_prompts_rejects_unsafe_exact_rotating_hit(self, monkeypatch):
         from mlx_lm.models.cache import CacheList, KVCache, RotatingKVCache
@@ -2052,6 +2145,32 @@ class TestChunkedPrefillCacheHandling:
             cache.update_and_fetch(k, v)
             mx.eval(cache.keys, cache.values)
         return cache
+
+    def test_chunked_prefill_skips_audio_request(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen.prefix_cache = SimpleNamespace(fetch=MagicMock())
+        gen.language_model = MagicMock()
+        original_next = MagicMock(return_value=[])
+        gen._next = original_next
+        install_chunked_prefill_mllm(gen, budget=1024)
+
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="audio-prefix",
+            prompt="transcribe",
+            audio=["sample.wav"],
+        )
+        gen.unprocessed_requests.append(request)
+
+        gen._next()
+
+        gen.prefix_cache.fetch.assert_not_called()
+        original_next.assert_called_once()
 
     def test_exact_hit_uses_safe_rewind(self):
         """An exact hit must use the type-preserving safe rewind path."""

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -218,7 +218,7 @@ class MLLMBatchRequest:
     image_grid_thw: Optional[mx.array] = None
     extra_kwargs: Dict[str, Any] = field(default_factory=dict)
 
-    # Text-only flag (no images/videos — eligible for prefix cache)
+    # Text-only flag (no image, video, or audio — eligible for prefix cache)
     is_text_only: bool = False
 
     # Generation state
@@ -1490,15 +1490,16 @@ class MLLMBatchGenerator:
                     self._aborted_request_ids.discard(req.request_id)
                     raise PrefillAbortedError(req.request_id)
 
-                # Try prefix cache for all requests (text-only and multimodal).
-                # VLM forward writes the same KV state as language model forward
-                # for text tokens, so cached KV from a previous VLM run is valid.
-                # However, if the remaining (uncached) tokens contain image
-                # placeholders, we must fall back to VLM forward instead of
-                # running them through the language model alone.
+                # Token-only cache keys cannot distinguish media content. A
+                # multimodal hit could therefore reuse KV state from a different
+                # image, video, or audio input with the same text prompt.
                 cached_kv = None
                 remaining_ids = None
-                if self.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    self.prefix_cache is not None
+                    and req.is_text_only
+                    and req.input_ids is not None
+                ):
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Strip think suffix from lookup key so stored entries
                     # (also stripped) match as clean PREFIX.
@@ -1928,7 +1929,11 @@ class MLLMBatchGenerator:
             self, "_allow_mid_batch_extend", True
         ):
             text_only = self._compatible_pending_requests(
-                [r for r in self.unprocessed_requests if not r.images and not r.videos],
+                [
+                    r
+                    for r in self.unprocessed_requests
+                    if not r.images and not r.videos and not r.audio
+                ],
                 self.completion_batch_size,
             )
 
@@ -2144,7 +2149,7 @@ class MLLMBatchGenerator:
             return
         for i in end_indices:
             req = batch.requests[i]
-            if req.input_ids is not None:
+            if req.is_text_only and req.input_ids is not None:
                 try:
                     extracted = batch.extract_cache(i)
                     input_ids_list = req.input_ids.reshape(-1).tolist()
@@ -3049,7 +3054,7 @@ def install_chunked_prefill_mllm(
                         else req
                     )
                     for r in batch_gen.unprocessed_requests:
-                        if r.images or r.videos:
+                        if r.images or r.videos or r.audio:
                             continue
                         if not batch_gen._compatible_pending_requests(
                             [r], 1, reference=reference
@@ -3189,7 +3194,11 @@ def install_chunked_prefill_mllm(
                     batch_gen.active_batch = new_batch
 
                 # Store in prefix cache (prompt-only)
-                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    batch_gen.prefix_cache is not None
+                    and req.is_text_only
+                    and req.input_ids is not None
+                ):
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
                         S = batch_gen._think_suffix_len
@@ -3234,7 +3243,7 @@ def install_chunked_prefill_mllm(
                 len(batch_gen.unprocessed_requests),
             )
             for r in compatible_pending:
-                if not r.images and not r.videos:
+                if not r.images and not r.videos and not r.audio:
                     text_only_req = r
                     break
 
@@ -3269,7 +3278,7 @@ def install_chunked_prefill_mllm(
                 cached_count = 0
                 total_tokens = input_ids.shape[1]
 
-                if batch_gen.prefix_cache is not None:
+                if batch_gen.prefix_cache is not None and text_only_req.is_text_only:
                     input_ids_list = input_ids.reshape(-1).tolist()
                     S = batch_gen._think_suffix_len
                     lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list

--- a/vllm_mlx/mllm_cache.py
+++ b/vllm_mlx/mllm_cache.py
@@ -161,7 +161,10 @@ def compute_image_hash(image_path: str) -> str:
 
 def compute_images_hash(images: list[str]) -> str:
     """
-    Compute combined hash for multiple images.
+    Compute an order-sensitive combined hash for multiple images.
+
+    Image order is part of the model input. Reordering the same images changes
+    the visual embeddings and must not reuse the previous request's KV state.
 
     Args:
         images: List of image paths/URLs
@@ -173,7 +176,7 @@ def compute_images_hash(images: list[str]) -> str:
         return "no_images"
 
     hashes = [compute_image_hash(img) for img in images]
-    combined = "_".join(sorted(hashes))
+    combined = "_".join(hashes)
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 


### PR DESCRIPTION
## Summary

- keep continuous-batching KV prefix reuse text-only across normal and interleaved paths
- exclude image, video, and audio requests from text-only batch extension
- preserve media order in MLLM cache keys
- cover media fetch/store isolation without loading a model

## Why

The continuous-batching cache is keyed only by token IDs, so identical text could reuse KV state from a different media input. The separate MLLM cache also treated reordered images as equivalent even though their embedding order changes.

## Tests

- `101 passed, 4 deselected` across MLLM continuous batching, config wiring, and cache suites
- Black, Ruff, and `git diff --check`

Fixes #718
