### PR TITLE
fix(cli): honor --prefill-step-size with continuous batching

### DIFF
--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -177,6 +177,15 @@ class TestRequestOutput:
 class TestSchedulerConfig:
     """Tests for SchedulerConfig."""
 
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_rejects_nonpositive_prefill_step_size(self, value):
+        with pytest.raises(ValueError, match="prefill_step_size must be > 0"):
+            SchedulerConfig(prefill_step_size=value)
+
+    @pytest.mark.parametrize("value", [1, 512, 2048])
+    def test_accepts_positive_prefill_step_size(self, value):
+        assert SchedulerConfig(prefill_step_size=value).prefill_step_size == value
+
     def test_default_config(self):
         """Test default scheduler config."""
         config = SchedulerConfig()
@@ -185,6 +194,7 @@ class TestSchedulerConfig:
         assert config.policy == SchedulingPolicy.FCFS
         assert config.prefill_batch_size == 8
         assert config.completion_batch_size == 32
+        assert config.prefill_step_size == 2048
 
     def test_custom_config(self):
         """Test custom scheduler config."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -10,6 +11,7 @@ def _serve_args(**overrides):
         "cache_memory_mb": None,
         "cache_memory_percent": 0.2,
         "chunked_prefill_tokens": 0,
+        "completion_batch_size": 32,
         "continuous_batching": False,
         "default_min_p": None,
         "default_presence_penalty": None,
@@ -70,6 +72,76 @@ def _serve_args(**overrides):
     }
     args.update(overrides)
     return SimpleNamespace(**args)
+
+
+def test_continuous_batching_forwards_prefill_step_size_to_scheduler_config(
+    monkeypatch,
+):
+    """Serve passes the LLM and MLLM prefill controls to SchedulerConfig."""
+    import vllm_mlx
+
+    pytest.importorskip("transformers")
+    from vllm_mlx import cli
+
+    captured = {}
+
+    class SchedulerConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            captured["scheduler_config"] = self
+
+    server = ModuleType("vllm_mlx.server")
+    server._metrics = SimpleNamespace(configure=lambda **kwargs: None)
+    server.RateLimiter = lambda **kwargs: SimpleNamespace(**kwargs)
+    server.app = object()
+    server.load_model = lambda *args, **kwargs: captured.update(load_model=kwargs)
+    server.load_model_registry = lambda *args, **kwargs: None
+
+    uvicorn = ModuleType("uvicorn")
+    uvicorn.run = lambda *args, **kwargs: None
+
+    model_registry = ModuleType("vllm_mlx.model_registry")
+    model_registry.RegistryServeDefaults = lambda **kwargs: SimpleNamespace(**kwargs)
+
+    scheduler = ModuleType("vllm_mlx.scheduler")
+    scheduler.SchedulerConfig = SchedulerConfig
+
+    api = ModuleType("vllm_mlx.api")
+    api_utils = ModuleType("vllm_mlx.api.utils")
+    api_utils.is_mllm_model = lambda model: False
+
+    utils = ModuleType("vllm_mlx.utils")
+    download = ModuleType("vllm_mlx.utils.download")
+    download.DownloadConfig = lambda **kwargs: SimpleNamespace(**kwargs)
+    download.ensure_model_downloaded = lambda *args, **kwargs: None
+
+    for name, module in {
+        "uvicorn": uvicorn,
+        "vllm_mlx.server": server,
+        "vllm_mlx.model_registry": model_registry,
+        "vllm_mlx.scheduler": scheduler,
+        "vllm_mlx.api": api,
+        "vllm_mlx.api.utils": api_utils,
+        "vllm_mlx.utils": utils,
+        "vllm_mlx.utils.download": download,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setattr(vllm_mlx, "server", server, raising=False)
+    monkeypatch.setattr(vllm_mlx, "model_registry", model_registry, raising=False)
+    monkeypatch.setattr(vllm_mlx, "scheduler", scheduler, raising=False)
+    monkeypatch.setattr(vllm_mlx, "api", api, raising=False)
+    monkeypatch.setattr(vllm_mlx, "utils", utils, raising=False)
+    cli.serve_command(
+        _serve_args(
+            continuous_batching=True,
+            mllm_prefill_step_size=256,
+            prefill_step_size=512,
+        )
+    )
+
+    assert captured["scheduler_config"].prefill_step_size == 512
+    assert captured["scheduler_config"].mllm_prefill_step_size == 256
 
 
 def test_serve_command_propagates_all_sampling_defaults(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,36 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
     assert loaded["kwargs"]["specprefill_backbone_pct"] == 0.25
 
 
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_serve_parser_rejects_nonpositive_prefill_step_size(value, capsys):
+    from vllm_mlx.cli import create_parser
+
+    with pytest.raises(SystemExit) as exc:
+        create_parser().parse_args(
+            ["serve", "--model", "local-test-model", "--prefill-step-size", value]
+        )
+
+    assert exc.value.code == 2
+    assert "--prefill-step-size must be a positive integer" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("value", [1, 512, 2048])
+def test_serve_parser_accepts_positive_prefill_step_size(value):
+    from vllm_mlx.cli import create_parser
+
+    args = create_parser().parse_args(
+        ["serve", "--model", "local-test-model", "--prefill-step-size", str(value)]
+    )
+    assert args.prefill_step_size == value
+
+
+def test_serve_parser_defaults_prefill_step_size():
+    from vllm_mlx.cli import create_parser
+
+    args = create_parser().parse_args(["serve", "--model", "local-test-model"])
+    assert args.prefill_step_size == 2048
+
+
 def test_serve_parser_accepts_registered_step3p5_tool_parser():
     from vllm_mlx import cli
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -10,6 +10,7 @@ import re
 import time
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -454,6 +455,73 @@ GB = 1024**3
 def _defaults_with(**overrides: Any) -> RegistryServeDefaults:
     base = _defaults()
     return dataclasses.replace(base, **overrides)
+
+
+@pytest.mark.parametrize("override", [None, 1, 2048])
+def test_batched_engine_receives_resolved_prefill_step_size(
+    tmp_path, monkeypatch, override
+):
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 1, "beta": 1})
+    registry["alpha"] = dataclasses.replace(
+        registry["alpha"], prefill_step_size=override
+    )
+    shared = SchedulerConfig(prefill_step_size=512, mllm_prefill_step_size=256)
+    manager = ModelManager(
+        _manager_config(budget_gb=8),
+        registry,
+        _defaults_with(
+            continuous_batching=True, prefill_step_size=512, scheduler_config=shared
+        ),
+    )
+    engine = MagicMock()
+    engine.start = AsyncMock()
+    constructor = MagicMock(return_value=engine)
+    monkeypatch.setattr("vllm_mlx.model_registry.BatchedEngine", constructor)
+
+    async def _run():
+        for entry in registry.values():
+            await manager._instantiate_model(entry, entry.source)
+
+    asyncio.run(_run())
+    alpha, beta = [
+        call.kwargs["scheduler_config"] for call in constructor.call_args_list
+    ]
+    assert alpha.prefill_step_size == (512 if override is None else override)
+    assert beta.prefill_step_size == 512
+    assert alpha is not beta and alpha is not shared and beta is not shared
+    assert shared.prefill_step_size == 512
+    assert alpha.mllm_prefill_step_size == beta.mllm_prefill_step_size == 256
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_registry_rejects_nonpositive_prefill_override(tmp_path, value):
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    registry = _registry(tmp_path, {"alpha": 1})
+    entry = dataclasses.replace(registry["alpha"], prefill_step_size=value)
+    manager = ModelManager(
+        _manager_config(budget_gb=8),
+        registry,
+        _defaults_with(
+            continuous_batching=True,
+            prefill_step_size=512,
+            scheduler_config=SchedulerConfig(prefill_step_size=512),
+        ),
+    )
+    with pytest.raises(ValueError, match="prefill_step_size must be > 0"):
+        manager._resolve_model_config(entry, entry.source)
+
+
+def test_registry_prefill_override_preserves_absent_scheduler_config(tmp_path):
+    registry = _registry(tmp_path, {"alpha": 1})
+    entry = dataclasses.replace(registry["alpha"], prefill_step_size=512)
+    manager = ModelManager(_manager_config(budget_gb=8), registry, _defaults())
+
+    resolved = manager._resolve_model_config(entry, entry.source)
+    assert resolved.prefill_step_size == 512
+    assert resolved.scheduler_config is None
 
 
 def test_budget_report_flags_budget_above_allocation_ceiling(tmp_path):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -299,6 +299,7 @@ def serve_command(args):
         scheduler_config = SchedulerConfig(
             max_num_seqs=args.max_num_seqs,
             prefill_batch_size=args.prefill_batch_size,
+            prefill_step_size=args.prefill_step_size,
             completion_batch_size=args.completion_batch_size,
             enable_prefix_cache=enable_prefix_cache,
             prefix_cache_size=args.prefix_cache_size,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1289,7 +1289,7 @@ Examples:
     # Prefill step size
     serve_parser.add_argument(
         "--prefill-step-size",
-        type=int,
+        type=make_positive_int_arg_parser("--prefill-step-size"),
         default=2048,
         help="Chunk size for prompt prefill processing. Larger values use more memory "
         "but can improve prefill throughput. (default: 2048)",

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -241,11 +241,15 @@ class ModelLease:
         await self.release()
 
 
-def _clone_scheduler_config(config: SchedulerConfig | None) -> SchedulerConfig | None:
+def _clone_scheduler_config(
+    config: SchedulerConfig | None, *, prefill_step_size: int
+) -> SchedulerConfig | None:
     """Clone a SchedulerConfig so per-model overrides do not mutate globals."""
     if config is None:
         return None
-    return SchedulerConfig(**vars(config))
+    values = vars(config).copy()
+    values["prefill_step_size"] = prefill_step_size
+    return SchedulerConfig(**values)
 
 
 def _parse_memory_budget_bytes(value: Any) -> int:
@@ -1228,8 +1232,6 @@ class ModelManager:
     def _resolve_model_config(
         self, entry: RegisteredModel, resolved_source: str
     ) -> ResolvedModelConfig:
-        scheduler_config = _clone_scheduler_config(self._defaults.scheduler_config)
-
         continuous_batching = (
             entry.continuous_batching
             if entry.continuous_batching is not None
@@ -1249,6 +1251,9 @@ class ModelManager:
             entry.prefill_step_size
             if entry.prefill_step_size is not None
             else self._defaults.prefill_step_size
+        )
+        scheduler_config = _clone_scheduler_config(
+            self._defaults.scheduler_config, prefill_step_size=prefill_step_size
         )
         specprefill_enabled = (
             entry.specprefill_enabled

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -136,6 +136,8 @@ class SchedulerConfig:
     mtp_optimistic: bool = False  # Skip acceptance check for max speed
 
     def __post_init__(self) -> None:
+        if self.prefill_step_size <= 0:
+            raise ValueError("prefill_step_size must be > 0")
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
             raise ValueError("mllm_prefill_step_size must be > 0 when provided")
 


### PR DESCRIPTION
Refs #711

I pass `--prefill-step-size` into the continuous-batching scheduler so the configured chunk size is honored. The CLI and `SchedulerConfig` reject nonpositive sizes. Registry overrides are validated when constructing per-model scheduler clones, preserving global and sibling settings.

Verification at `0f97fa4`:
- Eight boundary/precedence regressions fail against the previous `8651193` source.
- All 68 focused CLI, scheduler-config and registry tests pass with the fix.
- Black, Ruff and diff checks pass.

The default remains 2048; the separate MLLM prefill setting is unchanged. This is source regression coverage, not a new live-model memory or performance measurement.