### PR TITLE
fix(cli): wire prefill step into batching

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,6 +119,40 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
     assert loaded["kwargs"]["specprefill_backbone_pct"] == 0.25
 
 
+def test_serve_command_wires_prefill_step_size_into_batched_scheduler(monkeypatch):
+    from vllm_mlx import cli, server
+    from vllm_mlx.utils import download
+
+    loaded = {}
+    monkeypatch.setattr(
+        download, "ensure_model_downloaded", lambda *args, **kwargs: "local-test-model"
+    )
+    monkeypatch.setattr(
+        server,
+        "load_model",
+        lambda *args, **kwargs: loaded.update({"args": args, "kwargs": kwargs}),
+    )
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    args = cli.create_parser().parse_args(
+        [
+            "serve",
+            "local-test-model",
+            "--continuous-batching",
+            "--prefill-step-size",
+            "512",
+            "--mllm-prefill-step-size",
+            "256",
+            "--offline",
+        ]
+    )
+    cli.serve_command(args)
+
+    scheduler_config = loaded["kwargs"]["scheduler_config"]
+    assert scheduler_config.prefill_step_size == 512
+    assert scheduler_config.mllm_prefill_step_size == 256
+
+
 def test_serve_parser_accepts_registered_step3p5_tool_parser():
     from vllm_mlx import cli
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -299,6 +299,7 @@ def serve_command(args):
         scheduler_config = SchedulerConfig(
             max_num_seqs=args.max_num_seqs,
             prefill_batch_size=args.prefill_batch_size,
+            prefill_step_size=args.prefill_step_size,
             completion_batch_size=args.completion_batch_size,
             enable_prefix_cache=enable_prefix_cache,
             prefix_cache_size=args.prefix_cache_size,


### PR DESCRIPTION
## Summary

- pass `--prefill-step-size` into the continuous-batching scheduler
- preserve the separate MLLM-specific override
- cover the full CLI-to-scheduler wiring with a real-parser regression

## Why

`serve_command` accepted the flag but omitted it when constructing `SchedulerConfig`, so continuous batching silently used the default instead of the requested prefill bound.

## Tests

- `30 passed` across CLI, lifecycle CLI, MLLM config, and scheduler wiring coverage
- Black, Ruff, and `git diff --check`

Fixes #711
