### PR TITLE
fix(registry): populate /metrics engine-state gauges in registry mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
             tests/test_llm.py \
             tests/test_mllm.py \
             tests/test_server.py \
+            tests/test_metrics.py \
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \
             tests/test_scheduler_max_kv_size.py \

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -153,6 +153,70 @@ class TestMetricsEndpoint:
 
         assert response.status_code == 404
 
+    def test_metrics_endpoint_reports_dead_gauges_without_engine_or_manager(
+        self, metrics_client
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        assert server._engine is None
+        assert server._model_manager is None
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 0.0" in response.text
+        assert "vllm_mlx_scheduler_waiting_requests 0.0" in response.text
+
+    def test_metrics_endpoint_scrapes_registry_mode_engine(
+        self, metrics_client, monkeypatch
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+
+        class FakeModelManager:
+            def __init__(self, engine):
+                self._engine = engine
+
+            def get_metrics_engine(self):
+                return self._engine
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(server, "_model_manager", FakeModelManager(FakeEngine()))
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 1.0" in response.text
+        assert "vllm_mlx_scheduler_waiting_requests 2.0" in response.text
+        assert (
+            'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
+        )
+
+    def test_metrics_endpoint_registry_mode_dead_gauges_when_idle(
+        self, metrics_client, monkeypatch
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+
+        class FakeModelManager:
+            def get_metrics_engine(self):
+                return None
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(server, "_model_manager", FakeModelManager())
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 0.0" in response.text
+
     def test_metrics_endpoint_scrapes_runtime_stats(self, metrics_client, monkeypatch):
         client, server, collector = metrics_client
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -339,6 +339,65 @@ def test_preempt_policy_cancels_active_request_and_loads_waiting_model(tmp_path)
     asyncio.run(_run())
 
 
+def test_get_metrics_engine_returns_none_when_idle(tmp_path):
+    registry = _registry(tmp_path, {"alpha": 4})
+    manager = ModelManager(
+        _manager_config(budget_gb=8),
+        registry,
+        _defaults(),
+        engine_factory=lambda config: FakeEngine(config),
+    )
+
+    assert manager.get_metrics_engine() is None
+
+
+def test_get_metrics_engine_returns_sole_loaded_engine(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=8),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease = await manager.acquire("alpha")
+
+        assert manager.get_metrics_engine() is manager._loaded["alpha"].engine
+
+        await lease.release()
+
+    asyncio.run(_run())
+
+
+def test_get_metrics_engine_returns_most_recently_used_when_multiple_loaded(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4, "beta": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=9),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease_a = await manager.acquire("alpha")
+        await lease_a.release()
+        await asyncio.sleep(0.01)  # ensure last_used_at ordering is unambiguous
+        lease_b = await manager.acquire("beta")
+        await lease_b.release()
+
+        assert manager.get_metrics_engine() is manager._loaded["beta"].engine
+
+        # Touching alpha again makes it the most recently used.
+        await asyncio.sleep(0.01)
+        lease_a = await manager.acquire("alpha")
+        await lease_a.release()
+
+        assert manager.get_metrics_engine() is manager._loaded["alpha"].engine
+
+    asyncio.run(_run())
+
+
 def test_non_local_registry_entry_requires_explicit_memory_estimate():
     async def _run():
         registry = {

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -736,6 +736,21 @@ class ModelManager:
             )
         return data
 
+    def get_metrics_engine(self) -> BaseEngine | None:
+        """Return the engine to source Prometheus gauges from, or None if idle.
+
+        The gauges this feeds (``/metrics``) are unlabeled scalars with no
+        ``model=`` dimension, so they can only ever describe one engine at a
+        time. With a single resident model that engine is the obvious and
+        exact choice. With more than one resident, there is no way to report
+        all of them without a schema change, so this reports the most
+        recently used one as a representative sample rather than reporting
+        nothing.
+        """
+        if not self._loaded:
+            return None
+        return max(self._loaded.values(), key=lambda loaded: loaded.last_used_at).engine
+
     async def preload(self) -> None:
         """Preload any entries marked preload=true."""
         for entry in self._registry.values():

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3666,8 +3666,11 @@ async def metrics():
     if not _metrics.enabled:
         raise HTTPException(status_code=404, detail="Metrics endpoint is disabled")
 
+    engine = (
+        _model_manager.get_metrics_engine() if _model_manager is not None else _engine
+    )
     payload, content_type = _metrics.render_metrics(
-        engine=_engine,
+        engine=engine,
         mcp_manager=_mcp_manager,
     )
     return Response(content=payload, headers={"Content-Type": content_type})


### PR DESCRIPTION
Refs #738

## Scope

This PR makes the following registry-mode (`--models-config`) `/metrics` gauges
live by resolving a real resident engine instead of the always-`None`
module-level `_engine`:

- `vllm_mlx_model_loaded`
- `vllm_mlx_scheduler_waiting_requests`, `vllm_mlx_scheduler_running_requests`
- `vllm_mlx_metal_memory_bytes{kind="active"|"peak"|"cache"}`
- the `vllm_mlx_cache_*` family (`cache_hits`, `cache_misses`, `cache_hit_rate`,
  `cache_evictions`, `cache_memory_bytes`, `cache_tokens_saved`, and the
  remaining `cache_*` gauges sourced from the same `get_stats()` dict)

**Not covered by this PR**: `vllm_mlx_engine_steps_executed` stays `0.0` for
MLLM-routed models. This is a separate, pre-existing gap in
`mllm_scheduler.get_stats()`/`BatchedEngine.get_stats()`'s MLLM branch, orthogonal
to registry mode (reproduces on the non-registry path too) — tracked separately
in #746 rather than folded into this PR, per review feedback. #738 stays open
until that residual is resolved or otherwise disposed of.

## Summary

`GET /metrics` renders every engine-state gauge (`vllm_mlx_model_loaded`,
`vllm_mlx_engine_steps_executed`, `vllm_mlx_scheduler_waiting_requests`,
`vllm_mlx_scheduler_running_requests`, `vllm_mlx_metal_memory_bytes`, all nine
`vllm_mlx_cache_*` gauges) from the module-level `_engine` global
(`server.py:3593`, `render_metrics(engine=_engine, ...)`). Servers started with
`--models-config` set `_engine = None` permanently in `load_model_registry()` and
route all serving through `_model_manager` instead, so every one of these gauges
reads `0`/`false` forever in registry mode, regardless of load — verified live:
`vllm_mlx_model_loaded` stayed `0.0` with `mlx-community/Qwen3.8-27B-8bit`
resident and actively serving requests. The counter-family metrics
(`inference_requests_total`, etc.) are driven by a separate mechanism
(`InferenceTracker`, wired directly into request handlers) and already work
correctly in this mode. `/v1/status` already solved this exact split with an `if
_model_manager is not None:` branch; `/metrics` never got the equivalent branch.

## Changes

- `vllm_mlx/model_registry.py`: add `ModelManager.get_metrics_engine() ->
  BaseEngine | None`, a read-only accessor over `self._loaded`. With one resident
  model it returns that model's engine. With zero, `None` (old behavior,
  unchanged). With more than one resident — these gauges are unlabeled scalars
  with no `model=` dimension, so they can't represent every resident model
  without a schema change — it returns the most recently used engine as a
  representative sample rather than reporting nothing. No locking beyond what
  `list_models()` already does without holding `self._condition`.
- `vllm_mlx/server.py`: the `/metrics` handler now resolves the engine from
  `_model_manager.get_metrics_engine()` when a model manager is present, falling
  back to the bare `_engine` otherwise — mirrors `/v1/status`'s existing branch
  shape:
  ```python
  engine = _model_manager.get_metrics_engine() if _model_manager is not None else _engine
  payload, content_type = _metrics.render_metrics(
      engine=engine,
      mcp_manager=_mcp_manager,
  )
  ```
- `vllm_mlx/metrics.py`: unchanged. `_update_engine_gauges`/`render_metrics`
  already duck-type `.get_stats()`, so passing a `LoadedModel.engine` instead of
  the module-level `_engine` is sufficient.

**Multi-model residency note:** this PR makes a deliberate, minimal choice for
registries with more than one resident model — report the most-recently-used
engine's stats rather than nothing. That's a reasonable default for an
unlabeled-scalar metric surface and matches what an operator watching the
dashboard during active traffic would expect, but the gauges can appear to
"jump" between models as residency changes. Per-model breakdown would need a
`model=` label threaded through every gauge's registration and through
`_update_engine_gauges`'s update loop — a larger, separate change, happy to take
on if maintainers want it, but out of scope here: this PR's job is fixing
"always dead," not "not per-model."

**Not fixed by this PR, disclosed rather than left for review to find:**
`vllm_mlx_engine_steps_executed` stays `0.0` for MLLM models even after this
patch. Separate root cause: `BatchedEngine.get_stats()`'s MLLM branch
(`engine/batched.py:1223-1242` at current `main`) promotes a fixed allowlist of
keys from `mllm_scheduler.get_stats()`, and `"steps_executed"` isn't in that
allowlist — `mllm_scheduler.get_stats()` (`mllm_scheduler.py:1236-1246`) never
produces the key at all. Reproduces identically on the non-registry path with an
MLLM model loaded directly, so it's orthogonal to the registry-mode bug this PR
fixes. Tracked separately as #746 (see Scope above).

## Type of change

- Bug fix

## Surface touched

- Model registry / multi-model manager
- Observability (Prometheus `/metrics`)

## Test plan

```
pytest tests/test_metrics.py tests/test_model_registry.py -v
pytest tests/ -q
```

6 new tests: 3 in `test_model_registry.py` for `get_metrics_engine()` (returns
`None` when idle, returns the sole loaded engine, returns the most-recently-used
engine when multiple models are resident — with a follow-up `acquire()`
re-promoting an older one to verify the ordering isn't just insertion order), 3
in `test_metrics.py` for the `/metrics` handler (registry mode with a resident
engine scrapes real gauge values; registry mode with no resident model reports
the same zero/false defaults as the pre-existing no-manager-no-engine case; an
explicit assertion pinning that no-manager/no-engine baseline so a future change
can't silently alter it).

## Test results

```
$ pytest tests/test_metrics.py tests/test_model_registry.py -q
54 passed in 5.70s
```

```
$ pytest tests/ -q
2959 passed, 25 skipped, 27 deselected
```
(`origin/main` baseline @ `22efb47`: 2953 passed; +6 new, 0 regressed.)

## Live end-to-end verification

- Hardware: Apple M3 Ultra, 128GB unified memory
- Model: `mlx-community/Qwen3.8-27B-8bit` (MLLM-routed), single-entry registry,
  `--continuous-batching --enable-prefix-cache --enable-metrics`

Before (registry mode, model resident and warm, 4 requests served):
```
vllm_mlx_model_loaded 0.0
vllm_mlx_scheduler_waiting_requests 0.0
vllm_mlx_metal_memory_bytes{kind="active"} 0.0
vllm_mlx_cache_hits 0.0
vllm_mlx_cache_misses 0.0
vllm_mlx_cache_tokens_saved 0.0
```

After (same server/config, this patch applied), following a request and a
cache-eligible repeat of the same >128-token prompt (`min_prefix_tokens`, this
engine's own floor for cache eligibility):
```
vllm_mlx_model_loaded 1.0
vllm_mlx_scheduler_waiting_requests 0.0
vllm_mlx_metal_memory_bytes{kind="active"} 3.398e+10
vllm_mlx_cache_hits 1.0
vllm_mlx_cache_misses 4.0
vllm_mlx_cache_hit_rate 0.2
vllm_mlx_cache_tokens_saved 190.0
```

Also verified downstream of this same `/metrics` scrape, unmodified by this PR
but previously fed permanently-zero data: a status-bar widget's HUD line went
from a fixed `q 0/0 · cache 0% · evict 0 · 0.0G` (always, regardless of load) to
real, moving values (`q 0/0 · cache 20% · evict 0 · 31.6G`); an OpenTelemetry
tracing proxy that stamps `engine.*` span attributes from a `/metrics` scrape
taken at request time went from always-`0.0` to real values (e.g.
`engine.metal_memory_bytes: 33979999999.999996`, `engine.cache_misses: 4.0`).

## Risk notes

Scoped to one new read-only accessor and one call-site branch. No behavior
change for the non-registry serving path (`_model_manager is None`, `/metrics`
falls back to `_engine` exactly as before). No behavior change to `metrics.py`
or to request handling — this only changes which engine object `/metrics`
reads from.

