### PR TITLE
fix(mllm): keep media requests out of prefix cache

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -564,12 +564,12 @@ class TestGetAvailableMemory:
             pass
 
 
-def test_load_rejects_v3_cache_after_rewind_semantics_change(tmp_path, caplog):
-    """Caches written before safe MLLM rewind must not survive an upgrade."""
+def test_load_rejects_v4_cache_after_media_isolation_change(tmp_path, caplog):
+    """Caches that may contain media KV must not survive the text-only change."""
     import json
 
     (tmp_path / "index.json").write_text(
-        json.dumps({"version": 3, "model_fingerprint": "", "entries": []})
+        json.dumps({"version": 4, "model_fingerprint": "", "entries": []})
     )
     cache = MemoryAwarePrefixCache(MagicMock(), MemoryCacheConfig(max_memory_mb=1))
 
@@ -582,4 +582,4 @@ def test_load_rejects_v3_cache_after_rewind_semantics_change(tmp_path, caplog):
         },
     ):
         assert cache.load_from_disk(str(tmp_path)) == 0
-    assert "version mismatch: disk=3 current=4" in caplog.text
+    assert "version mismatch: disk=4 current=5" in caplog.text

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -853,6 +853,68 @@ if __name__ == "__main__":
 
 
 class TestMLLMBatchGeneratorMTPGuards:
+    def test_process_prompts_never_fetches_media_from_token_only_cache(
+        self, monkeypatch
+    ):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FakeCache:
+            def merge(self, caches):
+                return self
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache",
+            lambda model, **kwargs: [FakeCache()],
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = MagicMock()
+        generator._think_suffix_len = 0
+        generator.prefill_step_size = 512
+        generator.language_model = object()
+        generator.model = MagicMock()
+        generator.sampler = MagicMock()
+        generator._preprocess_request = lambda req: None
+        generator._run_chunked_text_prefill = MagicMock(
+            side_effect=AssertionError("media request used text prefill")
+        )
+        vision_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator._run_vision_encoding = vision_prefill
+
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="image-b",
+            prompt="same text, different image",
+            images=["image-b.png"],
+        )
+        request.input_ids = mx.array([[10, 20, 30]], dtype=mx.uint32)
+        request.is_text_only = False
+
+        batch = MLLMBatchGenerator._process_prompts(generator, [request])
+
+        generator.prefix_cache.fetch.assert_not_called()
+        vision_prefill.assert_called_once()
+        assert batch.requests == [request]
+
     def test_process_prompts_rejects_unsafe_exact_rotating_hit(self, monkeypatch):
         from mlx_lm.models.cache import CacheList, KVCache, RotatingKVCache
 
@@ -1959,6 +2021,22 @@ class TestBatchedMLLMConfigWiring:
         assert captured["config_kwargs"]["prefix_cache_memory_mb"] == 123
 
 
+@pytest.mark.parametrize("media_field", ["images", "videos", "audio"])
+def test_text_only_selectors_reject_every_media_kind(media_field):
+    from vllm_mlx.mllm_batch_generator import MLLMBatchRequest, _request_has_media
+
+    request = MLLMBatchRequest(uid=1, request_id=media_field, prompt="same text")
+    setattr(request, media_field, [f"{media_field}-input"])
+
+    assert _request_has_media(request) is True
+    assert (
+        _request_has_media(
+            MLLMBatchRequest(uid=2, request_id="text", prompt="text only")
+        )
+        is False
+    )
+
+
 class TestPreprocessIdempotent:
     """_preprocess_request must be idempotent for text-only requests.
 
@@ -2190,6 +2268,33 @@ class TestChunkedPrefillCacheHandling:
             1
         ], f"Expected _copy_prefix_cache called once, got {copy_calls}"
         assert rewind_calls == []
+
+    def test_audio_request_is_not_selected_for_text_only_chunked_prefill(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen.prefix_cache = MagicMock()
+        original_next = MagicMock(return_value=[])
+        gen._next = original_next
+        install_chunked_prefill_mllm(gen, budget=2)
+
+        request = MLLMBatchRequest(
+            uid=3,
+            request_id="audio-request",
+            prompt="transcribe",
+            audio=["audio.wav"],
+        )
+        request.input_ids = mx.array([[1, 2, 3, 4]])
+        request.is_text_only = False
+        gen.unprocessed_requests.append(request)
+
+        gen._next()
+
+        gen.prefix_cache.fetch.assert_not_called()
+        original_next.assert_called_once()
 
     def test_abort_cleans_up_partial_prefill(self):
         """Aborting a request during chunked prefill must clean up _partial."""

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -597,7 +597,9 @@ class TestMLLMCompletionCacheStore:
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
         request = SimpleNamespace(
-            request_id="saturated", input_ids=mx.array([[1, 2, 3, 4]])
+            request_id="saturated",
+            input_ids=mx.array([[1, 2, 3, 4]]),
+            is_text_only=True,
         )
         batch = SimpleNamespace(
             requests=[request],
@@ -627,7 +629,11 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
-        request = SimpleNamespace(request_id="flat", input_ids=mx.array([[1, 2, 3, 4]]))
+        request = SimpleNamespace(
+            request_id="flat",
+            input_ids=mx.array([[1, 2, 3, 4]]),
+            is_text_only=True,
+        )
         batch = SimpleNamespace(
             requests=[request],
             num_tokens=[4],
@@ -654,7 +660,11 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
-        request = SimpleNamespace(request_id="plain", input_ids=mx.array([[1, 2, 3]]))
+        request = SimpleNamespace(
+            request_id="plain",
+            input_ids=mx.array([[1, 2, 3]]),
+            is_text_only=True,
+        )
         batch = SimpleNamespace(
             requests=[request],
             num_tokens=[1],
@@ -667,6 +677,34 @@ class TestMLLMCompletionCacheStore:
         _, stored = generator.prefix_cache.store.call_args.args
         assert estimate_kv_cache_memory(stored) > 0
         assert [child.offset for child in stored[0].caches] == [3, 3]
+
+    def test_multimodal_request_is_never_stored_in_token_only_cache(self):
+        from types import SimpleNamespace
+
+        mx = pytest.importorskip("mlx.core")
+        pytest.importorskip("mlx.nn")
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator._think_suffix_len = 0
+        request = SimpleNamespace(
+            request_id="image-b",
+            input_ids=mx.array([[1, 2, 3]]),
+            is_text_only=False,
+        )
+        extract_cache = MagicMock()
+        batch = SimpleNamespace(
+            requests=[request],
+            num_tokens=[1],
+            extract_cache=extract_cache,
+        )
+
+        generator._maybe_store_prefix_cache(batch, [0])
+
+        extract_cache.assert_not_called()
+        generator.prefix_cache.store.assert_not_called()
 
     def test_zero_trim_flat_snapshot_does_not_alias_live_cache(self):
         mx = pytest.importorskip("mlx.core")

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -40,9 +40,11 @@ _BYTES_PER_MB = 1024 * 1024
 _DEFAULT_MEMORY_PERCENT = 0.20  # 20% of available RAM
 _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
 _MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
-# Bump this when the cache on-disk format or KV semantics change.
+# Bump this when the cache on-disk format or KV semantics change. Version 5
+# invalidates entries written before MLLM caching became text-only; those files
+# cannot reveal whether their KV state contains vision/audio content.
 # Loading a cache with a different version is rejected automatically.
-_CACHE_PERSIST_VERSION = 4
+_CACHE_PERSIST_VERSION = 5
 
 
 def _get_available_memory() -> int:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -34,6 +34,11 @@ from .vision_embedding_cache import VisionEmbeddingCache
 logger = logging.getLogger(__name__)
 
 
+def _request_has_media(request: Any) -> bool:
+    """Return whether a request requires vision or audio processing."""
+    return bool(request.images or request.videos or request.audio)
+
+
 def _processors_can_retire(processors: Optional[List[Callable]]) -> bool:
     """True when any processor advertises a retire-to-content transition."""
     if os.getenv("VLLM_MLX_ENABLE_THINKING_RETIREMENT_RESUME") != "1":
@@ -218,7 +223,7 @@ class MLLMBatchRequest:
     image_grid_thw: Optional[mx.array] = None
     extra_kwargs: Dict[str, Any] = field(default_factory=dict)
 
-    # Text-only flag (no images/videos — eligible for prefix cache)
+    # Text-only flag (no images/videos/audio — eligible for prefix cache)
     is_text_only: bool = False
 
     # Generation state
@@ -1490,15 +1495,17 @@ class MLLMBatchGenerator:
                     self._aborted_request_ids.discard(req.request_id)
                     raise PrefillAbortedError(req.request_id)
 
-                # Try prefix cache for all requests (text-only and multimodal).
-                # VLM forward writes the same KV state as language model forward
-                # for text tokens, so cached KV from a previous VLM run is valid.
-                # However, if the remaining (uncached) tokens contain image
-                # placeholders, we must fall back to VLM forward instead of
-                # running them through the language model alone.
+                # Vision/audio content is not represented in the token-only
+                # prefix-cache key. Reusing one of those entries can attach a
+                # previous request's media state to the current prompt, so only
+                # text-only requests are eligible.
                 cached_kv = None
                 remaining_ids = None
-                if self.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    self.prefix_cache is not None
+                    and req.is_text_only
+                    and req.input_ids is not None
+                ):
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Strip think suffix from lookup key so stored entries
                     # (also stripped) match as clean PREFIX.
@@ -1509,19 +1516,6 @@ class MLLMBatchGenerator:
                     # sees the full generation prompt (<think>\n).
                     if cached_kv is not None and S > 0:
                         remaining_ids = list(remaining_ids) + input_ids_list[-S:]
-
-                    # If remaining tokens contain image placeholders, the
-                    # language-model-only path cannot handle them — clear the
-                    # cache hit so we fall through to full VLM forward.
-                    if cached_kv is not None and remaining_ids:
-                        img_tok = getattr(
-                            getattr(self.model, "config", None),
-                            "image_token_index",
-                            None,
-                        )
-                        if img_tok is not None and img_tok in remaining_ids:
-                            cached_kv = None
-                            remaining_ids = None
 
                 # Detect empty RotatingKVCache in cached entry — if any sliding-window
                 # layer has keys=None (all entries trimmed), the cache is unusable.
@@ -1928,7 +1922,7 @@ class MLLMBatchGenerator:
             self, "_allow_mid_batch_extend", True
         ):
             text_only = self._compatible_pending_requests(
-                [r for r in self.unprocessed_requests if not r.images and not r.videos],
+                [r for r in self.unprocessed_requests if not _request_has_media(r)],
                 self.completion_batch_size,
             )
 
@@ -2144,7 +2138,7 @@ class MLLMBatchGenerator:
             return
         for i in end_indices:
             req = batch.requests[i]
-            if req.input_ids is not None:
+            if req.is_text_only and req.input_ids is not None:
                 try:
                     extracted = batch.extract_cache(i)
                     input_ids_list = req.input_ids.reshape(-1).tolist()
@@ -3049,7 +3043,7 @@ def install_chunked_prefill_mllm(
                         else req
                     )
                     for r in batch_gen.unprocessed_requests:
-                        if r.images or r.videos:
+                        if _request_has_media(r):
                             continue
                         if not batch_gen._compatible_pending_requests(
                             [r], 1, reference=reference
@@ -3189,7 +3183,11 @@ def install_chunked_prefill_mllm(
                     batch_gen.active_batch = new_batch
 
                 # Store in prefix cache (prompt-only)
-                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    batch_gen.prefix_cache is not None
+                    and req.is_text_only
+                    and req.input_ids is not None
+                ):
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
                         S = batch_gen._think_suffix_len
@@ -3234,7 +3232,7 @@ def install_chunked_prefill_mllm(
                 len(batch_gen.unprocessed_requests),
             )
             for r in compatible_pending:
-                if not r.images and not r.videos:
+                if not _request_has_media(r):
                     text_only_req = r
                     break
 
@@ -3269,7 +3267,7 @@ def install_chunked_prefill_mllm(
                 cached_count = 0
                 total_tokens = input_ids.shape[1]
 
-                if batch_gen.prefix_cache is not None:
+                if batch_gen.prefix_cache is not None and text_only_req.is_text_only:
                     input_ids_list = input_ids.reshape(-1).tolist()
                     S = batch_gen._think_suffix_len
                     lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list


### PR DESCRIPTION
## Summary

- restrict MLLM prefix-cache fetch and store to text-only requests
- keep image, video, and audio requests out of text-only batching paths
- invalidate legacy disk entries that may already contain media KV

## Verification

- 69 focused no-MLX tests passed; 20 MLX-only cases skipped
- new image/audio regressions are included in the Apple Silicon test job
- formatting, compile, and diff checks passed

The configured prefix-cache flag is already forwarded on current `main`; this fixes the remaining media-isolation defect.

Fixes #718.