### PR TITLE
fix(mllm): make prefix-cache rewind gate aware of non-KV hybrid leaves

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2053,6 +2053,230 @@ class TestChunkedPrefillCacheHandling:
             mx.eval(cache.keys, cache.values)
         return cache
 
+    def _make_fake_arrays_cache(self):
+        """Create a real ArraysCache (SSM/hybrid state leaf, no .keys)."""
+        from mlx_lm.models.cache import ArraysCache
+
+        cache = ArraysCache(2)
+        cache[0] = mx.ones((1, 4, 8))
+        cache[1] = mx.full((1, 4, 8), 2.0)
+        mx.eval(*[c for c in cache.state if c is not None])
+        return cache
+
+    def _make_hybrid_cache(self, kv_offset=50):
+        """A cache list mixing a real KVCache leaf with a real ArraysCache
+        leaf, mirroring a hybrid (e.g. Qwen3.5-family) architecture where
+        only some layers carry a real KV cache."""
+        return [
+            self._make_fake_kv_cache(offset=kv_offset),
+            self._make_fake_arrays_cache(),
+        ]
+
+    def test_can_rewind_hybrid_cache_ignores_non_kv_leaf(self):
+        """A non-KV leaf (no .keys) must not block rewind of the KV leaf."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        hybrid = self._make_hybrid_cache(kv_offset=50)
+        assert MLLMBatchGenerator._can_rewind_prefix_cache(hybrid, 1) is True
+
+    def test_can_rewind_hybrid_cache_still_rejects_bad_kv_leaf(self):
+        """The strict contract must still apply to the KV leaf itself --
+        offset < trim_by must still fail closed even with a non-KV leaf
+        present."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        hybrid = self._make_hybrid_cache(kv_offset=0)  # offset 0 < trim_by
+        assert MLLMBatchGenerator._can_rewind_prefix_cache(hybrid, 1) is False
+
+    def test_rewind_hybrid_cache_trims_kv_leaf_and_copies_non_kv_leaf(self):
+        """Rewinding a hybrid cache must trim the KV leaf's offset and
+        return an isolated copy of the non-KV leaf (not the same object,
+        not blocked by lacking .trim())."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv, arrays = self._make_hybrid_cache(kv_offset=50)
+        result = MLLMBatchGenerator._rewind_prefix_cache([kv, arrays], 1)
+
+        assert result is not None
+        new_kv, new_arrays = result
+        assert new_kv.offset == 49
+        assert new_arrays is not arrays  # isolated copy, per bf5ccb4's ownership goal
+        assert len(new_arrays.state) == len(arrays.state)
+
+    def test_hybrid_store_prefix_snapshot_succeeds(self):
+        """The completion-store path must not silently skip a hybrid cache
+        the way it did before this fix (only a DEBUG log, no error)."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchStats
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+        gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        gen._stats = MLLMBatchStats()
+        gen.prefix_cache = MemoryAwarePrefixCache(
+            model=object(), config=MemoryCacheConfig(min_prefix_tokens=1)
+        )
+
+        hybrid = self._make_hybrid_cache(kv_offset=50)
+        ok = gen._store_prefix_snapshot(
+            list(range(50)),
+            hybrid,
+            trim_by=1,
+            request_id="hybrid-store",
+            source="completion",
+        )
+
+        assert ok is True
+        assert len(gen.prefix_cache._entries) == 1
+
+    def test_copy_prefix_cache_handles_hybrid_leaves(self):
+        """_copy_prefix_cache (the prefix/LCP-match path's cache prep) was
+        never part of this bug -- it already produces an isolated copy for
+        both KV and non-KV leaves via _copy_cache_layer's from_state
+        fallback. This locks that in as regression coverage."""
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        kv, arrays = self._make_hybrid_cache(kv_offset=50)
+        result = MLLMBatchGenerator._copy_prefix_cache([kv, arrays])
+
+        assert result is not None
+        new_kv, new_arrays = result
+        assert new_kv is not kv
+        assert new_arrays is not arrays
+        assert new_kv.offset == kv.offset
+
+    def test_process_prompts_exact_hit_with_hybrid_cache(self, monkeypatch):
+        """End-to-end on the primary _process_prompts fetch site (not the
+        interleaved path, which only commits to its own fetch when a prompt
+        is long enough to need interleaving): an exact hit on a hybrid
+        (KV + ArraysCache) cache must take the rewind-and-replay-last-token
+        path, not silently fall through to a full miss the way it did
+        before this fix."""
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FreshCache:
+            def merge(self, caches):
+                return self
+
+        kv, arrays = self._make_hybrid_cache(kv_offset=6)
+        stored = [kv, arrays]
+
+        class PrefixCache:
+            def fetch(self, _):
+                return stored, []  # exact hit
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_, **__: [FreshCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = PrefixCache()
+        generator._think_suffix_len = 0
+        generator.prefill_step_size = 512
+        generator.language_model = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator.model = MagicMock()
+        generator.sampler = MagicMock()
+        generator._preprocess_request = lambda req: None
+        full_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator._run_chunked_text_prefill = full_prefill
+
+        request = MLLMBatchRequest(uid=1, request_id="hybrid-exact", prompt="x")
+        request.input_ids = mx.array([[1, 2, 3, 4, 5, 6]])
+        request.is_text_only = True
+
+        MLLMBatchGenerator._process_prompts(generator, [request])
+
+        # Before this fix, the hybrid cache's ArraysCache leaf made
+        # _rewind_prefix_cache return None, forcing a fall-through to a full
+        # miss (_run_chunked_text_prefill). It must not be called here.
+        full_prefill.assert_not_called()
+        generator.language_model.assert_called_once()
+        (called_with_tokens,), call_kwargs = generator.language_model.call_args
+        assert called_with_tokens.shape == (1, 1)  # replays only the last token
+        # The rewound cache is an isolated copy -- the stored original must
+        # be untouched (bf5ccb4's ownership-hardening goal, preserved).
+        assert kv.offset == 6
+        assert call_kwargs["cache"][0].offset == 5
+
+    def test_process_prompts_prefix_extension_hit_with_hybrid_cache(self, monkeypatch):
+        """A genuine prefix/LCP-match (remaining_ids non-empty) against a
+        hybrid cache. This path (_copy_prefix_cache + _prepare_rotating_caches)
+        was never part of the regression, but is covered here as an explicit
+        prefix-extension regression test alongside the exact-hit and store
+        cases, per the fix's test plan."""
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        kv, arrays = self._make_hybrid_cache(kv_offset=4)
+        stored = [kv, arrays]
+
+        class PrefixCache:
+            def fetch(self, ids):
+                return stored, ids[4:]  # first 4 tokens cached, 2 remaining
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = PrefixCache()
+        generator._think_suffix_len = 0
+        generator.prefill_step_size = 512
+        generator.model = MagicMock()
+        generator.sampler = MagicMock()
+        generator._preprocess_request = lambda req: None
+        remaining_call = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator.language_model = remaining_call
+        full_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+        generator._run_chunked_text_prefill = full_prefill
+
+        request = MLLMBatchRequest(uid=2, request_id="hybrid-prefix", prompt="x")
+        request.input_ids = mx.array([[1, 2, 3, 4, 5, 6]])
+        request.is_text_only = True
+
+        MLLMBatchGenerator._process_prompts(generator, [request])
+
+        full_prefill.assert_not_called()
+        remaining_call.assert_called_once()
+        (called_with_tokens,), _ = remaining_call.call_args
+        assert called_with_tokens.shape == (1, 2)  # only the 2 remaining tokens
+
     def test_exact_hit_uses_safe_rewind(self):
         """An exact hit must use the type-preserving safe rewind path."""
         from vllm_mlx.mllm_batch_generator import (

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1164,10 +1164,27 @@ class MLLMBatchGenerator:
 
     @classmethod
     def _can_rewind_prefix_cache(cls, cache_list, trim_by: int) -> bool:
-        """Return whether every cache leaf retains the positions to rewind."""
+        """Return whether every position-indexed cache leaf retains the
+        positions to rewind.
+
+        Hybrid architectures (e.g. Qwen3.5-family) mix real KV-cache layers
+        with non-KV state leaves (mlx_lm/mlx_vlm ``ArraysCache``, used for
+        SSM/linear-attention layers). Those leaves have no ``.keys``
+        attribute at all -- they're not a position-indexed buffer, so
+        "rewinding by N positions" isn't a meaningful operation on them and
+        replaying the trimmed tokens through the model doesn't re-enter them
+        the way it re-enters a KV cache. Only leaves that expose ``.keys``
+        (i.e. claim to be KV-shaped) are held to the strict rewind contract
+        below; anything else is left alone here and simply carried through
+        as an isolated copy by ``_rewind_prefix_cache``. A leaf that *does*
+        expose ``.keys`` but is empty/invalid (e.g. a fully-evicted
+        RotatingKVCache with ``keys=None``) still correctly fails closed.
+        """
         if trim_by <= 0:
             return True
         for cache in cls._cache_leaves(cache_list):
+            if not hasattr(cache, "keys"):
+                continue
             keys = getattr(cache, "keys", None)
             offset = getattr(cache, "offset", None)
             if keys is None or offset is None or offset < trim_by:
@@ -1181,7 +1198,9 @@ class MLLMBatchGenerator:
 
     @classmethod
     def _rewind_prefix_cache(cls, cache_list, trim_by: int):
-        """Clone and safely rewind every leaf, or return None to fail closed."""
+        """Clone and safely rewind every KV leaf; pass non-KV leaves through
+        as an isolated copy (see ``_can_rewind_prefix_cache``), or return
+        None to fail closed."""
         if not cls._can_rewind_prefix_cache(cache_list, trim_by):
             return None
         copied = cls._copy_prefix_cache(cache_list)
@@ -1192,8 +1211,13 @@ class MLLMBatchGenerator:
         # This preserves type-specific metadata such as ChunkedKVCache's
         # chunk_size/start_position instead of reconstructing a generic KV
         # wrapper. Verify the full rewind so a partially retained window cannot
-        # be stored under a longer token key.
+        # be stored under a longer token key. Non-KV leaves (no ``.keys``)
+        # have nothing position-indexed to trim -- _copy_prefix_cache already
+        # gave them an isolated copy via from_state/meta_state, so skip them
+        # here rather than rejecting the whole cache for lacking .trim().
         for cache in cls._cache_leaves(copied):
+            if not hasattr(cache, "keys"):
+                continue
             trim = getattr(cache, "trim", None)
             if not callable(trim) or trim(trim_by) != trim_by:
                 return None


### PR DESCRIPTION
Refs #730

> **Superseded by #744.** Per [review on #730](https://github.com/waybarrios/vllm-mlx/issues/730#issuecomment-5468495295) and [review on this PR](https://github.com/waybarrios/vllm-mlx/pull/731#issuecomment-5468493922), owner PR [#744](https://github.com/waybarrios/vllm-mlx/pull/744) implements detached prompt-boundary ownership/replay for the same hybrid-cache path and supersedes this narrow rewind-gate fix. Kept open for reference until #744 lands; not intended to merge independently. The fix described below remains deployed on the reporter's fork (pin `bd283d8`) in production.

## Summary

#691 (`bf5ccb4`, "harden MLLM prefix cache ownership and rewind safety") introduced `_can_rewind_prefix_cache`/`_rewind_prefix_cache`, requiring every cache leaf to expose real KV semantics before any rewind is permitted. Hybrid architectures (Qwen3.5-family) mix KV leaves with `ArraysCache` (SSM/linear-attention) leaves that have no `.keys` attribute at all and inherit `is_trimmable() -> False` — so the all-or-nothing gate silently rejects every rewind for any hybrid model, both at completion-time store and at exact-match fetch. Verified live: an identical 24k-token prompt resent back-to-back against `mlx-community/Qwen3.8-27B-8bit` showed zero speedup and re-ran the full chunked prefill both times on `origin/main` @ `4b654c0`; the same test against `db90a1c` (the commit immediately before #691) showed a ~58x speedup. The failure is silent — rejection only logs at `DEBUG`.

## What db90a1c did, and why it's the right semantics to restore

`db90a1c`'s `_trim_cache_offset` (`memory_cache.py`, the function #691 replaced) handled recognized KV-family types explicitly and had a catch-all `else: trimmed.append(layer_cache)` for everything else — no rewind attempted, no rejection, because a non-KV leaf isn't a position-indexed buffer and "rewind by N tokens" was never a meaningful operation on it. That catch-all is where `ArraysCache` leaves landed, via a raw shared reference (no copy) — exactly the ownership gap #691 set out to close.

## Changes

- `_can_rewind_prefix_cache`: skip leaves without a `.keys` attribute entirely (`hasattr(cache, "keys")` as the discriminator); leaves that *do* have `.keys` — including an empty/invalid `RotatingKVCache` (`.keys = None`, attribute present) — are still held to the full existing contract and still correctly fail closed.
- `_rewind_prefix_cache`'s post-copy trim loop: same skip, since `_copy_prefix_cache` already gave non-KV leaves a correct isolated copy via `_copy_cache_layer`'s `from_state`/`meta_state` fallback — #691's real improvement over `db90a1c`'s shared reference, preserved here, not reverted.
- No change to `_copy_prefix_cache`/`_prepare_rotating_caches` (the prefix/LCP-match fetch path) — confirmed by dedicated regression test that this path was never affected: `_prepare_rotating_caches` already skips non-`RotatingKVCache` leaves, and `_copy_cache_layer`'s generic fallback already handles `ArraysCache`.

This is the same problem class #642 already named in this file ("hybrid layers (`ArraysCache`) expose their mutable state container via `.state`") — not a new architecture edge case to this codebase.

## Type of change

- Bug fix

## Surface touched

- KV cache / prefix cache

## Test plan

```
pytest tests/test_mllm_continuous_batching.py -v
pytest tests/ -q
```

7 new cases in `TestChunkedPrefillCacheHandling`, built on real `KVCache` + real `ArraysCache` objects (not mocks): both gate functions directly (including that a genuinely invalid KV leaf still fails closed alongside a valid non-KV leaf), an end-to-end store test, and end-to-end `_process_prompts` tests for both exact-match and prefix-extension fetch.

**Verified these are real regression tests, not tautologies:** reverted the fix and reran — the 4 tests targeting the actually-broken paths failed; the 3 tests covering paths that were never broken (bad-KV-leaf rejection, `_copy_prefix_cache`, prefix-extension) correctly passed in both states. Restored the fix, all 7 pass.

## Test results

```
$ pytest tests/ -q
2694 passed, 25 skipped, 27 deselected
```
(`origin/main` baseline: 2687 passed; +7 new, 0 regressed.)

```
$ ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841
All checks passed!
$ black --check vllm_mlx/ tests/
All done! ✨ 🍰 ✨
$ mypy vllm_mlx/mllm_batch_generator.py --ignore-missing-imports --no-error-summary
# zero new errors on the changed lines
```

## Performance impact

- Hardware: Apple M5 Max, 128 GB RAM
- Model and quantization: `mlx-community/Qwen3.8-27B-8bit`
- Benchmark: identical ~24-28k-token prompt sent twice, back to back, `max_tokens=1`, `temperature=0`, measured via `curl` wall time and server logs
- Metrics measured: end-to-end wall time (cold vs. warm), presence/absence of `[chunked_prefill]` log lines
- Delta vs. `main` (i.e. vs. the still-broken state): cold 46.60s → warm **0.42s** (~111x). On `main` as-is (unfixed), warm shows no improvement over cold at all (both ~46s) — this PR is a pure improvement with no metric that could regress, since the broken behavior is "always full re-prefill."

## Output parity

Not applicable in the sense of "different code path, different tokens": this changes *whether* a cache is reused, not how generation is sampled. The KV state served by the fixed path (real KV leaves trimmed by the existing rewind contract, non-KV leaves passed through as an isolated copy) is bit-identical to what the model would have computed from scratch for the same tokens — that's the entire correctness property being restored, not something new to verify separately. No sampling, tokenization, or model code changed.

## Risk notes

Scoped to two `classmethod`s used at exactly the call sites #691 added them for (exact-match fetch, completion-time store). No behavior change for any model where every cache leaf is KV-shaped (pure-transformer models) — the strict contract is untouched for that case, verified by `test_can_rewind_hybrid_cache_still_rejects_bad_kv_leaf` and the pre-existing non-hybrid tests in the same file continuing to pass unchanged.
