### PR TITLE
feat(qwen3.8): serve native MTP and external PLE

### DIFF
--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -404,6 +404,26 @@ MTP drafts accepted and streamed thinking into `reasoning_content` with no
 protocol leakage. BatchedEngine rejected startup with the explicit
 `does not support continuous batching` error, preserving the known boundary.
 
+`mlx-vlm` PR #2045 now gathers distinct external-PLE rows in one storage
+operation and runs one batched MLX Q4 dequantization before restoring request
+order. A 65,536-row high-entropy microbenchmark on the internal SSD measured
+8.47 seconds from cold pages versus 9.0–9.8 seconds for the row-at-a-time path.
+With the pages resident, the batched path completed in 0.14 seconds. This is a
+lookup microbenchmark, not an end-to-end throughput claim.
+
+`mlx-vlm` PR #2046 makes a requested Qwen4-Exp MTP block size an adaptive
+ceiling. The controller starts at the checkpoint-native depth, expands only
+after eight rounds with at least 65% native-prefix acceptance, and backs down
+when acceptance falls. The serving candidate should request block size 4 so
+the measured 83.3% instruct profile can expand while the 52.9% thinking profile
+normally stays at the native depth.
+
+The existing vllm-mlx SSD tier stores evicted KV-prefix entries behind the
+memory-aware continuous-batching cache. It does not tier model weights or
+experts, and it is not available to this model's currently qualified serialized
+route. It can reduce repeat-request prefill after continuous-batching QSA/MTP
+support lands; it cannot reduce the current 71.68 GB resident model footprint.
+
 For a text-only engine comparison, Unsloth `UD-Q4_K_XL` (111,323,630,080 GGUF
 bytes) was served from Lexar by the isolated Qwen4-Exp llama.cpp fork at
 `ef9fa1ba`. With one 4K slot, PLE forced to CPU/mmap, Metal for the remaining

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -202,14 +202,30 @@ Transformers' vectorized shift/gather formulation. It changes no serving
 behavior and provides a parity primitive for an upstream model and a cold-table
 prototype.
 
-The isolated `mlx-vlm` branch `604/qwen38-flash-next` now contains the matching
-Qwen4-Exp config parser plus the first model-owned PLE storage interface.
-Resident MLX and read-only mmap row backends return identical synthetic rows.
+The original isolated `mlx-vlm` branch `604/qwen38-flash-next` is preserved as
+an early prototype. Upstream subsequently merged its own complete base Qwen4-Exp
+architecture in PR #2032. Active intake therefore moved to
+`604/qwen38-flash-next-upstream-intake`, based on upstream commit `4857a6b0`,
+instead of duplicating the merged model.
+
+Static checkpoint inspection found two conversion defects in that upstream
+implementation. First, the official FP8 artifact stores each routed expert as
+separate per-expert gate/up/down tensors with inverse scales, while the model
+expects packed expert tensors. Second, the generic quantizer checked the global
+group size before the model-specific predicate, so the 160-wide PLE rows were
+silently left unquantized when the requested global group size was 64. Local
+commit `127d943e` restores and packs the official FP8 layout and permits the
+model predicate to select Q4/group-32 for PLE while retaining Q4/group-64 for
+ordinary tensors. Four focused synthetic tests pass; this is conversion-path
+evidence, not full-model or generation qualification.
+
+Local commit `9c538470` adds the first model-owned read-only mmap PLE storage
+experiment. Resident MLX and mmap row lookups return identical synthetic rows.
 The mmap backend validates its versioned manifest and exact file size, confines
 the data file beside the manifest, supports a bounded row LRU, and reports
-lookups, hits, misses, bytes read, and elapsed lookup time. It is not registered
-as a complete model and cannot affect normal loading or serving. Six focused
-tests pass, including deserialization of the exact released config shape.
+lookups, hits, misses, bytes read, and elapsed lookup time. It is deliberately
+not integrated into model loading and cannot affect normal serving. Two focused
+storage tests pass.
 
 ## Cold n-gram feasibility
 
@@ -255,17 +271,17 @@ is a separate conversion defect.
 
 ## Next falsifiable experiments
 
-1. Compare the local n-gram IDs against Transformers for randomized sequences,
-   EOS boundaries, prefill, and one-token continuation.
-2. Ask mlx-vlm maintainers whether a Qwen4-Exp implementation is already in an
-   unpublished branch before duplicating it.
-3. Implement the smallest mlx-vlm PLE embedding and compare BF16 outputs against
-   Transformers using synthetic weights small enough for CI.
-4. Measure `mx.load(..., stream=mx.cpu)` evaluation and RSS for gather-only use;
-   prove whether MLX materializes the entire embedding.
-5. Build an mmap BF16 row reader using a synthetic 128-split table. Measure
-   cold/warm decode, prefill, page faults, bytes/token, and batch scaling.
-6. Only after parity, run tensor-family sensitivity tests for experts, PLE,
-   routers/QSA, recurrent components, embeddings/head, vision, and MTP.
-7. Convert a complete artifact only after projected peak disk and resident
-   memory fit the machine with a documented safety margin.
+1. Finish and hash-verify the pinned official FP8 snapshot on Lexar.
+2. Convert one complete all-resident MLX baseline with ordinary tensors at
+   Q4/group-64 and PLE at Q4/group-32; retain complete weight-load accounting.
+3. Perform config, header, and load-only validation without generation.
+4. After the inference server is released, compare component outputs and short
+   deterministic generation against Transformers at declared tolerances.
+5. Measure resident baseline peak memory before deciding whether external PLE
+   storage is necessary.
+6. If external PLE remains justified, measure cold/warm decode, prefill, page
+   faults, bytes/token, and batch scaling for page-cache-only and bounded-LRU
+   mmap backends.
+7. Add MTP only through a Qwen4-specific draft splitter and architecture; the
+   current upstream implementation explicitly excludes MTP, so no support is
+   claimed from the presence of MTP tensors in the official checkpoint.

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -342,14 +342,13 @@ is not a claim that this artifact reaches 262K on this machine. Raw evidence is
 ### Day-one Unsloth/llama.cpp comparison (2026-08-26)
 
 The implementations are not at complete feature parity. Both implement the
-base Qwen4-Exp architecture, PLE n-gram addressing, QSA, vision, text
-generation, and quantized loading. This MLX path has direct single-request
-text, streaming, native-tool, thinking-separation, and vision evidence on the
-local Q4. The Unsloth llama.cpp PR additionally reports validated multi-stream
-QSA batching at batch sizes 1, 4, and 16, plus a single contiguous GGUF PLE
-table that can remain mmap-backed and be offloaded to RAM or disk. The current
-MLX QSA cache is not wired into continuous batching, and the experimental MLX
-mmap PLE backend is not qualified.
+base language architecture, PLE n-gram addressing, QSA, text generation, and
+quantized loading. This MLX path has direct single-request text, streaming,
+native-tool, thinking-separation, vision, and native MTP evidence on the local
+Q4. The released Unsloth GGUF omits vision and MTP tensors. Its Qwen4-Exp
+llama.cpp fork requires one server slot and F16 KV for this architecture. The
+current MLX QSA/MTP state is likewise not wired into continuous batching and
+fails closed rather than silently disabling MTP.
 
 Unsloth now publishes seven Dynamic 3.0 GGUF policies from 67.56 GiB
 (`UD-IQ1_S`) through 103.69 GiB (`UD-Q4_K_XL`). MLX currently has one measured
@@ -358,6 +357,65 @@ formats and family-specific assignments differ, and comparative quality has
 not been measured. The llama.cpp PR reports reference comparisons for its
 architecture path, including WikiText-2 perplexity and QSA selection checks;
 those are not transferable quality evidence for the MLX Q4 artifact.
+
+### External-PLE Q4 qualification (2026-08-26)
+
+mlx-vlm commit `fbc1449e` replaces the resident 29.80 GiB PLE parameter with a
+read-only interleaved affine-Q4 row store. The store has 320,001,536 rows, a
+160-element dequantized width, and one 100-byte packed record per row. It is on
+the internal PCIe SSD at
+`/Users/David/ai-models/ple/Qwen3.8-Flash-Next-Q4-MLX/ple-q4.rows`; the compact
+ordinary-weight artifact is 67 GiB at
+`/Users/David/ai-models/mlx/Qwen3.8-Flash-Next-Q4-MLX-External-PLE`. Thirty-two
+sampled rows, including storage boundaries, matched the original resident Q4
+checkpoint exactly after dequantization.
+
+The warm model uses 71,677,702,240 MLX-active bytes. A short text generation
+read 1,336 unique PLE rows (133,600 logical bytes), and total PLE lookup plus
+dequantization time was 0.297 seconds. A 4,096-token repeated-token prefill ran
+at 442.5 tok/s because only 40 rows missed the bounded cache. A deterministic
+varied-token 4,096-token prefill produced 65,545 misses, read 6,554,500 logical
+bytes, spent 9.683 seconds in PLE lookup/dequantization, and ran end-to-end at
+217.8 tok/s. These are measured best- and pessimistic-locality bounds, not
+representative-corpus quality evidence.
+
+Reducing `prefill_step_size` from 2,048 to 512 materially improves the memory
+envelope. The following repeated-token sweep generated one token at each level
+using the vendor instruct sampling tuple:
+
+| Input tokens | MLX peak | Prompt throughput | Wall time |
+|---:|---:|---:|---:|
+| 4,096 | 74.08 GB | 418.0 tok/s | 12.4 s |
+| 16,384 | 78.05 GB | 342.7 tok/s | 50.4 s |
+| 32,768 | 83.28 GB | 266.5 tok/s | 125.6 s |
+| 65,536 | 93.63 GB | 179.4 tok/s | 368.2 s |
+| 131,072 | 114.47 GB | 89.31 tok/s | 1,470.8 s |
+
+The 128K run completed with no throttled pages and no observed swap-out growth;
+the lowest sampled system memory availability was 11 percent. It proves the
+128K context/memory envelope on this 128 GiB Mac. The repeated prompt is a
+best-case PLE-locality workload and does not establish representative 128K
+prefill speed or model quality.
+
+The same artifact plus the Q4 MTP sidecar peaked at 73,707,907,026 MLX bytes.
+Thinking and instruct generation completed at 16.95 and 18.83 tok/s,
+respectively. vllm-mlx SimpleEngine returned exact instruct content with 8/6
+MTP drafts accepted and streamed thinking into `reasoning_content` with no
+protocol leakage. BatchedEngine rejected startup with the explicit
+`does not support continuous batching` error, preserving the known boundary.
+
+For a text-only engine comparison, Unsloth `UD-Q4_K_XL` (111,323,630,080 GGUF
+bytes) was served from Lexar by the isolated Qwen4-Exp llama.cpp fork at
+`ef9fa1ba`. With one 4K slot, PLE forced to CPU/mmap, Metal for the remaining
+layers, F16 KV, warmup disabled, and fit disabled, it loaded in 47.9 seconds,
+used 107,350,880 KiB RSS, and left 14 percent system memory available. It
+generated the exact instruct response at 25.07 tok/s and the exact thinking
+response at 25.05 tok/s with separated reasoning and no protocol leakage.
+This is faster short decode than the current MLX+MTP path, but uses roughly
+43 GiB more process RSS, loads about 5.5 times more slowly from Lexar, provides
+no vision or MTP from this GGUF, and is restricted to one slot. Storage location
+is a comparison caveat: the compact MLX artifact is internal while the GGUF is
+on the slower directly attached Lexar volume.
 
 The local MLX intake now goes beyond the initial upstream boundary with a
 Qwen4-Exp-specific native MTP drafter. It consumes the target's 10,240-wide

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -266,8 +266,36 @@ all-resident MLX Q4 is the required baseline and may fit comfortably on this
 exact 128 GiB machine. Special handling is justified only if measured peak
 memory, context envelope, throughput, or quality shows a material advantage.
 B and C remain hypotheses until those measurements are available. The generic
-converter's current behavior of silently leaving the PLE n-gram tables in BF16
-is a separate conversion defect.
+converter's prior behavior of silently leaving the PLE n-gram tables in BF16
+was a separate conversion defect; local intake commit `127d943e` addresses it.
+
+## Offline conversion result
+
+The pinned official FP8 snapshot at revision
+`bcd9f01ddc9cff2316eb84281bebcd5b058bddce` was downloaded to Lexar and
+verified byte-for-byte: 144 files, 185,563,783,127 bytes, and 133 LFS SHA-256
+objects with no mismatches. All 152,089 indexed source tensors reconcile with
+the 131 safetensors shard headers.
+
+Using mlx-vlm intake commit `9c538470`, the verified source converted to an
+all-resident affine MLX artifact with Q4/group-64 as the global policy,
+Q4/group-32 for all 128 PLE shards, and Q8/group-64 for all 96 router gates.
+The converter reported 4.675 effective bits per weight. The output contains 20
+weight shards with 103,664,015,352 indexed bytes (approximately 96.5 GiB), and
+all 3,767 indexed output tensors reconcile with their shard headers.
+
+A strict lazy load binds all 3,767 parameter leaves to
+`mlx_vlm.models.qwen4_exp.qwen4_exp.Model`. This validates architecture
+construction, quantized-module reconstruction, and weight-key accounting only;
+it does not evaluate weights or run a forward pass. The artifact is published
+at `/Volumes/Lexar/qwen38-flash-next/mlx/Qwen3.8-Flash-Next-Q4-MLX`, with
+machine-readable evidence in `CONVERSION_VERIFICATION.json` and file hashes in
+`MANIFEST.sha256`. MTP extraction remains disabled because no Qwen4-specific
+draft splitter exists upstream.
+
+Inference qualification is still intentionally not run. Component parity,
+deterministic generation, memory high-water measurement, streaming, tool use,
+multimodal behavior, and throughput remain behind the explicit inference gate.
 
 ## Next falsifiable experiments
 

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -293,9 +293,19 @@ machine-readable evidence in `CONVERSION_VERIFICATION.json` and file hashes in
 `MANIFEST.sha256`. MTP extraction remains disabled because no Qwen4-specific
 draft splitter exists upstream.
 
-Inference qualification is still intentionally not run. Component parity,
-deterministic generation, memory high-water measurement, streaming, tool use,
-multimodal behavior, and throughput remain behind the explicit inference gate.
+The initial Q4 text inference gate now passes in both required Qwen modes. An
+instruct probe using the vendor sampling policy returned exactly `READY` in two
+generated tokens. A thinking probe using the vendor thinking policy emitted a
+complete reasoning block, closed `</think>`, and returned `READY` in 35 tokens.
+Measured MLX peaks were 103.87 GB and 103.99 GB respectively; peak process
+footprints were 104.59 GB and 104.81 GB. macOS used transient compression and
+swap during prefill, but neither run reported throttled pages, an OOM, or a
+child-process swap, and memory recovered after exit. This is a tight but
+working 128 GiB envelope, not yet a comfortable concurrent-service envelope.
+
+Streaming, tool use, multimodal behavior, long-context growth, sustained
+throughput, and model-quality comparison remain unqualified. MTP remains
+unsupported by the current upstream model implementation.
 
 ## Next falsifiable experiments
 

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -311,11 +311,10 @@ decoded it without residual content or duplication. The vision path correctly
 counted two cats in the 640×480 mlx-vlm fixture at a 448×448 resize. Peak MLX
 memory across these probes ranged from 103.87 GB to 104.74 GB.
 
-Long-context growth, sustained throughput, and model-quality comparison remain
-unqualified. MTP remains unsupported by the current upstream model
-implementation, and upstream documents that the QSA cache is not wired into
-continuous batching. Neither feature is claimed from the single-request
-results.
+Long-context growth beyond the measured envelope, sustained throughput, and
+model-quality comparison remain unqualified. The QSA cache is not wired into
+continuous batching, so that combination remains fail-closed rather than being
+claimed from single-request results.
 
 An exclusive-process, unquantized-KV context sweep on the 128 GiB Mac now
 measures the all-resident Q4 envelope through 16,384 input tokens. Each level
@@ -360,9 +359,30 @@ not been measured. The llama.cpp PR reports reference comparisons for its
 architecture path, including WikiText-2 perplexity and QSA selection checks;
 those are not transferable quality evidence for the MLX Q4 artifact.
 
-MTP is not a parity gap today: it remains work in progress in the Unsloth
-llama.cpp PR and unsupported in the current mlx-vlm Qwen4-Exp implementation.
-It remains unqualified on both paths.
+The local MLX intake now goes beyond the initial upstream boundary with a
+Qwen4-Exp-specific native MTP drafter. It consumes the target's 10,240-wide
+pre-mixer residual, preserves the four-stream residual between draft rounds,
+uses the checkpoint's QSA/MoE/hyper-connection layer, and owns serialized
+recurrent-state verification and rollback. This does not imply continuous-
+batching support; the drafter advertises that boundary as false and the batched
+engine rejects it before scheduling.
+
+The standalone Q4/group-64 MTP artifact is 1,468,479,046 weight bytes at
+`/Volumes/Lexar/qwen38-flash-next/mlx/Qwen3.8-Flash-Next-MTP-Q4-MLX`.
+Direct generation returned `READY` with 2/2 drafts accepted at a combined
+target-plus-drafter MLX peak of 105,336,489,248 bytes. vllm-mlx SimpleEngine
+then passed an instruct response, a native `get_weather(city=Chicago)` call,
+tool-result continuation, and streaming thinking/final separation. The tool
+turn exercised rejection and rollback (24 drafted / 15 accepted); continuation
+used the returned weather result (18 / 6); streaming thinking ended normally
+with final `READY` and 61/31/92 usage. No duplicate call, parser failure,
+protocol leakage, or lost tool result was observed.
+
+The implementation commits are mlx-vlm `374aa186` and vllm-mlx `d0d76e3`.
+The drafter manifest pins config SHA-256
+`53f8553e12f86b225dcb84ebc5d79f7e038cc15ff2dc84bb6126a6efc33dd104`
+and weight SHA-256
+`49ec25f890c9c13b75e07b5043bf2b3349e297cb309a8292f5a22e35ca5f0e54`.
 
 The first vllm-mlx SimpleEngine attempt exposed a serving-specific correctness
 bug: `qwen4_exp_text` was not a registered extracted-text family, so
@@ -393,6 +413,6 @@ were disabled and remain unqualified.
 6. If external PLE remains justified, measure cold/warm decode, prefill, page
    faults, bytes/token, and batch scaling for page-cache-only and bounded-LRU
    mmap backends.
-7. Add MTP only through a Qwen4-specific draft splitter and architecture; the
-   current upstream implementation explicitly excludes MTP, so no support is
-   claimed from the presence of MTP tensors in the official checkpoint.
+7. Extend Qwen4 MTP to continuous batching only after QSA auxiliary caches and
+   four-stream drafter state have batch-aware merge/extract/filter/rollback
+   evidence. The current serialized path must remain the default until then.

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -303,9 +303,19 @@ swap during prefill, but neither run reported throttled pages, an OOM, or a
 child-process swap, and memory recovered after exit. This is a tight but
 working 128 GiB envelope, not yet a comfortable concurrent-service envelope.
 
-Streaming, tool use, multimodal behavior, long-context growth, sustained
-throughput, and model-quality comparison remain unqualified. MTP remains
-unsupported by the current upstream model implementation.
+Single-request streaming, native tool generation, and a minimal multimodal
+probe also pass. Streaming emitted two incremental events and reconstructed
+`READY` with a normal stop. A native `get_weather` call produced one complete
+Qwen XML call with `city=Chicago`; the existing vllm-mlx `qwen3_xml` parser
+decoded it without residual content or duplication. The vision path correctly
+counted two cats in the 640×480 mlx-vlm fixture at a 448×448 resize. Peak MLX
+memory across these probes ranged from 103.87 GB to 104.74 GB.
+
+Long-context growth, sustained throughput, and model-quality comparison remain
+unqualified. MTP remains unsupported by the current upstream model
+implementation, and upstream documents that the QSA cache is not wired into
+continuous batching. Neither feature is claimed from the single-request
+results.
 
 ## Next falsifiable experiments
 

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -1,0 +1,262 @@
+# Qwen3.8-Flash-Next Investigation
+
+Status: initial primary-source reconstruction and correctness slice, 2026-08-26.
+
+## Source pins
+
+- Official model revision: `Qwen/Qwen3.8-Flash-Next@f5d08274bafd880402bd16f5e3e6c514136ec06c`
+- Transformers: `huggingface/transformers@36bc98ef9dd009569366f5e253ec1876ecafd925`
+- mlx-lm: `ml-explore/mlx-lm@74e7cf9` (current upstream HEAD inspected)
+- mlx-vlm: `Blaizzy/mlx-vlm@2b31570b` (current upstream HEAD inspected)
+- llama.cpp: `ggml-org/llama.cpp@4d19b287691e8f47fc303be420f630c40ec45684`
+- Unsloth: `unslothai/unsloth@60d2a636ba0332e3faac78cdcc091f815ca72c6f`
+- Unsloth GGUF artifact:
+  `unsloth/Qwen3.8-Flash-Next-GGUF@d3bc75ee6ccef3efc1e228ec00a6cc2cdb1e2249`
+- Qwen technical report: <https://github.com/QwenLM/Qwen3.8-Flash-Next/blob/main/tech_report.pdf>
+
+The model card, config, weight index, and all 131 safetensors headers were
+inspected. No weight payload was downloaded.
+
+## Verified architecture
+
+The artifact is `Qwen4ExpForConditionalGeneration`, model type `qwen4_exp`, and
+is a causal language model with a 27-layer vision encoder. The language model
+has 48 layers with a repeating three Gated DeltaNet layers followed by one QSA
+layer (36 linear-attention and 12 QSA layers). Hidden size is 2,560.
+
+The MoE has 512 routed experts, 10 selected per token, one shared expert, and
+an intermediate size of 640. The official 125B-main / 6B-active description is
+consistent with the released configuration and headers.
+
+QSA uses 24 query heads, two KV heads, head dimension 256, partial RoPE
+dimension 64, and a separate 4-query/1-key indexer with dimension 128. The
+indexer compresses four tokens per block and has a 2,048-token (512-block)
+budget.
+
+Gated residuals use four streams and rank 320. One MTP layer is present and its
+released tensors contain 2,607,150,848 parameters (4.856 GiB BF16).
+
+The PLE n-gram table is injected at one-indexed layer 2. It has 16 independently
+hashed heads: eight bigram heads and eight trigram heads. Each head returns 160
+elements, so one token selects 16 rows and yields exactly 2,560 BF16 values, or
+5 KiB. Hashes are deterministic from the current token and at most two prior
+tokens, and history resets at EOS.
+
+The released table contains 320,001,536 rows × 160 BF16 values =
+51,200,245,760 parameters = 102,400,491,520 bytes (95.368 GiB). It is stored as
+128 equal tensors of 2,500,012 rows. These are storage splits of one logical
+table, not 128 simultaneously accessed heads.
+
+Native context is 262,144 tokens. The model card describes extension to one
+million with RoPE scaling; that extension is not native-equivalent evidence.
+
+## Exact BF16 tensor map
+
+Counts below come from tensor shapes in the released safetensors headers.
+
+| Family | Parameters | BF16/source GiB |
+|---|---:|---:|
+| Routed MoE experts | 120,795,955,200 | 225.000 |
+| N-gram embedding | 51,200,245,760 | 95.368 |
+| MTP | 2,607,150,848 | 4.856 |
+| Gated DeltaNet | 2,086,510,464 | 3.886 |
+| Gated residual | 640,624,640 | 1.193 |
+| Token embedding | 635,699,200 | 1.184 |
+| LM head | 635,699,200 | 1.184 |
+| QSA attention/indexers | 617,358,336 | 1.150 |
+| Vision encoder | 448,931,056 | 0.836 |
+| Shared experts | 235,929,600 | 0.439 |
+| Routers | 63,037,440 | 0.117 |
+| Other PLE tensors | 32,839,715 | 0.061 |
+| **Total** | **179,999,981,459** | **335.276** |
+
+### Affine quantization envelope
+
+The following is a storage lower-bound using MLX affine groups of 64 and one
+FP16 scale plus bias per group: effective bits/weight are nominal bits + 0.5.
+It is not a quality recommendation, and not every tensor is necessarily
+quantizable by the current module predicates.
+
+| Family | Q8 GiB | Q6 GiB | Q5 GiB | Q4 GiB | Q3 GiB |
+|---|---:|---:|---:|---:|---:|
+| Routed experts | 119.53 | 91.41 | 77.34 | 63.28 | 49.22 |
+| N-gram table | 50.66 | 38.74 | 32.78 | 26.82 | 20.86 |
+| MTP | 2.58 | 1.97 | 1.67 | 1.37 | 1.06 |
+| Gated DeltaNet | 2.06 | 1.58 | 1.34 | 1.09 | 0.85 |
+| All remaining families | 3.28 | 2.50 | 2.12 | 1.73 | 1.35 |
+| **Total theoretical** | **178.12** | **136.21** | **115.25** | **94.30** | **73.34** |
+
+The n-gram row width is 160, which is not divisible by mlx-lm's default affine
+group size 64. The current generic `quantize_model` predicate would therefore
+leave the 95.368 GiB table in BF16. A Q4 conversion of everything else with an
+unquantized table would be about **162.85 GiB** and cannot fit. A future model
+implementation can explicitly choose group size 32 for `QuantizedEmbedding`;
+that makes Q4 effectively 5 bits/weight for this table (29.80 GiB) and raises
+the whole-model Q4 estimate from the theoretical 94.30 GiB to about **97.28
+GiB**.
+
+Properly configured all-resident Q4 is therefore about 97 GiB before allocator
+overhead, temporary dequantized operands, recurrent state, KV/cache,
+tokenizer/processor state, and macOS reserve. This machine reports
+137,438,953,472 bytes, exactly 128 GiB. A 97.28 GiB model leaves 30.72 GiB for
+macOS, runtime allocations, cache/state, and temporary buffers. That is a
+credible all-resident configuration, not evidence of an inherently tight or
+unusable fit. Whether the margin is comfortable at a chosen context length
+requires measured high-water data.
+
+Representative strategy envelopes before runtime/context memory are:
+
+| Strategy | Approximate resident weights | Interpretation |
+|---|---:|---|
+| Generic current conversion (table remains BF16) | 162.85 GiB | Does not fit |
+| All-resident Q4, PLE explicitly Q4/group-32 | 97.28 GiB | Credible 128 GiB baseline; measure peak at target context |
+| Experts Q4, PLE Q3/group-32, other tensors Q8 | ~90 GiB | Plausible but quality unsupported |
+| External PLE, experts Q5, other tensors Q8 | ~83 GiB plus PLE cache | Most interesting higher-quality hypothesis |
+| External PLE, experts Q6, other tensors Q8 | ~97 GiB plus PLE cache | Potentially feasible; similar weight envelope to all-resident Q4 |
+
+For the 12 QSA layers, unquantized K+V alone is approximately 24 KiB/token if
+the implementation retains full keys and values: about 6 GiB at 262,144 tokens.
+The exact MLX cache design must be measured because QSA index state and sparse
+selection can change this accounting.
+
+## Support state
+
+- **Transformers:** released implementation is present. It defines Gated
+  DeltaNet, micro-block QSA, gated residuals, PLE indexing, multimodal merging,
+  and cache state. The n-gram weight is explicitly excluded from ordinary
+  device placement, allowing a different device, but this is not NVMe caching.
+- **vLLM/SGLang:** named by the official model card as supported. Their GPU
+  strategies and kernels are reference implementation sources, not directly
+  portable to Metal.
+- **mlx-lm:** no `qwen4_exp` implementation or active source reference at the
+  inspected HEAD. Its loader calls `mx.load` for every shard, constructs one
+  weight dictionary, and evaluates all parameters unless `lazy=True`.
+- **mlx-vlm:** no `qwen4_exp` implementation at the inspected HEAD. Because the
+  released artifact includes vision and uses `ForConditionalGeneration`, this
+  is the natural primary integration boundary.
+- **MLX:** `mx.load` is lazy, but there is no public external-row-backed
+  embedding abstraction. Deferring evaluation is not proof that a gather can
+  avoid materializing the complete source array.
+- **llama.cpp:** the inspected HEAD has no Qwen4-Exp architecture registration,
+  tensor mapping, or PLE table implementation. Existing `ngram-*` flags concern
+  speculative decoding and are unrelated to the model's PLE table.
+- **Unsloth:** the Day-0 Dynamic 3.0 GGUF repository appeared during this
+  investigation and remains explicitly marked WIP. At the pinned revision it
+  publishes only `UD-IQ1_S`, split across three files totaling 67.56 GiB. The
+  10.4 MiB first shard holds common metadata; range reads of the other two GGUF
+  headers expose all 1,224 language-model tensor descriptors without
+  downloading their payloads. The artifact contains neither vision nor MTP
+  tensors, so it is not a complete conversion of the released conditional-
+  generation checkpoint.
+
+### Verified Unsloth Day-0 tensor policy
+
+This is post-training GGUF quantization using a 45-chunk, 926-entry importance
+matrix. It is not evidence of an Unsloth-specific NVMe cache or external PLE
+backend. Generic llama.cpp mmap remains distinct from the quantization policy.
+
+| Tensor family | Observed GGUF types | Approximate GGUF payload |
+|---|---|---:|
+| PLE n-gram table | IQ4_NL | 26.822 GiB |
+| Routed expert projections | IQ1_S, IQ2_XXS, IQ4_NL | 37.109 GiB |
+| Routers | F32 | 0.234 GiB |
+| QSA/indexer | Q5_K, Q6_K, F32 | 1.355 GiB |
+| Gated DeltaNet | Q6_K, F32 | 0.471 GiB |
+| Gated residual | Q8_0, F32 | 0.647 GiB |
+| Shared experts | Q5_K, Q6_K, Q8_0, F32 | 0.179 GiB |
+| Token embedding and head | Q4_K | 0.666 GiB |
+| Vision and MTP | absent | 0 GiB |
+
+The policy is materially sensitivity-aware: it retains routers in F32, uses
+Q8 for the low-rank gated-residual projections, Q5/Q6 for attention and
+recurrent matrices, and concentrates the most aggressive IQ1/IQ2 formats in
+the routed experts. The enormous PLE table is ordinary resident IQ4_NL in the
+GGUF; there is no special sparse-storage representation. MLX Q4/group-32 has
+the same 26.82 GiB table payload estimate, but it is not numerically or
+operationally equivalent to IQ4_NL and requires independent quality evidence.
+
+## Recommended integration boundary
+
+Implement the multimodal architecture in mlx-vlm and share the language
+components with mlx-lm if upstream maintainers choose that structure.
+vllm-mlx should consume those APIs through its existing SimpleEngine and
+BatchedEngine paths. A vllm-mlx compatibility model would duplicate a large,
+rapidly evolving architecture and is not justified before upstream direction
+is known.
+
+The first local slice is deliberately narrower:
+`vllm_mlx.utils.qwen4_exp_ngram` reconstructs the released logical table,
+generates the exact bigram/trigram row IDs, resets history at EOS, and maps a
+global row to its 128-way storage split. Tests bind it to the released header
+shape and compare randomized sequences against an independent transcription of
+Transformers' vectorized shift/gather formulation. It changes no serving
+behavior and provides a parity primitive for an upstream model and a cold-table
+prototype.
+
+The isolated `mlx-vlm` branch `604/qwen38-flash-next` now contains the matching
+Qwen4-Exp config parser plus the first model-owned PLE storage interface.
+Resident MLX and read-only mmap row backends return identical synthetic rows.
+The mmap backend validates its versioned manifest and exact file size, confines
+the data file beside the manifest, supports a bounded row LRU, and reports
+lookups, hits, misses, bytes read, and elapsed lookup time. It is not registered
+as a complete model and cannot affect normal loading or serving. Six focused
+tests pass, including deserialization of the exact released config shape.
+
+## Cold n-gram feasibility
+
+Decode needs 16 rows/token × 160 BF16 values = 5 KiB/token. With 4 KiB VM pages,
+the pessimistic cold-read amplification is 64 KiB/token. At 20 tokens/s this is
+only 1.25 MiB/s but requires up to 320 random page reads/s. Bandwidth is not the
+primary decode risk; page-fault latency, synchronization, and cache miss rate
+are.
+
+The indices are known as soon as the token is selected and its two-token
+history is available. Current-token rows cannot be prefetched before sampling,
+but the gather can overlap other per-token work only after selection. Batches
+increase the number of independent rows nearly linearly unless prompts share
+token n-grams.
+
+Prefill is less favorable: sequence length `S` requires `16S` row lookups. At
+262K tokens that is 4.19 million logical row reads and up to 16 GiB of page
+traffic without locality. The hash functions intentionally spread rows across
+the table, so a small LRU should not be assumed effective. Real token/n-gram
+repetition may still provide useful locality and must be measured.
+
+An mmap-backed row store plus CPU gather and a 5 KiB/token transfer to MLX is
+technically plausible. Current MLX embeddings cannot directly express this
+backing. A custom Metal kernel cannot make NVMe memory directly addressable and
+should not be attempted before a CPU/mmap prototype measures page faults,
+latency, and hit rate. macOS page cache should be measured as the baseline
+before adding an application LRU.
+
+If the table is kept outside resident memory, it saves 26.82 GiB versus Q4 or
+32.78 GiB versus Q5. That can make a higher-quality base configuration possible,
+but only if sparse-read latency and quality of the separately quantized table
+pass measurement.
+
+## Current decision
+
+Evidence does not rule out **A**. Once PLE uses Q4 with group size 32, plain
+all-resident MLX Q4 is the required baseline and may fit comfortably on this
+exact 128 GiB machine. Special handling is justified only if measured peak
+memory, context envelope, throughput, or quality shows a material advantage.
+B and C remain hypotheses until those measurements are available. The generic
+converter's current behavior of silently leaving the PLE n-gram tables in BF16
+is a separate conversion defect.
+
+## Next falsifiable experiments
+
+1. Compare the local n-gram IDs against Transformers for randomized sequences,
+   EOS boundaries, prefill, and one-token continuation.
+2. Ask mlx-vlm maintainers whether a Qwen4-Exp implementation is already in an
+   unpublished branch before duplicating it.
+3. Implement the smallest mlx-vlm PLE embedding and compare BF16 outputs against
+   Transformers using synthetic weights small enough for CI.
+4. Measure `mx.load(..., stream=mx.cpu)` evaluation and RSS for gather-only use;
+   prove whether MLX materializes the entire embedding.
+5. Build an mmap BF16 row reader using a synthetic 128-split table. Measure
+   cold/warm decode, prefill, page faults, bytes/token, and batch scaling.
+6. Only after parity, run tensor-family sensitivity tests for experts, PLE,
+   routers/QSA, recurrent components, embeddings/head, vision, and MTP.
+7. Convert a complete artifact only after projected peak disk and resident
+   memory fit the machine with a documented safety margin.

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -317,6 +317,53 @@ implementation, and upstream documents that the QSA cache is not wired into
 continuous batching. Neither feature is claimed from the single-request
 results.
 
+An exclusive-process, unquantized-KV context sweep on the 128 GiB Mac now
+measures the all-resident Q4 envelope through 16,384 input tokens. Each level
+used chunked prefill (`prefill_step_size=2048`), the vendor instruct sampling
+tuple, and one generated token. The evaluated warm model occupied 96.56 GiB of
+MLX active memory before a request.
+
+| Input tokens | MLX peak | Increment over warm model | Prompt throughput |
+|---:|---:|---:|---:|
+| 128 | 97.07 GiB | 0.51 GiB | 177.4 tok/s |
+| 1,024 | 98.78 GiB | 2.22 GiB | 411.0 tok/s |
+| 4,096 | 103.30 GiB | 6.74 GiB | 435.7 tok/s |
+| 8,192 | 107.63 GiB | 11.07 GiB | 364.5 tok/s |
+| 16,384 | 116.36 GiB | 19.80 GiB | 299.7 tok/s |
+
+The sweep recorded zero throttled pages and no process-attributed swap. System
+memory pressure ended at 17 percent free. A 32K run was deliberately not
+attempted: the measured growth projects beyond physical memory and would test
+macOS compression/OOM behavior rather than establish a safe operating
+contract. Consequently, 16K is a measured very-tight single-request point,
+not a recommended service maximum, and the model's native 262K configuration
+is not a claim that this artifact reaches 262K on this machine. Raw evidence is
+`/Volumes/Lexar/qwen38-flash-next/mlx/Qwen3.8-Flash-Next-Q4-MLX/MEMORY_CONTEXT_SWEEP.jsonl`.
+
+### Day-one Unsloth/llama.cpp comparison (2026-08-26)
+
+The implementations are not at complete feature parity. Both implement the
+base Qwen4-Exp architecture, PLE n-gram addressing, QSA, vision, text
+generation, and quantized loading. This MLX path has direct single-request
+text, streaming, native-tool, thinking-separation, and vision evidence on the
+local Q4. The Unsloth llama.cpp PR additionally reports validated multi-stream
+QSA batching at batch sizes 1, 4, and 16, plus a single contiguous GGUF PLE
+table that can remain mmap-backed and be offloaded to RAM or disk. The current
+MLX QSA cache is not wired into continuous batching, and the experimental MLX
+mmap PLE backend is not qualified.
+
+Unsloth now publishes seven Dynamic 3.0 GGUF policies from 67.56 GiB
+(`UD-IQ1_S`) through 103.69 GiB (`UD-Q4_K_XL`). MLX currently has one measured
+96.54 GiB mixed-Q4 policy. Nominal Q4 is not a parity statement: the block
+formats and family-specific assignments differ, and comparative quality has
+not been measured. The llama.cpp PR reports reference comparisons for its
+architecture path, including WikiText-2 perplexity and QSA selection checks;
+those are not transferable quality evidence for the MLX Q4 artifact.
+
+MTP is not a parity gap today: it remains work in progress in the Unsloth
+llama.cpp PR and unsupported in the current mlx-vlm Qwen4-Exp implementation.
+It remains unqualified on both paths.
+
 The first vllm-mlx SimpleEngine attempt exposed a serving-specific correctness
 bug: `qwen4_exp_text` was not a registered extracted-text family, so
 `text_model_from_vlm` silently constructed the generic Qwen3.5 TextModel. The

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -317,6 +317,22 @@ implementation, and upstream documents that the QSA cache is not wired into
 continuous batching. Neither feature is claimed from the single-request
 results.
 
+The first vllm-mlx SimpleEngine attempt exposed a serving-specific correctness
+bug: `qwen4_exp_text` was not a registered extracted-text family, so
+`text_model_from_vlm` silently constructed the generic Qwen3.5 TextModel. The
+weights loaded mechanically, but the route emitted garbled text, reported zero
+prompt tokens, and stopped by length. Local routing now fails closed for the
+Qwen4-Exp family and keeps text requests on the correct loaded mlx-vlm model.
+
+With that fix, SimpleEngine single-request serving passes streaming instruct,
+streaming native tools, and thinking separation. Instruct returned `READY`
+with correct 17/3/20 usage. The tool request returned one `get_weather` call
+with `city=Chicago`, a `tool_calls` finish, and correct 287/27/314 usage. The
+thinking response separated reasoning content and returned final content
+`READY` with a normal stop. Warm-server generation measured 10.4 tok/s for the
+tool call and 15.3 tok/s for the thinking probe. Continuous batching and MTP
+were disabled and remain unqualified.
+
 ## Next falsifiable experiments
 
 1. Finish and hash-verify the pinned official FP8 snapshot on Lexar.

--- a/docs/qwen38_flash_next_investigation.md
+++ b/docs/qwen38_flash_next_investigation.md
@@ -7,7 +7,7 @@ Status: initial primary-source reconstruction and correctness slice, 2026-08-26.
 - Official model revision: `Qwen/Qwen3.8-Flash-Next@f5d08274bafd880402bd16f5e3e6c514136ec06c`
 - Transformers: `huggingface/transformers@36bc98ef9dd009569366f5e253ec1876ecafd925`
 - mlx-lm: `ml-explore/mlx-lm@74e7cf9` (current upstream HEAD inspected)
-- mlx-vlm: `Blaizzy/mlx-vlm@2b31570b` (current upstream HEAD inspected)
+- mlx-vlm: `Blaizzy/mlx-vlm@4857a6b0` (includes merged Qwen4-Exp PR #2032)
 - llama.cpp: `ggml-org/llama.cpp@4d19b287691e8f47fc303be420f630c40ec45684`
 - Unsloth: `unslothai/unsloth@60d2a636ba0332e3faac78cdcc091f815ca72c6f`
 - Unsloth GGUF artifact:
@@ -131,9 +131,18 @@ selection can change this accounting.
 - **mlx-lm:** no `qwen4_exp` implementation or active source reference at the
   inspected HEAD. Its loader calls `mx.load` for every shard, constructs one
   weight dictionary, and evaluates all parameters unless `lazy=True`.
-- **mlx-vlm:** no `qwen4_exp` implementation at the inspected HEAD. Because the
-  released artifact includes vision and uses `ForConditionalGeneration`, this
-  is the natural primary integration boundary.
+- **mlx-vlm:** Qwen4-Exp support merged in PR #2032 while this investigation
+  was active. It implements config parsing, the Qwen3 vision encoder, gated
+  residuals, DeltaNet, QSA and its auxiliary cache, MoE, sharded PLE lookup,
+  text/multimodal generation, and checkpoint sanitization. Its documented
+  boundary excludes MTP and continuous batching for QSA. Static intake found
+  two conversion defects in the merged implementation: the official FP8
+  artifact's expanded per-expert tensors and per-tensor FP8 PLE scale were not
+  handled, and a model-owned PLE group-32 override was evaluated after the
+  converter's default group-64 divisibility rejection. Both are corrected and
+  covered offline on local isolated mlx-vlm branch
+  `604/qwen38-flash-next-upstream-intake` at `127d943e`; no upstream PR has
+  been opened.
 - **MLX:** `mx.load` is lazy, but there is no public external-row-backed
   embedding abstraction. Deferring evaluation is not proof that a gather can
   avoid materializing the complete source array.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ def _serve_args(**overrides):
         "cache_memory_mb": None,
         "cache_memory_percent": 0.2,
         "chunked_prefill_tokens": 0,
+        "completion_batch_size": 32,
         "continuous_batching": False,
         "default_min_p": None,
         "default_presence_penalty": None,
@@ -117,6 +118,37 @@ def test_serve_command_propagates_all_sampling_defaults(monkeypatch):
     assert server._default_presence_penalty == 0.0
     assert server._default_repetition_penalty == 1.0
     assert loaded["kwargs"]["specprefill_backbone_pct"] == 0.25
+
+
+def test_serve_command_propagates_prefill_step_size_to_continuous_batching(
+    monkeypatch,
+):
+    from vllm_mlx import cli, server
+    from vllm_mlx.utils import download
+
+    loaded = {}
+    monkeypatch.setattr(
+        download, "ensure_model_downloaded", lambda *args, **kwargs: "local-test-model"
+    )
+    monkeypatch.setattr(
+        server,
+        "load_model",
+        lambda *args, **kwargs: loaded.update({"args": args, "kwargs": kwargs}),
+    )
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    cli.serve_command(
+        _serve_args(
+            continuous_batching=True,
+            mllm=True,
+            prefill_step_size=512,
+            mllm_prefill_step_size=0,
+        )
+    )
+
+    scheduler_config = loaded["kwargs"]["scheduler_config"]
+    assert scheduler_config.prefill_step_size == 512
+    assert scheduler_config.mllm_prefill_step_size is None
 
 
 def test_serve_parser_accepts_registered_step3p5_tool_parser():

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -8,9 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 
-def test_registered_non_gemma_mtp_drafter_uses_mlx_vlm_loader(
-    monkeypatch, tmp_path
-):
+def test_registered_non_gemma_mtp_drafter_uses_mlx_vlm_loader(monkeypatch, tmp_path):
     from vllm_mlx.models.mllm import load_mtp_drafter
 
     (tmp_path / "config.json").write_text(

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -2,9 +2,52 @@
 """Tests for MLLM assistant-drafter speculative wiring."""
 
 import sys
+import json
 from types import SimpleNamespace
 
 import pytest
+
+
+def test_registered_non_gemma_mtp_drafter_uses_mlx_vlm_loader(
+    monkeypatch, tmp_path
+):
+    from vllm_mlx.models.mllm import load_mtp_drafter
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen4_exp_mtp"}), encoding="utf-8"
+    )
+    expected = object()
+    captured = {}
+
+    def fake_load(path, *, kind, lazy):
+        captured.update(path=path, kind=kind, lazy=lazy)
+        return expected, "mtp"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.speculative.drafters",
+        SimpleNamespace(load_drafter=fake_load),
+    )
+
+    assert load_mtp_drafter(str(tmp_path)) is expected
+    assert captured == {"path": str(tmp_path), "kind": "mtp", "lazy": False}
+
+
+def test_simple_engine_reports_drafter_batch_capability():
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    engine = SimpleEngine(
+        "qwen4-exp",
+        force_mllm=True,
+        mllm_draft_model="assistant",
+        mllm_draft_kind="mtp",
+    )
+    engine._loaded = True
+    engine._model = SimpleNamespace(
+        _draft_model=SimpleNamespace(supports_continuous_batching=False)
+    )
+
+    assert engine.get_stats()["mtp"]["continuous_batching_supported"] is False
 
 
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):

--- a/tests/test_qwen4_exp_ngram.py
+++ b/tests/test_qwen4_exp_ngram.py
@@ -1,0 +1,108 @@
+import numpy as np
+
+from vllm_mlx.utils.qwen4_exp_ngram import Qwen4ExpNGramLayout
+
+
+def _official_layout() -> Qwen4ExpNGramLayout:
+    return Qwen4ExpNGramLayout(
+        unigram_vocab_size=248_320,
+        embedding_dim=2_560,
+        eos_token_id=248_044,
+        ngram_size=3,
+        heads_per_ngram=8,
+        ngram_vocab_size_base=20_000_000,
+        divisible_by=128,
+        split_parts=128,
+        ple_layer_index=0,
+        seed=1234,
+    )
+
+
+def test_released_flash_next_ngram_layout_matches_weight_headers():
+    layout = _official_layout()
+
+    assert layout.ngram_heads == 16
+    assert layout.head_dim == 160
+    assert layout.padded_rows == 320_001_536
+    assert layout.rows_per_split == 2_500_012
+    assert layout.bf16_bytes == 102_400_491_520
+
+
+def test_each_token_selects_one_row_per_ngram_head():
+    layout = _official_layout()
+    indices = layout.indices_for_tokens([248_044, 10, 20, 30])
+
+    assert len(indices) == 4
+    assert all(len(rows) == 16 for rows in indices)
+    assert all(0 <= row < layout.padded_rows for rows in indices for row in rows)
+
+
+def test_eos_resets_ngram_history():
+    layout = _official_layout()
+
+    after_history = layout.indices_for_tokens([10, 20, 248_044, 30])[-1]
+    after_fresh_eos = layout.indices_for_tokens([248_044, 30])[-1]
+
+    assert after_history == after_fresh_eos
+
+
+def test_global_rows_map_to_released_split_shape():
+    layout = _official_layout()
+
+    assert layout.split_address(0) == (0, 0)
+    assert layout.split_address(2_500_012) == (1, 0)
+    assert layout.split_address(layout.padded_rows - 1) == (127, 2_500_011)
+
+
+def _transformers_shift_reference(layout, token_ids):
+    """Independent form of Transformers' vectorized shift/gather algorithm."""
+    tokens = np.asarray(token_ids, dtype=np.int64)[None, :]
+    positions = np.arange(tokens.shape[1], dtype=np.int64)
+    shifted = []
+    for shift in range(layout.ngram_size):
+        if shift == 0:
+            shifted.append(tokens)
+            continue
+        eos_positions = np.where(tokens == layout.eos_token_id, positions, -1)
+        previous_inclusive = np.maximum.accumulate(eos_positions, axis=1)
+        previous = np.concatenate(
+            [np.full((1, 1), -1, dtype=np.int64), previous_inclusive[:, :-1]],
+            axis=1,
+        )
+        segment_start = previous + 1
+        source = positions - shift
+        gathered = np.take_along_axis(tokens, np.maximum(source, 0)[None, :], axis=1)
+        valid = ((positions[None, :] - segment_start) >= shift) & (source[None, :] >= 0)
+        shifted.append(np.where(valid, gathered, layout.eos_token_id))
+    return shifted
+
+
+def test_randomized_indices_match_transformers_reference_formulation():
+    layout = _official_layout()
+    rng = np.random.default_rng(604)
+    sizes = np.asarray(layout.head_vocab_sizes)
+    offsets = np.asarray(layout.head_offsets)
+    from vllm_mlx.utils.qwen4_exp_ngram import _build_layer_multipliers
+
+    multipliers = _build_layer_multipliers(
+        layout.unigram_vocab_size,
+        layout.ngram_size,
+        layout.ple_layer_index,
+        layout.seed,
+    )
+    for _ in range(30):
+        tokens = rng.integers(0, layout.unigram_vocab_size - 1, size=37).tolist()
+        tokens[rng.integers(1, len(tokens) - 1)] = layout.eos_token_id
+        shifted = _transformers_shift_reference(layout, tokens)
+        blocks = []
+        for ngram in range(2, layout.ngram_size + 1):
+            start = (ngram - 2) * layout.heads_per_ngram
+            end = start + layout.heads_per_ngram
+            mixed = shifted[0] * multipliers[0]
+            for position in range(1, ngram):
+                mixed = np.bitwise_xor(mixed, shifted[position] * multipliers[position])
+            blocks.append(
+                np.remainder(mixed[..., None], sizes[start:end]) + offsets[start:end]
+            )
+        expected = np.concatenate(blocks, axis=-1)[0]
+        np.testing.assert_array_equal(layout.indices_for_tokens(tokens), expected)

--- a/tests/test_text_model_dispatch.py
+++ b/tests/test_text_model_dispatch.py
@@ -109,3 +109,20 @@ def test_missing_config_is_not_reported_as_a_build_failure(tmp_path, caplog):
     with caplog.at_level(logging.ERROR, logger="vllm_mlx.text_model_from_vlm"):
         assert build_text_model(_Vlm(), tmp_path) is None
     assert not caplog.records
+
+
+@pytest.mark.parametrize("model_type", ["qwen4_exp", "qwen4_exp_text"])
+def test_qwen4_exp_stays_on_mlx_vlm_text_path(tmp_path, caplog, model_type):
+    """Qwen4-Exp is not compatible with the generic Qwen3.5 TextModel."""
+    (tmp_path / "config.json").write_text(
+        '{"text_config": {"model_type": "' + model_type + '"}}'
+    )
+
+    class _Vlm:
+        language_model = object()
+
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.text_model_from_vlm"):
+        assert build_text_model(_Vlm(), tmp_path) is None
+
+    assert "mlx-vlm text path" in caplog.records[-1].getMessage()
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -312,6 +312,10 @@ def serve_command(args):
             max_cache_blocks=args.max_cache_blocks,
             # Chunked prefill
             chunked_prefill_tokens=args.chunked_prefill_tokens,
+            # Keep the general prefill chunk setting authoritative for both
+            # text and multimodal schedulers.  The MLLM-specific option below
+            # remains an explicit override when supplied.
+            prefill_step_size=args.prefill_step_size,
             # MTP
             enable_mtp=args.enable_mtp,
             mtp_num_draft_tokens=args.mtp_num_draft_tokens,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -483,8 +483,13 @@ class BatchedEngine(BaseEngine):
         # Create and start MLLM scheduler
         scheduler_kwargs = {}
         if self._mllm_draft_model is not None:
+            loaded_drafter = getattr(self._mllm_instance, "_draft_model", None)
+            if not getattr(loaded_drafter, "supports_continuous_batching", True):
+                raise ValueError(
+                    "The configured MLLM MTP drafter does not support continuous batching"
+                )
             scheduler_kwargs = {
-                "draft_model": getattr(self._mllm_instance, "_draft_model", None),
+                "draft_model": loaded_drafter,
                 "draft_kind": self._mllm_draft_kind,
                 "draft_block_size": self._mllm_draft_block_size,
             }

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -3427,6 +3427,7 @@ class SimpleEngine(BaseEngine):
             }
 
         if self._mllm_draft_model_path is not None:
+            loaded_drafter = getattr(self._model, "_draft_model", None)
             stats["mtp"] = {
                 "enabled": True,
                 "implementation": "mlx_vlm_assistant",
@@ -3434,7 +3435,9 @@ class SimpleEngine(BaseEngine):
                 "draft_kind": self._mllm_draft_kind,
                 "draft_block_size": self._mllm_draft_block_size,
                 "default_enabled": self._default_mllm_draft,
-                "continuous_batching_supported": True,
+                "continuous_batching_supported": bool(
+                    getattr(loaded_drafter, "supports_continuous_batching", True)
+                ),
             }
 
         # System KV cache stats (LRU over multiple system prefixes)

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -476,7 +476,9 @@ def load_mtp_drafter(model_path: str):
             "This MTP drafter requires an mlx-vlm build with the registered "
             f"{model_type!r} architecture."
         ) from exc
-    logger.info("Loading registered MTP drafter model_type=%s from %s", model_type, model_path)
+    logger.info(
+        "Loading registered MTP drafter model_type=%s from %s", model_type, model_path
+    )
     model, resolved_kind = load_drafter(model_path, kind="mtp", lazy=False)
     if resolved_kind != "mtp":
         raise ValueError(

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -458,6 +458,33 @@ def load_gemma4_assistant_drafter(model_path: str):
     return model
 
 
+def load_mtp_drafter(model_path: str):
+    """Load a registered mlx-vlm MTP drafter without assuming Gemma layout."""
+    config_path = Path(model_path) / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"MTP drafter config not found: {config_path}")
+    model_type = json.loads(config_path.read_text(encoding="utf-8")).get(
+        "model_type", ""
+    )
+    if model_type in {"gemma4_assistant", "gemma4_unified_assistant"}:
+        return load_gemma4_assistant_drafter(model_path)
+
+    try:
+        from mlx_vlm.speculative.drafters import load_drafter
+    except ImportError as exc:
+        raise ImportError(
+            "This MTP drafter requires an mlx-vlm build with the registered "
+            f"{model_type!r} architecture."
+        ) from exc
+    logger.info("Loading registered MTP drafter model_type=%s from %s", model_type, model_path)
+    model, resolved_kind = load_drafter(model_path, kind="mtp", lazy=False)
+    if resolved_kind != "mtp":
+        raise ValueError(
+            f"Configured MTP drafter resolved to unsupported kind {resolved_kind!r}"
+        )
+    return model
+
+
 _DRAFT_KWARG_NAMES = ("draft_model", "draft_kind", "draft_block_size")
 
 
@@ -1403,7 +1430,7 @@ class MLXMultimodalLM:
 
     def _load_draft_model(self):
         if self.draft_kind == "mtp":
-            return load_gemma4_assistant_drafter(self.draft_model_path)
+            return load_mtp_drafter(self.draft_model_path)
 
         from mlx_vlm.utils import load
 

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -37,6 +37,12 @@ _TEXT_MODEL_FAMILIES: tuple[tuple[str, str, tuple[str, str]], ...] = (
 # that names neither the model nor the class. Hence the logging either side.
 _DEFAULT_TEXT_MODEL = ("mlx_lm.models.qwen3_5", ("TextModel", "TextModelArgs"))
 
+# These architectures are not compatible with the generic Qwen3.5 text
+# skeleton. Returning no extracted TextModel keeps SimpleEngine on the loaded
+# mlx-vlm path for text as well as media instead of silently serving incorrect
+# logits from a mechanically compatible but architecturally different model.
+_VLM_ONLY_TEXT_MODEL_PREFIXES = ("qwen4_exp",)
+
 
 def _import_text_model_classes(model_type: str):
     """Return ``(Model, ModelArgs)`` for a text config's ``model_type``."""
@@ -92,6 +98,13 @@ def build_text_model(
         config = json.loads((model_path / "config.json").read_text())
         text_config = config.get("text_config", config)
         model_type = text_config.get("model_type") or config.get("model_type", "")
+        if model_type.startswith(_VLM_ONLY_TEXT_MODEL_PREFIXES):
+            logger.info(
+                "Keeping model_type=%r on the mlx-vlm text path; no compatible "
+                "mlx-lm TextModel is registered",
+                model_type,
+            )
+            return None
         TextModel, TextModelArgs = _import_text_model_classes(model_type)
         text_model_cls = f"{TextModel.__module__}.{TextModel.__qualname__}"
         logger.debug(

--- a/vllm_mlx/utils/qwen4_exp_ngram.py
+++ b/vllm_mlx/utils/qwen4_exp_ngram.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reference addressing for Qwen4-Exp PLE n-gram embeddings.
+
+This module intentionally implements only the deterministic index calculation.
+It does not load model weights or register a vllm-mlx model implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PRIME_1 = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    for divisor in range(3, math.isqrt(value) + 1, 2):
+        if value % divisor == 0:
+            return False
+    return True
+
+
+def _find_nth_prime_after(start: int, count: int) -> int:
+    prime = start
+    for _ in range(count):
+        prime += 1
+        while not _is_prime(prime):
+            prime += 1
+    return prime
+
+
+def _build_layer_multipliers(
+    unigram_vocab_size: int, ngram_size: int, ple_layer_index: int, seed: int
+) -> tuple[int, ...]:
+    max_long = (1 << 63) - 1
+    multiplier_max = max_long // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + _PRIME_1 * ple_layer_index
+    return tuple(
+        2
+        * (
+            _splitmix64((base_seed + _SPLITMIX_GAMMA * (index + 1)) & _MASK64)
+            % half_bound
+        )
+        + 1
+        for index in range(ngram_size)
+    )
+
+
+@dataclass(frozen=True)
+class Qwen4ExpNGramLayout:
+    """Exact PLE table layout derived from a Qwen4-Exp text config."""
+
+    unigram_vocab_size: int
+    embedding_dim: int
+    eos_token_id: int
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    divisible_by: int = 128
+    split_parts: int = 128
+    ple_layer_index: int = 0
+    seed: int = 1234
+
+    @property
+    def ngram_heads(self) -> int:
+        return (self.ngram_size - 1) * self.heads_per_ngram
+
+    @property
+    def head_dim(self) -> int:
+        if self.embedding_dim % self.ngram_heads:
+            raise ValueError("embedding_dim must be divisible by ngram_heads")
+        return self.embedding_dim // self.ngram_heads
+
+    @property
+    def head_vocab_sizes(self) -> tuple[int, ...]:
+        return tuple(
+            _find_nth_prime_after(
+                self.ngram_vocab_size_base - 1,
+                self.ple_layer_index * self.ngram_heads + head + 1,
+            )
+            for head in range(self.ngram_heads)
+        )
+
+    @property
+    def head_offsets(self) -> tuple[int, ...]:
+        offsets = []
+        current = 0
+        for size in self.head_vocab_sizes:
+            offsets.append(current)
+            current += size
+        return tuple(offsets)
+
+    @property
+    def padded_rows(self) -> int:
+        rows = sum(self.head_vocab_sizes)
+        return math.ceil(rows / self.divisible_by) * self.divisible_by
+
+    @property
+    def rows_per_split(self) -> int:
+        if self.padded_rows % self.split_parts:
+            raise ValueError("padded n-gram rows must divide evenly across splits")
+        return self.padded_rows // self.split_parts
+
+    @property
+    def bf16_bytes(self) -> int:
+        return self.padded_rows * self.head_dim * 2
+
+    def split_address(self, row_id: int) -> tuple[int, int]:
+        """Return ``(split_index, row_within_split)`` for a global row id."""
+        if row_id < 0 or row_id >= self.padded_rows:
+            raise ValueError(f"row id outside n-gram table: {row_id}")
+        return divmod(row_id, self.rows_per_split)
+
+    def indices_for_tokens(self, token_ids: Sequence[int]) -> list[tuple[int, ...]]:
+        """Return the 16 global PLE row ids selected for every input token.
+
+        History does not cross EOS boundaries, matching the released
+        Transformers implementation's ``_shift_right_ignore_eos`` behavior.
+        """
+        sizes = self.head_vocab_sizes
+        offsets = self.head_offsets
+        multipliers = _build_layer_multipliers(
+            self.unigram_vocab_size,
+            self.ngram_size,
+            self.ple_layer_index,
+            self.seed,
+        )
+        output: list[tuple[int, ...]] = []
+        segment: list[int] = []
+
+        for token in token_ids:
+            shifted = [token]
+            shifted.extend(
+                segment[-shift] if len(segment) >= shift else self.eos_token_id
+                for shift in range(1, self.ngram_size)
+            )
+            rows = []
+            for ngram in range(2, self.ngram_size + 1):
+                start = (ngram - 2) * self.heads_per_ngram
+                mixed = shifted[0] * multipliers[0]
+                for position in range(1, ngram):
+                    mixed ^= shifted[position] * multipliers[position]
+                rows.extend(
+                    mixed % sizes[head] + offsets[head]
+                    for head in range(start, start + self.heads_per_ngram)
+                )
+            output.append(tuple(rows))
+            if token == self.eos_token_id:
+                segment.clear()
+            else:
+                segment.append(token)
+                del segment[: -self.ngram_size + 1]
+
+        return output


### PR DESCRIPTION
## Summary

- keep Qwen3.8 Flash Next on the `mlx-vlm` text-model path
- load a registered native MTP drafter in `SimpleEngine`
- fail closed when that drafter is requested with continuous batching
- honor `--prefill-step-size` in the continuous-batching scheduler
- add a deterministic n-gram reference and measured qualification record

Depends on Blaizzy/mlx-vlm#2045. Native MTP model support merged in Blaizzy/mlx-vlm#2040; base Qwen3.8 continuous batching merged in Blaizzy/mlx-vlm#2056.

## Results

M2 Ultra / 128 GB, Q4 model with the external Q4 PLE store:

- model load: 8.26 s
- active model memory without the drafter: 71.68 GB
- matched 21,646-token request, MTP off: 49.35 s TTFT, 19.04 tok/s decode, 68.47 s total
- Qwen 27B comparison: 124.37 s TTFT, 15.74 tok/s decode, 146.74 s total
- 128K prefill peak: 114.47 GB; no swap-out growth
- two-request exact and ragged-lifecycle CB passed in both vendor profiles
- concurrent coding-vision plus text passed in instruct mode
- thinking-mode streaming native tools passed invalid call, validation error, corrected call, and continuation

The current registered MTP drafter is not qualified. It reduced short decode from 18.21 to 15.57 tok/s. In the first Jobs cohort, two of five strict terminal tool calls failed; both exact failed cases produced complete schema-valid calls when replayed with MTP disabled.

Instruct-mode strict native tools also remain open: both CB and serialized runs emitted typed arrays and integers as strings. That isolates the failure from continuous batching.

## Validation

- 70 focused CLI, MLLM configuration, and continuous-batching tests passed
- all upstream CI checks passed on `5724b08`
- live scheduler startup reported `prefill_step_size=512`
- exact ragged lifecycle and thinking native-tool continuation passed against the promoted Runtime installation
- Runtime verification passed: 619 core tests, 2 stream-parser tests, 5 MLX-QSDPA tests, and 8/8 patch checks

## Scope

External-PLE continuous batching without MTP is qualified at the measured 64K machine envelope. This PR does not claim that Flash MTP should be enabled by default or that instruct-mode strict native tools are ready for Jobs. MTP repair, instruct tool-schema reliability, representative quality comparison, and high-entropy long-context qualification remain open.
