### PR TITLE
fix(scheduler): guard MTP install against mlx-lm >= 0.31 BatchGenerator

### DIFF
--- a/tests/test_mtp_mlxlm_compat.py
+++ b/tests/test_mtp_mlxlm_compat.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: --enable-mtp must not crash on mlx-lm >= 0.31.
+
+The MTP monkey-patch wraps ``BatchGenerator._step``, which was refactored
+away in mlx-lm 0.31.x (decode moved to ``GenerationBatch._step``).  On an
+incompatible BatchGenerator the install must warn and no-op instead of
+raising ``AttributeError`` at generator creation.
+"""
+
+import logging
+
+from mlx_lm.generate import BatchGenerator
+
+from vllm_mlx.scheduler import _install_mtp
+
+
+class _ModernBatchGenerator:
+    """Mimics the mlx-lm >= 0.31 BatchGenerator surface (no ``_step``)."""
+
+    def insert(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def remove(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def next(self):
+        raise NotImplementedError
+
+
+def test_install_mtp_skips_without_step_hook(caplog):
+    bg = _ModernBatchGenerator()
+
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+        _install_mtp(bg, model=None)
+
+    assert not hasattr(bg, "_step")
+    assert bg.__dict__.get("_next") is None
+    assert any("[MTP] disabled" in rec.message for rec in caplog.records)
+
+
+def test_installed_mlx_lm_batch_generator_lacks_step_hook():
+    # Documents the incompatibility this guard exists for: if this ever
+    # fails, mlx-lm regained a _step hook and the MTP patch (and this
+    # guard) should be revisited.
+    assert not hasattr(BatchGenerator, "_step")

--- a/tests/test_mtp_mlxlm_compat.py
+++ b/tests/test_mtp_mlxlm_compat.py
@@ -43,3 +43,56 @@ def test_installed_mlx_lm_batch_generator_lacks_step_hook():
     # fails, mlx-lm regained a _step hook and the MTP patch (and this
     # guard) should be revisited.
     assert not hasattr(BatchGenerator, "_step")
+
+
+def test_scheduler_enable_mtp_survives_modern_batch_generator(caplog):
+    """Integration: the real construction path with enable_mtp=True.
+
+    Builds a real Scheduler and calls _create_batch_generator, so the guard is
+    exercised through the actual call path with the installed mlx-lm
+    BatchGenerator (which lacks the _step hook).  Construction and request
+    scheduling must continue, MTP must be absent from the generator, and the
+    operator-visible warning must be emitted.
+    """
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import (
+        Request,
+        SamplingParams,
+        Scheduler,
+        SchedulerConfig,
+    )
+
+    model = SimpleNamespace(mtp=object())  # has an MTP head: only the guard disables
+    tokenizer = SimpleNamespace(
+        encode=lambda text: list(range(len(text.split()))),
+        decode=lambda ids: " ".join(str(i) for i in ids),
+        eos_token_id=0,
+        eos_token_ids={0},
+    )
+    scheduler = Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(enable_prefix_cache=False, enable_mtp=True),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+        bg = scheduler._create_batch_generator(SamplingParams())
+
+    # Construction survived on the real, modern BatchGenerator.
+    assert bg is not None
+    assert not hasattr(bg, "_step")
+    # MTP is absent: the install no-oped, so no MTP surface was attached.
+    assert not hasattr(bg, "get_mtp_stats")
+    assert any("[MTP] disabled" in rec.message for rec in caplog.records)
+
+    # Request scheduling continues.
+    scheduler.add_request(
+        Request(
+            request_id="mtp-guard-1",
+            prompt="hello there",
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+    )
+    assert scheduler.has_requests()
+    assert scheduler.get_num_waiting() == 1

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -810,6 +810,19 @@ def _install_mtp(
        Reject: trim KVCache by 1, skip_state from pos 0 (no cold start)
     5. Draft is emitted in the NEXT generation step after primary
     """
+    # The MTP monkey-patch relies on BatchGenerator._step, which was
+    # refactored away in mlx-lm 0.31.x (decode now lives on
+    # GenerationBatch._step).  Skip gracefully when the required API is
+    # absent instead of crashing at generator creation — mirrors the
+    # chunked prefill compatibility guard.
+    if not hasattr(batch_gen, "_step"):
+        logger.warning(
+            "[MTP] disabled: mlx-lm BatchGenerator lacks the _step hook "
+            "required by the MTP monkey-patch (refactored in mlx-lm 0.31.x). "
+            "Generation continues without multi-token prediction."
+        )
+        return
+
     _orig_step = batch_gen._step
 
     # Greedy sampler for MTP draft tokens


### PR DESCRIPTION
## Problem

`_install_mtp` wraps `BatchGenerator._step`, which was refactored away in
mlx-lm 0.31.x (decode now lives on `GenerationBatch._step`). Against the
pinned `mlx-lm>=0.31.3`, running `vllm-mlx serve <mtp-capable model>
--enable-mtp` raises `AttributeError: 'BatchGenerator' object has no
attribute '_step'` at BatchGenerator creation — i.e. on the first
scheduled request.

The sibling monkey-patches (`_install_chunked_prefill`,
`_install_prompt_cache_save`) already have `hasattr` compatibility guards
and skip with a warning on 0.31.x; the MTP install is the only unguarded
one. See #736 for the full diagnosis of the patch layer vs the 0.31.x API
(chunked prefill and prompt-cache-save are currently silently inert) and
suggested porting seams.

## Change

- `_install_mtp` checks for the `_step` hook and warns + no-ops when it is
  absent, mirroring the chunked-prefill compatibility guard. Generation
  continues without multi-token prediction instead of failing the request
  loop.
- `tests/test_mtp_mlxlm_compat.py`: the guard no-ops on a 0.31-style
  BatchGenerator (no exception, nothing patched, warning logged), plus a
  tripwire test asserting the installed mlx-lm's BatchGenerator has no
  `_step` — if that ever fails, the API came back and the guard/port
  should be revisited.

This deliberately does NOT port the MTP hook to the 0.31.x API: that means
re-pointing the wrap at `GenerationBatch._step` (a per-batch object, so the
install site moves) and needs hardware verification with a real MTP model.
Scoped out to keep this a safe crash fix; follow-up directions are in #736.

## Verification

- `ruff check` and `black --check` clean on changed files.
- New regression tests pass; the guard no-ops cleanly and the tripwire
  confirms `BatchGenerator` has no `_step` on current mlx-lm.

Closes the crash path described in #736.
