### PR TITLE
feat(api): surface prefix-cache reuse via usage.prompt_tokens_details.cached_tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
             tests/test_streaming_tool_filter.py \
             tests/test_tool_call_promotion.py \
             -v --tb=short \
-            -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
+            -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache and not GetUsage and not ChatCompletionCachedTokens" \
             --cov=vllm_mlx \
             --cov-report=term-missing \
             --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
             tests/test_memory_cache.py \
             tests/test_prefix_cache.py \
             tests/test_mllm_cache.py \
+            tests/test_cache_token_usage.py \
             tests/test_api_models.py \
             tests/test_api_utils.py \
             tests/test_request.py \
@@ -178,6 +179,7 @@ jobs:
             tests/test_batched_engine_mllm_config.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
+            tests/test_cache_token_usage.py \
             tests/test_optimizations.py \
             tests/test_simple_engine.py \
             tests/test_simple_engine_prefix_trie_cache.py \

--- a/tests/test_cache_token_usage.py
+++ b/tests/test_cache_token_usage.py
@@ -8,6 +8,8 @@ non-streaming and (the historically broken) streaming chat completion paths.
 """
 
 import json
+import platform
+import sys
 
 import pytest
 
@@ -228,3 +230,75 @@ class TestChatCompletionCachedTokens:
         # Every usage-bearing chunk reports the cache reuse.
         for usage in usages:
             assert usage["prompt_tokens_details"] == {"cached_tokens": 15}
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires MLX (vllm_mlx.mllm_scheduler imports mlx.core)",
+)
+class TestAbortAndReuseRequestId:
+    """Aborting a request must not leak cache accounting into a reused ID.
+
+    The MLLM scheduler pools requests by ``request_id`` in several dicts
+    (``requests``, ``running``, ``request_id_to_uid``/``uid_to_request_id``).
+    A client is free to reuse a request ID once the previous request has
+    finished/aborted; the request-lifetime contract is that ``add_request``
+    always creates a brand-new ``MLLMRequest``, so ``cached_tokens`` and its
+    high-water mark ``peak_cached_tokens`` must start fresh at 0 rather than
+    inheriting whatever the aborted request last reported.
+    """
+
+    def _make_scheduler(self):
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+        class FakeTokenizer:
+            eos_token_id = None
+
+            def encode(self, text):
+                return [1, 2, 3]
+
+        class FakeProcessor:
+            tokenizer = FakeTokenizer()
+
+        class FakeModel:
+            config = None
+
+        return MLLMScheduler(model=FakeModel(), processor=FakeProcessor())
+
+    def test_abort_mid_flight_then_reuse_request_id_gives_fresh_peak(self):
+        from vllm_mlx.request import RequestStatus
+
+        scheduler = self._make_scheduler()
+        request_id = "dup-request-id"
+
+        scheduler.add_request(prompt="hello", request_id=request_id, max_tokens=8)
+        first = scheduler.requests[request_id]
+
+        # Simulate the request having progressed far enough to record a
+        # prefix-cache hit before the client disconnects mid-flight.
+        first.status = RequestStatus.RUNNING
+        first.cached_tokens = 42
+        first.peak_cached_tokens = 42
+        scheduler.waiting.remove(first)
+        scheduler.running[request_id] = first
+        scheduler.request_id_to_uid[request_id] = 7
+        scheduler.uid_to_request_id[7] = request_id
+
+        assert scheduler.abort_request(request_id) is True
+
+        # Abort must fully clear the ID from every bookkeeping structure --
+        # a stale entry in any of these would let the old request's state
+        # leak into the reused ID below.
+        assert request_id not in scheduler.requests
+        assert request_id not in scheduler.running
+        assert request_id not in scheduler.request_id_to_uid
+        assert 7 not in scheduler.uid_to_request_id
+
+        # Client reuses the same request ID for an unrelated new request.
+        scheduler.add_request(prompt="hello again", request_id=request_id, max_tokens=8)
+        second = scheduler.requests[request_id]
+
+        assert second is not first
+        assert second.status == RequestStatus.WAITING
+        assert second.cached_tokens == 0
+        assert second.peak_cached_tokens == 0

--- a/tests/test_cache_token_usage.py
+++ b/tests/test_cache_token_usage.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for surfacing prefix-cache reuse in the OpenAI-compatible usage.
+
+The prefix cache already computes how many prompt tokens are served from the
+KV/prefix cache; these tests lock in that the value is threaded all the way to
+the client under ``usage.prompt_tokens_details.cached_tokens`` for both the
+non-streaming and (the historically broken) streaming chat completion paths.
+"""
+
+import json
+
+import pytest
+
+from vllm_mlx.api.models import PromptTokensDetails, Usage
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.request import Request, RequestOutput, SamplingParams
+
+
+class TestCachedTokensDataModel:
+    """Field plumbing through the data model layer."""
+
+    def test_usage_prompt_tokens_details_defaults_none(self):
+        assert Usage().prompt_tokens_details is None
+
+    def test_usage_serializes_cached_tokens(self):
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=2,
+            total_tokens=12,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=7),
+        )
+        assert usage.model_dump()["prompt_tokens_details"] == {"cached_tokens": 7}
+
+    def test_prompt_tokens_details_default_cached_zero(self):
+        assert PromptTokensDetails().cached_tokens == 0
+
+    def test_request_output_carries_cached_tokens(self):
+        out = RequestOutput(
+            request_id="r", prompt_tokens=10, completion_tokens=2, cached_tokens=7
+        )
+        assert out.cached_tokens == 7
+        # The OpenAI-compatible usage dict exposes it too.
+        assert out.usage["cached_tokens"] == 7
+
+    def test_generation_output_cached_tokens_default(self):
+        assert GenerationOutput(text="x").cached_tokens == 0
+
+    def test_request_tracks_peak_cached_tokens(self):
+        req = Request(
+            request_id="r",
+            prompt="hi",
+            sampling_params=SamplingParams(),
+            cached_tokens=12,
+            peak_cached_tokens=12,
+        )
+        assert req.peak_cached_tokens == 12
+
+
+class TestOutputCollectorMerge:
+    """Aggregated streaming output must not drop the cache-reuse count."""
+
+    def test_merge_keeps_max_cached_tokens(self):
+        # Simulate the producer getting ahead of the consumer: the early step
+        # carries the prefix-cache reuse, a later step reports 0. The merged
+        # output the consumer eventually reads must retain the peak.
+        collector = RequestOutputCollector(aggregate=True)
+        collector.put(
+            RequestOutput(
+                request_id="r", new_text="a", completion_tokens=1, cached_tokens=9
+            )
+        )
+        collector.put(
+            RequestOutput(
+                request_id="r",
+                new_text="b",
+                completion_tokens=2,
+                cached_tokens=0,
+                finished=True,
+            )
+        )
+        merged = collector.get_nowait()
+        assert merged is not None
+        assert merged.finished is True
+        assert merged.cached_tokens == 9
+
+
+class TestGetUsage:
+    """The shared streaming usage builder surfaces cache reuse."""
+
+    def test_get_usage_surfaces_cached_tokens(self):
+        from vllm_mlx.server import get_usage
+
+        usage = get_usage(
+            GenerationOutput(
+                text="x", prompt_tokens=10, completion_tokens=2, cached_tokens=7
+            )
+        )
+        assert usage.prompt_tokens == 10
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 7
+
+    def test_get_usage_zero_cache(self):
+        from vllm_mlx.server import get_usage
+
+        usage = get_usage(
+            GenerationOutput(text="x", prompt_tokens=10, completion_tokens=2)
+        )
+        assert usage.prompt_tokens_details.cached_tokens == 0
+
+
+class TestChatCompletionCachedTokens:
+    """End-to-end: cached_tokens reaches the client on both paths."""
+
+    @pytest.mark.anyio
+    async def test_non_streaming_chat_surfaces_cached_tokens(self, monkeypatch):
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                return GenerationOutput(
+                    text="ok",
+                    prompt_tokens=20,
+                    completion_tokens=4,
+                    cached_tokens=15,
+                    finish_reason="stop",
+                )
+
+        fake_engine = FakeEngine()
+
+        async def fake_acquire(raw_request, **kwargs):
+            return fake_engine
+
+        async def fake_release(**kwargs):
+            return None
+
+        monkeypatch.setattr(server, "_validate_model_name", lambda _m: None)
+        monkeypatch.setattr(server, "_acquire_default_engine_for_request", fake_acquire)
+        monkeypatch.setattr(server, "_release_default_engine", fake_release)
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_default_max_tokens", 128)
+        monkeypatch.setattr(server, "_default_timeout", 30.0)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Hello")],
+            max_tokens=16,
+        )
+
+        response = await create_chat_completion(request, raw_request=None)
+
+        assert response.usage.prompt_tokens == 20
+        assert response.usage.prompt_tokens_details is not None
+        assert response.usage.prompt_tokens_details.cached_tokens == 15
+
+    @pytest.mark.anyio
+    async def test_streaming_chat_surfaces_cached_tokens(self, monkeypatch):
+        """The finished streaming chunk must report cache reuse.
+
+        This is the path that previously lost the value: the streamed chunks
+        are consumed one at a time, so the finished chunk itself has to carry
+        the preserved peak rather than relying on aggregation.
+        """
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+        import vllm_mlx.server as server
+
+        class FakeEngine:
+            model_name = "fake-engine"
+
+            async def stream_chat(self, messages, **kwargs):
+                # Intermediate chunks stream text; the finished chunk carries the
+                # preserved prefix-cache reuse count.
+                yield GenerationOutput(
+                    text="Hel", new_text="Hel", finished=False, cached_tokens=15
+                )
+                yield GenerationOutput(
+                    text="Hello",
+                    new_text="lo",
+                    finished=True,
+                    finish_reason="stop",
+                    prompt_tokens=20,
+                    completion_tokens=2,
+                    cached_tokens=15,
+                )
+
+        monkeypatch.setattr(server, "_model_name", "served-model")
+        monkeypatch.setattr(server, "_reasoning_parser", None)
+        monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+        monkeypatch.setattr(server, "_tool_call_parser", None)
+        monkeypatch.setattr(server, "_tool_parser_instance", None)
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+        payloads = [
+            json.loads(chunk.removeprefix("data: ").strip())
+            for chunk in chunks
+            if chunk != "data: [DONE]\n\n"
+        ]
+
+        usages = [p["usage"] for p in payloads if p.get("usage")]
+        assert usages, "expected at least one chunk carrying usage"
+        # Every usage-bearing chunk reports the cache reuse.
+        for usage in usages:
+            assert usage["prompt_tokens_details"] == {"cached_tokens": 15}

--- a/tests/test_memory_stability.py
+++ b/tests/test_memory_stability.py
@@ -228,6 +228,11 @@ class TestIncrementalCacheEval:
         mock_request.output_token_ids = [100]
         mock_request.num_output_tokens = 1
         mock_request.num_prompt_tokens = 3
+        # Prefix-cache reuse counters are real ints on a Request; set them so the
+        # peak-tracking arithmetic in _process_batch_responses has numbers to work
+        # with rather than MagicMock attributes.
+        mock_request.cached_tokens = 0
+        mock_request.peak_cached_tokens = 0
         scheduler.running["req-1"] = mock_request
         scheduler.uid_to_request_id[42] = "req-1"
 

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -223,6 +223,7 @@ class TestMLLMBatchRequest:
         assert req.top_p == 0.9
         assert req.mllm_draft is False
         assert req.output_tokens == []
+        assert req.cached_tokens == 0
 
 
 class TestMLLMBatchResponse:
@@ -246,6 +247,7 @@ class TestMLLMBatchResponse:
         assert resp.request_id == "test-1"
         assert resp.token == 42
         assert resp.finish_reason is None
+        assert resp.cached_tokens == 0
 
     def test_finished_response(self):
         """Test response with finish reason."""
@@ -307,6 +309,51 @@ class TestMLLMBatchResponse:
         assert "req-err" not in scheduler._detokenizer_pool
         assert len(outputs) == 1
         assert outputs[0].new_text == ""
+
+    def test_process_batch_responses_surfaces_cached_tokens(self):
+        """response.cached_tokens must land on both the persistent request
+        and the emitted RequestOutput, unaccumulated (set, not +=)."""
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import RequestStatus
+
+        scheduler = MLLMScheduler.__new__(MLLMScheduler)
+        scheduler._detokenizer_pool = {}
+        scheduler.uid_to_request_id = {0: "req-cached"}
+        scheduler.total_completion_tokens = 0
+        scheduler.num_requests_processed = 0
+
+        mock_tokenizer = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor.tokenizer = mock_tokenizer
+        scheduler.processor = mock_processor
+
+        mock_request = MagicMock()
+        mock_request.request_id = "req-cached"
+        mock_request.output_tokens = []
+        mock_request.num_output_tokens = 0
+        mock_request.num_prompt_tokens = 500
+        mock_request.status = RequestStatus.RUNNING
+        mock_request.mtp_drafts = 0
+        mock_request.mtp_accepted = 0
+        mock_request.first_token_time = None
+        scheduler.running = {"req-cached": mock_request}
+
+        resp = MLLMBatchResponse(
+            uid=0,
+            request_id="req-cached",
+            token=42,
+            logprobs=mx.array([0.0]),
+            finish_reason=None,
+            cached_tokens=384,
+        )
+
+        outputs, _finished = scheduler._process_batch_responses([resp])
+
+        assert mock_request.cached_tokens == 384
+        assert outputs[0].cached_tokens == 384
 
 
 class TestMLLMBatch:
@@ -503,6 +550,7 @@ class TestMLLMRequest:
         assert req.status == RequestStatus.WAITING
         assert req.mllm_draft is False
         assert req.output_text == ""
+        assert req.cached_tokens == 0
 
 
 class TestMLLMSchedulerOutput:
@@ -2103,6 +2151,71 @@ class TestChunkedPrefillCacheHandling:
         gen._next()
 
         assert rewind_calls == [1]
+
+    def test_exact_hit_sets_cached_tokens(self):
+        """An exact hit must record cached_tokens = total_tokens - 1 on the
+        request so it survives to RequestOutput.cached_tokens."""
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        fake_kv = [self._make_fake_kv_cache(offset=50)]
+
+        class FakePrefixCache:
+            def fetch(self, ids):
+                return fake_kv, []  # exact hit
+
+        gen.prefix_cache = FakePrefixCache()
+        gen.language_model = MagicMock()
+        gen._next = lambda: []
+
+        install_chunked_prefill_mllm(gen, budget=1024)
+
+        req = MLLMBatchRequest(uid=1, request_id="req-exact", prompt="hello")
+        req.input_ids = mx.array([[10, 20, 30, 40, 50]])
+        req.is_text_only = True
+        req.images = None
+        req.videos = None
+        gen.unprocessed_requests.append(req)
+        gen._preprocess_request = lambda r: None
+
+        gen._next()
+
+        assert req.cached_tokens == 4  # 5 input tokens, exact hit minus 1
+
+    def test_cache_miss_resets_cached_tokens(self):
+        """A cache miss must leave cached_tokens at 0, not a stale prior hit."""
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+
+        class MissingPrefixCache:
+            def fetch(self, ids):
+                return None, ids  # miss
+
+        gen.prefix_cache = MissingPrefixCache()
+        gen.language_model = MagicMock()
+        gen._next = lambda: []
+
+        install_chunked_prefill_mllm(gen, budget=1024)
+
+        req = MLLMBatchRequest(uid=2, request_id="req-miss", prompt="hello")
+        req.input_ids = mx.array([[10, 20, 30, 40, 50]])
+        req.is_text_only = True
+        req.images = None
+        req.videos = None
+        req.cached_tokens = 999  # stale value from a prior prefill on this uid
+        gen.unprocessed_requests.append(req)
+        gen._preprocess_request = lambda r: None
+
+        gen._next()
+
+        assert req.cached_tokens == 0
 
     def test_saturated_rotating_exact_hit_falls_back(self, monkeypatch):
         from mlx_lm.models.cache import CacheList, RotatingKVCache

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -339,6 +339,8 @@ class TestMLLMBatchResponse:
         mock_request.mtp_drafts = 0
         mock_request.mtp_accepted = 0
         mock_request.first_token_time = None
+        mock_request.cached_tokens = 0
+        mock_request.peak_cached_tokens = 0
         scheduler.running = {"req-cached": mock_request}
 
         resp = MLLMBatchResponse(
@@ -353,7 +355,114 @@ class TestMLLMBatchResponse:
         outputs, _finished = scheduler._process_batch_responses([resp])
 
         assert mock_request.cached_tokens == 384
+        assert mock_request.peak_cached_tokens == 384
         assert outputs[0].cached_tokens == 384
+
+    def test_mtp_deferred_draft_does_not_clobber_cached_tokens(self):
+        """Regression for the MTP-wrapper prefix-cache-hit defect (PR #732
+        review): the ``_mtp_next`` wrapper in mllm_batch_generator.py appends
+        deferred draft responses (see the augmentation sites around
+        ``MLLMBatchResponse(uid=uid, request_id=r.request_id, token=draft_t,
+        ...)``) without a ``cached_tokens`` argument, so they default to 0.
+        Ordinary decode-step primary responses also report cached_tokens=0
+        (the cache is only consulted at prefill). Before the fix, either of
+        these zero-carrying responses unconditionally overwrote
+        ``request.cached_tokens``, so a prefix-cache hit established on the
+        prefill step read back as a miss on every later output -- including
+        the finished one the client actually sees usage for.
+        """
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+        from vllm_mlx.request import RequestStatus
+
+        scheduler = MLLMScheduler.__new__(MLLMScheduler)
+        scheduler._detokenizer_pool = {}
+        scheduler.uid_to_request_id = {0: "req-mtp"}
+        scheduler.total_completion_tokens = 0
+        scheduler.num_requests_processed = 0
+
+        mock_tokenizer = MagicMock()
+        mock_processor = MagicMock()
+        mock_processor.tokenizer = mock_tokenizer
+        scheduler.processor = mock_processor
+
+        mock_request = MagicMock()
+        mock_request.request_id = "req-mtp"
+        mock_request.output_tokens = []
+        mock_request.num_output_tokens = 0
+        mock_request.num_prompt_tokens = 500
+        mock_request.status = RequestStatus.RUNNING
+        mock_request.mtp_drafts = 0
+        mock_request.mtp_accepted = 0
+        mock_request.first_token_time = None
+        mock_request.cached_tokens = 0
+        mock_request.peak_cached_tokens = 0
+        scheduler.running = {"req-mtp": mock_request}
+
+        HIT = 512
+
+        # Step 1: prefill resolves the prefix-cache lookup on the primary
+        # response.
+        primary_prefill = MLLMBatchResponse(
+            uid=0,
+            request_id="req-mtp",
+            token=1,
+            logprobs=mx.array([0.0]),
+            finish_reason=None,
+            cached_tokens=HIT,
+        )
+        outputs_1, _ = scheduler._process_batch_responses([primary_prefill])
+        assert outputs_1[0].cached_tokens == HIT
+        assert outputs_1[0].usage["cached_tokens"] == HIT
+
+        # Step 2: shape mirrors what `_mtp_next` returns -- the batch's
+        # primary decode-step response (cached_tokens defaults to 0; no new
+        # cache lookup happens on decode) followed by the deferred MTP draft
+        # response, also with no cached_tokens argument, which finishes the
+        # request (the "final deferred draft" the review calls out).
+        primary_decode = MLLMBatchResponse(
+            uid=0,
+            request_id="req-mtp",
+            token=2,
+            logprobs=mx.array([0.0]),
+            finish_reason=None,
+        )
+        deferred_draft = MLLMBatchResponse(
+            uid=0,
+            request_id="req-mtp",
+            token=3,
+            logprobs=mx.array([0.0]),
+            finish_reason="stop",
+            from_draft=True,
+        )
+        assert primary_decode.cached_tokens == 0
+        assert deferred_draft.cached_tokens == 0
+
+        outputs_2, finished = scheduler._process_batch_responses(
+            [primary_decode, deferred_draft]
+        )
+
+        assert "req-mtp" in finished
+        # Every output in this batch -- the decode-step primary and the
+        # finishing deferred draft alike -- must still report the cache hit.
+        for output in outputs_2:
+            assert output.cached_tokens == HIT
+            assert output.usage["cached_tokens"] == HIT
+
+        # The final deferred draft is what the client's usage object is
+        # built from.
+        final_output = outputs_2[-1]
+        assert final_output.finished is True
+        assert final_output.cached_tokens == HIT
+        assert final_output.usage["cached_tokens"] == HIT
+
+        # Raw cached_tokens tracks the last response's value (0 on this
+        # decode step, matching the LLM-path's identical semantics); the
+        # peak is what's actually reported to the client and must survive.
+        assert mock_request.cached_tokens == 0
+        assert mock_request.peak_cached_tokens == HIT
 
 
 class TestMLLMBatch:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2237,6 +2237,8 @@ class TestStreamChatCompletion:
             "prompt_tokens": 5,
             "completion_tokens": 7,
             "total_tokens": 12,
+            # Prefix-cache reuse is surfaced OpenAI-style; no reuse here -> 0.
+            "prompt_tokens_details": {"cached_tokens": 0},
         }
 
     @pytest.mark.anyio
@@ -2971,6 +2973,8 @@ class TestStreamChatCompletion:
             "prompt_tokens": 7,
             "completion_tokens": 3,
             "total_tokens": 10,
+            # Prefix-cache reuse is surfaced OpenAI-style; no reuse here -> 0.
+            "prompt_tokens_details": {"cached_tokens": 0},
         }
 
     @pytest.mark.anyio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3243,6 +3243,8 @@ class TestStreamChatCompletion:
             "prompt_tokens": 3,
             "completion_tokens": 1,
             "total_tokens": 4,
+            # Prefix-cache reuse is surfaced OpenAI-style; no reuse here -> 0.
+            "prompt_tokens_details": {"cached_tokens": 0},
         }
 
     @pytest.mark.anyio
@@ -3320,6 +3322,8 @@ class TestStreamChatCompletion:
             "prompt_tokens": 5,
             "completion_tokens": 2,
             "total_tokens": 7,
+            # Prefix-cache reuse is surfaced OpenAI-style; no reuse here -> 0.
+            "prompt_tokens_details": {"cached_tokens": 0},
         }
 
     @pytest.mark.anyio

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -252,12 +252,26 @@ class ChatCompletionChoice(BaseModel):
     finish_reason: str | None = "stop"
 
 
+class PromptTokensDetails(BaseModel):
+    """Breakdown of prompt tokens (OpenAI-compatible).
+
+    ``cached_tokens`` is the number of prompt tokens served from the prefix/KV
+    cache. This mirrors OpenAI's ``usage.prompt_tokens_details.cached_tokens``
+    so observability tools (Phoenix, Langfuse, ...) pick it up automatically.
+    """
+
+    cached_tokens: int = 0
+
+
 class Usage(BaseModel):
     """Token usage statistics."""
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    # Present whenever the serving path reports cache reuse; matches OpenAI,
+    # which always includes prompt_tokens_details when applicable.
+    prompt_tokens_details: PromptTokensDetails | None = None
 
 
 class GenerationMetadata(BaseModel):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -27,6 +27,9 @@ class GenerationOutput:
     tokens: list[int] = field(default_factory=list)
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Prompt tokens served from the prefix/KV cache. Surfaced to clients via
+    # usage.prompt_tokens_details.cached_tokens (OpenAI-compatible).
+    cached_tokens: int = 0
     finish_reason: str | None = "stop"
     mtp_drafts: int = 0
     mtp_accepted: int = 0

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -863,6 +863,7 @@ class BatchedEngine(BaseEngine):
                 tokens=output.output_token_ids,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
+                cached_tokens=getattr(output, "cached_tokens", 0),
                 finish_reason=output.finish_reason,
                 mtp_drafts=output.mtp_drafts,
                 mtp_accepted=output.mtp_accepted,
@@ -895,6 +896,7 @@ class BatchedEngine(BaseEngine):
             tokens=output.output_token_ids,
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
+            cached_tokens=getattr(output, "cached_tokens", 0),
             finish_reason=output.finish_reason,
         )
 
@@ -954,6 +956,7 @@ class BatchedEngine(BaseEngine):
                     new_text=output.new_text,
                     prompt_tokens=output.prompt_tokens,
                     completion_tokens=output.completion_tokens,
+                    cached_tokens=getattr(output, "cached_tokens", 0),
                     finished=output.finished,
                     finish_reason=output.finish_reason,
                     mtp_drafts=output.mtp_drafts,
@@ -991,6 +994,7 @@ class BatchedEngine(BaseEngine):
                 new_text=output.new_text,
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
+                cached_tokens=getattr(output, "cached_tokens", 0),
                 finished=output.finished,
                 finish_reason=output.finish_reason,
             )

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1200,6 +1200,7 @@ class SimpleEngine(BaseEngine):
             tokens=list(last_output.tokens),
             prompt_tokens=last_output.prompt_tokens,
             completion_tokens=last_output.completion_tokens,
+            cached_tokens=getattr(last_output, "cached_tokens", 0),
             finish_reason=last_output.finish_reason,
             finished=True,
         )
@@ -1597,6 +1598,7 @@ class SimpleEngine(BaseEngine):
                 tokens=list(final_output.tokens),
                 prompt_tokens=final_output.prompt_tokens,
                 completion_tokens=final_output.completion_tokens,
+                cached_tokens=getattr(final_output, "cached_tokens", 0),
                 finish_reason=final_output.finish_reason,
                 mtp_drafts=final_output.mtp_drafts,
                 mtp_accepted=final_output.mtp_accepted,
@@ -2365,6 +2367,9 @@ class SimpleEngine(BaseEngine):
                         new_text=new_text,
                         prompt_tokens=full_token_count,
                         completion_tokens=token_count,
+                        # System-prefix KV-cache reuse: on a HIT the whole system
+                        # prefix is served from cache; a MISS prefills it fresh.
+                        cached_tokens=system_token_count if cache_hit else 0,
                         finished=finished,
                         finish_reason=finish_reason,
                     )

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -221,6 +221,11 @@ class MLLMBatchRequest:
     # Text-only flag (no images/videos — eligible for prefix cache)
     is_text_only: bool = False
 
+    # Prompt tokens served from the prefix cache at prefill time (0 = miss).
+    # Set once when the fetch resolves; carried on this request for its
+    # whole lifetime so every emitted response can report it.
+    cached_tokens: int = 0
+
     # Generation state
     num_tokens: int = 0  # Tokens generated so far
     output_tokens: List[int] = field(default_factory=list)
@@ -248,6 +253,7 @@ class MLLMBatchResponse:
     from_draft: bool = False  # True when this response is an accepted MTP draft
     mtp_attempted: bool = False  # True when the primary step attempted MTP
     mtp_attempted_count: int = 0  # Number of draft tokens attempted
+    cached_tokens: int = 0  # Prompt tokens served from the prefix cache
 
 
 @dataclass
@@ -1626,6 +1632,7 @@ class MLLMBatchGenerator:
 
                     per_request_caches.append(request_cache)
                     req.vision_encoded = True
+                    req.cached_tokens = cached_count
                     logger.debug(
                         f"Prefix cache hit for {req.request_id}: "
                         f"cached={cached_count}, "
@@ -1660,6 +1667,7 @@ class MLLMBatchGenerator:
 
                     per_request_caches.append(request_cache)
                     req.vision_encoded = True
+                    req.cached_tokens = total_tokens - 1
                     logger.debug(
                         f"Prefix cache exact hit for {req.request_id}: "
                         f"all {total_tokens} tokens cached"
@@ -1667,6 +1675,7 @@ class MLLMBatchGenerator:
 
                 else:
                     # Cache miss — full forward pass
+                    req.cached_tokens = 0
                     request_cache = make_prompt_cache(
                         self.language_model,
                         max_kv_size=self.max_kv_size or None,
@@ -2073,6 +2082,7 @@ class MLLMBatchGenerator:
                     logprobs=logprobs[i],
                     finish_reason=finish_reason,
                     prompt_cache=cache_fn,
+                    cached_tokens=getattr(req, "cached_tokens", 0),
                 )
             )
 
@@ -2970,6 +2980,7 @@ def install_chunked_prefill_mllm(
                         if finish_reason is not None
                         else None
                     ),
+                    cached_tokens=getattr(req, "cached_tokens", 0),
                 )
             )
 
@@ -3321,6 +3332,11 @@ def install_chunked_prefill_mllm(
                     remaining = input_ids
                     cached_count = 0
                     remaining_count = total_tokens
+
+                # Persist on the request so every response emitted for it
+                # (immediate or across interleaved chunks) can report the
+                # prefix-cache reuse from this prefill.
+                text_only_req.cached_tokens = cached_count
 
                 # Decide: interleave or immediate
                 if remaining_count > batch_gen._chunked_prefill_budget:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -124,6 +124,10 @@ class MLLMRequest:
     mtp_drafts: int = 0
     mtp_accepted: int = 0
     cached_tokens: int = 0  # Prompt tokens served from the prefix cache (0 = miss)
+    # High-water mark of cached_tokens across this request's responses. See
+    # the peak-tracking comment in the scheduler loop for why a separate
+    # field is needed rather than reading cached_tokens directly.
+    peak_cached_tokens: int = 0
 
     # Timing
     first_token_time: Optional[float] = None
@@ -685,10 +689,20 @@ class MLLMScheduler:
                 request.mtp_drafts += response.mtp_attempted_count
             if response.from_draft:
                 request.mtp_accepted += 1
-            # Set once at prefill, not accumulated: response.cached_tokens is
-            # the same stable value on every response for this request's
-            # lifetime (the batch generator's MLLMBatchRequest carries it).
             request.cached_tokens = response.cached_tokens
+
+            # Track the high-water mark of prefix-cache reuse, mirroring the
+            # LLM-path scheduler (see scheduler.py's identical comment).
+            # cached_tokens is established once at prefill on the primary
+            # response, but synthetic/deferred responses -- e.g. the MTP
+            # wrapper's appended draft-token responses at
+            # mllm_batch_generator.py's deferred-draft augmentation sites --
+            # carry no cache accounting of their own and default to 0. Emit
+            # the peak so a draft response never makes a cache hit read back
+            # as a miss.
+            request.peak_cached_tokens = max(
+                request.peak_cached_tokens, request.cached_tokens
+            )
 
             if request.first_token_time is None and request.num_output_tokens > 0:
                 request.first_token_time = time.time()
@@ -717,8 +731,10 @@ class MLLMScheduler:
                 # response.cached_tokens above; getattr kept defensively in
                 # case a future request type reaches this path without the
                 # field (e.g. the error-response branch's plain Request-less
-                # construction elsewhere in this method).
-                cached_tokens=getattr(request, "cached_tokens", 0),
+                # construction elsewhere in this method). peak_cached_tokens,
+                # not cached_tokens, so a zero-default deferred/draft
+                # response can't clobber an already-reported cache hit.
+                cached_tokens=getattr(request, "peak_cached_tokens", 0),
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
             )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -708,6 +708,10 @@ class MLLMScheduler:
                 output_token_ids=request.output_tokens,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                # MLLM does not yet track prefix-cache reuse at the request
+                # level; thread it defensively so it surfaces automatically if
+                # ``cached_tokens`` is ever populated here.
+                cached_tokens=getattr(request, "cached_tokens", 0),
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
             )

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -123,6 +123,7 @@ class MLLMRequest:
     num_output_tokens: int = 0
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    cached_tokens: int = 0  # Prompt tokens served from the prefix cache (0 = miss)
 
     # Timing
     first_token_time: Optional[float] = None
@@ -684,6 +685,10 @@ class MLLMScheduler:
                 request.mtp_drafts += response.mtp_attempted_count
             if response.from_draft:
                 request.mtp_accepted += 1
+            # Set once at prefill, not accumulated: response.cached_tokens is
+            # the same stable value on every response for this request's
+            # lifetime (the batch generator's MLLMBatchRequest carries it).
+            request.cached_tokens = response.cached_tokens
 
             if request.first_token_time is None and request.num_output_tokens > 0:
                 request.first_token_time = time.time()
@@ -708,9 +713,11 @@ class MLLMScheduler:
                 output_token_ids=request.output_tokens,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
-                # MLLM does not yet track prefix-cache reuse at the request
-                # level; thread it defensively so it surfaces automatically if
-                # ``cached_tokens`` is ever populated here.
+                # Populated from MLLMBatchGenerator's fetch-site accounting via
+                # response.cached_tokens above; getattr kept defensively in
+                # case a future request type reaches this path without the
+                # field (e.g. the error-response branch's plain Request-less
+                # construction elsewhere in this method).
                 cached_tokens=getattr(request, "cached_tokens", 0),
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -149,6 +149,9 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            # Cache reuse is a per-request constant; keep the max so it is never
+            # lost when a cache-bearing early step is merged with a later one.
+            cached_tokens=max(existing.cached_tokens, new.cached_tokens),
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -116,6 +116,12 @@ class Request:
     prompt_cache: Optional[List[Any]] = None  # Cached KV state from prefix cache
     prompt_cache_key: Optional[List[int]] = None  # Actual shared-cache entry key
     cached_tokens: int = 0  # Number of tokens retrieved from cache
+    # High-water mark of ``cached_tokens`` for this request. ``cached_tokens``
+    # reflects the *current* prefill reuse and can be cleared on cache
+    # fallback/retry paths, so we track the peak separately and report it in
+    # usage — otherwise the value observed at prefill would be lost by the time
+    # the final (streamed or aggregated) output is built.
+    peak_cached_tokens: int = 0
     remaining_tokens: Optional[List[int]] = None  # Tokens still needing processing
     prefix_boundary: int = 0  # Token count for shared prefix (messages[:-1])
 
@@ -214,6 +220,8 @@ class RequestOutput:
     # Timing
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    # Prompt tokens served from the prefix/KV cache (prefix-cache reuse).
+    cached_tokens: int = 0
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
@@ -225,4 +233,5 @@ class RequestOutput:
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.prompt_tokens + self.completion_tokens,
+            "cached_tokens": self.cached_tokens,
         }

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2801,6 +2801,17 @@ class Scheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
+            # Track the high-water mark of prefix-cache reuse. ``cached_tokens``
+            # holds the reuse count set at prefill (memory-tier LCP hit, SSD-tier
+            # promotion, or legacy/paged hit); it can be cleared later on a
+            # cache-fallback/retry path, so we carry the peak forward. This is
+            # what lets the FINAL output — the finished streaming chunk as well
+            # as the aggregated non-streaming result — report cache reuse even
+            # though the streamed chunks are consumed one at a time.
+            request.peak_cached_tokens = max(
+                request.peak_cached_tokens, request.cached_tokens
+            )
+
             # Create output
             output = RequestOutput(
                 request_id=request_id,
@@ -2809,6 +2820,7 @@ class Scheduler:
                 output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                cached_tokens=request.peak_cached_tokens,
             )
 
             # Check if finished

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -98,6 +98,7 @@ from .api.models import (
     Message,  # noqa: F401
     ModelInfo,  # noqa: F401
     ModelsResponse,
+    PromptTokensDetails,
     RerankRequest,
     RerankResponse,
     RerankResult,
@@ -128,6 +129,7 @@ from .api.responses_models import (
     ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent,
     ResponseReasoningTextPart,
+    ResponsesInputTokenDetails,
     ResponseTextContentPart,
     ResponsesRequest,
     ResponsesUsage,
@@ -2407,6 +2409,7 @@ def _build_response_object(
     completion_tokens: int,
     finish_reason: str | None,
     response_id: str | None = None,
+    cached_tokens: int = 0,
 ) -> ResponseObject:
     """Build a full Responses API object."""
     response = ResponseObject(
@@ -2430,6 +2433,10 @@ def _build_response_object(
             input_tokens=prompt_tokens,
             output_tokens=completion_tokens,
             total_tokens=prompt_tokens + completion_tokens,
+            # Responses API surfaces prefix-cache reuse under input_tokens_details.
+            input_tokens_details=ResponsesInputTokenDetails(
+                cached_tokens=cached_tokens
+            ),
         ),
     )
     if finish_reason == "length":
@@ -2535,6 +2542,7 @@ async def _run_responses_request(
         prompt_tokens=output.prompt_tokens,
         completion_tokens=output.completion_tokens,
         finish_reason=output.finish_reason,
+        cached_tokens=getattr(output, "cached_tokens", 0) or 0,
     )
 
     persisted_messages = _responses_request_to_persisted_messages(request)
@@ -2965,6 +2973,7 @@ async def _stream_responses_request(request: ResponsesRequest) -> AsyncIterator[
         completion_tokens=completion_tokens,
         finish_reason=finish_reason,
         response_id=response_id,
+        cached_tokens=getattr(last_output, "cached_tokens", 0) or 0,
     )
 
     if request.store and last_output is not None:
@@ -3657,6 +3666,9 @@ def get_usage(output: GenerationOutput) -> Usage:
         prompt_tokens=total_prompt_tokens,
         completion_tokens=total_completion_tokens,
         total_tokens=total_prompt_tokens + total_completion_tokens,
+        prompt_tokens_details=PromptTokensDetails(
+            cached_tokens=getattr(output, "cached_tokens", 0) or 0
+        ),
     )
 
 
@@ -5114,6 +5126,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         choices = []
         total_completion_tokens = 0
         total_prompt_tokens = 0
+        total_cached_tokens = 0
         for i, prompt in enumerate(prompts):
             generate_kwargs = {
                 "prompt": prompt,
@@ -5175,6 +5188,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             total_prompt_tokens += (
                 output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
             )
+            total_cached_tokens += getattr(output, "cached_tokens", 0) or 0
 
         elapsed = time.perf_counter() - start_time
         tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
@@ -5194,6 +5208,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 prompt_tokens=total_prompt_tokens,
                 completion_tokens=total_completion_tokens,
                 total_tokens=total_prompt_tokens + total_completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=total_cached_tokens
+                ),
             ),
         )
     finally:
@@ -5389,6 +5406,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 total_tokens=output.prompt_tokens + output.completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=getattr(output, "cached_tokens", 0) or 0
+                ),
             ),
             generation_metadata=_generation_metadata(
                 prepared.thinking_processor, output
@@ -5847,6 +5867,9 @@ async def create_anthropic_message(
             usage=AnthropicUsage(
                 input_tokens=output.prompt_tokens,
                 output_tokens=output.completion_tokens,
+                # Anthropic surfaces prefix-cache reuse as cache_read_input_tokens.
+                cache_read_input_tokens=(getattr(output, "cached_tokens", 0) or 0)
+                or None,
             ),
         )
         tracker.finish(
@@ -6890,6 +6913,9 @@ async def stream_chat_completion(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    prompt_tokens_details=PromptTokensDetails(
+                        cached_tokens=getattr(last_output, "cached_tokens", 0) or 0
+                    ),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"


### PR DESCRIPTION
Refs #522
Depends on #731 for the live "both numbers move together" demonstration below (this PR's plumbing is independently correct and tested without it — see Performance impact).

## Summary

This repo doesn't currently expose per-request prefix-cache hit information anywhere in the API response, for any engine path — the internal `Request.cached_tokens` bookkeeping (present since the shared Phase-4 continuous-batching work) has always fed scheduler logging and `/v1/status` only, never the OpenAI-compatible `usage` object. This PR adds that surface — `usage.prompt_tokens_details.cached_tokens` (OpenAI schema), plus the equivalent Responses API and Anthropic-adapter fields — populated correctly for the `SimpleEngine`, plain-text `BatchedEngine`, and MLLM `BatchedEngine` (continuous-batching) paths.

**Why now:** #522 ("tokens_to_prefill always matches prompt_tokens, and caching does not seem to work when using claude code") has sat open since May with a maintainer reply explicitly naming *"metric reporting mismatch"* as one of several candidate explanations still needing to be ruled out, and noting *"SimpleEngine pure-LLM, MLLM text route, continuous batching, and paged-cache path do not all share the same implementation."* This field answers that question directly, in the API response itself, for every request — no `/v1/cache/stats` before/after diffing needed.

## Changes

- `PromptTokensDetails` / `Usage.prompt_tokens_details` (OpenAI schema), populated on every chat/completions path, streaming and non-streaming; the pre-existing but previously-unpopulated Responses API and Anthropic-adapter cache fields are wired up too.
- Plain-text (`scheduler.py`) and `SimpleEngine`: threads the existing `Request.cached_tokens` / new `peak_cached_tokens` high-water-mark through `RequestOutput`/`GenerationOutput`, correct across both streaming (finished-chunk) and non-streaming (drained+merged) construction, and cache-fallback/retry resets.
- MLLM (`mllm_scheduler.py`/`mllm_batch_generator.py`): same accounting, threaded through `MLLMBatchRequest` → `MLLMBatchResponse` → `MLLMRequest` → `RequestOutput`, covering the prefix/LCP-match, exact-match, and cache-miss branches at both the primary (`_process_prompts`) and interleaved chunked-prefill (`_generation_step`) fetch sites.

**Coverage boundary, disclosed rather than left for review to find:** MLLM requests served through `SimpleEngine` (non-continuous-batching multimodal serving, if/where that combination exists) were not touched or verified — this PR covers `SimpleEngine` for text and `BatchedEngine` for both text and MLLM, which are the three paths #522 and this investigation actually exercised live.

## Type of change

- New feature

## Surface touched

- OpenAI API endpoints
- Anthropic API endpoints
- Scheduler / batching
- KV cache / prefix cache

## Test plan

```
pytest tests/test_cache_token_usage.py tests/test_mllm_continuous_batching.py tests/test_server.py -v
pytest tests/ -q
```

Unit coverage for the data-model plumbing, `RequestOutputCollector` merge semantics (keeps the max reuse count), `get_usage()`, end-to-end streaming/non-streaming chat completions (plain-text path); MLLM-side dataclass defaults and three behavioral tests (exact-hit accounting, miss-reset, scheduler-level propagation from response → request → output, unaccumulated).

## Test results

```
$ pytest tests/ -q
2701 passed, 25 skipped, 27 deselected
```
(`origin/main` baseline 2687; +14 new, 0 regressed.)

```
$ ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841
All checks passed!
$ black --check vllm_mlx/ tests/
All done! ✨ 🍰 ✨
```

## Performance impact

- Hardware: Apple M5 Max, 128 GB RAM
- Model and quantization: `mlx-community/Qwen3.8-27B-8bit`
- This PR only adds counter bookkeeping (integer arithmetic and field assignment on objects already being constructed per-request/per-step) — no additional model inference, no additional allocation on the hot tensor path. Not independently benchmarked in isolation; verified live alongside #731 where the dominant cost (prefill) changed by ~111x for unrelated reasons (that fix), and this PR's own overhead was not separately measurable against that.
- Live demonstration, this PR + #731 together: identical ~28k-token prompt sent twice — cold 46.60s / `cached_tokens: 0`, warm **0.42s** / `cached_tokens: 28062`.

## Output parity

No change to sampling, tokenization, scheduling decisions, or generated content — this PR only adds a new, previously-always-zero field to response metadata. Verified by the existing exact-equality usage-dict assertions in `test_server.py` (two of which needed updating for the new field, included in this PR, since they were added on `main` after this branch's own commits last touched them) continuing to pass for every other field.

## Risk notes

Purely additive: new dataclass fields default to `0`/unset, new response fields default to the same "no reuse" value pre-existing clients already see today. No existing field's value or type changes. The one thing worth a reviewer's attention: this PR's own live proof of "the number is real, not just wired to zero" currently depends on #731 also landing (or testing against a non-hybrid model) — noted explicitly rather than glossed over.
