### PR TITLE
Fix schema-aware streamed tool arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \
             tests/test_tool_call_promotion.py \
+            tests/test_tool_argument_coercion.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \
             tests/test_tool_call_promotion.py \
-            tests/test_tool_argument_coercion.py \
             -v --tb=short \
             -k "not Integration and not InjectJson and not TestMLXMultimodalLMCache" \
             --cov=vllm_mlx \
@@ -197,6 +196,7 @@ jobs:
             tests/test_normalize_messages.py \
             tests/test_responses_api.py \
             tests/test_thinking_aware_processor.py \
+            tests/test_tool_argument_coercion.py \
             tests/test_tool_choice_forced.py \
             tests/test_tool_choice_none.py \
             tests/test_harmony_render.py \

--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -45,6 +45,25 @@ if response.choices[0].message.tool_calls:
         print(f"Arguments: {tc.function.arguments}")
 ```
 
+## Streaming argument recovery
+
+Chat Completions streams parser-produced tool argument fragments unchanged by
+default, including when tools declare arrays or other non-string parameters.
+To opt into schema-aware recovery, send the request extension
+`"tool_argument_recovery": "buffered"` (with the OpenAI Python client, use
+`extra_body={"tool_argument_recovery": "buffered"}`). The default is `"none"`;
+other values are rejected by request validation.
+
+Buffered mode emits each call's ID/name when established and continues emitting
+independent content/reasoning. Only argument bytes wait until the entire
+generation finishes, including for already-valid arguments. This does not
+provide early per-call completion. Complete arguments can then recover, for
+example, a JSON-encoded array string into a schema-declared array. Already-correct
+strings are preserved; actual objects/lists targeting strings use compact UTF-8
+JSON without sorting keys. Nonfinite or incompatible values are not repaired.
+This option does not enforce the full tool schema or change non-streaming
+recovery behavior.
+
 ## Supported Parsers
 
 Use `--tool-call-parser` to select a parser for your model family:

--- a/tests/test_tool_argument_coercion.py
+++ b/tests/test_tool_argument_coercion.py
@@ -61,12 +61,30 @@ def test_preserves_value_that_already_matches_any_union_type():
     assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
 
 
-def test_preserves_existing_object_to_string_normalization():
-    arguments = json.dumps({"content": {"answer": 42}})
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            {"answer": 42, "labels": ["café", "ok"]},
+            '{"answer":42,"labels":["café","ok"]}',
+        ),
+        ([{"answer": 42}, "café"], '[{"answer":42},"café"]'),
+    ],
+)
+def test_object_and_array_to_string_normalization_uses_compact_json(value, expected):
+    arguments = json.dumps({"content": value})
     tools = _tool_schema({"content": {"type": "string"}})
 
     normalized = json.loads(_coerce_tool_arguments(arguments, "terminal", tools))
-    assert json.loads(normalized["content"]) == {"answer": 42}
+    assert normalized["content"] == expected
+
+
+def test_preserves_existing_string_bytes():
+    content = '{\n  "answer": 42,\n  "label": "café"\n}'
+    arguments = json.dumps({"content": content})
+    tools = _tool_schema({"content": {"type": "string"}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
 
 
 def test_coerces_json_boolean_without_treating_it_as_integer():

--- a/tests/test_tool_argument_coercion.py
+++ b/tests/test_tool_argument_coercion.py
@@ -430,8 +430,9 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
         def __init__(self, tokenizer=None):
             self.index = 0
 
-        def reset_state(self):
+        def reset_state(self, implicit_mode: bool = False):
             self.index = 0
+            self._implicit_mode = implicit_mode
 
         def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
             if self.index == 0:
@@ -441,6 +442,15 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
                 )
             self.index += 1
             return SimpleNamespace(reasoning=None, content=delta_text)
+
+    # Bind the current server's keyword call even on older no-argument routes.
+    reset_probe = FakeReasoningParser()
+    reset_probe.index = 7
+    reset_probe.reset_state(implicit_mode=True)
+    assert reset_probe.index == 0 and reset_probe._implicit_mode is True
+    reset_probe.index = 7
+    reset_probe.reset_state()
+    assert reset_probe.index == 0 and reset_probe._implicit_mode is False
 
     monkeypatch.setattr(server, "_model_name", "served-model")
     monkeypatch.setattr(

--- a/tests/test_tool_argument_coercion.py
+++ b/tests/test_tool_argument_coercion.py
@@ -97,6 +97,96 @@ def test_coerces_json_boolean_without_treating_it_as_integer():
     }
 
 
+@pytest.mark.parametrize("encoded", ["1e999", "-1e999", "NaN", "Infinity"])
+def test_preserves_nonfinite_numeric_strings_byte_for_byte(encoded):
+    arguments = json.dumps({"value": encoded})
+    tools = _tool_schema({"value": {"type": "number"}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+@pytest.mark.parametrize(
+    ("encoded", "declared_type", "expected"),
+    [
+        (
+            '[[1, 2], {"nested": [3, 4]}]',
+            "array",
+            [[1, 2], {"nested": [3, 4]}],
+        ),
+        (
+            '{"nested": {"values": [1, 2]}, "ok": true}',
+            "object",
+            {"nested": {"values": [1, 2]}, "ok": True},
+        ),
+    ],
+)
+def test_recovers_finite_nested_arrays_and_objects_without_bare_nonfinite(
+    encoded, declared_type, expected
+):
+    arguments = json.dumps({"value": encoded}, ensure_ascii=False)
+    tools = _tool_schema({"value": {"type": declared_type}})
+
+    normalized = _coerce_tool_arguments(arguments, "terminal", tools)
+
+    def reject_nonfinite(token):
+        raise AssertionError(f"unexpected nonfinite JSON constant: {token}")
+
+    assert json.loads(normalized, parse_constant=reject_nonfinite) == {
+        "value": expected
+    }
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    ['[1, {"nested": 1e999}]', '{"nested": [Infinity]}'],
+)
+def test_preserves_nested_nonfinite_json_strings_byte_for_byte(encoded):
+    arguments = json.dumps({"value": encoded})
+    declared_type = "object" if encoded.startswith("{") else "array"
+    tools = _tool_schema({"value": {"type": declared_type}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+def test_preserves_invalid_object_instead_of_stringifying_nonfinite_values():
+    arguments = '{ "value": {"nested": [NaN]} }'
+    tools = _tool_schema({"value": {"type": "string"}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+def test_preserves_invalid_outer_payload_when_another_field_is_recoverable():
+    arguments = '{ "count": "1", "unrelated": Infinity }'
+    tools = _tool_schema({"count": {"type": "integer"}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+def test_changed_serialization_never_emits_bare_nonfinite():
+    arguments = json.dumps(
+        {"argv": '["printf"]', "value": "1e999", "options": '{"ok": true}'},
+        ensure_ascii=False,
+    )
+    tools = _tool_schema(
+        {
+            "argv": {"type": "array"},
+            "value": {"type": "number"},
+            "options": {"type": "object"},
+        }
+    )
+
+    normalized = _coerce_tool_arguments(arguments, "terminal", tools)
+
+    def reject_nonfinite(token):
+        raise AssertionError(f"unexpected nonfinite JSON constant: {token}")
+
+    assert json.loads(normalized, parse_constant=reject_nonfinite) == {
+        "argv": ["printf"],
+        "value": "1e999",
+        "options": {"ok": True},
+    }
+
+
 def test_buffers_typed_stream_fragments_until_complete_json_is_available():
     tools = _tool_schema(
         {"argv": {"type": "array"}, "timeout_seconds": {"type": "integer"}}
@@ -218,4 +308,131 @@ async def test_stream_buffers_fragments_before_schema_coercion(monkeypatch):
         "argv": ["printf"],
         "timeout_seconds": 1,
     }
+    assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("use_reasoning_parser", [False, True])
+async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_call(
+    monkeypatch, use_reasoning_parser
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.server import stream_chat_completion
+    import vllm_mlx.server as server
+
+    fragments = [
+        {"index": 0, "id": "call_1", "function": {"name": "terminal"}},
+        {"index": 0, "function": {"arguments": '{"argv": '}},
+        {"index": 0, "function": {"arguments": '"[\\"printf\\"]"}'}},
+    ]
+    parser_results = [
+        {"tool_calls": [fragments[0]], "content": "sibling content"},
+        {"tool_calls": [fragments[1]]},
+        {"tool_calls": [fragments[2]]},
+        None,
+    ]
+
+    class FakeEngine:
+        model_name = "fake-engine"
+
+        async def stream_chat(self, messages, **kwargs):
+            for index in range(len(parser_results)):
+                yield GenerationOutput(
+                    text="",
+                    new_text="<tool_call>" if index == 0 else "delta",
+                    finished=index == len(parser_results) - 1,
+                    finish_reason="stop" if index == len(parser_results) - 1 else None,
+                    prompt_tokens=3 if index == len(parser_results) - 1 else 0,
+                    completion_tokens=4 if index == len(parser_results) - 1 else 0,
+                )
+
+    class FakeParser:
+        def __init__(self):
+            self.index = 0
+
+        def extract_tool_calls_streaming(
+            self, previous_text, current_text, delta_text, request=None
+        ):
+            result = parser_results[self.index]
+            self.index += 1
+            return result
+
+    class FakeReasoningParser:
+        def __init__(self, tokenizer=None):
+            self.index = 0
+
+        def reset_state(self):
+            self.index = 0
+
+        def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
+            if self.index == 0:
+                self.index += 1
+                return SimpleNamespace(
+                    reasoning="sibling reasoning", content=delta_text
+                )
+            self.index += 1
+            return SimpleNamespace(reasoning=None, content=delta_text)
+
+    monkeypatch.setattr(server, "_model_name", "served-model")
+    monkeypatch.setattr(
+        server,
+        "_reasoning_parser",
+        FakeReasoningParser() if use_reasoning_parser else None,
+    )
+    monkeypatch.setattr(server, "_reasoning_parser_name", None)
+    monkeypatch.setattr(server, "_get_streaming_tool_parser", lambda *_: FakeParser())
+    monkeypatch.setattr(
+        server, "_streaming_tool_markup_possible_after_delta", lambda *_: True
+    )
+
+    request = ChatCompletionRequest(
+        model="served-model",
+        messages=[Message(role="user", content="run it")],
+        tools=_tool_schema({"argv": {"type": "array"}}),
+        stream=True,
+    )
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            FakeEngine(), request.messages, request
+        )
+    ]
+    payloads = [
+        json.loads(chunk.removeprefix("data: ").strip())
+        for chunk in chunks
+        if chunk != "data: [DONE]\n\n"
+    ]
+    choices = [payload["choices"][0] for payload in payloads if payload["choices"]]
+    content_deltas = [
+        choice["delta"].get("content")
+        for choice in choices
+        if choice["delta"].get("content")
+    ]
+    reasoning_deltas = [
+        choice["delta"].get("reasoning_content")
+        for choice in choices
+        if choice["delta"].get("reasoning_content")
+    ]
+    tool_payloads = [
+        payload
+        for payload in payloads
+        if payload["choices"] and payload["choices"][0]["delta"].get("tool_calls")
+    ]
+
+    assert content_deltas == ["sibling content"]
+    assert reasoning_deltas == (["sibling reasoning"] if use_reasoning_parser else [])
+    assert len(tool_payloads) == 1
+    tool_index = payloads.index(tool_payloads[0])
+    sibling_index = next(
+        index
+        for index, payload in enumerate(payloads)
+        if payload["choices"]
+        and payload["choices"][0]["delta"].get("content") == "sibling content"
+    )
+    assert sibling_index < tool_index
+    call = tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]
+    assert json.loads(call["function"]["arguments"]) == {"argv": ["printf"]}
     assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"

--- a/tests/test_tool_argument_coercion.py
+++ b/tests/test_tool_argument_coercion.py
@@ -1,0 +1,203 @@
+import json
+
+import pytest
+
+from vllm_mlx.server import (
+    _coerce_tool_arguments,
+    _finalize_streaming_tool_calls,
+    _merge_streaming_tool_call_fragments,
+    _requires_buffered_tool_argument_coercion,
+)
+
+
+def _tool_schema(properties):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "parameters": {"type": "object", "properties": properties},
+            },
+        }
+    ]
+
+
+def test_coerces_json_encoded_array_and_integer_to_declared_types():
+    arguments = json.dumps(
+        {
+            "argv": '["/usr/bin/printf", "transport-ok\\n"]',
+            "timeout_seconds": "1",
+        }
+    )
+    tools = _tool_schema(
+        {
+            "argv": {"type": "array", "items": {"type": "string"}},
+            "timeout_seconds": {"type": "integer"},
+        }
+    )
+
+    assert json.loads(_coerce_tool_arguments(arguments, "terminal", tools)) == {
+        "argv": ["/usr/bin/printf", "transport-ok\n"],
+        "timeout_seconds": 1,
+    }
+
+
+def test_preserves_invalid_value_when_conversion_is_not_lossless():
+    arguments = json.dumps({"argv": "not-json", "timeout_seconds": "1.5"})
+    tools = _tool_schema(
+        {
+            "argv": {"type": "array"},
+            "timeout_seconds": {"type": "integer"},
+        }
+    )
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+def test_preserves_value_that_already_matches_any_union_type():
+    arguments = json.dumps({"timeout_seconds": "1"})
+    tools = _tool_schema({"timeout_seconds": {"type": ["integer", "string"]}})
+
+    assert _coerce_tool_arguments(arguments, "terminal", tools) == arguments
+
+
+def test_preserves_existing_object_to_string_normalization():
+    arguments = json.dumps({"content": {"answer": 42}})
+    tools = _tool_schema({"content": {"type": "string"}})
+
+    normalized = json.loads(_coerce_tool_arguments(arguments, "terminal", tools))
+    assert json.loads(normalized["content"]) == {"answer": 42}
+
+
+def test_coerces_json_boolean_without_treating_it_as_integer():
+    arguments = json.dumps({"enabled": "true", "count": True})
+    tools = _tool_schema({"enabled": {"type": "boolean"}, "count": {"type": "integer"}})
+
+    assert json.loads(_coerce_tool_arguments(arguments, "terminal", tools)) == {
+        "enabled": True,
+        "count": True,
+    }
+
+
+def test_buffers_typed_stream_fragments_until_complete_json_is_available():
+    tools = _tool_schema(
+        {"argv": {"type": "array"}, "timeout_seconds": {"type": "integer"}}
+    )
+    calls = {}
+    fragments = [
+        {"index": 0, "id": "call_1", "function": {"name": "terminal"}},
+        {"index": 0, "function": {"arguments": '{"argv": "[\\"printf\\"]", '}},
+        {"index": 0, "function": {"arguments": '"timeout_seconds": "1"}'}},
+    ]
+
+    assert _requires_buffered_tool_argument_coercion(tools) is True
+    for fragment in fragments:
+        _merge_streaming_tool_call_fragments(calls, [fragment])
+
+    finalized = _finalize_streaming_tool_calls(calls, tools)
+    assert finalized == [
+        {
+            "index": 0,
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "arguments": json.dumps(
+                    {"argv": ["printf"], "timeout_seconds": 1},
+                    ensure_ascii=False,
+                ),
+            },
+        }
+    ]
+
+
+def test_string_only_schema_preserves_incremental_streaming():
+    assert (
+        _requires_buffered_tool_argument_coercion(
+            _tool_schema({"content": {"type": "string"}})
+        )
+        is False
+    )
+
+
+@pytest.mark.anyio
+async def test_stream_buffers_fragments_before_schema_coercion(monkeypatch):
+    from vllm_mlx.api.models import ChatCompletionRequest, Message
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.server import stream_chat_completion
+    import vllm_mlx.server as server
+
+    fragments = [
+        {"index": 0, "id": "call_1", "function": {"name": "terminal"}},
+        {"index": 0, "function": {"arguments": '{"argv": '}},
+        {"index": 0, "function": {"arguments": '"[\\"printf\\"]"'}},
+        {"index": 0, "function": {"arguments": ', "timeout_seconds": "1"}'}},
+    ]
+
+    class FakeEngine:
+        model_name = "fake-engine"
+
+        async def stream_chat(self, messages, **kwargs):
+            for index in range(len(fragments) + 1):
+                finished = index == len(fragments)
+                yield GenerationOutput(
+                    text="",
+                    new_text=f"fragment-{index}",
+                    finished=finished,
+                    finish_reason="stop" if finished else None,
+                    prompt_tokens=3 if finished else 0,
+                    completion_tokens=4 if finished else 0,
+                )
+
+    class FakeParser:
+        def __init__(self):
+            self.index = 0
+
+        def extract_tool_calls_streaming(
+            self, previous_text, current_text, delta_text, request=None
+        ):
+            if self.index == len(fragments):
+                return None
+            fragment = fragments[self.index]
+            self.index += 1
+            return {"tool_calls": [fragment]}
+
+    monkeypatch.setattr(server, "_model_name", "served-model")
+    monkeypatch.setattr(server, "_reasoning_parser", None)
+    monkeypatch.setattr(server, "_get_streaming_tool_parser", lambda *_: FakeParser())
+    monkeypatch.setattr(
+        server, "_streaming_tool_markup_possible_after_delta", lambda *_: True
+    )
+
+    request = ChatCompletionRequest(
+        model="served-model",
+        messages=[Message(role="user", content="run it")],
+        tools=_tool_schema(
+            {"argv": {"type": "array"}, "timeout_seconds": {"type": "integer"}}
+        ),
+        stream=True,
+    )
+    chunks = [
+        chunk
+        async for chunk in stream_chat_completion(
+            FakeEngine(), request.messages, request
+        )
+    ]
+    payloads = [
+        json.loads(chunk.removeprefix("data: ").strip())
+        for chunk in chunks
+        if chunk != "data: [DONE]\n\n"
+    ]
+    tool_payloads = [
+        payload
+        for payload in payloads
+        if payload["choices"] and payload["choices"][0]["delta"].get("tool_calls")
+    ]
+
+    assert len(tool_payloads) == 1
+    call = tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]
+    assert json.loads(call["function"]["arguments"]) == {
+        "argv": ["printf"],
+        "timeout_seconds": 1,
+    }
+    assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"

--- a/tests/test_tool_argument_coercion.py
+++ b/tests/test_tool_argument_coercion.py
@@ -6,7 +6,6 @@ from vllm_mlx.server import (
     _coerce_tool_arguments,
     _finalize_streaming_tool_calls,
     _merge_streaming_tool_call_fragments,
-    _requires_buffered_tool_argument_coercion,
 )
 
 
@@ -198,18 +197,23 @@ def test_buffers_typed_stream_fragments_until_complete_json_is_available():
         {"index": 0, "function": {"arguments": '"timeout_seconds": "1"}'}},
     ]
 
-    assert _requires_buffered_tool_argument_coercion(tools) is True
+    identities = []
     for fragment in fragments:
-        _merge_streaming_tool_call_fragments(calls, [fragment])
+        identities.extend(_merge_streaming_tool_call_fragments(calls, [fragment]))
+    assert identities == [
+        {
+            "index": 0,
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "terminal"},
+        }
+    ]
 
     finalized = _finalize_streaming_tool_calls(calls, tools)
     assert finalized == [
         {
             "index": 0,
-            "id": "call_1",
-            "type": "function",
             "function": {
-                "name": "terminal",
                 "arguments": json.dumps(
                     {"argv": ["printf"], "timeout_seconds": 1},
                     ensure_ascii=False,
@@ -219,13 +223,44 @@ def test_buffers_typed_stream_fragments_until_complete_json_is_available():
     ]
 
 
-def test_string_only_schema_preserves_incremental_streaming():
+def test_recovery_defaults_to_none():
+    from vllm_mlx.api.models import ChatCompletionRequest
+
+    request = ChatCompletionRequest(model="test", messages=[])
+    assert request.tool_argument_recovery == "none"
+
+
+@pytest.mark.parametrize(
+    "value", [None, True, False, 0, 1, "true", "BUFFERED", "unknown", {}, []]
+)
+def test_invalid_recovery_selector_is_rejected(value):
+    from pydantic import ValidationError
+    from vllm_mlx.api.models import ChatCompletionRequest
+
+    with pytest.raises(ValidationError) as exc:
+        ChatCompletionRequest(model="test", messages=[], tool_argument_recovery=value)
+    assert exc.value.errors()[0]["loc"] == ("tool_argument_recovery",)
+
+
+def test_buffered_identity_is_not_repeated_for_interleaved_calls():
+    calls = {}
+    first = {"index": 0, "id": "a", "function": {"name": "terminal", "arguments": "{"}}
+    second = {
+        "index": 1,
+        "id": "b",
+        "function": {"name": "terminal", "arguments": "{}"},
+    }
+    assert len(_merge_streaming_tool_call_fragments(calls, [first, second])) == 2
     assert (
-        _requires_buffered_tool_argument_coercion(
-            _tool_schema({"content": {"type": "string"}})
+        _merge_streaming_tool_call_fragments(
+            calls, [{**first, "function": {"name": "terminal", "arguments": "}"}}]
         )
-        is False
+        == []
     )
+    assert _finalize_streaming_tool_calls(calls, None) == [
+        {"index": 0, "function": {"arguments": "{}"}},
+        {"index": 1, "function": {"arguments": "{}"}},
+    ]
 
 
 @pytest.mark.anyio
@@ -284,6 +319,7 @@ async def test_stream_buffers_fragments_before_schema_coercion(monkeypatch):
             {"argv": {"type": "array"}, "timeout_seconds": {"type": "integer"}}
         ),
         stream=True,
+        tool_argument_recovery="buffered",
     )
     chunks = [
         chunk
@@ -302,19 +338,49 @@ async def test_stream_buffers_fragments_before_schema_coercion(monkeypatch):
         if payload["choices"] and payload["choices"][0]["delta"].get("tool_calls")
     ]
 
-    assert len(tool_payloads) == 1
-    call = tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]
+    assert len(tool_payloads) == 2
+    assert tool_payloads[0]["choices"][0]["delta"]["tool_calls"] == [
+        {
+            "index": 0,
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "terminal"},
+        }
+    ]
+    call = tool_payloads[-1]["choices"][0]["delta"]["tool_calls"][0]
     assert json.loads(call["function"]["arguments"]) == {
         "argv": ["printf"],
         "timeout_seconds": 1,
     }
-    assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+    assert tool_payloads[-1]["choices"][0]["finish_reason"] == "tool_calls"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("use_reasoning_parser", [False, True])
+@pytest.mark.parametrize("recovery", [None, "none", "buffered"])
+@pytest.mark.parametrize(
+    "arguments,properties,normalized",
+    [
+        (
+            '{"argv": "[\\"printf\\"]"}',
+            {"argv": {"type": "array"}},
+            {"argv": ["printf"]},
+        ),
+        (
+            '{"value": "[1, {\\"nested\\": 1e999}]"}',
+            {"value": {"type": "array"}},
+            {"value": '[1, {"nested": 1e999}]'},
+        ),
+        ('{ "content": "café" }', {"content": {"type": "string"}}, {"content": "café"}),
+        (
+            '{"content": {"b": "café", "a": 1}}',
+            {"content": {"type": "string"}},
+            {"content": '{"b":"café","a":1}'},
+        ),
+    ],
+)
 async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_call(
-    monkeypatch, use_reasoning_parser
+    monkeypatch, use_reasoning_parser, recovery, arguments, properties, normalized
 ):
     from types import SimpleNamespace
 
@@ -325,8 +391,8 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
 
     fragments = [
         {"index": 0, "id": "call_1", "function": {"name": "terminal"}},
-        {"index": 0, "function": {"arguments": '{"argv": '}},
-        {"index": 0, "function": {"arguments": '"[\\"printf\\"]"}'}},
+        {"index": 0, "function": {"arguments": arguments[:5]}},
+        {"index": 0, "function": {"arguments": arguments[5:]}},
     ]
     parser_results = [
         {"tool_calls": [fragments[0]], "content": "sibling content"},
@@ -391,8 +457,9 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
     request = ChatCompletionRequest(
         model="served-model",
         messages=[Message(role="user", content="run it")],
-        tools=_tool_schema({"argv": {"type": "array"}}),
+        tools=_tool_schema(properties),
         stream=True,
+        **({"tool_argument_recovery": recovery} if recovery is not None else {}),
     )
     chunks = [
         chunk
@@ -424,8 +491,27 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
 
     assert content_deltas == ["sibling content"]
     assert reasoning_deltas == (["sibling reasoning"] if use_reasoning_parser else [])
-    assert len(tool_payloads) == 1
-    tool_index = payloads.index(tool_payloads[0])
+    assert len(tool_payloads) == (2 if recovery == "buffered" else 3)
+    all_calls = [
+        call
+        for payload in tool_payloads
+        for call in payload["choices"][0]["delta"]["tool_calls"]
+    ]
+    assert [call["id"] for call in all_calls if "id" in call] == ["call_1"]
+    assert [
+        call["function"]["name"]
+        for call in all_calls
+        if "name" in call.get("function", {})
+    ] == ["terminal"]
+    argument_payloads = [
+        payload
+        for payload in tool_payloads
+        if any(
+            "arguments" in call.get("function", {})
+            for call in payload["choices"][0]["delta"]["tool_calls"]
+        )
+    ]
+    tool_index = payloads.index(argument_payloads[0])
     sibling_index = next(
         index
         for index, payload in enumerate(payloads)
@@ -433,6 +519,19 @@ async def test_stream_emits_sibling_content_and_reasoning_before_terminal_tool_c
         and payload["choices"][0]["delta"].get("content") == "sibling content"
     )
     assert sibling_index < tool_index
-    call = tool_payloads[0]["choices"][0]["delta"]["tool_calls"][0]
-    assert json.loads(call["function"]["arguments"]) == {"argv": ["printf"]}
-    assert tool_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+    assert payloads.index(tool_payloads[0]) == sibling_index
+    emitted_arguments = "".join(
+        call.get("function", {}).get("arguments", "") for call in all_calls
+    )
+    if recovery == "buffered":
+        assert len(argument_payloads) == 1
+        assert json.loads(emitted_arguments) == normalized
+        assert argument_payloads[0]["choices"][0]["finish_reason"] == "tool_calls"
+        if json.loads(arguments) == normalized:
+            assert emitted_arguments == arguments
+    else:
+        assert emitted_arguments == arguments
+        assert all(
+            payload["choices"][0]["finish_reason"] is None
+            for payload in argument_payloads
+        )

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -12,7 +12,7 @@ These models define the request and response schemas for:
 import re
 import time
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, Field, model_serializer, model_validator
 
@@ -184,6 +184,9 @@ class ChatCompletionRequest(BaseModel):
     # Tool calling
     tools: list[ToolDefinition] | None = None
     tool_choice: str | dict | None = None  # "auto", "none", or specific tool
+    # Streaming extension: buffer arguments until generation finishes before
+    # schema-aware recovery. IDs/names and content still stream immediately.
+    tool_argument_recovery: Literal["none", "buffered"] = "none"
     # Structured output
     response_format: ResponseFormat | dict | None = None
     # OpenAI-compatible token bias map: token id string -> bias value

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1821,13 +1821,7 @@ def get_engine() -> BaseEngine:
 def _coerce_tool_arguments(
     arguments_json: str, tool_name: str, tools: list[dict] | None
 ) -> str:
-    """
-    Coerce tool call arguments to match the tool schema.
-
-    If a schema field expects "string" but the model produced an object/array,
-    JSON-stringify the value. This fixes a common LLM failure mode where models
-    output raw JSON objects instead of JSON strings for file content, etc.
-    """
+    """Losslessly recover tool argument types from the request schema."""
     if not tools:
         return arguments_json
 
@@ -1853,16 +1847,133 @@ def _coerce_tool_arguments(
     changed = False
 
     for key, value in arguments.items():
-        if key in properties:
-            expected_type = properties[key].get("type")
-            if expected_type == "string" and isinstance(value, (dict, list)):
-                arguments[key] = json.dumps(value, ensure_ascii=False, indent=2)
-                changed = True
+        property_schema = properties.get(key)
+        if not isinstance(property_schema, dict):
+            continue
+        normalized = _coerce_tool_argument_value(value, property_schema.get("type"))
+        if normalized != value or type(normalized) is not type(value):
+            arguments[key] = normalized
+            changed = True
 
     if changed:
         return json.dumps(arguments, ensure_ascii=False)
 
     return arguments_json
+
+
+def _coerce_tool_argument_value(value: object, declared_type: object) -> object:
+    if isinstance(declared_type, str):
+        expected_types = (declared_type,)
+    elif isinstance(declared_type, list):
+        expected_types = tuple(item for item in declared_type if isinstance(item, str))
+    else:
+        return value
+
+    if any(_tool_argument_matches_type(value, kind) for kind in expected_types):
+        return value
+
+    if "string" in expected_types and isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, indent=2)
+
+    if not isinstance(value, str):
+        return value
+
+    for kind in expected_types:
+        normalized = _decode_tool_argument_string(value, kind)
+        if _tool_argument_matches_type(normalized, kind):
+            return normalized
+    return value
+
+
+def _decode_tool_argument_string(value: str, expected_type: str) -> object:
+    if expected_type not in {"array", "object", "integer", "number", "boolean", "null"}:
+        return value
+    try:
+        decoded = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+    return decoded
+
+
+def _tool_argument_matches_type(value: object, expected_type: str) -> bool:
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "null":
+        return value is None
+    return False
+
+
+def _requires_buffered_tool_argument_coercion(tools: list[dict] | None) -> bool:
+    """Return whether streamed arguments must be complete before coercion."""
+    recoverable_types = {"array", "object", "integer", "number", "boolean", "null"}
+    for tool in tools or []:
+        function = tool.get("function", {})
+        parameters = function.get("parameters", {})
+        for property_schema in parameters.get("properties", {}).values():
+            if not isinstance(property_schema, dict):
+                continue
+            declared_type = property_schema.get("type")
+            if isinstance(declared_type, str):
+                declared_types = {declared_type}
+            elif isinstance(declared_type, list):
+                declared_types = {
+                    item for item in declared_type if isinstance(item, str)
+                }
+            else:
+                continue
+            if declared_types & recoverable_types:
+                return True
+    return False
+
+
+def _merge_streaming_tool_call_fragments(
+    calls: dict[int, dict], fragments: list[dict]
+) -> None:
+    """Accumulate OpenAI tool-call deltas without interpreting partial JSON."""
+    for fragment in fragments:
+        index = int(fragment.get("index", 0))
+        call = calls.setdefault(
+            index,
+            {
+                "index": index,
+                "id": "",
+                "type": "function",
+                "function": {"name": "", "arguments": ""},
+            },
+        )
+        if fragment.get("id") and not call["id"]:
+            call["id"] = fragment["id"]
+        if fragment.get("type"):
+            call["type"] = fragment["type"]
+        function = fragment.get("function") or {}
+        if function.get("name") and not call["function"]["name"]:
+            call["function"]["name"] = function["name"]
+        call["function"]["arguments"] += function.get("arguments") or ""
+
+
+def _finalize_streaming_tool_calls(
+    calls: dict[int, dict], tools: list[dict] | None
+) -> list[dict]:
+    """Normalize complete buffered arguments and return ordered tool calls."""
+    finalized = []
+    for index in sorted(calls):
+        call = calls[index]
+        function = call["function"]
+        function["arguments"] = _coerce_tool_arguments(
+            function["arguments"], function["name"], tools
+        )
+        finalized.append(call)
+    return finalized
 
 
 def _validate_model_name(request_model: str) -> None:
@@ -6145,6 +6256,7 @@ async def _stream_anthropic_messages(
                             tool_result = _finalize_streaming_tool_result(
                                 tool_parser, tool_accumulated_text, tool_result
                             )
+
                         if tool_result is None:
                             # Inside tool markup, so suppress this delta.
                             continue
@@ -6217,6 +6329,7 @@ async def _stream_anthropic_messages(
                             tool_result = _finalize_streaming_tool_result(
                                 tool_parser, tool_accumulated_text, tool_result
                             )
+
                         if tool_result is None:
                             # Inside tool markup, so suppress this delta.
                             continue
@@ -6464,6 +6577,8 @@ async def stream_chat_completion(
     tool_calls_detected = False
     tool_parser = _get_streaming_tool_parser(request, engine)
     tool_markup_possible = _requires_eager_tool_streaming(tool_parser)
+    buffer_typed_tool_calls = _requires_buffered_tool_argument_coercion(tools_dict)
+    buffered_tool_calls: dict[int, dict] = {}
     # Whether any emitted chunk carried a terminal finish_reason. The engine's
     # finished=True output can be swallowed by a parser `continue` below (e.g.
     # a bare end-of-turn token arriving after a completed tool call); without
@@ -6559,6 +6674,14 @@ async def stream_chat_completion(
                                 tool_parser, tool_accumulated_text, tool_result
                             )
 
+                        if (
+                            output.finished
+                            and buffer_typed_tool_calls
+                            and buffered_tool_calls
+                            and not (tool_result or {}).get("tool_calls")
+                        ):
+                            tool_result = {**(tool_result or {}), "tool_calls": []}
+
                         if tool_result is None:
                             # Inside tool markup - suppress content output
                             if reasoning:
@@ -6582,8 +6705,17 @@ async def stream_chat_completion(
                         if "tool_calls" in tool_result:
                             # Emit structured tool calls
                             tool_calls_detected = True
-                            # Coerce arguments against tool schemas
-                            if tools_dict:
+                            emitted_tool_calls = tool_result["tool_calls"]
+                            if buffer_typed_tool_calls:
+                                _merge_streaming_tool_call_fragments(
+                                    buffered_tool_calls, emitted_tool_calls
+                                )
+                                if not output.finished:
+                                    continue
+                                emitted_tool_calls = _finalize_streaming_tool_calls(
+                                    buffered_tool_calls, tools_dict
+                                )
+                            elif tools_dict:
                                 for tc in tool_result["tool_calls"]:
                                     fn = tc.get("function", {})
                                     if "arguments" in fn and "name" in fn:
@@ -6596,7 +6728,7 @@ async def stream_chat_completion(
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
-                                            tool_calls=tool_result["tool_calls"],
+                                            tool_calls=emitted_tool_calls,
                                             content=tool_result.get("content") or None,
                                             reasoning=reasoning,
                                         ),
@@ -6710,6 +6842,14 @@ async def stream_chat_completion(
                                 tool_parser, tool_accumulated_text, tool_result
                             )
 
+                        if (
+                            output.finished
+                            and buffer_typed_tool_calls
+                            and buffered_tool_calls
+                            and not (tool_result or {}).get("tool_calls")
+                        ):
+                            tool_result = {**(tool_result or {}), "tool_calls": []}
+
                         if tool_result is None:
                             # Inside tool markup - suppress output
                             continue
@@ -6717,8 +6857,17 @@ async def stream_chat_completion(
                         if "tool_calls" in tool_result:
                             # Emit structured tool calls
                             tool_calls_detected = True
-                            # Coerce arguments against tool schemas
-                            if tools_dict:
+                            emitted_tool_calls = tool_result["tool_calls"]
+                            if buffer_typed_tool_calls:
+                                _merge_streaming_tool_call_fragments(
+                                    buffered_tool_calls, emitted_tool_calls
+                                )
+                                if not output.finished:
+                                    continue
+                                emitted_tool_calls = _finalize_streaming_tool_calls(
+                                    buffered_tool_calls, tools_dict
+                                )
+                            elif tools_dict:
                                 for tc in tool_result["tool_calls"]:
                                     fn = tc.get("function", {})
                                     if "arguments" in fn and "name" in fn:
@@ -6731,7 +6880,7 @@ async def stream_chat_completion(
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
-                                            tool_calls=tool_result["tool_calls"],
+                                            tool_calls=emitted_tool_calls,
                                             content=tool_result.get("content") or None,
                                         ),
                                         finish_reason=(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1873,7 +1873,7 @@ def _coerce_tool_argument_value(value: object, declared_type: object) -> object:
         return value
 
     if "string" in expected_types and isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False, indent=2)
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
 
     if not isinstance(value, str):
         return value

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1856,7 +1856,11 @@ def _coerce_tool_arguments(
             changed = True
 
     if changed:
-        return json.dumps(arguments, ensure_ascii=False)
+        try:
+            return json.dumps(arguments, ensure_ascii=False, allow_nan=False)
+        except ValueError:
+            # Do not replace non-JSON numbers or alter an invalid source payload.
+            return arguments_json
 
     return arguments_json
 
@@ -1873,7 +1877,12 @@ def _coerce_tool_argument_value(value: object, declared_type: object) -> object:
         return value
 
     if "string" in expected_types and isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        try:
+            return json.dumps(
+                value, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+            )
+        except ValueError:
+            return value
 
     if not isinstance(value, str):
         return value
@@ -1890,7 +1899,10 @@ def _decode_tool_argument_string(value: str, expected_type: str) -> object:
         return value
     try:
         decoded = json.loads(value)
-    except (json.JSONDecodeError, TypeError):
+        # Check nested values too: Python accepts NaN/Infinity and overflow
+        # during loads, but these must not become newly emitted JSON numbers.
+        json.dumps(decoded, allow_nan=False)
+    except (ValueError, TypeError):
         return value
     return decoded
 
@@ -6711,10 +6723,13 @@ async def stream_chat_completion(
                                     buffered_tool_calls, emitted_tool_calls
                                 )
                                 if not output.finished:
-                                    continue
-                                emitted_tool_calls = _finalize_streaming_tool_calls(
-                                    buffered_tool_calls, tools_dict
-                                )
+                                    emitted_tool_calls = []
+                                    if not tool_result.get("content") and not reasoning:
+                                        continue
+                                else:
+                                    emitted_tool_calls = _finalize_streaming_tool_calls(
+                                        buffered_tool_calls, tools_dict
+                                    )
                             elif tools_dict:
                                 for tc in tool_result["tool_calls"]:
                                     fn = tc.get("function", {})
@@ -6728,7 +6743,7 @@ async def stream_chat_completion(
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
-                                            tool_calls=emitted_tool_calls,
+                                            tool_calls=emitted_tool_calls or None,
                                             content=tool_result.get("content") or None,
                                             reasoning=reasoning,
                                         ),
@@ -6863,10 +6878,13 @@ async def stream_chat_completion(
                                     buffered_tool_calls, emitted_tool_calls
                                 )
                                 if not output.finished:
-                                    continue
-                                emitted_tool_calls = _finalize_streaming_tool_calls(
-                                    buffered_tool_calls, tools_dict
-                                )
+                                    emitted_tool_calls = []
+                                    if not tool_result.get("content"):
+                                        continue
+                                else:
+                                    emitted_tool_calls = _finalize_streaming_tool_calls(
+                                        buffered_tool_calls, tools_dict
+                                    )
                             elif tools_dict:
                                 for tc in tool_result["tool_calls"]:
                                     fn = tc.get("function", {})
@@ -6880,7 +6898,7 @@ async def stream_chat_completion(
                                 choices=[
                                     ChatCompletionChunkChoice(
                                         delta=ChatCompletionChunkDelta(
-                                            tool_calls=emitted_tool_calls,
+                                            tool_calls=emitted_tool_calls or None,
                                             content=tool_result.get("content") or None,
                                         ),
                                         finish_reason=(

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1925,33 +1925,11 @@ def _tool_argument_matches_type(value: object, expected_type: str) -> bool:
     return False
 
 
-def _requires_buffered_tool_argument_coercion(tools: list[dict] | None) -> bool:
-    """Return whether streamed arguments must be complete before coercion."""
-    recoverable_types = {"array", "object", "integer", "number", "boolean", "null"}
-    for tool in tools or []:
-        function = tool.get("function", {})
-        parameters = function.get("parameters", {})
-        for property_schema in parameters.get("properties", {}).values():
-            if not isinstance(property_schema, dict):
-                continue
-            declared_type = property_schema.get("type")
-            if isinstance(declared_type, str):
-                declared_types = {declared_type}
-            elif isinstance(declared_type, list):
-                declared_types = {
-                    item for item in declared_type if isinstance(item, str)
-                }
-            else:
-                continue
-            if declared_types & recoverable_types:
-                return True
-    return False
-
-
 def _merge_streaming_tool_call_fragments(
     calls: dict[int, dict], fragments: list[dict]
-) -> None:
-    """Accumulate OpenAI tool-call deltas without interpreting partial JSON."""
+) -> list[dict]:
+    """Buffer arguments, returning newly established call identity once."""
+    identities = []
     for fragment in fragments:
         index = int(fragment.get("index", 0))
         call = calls.setdefault(
@@ -1963,28 +1941,35 @@ def _merge_streaming_tool_call_fragments(
                 "function": {"name": "", "arguments": ""},
             },
         )
+        identity = {"index": index}
         if fragment.get("id") and not call["id"]:
             call["id"] = fragment["id"]
+            identity["id"] = call["id"]
+            identity["type"] = fragment.get("type") or "function"
         if fragment.get("type"):
             call["type"] = fragment["type"]
         function = fragment.get("function") or {}
         if function.get("name") and not call["function"]["name"]:
             call["function"]["name"] = function["name"]
+            identity["function"] = {"name": function["name"]}
         call["function"]["arguments"] += function.get("arguments") or ""
+        if len(identity) > 1:
+            identities.append(identity)
+    return identities
 
 
 def _finalize_streaming_tool_calls(
     calls: dict[int, dict], tools: list[dict] | None
 ) -> list[dict]:
-    """Normalize complete buffered arguments and return ordered tool calls."""
+    """Emit complete arguments only; call identities have already streamed."""
     finalized = []
     for index in sorted(calls):
         call = calls[index]
         function = call["function"]
-        function["arguments"] = _coerce_tool_arguments(
+        arguments = _coerce_tool_arguments(
             function["arguments"], function["name"], tools
         )
-        finalized.append(call)
+        finalized.append({"index": index, "function": {"arguments": arguments}})
     return finalized
 
 
@@ -6589,7 +6574,7 @@ async def stream_chat_completion(
     tool_calls_detected = False
     tool_parser = _get_streaming_tool_parser(request, engine)
     tool_markup_possible = _requires_eager_tool_streaming(tool_parser)
-    buffer_typed_tool_calls = _requires_buffered_tool_argument_coercion(tools_dict)
+    buffer_typed_tool_calls = request.tool_argument_recovery == "buffered"
     buffered_tool_calls: dict[int, dict] = {}
     # Whether any emitted chunk carried a terminal finish_reason. The engine's
     # finished=True output can be swallowed by a parser `continue` below (e.g.
@@ -6719,24 +6704,24 @@ async def stream_chat_completion(
                             tool_calls_detected = True
                             emitted_tool_calls = tool_result["tool_calls"]
                             if buffer_typed_tool_calls:
-                                _merge_streaming_tool_call_fragments(
-                                    buffered_tool_calls, emitted_tool_calls
+                                emitted_tool_calls = (
+                                    _merge_streaming_tool_call_fragments(
+                                        buffered_tool_calls, emitted_tool_calls
+                                    )
                                 )
                                 if not output.finished:
-                                    emitted_tool_calls = []
-                                    if not tool_result.get("content") and not reasoning:
+                                    if (
+                                        not emitted_tool_calls
+                                        and not tool_result.get("content")
+                                        and not reasoning
+                                    ):
                                         continue
                                 else:
-                                    emitted_tool_calls = _finalize_streaming_tool_calls(
-                                        buffered_tool_calls, tools_dict
-                                    )
-                            elif tools_dict:
-                                for tc in tool_result["tool_calls"]:
-                                    fn = tc.get("function", {})
-                                    if "arguments" in fn and "name" in fn:
-                                        fn["arguments"] = _coerce_tool_arguments(
-                                            fn["arguments"], fn["name"], tools_dict
+                                    emitted_tool_calls += (
+                                        _finalize_streaming_tool_calls(
+                                            buffered_tool_calls, tools_dict
                                         )
+                                    )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
                                 model=_response_model_name(request.model),
@@ -6874,24 +6859,22 @@ async def stream_chat_completion(
                             tool_calls_detected = True
                             emitted_tool_calls = tool_result["tool_calls"]
                             if buffer_typed_tool_calls:
-                                _merge_streaming_tool_call_fragments(
-                                    buffered_tool_calls, emitted_tool_calls
+                                emitted_tool_calls = (
+                                    _merge_streaming_tool_call_fragments(
+                                        buffered_tool_calls, emitted_tool_calls
+                                    )
                                 )
                                 if not output.finished:
-                                    emitted_tool_calls = []
-                                    if not tool_result.get("content"):
+                                    if not emitted_tool_calls and not tool_result.get(
+                                        "content"
+                                    ):
                                         continue
                                 else:
-                                    emitted_tool_calls = _finalize_streaming_tool_calls(
-                                        buffered_tool_calls, tools_dict
-                                    )
-                            elif tools_dict:
-                                for tc in tool_result["tool_calls"]:
-                                    fn = tc.get("function", {})
-                                    if "arguments" in fn and "name" in fn:
-                                        fn["arguments"] = _coerce_tool_arguments(
-                                            fn["arguments"], fn["name"], tools_dict
+                                    emitted_tool_calls += (
+                                        _finalize_streaming_tool_calls(
+                                            buffered_tool_calls, tools_dict
                                         )
+                                    )
                             chunk = ChatCompletionChunk(
                                 id=response_id,
                                 model=_response_model_name(request.model),


### PR DESCRIPTION
## Summary

- Recover JSON-encoded tool values conservatively using the declared schema.
- Preserve default incremental argument streaming. Explicit `tool_argument_recovery="buffered"` delays argument bytes until generation finishes while emitting established IDs/names and independent content/reasoning.
- Leave nonfinite, overflowing, or incompatible values unconverted rather than introducing invalid JSON numbers.
- Serialize actual dict/list values targeting strings as compact UTF-8 JSON without sorting keys; preserve already-correct string bytes.

## Why

Models can emit arrays or integers as JSON-encoded strings that strict tool clients reject. Safe recovery needs complete arguments. Buffered streaming is therefore opt-in and delays even already-valid arguments; it does not provide early per-call completion. The selector affects streaming only. Non-streaming continues to recover complete arguments. This is conservative type recovery, not full schema enforcement.

## Verification

- At `4054645`, 56 focused tests passed, covering both streaming branches, selector validation, mixed content/reasoning, call identity, finite JSON, and exact string bytes.
- Selected-source suite: 2,975 passed, 17 skipped for optional Harmony/model-artifact prerequisites, and 69 deselected by slow/integration filters.
- The new selectable streaming mode has not been live-qualified or locally adopted. Local test results above are from `4054645`; `cec511f` changes only the reasoning-parser test fixture. All 10 GitHub checks pass on `cec511f`, including both Apple Silicon jobs.
