### PR TITLE
fix(video): video requests silently dropped, then broken on mlx-vlm 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
             tests/test_mllm_cache.py \
             tests/test_api_models.py \
             tests/test_api_utils.py \
+            tests/test_video_pipeline.py \
             tests/test_request.py \
             tests/test_anthropic_models.py \
             tests/test_anthropic_adapter.py \

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -65,6 +65,89 @@ def test_create_chat_function_uses_configured_served_model_name(monkeypatch):
     assert captured["json"]["model"] == "my-served-model"
 
 
+def test_create_chat_function_does_not_replay_historical_media(monkeypatch):
+    captured_requests = []
+
+    def fake_post(url, json, timeout):
+        captured_requests.append(json)
+        return DummyResponse("ok")
+
+    monkeypatch.setattr(gradio_app.requests, "post", fake_post)
+    monkeypatch.setattr(
+        gradio_app,
+        "build_media_items",
+        lambda files: [
+            {
+                "type": "video_url",
+                "video_url": {"url": "data:video/quicktime;base64,AAAA"},
+            }
+        ],
+    )
+
+    chat_fn = gradio_app.create_chat_function(
+        server_url="http://localhost:8000",
+        max_tokens=128,
+        temperature=0.3,
+    )
+    chat_fn(
+        {"text": "Identify the instrument.", "files": ["clip.mov"]},
+        history=[],
+    )
+    chat_fn(
+        {"text": "What pattern is on the strap?", "files": []},
+        history=[
+            {"role": "user", "content": "Identify the instrument."},
+            {"role": "assistant", "content": "An electric guitar."},
+        ],
+    )
+
+    first_messages = captured_requests[0]["messages"]
+    assert first_messages[0]["content"][1]["type"] == "video_url"
+
+    follow_up_messages = captured_requests[1]["messages"]
+    assert all(isinstance(message["content"], str) for message in follow_up_messages)
+    assert gradio_app.OMITTED_MEDIA_NOTE in follow_up_messages[0]["content"]
+    assert "data:video/" not in str(follow_up_messages)
+
+
+def test_create_chat_function_clears_media_indexes_for_new_chat(monkeypatch):
+    captured_requests = []
+
+    def fake_post(url, json, timeout):
+        captured_requests.append(json)
+        return DummyResponse("ok")
+
+    monkeypatch.setattr(gradio_app.requests, "post", fake_post)
+    monkeypatch.setattr(
+        gradio_app,
+        "build_media_items",
+        lambda files: [
+            {
+                "type": "video_url",
+                "video_url": {"url": "data:video/quicktime;base64,AAAA"},
+            }
+        ],
+    )
+
+    chat_fn = gradio_app.create_chat_function(
+        server_url="http://localhost:8000",
+        max_tokens=128,
+        temperature=0.3,
+    )
+    chat_fn({"text": "Old chat", "files": ["clip.mov"]}, history=[])
+    chat_fn({"text": "New chat", "files": []}, history=[])
+    chat_fn(
+        {"text": "Follow up", "files": []},
+        history=[
+            {"role": "user", "content": "New chat"},
+            {"role": "assistant", "content": "ok"},
+        ],
+    )
+
+    new_chat_follow_up = captured_requests[2]["messages"]
+    assert gradio_app.OMITTED_MEDIA_NOTE not in str(new_chat_follow_up)
+
+
 def test_main_text_only_uses_configured_served_model_name(monkeypatch):
     captured = {}
 

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -121,6 +121,81 @@ def test_name_patterns_remain_the_fallback():
     assert is_mllm_model("some-org/definitely-a-text-model") is False
 
 
+@pytest.fixture
+def no_network(monkeypatch):
+    """Any socket creation fails the test: these paths must stay offline."""
+    import socket
+
+    def _refuse(*args, **kwargs):
+        raise AssertionError("network access attempted in a no-network test")
+
+    monkeypatch.setattr(socket, "socket", _refuse)
+    monkeypatch.setattr(socket, "create_connection", _refuse)
+
+
+@pytest.fixture
+def hub_cache(tmp_path, monkeypatch):
+    """Redirect huggingface_hub's cache lookup to an isolated directory,
+    keeping the real cache-layout parsing in the loop."""
+    import functools
+
+    import huggingface_hub
+
+    real = huggingface_hub.try_to_load_from_cache
+    monkeypatch.setattr(
+        huggingface_hub,
+        "try_to_load_from_cache",
+        functools.partial(real, cache_dir=str(tmp_path)),
+    )
+    return tmp_path
+
+
+def _write_hub_cached_config(cache_root, repo_id: str, config: str) -> None:
+    """Lay out config.json the way huggingface_hub stores a cached repo."""
+    repo_dir = cache_root / f"models--{repo_id.replace('/', '--')}"
+    rev = "0" * 40
+    (repo_dir / "snapshots" / rev).mkdir(parents=True)
+    (repo_dir / "refs").mkdir()
+    (repo_dir / "refs" / "main").write_text(rev)
+    (repo_dir / "snapshots" / rev / "config.json").write_text(config)
+
+
+def test_cached_neutral_id_is_detected_from_hub_config(no_network, hub_cache):
+    """A neutral repo ID (no VL marker) already in the hub cache must be
+    classified by its own config.json - the case that silently dropped video
+    for Qwen3.8 - and without any network traffic."""
+    _write_hub_cached_config(
+        hub_cache,
+        "mlx-community/Qwen-Neutral-Name-4bit",
+        '{"architectures": ["Qwen3_5ForConditionalGeneration"],'
+        ' "vision_config": {}, "video_token_id": 248057}',
+    )
+    assert is_mllm_model("mlx-community/Qwen-Neutral-Name-4bit") is True
+
+
+def test_cached_text_only_id_stays_text_only(no_network, hub_cache):
+    """The cached config governs in both directions: a text-only config keeps
+    a model text-only even if a broad name pattern would have matched."""
+    _write_hub_cached_config(
+        hub_cache,
+        "mlx-community/SomePixtral-Like-Name",
+        '{"architectures": ["Qwen3ForCausalLM"]}',
+    )
+    assert is_mllm_model("mlx-community/SomePixtral-Like-Name") is False
+
+
+def test_cold_neutral_id_falls_back_to_name_patterns_offline(no_network, hub_cache):
+    """A neutral ID with nothing cached is decided by name patterns alone,
+    before any download. This pins the current pre-download behaviour: the
+    CLI's MLLM-versus-LLM routing decision for a cold neutral ID is made from
+    the name, with no network attempted, and misroutes a neutrally-named VLM
+    until its config is cached. Resolving hub metadata before that decision
+    is a known follow-up; this test exists so the limitation is deliberate.
+    """
+    assert is_mllm_model("mlx-community/Totally-Uncached-Neutral-Model") is False
+    assert is_mllm_model("mlx-community/Uncached-Qwen3-VL-Named-Model") is True
+
+
 # --------------------------------------------------------------------------
 # The pinned mlx-vlm contract
 # --------------------------------------------------------------------------
@@ -215,15 +290,15 @@ def test_mixed_image_video_audio_are_routed_separately(fake_mlx_vlm, monkeypatch
     assert isinstance(gen_kwargs["video"][0], np.ndarray)
 
 
-def test_multiple_videos_share_the_first_clips_sampled_rate(fake_mlx_vlm, monkeypatch):
-    """Known limitation, pinned so a change is deliberate rather than accidental.
+def test_multiple_videos_fail_closed(fake_mlx_vlm, monkeypatch):
+    """More than one video per native request must be rejected, not mislabeled.
 
-    mlx_vlm.prepare_inputs takes a single scalar fps and fans it out to every
-    video, so a request carrying two clips labels the second one's frames using
-    the first one's rate. That value drives Qwen's interleaved timestamps.
-    Fixing it means calling the processor directly instead of going through
-    mlx_vlm.generate; until then this test documents the behaviour rather than
-    letting it pass unnoticed.
+    mlx_vlm.generate takes a single scalar fps and fans it out to every video,
+    so a request carrying two clips would label the second one's frames with
+    the first one's sampled rate - and that value drives Qwen's interleaved
+    timestamp tokens. Correct per-video timestamps mean calling the processor
+    directly instead of going through mlx_vlm.generate; until that exists the
+    path fails closed with the reason, before any decoding work is done.
     """
     messages = [
         {
@@ -234,12 +309,18 @@ def test_multiple_videos_share_the_first_clips_sampled_rate(fake_mlx_vlm, monkey
             ],
         }
     ]
-    _, gen_kwargs = _prepare(monkeypatch, messages)
+    with pytest.raises(ValueError, match="one video per request"):
+        _prepare(monkeypatch, messages)
 
-    decoded_rates = [2.5, 3.5]  # what the stub returned for the two clips
-    assert len(gen_kwargs["video"]) == 2
-    assert gen_kwargs["fps"] == decoded_rates[0]
-    assert gen_kwargs["fps"] != decoded_rates[1], "second clip's rate is discarded"
+    assert fake_mlx_vlm["load_video"] == [], "rejected before decoding starts"
+
+
+def test_single_video_is_unaffected_by_the_multi_video_guard(fake_mlx_vlm, monkeypatch):
+    messages = [
+        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
+    ]
+    _, gen_kwargs = _prepare(monkeypatch, messages)
+    assert len(gen_kwargs["video"]) == 1
 
 
 def test_empty_decode_stops_the_request(fake_mlx_vlm, monkeypatch):

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit coverage for the native video path.
+
+These run without MLX. vllm_mlx.models.mllm imports mlx lazily inside the
+functions that need it, so the decode and preprocessing logic can be exercised
+with a stand-in mlx_vlm — which is the point: the failures this file guards
+against were an upstream module rename and a silently empty decode, and neither
+needs a GPU to catch.
+
+A second file's worth of behaviour — the actual model output — needs Apple
+Silicon and is not attempted here.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from vllm_mlx.api.utils import is_mllm_model
+from vllm_mlx.models.mllm import (
+    MAX_FRAMES,
+    MIN_FRAME_DIMENSION,
+    VIDEO_MIME_TO_SUFFIX,
+    assert_video_decoded,
+    decode_base64_video,
+)
+
+
+def _frames(count: int, height: int = 64, width: int = 48) -> np.ndarray:
+    """A (T, C, H, W) stack shaped the way mlx_vlm.utils.load_video returns."""
+    return np.zeros((count, 3, height, width), dtype=np.uint8)
+
+
+# --------------------------------------------------------------------------
+# Decode failures must raise, not return empty
+# --------------------------------------------------------------------------
+
+
+def test_zero_frames_raises_and_names_the_layer():
+    """An empty decode is the failure that reads as a model failure.
+
+    The message has to say which layer failed, because the symptom a user sees
+    is a fluent "I don't see any video" and the instinct is to blame the model.
+    """
+    with pytest.raises(ValueError, match="decode failure, not a model failure"):
+        assert_video_decoded([], "clip.mov")
+
+
+def test_implausible_frame_size_raises():
+    tiny = _frames(4, height=MIN_FRAME_DIMENSION - 1, width=MIN_FRAME_DIMENSION - 1)
+    with pytest.raises(ValueError, match="Implausible frame size"):
+        assert_video_decoded(tiny, "clip.mov", height_axis=1, width_axis=2)
+
+
+def test_malformed_frame_shape_raises():
+    with pytest.raises(ValueError, match="unexpected shape"):
+        assert_video_decoded([np.zeros(())], "clip.mov")
+
+
+def test_valid_decode_reports_display_orientation():
+    """Returned dims are used to spot a transposed read, so check the axes."""
+    count, width, height = assert_video_decoded(
+        _frames(16, height=2604, width=2160), "clip.mov", height_axis=1, width_axis=2
+    )
+    assert (count, width, height) == (16, 2160, 2604)
+
+
+# --------------------------------------------------------------------------
+# Container suffix: the MIME subtype is not the container name
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mime,suffix",
+    [
+        ("video/quicktime", ".mov"),
+        ("video/mp4", ".mp4"),
+        ("video/x-matroska", ".mkv"),
+        ("video/x-msvideo", ".avi"),
+    ],
+)
+def test_base64_video_gets_a_real_container_suffix(mime, suffix):
+    """Splitting the MIME type yields ".quicktime"; decoders infer from this."""
+    assert VIDEO_MIME_TO_SUFFIX[mime] == suffix
+    path = decode_base64_video(f"data:{mime};base64," + base64.b64encode(b"\0" * 16).decode())
+    assert path.endswith(suffix)
+
+
+def test_unknown_video_mime_falls_back_to_mp4():
+    payload = base64.b64encode(b"\0" * 16).decode()
+    path = decode_base64_video(f"data:video/x-unheard-of;base64,{payload}")
+    assert path.endswith(".mp4")
+
+
+# --------------------------------------------------------------------------
+# Multimodal model detection
+# --------------------------------------------------------------------------
+
+
+def test_local_config_beats_the_name(tmp_path):
+    """A model whose name carries no VLM marker is still multimodal."""
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["Qwen3_5ForConditionalGeneration"],'
+        ' "vision_config": {}, "video_token_id": 248057}'
+    )
+    assert is_mllm_model(str(tmp_path)) is True
+
+
+def test_text_only_config_stays_text_only(tmp_path):
+    (tmp_path / "config.json").write_text('{"architectures": ["Qwen3ForCausalLM"]}')
+    assert is_mllm_model(str(tmp_path)) is False
+
+
+def test_name_patterns_remain_the_fallback():
+    """With no config reachable, the legacy substring match still applies."""
+    assert is_mllm_model("some-org/Qwen3-VL-4B-Instruct-3bit") is True
+    assert is_mllm_model("some-org/definitely-a-text-model") is False
+
+
+# --------------------------------------------------------------------------
+# The pinned mlx-vlm contract
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_mlx_vlm(monkeypatch):
+    """Stand in for mlx_vlm, recording how the native path calls it.
+
+    The dependency that broke was a module rename: mlx_vlm.video_generate
+    disappeared in 0.6 and every video request became a 500. Pinning the call
+    shape here means a rename fails a test instead of production.
+    """
+    calls: dict[str, list] = {"load_video": []}
+
+    def load_video(path, fps=None, max_frames=None, min_frames=None, frame_factor=None):
+        calls["load_video"].append(
+            {
+                "path": path,
+                "fps": fps,
+                "max_frames": max_frames,
+                "min_frames": min_frames,
+                "frame_factor": frame_factor,
+            }
+        )
+        # Distinct sampled rate per clip, so callers that collapse them show it.
+        return _frames(8), 1.5 + len(calls["load_video"])
+
+    utils = types.ModuleType("mlx_vlm.utils")
+    utils.load_video = load_video
+    package = types.ModuleType("mlx_vlm")
+    package.utils = utils
+    monkeypatch.setitem(sys.modules, "mlx_vlm", package)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", utils)
+    return calls
+
+
+def _prepare(monkeypatch, native_messages, **kwargs):
+    """Call _prepare_native_video_inputs against a stub model object."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    class Stub:
+        _video_native = True
+        _video_native_with_audio = False
+
+        class processor:
+            @staticmethod
+            def apply_chat_template(messages, **kw):
+                return "PROMPT"
+
+        @staticmethod
+        def _translate_messages_for_native_video(messages, fps, max_frames):
+            return native_messages
+
+    return MLXMultimodalLM._prepare_native_video_inputs(
+        Stub(), [{"role": "user", "content": []}], **kwargs
+    )
+
+
+def test_native_path_calls_load_video_with_our_caps(fake_mlx_vlm, monkeypatch):
+    """video_max_frames must reach the decoder: upstream's default cap is 768."""
+    messages = [
+        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
+    ]
+    text, gen_kwargs = _prepare(monkeypatch, messages, video_fps=2.0, video_max_frames=MAX_FRAMES)
+
+    assert text == "PROMPT"
+    call = fake_mlx_vlm["load_video"][0]
+    assert call["path"] == "/tmp/a.mov"
+    assert call["fps"] == 2.0
+    assert call["max_frames"] == MAX_FRAMES
+    assert len(gen_kwargs["video"]) == 1
+
+
+def test_mixed_image_video_audio_are_routed_separately(fake_mlx_vlm, monkeypatch):
+    """Images stay paths, videos become arrays, audio stays paths."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": "/tmp/pic.png"},
+                {"type": "video", "video": "/tmp/a.mov"},
+                {"type": "audio", "audio": "/tmp/a.wav"},
+            ],
+        }
+    ]
+    _, gen_kwargs = _prepare(monkeypatch, messages)
+
+    assert gen_kwargs["image"] == ["/tmp/pic.png"]
+    assert gen_kwargs["audio"] == ["/tmp/a.wav"]
+    assert len(gen_kwargs["video"]) == 1
+    assert isinstance(gen_kwargs["video"][0], np.ndarray)
+
+
+def test_multiple_videos_share_the_first_clips_sampled_rate(fake_mlx_vlm, monkeypatch):
+    """Known limitation, pinned so a change is deliberate rather than accidental.
+
+    mlx_vlm.prepare_inputs takes a single scalar fps and fans it out to every
+    video, so a request carrying two clips labels the second one's frames using
+    the first one's rate. That value drives Qwen's interleaved timestamps.
+    Fixing it means calling the processor directly instead of going through
+    mlx_vlm.generate; until then this test documents the behaviour rather than
+    letting it pass unnoticed.
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "video", "video": "/tmp/a.mov"},
+                {"type": "video", "video": "/tmp/b.mov"},
+            ],
+        }
+    ]
+    _, gen_kwargs = _prepare(monkeypatch, messages)
+
+    decoded_rates = [2.5, 3.5]  # what the stub returned for the two clips
+    assert len(gen_kwargs["video"]) == 2
+    assert gen_kwargs["fps"] == decoded_rates[0]
+    assert gen_kwargs["fps"] != decoded_rates[1], "second clip's rate is discarded"
+
+
+def test_empty_decode_stops_the_request(fake_mlx_vlm, monkeypatch):
+    """A decoder returning nothing must raise before the model is called."""
+    import vllm_mlx.models.mllm as mllm
+
+    monkeypatch.setitem(
+        sys.modules["mlx_vlm.utils"].__dict__,
+        "load_video",
+        lambda *a, **k: (_frames(0), 2.0),
+    )
+    messages = [
+        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
+    ]
+    with pytest.raises(ValueError, match="Decoded 0 frames"):
+        _prepare(monkeypatch, messages)
+
+    assert mllm.MAX_FRAMES  # module still importable after the failure
+
+
+def test_missing_upstream_module_is_reported_not_swallowed(monkeypatch):
+    """The 0.6 rename produced ModuleNotFoundError; it must stay an ImportError."""
+    monkeypatch.setitem(sys.modules, "mlx_vlm", None)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", None)
+    messages = [
+        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
+    ]
+    with pytest.raises((ImportError, AttributeError, TypeError)):
+        _prepare(monkeypatch, messages)
+
+
+# --------------------------------------------------------------------------
+# The real dependency, where it is installed
+# --------------------------------------------------------------------------
+
+
+def test_real_mlx_vlm_still_exposes_the_pinned_api():
+    """Pins the two entry points this path depends on, on Apple Silicon.
+
+    mlx_vlm.video_generate vanished in 0.6 and took the whole video path with
+    it. If load_video or generate(video=...) moves again, this fails here
+    rather than in a user's request.
+    """
+    # Guard on mlx, not mlx_vlm: mlx_vlm can be installed and still fail to
+    # import when MLX is absent, which importorskip would surface as an error
+    # rather than a skip.
+    pytest.importorskip("mlx")
+    pytest.importorskip("mlx_vlm")
+    import inspect
+
+    from mlx_vlm.generate import generate
+    from mlx_vlm.utils import load_video
+
+    assert "video" in inspect.signature(generate).parameters
+    load_params = inspect.signature(load_video).parameters
+    for expected in ("fps", "max_frames", "min_frames", "frame_factor"):
+        assert expected in load_params, f"load_video lost {expected}"

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -86,7 +86,9 @@ def test_valid_decode_reports_display_orientation():
 def test_base64_video_gets_a_real_container_suffix(mime, suffix):
     """Splitting the MIME type yields ".quicktime"; decoders infer from this."""
     assert VIDEO_MIME_TO_SUFFIX[mime] == suffix
-    path = decode_base64_video(f"data:{mime};base64," + base64.b64encode(b"\0" * 16).decode())
+    path = decode_base64_video(
+        f"data:{mime};base64," + base64.b64encode(b"\0" * 16).decode()
+    )
     assert path.endswith(suffix)
 
 
@@ -257,10 +259,10 @@ def _prepare(monkeypatch, native_messages, **kwargs):
 
 def test_native_path_calls_load_video_with_our_caps(fake_mlx_vlm, monkeypatch):
     """video_max_frames must reach the decoder: upstream's default cap is 768."""
-    messages = [
-        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
-    ]
-    text, gen_kwargs = _prepare(monkeypatch, messages, video_fps=2.0, video_max_frames=MAX_FRAMES)
+    messages = [{"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}]
+    text, gen_kwargs = _prepare(
+        monkeypatch, messages, video_fps=2.0, video_max_frames=MAX_FRAMES
+    )
 
     assert text == "PROMPT"
     call = fake_mlx_vlm["load_video"][0]
@@ -316,9 +318,7 @@ def test_multiple_videos_fail_closed(fake_mlx_vlm, monkeypatch):
 
 
 def test_single_video_is_unaffected_by_the_multi_video_guard(fake_mlx_vlm, monkeypatch):
-    messages = [
-        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
-    ]
+    messages = [{"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}]
     _, gen_kwargs = _prepare(monkeypatch, messages)
     assert len(gen_kwargs["video"]) == 1
 
@@ -332,9 +332,7 @@ def test_empty_decode_stops_the_request(fake_mlx_vlm, monkeypatch):
         "load_video",
         lambda *a, **k: (_frames(0), 2.0),
     )
-    messages = [
-        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
-    ]
+    messages = [{"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}]
     with pytest.raises(ValueError, match="Decoded 0 frames"):
         _prepare(monkeypatch, messages)
 
@@ -345,9 +343,7 @@ def test_missing_upstream_module_is_reported_not_swallowed(monkeypatch):
     """The 0.6 rename produced ModuleNotFoundError; it must stay an ImportError."""
     monkeypatch.setitem(sys.modules, "mlx_vlm", None)
     monkeypatch.setitem(sys.modules, "mlx_vlm.utils", None)
-    messages = [
-        {"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}
-    ]
+    messages = [{"role": "user", "content": [{"type": "video", "video": "/tmp/a.mov"}]}]
     with pytest.raises((ImportError, AttributeError, TypeError)):
         _prepare(monkeypatch, messages)
 

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -405,6 +405,22 @@ _VLM_ARCHITECTURE_KEYWORDS = (
 _MAX_CONFIG_JSON_BYTES = 1 * 1024 * 1024
 
 
+def _read_config_json_file(config_path: Path) -> dict | None:
+    """Parse a config.json file, bounded by _MAX_CONFIG_JSON_BYTES."""
+    if not config_path.is_file():
+        return None
+
+    try:
+        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
+            return None
+        with config_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
 def _try_read_config_json(name_or_path: str) -> dict | None:
     """Read config.json from a local model directory.
 
@@ -419,19 +435,37 @@ def _try_read_config_json(name_or_path: str) -> dict | None:
     if not candidate.is_dir():
         return None
 
-    config_path = candidate / "config.json"
-    if not config_path.is_file():
+    return _read_config_json_file(candidate / "config.json")
+
+
+def _try_read_hub_config_json(repo_id: str) -> dict | None:
+    """Read config.json for a HuggingFace repo ID from the local hub cache.
+
+    A repo ID never resolves as a local directory, so without this the
+    authoritative config.json is skipped and detection falls back to matching
+    substrings against the repo name. That silently misclassifies multimodal
+    models whose name carries no VLM marker (e.g. Qwen3.8-27B-4bit, whose
+    config declares vision_config, image_token_id and video_token_id): the
+    model loads text-only and every image/video content part is dropped from
+    the request with no error. The weights are already in the hub cache by the
+    time a model is served, so the config is readable without a network call.
+
+    Returns None when the repo is not cached or the file cannot be parsed.
+    """
+    if not isinstance(repo_id, str) or repo_id.count("/") != 1:
         return None
 
     try:
-        if config_path.stat().st_size > _MAX_CONFIG_JSON_BYTES:
-            return None
-        with config_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        from huggingface_hub import try_to_load_from_cache
+
+        cached = try_to_load_from_cache(repo_id, "config.json")
+    except Exception:  # missing hub package, unreadable cache, malformed id
         return None
 
-    return data if isinstance(data, dict) else None
+    if not isinstance(cached, str):  # _CACHED_NO_EXIST sentinel or None
+        return None
+
+    return _read_config_json_file(Path(cached))
 
 
 def _config_indicates_vlm(config: dict) -> bool:
@@ -472,10 +506,11 @@ def is_mllm_model(model_name: str) -> bool:
     Two complementary validations are run:
 
     1. config.json inspection: when ``model_name`` resolves to a local
-       directory containing a readable config.json, inspect the model's
-       own metadata (``architectures`` field, ``vision_config``,
-       ``audio_config``, etc.). Authoritative when available because it
-       reflects what the model actually is, not how it is named on disk.
+       directory, or to a HuggingFace repo ID already present in the local
+       hub cache, inspect the model's own metadata (``architectures`` field,
+       ``vision_config``, ``audio_config``, etc.). Authoritative when
+       available because it reflects what the model actually is, not how it
+       is named on disk.
 
     2. Legacy substring match against ``MLLM_PATTERNS``: applied when no
        config.json is reachable (e.g., a HuggingFace repo ID before the
@@ -488,6 +523,8 @@ def is_mllm_model(model_name: str) -> bool:
         True if the model is detected as multimodal (MLLM/VLM).
     """
     config = _try_read_config_json(model_name)
+    if config is None:
+        config = _try_read_hub_config_json(model_name)
     if config is not None:
         return _config_indicates_vlm(config)
     return _check_legacy_string_patterns(model_name)

--- a/vllm_mlx/gradio_app.py
+++ b/vllm_mlx/gradio_app.py
@@ -161,6 +161,14 @@ def build_message_content(
 # the attachment never reached the model.
 MIN_PROMPT_TOKENS_WITH_MEDIA = 200
 
+# Historical image/video bytes are intentionally not replayed on every turn.
+# Reattaching is explicit and avoids repeatedly decoding and prefilling the same
+# large media payload for ordinary text follow-ups.
+OMITTED_MEDIA_NOTE = (
+    "[A media attachment from this earlier turn is not included in this request. "
+    "Ask the user to reattach it before making new claims about its visual content.]"
+)
+
 
 def media_drop_warning(media_items: list[dict], prompt_tokens: int) -> str | None:
     """Detect an attachment that was accepted and then silently dropped.
@@ -232,8 +240,10 @@ def create_chat_function(
     Returns:
         Chat function compatible with gr.ChatInterface
     """
-    # Store media from previous messages to include in context
-    media_cache = {}  # Maps message index to list of file data URLs
+    # Remember which historical user messages had media without retaining or
+    # replaying their base64 payloads. A 16 MB video becomes roughly 22 MB in a
+    # request and otherwise gets decoded and prefetched again on every turn.
+    media_message_indexes: set[int] = set()
 
     def chat(message: dict, history: list) -> str:
         """
@@ -246,11 +256,15 @@ def create_chat_function(
         Returns:
             Assistant response text
         """
-        nonlocal media_cache
-
         # Extract text and files from message
         text = message.get("text", "") if isinstance(message, dict) else message
         files = message.get("files", []) if isinstance(message, dict) else []
+
+        # Gradio reuses the chat function after the user clears the conversation.
+        # Drop indexes from the previous conversation so they cannot annotate a
+        # new chat whose message numbering starts at zero again.
+        if not history:
+            media_message_indexes.clear()
 
         # Debug output
         import sys
@@ -263,49 +277,43 @@ def create_chat_function(
         # Build messages list for API
         messages = []
 
-        # Process history - keep media content for multimodal context
+        omitted_media_count = 0
+        # Process history as text only. Historical media is represented by a
+        # marker so the model knows it must request a reattachment rather than
+        # hallucinating unseen visual details.
         for i, msg in enumerate(history):
             if isinstance(msg, dict):
                 role = msg.get("role", "user")
                 content = msg.get("content", "")
 
-                # Check if this message had media cached
-                if i in media_cache and role == "user":
-                    # Rebuild multimodal content with cached media
-                    if isinstance(content, str):
-                        rebuilt_content = [{"type": "text", "text": content}]
-                    elif isinstance(content, list):
-                        # Extract just text parts
-                        text_parts = [
-                            p.get("text", "")
-                            for p in content
-                            if isinstance(p, dict) and p.get("type") == "text"
-                        ]
-                        rebuilt_content = (
-                            [{"type": "text", "text": " ".join(text_parts)}]
-                            if text_parts
-                            else []
-                        )
-                    else:
-                        rebuilt_content = [{"type": "text", "text": str(content)}]
+                if isinstance(content, list):
+                    text_parts = [
+                        p.get("text", "")
+                        for p in content
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    ]
+                    content = " ".join(text_parts)
+                elif isinstance(content, dict):
+                    content = content.get("text", str(content))
+                elif not isinstance(content, str):
+                    content = str(content)
 
-                    # Add cached media
-                    for media_item in media_cache[i]:
-                        rebuilt_content.append(media_item)
+                if i in media_message_indexes and role == "user":
+                    content = (
+                        f"{content}\n\n{OMITTED_MEDIA_NOTE}"
+                        if content
+                        else OMITTED_MEDIA_NOTE
+                    )
+                    omitted_media_count += 1
 
-                    messages.append({"role": role, "content": rebuilt_content})
-                else:
-                    # No media, just text
-                    if isinstance(content, list):
-                        text_parts = [
-                            p.get("text", "")
-                            for p in content
-                            if isinstance(p, dict) and p.get("type") == "text"
-                        ]
-                        content = " ".join(text_parts)
-                    elif isinstance(content, dict):
-                        content = content.get("text", str(content))
-                    messages.append({"role": role, "content": content})
+                messages.append({"role": role, "content": content})
+
+        if omitted_media_count:
+            print(
+                f"[Chat] Omitted historical media from {omitted_media_count} "
+                "message(s); reattach to analyze it again",
+                flush=True,
+            )
 
         # Encode attachments once: a phone video is tens of megabytes and
         # base64-encoding it twice per turn is pure latency.
@@ -314,18 +322,20 @@ def create_chat_function(
         except ValueError as e:
             return f"Error: {e}"
 
-        # Build current message content and cache media
+        # Build current message content. Media is sent only on this upload turn.
         current_content = build_message_content(
             text, files if files else None, media_items=media_items
         )
         messages.append({"role": "user", "content": current_content})
 
-        # Cache media for this message (will be at index len(history) after this turn)
+        # Remember attachment presence, not its base64 bytes. This message will
+        # appear at index len(history) when Gradio submits the next turn.
         if media_items:
             current_idx = len(history)
-            media_cache[current_idx] = media_items
+            media_message_indexes.add(current_idx)
             print(
-                f"[Chat] Cached {len(media_items)} media items for message {current_idx}",
+                f"[Chat] Sent {len(media_items)} media item(s) for message {current_idx}; "
+                "historical replay disabled",
                 flush=True,
             )
 
@@ -508,7 +518,8 @@ Note: Make sure the vllm-mlx server is running with a multimodal model:
         # Create ChatInterface with multimodal support
         description = (
             "Chat with vision-language models on Apple Silicon. "
-            "Upload images or videos!"
+            "Upload images or videos! Attachments are analyzed only on the turn "
+            "where they are uploaded; reattach one for later visual questions."
         )
         if capability_warning:
             description += f"\n\n**WARNING:** {capability_warning}"

--- a/vllm_mlx/gradio_app.py
+++ b/vllm_mlx/gradio_app.py
@@ -24,51 +24,84 @@ Note:
 
 import argparse
 import base64
+import mimetypes
 from pathlib import Path
 
 import gradio as gr
 import requests
+
+# Image MIME types by extension.
+IMAGE_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+}
+
+# Video MIME types by extension. ".mov" is what an iPhone produces and
+# "video/quicktime" is the MIME browsers report for it — an allow-list missing
+# either entry drops the attachment with no error anywhere in the stack.
+VIDEO_TYPES = {
+    ".mp4": "video/mp4",
+    ".m4v": "video/x-m4v",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+    ".qt": "video/quicktime",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+    ".mpeg": "video/mpeg",
+    ".mpg": "video/mpeg",
+    ".ogv": "video/ogg",
+    ".3gp": "video/3gpp",
+}
+
+# Extensions accepted by the upload widget, listed explicitly alongside the
+# "image"/"video" categories so a container the browser fails to type-sniff is
+# still offered to the server rather than rejected in the file picker.
+UPLOAD_FILE_TYPES = ["image", "video"] + sorted(IMAGE_TYPES) + sorted(VIDEO_TYPES)
 
 
 def encode_file_to_base64(file_path: str) -> tuple[str, str]:
     """
     Encode a file to base64 data URL.
 
+    Resolution order: known extension, then the system MIME database, then
+    an error. Guessing wrong here is worse than failing: labelling a video
+    "image/jpeg" makes the server reject or misread it, and labelling
+    anything unknown as an image is how an attachment ends up silently
+    dropped instead of reported.
+
     Returns:
         Tuple of (data_url, media_type) where media_type is 'image' or 'video'
+
+    Raises:
+        ValueError: If the file type cannot be resolved to an image or video.
     """
     path = Path(file_path)
     suffix = path.suffix.lower()
 
-    # Image MIME types
-    image_types = {
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".png": "image/png",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-        ".bmp": "image/bmp",
-    }
-
-    # Video MIME types
-    video_types = {
-        ".mp4": "video/mp4",
-        ".webm": "video/webm",
-        ".mov": "video/quicktime",
-        ".avi": "video/x-msvideo",
-        ".mkv": "video/x-matroska",
-    }
-
-    if suffix in image_types:
-        mime_type = image_types[suffix]
-        media_type = "image"
-    elif suffix in video_types:
-        mime_type = video_types[suffix]
-        media_type = "video"
+    if suffix in IMAGE_TYPES:
+        mime_type, media_type = IMAGE_TYPES[suffix], "image"
+    elif suffix in VIDEO_TYPES:
+        mime_type, media_type = VIDEO_TYPES[suffix], "video"
     else:
-        # Default to image/jpeg for unknown
-        mime_type = "image/jpeg"
-        media_type = "image"
+        guessed, _ = mimetypes.guess_type(file_path)
+        if guessed and guessed.startswith("image/"):
+            mime_type, media_type = guessed, "image"
+        elif guessed and guessed.startswith("video/"):
+            mime_type, media_type = guessed, "video"
+        else:
+            raise ValueError(
+                f"Unsupported file type {suffix or path.name!r} "
+                f"(detected MIME: {guessed or 'unknown'}). "
+                "Supported: " + ", ".join(sorted(IMAGE_TYPES) + sorted(VIDEO_TYPES))
+            )
 
     with open(file_path, "rb") as f:
         data = base64.b64encode(f.read()).decode("utf-8")
@@ -76,18 +109,38 @@ def encode_file_to_base64(file_path: str) -> tuple[str, str]:
     return f"data:{mime_type};base64,{data}", media_type
 
 
-def build_message_content(text: str, files: list[str] | None = None) -> list | str:
+def build_media_items(files: list[str]) -> list[dict]:
+    """Encode files into OpenAI-format media content parts.
+
+    Every file produces a part or an exception — no file is skipped, because a
+    skipped attachment is invisible to the user and to the server.
+    """
+    items = []
+    for file_path in files:
+        data_url, media_type = encode_file_to_base64(file_path)
+        key = "image_url" if media_type == "image" else "video_url"
+        items.append({"type": key, key: {"url": data_url}})
+    return items
+
+
+def build_message_content(
+    text: str,
+    files: list[str] | None = None,
+    media_items: list[dict] | None = None,
+) -> list | str:
     """
     Build OpenAI-compatible message content with text and optional files.
 
     Args:
         text: The text message
         files: Optional list of file paths (images or videos)
+        media_items: Optional pre-encoded media parts, to avoid base64-encoding
+            the same (possibly very large) file twice in one turn
 
     Returns:
         Content in OpenAI multimodal format
     """
-    if not files:
+    if not files and not media_items:
         return text
 
     content = []
@@ -96,16 +149,69 @@ def build_message_content(text: str, files: list[str] | None = None) -> list | s
     if text:
         content.append({"type": "text", "text": text})
 
-    # Add files
-    for file_path in files:
-        data_url, media_type = encode_file_to_base64(file_path)
-
-        if media_type == "image":
-            content.append({"type": "image_url", "image_url": {"url": data_url}})
-        elif media_type == "video":
-            content.append({"type": "video_url", "video_url": {"url": data_url}})
+    if media_items is None:
+        media_items = build_media_items(files or [])
+    content.extend(media_items)
 
     return content if content else text
+
+
+# A single image or a sampled video costs the model hundreds to thousands of
+# prompt tokens. If media was attached and the whole prompt came in under this,
+# the attachment never reached the model.
+MIN_PROMPT_TOKENS_WITH_MEDIA = 200
+
+
+def media_drop_warning(media_items: list[dict], prompt_tokens: int) -> str | None:
+    """Detect an attachment that was accepted and then silently dropped.
+
+    Every media-handling bug found in this stack returned HTTP 200 with a
+    fluent answer — "I don't see any video" — and everyone blamed the model.
+    The cheapest reliable discriminator needs no ground truth: compare the
+    prompt token count against the same request with no attachment. A dropped
+    attachment leaves it in the dozens; a real one puts it in the thousands.
+    """
+    if not media_items or not prompt_tokens:
+        return None
+    if prompt_tokens >= MIN_PROMPT_TOKENS_WITH_MEDIA:
+        return None
+    kinds = ", ".join(sorted({item["type"].replace("_url", "") for item in media_items}))
+    return (
+        f"WARNING: {len(media_items)} attachment(s) ({kinds}) were sent, but the "
+        f"server counted only {prompt_tokens} prompt tokens - far too few to "
+        "contain them. The attachment was almost certainly dropped before the "
+        "model saw it, so the answer above describes nothing. Check that the "
+        "server loaded a multimodal model (GET /health -> model_type should be "
+        '"mllm"; force it with `vllm-mlx serve --mllm ...`).'
+    )
+
+
+def check_server_multimodal(server_url: str) -> str | None:
+    """Return a warning if the server is not serving a multimodal model.
+
+    Model capability is detected from the model's config.json, but a text-only
+    load accepts image/video requests anyway and silently discards the media
+    parts. Better to say so at startup than to let every answer look like a
+    model that cannot see.
+    """
+    try:
+        response = requests.get(f"{server_url}/health", timeout=10)
+        response.raise_for_status()
+        health = response.json()
+    except Exception as e:
+        return f"Could not reach {server_url}/health ({e}); is the server running?"
+
+    if not health.get("model_loaded", False):
+        return None  # lazy load: capability is not known yet
+
+    if health.get("model_type") != "mllm":
+        return (
+            f"Server model {health.get('model_name')!r} is loaded as text-only "
+            f"(model_type={health.get('model_type')!r}). Images and videos will "
+            "be dropped from every request without an error. Restart the server "
+            "with a multimodal model, or force it with `vllm-mlx serve --mllm`."
+        )
+    return None
 
 
 def create_chat_function(
@@ -201,30 +307,27 @@ def create_chat_function(
                         content = content.get("text", str(content))
                     messages.append({"role": role, "content": content})
 
+        # Encode attachments once: a phone video is tens of megabytes and
+        # base64-encoding it twice per turn is pure latency.
+        try:
+            media_items = build_media_items(files) if files else []
+        except ValueError as e:
+            return f"Error: {e}"
+
         # Build current message content and cache media
-        current_content = build_message_content(text, files if files else None)
+        current_content = build_message_content(
+            text, files if files else None, media_items=media_items
+        )
         messages.append({"role": "user", "content": current_content})
 
         # Cache media for this message (will be at index len(history) after this turn)
-        if files:
+        if media_items:
             current_idx = len(history)
-            media_items = []
-            for file_path in files:
-                data_url, media_type = encode_file_to_base64(file_path)
-                if media_type == "image":
-                    media_items.append(
-                        {"type": "image_url", "image_url": {"url": data_url}}
-                    )
-                elif media_type == "video":
-                    media_items.append(
-                        {"type": "video_url", "video_url": {"url": data_url}}
-                    )
-            if media_items:
-                media_cache[current_idx] = media_items
-                print(
-                    f"[Chat] Cached {len(media_items)} media items for message {current_idx}",
-                    flush=True,
-                )
+            media_cache[current_idx] = media_items
+            print(
+                f"[Chat] Cached {len(media_items)} media items for message {current_idx}",
+                flush=True,
+            )
 
         # Debug
         print(f"[Chat] Sending {len(messages)} messages to server")
@@ -245,7 +348,17 @@ def create_chat_function(
             )
             response.raise_for_status()
             result = response.json()
-            return result["choices"][0]["message"]["content"]
+            answer = result["choices"][0]["message"]["content"]
+
+            usage = result.get("usage", {}) or {}
+            prompt_tokens = usage.get("prompt_tokens", 0)
+            print(f"[Chat] prompt_tokens={prompt_tokens}", flush=True)
+
+            warning = media_drop_warning(media_items, prompt_tokens)
+            if warning:
+                print(f"[Chat] {warning}", flush=True)
+                return f"{answer}\n\n---\n{warning}"
+            return answer
 
         except requests.exceptions.ConnectionError:
             return "Error: Cannot connect to server. Make sure vllm-mlx is running."
@@ -380,6 +493,10 @@ Note: Make sure the vllm-mlx server is running with a multimodal model:
     else:
         print("Mode: Multimodal (text, image, and video)")
 
+        capability_warning = check_server_multimodal(args.server_url)
+        if capability_warning:
+            print(f"WARNING: {capability_warning}")
+
         # Create chat function
         chat_fn = create_chat_function(
             server_url=args.server_url,
@@ -389,13 +506,20 @@ Note: Make sure the vllm-mlx server is running with a multimodal model:
         )
 
         # Create ChatInterface with multimodal support
+        description = (
+            "Chat with vision-language models on Apple Silicon. "
+            "Upload images or videos!"
+        )
+        if capability_warning:
+            description += f"\n\n**WARNING:** {capability_warning}"
+
         demo = gr.ChatInterface(
             fn=chat_fn,
             title="vllm-mlx Multimodal Chat",
-            description="Chat with vision-language models on Apple Silicon. Upload images or videos!",
+            description=description,
             multimodal=True,
             textbox=gr.MultimodalTextbox(
-                file_types=["image", "video"],
+                file_types=UPLOAD_FILE_TYPES,
                 file_count="multiple",
                 placeholder="Type a message or upload an image/video...",
             ),

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1283,9 +1283,7 @@ def assert_video_decoded(
             f"Implausible frame size {width}x{height} decoded from {video_path}"
         )
 
-    logger.info(
-        f"Video decode OK: {count} frames, {width}x{height}, from {video_path}"
-    )
+    logger.info(f"Video decode OK: {count} frames, {width}x{height}, from {video_path}")
     return count, width, height
 
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1799,6 +1799,21 @@ class MLXMultimodalLM:
                 elif ntype == "audio" and nitem.get("audio"):
                     audio_inputs.append(nitem["audio"])
 
+        # Fail closed on multi-video requests: mlx_vlm.generate takes one
+        # scalar fps and fans it out to every clip, so a second video's frames
+        # would be timestamped with the first video's sampled rate - silently
+        # wrong timestamps rather than an error. Until per-video timestamp
+        # handling exists (calling the processor directly instead of going
+        # through mlx_vlm.generate), reject the request with the reason.
+        if len(video_paths) > 1:
+            raise ValueError(
+                f"Native video supports one video per request; got "
+                f"{len(video_paths)}. Multiple clips would share the first "
+                "clip's sampled fps for timestamp tokens, mislabeling every "
+                "frame of the others. Send one video per request, or "
+                "concatenate the clips first."
+            )
+
         # Decode each video to (T, C, H, W) frames and validate the result
         # before it can reach the model.
         videos: list[np.ndarray] = []

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1221,6 +1221,23 @@ def smart_nframes(
     return int(nframes)
 
 
+def _log_native_video_fallback(exc: Exception) -> None:
+    """Report a native-video pipeline failure before falling back to frames.
+
+    The frames-as-images path is a working substitute, not an equivalent one:
+    it sends stills through the image encoder instead of the model's temporal
+    3D conv, so the token cost per frame, the effective resolution and the
+    model's ability to track motion all differ. Results measured on one path
+    are not comparable with the other, which is why this is a warning and not
+    a debug line.
+    """
+    logger.warning(
+        f"Native video pipeline unavailable ({exc}); falling back to "
+        "frames-as-images. The two paths are NOT token-equivalent - do not "
+        "compare results across them."
+    )
+
+
 def assert_video_decoded(
     frames: "list[np.ndarray] | np.ndarray",
     video_path: str,
@@ -1697,25 +1714,33 @@ class MLXMultimodalLM:
         video_max_frames: int = MAX_FRAMES,
         tools: list | None = None,
     ) -> tuple[str, dict]:
-        """Preprocess messages into prompt + generation kwargs for native video.
+        """Preprocess messages into prompt + media kwargs for native video.
 
-        Mirrors the preprocessing in mlx_vlm.video_generate.main() so that
-        upstream improvements are easy to adopt. Returns the formatted prompt
-        text and a dict of kwargs ready to pass to video_generate.generate().
+        Returns the formatted prompt text and a dict of media kwargs ready to
+        pass to mlx_vlm.generate.generate() (decoded video frame arrays, plus
+        any image/audio paths).
+
+        mlx-vlm 0.6.x removed the `mlx_vlm.video_generate` module and
+        `process_vision_info` along with it; the equivalent entry points are
+        `mlx_vlm.utils.load_video` for decoding and `generate(video=...)`,
+        which routes the arrays through the processor's own video path
+        (temporal 3D conv + M-RoPE). Frames are decoded here rather than
+        inside prepare_inputs so that video_max_frames is honored - upstream's
+        default cap is 768 frames - and so a failed decode raises instead of
+        yielding an empty frame list that reaches the model as "no video".
 
         Currently Qwen-family-specific (video_token_id / video_token_index).
         """
-        import mlx.core as mx
-
         try:
-            from mlx_vlm.video_generate import process_vision_info
-        except ImportError:
+            from mlx_vlm.utils import load_video
+        except ImportError as exc:  # pragma: no cover - depends on mlx-vlm
             raise ImportError(
-                "mlx_vlm.video_generate is required for native video support. "
-                "Upgrade with: pip install --upgrade mlx-vlm"
-            )
+                "mlx_vlm.utils.load_video is required for native video "
+                "support. Upgrade with: pip install --upgrade mlx-vlm"
+            ) from exc
 
-        # Translate OpenAI API messages into process_vision_info format
+        # Translate OpenAI API messages into mlx-vlm's media format, resolving
+        # every URL / base64 payload to a local path.
         native_messages = self._translate_messages_for_native_video(
             messages, video_fps, video_max_frames
         )
@@ -1732,80 +1757,64 @@ class MLXMultimodalLM:
             **template_kwargs,
         )
 
-        # Extract vision inputs via mlx-vlm's process_vision_info
-        image_inputs, video_inputs, fps_info = process_vision_info(
-            native_messages, return_video_kwargs=True
-        )
-
-        # Collect audio paths emitted by the translation step
-        # (explicit audio_url, or auto-extracted from video_url for omni
-        # models).
+        # Collect the media paths emitted by the translation step: images,
+        # videos, and audio (explicit audio_url, or auto-extracted from
+        # video_url for omni models).
+        image_paths: list[str] = []
+        video_paths: list[str] = []
         audio_inputs: list[str] = []
         for nmsg in native_messages:
             ncontent = nmsg.get("content", [])
             if not isinstance(ncontent, list):
                 continue
             for nitem in ncontent:
-                if isinstance(nitem, dict) and nitem.get("type") == "audio":
-                    apath = nitem.get("audio")
-                    if apath:
-                        audio_inputs.append(apath)
+                if not isinstance(nitem, dict):
+                    continue
+                ntype = nitem.get("type")
+                if ntype == "image" and nitem.get("image"):
+                    image_paths.append(nitem["image"])
+                elif ntype == "video" and nitem.get("video"):
+                    video_paths.append(nitem["video"])
+                elif ntype == "audio" and nitem.get("audio"):
+                    audio_inputs.append(nitem["audio"])
 
-        # Process through HF processor to get input_ids, pixel_values, grid_thw
-        # and (for omni models) sound_clips / input_features.
-        processor_kwargs: dict = {
-            "text": [text],
-            "images": image_inputs,
-            "videos": video_inputs,
-            "padding": True,
-            "return_tensors": "pt",
-        }
+        # Decode each video to (T, C, H, W) frames and validate the result
+        # before it can reach the model.
+        videos: list[np.ndarray] = []
+        sample_fps: float | None = None
+        for path in video_paths:
+            frames, decoded_fps = load_video(
+                path,
+                fps=video_fps,
+                max_frames=video_max_frames,
+                min_frames=MIN_FRAMES,
+                frame_factor=FRAME_FACTOR,
+            )
+            # load_video stacks to (T, C, H, W), so H/W are axes 1 and 2 of
+            # a single frame.
+            assert_video_decoded(frames, path, height_axis=1, width_axis=2)
+            videos.append(frames)
+            if sample_fps is None:
+                sample_fps = decoded_fps
+
+        gen_kwargs: dict = {"video": videos}
+        if image_paths:
+            gen_kwargs["image"] = image_paths
         if audio_inputs:
-            processor_kwargs["audio"] = audio_inputs
-        inputs = self.processor(**processor_kwargs)
-
-        input_ids = mx.array(inputs["input_ids"])
-        pixel_values = inputs.get(
-            "pixel_values_videos", inputs.get("pixel_values", None)
-        )
-        if pixel_values is not None:
-            pixel_values = mx.array(pixel_values)
-        mask = mx.array(inputs["attention_mask"])
-
-        gen_kwargs: dict = {}
-        if inputs.get("video_grid_thw", None) is not None:
-            gen_kwargs["video_grid_thw"] = mx.array(inputs["video_grid_thw"])
-        if inputs.get("image_grid_thw", None) is not None:
-            gen_kwargs["image_grid_thw"] = mx.array(inputs["image_grid_thw"])
-
-        # Forward audio embeddings/clips from the processor so the omni
-        # model's sound encoder gets fed alongside the visual stream.
-        for audio_key in (
-            "sound_clips",
-            "input_features",
-            "feature_attention_mask",
-            "audio_feature_lengths",
-            "sound_feature_lengths",
-            "sound_attention_mask",
-        ):
-            val = inputs.get(audio_key, None)
-            if val is not None:
-                gen_kwargs[audio_key] = val
-        if audio_inputs:
+            gen_kwargs["audio"] = audio_inputs
             logger.info(
                 f"Native video: forwarding audio ({len(audio_inputs)} clip(s)) "
-                f"to omni model via "
-                f"{[k for k in gen_kwargs if k in ('sound_clips', 'input_features')]}"
+                "to omni model alongside the video stream"
             )
+        if sample_fps:
+            # The processor needs the fps of the SAMPLED sequence (used for
+            # timestamp tokens), not the source video's fps.
+            gen_kwargs["fps"] = sample_fps
 
-        gen_kwargs["input_ids"] = input_ids
-        gen_kwargs["pixel_values"] = pixel_values
-        gen_kwargs["mask"] = mask
-
-        grid_thw_info = gen_kwargs.get("video_grid_thw")
         logger.info(
-            f"Native video: {input_ids.size} input tokens, "
-            f"video_grid_thw={grid_thw_info.tolist() if grid_thw_info is not None else None}"
+            f"Native video: {len(videos)} video(s), "
+            f"{sum(len(v) for v in videos)} frames total, "
+            f"sampled at {sample_fps if sample_fps else video_fps:.2f} fps"
         )
 
         return text, gen_kwargs
@@ -1823,16 +1832,16 @@ class MLXMultimodalLM:
         """Generate using native video pipeline (Qwen-family models).
 
         Delegates preprocessing to _prepare_native_video_inputs and generation
-        to mlx_vlm.video_generate.generate(), keeping our code aligned with
+        to mlx_vlm.generate.generate(), keeping our code aligned with
         upstream's video pipeline so improvements are easy to adopt.
         """
         try:
-            from mlx_vlm.video_generate import generate
-        except ImportError:
+            from mlx_vlm.generate import generate
+        except ImportError as exc:  # pragma: no cover - depends on mlx-vlm
             raise ImportError(
-                "mlx_vlm.video_generate is required for native video support. "
-                "Upgrade with: pip install --upgrade mlx-vlm"
-            )
+                "mlx_vlm.generate.generate is required for native video "
+                "support. Upgrade with: pip install --upgrade mlx-vlm"
+            ) from exc
 
         text, gen_kwargs = self._prepare_native_video_inputs(
             messages, video_fps, video_max_frames, tools
@@ -2313,15 +2322,18 @@ class MLXMultimodalLM:
 
         # Use native video pipeline for supported models
         if self._video_native and _msg_video_inputs:
-            return self._generate_native_video(
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                video_fps=video_fps,
-                video_max_frames=video_max_frames,
-                tools=tools,
-                **kwargs,
-            )
+            try:
+                return self._generate_native_video(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    video_fps=video_fps,
+                    video_max_frames=video_max_frames,
+                    tools=tools,
+                    **kwargs,
+                )
+            except ImportError as exc:
+                _log_native_video_fallback(exc)
 
         # Fallback: extract frames and treat as individual images
         _msg_video_frame_counts: dict[int, int] = {}
@@ -2717,22 +2729,28 @@ class MLXMultimodalLM:
 
         # Use native video pipeline for supported models.
         # NOTE: Native video yields a single chunk (not incremental streaming)
-        # because mlx_vlm.video_generate has no streaming API. The event loop
-        # is NOT blocked at the server level — SimpleEngine wraps this in
-        # asyncio.to_thread(). True token-level streaming requires upstream
-        # mlx-vlm support for video stream_generate.
+        # because we call mlx_vlm.generate.generate(). The event loop is NOT
+        # blocked at the server level — SimpleEngine wraps this in
+        # asyncio.to_thread(). Token-level streaming would mean switching to
+        # mlx_vlm.generate.stream_generate() and threading its chunks through
+        # the native-video branch in SimpleEngine.
         if self._video_native and _msg_video_inputs:
-            output = self._generate_native_video(
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                video_fps=video_fps,
-                video_max_frames=video_max_frames,
-                tools=tools,
-                **kwargs,
-            )
-            yield output
-            return
+            output = None
+            try:
+                output = self._generate_native_video(
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    video_fps=video_fps,
+                    video_max_frames=video_max_frames,
+                    tools=tools,
+                    **kwargs,
+                )
+            except ImportError as exc:
+                _log_native_video_fallback(exc)
+            if output is not None:
+                yield output
+                return
 
         # Fallback: frames as images
         _msg_video_frame_counts: dict[int, int] = {}

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -105,6 +105,23 @@ FRAME_FACTOR = 2  # Frames must be divisible by this
 DEFAULT_FPS = 2.0  # Default frames per second for video
 MIN_FRAMES = 4
 MAX_FRAMES = 128  # Practical limit for most MLLMs
+MIN_FRAME_DIMENSION = 16  # Below this a "decoded" frame is not a real frame
+
+# Container suffix to use when spilling a base64 video to a temp file. The
+# subtype of the MIME type is not the container name ("video/quicktime" is a
+# .mov, "video/x-matroska" is a .mkv), and while ffmpeg content-sniffs, several
+# decoders infer the container from the filename extension instead.
+VIDEO_MIME_TO_SUFFIX = {
+    "video/quicktime": ".mov",
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+    "video/ogg": ".ogg",
+    "video/x-matroska": ".mkv",
+    "video/x-msvideo": ".avi",
+    "video/mpeg": ".mpeg",
+    "video/x-m4v": ".m4v",
+    "video/3gpp": ".3gp",
+}
 IMAGE_FACTOR = 28  # For smart resize
 
 # Security: File size limits (in bytes)
@@ -863,9 +880,16 @@ def decode_base64_video(
     if base64_string.startswith("data:video/"):
         # Format: data:video/mp4;base64,AAAA...
         header, data = base64_string.split(",", 1)
-        # Extract extension from header (e.g., "data:video/mp4;base64" -> "mp4")
-        format_part = header.split(";")[0]  # "data:video/mp4"
-        ext = "." + format_part.split("/")[-1]  # ".mp4"
+        # Extract the MIME type from the header
+        # (e.g. "data:video/quicktime;base64" -> "video/quicktime")
+        mime_type = header.split(";")[0][len("data:") :].strip().lower()
+        ext = VIDEO_MIME_TO_SUFFIX.get(mime_type, "")
+        if not ext:
+            # Unknown MIME: the subtype is usually the container name, but
+            # never trust it blindly - "video/x-matroska" would yield
+            # ".x-matroska". Fall back to .mp4 for anything unrecognised.
+            subtype = mime_type.split("/")[-1]
+            ext = f".{subtype}" if subtype.isalnum() else ".mp4"
     else:
         # Assume mp4 if no header
         data = base64_string
@@ -1197,6 +1221,57 @@ def smart_nframes(
     return int(nframes)
 
 
+def assert_video_decoded(
+    frames: "list[np.ndarray] | np.ndarray",
+    video_path: str,
+    *,
+    height_axis: int = 0,
+    width_axis: int = 1,
+) -> tuple[int, int, int]:
+    """Validate a decoded frame sequence before it is handed to a model.
+
+    Every video failure mode seen so far (unreadable container, unseekable
+    input, a codec the build cannot decode) produced an empty or degenerate
+    frame list and then a perfectly plausible HTTP 200 answer of the form
+    "I don't see any video" — which reads as a model failure and is not one.
+    Assert on the frames, not on the absence of an exception.
+
+    Args:
+        frames: Decoded frames, either a list of HWC arrays or a stacked
+            array whose per-frame axes are given by height_axis/width_axis.
+        video_path: Source path, for the error message.
+        height_axis: Index of the height axis within a single frame.
+        width_axis: Index of the width axis within a single frame.
+
+    Returns:
+        Tuple of (frame_count, width, height).
+    """
+    count = len(frames)
+    if count == 0:
+        raise ValueError(
+            f"Decoded 0 frames from {video_path}. The container or codec could "
+            "not be read - this is a decode failure, not a model failure."
+        )
+
+    first = frames[0]
+    shape = getattr(first, "shape", ())
+    if len(shape) <= max(height_axis, width_axis):
+        raise ValueError(
+            f"Decoded frames from {video_path} have unexpected shape {shape}"
+        )
+
+    height, width = int(shape[height_axis]), int(shape[width_axis])
+    if height < MIN_FRAME_DIMENSION or width < MIN_FRAME_DIMENSION:
+        raise ValueError(
+            f"Implausible frame size {width}x{height} decoded from {video_path}"
+        )
+
+    logger.info(
+        f"Video decode OK: {count} frames, {width}x{height}, from {video_path}"
+    )
+    return count, width, height
+
+
 def extract_video_frames_smart(
     video_path: str,
     fps: float = DEFAULT_FPS,
@@ -1260,6 +1335,15 @@ def extract_video_frames_smart(
         frames.append(frame)
 
     cap.release()
+
+    # Seeking by frame index can silently return nothing on long-GOP codecs,
+    # so report what was actually decoded rather than what was requested.
+    if len(frames) < nframes:
+        logger.warning(
+            f"Requested {nframes} frames from {video_path} but decoded "
+            f"{len(frames)}: seeking skipped {nframes - len(frames)} frame(s)"
+        )
+    assert_video_decoded(frames, video_path)
 
     return frames
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1713,6 +1713,8 @@ class MLXMultimodalLM:
         video_fps: float = DEFAULT_FPS,
         video_max_frames: int = MAX_FRAMES,
         tools: list | None = None,
+        enable_thinking: bool = True,
+        chat_template_kwargs: dict | None = None,
     ) -> tuple[str, dict]:
         """Preprocess messages into prompt + media kwargs for native video.
 
@@ -1745,17 +1747,36 @@ class MLXMultimodalLM:
             messages, video_fps, video_max_frames
         )
 
-        # Use HF processor's chat template (handles timestamp interleaving)
-        template_kwargs: dict = {}
+        # Use HF processor's chat template (handles timestamp interleaving).
+        # enable_thinking and any other chat_template_kwargs have to reach this
+        # template too. The frames-as-images path forwards them, so a video
+        # request that dropped them would keep reasoning for thousands of
+        # tokens after the operator had turned thinking off server-wide with
+        # --default-chat-template-kwargs '{"enable_thinking": false}' - and the
+        # flag would appear to work, because text and image requests honor it.
+        template_kwargs: dict = dict(chat_template_kwargs or {})
         if tools:
             template_kwargs["tools"] = tools
+        template_kwargs.setdefault("enable_thinking", enable_thinking)
 
-        text = self.processor.apply_chat_template(
-            native_messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            **template_kwargs,
-        )
+        try:
+            text = self.processor.apply_chat_template(
+                native_messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                **template_kwargs,
+            )
+        except TypeError:
+            # This template doesn't accept some forwarded chat_template_kwargs
+            # - drop the optional ones and retry, mirroring the frames path.
+            for key in chat_template_kwargs or {}:
+                template_kwargs.pop(key, None)
+            text = self.processor.apply_chat_template(
+                native_messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                **template_kwargs,
+            )
 
         # Collect the media paths emitted by the translation step: images,
         # videos, and audio (explicit audio_url, or auto-extracted from
@@ -1827,6 +1848,8 @@ class MLXMultimodalLM:
         video_fps: float = DEFAULT_FPS,
         video_max_frames: int = MAX_FRAMES,
         tools: list | None = None,
+        enable_thinking: bool = True,
+        chat_template_kwargs: dict | None = None,
         **kwargs,
     ) -> MLLMOutput:
         """Generate using native video pipeline (Qwen-family models).
@@ -1844,7 +1867,12 @@ class MLXMultimodalLM:
             ) from exc
 
         text, gen_kwargs = self._prepare_native_video_inputs(
-            messages, video_fps, video_max_frames, tools
+            messages,
+            video_fps,
+            video_max_frames,
+            tools,
+            enable_thinking=enable_thinking,
+            chat_template_kwargs=chat_template_kwargs,
         )
         gen_kwargs["temperature"] = temperature
 
@@ -2330,6 +2358,8 @@ class MLXMultimodalLM:
                     video_fps=video_fps,
                     video_max_frames=video_max_frames,
                     tools=tools,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
                     **kwargs,
                 )
             except ImportError as exc:
@@ -2744,6 +2774,8 @@ class MLXMultimodalLM:
                     video_fps=video_fps,
                     video_max_frames=video_max_frames,
                     tools=tools,
+                    enable_thinking=enable_thinking,
+                    chat_template_kwargs=chat_template_kwargs,
                     **kwargs,
                 )
             except ImportError as exc:

--- a/vllm_mlx/multimodal_processor.py
+++ b/vllm_mlx/multimodal_processor.py
@@ -120,15 +120,21 @@ class MultimodalProcessor:
         """
         from mlx_vlm.utils import prepare_inputs
 
-        # Process raw images
+        # Process raw images.
+        #
+        # Media failures are raised, not logged: a dropped attachment leaves a
+        # request that still generates a fluent, confident answer about nothing
+        # ("I don't see any image"), which reads as a model failure and sends
+        # everyone debugging the wrong layer. A 4xx/5xx naming the real cause
+        # is worth far more than a plausible HTTP 200.
         all_images = []
         if images:
             for img in images:
                 try:
                     path = process_image_input(img)
-                    all_images.append(path)
                 except Exception as e:
-                    logger.warning(f"Failed to process image: {e}")
+                    raise ValueError(f"Failed to process image input: {e}") from e
+                all_images.append(path)
 
         # Extract frames from videos
         if videos:
@@ -141,10 +147,10 @@ class MultimodalProcessor:
                         max_frames=video_max_frames,
                     )
                     frame_paths = save_frames_to_temp(frames)
-                    all_images.extend(frame_paths)
-                    logger.debug(f"Extracted {len(frame_paths)} frames from video")
                 except Exception as e:
-                    logger.warning(f"Failed to process video: {e}")
+                    raise ValueError(f"Failed to process video input: {e}") from e
+                all_images.extend(frame_paths)
+                logger.info(f"Extracted {len(frame_paths)} frames from video")
 
         # Determine add_special_tokens based on model type
         if self.config and self.config.model_type in ["gemma3", "gemma3n"]:


### PR DESCRIPTION
Six fixes for a chain of failures that made video requests unusable, each of which returned HTTP 200 (or a fluent answer) rather than an error. Found while serving `mlx-community/Qwen3.8-27B-4bit` and reproduced end to end against an 8.17s 2604x2160 HEVC `.mov` from an iPhone.

The headline symptom: a 22 MB video attachment cost **exactly as many prompt tokens as sending no video at all** — 68 both times, byte-identical replies — and the model politely explained that no video had been attached.

## What was wrong

**1. `is_mllm_model()` guessed capability from the model's name** (`vllm_mlx/api/utils.py`)

`_try_read_config_json()` only reads `config.json` when the argument resolves to a local directory. Given an HF repo ID it falls through to substring matching against `MLLM_PATTERNS`. `mlx-community/Qwen3.8-27B-4bit` matches none of those patterns, despite a config declaring `vision_config`, `image_token_id: 248056` and `video_token_id: 248057` — so it loaded as a text-only LLM (`SimpleEngine loaded: ... (MLLM=False)`) and every media content part was flattened out of the request with no error.

The config is in the local hub cache the whole time. Now: local dir, then `try_to_load_from_cache()` (no network), then the name patterns as the pre-download fallback.

Audited against all 25 models in one hub cache: six flip `False -> True`, all genuinely multimodal (Qwen3.5/3.6/3.8 `ForConditionalGeneration`, Qwen3-Omni, Muse-Glimmer), each carrying `vision_config`. Nothing flips the other way.

**2. The native video path imported a module mlx-vlm had deleted** (`vllm_mlx/models/mllm.py`)

`from mlx_vlm.video_generate import process_vision_info, generate` — that module does not exist in mlx-vlm 0.6.x (layout is `mlx_vlm.generate.*`; `process_vision_info` was removed). Every video request against a model with `video_token_id` raised `ModuleNotFoundError` -> HTTP 500.

Ported to `mlx_vlm.utils.load_video` + `mlx_vlm.generate.generate(video=...)`. Decoding happens here rather than inside `prepare_inputs` so `video_max_frames` is honored (upstream's default cap is 768 frames) and the result can be validated before it reaches the model. Falls back to the frames-as-images path instead of raising, with a warning that the two paths are not token-equivalent.

**3. Media failures were silent** (`mllm.py`, `multimodal_processor.py`)

- `extract_video_frames_smart()` returned whatever it managed to decode, including `[]` — frame seeking can silently skip frames on long-GOP codecs. Now `assert_video_decoded()` rejects empty/degenerate results and logs `Video decode OK: N frames, WxH` on success, so frame count and orientation are visible in the log.
- `MultimodalProcessor.process()` caught every media exception and continued with `logger.warning`. Now raises.
- `decode_base64_video()` built the temp-file suffix as `mime.split("/")[-1]`, giving `.quicktime` for a `.mov` and `.x-matroska` for a `.mkv`. Latent with OpenCV (ffmpeg content-sniffs; verified `.quicktime`/`.mov`/no-suffix all decode identically) but live for any decoder that infers the container from the extension. Replaced with a MIME->container map.

**4. The chat UI could display a chip for a file it had discarded** (`vllm_mlx/gradio_app.py`)

Unknown extensions defaulted to `image/jpeg`; resolution is now extension -> system MIME db -> raise, with `.mov`/`video/quicktime`, `.m4v`, `.mkv`, `.heic` added. Replies now carry a visible warning when attachments were sent but `prompt_tokens` is implausibly low, and startup checks `/health` for a text-only model in multimodal mode. Attachments are base64-encoded once per turn instead of twice.

**5. `enable_thinking` was dropped on the native video path** (`mllm.py`)

The native branch built its chat-template kwargs from `tools` alone. A server started with `--default-chat-template-kwargs '{"enable_thinking": false}'` therefore honored it for text and images and ignored it for video — the model reasoned to the full `max_tokens` and tripped the request timeout with a 504. The Qwen3.5 template renders `<think>\n\n</think>` when false and leaves `<think>` open when true, so the dropped kwarg was the whole difference. Now forwarded, with the same `TypeError` retry the frames path uses.

**6. The chat UI replayed all historical media every turn** (`gradio_app.py`, + tests)

Payload grew 22.3 MB -> 66.3 MB across three turns and the server re-decoded every prior video on each one. History is now text-only; media stays with the turn it belongs to.

## Verification

Same server, same clip, `mlx-community/Qwen3.8-27B-4bit`:

| | prompt_tokens | result |
|---|---|---|
| before | 68 | "I don't see any video" |
| after fix 1 only | — | HTTP 500, `ModuleNotFoundError` |
| after fixes 1+2 | 12,110 | correct description |

With thinking disabled, a video reply is **396 tokens in 60.8s** where it previously ran past the 300s timeout. Regression checks: `mlx-community/Qwen3-8B-4bit` still loads `MLLM=False` and answers normally; text and image requests unaffected; the frames-as-images fallback still decodes 16 frames at correct orientation.

Decode correctness was confirmed by writing frames to PNG and inspecting them — OpenCV 5.0.0 auto-rotates (`CAP_PROP_ORIENTATION_AUTO=1`), so the `rotation=-90` display matrix is applied and no orientation compensation was added.

## Known limitations, not addressed here

- **Multi-video requests use the first clip's sampled fps for all clips.** `mlx_vlm.prepare_inputs` takes a single scalar `fps`, and that value drives Qwen's interleaved timestamp tokens. Fixing it properly means calling the processor directly instead of routing through `mlx_vlm.generate`. Happy to do that in a follow-up if you'd prefer it here.
- **The shutdown segfault workaround has been removed from this PR** and now lives in `fix/shutdown-tls-segfault`, opened separately, with the cleanup-exception defect fixed and lifecycle tests added. It is a process-wide behaviour change and does not belong here.
- **The chat-UI document pipeline** (PDF/DOCX/XLSX attachments) has likewise been split out to `feat/document-attachments`; it is stacked on this branch and will be opened once this merges, to avoid a PR that contains this one's commits.

Each commit is self-contained and reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Update after review

Rebased on `22efb47`. This PR is now video-only: no `cli.py`, no `server.py`, no document
pipeline. 7 commits, 7 files.

Added `tests/test_video_pipeline.py`, wired into the existing no-MLX CI job. It runs on
`ubuntu-latest` without MLX by injecting a stand-in `mlx_vlm`, which suits what is being
guarded — the two failures behind this work were an upstream module rename and a silently
empty decode, and neither needs a GPU to catch. Verified by running the file with `mlx`
blocked at the import hook: 17 pass, 1 skips.

Coverage, against the list requested:

| asked for | test |
|---|---|
| pinned mlx-vlm API | `test_real_mlx_vlm_still_exposes_the_pinned_api` — asserts `load_video` still takes fps/max_frames/min_frames/frame_factor and `generate()` still accepts `video=`. Skips without MLX, so it needs an Apple Silicon runner to be meaningful. |
| decode failures | `test_zero_frames_raises_and_names_the_layer`, `test_implausible_frame_size_raises`, `test_malformed_frame_shape_raises`, `test_empty_decode_stops_the_request` |
| mixed image/video/audio | `test_mixed_image_video_audio_are_routed_separately` |
| multiple videos, distinct rates | `test_multiple_videos_share_the_first_clips_sampled_rate` |
| frames fallback | `test_missing_upstream_module_is_reported_not_swallowed` |

One of those pins a limitation rather than asserting correctness.
`prepare_inputs` takes a single scalar `fps` and fans it out to every video, so a second
clip's frames are labelled with the first clip's sampled rate — which drives Qwen's
interleaved timestamps. The test says so and asserts the second rate is discarded, so a
future fix changes a test deliberately instead of quietly altering timestamps. Fixing it
means calling the processor directly rather than going through `mlx_vlm.generate`; happy to
do that here if you would rather it not ship as a known gap.

Native-video model output still needs an Apple Silicon window and is not covered by these.
