### PR TITLE
Fix streaming token loss at --stream-interval>1, DSA CacheList SSD spill, bf16 upcast on mlx 0.31.x, and forced-<think> reasoning

### DIFF
--- a/tests/test_memory_cache_stream_safety.py
+++ b/tests/test_memory_cache_stream_safety.py
@@ -64,8 +64,7 @@ class TestStoreMaterializesOnProducerThread:
 
     def test_cache_list_survives_numpy_on_another_thread(self):
         """GLM-5.2 DSA shape: CacheList layers, no KVCache trim path at all."""
-        result = _run_subprocess(
-            """
+        result = _run_subprocess("""
             from mlx_lm.models.cache import CacheList
 
             cache_obj = MemoryAwarePrefixCache(
@@ -88,8 +87,7 @@ class TestStoreMaterializesOnProducerThread:
                     assert np.array(inner.keys).sum() > 0
                     assert np.array(inner.values).sum() > 0
             print("SURVIVED")
-            """
-        )
+            """)
         assert result.returncode == 0, (
             f"exit={result.returncode} (134 == SIGABRT)\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"
@@ -98,8 +96,7 @@ class TestStoreMaterializesOnProducerThread:
 
     def test_quantized_cache_survives_numpy_on_another_thread(self):
         """`_quantize_cache` builds fresh lazy arrays AFTER the trim step."""
-        result = _run_subprocess(
-            """
+        result = _run_subprocess("""
             cache_obj = MemoryAwarePrefixCache(
                 model=object(),
                 config=MemoryCacheConfig(
@@ -123,8 +120,7 @@ class TestStoreMaterializesOnProducerThread:
                 for part in (*layer.keys, *layer.values):
                     np.array(part)
             print("SURVIVED")
-            """
-        )
+            """)
         assert result.returncode == 0, (
             f"exit={result.returncode} (134 == SIGABRT)\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"

--- a/tests/test_memory_cache_stream_safety.py
+++ b/tests/test_memory_cache_stream_safety.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX thread-locality regression tests for ``MemoryAwarePrefixCache.store``.
+
+MLX streams are owned by the thread that created them, and every thread gets
+its *own* default GPU stream.  A **lazy** array built on thread A aborts the
+process when it is evaluated on thread B::
+
+    libc++abi: terminating due to uncaught exception of type std::runtime_error:
+    There is no Stream(gpu, 1) in current thread.
+
+Through ``mx.eval`` that surfaces as a catchable ``RuntimeError``; through
+numpy's buffer protocol (``np.array(arr)``, which the SSD spill path uses) the
+C++ exception unwinds with no handler and hits ``std::terminate`` -> SIGABRT.
+
+``_evict_lru`` structurally spills the *least-recently-used* entry, i.e. one
+built by an earlier request on a different thread, so any cache left lazy at
+``store()`` time is a latent uncatchable abort.  These tests pin the invariant
+that ``store()`` materializes on the producing thread.
+
+Upstream satisfies this invariant in ``_detach_cache_for_storage``, which
+accumulates every leaf into one ``eval_targets`` list -- recursing into
+``CacheList`` children -- and issues a single ``mx.eval`` on the calling
+thread (``memory_cache.py``, the ``is_root`` branch).  These tests are
+black-box on purpose: they pin the *invariant*, not that mechanism.
+
+The cross-thread cases run in a subprocess because the failure mode is
+``abort()``, which would take the whole pytest run with it.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+PRELUDE = """
+import threading
+import numpy as np
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache
+from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+
+mx.eval(mx.ones((2, 2)))  # bind the main thread's gpu stream
+
+def make_kv(lazy_scale):
+    layer = KVCache()
+    # `* lazy_scale` keeps the graph UNEVALUATED, exactly like a real decode
+    layer.keys = mx.ones((1, 2, 8, 64), dtype=mx.float32) * lazy_scale
+    layer.values = mx.ones((1, 2, 8, 64), dtype=mx.float32) * lazy_scale
+    layer.offset = 8
+    return layer
+"""
+
+
+def _run_subprocess(body: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", PRELUDE + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+class TestStoreMaterializesOnProducerThread:
+    """``store()`` must leave nothing lazy for a later thread to evaluate."""
+
+    def test_cache_list_survives_numpy_on_another_thread(self):
+        """GLM-5.2 DSA shape: CacheList layers, no KVCache trim path at all."""
+        result = _run_subprocess(
+            """
+            from mlx_lm.models.cache import CacheList
+
+            cache_obj = MemoryAwarePrefixCache(
+                model=object(), config=MemoryCacheConfig(min_prefix_tokens=1)
+            )
+            tokens = list(range(16))
+
+            def producer():
+                layers = [CacheList(make_kv(3.0), make_kv(5.0)) for _ in range(2)]
+                assert cache_obj.store(tokens, layers)
+
+            t = threading.Thread(target=producer)
+            t.start()
+            t.join()
+
+            # The spill path: numpy buffer protocol, on a DIFFERENT thread.
+            entry = cache_obj._entries[tuple(tokens)]
+            for layer in entry.cache:
+                for inner in layer.caches:
+                    assert np.array(inner.keys).sum() > 0
+                    assert np.array(inner.values).sum() > 0
+            print("SURVIVED")
+            """
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode} (134 == SIGABRT)\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "SURVIVED" in result.stdout
+
+    def test_quantized_cache_survives_numpy_on_another_thread(self):
+        """`_quantize_cache` builds fresh lazy arrays AFTER the trim step."""
+        result = _run_subprocess(
+            """
+            cache_obj = MemoryAwarePrefixCache(
+                model=object(),
+                config=MemoryCacheConfig(
+                    min_prefix_tokens=1,
+                    kv_quantize=True,
+                    kv_min_quantize_tokens=1,
+                    kv_group_size=64,
+                ),
+            )
+            tokens = list(range(16))
+
+            def producer():
+                assert cache_obj.store(tokens, [make_kv(3.0), make_kv(5.0)])
+
+            t = threading.Thread(target=producer)
+            t.start()
+            t.join()
+
+            entry = cache_obj._entries[tuple(tokens)]
+            for layer in entry.cache:
+                for part in (*layer.keys, *layer.values):
+                    np.array(part)
+            print("SURVIVED")
+            """
+        )
+        assert result.returncode == 0, (
+            f"exit={result.returncode} (134 == SIGABRT)\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        assert "SURVIVED" in result.stdout

--- a/tests/test_reasoning_parser.py
+++ b/tests/test_reasoning_parser.py
@@ -1643,3 +1643,55 @@ class TestStreamingCostIsFlat:
             f"{small:.2f}ms at 250 tokens, {large:.2f}ms at 5000 — "
             "per-token cost is growing with output length"
         )
+
+
+class TestForcedThinkingStreaming:
+    """GLM-5.3's template injects an open <think>, so the model output begins
+    INSIDE the reasoning block and only ever emits the closing </think>.
+
+    The glm4 streaming parser assumed GLM-4.6-style autonomous thinking and
+    defaulted pre-</think> output to content, so the whole chain-of-thought
+    landed in ``content`` glued to the answer. Live capture on GLM-5.3:
+
+        streaming:     content='84 * 3 = 252\\n252 / 2 = 126**126**'
+                       reasoning_content=''
+        non-streaming: content='**126**'
+                       reasoning_content='84 * 3 / 2 = 252 / 2 = 126'
+    """
+
+    DELTAS = ["84 * 3 = 252\n", "252 / 2 = 126", "</think>", "**126**"]
+
+    def _run(self, parser):
+        reasoning, content = [], []
+        prev = ""
+        for d in self.DELTAS:
+            cur = prev + d
+            msg = parser.extract_reasoning_streaming(prev, cur, d)
+            if msg is not None:
+                if getattr(msg, "reasoning", None):
+                    reasoning.append(msg.reasoning)
+                if getattr(msg, "content", None):
+                    content.append(msg.content)
+            prev = cur
+        return "".join(reasoning), "".join(content)
+
+    def test_implicit_mode_routes_pre_close_text_to_reasoning(self):
+        from vllm_mlx.reasoning import get_parser
+
+        parser = get_parser("glm4")(None)
+        parser.reset_state(implicit_mode=True)
+        reasoning, content = self._run(parser)
+
+        assert reasoning == "84 * 3 = 252\n252 / 2 = 126"
+        assert content == "**126**"
+
+    def test_autonomous_mode_still_defaults_to_content(self):
+        """Without a forced <think>, GLM-4.6-style output is plain content."""
+        from vllm_mlx.reasoning import get_parser
+
+        parser = get_parser("glm4")(None)
+        parser.reset_state()
+        reasoning, content = self._run(parser)
+
+        assert reasoning == ""
+        assert content == "84 * 3 = 252\n252 / 2 = 126**126**"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2046,7 +2046,7 @@ class TestStreamChatCompletion:
             def __init__(self, tokenizer=None):
                 self.in_think = False
 
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 self.in_think = False
 
             def extract_reasoning_streaming(
@@ -2874,7 +2874,7 @@ class TestStreamChatCompletion:
                     yield chunk
 
         class FakeReasoningParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 self._in_reasoning = False
 
             def extract_reasoning_streaming(
@@ -3111,7 +3111,7 @@ class TestStreamChatCompletion:
                     yield chunk
 
         class FakeReasoningParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 pass
 
             def extract_reasoning_streaming(
@@ -3275,7 +3275,7 @@ class TestStreamChatCompletion:
                 )
 
         class FakeReasoningParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 pass
 
             def extract_reasoning_streaming(
@@ -3354,7 +3354,7 @@ class TestStreamChatCompletion:
                     yield chunk
 
         class FakeReasoningParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 pass
 
             def extract_reasoning_streaming(
@@ -3469,7 +3469,7 @@ class TestStreamChatCompletion:
                     yield chunk
 
         class FakeReasoningParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 self._in_reasoning = False
 
             def extract_reasoning_streaming(
@@ -3559,7 +3559,7 @@ class TestStreamChatCompletion:
                 )
 
         class ReasoningOnlyParser:
-            def reset_state(self):
+            def reset_state(self, implicit_mode: bool = False):
                 pass
 
             def extract_reasoning_streaming(
@@ -5271,3 +5271,66 @@ def pytest_addoption(parser):
         default="http://localhost:8000",
         help="URL of the vllm-mlx server for integration tests",
     )
+
+
+class TestDetectImplicitThinking:
+    """The probe that tells the streaming parser a <think> was injected."""
+
+    class _Engine:
+        model_name = "glm-5.3-flash"
+
+        def __init__(self, rendered):
+            self._rendered = rendered
+            self.calls = 0
+
+        def _apply_chat_template(self, messages, **kwargs):
+            self.calls += 1
+            return self._rendered
+
+    def _detect(self, engine, chat_kwargs=None):
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        return server._detect_implicit_thinking(engine, chat_kwargs)
+
+    def test_trailing_think_tag_is_implicit(self):
+        assert self._detect(self._Engine("<|user|>hi<|assistant|>\n<think>")) is True
+
+    def test_trailing_whitespace_after_tag_still_counts(self):
+        assert self._detect(self._Engine("<|assistant|>\n<think>\n  ")) is True
+
+    def test_template_without_injected_tag_is_not_implicit(self):
+        assert self._detect(self._Engine("<|user|>hi<|assistant|>\n")) is False
+
+    def test_think_elsewhere_in_prompt_does_not_count(self):
+        """Only a TRAILING <think> means generation starts inside the block."""
+        engine = self._Engine("<|user|>what is <think> for?<|assistant|>\n")
+        assert self._detect(engine) is False
+
+    def test_result_is_cached_per_model(self):
+        import vllm_mlx.server as server
+
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._implicit_thinking_cache.clear()
+        assert server._detect_implicit_thinking(engine, None) is True
+        assert server._detect_implicit_thinking(engine, None) is True
+        assert engine.calls == 1, "template should be rendered once, not per request"
+
+    def test_render_failure_is_not_cached_and_defaults_false(self):
+        import vllm_mlx.server as server
+
+        class Boom:
+            model_name = "boom"
+
+            def _apply_chat_template(self, messages, **kwargs):
+                raise RuntimeError("no template")
+
+        server._implicit_thinking_cache.clear()
+        assert server._detect_implicit_thinking(Boom(), None) is False
+        assert server._implicit_thinking_cache == {}
+
+    def test_engine_without_template_hook_defaults_false(self):
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        assert server._detect_implicit_thinking(object(), None) is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5276,13 +5276,28 @@ def pytest_addoption(parser):
 class TestDetectImplicitThinking:
     """The probe that tells the streaming parser a <think> was injected."""
 
+    class _Tokenizer:
+        """Stands in for the HF tokenizer the probe reads its template from.
+
+        Real engines always expose one (verified on GLM-5.3: a 10.6KB
+        ``chat_template`` string on both tokenizer and processor), so the
+        default harness must too -- otherwise every test here would silently
+        exercise the uncacheable path. See ``_NoTemplateEngine`` for that case.
+        """
+
+        def __init__(self, chat_template="{{ messages }}<|assistant|><think>"):
+            self.chat_template = chat_template
+
     class _Engine:
         model_name = "glm-5.3-flash"
 
-        def __init__(self, rendered):
+        def __init__(self, rendered, chat_template=None):
             self._rendered = rendered
             self.calls = 0
             self.seen_kwargs = []
+            self.tokenizer = TestDetectImplicitThinking._Tokenizer(
+                *([chat_template] if chat_template is not None else [])
+            )
 
         def _apply_chat_template(self, messages, **kwargs):
             self.calls += 1
@@ -5531,4 +5546,91 @@ class TestDetectImplicitThinking:
         server._implicit_thinking_cache.clear()
         engine = self._Engine("<|assistant|>\n<think>")
         assert server._detect_implicit_thinking(engine, {"tools": ["nonsense", None]})
+        server._implicit_thinking_cache.clear()
+
+    # --- template identity --------------------------------------------------
+    #
+    # model_name is only a proxy for the template. Two engines can share a
+    # name and render differently (a local override, a re-pull, a swapped
+    # tokenizer), and the cached verdict would follow the name, not the
+    # template that actually produced it.
+
+    class _NoTemplateEngine:
+        """An engine whose template can't be identified (no tokenizer)."""
+
+        model_name = "opaque"
+
+        def __init__(self, rendered):
+            self._rendered = rendered
+            self.calls = 0
+
+        def _apply_chat_template(self, messages, **kwargs):
+            self.calls += 1
+            return self._rendered
+
+    def test_changed_template_cannot_reuse_the_previous_verdict(self):
+        """The reviewer's regression: same engine, template swapped underneath."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>", chat_template="TEMPLATE A")
+        assert server._detect_implicit_thinking(engine, None) is True
+
+        # Swap in a template that does NOT open <think>.
+        engine.tokenizer.chat_template = "TEMPLATE B"
+        engine._rendered = "<|assistant|>\n"
+        assert server._detect_implicit_thinking(engine, None) is False
+        assert engine.calls == 2, "changed template must force a re-probe"
+        server._implicit_thinking_cache.clear()
+
+    def test_same_model_name_different_templates_do_not_collide(self):
+        """Two engines, one model_name, different templates -> two verdicts."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        implicit = self._Engine("<|assistant|>\n<think>", chat_template="A")
+        explicit = self._Engine("<|assistant|>\n", chat_template="B")
+        assert implicit.model_name == explicit.model_name
+        assert server._detect_implicit_thinking(implicit, None) is True
+        assert server._detect_implicit_thinking(explicit, None) is False
+        assert explicit.calls == 1, "second engine must probe, not reuse"
+        server._implicit_thinking_cache.clear()
+
+    def test_identical_template_still_shares_one_entry(self):
+        """The signature must not defeat caching for the common case."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        first = self._Engine("<|assistant|>\n<think>", chat_template="SAME")
+        second = self._Engine("<|assistant|>\n<think>", chat_template="SAME")
+        assert server._detect_implicit_thinking(first, None) is True
+        assert server._detect_implicit_thinking(second, None) is True
+        assert second.calls == 0, "identical template should hit the cache"
+        server._implicit_thinking_cache.clear()
+
+    def test_processor_template_is_part_of_the_identity(self):
+        """MLLM engines render via the processor, so its template counts too."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>", chat_template="SHARED")
+        engine._processor = self._Tokenizer("PROCESSOR A")
+        assert server._detect_implicit_thinking(engine, None) is True
+
+        engine._processor.chat_template = "PROCESSOR B"
+        engine._rendered = "<|assistant|>\n"
+        assert server._detect_implicit_thinking(engine, None) is False
+        assert engine.calls == 2
+        server._implicit_thinking_cache.clear()
+
+    def test_unidentifiable_template_is_probed_every_time(self):
+        """No signature means no way to invalidate -- so cache nothing."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._NoTemplateEngine("<|assistant|>\n<think>")
+        assert server._detect_implicit_thinking(engine, None) is True
+        assert server._detect_implicit_thinking(engine, None) is True
+        assert engine.calls == 2, "unidentifiable template must not be cached"
+        assert server._implicit_thinking_cache == {}
         server._implicit_thinking_cache.clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5415,3 +5415,120 @@ class TestDetectImplicitThinking:
         engine = self._Engine("<|assistant|>\n<think>")
         assert server._detect_implicit_thinking(engine, {"enable_thinking": False})
         server._implicit_thinking_cache.clear()
+
+    # --- tools ------------------------------------------------------------
+    #
+    # The probe used to render without `tools` while the real prompt render
+    # gets them from chat_kwargs["tools"], and the cache key ignored them --
+    # so a template whose <think> injection is tool-conditional could cache
+    # the no-tool verdict and serve it to a tool request.
+
+    _TOOL_A = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+    _TOOL_B = {
+        "type": "function",
+        "function": {"name": "send_email", "parameters": {"type": "object"}},
+    }
+
+    def test_probe_forwards_tools_to_the_template(self):
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(engine, {"tools": [self._TOOL_A]})
+        assert engine.seen_kwargs[-1].get("tools") == [self._TOOL_A]
+        server._implicit_thinking_cache.clear()
+
+    def test_no_tools_leaves_the_kwarg_out(self):
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(engine, {})
+        assert "tools" not in engine.seen_kwargs[-1]
+        server._implicit_thinking_cache.clear()
+
+    def test_tool_conditional_template_is_not_served_the_no_tool_verdict(self):
+        """The reviewer's scenario: <think> only opens when tools are absent."""
+        import vllm_mlx.server as server
+
+        def render(kwargs):
+            if kwargs.get("tools"):
+                return "<|assistant|>\n"
+            return "<|assistant|>\n<think>"
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine(render)
+        assert server._detect_implicit_thinking(engine, None) is True
+        assert server._detect_implicit_thinking(engine, {"tools": [self._TOOL_A]}) is (
+            False
+        )
+        assert engine.calls == 2, "tools must not share the no-tool cache entry"
+        server._implicit_thinking_cache.clear()
+
+    def test_verdict_is_cached_per_tool_set(self):
+        """Same tool names reuse the entry; a different set re-probes."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(engine, {"tools": [self._TOOL_A]})
+        server._detect_implicit_thinking(engine, {"tools": [self._TOOL_A]})
+        assert engine.calls == 1, "identical tool sets must hit the cache"
+        server._detect_implicit_thinking(engine, {"tools": [self._TOOL_B]})
+        assert engine.calls == 2, "a different tool set must re-probe"
+        server._implicit_thinking_cache.clear()
+
+    def test_tool_order_does_not_split_the_cache_entry(self):
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(
+            engine, {"tools": [self._TOOL_A, self._TOOL_B]}
+        )
+        server._detect_implicit_thinking(
+            engine, {"tools": [self._TOOL_B, self._TOOL_A]}
+        )
+        assert engine.calls == 1
+        server._implicit_thinking_cache.clear()
+
+    def test_forced_tool_choice_context_stays_implicit_on_glm53(self):
+        """Forced tool choice: tools filtered to one AND enable_thinking=False.
+
+        GLM-5.3 opens <think> regardless, so the verdict must stay True --
+        this is the exact combination _apply_forced_tool_choice produces.
+        """
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        forced = {"tools": [self._TOOL_A], "enable_thinking": False}
+        assert server._detect_implicit_thinking(engine, forced) is True
+        assert engine.seen_kwargs[-1].get("tools") == [self._TOOL_A]
+        assert engine.seen_kwargs[-1].get("enable_thinking") is False
+        server._implicit_thinking_cache.clear()
+
+    def test_cache_bound_holds_as_tool_sets_vary(self, monkeypatch):
+        """tools are request-controlled too, so they must not evade the bound."""
+        import vllm_mlx.server as server
+
+        monkeypatch.setattr(server, "_IMPLICIT_THINKING_CACHE_MAX_SIZE", 8)
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        for n in range(50):
+            tool = {"type": "function", "function": {"name": f"tool_{n}"}}
+            assert server._detect_implicit_thinking(engine, {"tools": [tool]}) is True
+        assert len(server._implicit_thinking_cache) == 8
+        server._implicit_thinking_cache.clear()
+
+    def test_malformed_tool_entries_do_not_break_the_probe(self):
+        """tools come from a client-shaped list; a stray non-dict must not 500."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        assert server._detect_implicit_thinking(engine, {"tools": ["nonsense", None]})
+        server._implicit_thinking_cache.clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5334,3 +5334,22 @@ class TestDetectImplicitThinking:
 
         server._implicit_thinking_cache.clear()
         assert server._detect_implicit_thinking(object(), None) is False
+
+    def test_cache_is_bounded_against_client_supplied_template_kwargs(
+        self, monkeypatch
+    ):
+        """chat_template_kwargs is request-controlled, so the key space is too."""
+        import vllm_mlx.server as server
+
+        monkeypatch.setattr(server, "_IMPLICIT_THINKING_CACHE_MAX_SIZE", 8)
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        for n in range(50):
+            assert (
+                server._detect_implicit_thinking(
+                    engine, {"chat_template_kwargs": {"junk": n}}
+                )
+                is True
+            )
+        assert len(server._implicit_thinking_cache) == 8
+        server._implicit_thinking_cache.clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5282,9 +5282,13 @@ class TestDetectImplicitThinking:
         def __init__(self, rendered):
             self._rendered = rendered
             self.calls = 0
+            self.seen_kwargs = []
 
         def _apply_chat_template(self, messages, **kwargs):
             self.calls += 1
+            self.seen_kwargs.append(kwargs)
+            if callable(self._rendered):
+                return self._rendered(kwargs)
             return self._rendered
 
     def _detect(self, engine, chat_kwargs=None):
@@ -5352,4 +5356,62 @@ class TestDetectImplicitThinking:
                 is True
             )
         assert len(server._implicit_thinking_cache) == 8
+        server._implicit_thinking_cache.clear()
+
+    def test_probe_renders_with_the_resolved_enable_thinking(self):
+        """The probe must see the same flag the real prompt render will get."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(engine, {"enable_thinking": False})
+        assert engine.seen_kwargs[-1].get("enable_thinking") is False
+        server._implicit_thinking_cache.clear()
+
+    def test_enable_thinking_omitted_when_request_does_not_set_it(self):
+        """Absent means 'let the engine default decide', not False."""
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        server._detect_implicit_thinking(engine, {})
+        assert "enable_thinking" not in engine.seen_kwargs[-1]
+        server._implicit_thinking_cache.clear()
+
+    def test_enable_thinking_is_part_of_the_cache_key(self):
+        """A template that honours the flag must not reuse the other verdict.
+
+        _apply_forced_tool_choice sets chat_kwargs["enable_thinking"] = False
+        without touching chat_template_kwargs, so keying on the latter alone
+        would serve a forced-tool request the thinking-enabled verdict.
+        """
+        import vllm_mlx.server as server
+
+        def render(kwargs):
+            if kwargs.get("enable_thinking") is False:
+                return "<|assistant|>\n"
+            return "<|assistant|>\n<think>"
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine(render)
+        assert server._detect_implicit_thinking(engine, None) is True
+        forced = {"enable_thinking": False}
+        assert server._detect_implicit_thinking(engine, forced) is False
+        assert engine.calls == 2, "the two flags must not share a cache entry"
+        assert server._detect_implicit_thinking(engine, forced) is False
+        assert engine.calls == 2, "each flag is still cached"
+        server._implicit_thinking_cache.clear()
+
+    def test_template_ignoring_the_flag_stays_implicit(self):
+        """GLM-5.3 opens <think> unconditionally, so forced tools stay implicit.
+
+        Its chat template has no enable_thinking variable at all, so disabling
+        thinking must NOT flip the verdict -- the prompt still starts inside
+        the reasoning block and the parser still has to route accordingly.
+        """
+        import vllm_mlx.server as server
+
+        server._implicit_thinking_cache.clear()
+        engine = self._Engine("<|assistant|>\n<think>")
+        assert server._detect_implicit_thinking(engine, {"enable_thinking": False})
         server._implicit_thinking_cache.clear()

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -1246,3 +1246,140 @@ class TestIntegrationSpillAndFetch:
             assert stats["ssd_hits"] >= 1
             assert stats["reload_bytes"] > 0
             assert stats["avg_reload_latency_ms"] > 0
+
+
+class TestCacheListSpillRoundTrip:
+    """SSD spill must round-trip GLM-5.2 / DeepSeek-V3.2 DSA caches.
+
+    A DSA layer is ``CacheList(KVCache latent, KVCache indexer)`` (full layers)
+    or ``CacheList(KVCache latent)`` (shared layers). The indexer sub-cache is
+    empty below the sparse ``index_topk`` threshold. ``CacheList`` exposes a
+    list ``.state``, so the duck-typed dispatcher used to mis-route it to
+    ``ArraysCacheSerializer``; iterating ``.state`` then yields per-sub
+    ``(keys, values)`` tuples and ``_mx_to_numpy_safe`` choked
+    (``'tuple' object has no attribute 'dtype'``), dropping every entry. A
+    dedicated ``CacheListSerializer`` round-trips them.
+    """
+
+    def _make_dsa_cache(self):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache, CacheList
+
+        # Full layer: populated bf16 latent + empty (dense-mode) indexer.
+        lat = KVCache()
+        lat.update_and_fetch(
+            mx.random.normal((1, 4, 6, 16)).astype(mx.bfloat16),
+            mx.random.normal((1, 4, 6, 16)).astype(mx.bfloat16),
+        )
+        idx = KVCache()
+        idx.keys = mx.zeros((1, 4, 0, 16), dtype=mx.float32)
+        idx.values = mx.zeros((1, 4, 0, 16), dtype=mx.float32)
+        idx.offset = 0
+        full = CacheList(lat, idx)
+
+        # Shared layer: single latent sub-cache.
+        lat2 = KVCache()
+        lat2.update_and_fetch(
+            mx.random.normal((1, 4, 6, 16)).astype(mx.bfloat16),
+            mx.random.normal((1, 4, 6, 16)).astype(mx.bfloat16),
+        )
+        shared = CacheList(lat2)
+        return [full, shared], lat, lat2
+
+    def test_dispatch_picks_cachelist_serializer(self):
+        from vllm_mlx.ssd_cache import (
+            get_serializer_for_layer,
+            CacheListSerializer,
+            ArraysCacheSerializer,
+        )
+
+        cache, _, _ = self._make_dsa_cache()
+        s = get_serializer_for_layer(cache[0])
+        assert isinstance(s, CacheListSerializer)
+        assert not isinstance(s, ArraysCacheSerializer)
+
+    def test_cachelist_in_support_matrix(self):
+        from vllm_mlx.ssd_cache import SERIALIZER_SUPPORT_MATRIX
+
+        assert "CacheList" in SERIALIZER_SUPPORT_MATRIX
+
+    def test_snapshot_serialize_deserialize_round_trip(self, tmp_path):
+        from vllm_mlx.ssd_cache import get_serializer_for_layer
+
+        cache, lat, lat2 = self._make_dsa_cache()
+        ser = get_serializer_for_layer(cache[0])
+        path = str(tmp_path / "layer_0.safetensors")
+
+        snap = ser.snapshot_layer(cache[0])
+        meta = ser.serialize_layer(snap, 0, path)
+        assert meta["layer_type"] == "CacheList"
+        assert meta["sub_count"] == 2
+        assert os.path.exists(path)
+
+        ld = ser.deserialize_layer(path, meta)
+        assert "cachelist_subs" in ld
+        subs = ld["cachelist_subs"]
+        assert len(subs) == 2
+        # Latent: offset + data preserved.
+        assert subs[0]["offset"] == 6
+        # Empty indexer preserved.
+        assert subs[1]["offset"] == 0
+        assert np.array(subs[1]["keys"]).size == 0
+
+    def test_full_roundtrip_reconstructs_cachelist(self, tmp_path):
+        import types
+        import mlx.core as mx
+        from vllm_mlx.ssd_cache import get_serializer_for_layer
+        from vllm_mlx.scheduler import Scheduler
+
+        cache, lat, lat2 = self._make_dsa_cache()
+
+        # snapshot -> serialize -> deserialize each layer (what _read_entry does)
+        dicts = []
+        for i, layer in enumerate(cache):
+            ser = get_serializer_for_layer(layer)
+            path = str(tmp_path / f"layer_{i}.safetensors")
+            snap = ser.snapshot_layer(layer)
+            meta = ser.serialize_layer(snap, i, path)
+            dicts.append(ser.deserialize_layer(path, meta))
+
+        # reconstruct (scheduler) — method only touches module globals, so a
+        # dummy self is sufficient.
+        result = Scheduler._reconstruct_ssd_layers(types.SimpleNamespace(), dicts)
+        assert result is not None
+        assert [type(c).__name__ for c in result] == ["CacheList", "CacheList"]
+        assert [len(c.caches) for c in result] == [2, 1]
+
+        # Latent: dtype, offset, and data round-trip (bf16 -> fp32 -> bf16).
+        r_lat = result[0].caches[0]
+        assert str(r_lat.keys.dtype).endswith("bfloat16")
+        assert r_lat.offset == 6
+        assert bool(
+            mx.allclose(
+                r_lat.keys[..., :6, :].astype(mx.float32),
+                lat.keys[..., :6, :].astype(mx.float32),
+            )
+        )
+        # Empty indexer preserved.
+        assert result[0].caches[1].offset == 0
+        assert result[0].caches[1].keys.size == 0
+        # Shared-layer latent round-trips too.
+        assert result[1].caches[0].offset == 6
+        assert bool(
+            mx.allclose(
+                result[1].caches[0].keys[..., :6, :].astype(mx.float32),
+                lat2.keys[..., :6, :].astype(mx.float32),
+            )
+        )
+
+    def test_plain_kvcache_still_dispatches_to_kvcache(self):
+        """Regression: non-DSA plain KVCache must NOT hit the CacheList path."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+        from vllm_mlx.ssd_cache import get_serializer_for_layer, KVCacheSerializer
+
+        layer = KVCache()
+        layer.update_and_fetch(
+            mx.random.normal((1, 4, 5, 16)), mx.random.normal((1, 4, 5, 16))
+        )
+        assert isinstance(get_serializer_for_layer(layer), KVCacheSerializer)

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -164,9 +164,10 @@ class TestSSDIndex:
 
         os.makedirs(db_dir, exist_ok=True)
         conn = sqlite3.connect(os.path.join(db_dir, "index.db"))
-        conn.executescript("""
+        conn.executescript(f"""
             CREATE TABLE schema_version (version INTEGER NOT NULL);
-            INSERT INTO schema_version (version) VALUES (1);
+            INSERT INTO schema_version (version)
+                VALUES ({SSDIndex._SCHEMA_VERSION});
             CREATE TABLE entries (
                 token_hash   TEXT PRIMARY KEY,
                 tokens_blob  BLOB NOT NULL,
@@ -1402,3 +1403,115 @@ class TestCacheListSpillRoundTrip:
             mx.random.normal((1, 4, 5, 16)), mx.random.normal((1, 4, 5, 16))
         )
         assert isinstance(get_serializer_for_layer(layer), KVCacheSerializer)
+
+
+class TestSchemaVersionInvalidation:
+    """A schema bump must drop entries written by an incompatible build.
+
+    Motivating case: before CacheList got a dedicated serializer, a GLM-5.2/5.3
+    DSA layer was mis-dispatched to ArraysCacheSerializer. With bf16 that raised
+    and the entry was dropped, but with fp16 ``np.array((keys, values))`` stacks
+    cleanly, so the spill was *written* -- tagged ``layer_type: "ArraysCache"``
+    and missing the per-sub offsets. ``_entry_hash`` is the token hash alone and
+    the cache dir is not build-namespaced, so such an entry still matches after
+    the upgrade and reconstructs into an ArraysCache the DSA model cannot use.
+    """
+
+    @staticmethod
+    def _seed(cache_dir, version):
+        import sqlite3
+        import time
+
+        from vllm_mlx import ssd_cache as ssd_cache_module
+
+        data_dir = os.path.join(cache_dir, "data")
+        os.makedirs(data_dir, exist_ok=True)
+        tokens = (1, 2, 3)
+        entry_dir = os.path.join(data_dir, ssd_cache_module._tokens_hash(tokens))
+        os.makedirs(entry_dir, exist_ok=True)
+        with open(os.path.join(entry_dir, "manifest.json"), "w") as fh:
+            fh.write('{"layers": [{"layer_type": "ArraysCache"}]}')
+
+        conn = sqlite3.connect(os.path.join(cache_dir, "index.db"))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            CREATE TABLE entries (
+                token_hash   TEXT PRIMARY KEY,
+                tokens_blob  BLOB NOT NULL,
+                prefix_hash  TEXT,
+                num_tokens   INTEGER NOT NULL,
+                file_path    TEXT NOT NULL,
+                memory_bytes INTEGER NOT NULL,
+                created_at   REAL NOT NULL,
+                accessed_at  REAL NOT NULL
+            );
+            """)
+        conn.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
+        now = time.time()
+        conn.execute(
+            "INSERT INTO entries VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                ssd_cache_module._tokens_hash(tokens),
+                ssd_cache_module._tokens_to_blob(tokens),
+                ssd_cache_module._prefix_hash(tokens),
+                len(tokens),
+                ssd_cache_module._tokens_hash(tokens),
+                1000,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return tokens, entry_dir
+
+    def test_older_schema_version_drops_every_entry(self, tmp_path):
+        cache_dir = str(tmp_path / "cache")
+        tokens, _ = self._seed(cache_dir, SSDIndex._SCHEMA_VERSION - 1)
+
+        idx = SSDIndex(cache_dir)
+        try:
+            assert idx.migrated_from == SSDIndex._SCHEMA_VERSION - 1
+            assert idx.get_entry_count() == 0
+            assert idx.lookup_exact(tokens) is None
+            with idx._db_lock:
+                cur = idx._conn.execute("SELECT version FROM schema_version")
+                assert cur.fetchone()[0] == SSDIndex._SCHEMA_VERSION
+        finally:
+            idx.close()
+
+    def test_current_schema_version_keeps_entries(self, tmp_path):
+        cache_dir = str(tmp_path / "cache")
+        tokens, _ = self._seed(cache_dir, SSDIndex._SCHEMA_VERSION)
+
+        idx = SSDIndex(cache_dir)
+        try:
+            assert idx.migrated_from is None
+            assert idx.lookup_exact(tokens) is not None
+        finally:
+            idx.close()
+
+    def test_tier_removes_stale_data_dirs_on_migration(self, tmp_path):
+        from vllm_mlx.ssd_cache import SSDCacheTier
+
+        cache_dir = str(tmp_path / "cache")
+        _, entry_dir = self._seed(cache_dir, SSDIndex._SCHEMA_VERSION - 1)
+        assert os.path.isdir(entry_dir)
+
+        tier = SSDCacheTier(SSDCacheConfig(cache_dir=cache_dir))
+        try:
+            assert not os.path.exists(entry_dir), (
+                "stale spill files must not survive a schema bump"
+            )
+            assert os.path.isdir(os.path.join(cache_dir, "data"))
+        finally:
+            tier.close()
+
+    def test_fresh_cache_dir_is_not_treated_as_a_migration(self, tmp_path):
+        cache_dir = str(tmp_path / "cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        idx = SSDIndex(cache_dir)
+        try:
+            assert idx.migrated_from is None
+        finally:
+            idx.close()

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -393,6 +393,25 @@ class TestLayerSerializer:
             == "supported_via_dequant_on_spill"
         )
 
+    def test_mx_to_numpy_safe_upcasts_a_real_bfloat16_array(self):
+        """Real bf16 mx.array, not a simulated exception.
+
+        The other bf16 tests raise the buffer-protocol error by hand, so they
+        pass regardless of which exception class mlx actually uses. That hid a
+        live bug: the handler caught only RuntimeError while mlx 0.31.x raises
+        ValueError ("'bfloat16' is not a valid PEP 3118 buffer format string"),
+        so every bf16 KV spill failed on current mlx. Drive the real array.
+        """
+        mx = pytest.importorskip("mlx.core")
+        from vllm_mlx.ssd_cache import _mx_to_numpy_safe
+
+        arr = mx.zeros((2, 3), dtype=mx.bfloat16)
+        np_arr, original_dtype = _mx_to_numpy_safe(arr)
+
+        assert original_dtype == "bfloat16"
+        assert np_arr.dtype == np.float32
+        assert np_arr.shape == (2, 3)
+
     def test_snapshot_layer_honors_original_dtype_sentinel(self):
         """When enqueue_spill's dequant path stashed a pre-cast dtype on the
         layer, snapshot_layer must surface it in the snapshot — without this,

--- a/tests/test_ssd_cache.py
+++ b/tests/test_ssd_cache.py
@@ -1500,9 +1500,9 @@ class TestSchemaVersionInvalidation:
 
         tier = SSDCacheTier(SSDCacheConfig(cache_dir=cache_dir))
         try:
-            assert not os.path.exists(entry_dir), (
-                "stale spill files must not survive a schema bump"
-            )
+            assert not os.path.exists(
+                entry_dir
+            ), "stale spill files must not survive a schema bump"
             assert os.path.isdir(os.path.join(cache_dir, "data"))
         finally:
             tier.close()
@@ -1515,3 +1515,92 @@ class TestSchemaVersionInvalidation:
             assert idx.migrated_from is None
         finally:
             idx.close()
+
+
+class TestUnsupportedSubCaches:
+    """A layer that cannot be spilled must fail loudly, not write junk.
+
+    ``snapshot_layer`` runs on the *writer* thread, where ``_writer_loop``
+    catches and logs. A guard that raises there costs one dropped entry and a
+    log line. Getting past the guard is worse: ``np.array(None)`` is a 0-d
+    object array whose ``.size`` is 1, so it slips past the ``keys_empty``
+    branch and only fails later in ``save_file`` ("dtype object is not
+    covered") -- same dropped entry, but with an orphaned .tmp directory and a
+    much less obvious message.
+    """
+
+    def _cache_list(self, *subs):
+        from mlx_lm.models.cache import CacheList
+
+        return CacheList(*subs)
+
+    def _populated_kv(self):
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        kv = KVCache()
+        kv.update_and_fetch(
+            mx.random.normal((1, 2, 4, 8)), mx.random.normal((1, 2, 4, 8))
+        )
+        return kv
+
+    def test_unpopulated_sub_cache_raises(self):
+        """KVCache leaves keys/values None until the first update_and_fetch."""
+        from mlx_lm.models.cache import KVCache
+        from vllm_mlx.ssd_cache import CacheListSerializer
+
+        layer = self._cache_list(self._populated_kv(), KVCache())
+        with pytest.raises(ValueError, match="not materialized"):
+            CacheListSerializer().snapshot_layer(layer)
+
+    def test_unpopulated_plain_kvcache_raises(self):
+        """Same guard protects a non-CacheList layer -- one invariant, one place."""
+        from mlx_lm.models.cache import KVCache
+        from vllm_mlx.ssd_cache import KVCacheSerializer
+
+        with pytest.raises(ValueError, match="not materialized"):
+            KVCacheSerializer().snapshot_layer(KVCache())
+
+    def test_empty_but_materialized_sub_cache_is_still_supported(self):
+        """Regression guard: the DSA indexer is size-0, NOT None.
+
+        The None check must not start rejecting the empty dense-mode indexer,
+        which is a normal, spillable state.
+        """
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+        from vllm_mlx.ssd_cache import CacheListSerializer
+
+        idx = KVCache()
+        idx.keys = mx.zeros((1, 2, 0, 8), dtype=mx.float32)
+        idx.values = mx.zeros((1, 2, 0, 8), dtype=mx.float32)
+        idx.offset = 0
+
+        snap = CacheListSerializer().snapshot_layer(
+            self._cache_list(self._populated_kv(), idx)
+        )
+        assert len(snap["sub_snapshots"]) == 2
+        assert snap["sub_snapshots"][1]["keys_np"].size == 0
+
+    def test_non_kvcache_sub_is_rejected_by_type(self):
+        """A sub-cache without the KVCache shape has no serializer at all."""
+        from vllm_mlx.ssd_cache import CacheListSerializer
+
+        class Alien:
+            pass
+
+        layer = self._cache_list(self._populated_kv(), Alien())
+        with pytest.raises(ValueError, match="not.*KVCache-like|unsupported"):
+            CacheListSerializer().snapshot_layer(layer)
+
+    def test_rejected_layer_writes_no_file(self, tmp_path):
+        """The guard fires before serialize_layer, so nothing lands on disk."""
+        from mlx_lm.models.cache import KVCache
+        from vllm_mlx.ssd_cache import CacheListSerializer
+
+        ser = CacheListSerializer()
+        path = str(tmp_path / "layer_0.safetensors")
+        with pytest.raises(ValueError):
+            snap = ser.snapshot_layer(self._cache_list(KVCache()))
+            ser.serialize_layer(snap, 0, path)
+        assert not os.path.exists(path)

--- a/tests/test_stream_interval.py
+++ b/tests/test_stream_interval.py
@@ -64,7 +64,7 @@ def test_get_nowait_holds_back_until_notified():
     collector = RequestOutputCollector(aggregate=True)
     collector.put(_step(2, 12), notify=False)  # mid-interval, not released yet
     assert collector.get_nowait() is None
-    collector.put(_step(3, 12), notify=True)   # interval boundary
+    collector.put(_step(3, 12), notify=True)  # interval boundary
     out = collector.get_nowait()
     assert out is not None
     # both the held-back and the boundary token's text are present
@@ -75,3 +75,82 @@ def test_interval_one_releases_every_token():
     received, releases = _drive(5, interval=1)
     assert "".join(received) == "1 2 3 4 5 "
     assert releases == 5
+
+
+def _drive_lagging(n_tokens: int, interval: int, drain_at: set[int]):
+    """Same loop, but the consumer only drains on the listed steps.
+
+    A real SSE consumer is a coroutine that may not be scheduled every engine
+    step, so releases pile up in the collector and get merged by ``put()``'s
+    aggregation. Nothing may be lost across that merge -- including the
+    terminal ``finished`` / ``finish_reason``.
+    """
+    collector = RequestOutputCollector(aggregate=True)
+    state = RequestStreamState(stream_interval=interval)
+    received = []
+    for i in range(1, n_tokens + 1):
+        out = _step(i, n_tokens)
+        send = state.should_send(out.completion_tokens, out.finished)
+        collector.put(out, notify=send)
+        if send:
+            state.mark_sent(out.completion_tokens)
+        if i in drain_at:
+            got = collector.get_nowait()
+            if got is not None:
+                received.append(got)
+    # Whatever the consumer has not picked up yet, it picks up at the end.
+    tail = collector.get_nowait()
+    if tail is not None:
+        received.append(tail)
+    return received
+
+
+def test_lagging_consumer_loses_no_text():
+    """Consumer never runs until the request is over."""
+    expected = "".join(f"{j} " for j in range(1, 13))
+    received = _drive_lagging(12, interval=5, drain_at=set())
+    assert len(received) == 1, "everything merged into one pending output"
+    assert received[0].new_text == expected
+
+
+def test_lagging_consumer_still_sees_the_finish():
+    received = _drive_lagging(12, interval=5, drain_at=set())
+    assert received[-1].finished is True
+    assert received[-1].finish_reason == "stop"
+
+
+def test_finish_survives_a_merge_with_earlier_releases():
+    """Finish lands mid-interval (token 12, last boundary was 11).
+
+    The consumer drains at step 6 only, so the token-11 release and the
+    token-12 finish merge; the merged output must carry both the text and
+    the terminal state.
+    """
+    received = _drive_lagging(12, interval=5, drain_at={6})
+    assert "".join(r.new_text for r in received) == "".join(
+        f"{j} " for j in range(1, 13)
+    )
+    assert received[-1].finished is True
+    assert received[-1].finish_reason == "stop"
+
+
+def test_run_shorter_than_the_interval_still_delivers():
+    """3 tokens at interval 5 never reaches a boundary -- finish must release."""
+    received = _drive_lagging(3, interval=5, drain_at=set())
+    assert "".join(r.new_text for r in received) == "1 2 3 "
+    assert received[-1].finished is True
+
+
+def test_single_token_response_delivers():
+    received = _drive_lagging(1, interval=5, drain_at=set())
+    assert "".join(r.new_text for r in received) == "1 "
+    assert received[-1].finished is True
+    assert received[-1].finish_reason == "stop"
+
+
+def test_cumulative_output_text_is_the_latest_not_the_concatenation():
+    """_merge_outputs keeps the newest cumulative fields, not a sum of them."""
+    received = _drive_lagging(12, interval=5, drain_at=set())
+    merged = received[-1]
+    assert merged.output_text == "".join(f"{j} " for j in range(1, 13))
+    assert merged.completion_tokens == 12

--- a/tests/test_stream_interval.py
+++ b/tests/test_stream_interval.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming must not drop tokens when --stream-interval > 1.
+
+Regression for the GLM-5.2 "word salad" bug: with stream_interval=5 the engine
+forwarded only every 5th per-step RequestOutput to the collector and dropped the
+4 in between. Since each step's RequestOutput carries only that step's ~1-token
+``new_text``, 4 of every 5 tokens' text was silently lost, so streamed output
+looked like scrambled fragments (e.g. "1alyze  Count by ...").
+
+The collector already aggregates ``new_text`` on ``put()``; the interval must
+gate *notification/release* to the consumer, never drop the accumulated text.
+"""
+
+from vllm_mlx.output_collector import RequestOutputCollector, RequestStreamState
+from vllm_mlx.request import RequestOutput
+
+
+def _step(i: int, n: int) -> RequestOutput:
+    """A single decode step emitting token ``i`` of ``n`` (text ``"i "``)."""
+    return RequestOutput(
+        request_id="r",
+        new_token_ids=[i],
+        new_text=f"{i} ",
+        output_token_ids=list(range(1, i + 1)),
+        output_text="".join(f"{j} " for j in range(1, i + 1)),
+        finished=(i == n),
+        finish_reason="stop" if i == n else None,
+        completion_tokens=i,
+    )
+
+
+def _drive(n_tokens: int, interval: int):
+    """Mimic the engine loop + a consumer draining the collector each step."""
+    collector = RequestOutputCollector(aggregate=True)
+    state = RequestStreamState(stream_interval=interval)
+    received = []
+    releases = 0
+    for i in range(1, n_tokens + 1):
+        out = _step(i, n_tokens)
+        send = state.should_send(out.completion_tokens, out.finished)
+        collector.put(out, notify=send)
+        if send:
+            state.mark_sent(out.completion_tokens)
+        got = collector.get_nowait()
+        if got is not None:
+            received.append(got.new_text)
+            releases += 1
+    return received, releases
+
+
+def test_no_text_dropped_across_interval():
+    expected = "".join(f"{j} " for j in range(1, 13))  # 12 tokens
+    received, _ = _drive(12, interval=5)
+    assert "".join(received) == expected
+
+
+def test_interval_batches_releases():
+    # 12 tokens, interval 5: releases at token 1 (first), 6, 11, and 12 (finish).
+    _, releases = _drive(12, interval=5)
+    assert releases == 4
+
+
+def test_get_nowait_holds_back_until_notified():
+    collector = RequestOutputCollector(aggregate=True)
+    collector.put(_step(2, 12), notify=False)  # mid-interval, not released yet
+    assert collector.get_nowait() is None
+    collector.put(_step(3, 12), notify=True)   # interval boundary
+    out = collector.get_nowait()
+    assert out is not None
+    # both the held-back and the boundary token's text are present
+    assert out.new_text == "2 3 "
+
+
+def test_interval_one_releases_every_token():
+    received, releases = _drive(5, interval=1)
+    assert "".join(received) == "1 2 3 4 5 "
+    assert releases == 5

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -343,12 +343,22 @@ class EngineCore:
                                     if use_simple_streaming:
                                         collector.put(req_output)
                                     else:
+                                        # Always put so the collector accumulates
+                                        # every step's new_text; only *release*
+                                        # (notify) on the interval boundary or on
+                                        # finish. Gating the put instead would drop
+                                        # the in-between tokens' text entirely.
                                         state = states.get(rid)
-                                        if state and state.should_send(
-                                            req_output.completion_tokens,
-                                            req_output.finished,
-                                        ):
-                                            collector.put(req_output)
+                                        send = (
+                                            state.should_send(
+                                                req_output.completion_tokens,
+                                                req_output.finished,
+                                            )
+                                            if state
+                                            else True
+                                        )
+                                        collector.put(req_output, notify=send)
+                                        if send and state:
                                             state.mark_sent(
                                                 req_output.completion_tokens
                                             )

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -52,7 +52,7 @@ class RequestOutputCollector:
         self.aggregate = aggregate
         self._is_waiting = False
 
-    def put(self, output: RequestOutput) -> None:
+    def put(self, output: RequestOutput, notify: bool = True) -> None:
         """
         Put an output into the collector (non-blocking).
 
@@ -61,6 +61,12 @@ class RequestOutputCollector:
 
         Args:
             output: The RequestOutput to store
+            notify: If True, release the accumulated output to the consumer.
+                If False, the output is *accumulated* (its ``new_text`` is
+                merged) but withheld until a later ``notify=True`` put. This
+                implements ``--stream-interval`` batching without dropping any
+                tokens: callers put every step but only release on the interval
+                boundary (or on finish). Requires ``aggregate=True``.
         """
         if self.output is None:
             self.output = output
@@ -70,7 +76,8 @@ class RequestOutputCollector:
         else:
             # Replace: just use the new output
             self.output = output
-        self.ready.set()
+        if notify:
+            self.ready.set()
 
     def get_nowait(self) -> Optional[RequestOutput]:
         """
@@ -80,8 +87,12 @@ class RequestOutputCollector:
         reducing latency under load.
 
         Returns:
-            The output if available, None otherwise
+            The output if available *and released* (notified), None otherwise.
+            Output accumulated via ``put(..., notify=False)`` is withheld until
+            a subsequent ``notify=True`` put sets the ready event.
         """
+        if not self.ready.is_set():
+            return None
         output = self.output
         if output is not None:
             self.output = None
@@ -105,7 +116,7 @@ class RequestOutputCollector:
             with RequestOutputCollector._waiting_lock:
                 RequestOutputCollector._waiting_consumers += 1
         try:
-            while self.output is None:
+            while not self.ready.is_set():
                 await self.ready.wait()
             output = self.get_nowait()
             # This should never be None after wait, but satisfy type checker

--- a/vllm_mlx/reasoning/base.py
+++ b/vllm_mlx/reasoning/base.py
@@ -99,13 +99,19 @@ class ReasoningParser(ABC):
         """
         pass
 
-    def reset_state(self):  # noqa: B027
+    def reset_state(self, implicit_mode: bool = False):  # noqa: B027
         """
         Reset any internal state for a new request.
 
         Called before starting to process a new streaming request.
         Override in subclasses if stateful parsing is needed.
         This is intentionally a default no-op implementation.
+
+        ``implicit_mode`` says the chat template injected an open ``<think>``,
+        so generation begins INSIDE the reasoning block and the model will
+        only ever emit the closing tag. Parsers that default untagged output
+        to content must invert that default when it is set. Parsers with no
+        such ambiguity may ignore it.
         """
         pass
 

--- a/vllm_mlx/reasoning/deepseek_v4_parser.py
+++ b/vllm_mlx/reasoning/deepseek_v4_parser.py
@@ -45,7 +45,7 @@ class DeepSeekV4ReasoningParser(DeepSeekR1ReasoningParser):
         self._in_tool_markup: bool = False
         self._current_text: str = ""
 
-    def reset_state(self):
+    def reset_state(self, implicit_mode: bool = False):  # noqa: ARG002
         """Reset state machine for a new streaming request."""
         super().reset_state()
         self._emitted_len = 0

--- a/vllm_mlx/reasoning/gemma4_parser.py
+++ b/vllm_mlx/reasoning/gemma4_parser.py
@@ -128,7 +128,7 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         # <|channel>response transition — used to strip the leading newline.
         self._content_seen: bool = False
 
-    def reset_state(self):
+    def reset_state(self, implicit_mode: bool = False):  # noqa: ARG002
         super().reset_state()
         self._pending = ""
         self._content_seen = False

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -98,7 +98,17 @@ class Glm4ReasoningParser(BaseThinkingReasoningParser):
                     previous_text, current_text, delta_text
                 )
 
-            # No tags yet — GLM-4 doesn't inject <think>, so this is content
+            # No tags yet. Autonomous GLM-4.6-style output is content, but a
+            # template that injected an open <think> (GLM-5.2/5.3) starts the
+            # model INSIDE the reasoning block, so untagged text is reasoning
+            # until </think> arrives. Without this the whole chain-of-thought
+            # is emitted as content, glued to the answer -- and the streaming
+            # result disagrees with what extract_reasoning() returns for the
+            # very same output.
+            if self._implicit_mode:
+                return super().extract_reasoning_streaming(
+                    previous_text, current_text, delta_text
+                )
             return DeltaMessage(content=delta_text)
 
         # In thinking or content phase, delegate to base class

--- a/vllm_mlx/reasoning/glm4_parser.py
+++ b/vllm_mlx/reasoning/glm4_parser.py
@@ -102,9 +102,13 @@ class Glm4ReasoningParser(BaseThinkingReasoningParser):
             # template that injected an open <think> (GLM-5.2/5.3) starts the
             # model INSIDE the reasoning block, so untagged text is reasoning
             # until </think> arrives. Without this the whole chain-of-thought
-            # is emitted as content, glued to the answer -- and the streaming
-            # result disagrees with what extract_reasoning() returns for the
-            # very same output.
+            # is emitted as content, glued to the answer.
+            #
+            # This does not make streaming agree with extract_reasoning() in
+            # every case: the non-streaming path has no implicit-mode signal,
+            # so output truncated before </think> still lands in content there
+            # and in reasoning here. Fixing that needs the flag threaded into
+            # extract_reasoning() as well.
             if self._implicit_mode:
                 return super().extract_reasoning_streaming(
                     previous_text, current_text, delta_text

--- a/vllm_mlx/reasoning/harmony_parser.py
+++ b/vllm_mlx/reasoning/harmony_parser.py
@@ -151,7 +151,7 @@ class HarmonyReasoningParser(ReasoningParser):
         # In commentary or unknown channel, suppress
         return None
 
-    def reset_state(self):
+    def reset_state(self, implicit_mode: bool = False):  # noqa: ARG002
         """Reset streaming state for a new request."""
         self._current_channel = None
         self._in_message = False

--- a/vllm_mlx/reasoning/think_parser.py
+++ b/vllm_mlx/reasoning/think_parser.py
@@ -86,9 +86,12 @@ class BaseThinkingReasoningParser(ReasoningParser):
         self._tool_call_buffer = ""
         # Trailing text withheld because it might be the start of a tag.
         self._pending = ""
+        # Template injected an open <think>: untagged output is reasoning.
+        self._implicit_mode = False
 
-    def reset_state(self):
+    def reset_state(self, implicit_mode: bool = False):
         """Reset state machine for a new streaming request."""
+        self._implicit_mode = implicit_mode
         self._phase = "pre_think"
         self._content_started = False
         self._content_buffer = ""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3680,7 +3680,7 @@ class Scheduler:
         Converts numpy arrays back to MLX arrays and creates KVCache objects.
         """
         try:
-            from mlx_lm.models.cache import ArraysCache, KVCache
+            from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
 
             # Cast restored arrays back to their original dtype if the spill
             # path upcast for numpy (bf16 → fp32). None = mlx lacks the named
@@ -3688,27 +3688,36 @@ class Scheduler:
             def _mx_dtype_from_name(name: str):
                 return getattr(mx, name, None)
 
+            def _mk_kv(d: dict):
+                """Rebuild a KVCache from a deserialized layer/sub dict."""
+                kv = KVCache()
+                kv.keys = mx.array(d["keys"])
+                kv.values = mx.array(d["values"])
+                keys_orig = d.get("keys_original_dtype")
+                if keys_orig is not None:
+                    dt = _mx_dtype_from_name(keys_orig)
+                    if dt is not None:
+                        kv.keys = kv.keys.astype(dt)
+                values_orig = d.get("values_original_dtype")
+                if values_orig is not None:
+                    dt = _mx_dtype_from_name(values_orig)
+                    if dt is not None:
+                        kv.values = kv.values.astype(dt)
+                kv.offset = d["offset"]
+                for attr in ("max_size", "keep", "step", "_idx"):
+                    if attr in d:
+                        setattr(kv, attr, d[attr])
+                return kv
+
             result = []
             for ld in layer_dicts:
                 if "keys" in ld and "values" in ld:
-                    kv = KVCache()
-                    kv.keys = mx.array(ld["keys"])
-                    kv.values = mx.array(ld["values"])
-                    keys_orig = ld.get("keys_original_dtype")
-                    if keys_orig is not None:
-                        dt = _mx_dtype_from_name(keys_orig)
-                        if dt is not None:
-                            kv.keys = kv.keys.astype(dt)
-                    values_orig = ld.get("values_original_dtype")
-                    if values_orig is not None:
-                        dt = _mx_dtype_from_name(values_orig)
-                        if dt is not None:
-                            kv.values = kv.values.astype(dt)
-                    kv.offset = ld["offset"]
-                    for attr in ("max_size", "keep", "step", "_idx"):
-                        if attr in ld:
-                            setattr(kv, attr, ld[attr])
-                    result.append(kv)
+                    result.append(_mk_kv(ld))
+                elif "cachelist_subs" in ld:
+                    # DSA CacheList: rebuild each KVCache sub and re-wrap.
+                    result.append(
+                        CacheList(*[_mk_kv(s) for s in ld["cachelist_subs"]])
+                    )
                 elif "state" in ld:
                     state_arrays = [mx.array(a) for a in ld["state"]]
                     state_dtypes = ld.get("state_original_dtypes")

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3715,9 +3715,7 @@ class Scheduler:
                     result.append(_mk_kv(ld))
                 elif "cachelist_subs" in ld:
                     # DSA CacheList: rebuild each KVCache sub and re-wrap.
-                    result.append(
-                        CacheList(*[_mk_kv(s) for s in ld["cachelist_subs"]])
-                    )
+                    result.append(CacheList(*[_mk_kv(s) for s in ld["cachelist_subs"]]))
                 elif "state" in ld:
                     state_arrays = [mx.array(a) for a in ld["state"]]
                     state_dtypes = ld.get("state_original_dtypes")

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1167,6 +1167,11 @@ def _build_reasoning_parser(engine: BaseEngine | None = None):
         return type(_reasoning_parser)()
 
 
+# Keyed partly on request-supplied chat_template_kwargs, so an adversarial or
+# merely varied client can mint unbounded entries. Bound it FIFO, same shape as
+# _responses_store above. Templates-per-model is tiny in practice; this is a
+# safety net, not a working-set limit.
+_IMPLICIT_THINKING_CACHE_MAX_SIZE: int = 256
 _implicit_thinking_cache: dict[tuple, bool] = {}
 
 
@@ -1182,6 +1187,11 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     probed once per (model, chat_template_kwargs) with a throwaway message
     and cached -- rendering the real prompt on every request would put a
     second template application in the hot path.
+
+    The probe renders without ``tools``, so a template that only opens
+    ``<think>`` when tools are present would be misread. GLM-5.3 opens it
+    unconditionally (verified live: tool-call requests still split reasoning
+    from content correctly), so the probe is sound for the models we ship.
     """
     apply_template = getattr(engine, "_apply_chat_template", None)
     if apply_template is None:
@@ -1206,6 +1216,8 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
 
     result = bool(prompt) and prompt.rstrip().endswith("<think>")
     _implicit_thinking_cache[key] = result
+    while len(_implicit_thinking_cache) > _IMPLICIT_THINKING_CACHE_MAX_SIZE:
+        _implicit_thinking_cache.pop(next(iter(_implicit_thinking_cache)))
     return result
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -40,6 +40,7 @@ The server provides:
 import argparse
 import asyncio
 import copy
+import hashlib
 from dataclasses import dataclass
 import json
 import logging
@@ -1175,6 +1176,35 @@ _IMPLICIT_THINKING_CACHE_MAX_SIZE: int = 256
 _implicit_thinking_cache: dict[tuple, bool] = {}
 
 
+def _template_signature(engine: BaseEngine) -> str | None:
+    """Stable identity for the chat template the engine will render with.
+
+    ``model_name`` is only a proxy for the template: a local override, a
+    re-pull, or a swapped tokenizer changes what ``<think>`` behaviour the
+    template has while the name stays put, and a verdict cached under the name
+    would outlive the template that produced it.
+
+    Both the processor's and the tokenizer's templates are hashed, rather than
+    re-deriving which one ``_apply_chat_template`` will actually pick. That
+    selection is engine-private (``_is_mllm`` and processor capability), and a
+    copy of it here is a second place to drift. Hashing both can only cost a
+    spurious re-probe if the unused one changes; missing a change would cost a
+    stale verdict, which is the bug this guards.
+
+    Returns ``None`` when no template is reachable -- the caller must then skip
+    the cache entirely, since there is nothing to invalidate against.
+    """
+    sources = []
+    for attr in ("_processor", "tokenizer"):
+        template = getattr(getattr(engine, attr, None), "chat_template", None)
+        if template is not None:
+            sources.append(f"{attr}={template!r}")
+    if not sources:
+        return None
+    joined = "\x00".join(sources).encode("utf-8", "surrogatepass")
+    return hashlib.sha256(joined).hexdigest()
+
+
 def _tool_signature(tools: list | None) -> tuple[str, ...] | None:
     """Stable, low-cardinality identity for a request's tool set.
 
@@ -1212,6 +1242,12 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     schema a client happens to send. A template that opened ``<think>`` based
     on a tool's *parameters* rather than its name would still be misread.
 
+    The key carries a hash of the chat template itself, not just the model
+    name: two engines can share a name and render differently, and the same
+    engine's template can be swapped underneath it. See ``_template_signature``.
+    A template that cannot be identified is probed every time rather than
+    cached under an identity that could go stale.
+
     ``enable_thinking`` is forwarded and keyed on because it is resolved
     per-request: ``_apply_forced_tool_choice`` sets it to ``False`` on
     ``chat_kwargs`` directly, not inside ``chat_template_kwargs``. Probing
@@ -1227,15 +1263,18 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     # False -- forward only what the request actually resolved.
     enable_thinking = (chat_kwargs or {}).get("enable_thinking")
     tools = (chat_kwargs or {}).get("tools") or None
+    template_sig = _template_signature(engine)
     key = (
         getattr(engine, "model_name", None),
+        template_sig,
         repr(sorted(ctk.items())),
         enable_thinking,
         _tool_signature(tools),
     )
-    cached = _implicit_thinking_cache.get(key)
-    if cached is not None:
-        return cached
+    if template_sig is not None:
+        cached = _implicit_thinking_cache.get(key)
+        if cached is not None:
+            return cached
 
     probe_kwargs: dict[str, object] = {"chat_template_kwargs": dict(ctk) or None}
     if enable_thinking is not None:
@@ -1252,6 +1291,8 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
         return False
 
     result = bool(prompt) and prompt.rstrip().endswith("<think>")
+    if template_sig is None:
+        return result
     _implicit_thinking_cache[key] = result
     while len(_implicit_thinking_cache) > _IMPLICIT_THINKING_CACHE_MAX_SIZE:
         _implicit_thinking_cache.pop(next(iter(_implicit_thinking_cache)))

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1175,6 +1175,22 @@ _IMPLICIT_THINKING_CACHE_MAX_SIZE: int = 256
 _implicit_thinking_cache: dict[tuple, bool] = {}
 
 
+def _tool_signature(tools: list | None) -> tuple[str, ...] | None:
+    """Stable, low-cardinality identity for a request's tool set.
+
+    Used in the implicit-thinking cache key. Tool *names* are what a chat
+    template can plausibly branch on; ordering is normalized so two requests
+    offering the same tools in a different order share one entry.
+    """
+    if not tools:
+        return None
+    names = []
+    for tool in tools:
+        name = _tool_name(tool) if isinstance(tool, dict) else None
+        names.append(name or repr(tool))
+    return tuple(sorted(names))
+
+
 def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> bool:
     """Return True iff the chat template injects an open ``<think>``.
 
@@ -1188,10 +1204,13 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     and cached -- rendering the real prompt on every request would put a
     second template application in the hot path.
 
-    The probe renders without ``tools``, so a template that only opens
-    ``<think>`` when tools are present would be misread. GLM-5.3 opens it
-    unconditionally (verified live: tool-call requests still split reasoning
-    from content correctly), so the probe is sound for the models we ship.
+    ``tools`` are forwarded and keyed on: a template may gate the ``<think>``
+    injection on tool presence, and ``chat_kwargs["tools"]`` is per-request.
+    The key carries the sorted tool *names*, not the full schemas -- enough to
+    separate "tools" from "no tools" and one tool set from another, without
+    minting a fresh entry (and a fresh template render) for every argument
+    schema a client happens to send. A template that opened ``<think>`` based
+    on a tool's *parameters* rather than its name would still be misread.
 
     ``enable_thinking`` is forwarded and keyed on because it is resolved
     per-request: ``_apply_forced_tool_choice`` sets it to ``False`` on
@@ -1207,10 +1226,12 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     # Absent means "let the engine pick its default", which is not the same as
     # False -- forward only what the request actually resolved.
     enable_thinking = (chat_kwargs or {}).get("enable_thinking")
+    tools = (chat_kwargs or {}).get("tools") or None
     key = (
         getattr(engine, "model_name", None),
         repr(sorted(ctk.items())),
         enable_thinking,
+        _tool_signature(tools),
     )
     cached = _implicit_thinking_cache.get(key)
     if cached is not None:
@@ -1219,6 +1240,8 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     probe_kwargs: dict[str, object] = {"chat_template_kwargs": dict(ctk) or None}
     if enable_thinking is not None:
         probe_kwargs["enable_thinking"] = enable_thinking
+    if tools:
+        probe_kwargs["tools"] = tools
 
     try:
         prompt = apply_template([{"role": "user", "content": "hi"}], **probe_kwargs)
@@ -1247,9 +1270,7 @@ def _prepare_streaming_reasoning_parser(
         return None
     parser = _build_reasoning_parser(engine)
     if parser is not None:
-        parser.reset_state(
-            implicit_mode=_detect_implicit_thinking(engine, chat_kwargs)
-        )
+        parser.reset_state(implicit_mode=_detect_implicit_thinking(engine, chat_kwargs))
     return parser
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1167,6 +1167,48 @@ def _build_reasoning_parser(engine: BaseEngine | None = None):
         return type(_reasoning_parser)()
 
 
+_implicit_thinking_cache: dict[tuple, bool] = {}
+
+
+def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> bool:
+    """Return True iff the chat template injects an open ``<think>``.
+
+    GLM-5.2/5.3 templates end the rendered prompt with ``<think>``, so
+    generation starts INSIDE the reasoning block and the model only ever
+    emits the closing tag. A streaming parser that defaults untagged output
+    to content would put the whole chain-of-thought in ``content``.
+
+    This is a property of the template, not of the conversation, so it is
+    probed once per (model, chat_template_kwargs) with a throwaway message
+    and cached -- rendering the real prompt on every request would put a
+    second template application in the hot path.
+    """
+    apply_template = getattr(engine, "_apply_chat_template", None)
+    if apply_template is None:
+        return False
+
+    ctk = (chat_kwargs or {}).get("chat_template_kwargs") or {}
+    key = (getattr(engine, "model_name", None), repr(sorted(ctk.items())))
+    cached = _implicit_thinking_cache.get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        prompt = apply_template(
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs=dict(ctk) or None,
+        )
+    except Exception:
+        # A template that won't render for the probe is not evidence either
+        # way -- don't cache, and leave the existing default in place.
+        logger.debug("implicit-thinking probe failed", exc_info=True)
+        return False
+
+    result = bool(prompt) and prompt.rstrip().endswith("<think>")
+    _implicit_thinking_cache[key] = result
+    return result
+
+
 def _prepare_streaming_reasoning_parser(
     engine: BaseEngine,
     request: ChatCompletionRequest | ResponsesRequest | None,
@@ -1179,7 +1221,9 @@ def _prepare_streaming_reasoning_parser(
         return None
     parser = _build_reasoning_parser(engine)
     if parser is not None:
-        parser.reset_state()
+        parser.reset_state(
+            implicit_mode=_detect_implicit_thinking(engine, chat_kwargs)
+        )
     return parser
 
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1192,22 +1192,36 @@ def _detect_implicit_thinking(engine: BaseEngine, chat_kwargs: dict | None) -> b
     ``<think>`` when tools are present would be misread. GLM-5.3 opens it
     unconditionally (verified live: tool-call requests still split reasoning
     from content correctly), so the probe is sound for the models we ship.
+
+    ``enable_thinking`` is forwarded and keyed on because it is resolved
+    per-request: ``_apply_forced_tool_choice`` sets it to ``False`` on
+    ``chat_kwargs`` directly, not inside ``chat_template_kwargs``. Probing
+    without it would let the engine default (``"coder" not in model_name``)
+    disagree with the flag the real prompt render is about to use.
     """
     apply_template = getattr(engine, "_apply_chat_template", None)
     if apply_template is None:
         return False
 
     ctk = (chat_kwargs or {}).get("chat_template_kwargs") or {}
-    key = (getattr(engine, "model_name", None), repr(sorted(ctk.items())))
+    # Absent means "let the engine pick its default", which is not the same as
+    # False -- forward only what the request actually resolved.
+    enable_thinking = (chat_kwargs or {}).get("enable_thinking")
+    key = (
+        getattr(engine, "model_name", None),
+        repr(sorted(ctk.items())),
+        enable_thinking,
+    )
     cached = _implicit_thinking_cache.get(key)
     if cached is not None:
         return cached
 
+    probe_kwargs: dict[str, object] = {"chat_template_kwargs": dict(ctk) or None}
+    if enable_thinking is not None:
+        probe_kwargs["enable_thinking"] = enable_thinking
+
     try:
-        prompt = apply_template(
-            [{"role": "user", "content": "hi"}],
-            chat_template_kwargs=dict(ctk) or None,
-        )
+        prompt = apply_template([{"role": "user", "content": "hi"}], **probe_kwargs)
     except Exception:
         # A template that won't render for the probe is not evidence either
         # way -- don't cache, and leave the existing default in place.

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -504,6 +504,22 @@ class KVCacheSerializer(LayerSerializer):
     _ROTATING_ATTRS = ("max_size", "keep", "step", "_idx")
 
     def snapshot_layer(self, layer: Any) -> dict[str, Any]:
+        # A KVCache leaves keys/values None until its first update_and_fetch.
+        # np.array(None) is a 0-d *object* array whose .size is 1, so it slips
+        # past serialize_layer's empty-array branch and only fails inside
+        # save_file ("dtype object is not covered") -- on the writer thread,
+        # where _writer_loop swallows the error and orphans the .tmp dir. Fail
+        # here instead: the same entry is dropped, but loudly and locally.
+        # NOTE: a size-0 array is NOT None -- the dense-mode DSA indexer is
+        # empty but materialized, and must still round-trip.
+        if (
+            getattr(layer, "keys", None) is None
+            or getattr(layer, "values", None) is None
+        ):
+            raise ValueError(
+                f"{type(layer).__name__} keys/values are not materialized "
+                "(None); layer cannot be spilled to SSD"
+            )
         keys_np, keys_orig_dtype = _mx_to_numpy_safe(layer.keys)
         values_np, values_orig_dtype = _mx_to_numpy_safe(layer.values)
 

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -409,6 +409,7 @@ SERIALIZER_SUPPORT_MATRIX = {
     "RotatingKVCache": "supported",  # Serialized as KVCache (keys/values/offset)
     "ArraysCache": "supported",
     "MambaCache": "supported",  # Legacy name for ArraysCache
+    "CacheList": "supported",  # DSA (GLM-5.2/DeepSeek-V3.2): list of KVCache subs
     "_QuantizedCacheWrapper": "supported_via_dequant_on_spill",
     "QuantizedKVCache": "supported_via_dequant_on_spill",
 }
@@ -613,15 +614,136 @@ class ArraysCacheSerializer(LayerSerializer):
         return result
 
 
+class CacheListSerializer(LayerSerializer):
+    """Serializer for DSA ``CacheList`` layers (GLM-5.2 / DeepSeek-V3.2).
+
+    A ``CacheList`` wraps N sub-caches — for DSA each is a ``KVCache``:
+    ``(latent, indexer)`` for full layers, ``(latent,)`` for shared layers.
+    Below the sparse ``index_topk`` threshold the indexer sub-cache is empty
+    (size-0 arrays).
+
+    ``CacheList`` also exposes a list ``.state``, so the duck-typed dispatcher
+    used to mis-route it to ``ArraysCacheSerializer``. Depending on the mlx_lm
+    build that either crashed (``.state`` yields per-sub ``(keys, values)``
+    tuples that ``_mx_to_numpy_safe`` cannot handle) or silently flattened the
+    sub-caches and lost the CacheList structure. This serializer instead walks
+    ``layer.caches`` directly — independent of ``.state`` semantics — snapshots
+    each sub ``KVCache`` (reusing ``KVCacheSerializer``), flattens their arrays
+    into one safetensors file under ``sub_{j}_*`` keys, and records the per-sub
+    layout (offset, dtype hints, empty-array shapes) in metadata.
+    """
+
+    def snapshot_layer(self, layer: Any) -> dict[str, Any]:
+        sub_ser = KVCacheSerializer()
+        sub_snapshots = []
+        for sub in layer.caches:
+            if not (
+                hasattr(sub, "keys")
+                and hasattr(sub, "values")
+                and hasattr(sub, "offset")
+            ):
+                raise ValueError(
+                    f"CacheList sub-cache {type(sub).__name__} is not "
+                    "KVCache-like; unsupported for SSD spill"
+                )
+            sub_snapshots.append(sub_ser.snapshot_layer(sub))
+        return {"sub_snapshots": sub_snapshots}
+
+    def serialize_layer(
+        self, snapshot: dict[str, Any], layer_idx: int, file_path: str
+    ) -> dict[str, Any]:
+        from safetensors.numpy import save_file
+
+        sub_snapshots = snapshot["sub_snapshots"]
+        tensors: dict[str, np.ndarray] = {}
+        sub_meta: list[dict[str, Any]] = []
+        for j, sub in enumerate(sub_snapshots):
+            keys_np = sub["keys_np"]
+            values_np = sub["values_np"]
+            m: dict[str, Any] = {"offset": sub["offset"]}
+            # Size-0 arrays (empty DSA indexer) can't go through safetensors;
+            # record shape+dtype and recreate on load, like the disk-persist path.
+            if getattr(keys_np, "size", 1) == 0:
+                m["keys_empty"] = [list(keys_np.shape), str(keys_np.dtype)]
+            else:
+                tensors[f"sub_{j}_keys"] = keys_np
+            if getattr(values_np, "size", 1) == 0:
+                m["values_empty"] = [list(values_np.shape), str(values_np.dtype)]
+            else:
+                tensors[f"sub_{j}_values"] = values_np
+            for k in ("keys_original_dtype", "values_original_dtype"):
+                if k in sub:
+                    m[k] = sub[k]
+            for attr in KVCacheSerializer._ROTATING_ATTRS:
+                if attr in sub:
+                    m[attr] = sub[attr]
+            sub_meta.append(m)
+
+        if not tensors:
+            # safetensors rejects an empty tensor dict; write a sentinel. (The
+            # latent sub-cache is always populated, so this is a guard only.)
+            tensors["__placeholder__"] = np.zeros((1,), dtype=np.uint8)
+        save_file(tensors, file_path)
+
+        return {
+            "layer_type": "CacheList",
+            "layer_idx": layer_idx,
+            "sub_count": len(sub_snapshots),
+            "sub_meta": sub_meta,
+        }
+
+    def deserialize_layer(self, file_path: str, metadata: dict[str, Any]) -> dict:
+        from safetensors.numpy import load_file
+
+        sub_count = metadata["sub_count"]
+        sub_meta = metadata["sub_meta"]
+        tensors = load_file(file_path)
+
+        subs = []
+        for j in range(sub_count):
+            m = sub_meta[j]
+            kkey, vkey = f"sub_{j}_keys", f"sub_{j}_values"
+            if kkey in tensors:
+                keys = tensors[kkey]
+            else:
+                shape, dt = m["keys_empty"]
+                keys = np.zeros(shape, dtype=np.dtype(dt))
+            if vkey in tensors:
+                values = tensors[vkey]
+            else:
+                shape, dt = m["values_empty"]
+                values = np.zeros(shape, dtype=np.dtype(dt))
+
+            sub_ld: dict[str, Any] = {
+                "keys": keys,
+                "values": values,
+                "offset": m["offset"],
+            }
+            for k in ("keys_original_dtype", "values_original_dtype"):
+                if k in m:
+                    sub_ld[k] = m[k]
+            for attr in KVCacheSerializer._ROTATING_ATTRS:
+                if attr in m:
+                    sub_ld[attr] = m[attr]
+            subs.append(sub_ld)
+        return {"cachelist_subs": subs}
+
+
 def get_serializer_for_layer(layer: Any) -> LayerSerializer:
     """Return the appropriate serializer for a cache layer.
 
     Dispatches based on duck-typing:
+    - If layer has .caches (DSA CacheList) -> CacheListSerializer
     - If layer has .keys and .values and .offset -> KVCacheSerializer
     - If layer has .state and it's a list -> ArraysCacheSerializer
 
+    The CacheList check comes first because a CacheList ALSO has a list
+    ``.state`` and would otherwise be mis-routed to ArraysCacheSerializer.
+
     Raises ValueError for unsupported layer types.
     """
+    if isinstance(getattr(layer, "caches", None), (list, tuple)):
+        return CacheListSerializer()
     if hasattr(layer, "keys") and hasattr(layer, "values") and hasattr(layer, "offset"):
         return KVCacheSerializer()
     if hasattr(layer, "state") and isinstance(getattr(layer, "state", None), list):
@@ -1125,6 +1247,8 @@ class SSDCacheTier:
                     serializer = KVCacheSerializer()
                 elif layer_type in ("ArraysCache", "MambaCache"):
                     serializer = ArraysCacheSerializer()
+                elif layer_type == "CacheList":
+                    serializer = CacheListSerializer()
                 else:
                     logger.warning(
                         f"[ssd_cache] unknown layer type {layer_type}, skipping"

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -158,11 +158,19 @@ class SSDIndex:
     The SQLite connection uses WAL mode for concurrent read/write safety.
     """
 
-    _SCHEMA_VERSION = 1
+    # 2: CacheList (GLM-5.2/5.3 DSA) layers gained a dedicated serializer.
+    #    Before it, they were mis-dispatched to ArraysCacheSerializer; with
+    #    fp16 that silently succeeded, writing an entry tagged
+    #    layer_type="ArraysCache" with the per-sub offsets lost. Those entries
+    #    still match on token hash after an upgrade, so they must be dropped.
+    _SCHEMA_VERSION = 2
 
     def __init__(self, cache_dir: str) -> None:
         self._cache_dir = cache_dir
         self._db_lock = threading.Lock()
+        # Set to the previous version when an incompatible index was purged,
+        # so the tier knows to clear the matching data directories.
+        self.migrated_from: int | None = None
         db_path = os.path.join(cache_dir, "index.db")
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -200,12 +208,27 @@ class SSDIndex:
             CREATE INDEX IF NOT EXISTS idx_entries_prefix_hash_num_tokens
                 ON entries(prefix_hash, num_tokens);
             """)
-        # Insert schema version if not present
-        cur = self._conn.execute("SELECT COUNT(*) FROM schema_version")
-        if cur.fetchone()[0] == 0:
+        # Insert schema version if not present, or drop an index written by an
+        # older, incompatible build. Entries are keyed on the token hash alone
+        # and the cache dir is not build-namespaced, so a stale entry would
+        # otherwise be served to a reader that cannot interpret it.
+        cur = self._conn.execute("SELECT version FROM schema_version")
+        row = cur.fetchone()
+        if row is None:
             self._conn.execute(
                 "INSERT INTO schema_version (version) VALUES (?)",
                 (self._SCHEMA_VERSION,),
+            )
+        elif row[0] != self._SCHEMA_VERSION:
+            self.migrated_from = row[0]
+            self._conn.execute("DELETE FROM entries")
+            self._conn.execute(
+                "UPDATE schema_version SET version = ?", (self._SCHEMA_VERSION,)
+            )
+            logger.info(
+                "[ssd_cache] index schema %s -> %s: dropped all entries",
+                row[0],
+                self._SCHEMA_VERSION,
             )
         self._backfill_prefix_hashes()
         self._conn.commit()
@@ -795,6 +818,8 @@ class SSDCacheTier:
         try:
             # Open SQLite index
             self._index = SSDIndex(self._cache_dir)
+            if getattr(self._index, "migrated_from", None) is not None:
+                self._purge_data_dir()
 
             # Stats
             self._stats = SSDCacheStats()
@@ -822,6 +847,31 @@ class SSDCacheTier:
                         "ssd_cache: failed to close index during init cleanup"
                     )
             raise
+
+    def _purge_data_dir(self) -> None:
+        """Delete every spilled entry after an incompatible schema bump.
+
+        The index rows are already gone, so reconcile() would eventually sweep
+        these as orphans -- but reconcile is not guaranteed to run before the
+        first spill, and leaving gigabytes of unreadable files on disk counting
+        against the size budget is worse than a short startup cost.
+        """
+        import shutil
+
+        if not os.path.isdir(self._data_dir):
+            return
+        for entry_name in os.listdir(self._data_dir):
+            entry_path = os.path.join(self._data_dir, entry_name)
+            if not os.path.isdir(entry_path):
+                continue
+            try:
+                shutil.rmtree(entry_path)
+            except OSError:
+                logger.warning(
+                    "[ssd_cache] failed to remove stale entry directory %s",
+                    entry_name,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _entry_hash(tokens: tuple[int, ...]) -> str:

--- a/vllm_mlx/ssd_cache.py
+++ b/vllm_mlx/ssd_cache.py
@@ -453,8 +453,11 @@ def _mx_to_numpy_safe(arr: Any) -> tuple[np.ndarray, str | None]:
     """
     try:
         return np.array(arr), None
-    except RuntimeError as exc:
-        # numpy ↔ mlx bf16 buffer-protocol mismatch on mlx ≥ 0.31. Re-raise
+    except (RuntimeError, ValueError) as exc:
+        # numpy ↔ mlx bf16 buffer-protocol mismatch. The exception type is not
+        # stable across mlx versions — older builds raise RuntimeError, mlx
+        # 0.31.x raises ValueError ("'bfloat16' is not a valid PEP 3118 buffer
+        # format string") — so match on the message, not the class. Re-raise
         # anything else — don't swallow unrelated errors.
         if "buffer format string" not in str(exc):
             raise


### PR DESCRIPTION
Five bug fixes plus one test, found while bringing up GLM-5.3-Flash (8-bit MLX) on a 512 GB M3 Ultra. Each is independent — **happy to split this into separate PRs if you'd rather review them piecemeal, in whatever grouping suits you.**

# Human note
While the port is fresh, I've been dragging some form or other of these fixes along with me since Qwen-397b. Opus totally could have made some mistakes pulling them in from my previous branch, but it was pulling from code that was already tested across millions of tokens.

## The fixes

**1. Streaming dropped 4 of every 5 tokens when `--stream-interval > 1`** (`160e587`)

The engine forwarded only every Nth per-step `RequestOutput` to the collector and dropped the ones in between. Each step's output carries ~1 token of `new_text`, so most of the text was silently lost — streamed output came out as scrambled fragments while `stream=False` on the same prompt was always correct.

The fix gates *notification* rather than the *put*: the collector already aggregates `new_text` on `put()`, so `put()` gains `notify=False` to accumulate without releasing, and `get()`/`get_nowait()` wait on the ready event. `engine_core` now always puts each step and only notifies on the interval boundary or at finish.

**2. DSA `CacheList` entries dropped or corrupted on SSD spill** (`65d2053`)

A DSA layer is `CacheList(KVCache latent, KVCache indexer)`. `get_serializer_for_layer` dispatched it to `ArraysCacheSerializer` because `CacheList` also exposes a list `.state` — but iterating that state yields per-sub `(keys, values)` tuples, which either raised inside the numpy conversion or silently flattened the sub-caches and lost the structure and offsets.

Adds a dedicated `CacheListSerializer` that walks `layer.caches` directly rather than relying on `.state` semantics, and moves the `.caches` check ahead of the `.state` branch in dispatch. A quantized sub-cache now raises a clear error so the entry drops cleanly instead of being written corrupted.

**3. bf16 upcast unreachable on mlx 0.31.x — wrong exception class** (`ff1390f`)

`_mx_to_numpy_safe`'s comment already says "bf16 buffer-protocol mismatch on mlx >= 0.31", but the handler catches only `RuntimeError`. mlx 0.31.x raises `ValueError`:

```
ValueError: 'bfloat16' is not a valid PEP 3118 buffer format string
```

So the fp32 fallback was dead code and **every bf16 KV spill to the SSD tier failed** on 0.31.x. Now matched on the message rather than the exception class, which isn't stable across mlx versions, and anything else re-raises.

This hid because the existing bf16 tests raise the error by hand and therefore pass under either class — so this also adds a test that drives a real `mx.bfloat16` array through the function.

**4. Forced-`<think>` chain-of-thought streamed as `content`** (`e67ace5`)

GLM-5.2/5.3 chat templates end the rendered prompt with an open `<think>`, so generation starts *inside* the reasoning block and the model only ever emits the closing tag. `Glm4ReasoningParser.extract_reasoning_streaming` overrides the base `pre_think` branch to default untagged output to `content` — correct for autonomous GLM-4.6-style thinking, wrong here. Streaming and non-streaming disagreed on identical output:

```
streaming:      content='84 * 3 = 252\n252 / 2 = 126**126**'   reasoning_content=''
non-streaming:  content='**126**'                              reasoning_content='84 * 3 / 2 = ...'
```

Adds `_detect_implicit_thinking()`, which renders the chat template once per `(model, chat_template_kwargs)` and checks for a trailing `<think>`, wired into `reset_state(implicit_mode=...)` at `_prepare_streaming_reasoning_parser` — the single chokepoint all streaming reasoning sites already share since #654.

Worth noting this **changes no default**: in implicit mode glm4 simply stops overriding and defers to the base state machine, whose no-tags branch already emits reasoning. It stops a subclass from shadowing that. qwen3, deepseek and gemma4 are untouched.

**5. Bound the implicit-thinking probe cache** (`ea31a7c`)

Follow-up to #4. The cache key includes `chat_template_kwargs`, which comes straight off the request, so a varied client could mint unbounded entries. Bounded FIFO at 256, matching the existing `_responses_store` treatment. Eviction is insertion-order rather than LRU — worst case is a redundant template render, not a wrong answer.

**6. Test only: pin the MLX producer-thread materialization invariant** (`91b3b61`)

No production change. MLX streams are thread-local, so a lazy array built on the request thread aborts the process (`std::terminate`, not a catchable exception) if the spill path evaluates it on another thread through numpy's buffer protocol. `_detach_cache_for_storage` already establishes the invariant by batching every leaf into one `mx.eval` on the calling thread; these are black-box regressions over `store()` covering the two shapes with no `KVCache` trim path to hide behind. Both pass on `main` as-is — they just guard against a future refactor silently dropping the batched eval. Drop this commit if you'd rather not carry it.

## Testing

Full suite on the target machine (mlx 0.31.x / mlx_lm 0.31.3 / mlx-vlm 0.6.17):

```
2974 passed, 2 failed, 24 skipped
```

Both failures (`test_mllm_mtp_routing.py::test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs`, `test_prefix_cache_scheduler_parity.py::test_identical_plain_kv_prompt_never_replays_a_supersequence`) reproduce on clean `22efb47` with none of these commits applied, so they're pre-existing and unrelated. I diffed the sorted failure sets before and after: zero new failures.

Also verified live against a running GLM-5.3-Flash-MLX-8bit server (`--mllm --enable-prefix-cache --continuous-batching --stream-interval 5 --chunked-prefill-tokens 256 --ssd-cache-dir`):

- streaming reasoning/content split correctly, no tag leakage, all chunks intact
- streaming and non-streaming now agree on the same prompt
- tool calling (`--tool-call-parser glm47`) still separates reasoning correctly
- vision requests return correct content and spatial ordering
- prefix cache round-trips through disk and reloads on restart

## Known limitation, not addressed here

On responses truncated mid-reasoning (`finish_reason=length`, no `</think>` ever emitted), streaming and non-streaming still disagree — streaming puts the text in `reasoning_content`, non-streaming in `content`.

**This is pre-existing on `main` and not introduced by these commits**: qwen3 shows the identical split today, in both implicit and autonomous mode, because `BaseThinkingReasoningParser.extract_reasoning()`'s no-tags branch returns `(None, model_output)` while the streaming state machine's no-tags branch defaults to reasoning. Commit #4 makes glm4-in-implicit-mode behave the way qwen3 already behaves.

I left it alone because the fix isn't local: `extract_reasoning()` takes only the output text, the non-streaming path uses the module-level shared `_reasoning_parser`, and implicit-ness is per-request — so it can't be stashed on the shared instance without a race. It wants either an explicit parameter or a per-request parser instance, which felt like a separate change from these. Happy to take it on separately if you'd like it fixed.

---

Written with Claude Opus 5 and tested on my own hardware (M3 Ultra, 512 GB) against a real GLM-5.3-Flash-MLX-8bit deployment.
