### PR TITLE
fix(mllm): make hybrid prefix-cache replay owned and exact

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -265,6 +265,14 @@ class TestCacheEntry:
         assert entry.cache is cache
         assert entry.memory_bytes == 200
 
+    def test_create_entry_accounts_for_auxiliary_arrays(self):
+        cache = [MockKVCache(100, 100)]
+        entry = _CacheEntry.create(
+            [1, 2, 3], cache, auxiliary={"last_logits": MockArray(64)}
+        )
+
+        assert entry.memory_bytes == 264
+
 
 class TestMemoryAwarePrefixCache:
     """Tests for MemoryAwarePrefixCache."""
@@ -298,6 +306,35 @@ class TestMemoryAwarePrefixCache:
         assert len(cache) == 0
         assert cache.memory_limit_mb == 100.0
 
+    def test_prepare_store_rejects_auxiliary_over_memory_limit(
+        self, small_cache, mock_kv_cache
+    ):
+        entry = small_cache.prepare_store(
+            [1, 2, 3],
+            mock_kv_cache(512 * 1024),
+            auxiliary={"last_logits": MockArray(600 * 1024)},
+        )
+
+        assert entry is None
+        assert len(small_cache) == 0
+        stats = small_cache.get_stats()
+        assert stats["store_rejections"] == 1
+        assert stats["current_memory_mb"] == 0
+
+    def test_commit_rejects_oversized_prepared_entry(self, small_cache):
+        entry = _CacheEntry(
+            tokens=(1, 2, 3),
+            cache=[],
+            memory_bytes=2 * 1024 * 1024,
+            auxiliary=None,
+        )
+
+        assert small_cache.commit_prepared(entry) is False
+        assert len(small_cache) == 0
+        stats = small_cache.get_stats()
+        assert stats["store_rejections"] == 1
+        assert stats["current_memory_mb"] == 0
+
     def test_store_and_fetch_exact_match(self, small_cache, mock_kv_cache):
         tokens = [1, 2, 3, 4, 5]
         kv = mock_kv_cache(1000)
@@ -315,6 +352,49 @@ class TestMemoryAwarePrefixCache:
         assert result[0].keys is kv[0].keys
         assert result[0].values is kv[0].values
         assert remaining == []
+
+    def test_prepared_kv_entry_is_not_contaminated_by_live_suffix(self, small_cache):
+        mx = pytest.importorskip("mlx.core")
+        KVCache = pytest.importorskip("mlx_lm.models.cache").KVCache
+
+        live = KVCache()
+        first_keys = mx.array([[[[1.0], [2.0], [3.0]]]])
+        first_values = mx.array([[[[11.0], [12.0], [13.0]]]])
+        live.update_and_fetch(first_keys, first_values)
+
+        prepared = small_cache.prepare_store([1, 2, 3], [live])
+        assert prepared is not None
+
+        live.update_and_fetch(
+            mx.array([[[[4.0], [5.0]]]]),
+            mx.array([[[[14.0], [15.0]]]]),
+        )
+        assert small_cache.commit_prepared(prepared)
+
+        stored, remaining = small_cache.fetch([1, 2, 3])
+        assert remaining == []
+        assert stored[0].offset == 3
+        assert stored[0].keys.shape[2] == 3
+        assert stored[0].keys.tolist() == first_keys.tolist()
+        assert stored[0].values.tolist() == first_values.tolist()
+
+    def test_commit_guard_rejects_before_prefix_eviction(
+        self, small_cache, mock_kv_cache
+    ):
+        base = [1, 2]
+        candidate = [1, 2, 3]
+        assert small_cache.store(base, mock_kv_cache(1000))
+
+        prepared = small_cache.prepare_store(candidate, mock_kv_cache(1000))
+        assert prepared is not None
+        assert not small_cache.commit_prepared(
+            prepared,
+            commit_lock=threading.Lock(),
+            commit_guard=lambda: False,
+        )
+
+        assert tuple(base) in small_cache._entries
+        assert tuple(candidate) not in small_cache._entries
 
     def test_short_prefix_reuse_is_rejected(self, model, mock_kv_cache):
         cache = MemoryAwarePrefixCache(

--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -378,6 +378,42 @@ class TestMemoryAwarePrefixCache:
         assert stored[0].keys.tolist() == first_keys.tolist()
         assert stored[0].values.tolist() == first_values.tolist()
 
+    def test_prepared_hybrid_entry_owns_arrays_and_state_containers(self, small_cache):
+        mx = pytest.importorskip("mlx.core")
+        cache_module = pytest.importorskip("mlx_lm.models.cache")
+
+        live_arrays = cache_module.ArraysCache(size=1)
+        prompt_state = mx.array([[1.0, 2.0, 3.0]])
+        live_arrays[0] = prompt_state
+        live_kv = cache_module.KVCache()
+        prompt_keys = mx.array([[[[1.0], [2.0], [3.0]]]])
+        prompt_values = prompt_keys + 10
+        live_kv.update_and_fetch(prompt_keys, prompt_values)
+
+        prepared = small_cache.prepare_store(
+            [1, 2, 3],
+            [live_arrays, live_kv],
+        )
+        assert prepared is not None
+
+        live_arrays[0] = mx.array([[9.0, 9.0, 9.0]])
+        live_kv.update_and_fetch(
+            mx.array([[[[4.0]]]]),
+            mx.array([[[[14.0]]]]),
+        )
+        assert small_cache.commit_prepared(prepared)
+
+        stored, remaining = small_cache.fetch([1, 2, 3])
+        assert remaining == []
+        assert stored[0] is not live_arrays
+        assert stored[0].state is not live_arrays.state
+        assert stored[0][0] is not prompt_state
+        assert stored[0][0].tolist() == [[1.0, 2.0, 3.0]]
+        assert stored[1] is not live_kv
+        assert stored[1].keys is not live_kv.keys
+        assert stored[1].keys.tolist() == prompt_keys.tolist()
+        assert stored[1].values.tolist() == prompt_values.tolist()
+
     def test_commit_guard_rejects_before_prefix_eviction(
         self, small_cache, mock_kv_cache
     ):

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -366,6 +366,106 @@ class TestMLLMBatch:
         assert batch.uids == [1, 3]
         assert batch.request_ids == ["req-1", "req-3"]
 
+    def test_batch_filter_preserves_request_local_mrope_rows(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+
+        requests = [
+            MLLMBatchRequest(
+                uid=i,
+                request_id=f"req-{i}",
+                prompt="prompt",
+                rope_deltas=mx.array([[delta]], dtype=mx.int32),
+            )
+            for i, delta in enumerate((4, 9))
+        ]
+        batch = MLLMBatch(
+            uids=[0, 1],
+            request_ids=["req-0", "req-1"],
+            y=mx.array([100, 200]),
+            logprobs=[mx.array([0.1]), mx.array([0.2])],
+            max_tokens=[10, 10],
+            num_tokens=[0, 0],
+            cache=[],
+            requests=requests,
+        )
+
+        assert MLLMBatchGenerator._batch_rope_deltas(batch.requests).tolist() == [
+            [4],
+            [9],
+        ]
+        batch.filter([1])
+        assert MLLMBatchGenerator._batch_rope_deltas(batch.requests).tolist() == [[9]]
+
+    def test_step_forwards_explicit_request_local_mrope(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        captured = []
+
+        def language_model(tokens, cache=None, rope_deltas=None):
+            del cache
+            captured.append(rope_deltas.tolist())
+            return mx.zeros((tokens.shape[0], tokens.shape[1], 4))
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.language_model = language_model
+        generator.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+        generator._step(
+            mx.array([[1], [2]]),
+            [],
+            rope_deltas=mx.array([[4], [9]], dtype=mx.int32),
+        )
+
+        assert captured == [[[4], [9]]]
+
+    def test_request_mrope_is_derived_from_full_processed_prompt(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+        )
+
+        captured = {}
+
+        class LanguageModel:
+            def get_rope_index(
+                self,
+                input_ids,
+                image_grid_thw=None,
+                video_grid_thw=None,
+                attention_mask=None,
+            ):
+                captured["input_ids"] = input_ids.tolist()
+                captured["image_grid_thw"] = image_grid_thw.tolist()
+                captured["video_grid_thw"] = video_grid_thw.tolist()
+                captured["attention_mask"] = attention_mask.tolist()
+                return mx.zeros((3, input_ids.shape[1])), mx.array([[11]])
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.language_model = LanguageModel()
+        request = MLLMBatchRequest(uid=1, request_id="media", prompt="prompt")
+        request.input_ids = mx.array([[1, 2, 3, 4]])
+        request.image_grid_thw = mx.array([[1, 2, 2]])
+        request.attention_mask = mx.ones((1, 4))
+        request.extra_kwargs = {"video_grid_thw": mx.array([[2, 2, 2]])}
+
+        rope_deltas = generator._derive_request_rope_deltas(request)
+
+        assert rope_deltas.tolist() == [[11]]
+        assert request.prompt_position_ids.tolist() == [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+        assert captured == {
+            "input_ids": [[1, 2, 3, 4]],
+            "image_grid_thw": [[1, 2, 2]],
+            "video_grid_thw": [[2, 2, 2]],
+            "attention_mask": [[1.0, 1.0, 1.0, 1.0]],
+        }
+
     def test_batch_extend_handles_empty_protocol_caches_without_keys(self):
         """Caches with empty()/extend() but no .keys still need batch extension."""
         from vllm_mlx.mllm_batch_generator import MLLMBatch, MLLMBatchRequest
@@ -997,6 +1097,172 @@ class TestMLLMBatchGeneratorMTPGuards:
         fallback_sampler.assert_not_called()
         assert sampler_calls == [{"temp": 0.3, "top_p": 0.8, "top_k": 0, "min_p": 0.0}]
 
+    def test_process_prompts_cold_and_prefix_hit_use_full_prompt_mrope(
+        self, monkeypatch
+    ):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FakeCache:
+            offset = 1
+
+            def is_trimmable(self):
+                return True
+
+            def merge(self, _caches):
+                return self
+
+        class PrefixCache:
+            warm = False
+
+            def fetch(self, _tokens):
+                return ([FakeCache()], [4]) if self.warm else (None, None)
+
+        class QwenLikeLanguageModel:
+            def __init__(self):
+                self.calls = []
+
+            def get_rope_index(self, input_ids, *_args):
+                positions = mx.broadcast_to(
+                    mx.arange(input_ids.shape[1])[None, None, :],
+                    (3, 1, input_ids.shape[1]),
+                )
+                return positions, mx.array([[13]])
+
+            def __call__(self, tokens, cache=None, rope_deltas=None, position_ids=None):
+                del cache
+                self.calls.append(
+                    (
+                        tokens.tolist(),
+                        rope_deltas.tolist(),
+                        position_ids.tolist(),
+                    )
+                )
+                logits = mx.zeros((1, tokens.shape[1], 4))
+                logits[:, -1, 2] = 5.0
+                return logits
+
+        monkeypatch.setattr(mx, "stream", lambda _stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_a, **_k: [FakeCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_kwargs: lambda scores: mx.argmax(scores, axis=-1),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_kwargs: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        generator.prefill_step_size = 512
+        generator._think_suffix_len = 0
+        generator.language_model = QwenLikeLanguageModel()
+        generator.model = MagicMock()
+        generator.sampler = lambda scores: mx.argmax(scores, axis=-1)
+        generator.prefix_cache = PrefixCache()
+        generator._preprocess_request = lambda _request: None
+        generator._prepare_rotating_caches = lambda _cache: True
+        generator._copy_prefix_cache = lambda cache: cache
+
+        def request(request_id):
+            req = MLLMBatchRequest(uid=1, request_id=request_id, prompt="prompt")
+            req.input_ids = mx.array([[1, 2, 3, 4]])
+            req.is_text_only = True
+            return req
+
+        cold = generator._process_prompts([request("cold")])
+        generator.prefix_cache.warm = True
+        warm = generator._process_prompts([request("warm")])
+
+        assert cold.y.tolist() == warm.y.tolist() == [2]
+        assert generator.language_model.calls == [
+            (
+                [[1, 2, 3, 4]],
+                [[13]],
+                [[[0, 1, 2, 3]], [[0, 1, 2, 3]], [[0, 1, 2, 3]]],
+            ),
+            ([[4]], [[13]], [[[3]], [[3]], [[3]]]),
+        ]
+
+    def test_hybrid_cold_path_samples_from_owned_prompt_logits(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        class FakeCache:
+            def merge(self, _caches):
+                return self
+
+        class PrefixCache:
+            def fetch(self, tokens):
+                return None, tokens
+
+            def prepare_store(self, tokens, cache, auxiliary=None):
+                assert int(mx.argmax(auxiliary["last_logits"], axis=-1).item()) == 1
+                return SimpleNamespace(
+                    tokens=tuple(tokens),
+                    cache=cache,
+                    auxiliary={"last_logits": mx.array([[0.0, 0.0, 9.0, 0.0]])},
+                )
+
+            def commit_prepared(self, _entry, **kwargs):
+                return kwargs["commit_guard"]()
+
+        monkeypatch.setattr(mx, "stream", lambda _stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_a, **_k: [FakeCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_kwargs: lambda scores: mx.argmax(scores, axis=-1),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_kwargs: []
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        generator.prefill_step_size = 512
+        generator._think_suffix_len = 0
+        generator.language_model = object()
+        generator.model = MagicMock()
+        generator.sampler = lambda scores: mx.argmax(scores, axis=-1)
+        generator.prefix_cache = PrefixCache()
+        generator._preprocess_request = lambda _request: None
+        generator._needs_prefill_checkpoint = lambda _cache: True
+        generator._clone_prefix_for_replay = lambda cache: list(cache)
+        generator._prepare_rotating_caches = lambda _cache: True
+        generator._run_chunked_text_prefill = lambda _request, cache: mx.array(
+            [[[0.0, 8.0, 0.0, 0.0]]]
+        )
+
+        request = MLLMBatchRequest(uid=1, request_id="cold-owned", prompt="prompt")
+        request.input_ids = mx.array([[1, 2, 3, 4]])
+        request.is_text_only = True
+
+        batch = generator._process_prompts([request])
+
+        assert batch.y.tolist() == [2]
+
     def test_next_passes_current_token_to_logits_processor_prefix(self):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatch,
@@ -1045,6 +1311,59 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert captured["input_tokens"] == [[7]]
         assert captured["output_tokens"] == [[5, 7]]
         assert request.output_tokens == [5, 7]
+
+    def test_next_reorders_request_local_mrope_after_filter(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+        )
+
+        captured = []
+
+        def fake_step(*_args, rope_deltas=None, **_kwargs):
+            captured.append(rope_deltas.tolist())
+            size = rope_deltas.shape[0]
+            return mx.ones((size,), dtype=mx.int32), [mx.zeros((4,))] * size
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator.stop_tokens = set()
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator._maybe_store_prefix_cache = lambda *_args: None
+        generator._step = fake_step
+
+        requests = [
+            MLLMBatchRequest(
+                uid=i,
+                request_id=f"req-{i}",
+                prompt="prompt",
+                max_tokens=10,
+                rope_deltas=mx.array([[delta]]),
+            )
+            for i, delta in enumerate((4, 9))
+        ]
+        generator.active_batch = MLLMBatch(
+            uids=[0, 1],
+            request_ids=["req-0", "req-1"],
+            y=mx.array([1, 1]),
+            logprobs=[mx.zeros((4,)), mx.zeros((4,))],
+            max_tokens=[10, 10],
+            num_tokens=[0, 0],
+            cache=[],
+            requests=requests,
+        )
+
+        generator._next()
+        generator.active_batch.filter([1])
+        generator._next()
+
+        assert captured == [[[4], [9]], [[9]]]
 
     def test_install_mtp_mllm_disables_mtp_when_logits_processors_active(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
@@ -1153,6 +1472,48 @@ class TestMLLMBatchGeneratorMTPGuards:
         original_step.assert_called_once()
         language_model.assert_not_called()
         assert batch_gen.get_mtp_stats()["attempted"] == 0
+        assert (
+            batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
+        )
+
+    def test_external_media_mtp_bypass_preserves_target_mrope(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_mtp_mllm,
+        )
+
+        rope_deltas = mx.array([[21]], dtype=mx.int32)
+        expected = (mx.array([2]), [mx.zeros((4,))])
+        original_step = MagicMock(return_value=expected)
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="media",
+            prompt="prompt",
+            images=["image"],
+            mllm_draft=True,
+            rope_deltas=rope_deltas,
+        )
+        batch_gen = SimpleNamespace(
+            model=object(),
+            _step=original_step,
+            _next=lambda: [],
+            active_batch=SimpleNamespace(uids=[1], requests=[request]),
+            sampler=lambda scores: mx.argmax(scores, axis=-1),
+        )
+        language_model = MagicMock()
+        draft_model = MagicMock()
+        install_mtp_mllm(batch_gen, language_model, draft_model=draft_model)
+
+        result = batch_gen._step(
+            mx.array([[1]]),
+            [],
+            rope_deltas=rope_deltas,
+        )
+
+        assert result is expected
+        original_step.assert_called_once()
+        assert original_step.call_args.kwargs["rope_deltas"].tolist() == [[21]]
+        language_model.assert_not_called()
         assert (
             batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
         )
@@ -1306,6 +1667,8 @@ class TestMLLMBatchGeneratorMTPGuards:
         generator._require_uniform_mllm_draft = True
         generator._allow_mid_batch_extend = False
         generator._pending_error_responses = []
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
         generator._process_prompts = MagicMock(side_effect=RuntimeError("failed"))
 
         responses = MLLMBatchGenerator._next(generator)
@@ -1408,6 +1771,78 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert model.mtp_calls == 1
         assert generator.get_mtp_stats()["attempted"] == 1
         assert generator.get_mtp_stats()["accepted"] == 1
+
+    def test_native_mtp_forwards_mrope_through_verify_and_hybrid_replay(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_mtp_mllm,
+        )
+
+        rope_deltas = mx.array([[7]], dtype=mx.int32)
+        request = MLLMBatchRequest(uid=7, request_id="mrope", prompt="prompt")
+
+        class Batch:
+            uids = [7]
+            requests = [request]
+
+            def __len__(self):
+                return 1
+
+        class Generator:
+            def __init__(self):
+                self.active_batch = Batch()
+                self._step = self._original_step
+                self._next = lambda: []
+                self.sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+
+            @staticmethod
+            def _original_step(*_args, **_kwargs):
+                raise AssertionError("native MTP must not take the bypass path")
+
+        class HybridCache:
+            def __init__(self):
+                self.state = [mx.zeros((1, 1))]
+
+            def is_trimmable(self):
+                return False
+
+        class LanguageModel:
+            def __init__(self):
+                self.calls = []
+
+            def mtp_forward(self, hidden_states, next_token_ids, mtp_cache=None):
+                del hidden_states, next_token_ids, mtp_cache
+                return mx.array([[[0.0, 5.0, -3.0]]])
+
+            def __call__(
+                self,
+                input_tokens,
+                cache=None,
+                return_hidden=False,
+                rope_deltas=None,
+            ):
+                del cache, return_hidden
+                self.calls.append((input_tokens.shape[1], rope_deltas.tolist()))
+                seq_len = input_tokens.shape[1]
+                logits = mx.full((1, seq_len, 3), -3.0)
+                if seq_len == 1:
+                    logits[:, :, 1] = 5.0
+                else:
+                    logits[:, 0, 2] = 5.0
+                    logits[:, 1, 2] = 5.0
+                return logits, mx.zeros((1, seq_len, 2))
+
+        generator = Generator()
+        model = LanguageModel()
+        install_mtp_mllm(generator, model)
+        generator._step(
+            mx.array([[0]], dtype=mx.uint32),
+            cache=[HybridCache()],
+            rope_deltas=rope_deltas,
+        )
+
+        assert model.calls == [(1, [[7]]), (2, [[7]]), (2, [[7]])]
+        assert generator.get_mtp_stats()["rejected"] == 1
 
     def test_concurrent_mtp_keeps_verified_state_with_uid_reordering(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
@@ -2029,6 +2464,8 @@ class TestChunkedPrefillCacheHandling:
         gen._pending_error_responses = []
         gen._aborted_request_ids = set()
         gen._prefill_progress = {}
+        gen._prefix_checkpoint_lock = threading.Lock()
+        gen._request_prefix_checkpoints = {}
         gen.active_batch = None
         gen.stop_tokens = set()
         gen.unprocessed_requests = []
@@ -2233,6 +2670,115 @@ class TestChunkedPrefillCacheHandling:
         abort_responses = [r for r in responses if r.finish_reason == "abort"]
         assert len(abort_responses) == 1
         assert abort_responses[0].request_id == "req-abort"
+
+    def test_interleaved_hybrid_publishes_boundary_checkpoint(self, monkeypatch):
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen._think_suffix_len = 2
+        gen.prefix_cache = MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1),
+        )
+        gen.sampler = lambda _logprobs: mx.array([0])
+        gen.stop_tokens = {0}
+
+        prompt_cache = [ArraysCache(size=1), KVCache()]
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache",
+            lambda *_args, **_kwargs: prompt_cache,
+        )
+
+        class LanguageModel:
+            def __init__(self):
+                self.rope_calls = []
+
+            def get_rope_index(self, input_ids, *_args):
+                return mx.zeros((3, 1, input_ids.shape[1])), mx.array([[17]])
+
+            def __call__(self, tokens, cache, rope_deltas=None, position_ids=None):
+                self.rope_calls.append(rope_deltas.tolist())
+                previous = 0 if cache[0][0] is None else int(cache[0][0].item())
+                cache[0][0] = mx.array([[previous + tokens.shape[1]]])
+                start = int(cache[1].offset)
+                values = mx.arange(start + 1, start + 1 + tokens.shape[1]).reshape(
+                    1, 1, -1, 1
+                )
+                cache[1].update_and_fetch(values, values + 100)
+                return mx.zeros((1, tokens.shape[1], 4))
+
+        gen.language_model = LanguageModel()
+        gen._next = lambda: []
+        install_chunked_prefill_mllm(gen, budget=4)
+
+        req = MLLMBatchRequest(uid=5, request_id="hybrid-interleaved", prompt="x")
+        req.input_ids = mx.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+        req.is_text_only = True
+        gen.unprocessed_requests.append(req)
+        gen._preprocess_request = lambda _: None
+
+        assert gen._next() == []
+        assert gen._next() == []
+        assert gen._partial["checkpoint_entry"] is None
+        gen._next()
+
+        assert gen.language_model.rope_calls == [[[17]], [[17]], [[17]], [[17]]]
+
+        full_prompt = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        stored, remaining = gen.prefix_cache.fetch(full_prompt)
+        assert remaining == []
+        assert gen.prefix_cache.fetch_exact_auxiliary(full_prompt) is not None
+        assert int(stored[0][0].item()) == 10
+        assert stored[1].offset == 10
+        assert stored[1].keys.shape[2] == 10
+        assert stored[1].keys.reshape(-1).tolist() == list(range(1, 11))
+
+    def test_interleaved_abort_during_checkpoint_commit_is_request_local(self):
+        from types import SimpleNamespace
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            PrefillAbortedError,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen.language_model = lambda tokens, cache: mx.zeros((1, tokens.shape[1], 4))
+        gen.sampler = lambda _logprobs: mx.array([0])
+        gen._next = lambda: []
+        install_chunked_prefill_mllm(gen, budget=4)
+
+        req = MLLMBatchRequest(uid=6, request_id="abort-at-commit", prompt="x")
+        req.input_ids = mx.array([[1, 2, 3, 4, 5]])
+        req.is_text_only = True
+        gen._partial = {
+            "request": req,
+            "cache": [self._make_fake_kv_cache(offset=3)],
+            "remaining_ids": mx.array([[4, 5]]),
+            "processed": 3,
+            "total": 5,
+            "cached_count": 0,
+            "chunk_count": 1,
+            "checkpoint_at": 3,
+            "checkpoint_key": [1, 2, 3],
+            "checkpoint_entry": SimpleNamespace(tokens=(1, 2, 3)),
+        }
+        gen._publish_prefill_checkpoint = MagicMock(
+            side_effect=PrefillAbortedError(req.request_id)
+        )
+
+        responses = gen._next()
+
+        assert gen._partial is None
+        assert len(responses) == 1
+        assert responses[0].request_id == req.request_id
+        assert responses[0].finish_reason == "abort"
 
     def test_short_prompt_falls_through_to_orig_next(self):
         """Short prompts (< budget) with no prefix cache must fall through

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1195,7 +1195,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             ([[4]], [[13]], [[[3]], [[3]], [[3]]]),
         ]
 
-    def test_hybrid_cold_path_samples_from_owned_prompt_logits(self, monkeypatch):
+    def test_hybrid_cold_path_keeps_request_cache_and_prompt_logits(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchGenerator,
             MLLMBatchRequest,
@@ -1206,11 +1206,14 @@ class TestMLLMBatchGeneratorMTPGuards:
             def merge(self, _caches):
                 return self
 
+        call_order = []
+
         class PrefixCache:
             def fetch(self, tokens):
                 return None, tokens
 
             def prepare_store(self, tokens, cache, auxiliary=None):
+                call_order.append("prepare")
                 assert int(mx.argmax(auxiliary["last_logits"], axis=-1).item()) == 1
                 return SimpleNamespace(
                     tokens=tuple(tokens),
@@ -1222,12 +1225,24 @@ class TestMLLMBatchGeneratorMTPGuards:
                 return kwargs["commit_guard"]()
 
         monkeypatch.setattr(mx, "stream", lambda _stream: nullcontext())
+        original_eval = mx.eval
+
+        def tracked_eval(*values):
+            call_order.append("eval")
+            return original_eval(*values)
+
+        monkeypatch.setattr(mx, "eval", tracked_eval)
         monkeypatch.setattr(
             "mlx_lm.models.cache.make_prompt_cache", lambda *_a, **_k: [FakeCache()]
         )
+
+        def sample(scores):
+            call_order.append("sample")
+            return mx.argmax(scores, axis=-1)
+
         monkeypatch.setattr(
             "mlx_lm.sample_utils.make_sampler",
-            lambda **_kwargs: lambda scores: mx.argmax(scores, axis=-1),
+            lambda **_kwargs: sample,
         )
         monkeypatch.setattr(
             "mlx_lm.sample_utils.make_logits_processors", lambda **_kwargs: []
@@ -1245,11 +1260,13 @@ class TestMLLMBatchGeneratorMTPGuards:
         generator._think_suffix_len = 0
         generator.language_model = object()
         generator.model = MagicMock()
-        generator.sampler = lambda scores: mx.argmax(scores, axis=-1)
+        generator.sampler = sample
         generator.prefix_cache = PrefixCache()
         generator._preprocess_request = lambda _request: None
         generator._needs_prefill_checkpoint = lambda _cache: True
-        generator._clone_prefix_for_replay = lambda cache: list(cache)
+        generator._clone_prefix_for_replay = MagicMock(
+            side_effect=AssertionError("cold request must not replay stored state")
+        )
         generator._prepare_rotating_caches = lambda _cache: True
         generator._run_chunked_text_prefill = lambda _request, cache: mx.array(
             [[[0.0, 8.0, 0.0, 0.0]]]
@@ -1261,7 +1278,9 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         batch = generator._process_prompts([request])
 
-        assert batch.y.tolist() == [2]
+        assert batch.y.tolist() == [1]
+        assert call_order[:3] == ["sample", "eval", "prepare"]
+        generator._clone_prefix_for_replay.assert_not_called()
 
     def test_next_passes_current_token_to_logits_processor_prefix(self):
         from vllm_mlx.mllm_batch_generator import (
@@ -2686,8 +2705,44 @@ class TestChunkedPrefillCacheHandling:
             MagicMock(),
             MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1),
         )
-        gen.sampler = lambda _logprobs: mx.array([0])
-        gen.stop_tokens = {0}
+        call_order = []
+        original_eval = mx.eval
+
+        def tracked_eval(*values):
+            call_order.append("eval")
+            return original_eval(*values)
+
+        monkeypatch.setattr(mx, "eval", tracked_eval)
+
+        def request_sample(logprobs):
+            call_order.append("sample")
+            return mx.argmax(logprobs, axis=-1)
+
+        def global_sample(_logprobs):
+            raise AssertionError("interleaved prefill must use the request sampler")
+
+        def make_request_sampler(**kwargs):
+            assert kwargs == {
+                "temp": 0.0,
+                "top_p": 1.0,
+                "top_k": 0,
+                "min_p": 0.0,
+            }
+            return request_sample
+
+        monkeypatch.setattr("mlx_lm.sample_utils.make_sampler", make_request_sampler)
+        gen.sampler = global_sample
+        gen.stop_tokens = {1}
+
+        original_prepare_store = gen.prefix_cache.prepare_store
+
+        def prepare_store(tokens, cache, auxiliary=None):
+            call_order.append("prepare")
+            assert auxiliary is not None
+            assert auxiliary["last_logits"].tolist() == [[0.0, 0.0, 0.0, 0.0]]
+            return original_prepare_store(tokens, cache, auxiliary=auxiliary)
+
+        gen.prefix_cache.prepare_store = prepare_store
 
         prompt_cache = [ArraysCache(size=1), KVCache()]
         monkeypatch.setattr(
@@ -2716,10 +2771,18 @@ class TestChunkedPrefillCacheHandling:
         gen.language_model = LanguageModel()
         gen._next = lambda: []
         install_chunked_prefill_mllm(gen, budget=4)
+        gen._clone_prefix_for_replay = MagicMock(
+            side_effect=AssertionError("cold request must not replay stored state")
+        )
 
         req = MLLMBatchRequest(uid=5, request_id="hybrid-interleaved", prompt="x")
         req.input_ids = mx.array([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
         req.is_text_only = True
+        req.temperature = 0.0
+        req.top_p = 1.0
+        req.logits_processors = [
+            lambda _tokens, logits: logits + mx.array([[0.0, 1.0, 0.0, 0.0]])
+        ]
         gen.unprocessed_requests.append(req)
         gen._preprocess_request = lambda _: None
 
@@ -2727,6 +2790,14 @@ class TestChunkedPrefillCacheHandling:
         assert gen._next() == []
         assert gen._partial["checkpoint_entry"] is None
         gen._next()
+
+        gen._clone_prefix_for_replay.assert_not_called()
+        sample_index = call_order.index("sample")
+        assert call_order[sample_index : sample_index + 3] == [
+            "sample",
+            "eval",
+            "prepare",
+        ]
 
         assert gen.language_model.rope_calls == [[[17]], [[17]], [[17]], [[17]]]
 
@@ -2772,6 +2843,55 @@ class TestChunkedPrefillCacheHandling:
         gen._publish_prefill_checkpoint = MagicMock(
             side_effect=PrefillAbortedError(req.request_id)
         )
+
+        responses = gen._next()
+
+        assert gen._partial is None
+        assert len(responses) == 1
+        assert responses[0].request_id == req.request_id
+        assert responses[0].finish_reason == "abort"
+
+    def test_interleaved_abort_during_full_prompt_commit_is_request_local(self):
+        from types import SimpleNamespace
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            PrefillAbortedError,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._make_fake_batch_gen()
+        gen.language_model = lambda tokens, cache: mx.zeros((1, tokens.shape[1], 4))
+        gen.sampler = lambda _logprobs: mx.array([0])
+        gen._next = lambda: []
+        gen._needs_prefill_checkpoint = lambda _cache: True
+        full_prompt_entry = SimpleNamespace(tokens=(1, 2, 3, 4, 5))
+        gen.prefix_cache = SimpleNamespace(
+            prepare_store=lambda *_args, **_kwargs: full_prompt_entry
+        )
+        install_chunked_prefill_mllm(gen, budget=4)
+
+        req = MLLMBatchRequest(uid=7, request_id="abort-full-prompt", prompt="x")
+        req.input_ids = mx.array([[1, 2, 3, 4, 5]])
+        req.is_text_only = True
+        gen._partial = {
+            "request": req,
+            "cache": [self._make_fake_kv_cache(offset=3)],
+            "remaining_ids": mx.array([[4, 5]]),
+            "processed": 3,
+            "total": 5,
+            "cached_count": 0,
+            "chunk_count": 1,
+            "checkpoint_at": None,
+            "checkpoint_key": None,
+            "checkpoint_entry": None,
+        }
+
+        def publish(_request_id, entry):
+            assert entry is full_prompt_entry
+            raise PrefillAbortedError(req.request_id)
+
+        gen._publish_prefill_checkpoint = publish
 
         responses = gen._next()
 

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,6 +6,8 @@ These tests verify the PrefixCacheManager for KV cache reuse
 to speed up inference with repeated prompts.
 """
 
+import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -596,6 +598,8 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
         request = SimpleNamespace(
             request_id="saturated", input_ids=mx.array([[1, 2, 3, 4]])
         )
@@ -627,6 +631,8 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
         request = SimpleNamespace(request_id="flat", input_ids=mx.array([[1, 2, 3, 4]]))
         batch = SimpleNamespace(
             requests=[request],
@@ -654,6 +660,8 @@ class TestMLLMCompletionCacheStore:
         generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
         generator.prefix_cache = MagicMock()
         generator._think_suffix_len = 0
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
         request = SimpleNamespace(request_id="plain", input_ids=mx.array([[1, 2, 3]]))
         batch = SimpleNamespace(
             requests=[request],
@@ -687,6 +695,286 @@ class TestMLLMCompletionCacheStore:
         assert stored[0] is not live
         live.offset = 99
         assert stored[0].offset == 3
+
+
+class TestMLLMHybridPrefillCheckpoint:
+    class _HybridCache:
+        def __init__(self, position=0):
+            self.position = position
+
+        @property
+        def state(self):
+            return [self.position]
+
+        @state.setter
+        def state(self, value):
+            self.position = value[0]
+
+        @property
+        def meta_state(self):
+            return []
+
+        @classmethod
+        def from_state(cls, state, _meta_state):
+            return cls(state[0])
+
+        def is_trimmable(self):
+            return False
+
+    class _KVCache(_HybridCache):
+        def is_trimmable(self):
+            return True
+
+    @staticmethod
+    def _request(input_ids):
+        return SimpleNamespace(
+            request_id="hybrid-prefill",
+            input_ids=input_ids,
+            vision_encoded=False,
+            pixel_values=None,
+            attention_mask=None,
+            image_grid_thw=None,
+            extra_kwargs={},
+        )
+
+    def test_nonrewindable_prompt_defers_store_until_full_prompt(self, monkeypatch):
+        import numpy as np
+
+        import vllm_mlx.mllm_batch_generator as module
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1),
+        )
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 2
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        cache = [self._HybridCache()]
+        calls = []
+
+        def language_model(tokens, cache):
+            calls.append(tokens.tolist())
+            cache[0].position += tokens.shape[1]
+            return np.zeros((1, tokens.shape[1], 4), dtype=np.float32)
+
+        generator.language_model = language_model
+        monkeypatch.setattr(module, "_eval_prompt_cache", lambda _cache: None)
+        monkeypatch.setattr(module.mx, "eval", lambda *_args: None)
+
+        request = self._request(np.array([[10, 11, 12, 13, 14]]))
+        generator._run_chunked_text_prefill(request, cache)
+
+        assert calls == [[[10, 11, 12, 13, 14]]]
+        assert generator.prefix_cache.get_stats()["entry_count"] == 0
+        assert cache[0].position == 5
+
+    def test_rewindable_prompt_keeps_single_forward(self, monkeypatch):
+        import numpy as np
+
+        import vllm_mlx.mllm_batch_generator as module
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 2
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        cache = [self._KVCache()]
+        calls = []
+
+        def language_model(tokens, cache):
+            calls.append(tokens.tolist())
+            cache[0].position += tokens.shape[1]
+            return np.zeros((1, tokens.shape[1], 4), dtype=np.float32)
+
+        generator.language_model = language_model
+        monkeypatch.setattr(module, "_eval_prompt_cache", lambda _cache: None)
+
+        request = self._request(np.array([[10, 11, 12, 13, 14]]))
+        generator._run_chunked_text_prefill(request, cache)
+
+        assert calls == [[[10, 11, 12, 13, 14]]]
+        generator.prefix_cache.prepare_store.assert_not_called()
+        generator.prefix_cache.commit_prepared.assert_not_called()
+
+    def test_no_think_hybrid_defers_store_until_final_logits_exist(self, monkeypatch):
+        import numpy as np
+
+        import vllm_mlx.mllm_batch_generator as module
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1),
+        )
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 0
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        cache = [self._HybridCache()]
+
+        def language_model(tokens, cache):
+            cache[0].position += tokens.shape[1]
+            return np.zeros((1, tokens.shape[1], 4), dtype=np.float32)
+
+        generator.language_model = language_model
+        monkeypatch.setattr(module, "_eval_prompt_cache", lambda _cache: None)
+        monkeypatch.setattr(module.mx, "eval", lambda *_args: None)
+
+        request = self._request(np.array([[10, 11, 12, 13, 14]]))
+        generator._run_chunked_text_prefill(request, cache)
+
+        stored, remaining = generator.prefix_cache.fetch([10, 11, 12, 13, 14])
+        assert stored is None
+        assert remaining == [10, 11, 12, 13, 14]
+
+    def test_full_prompt_store_does_not_replace_existing_prefix_during_prefill(
+        self, monkeypatch
+    ):
+        import numpy as np
+
+        import vllm_mlx.mllm_batch_generator as module
+        from vllm_mlx.memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        prefix_cache = MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(max_memory_mb=1, min_prefix_tokens=1),
+        )
+        assert prefix_cache.store([10, 11], [self._HybridCache(2)])
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = prefix_cache
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 2
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        cache = [self._HybridCache()]
+
+        def language_model(tokens, cache):
+            cache[0].position += tokens.shape[1]
+            return np.zeros((1, tokens.shape[1], 4), dtype=np.float32)
+
+        generator.language_model = language_model
+        monkeypatch.setattr(module, "_eval_prompt_cache", lambda _cache: None)
+        monkeypatch.setattr(module.mx, "eval", lambda *_args: None)
+        request = self._request(np.array([[10, 11, 12, 13, 14]]))
+        generator._run_chunked_text_prefill(request, cache)
+
+        assert (10, 11) in prefix_cache._entries
+        assert (10, 11, 12) not in prefix_cache._entries
+
+        original_entry = prefix_cache._entries[(10, 11)]
+        second = self._request(np.array([[10, 11, 12, 13, 14]]))
+        second.request_id = "duplicate-checkpoint"
+        generator._run_chunked_text_prefill(second, [self._HybridCache()])
+        generator.abort_prefill(second.request_id)
+
+        assert prefix_cache._entries[(10, 11)] is original_entry
+
+    def test_abort_after_checkpoint_does_not_publish_entry(self, monkeypatch):
+        import numpy as np
+
+        import vllm_mlx.mllm_batch_generator as module
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchGenerator,
+            PrefillAbortedError,
+        )
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = MagicMock()
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 2
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        cache = [self._HybridCache()]
+
+        def language_model(tokens, cache):
+            cache[0].position += tokens.shape[1]
+            generator._aborted_request_ids.add("hybrid-prefill")
+            return np.zeros((1, tokens.shape[1], 4), dtype=np.float32)
+
+        generator.language_model = language_model
+        monkeypatch.setattr(module, "_eval_prompt_cache", lambda _cache: None)
+
+        request = self._request(np.array([[10, 11, 12, 13, 14]]))
+        with pytest.raises(PrefillAbortedError):
+            generator._run_chunked_text_prefill(request, cache)
+
+        generator.prefix_cache.prepare_store.assert_not_called()
+        generator.prefix_cache.commit_prepared.assert_not_called()
+
+    def test_abort_during_checkpoint_commit_rejects_publication(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        store_started = threading.Event()
+        release_store = threading.Event()
+        prefix_cache = MagicMock()
+        prefix_cache._config = SimpleNamespace(min_prefix_tokens=1)
+
+        prepared_entry = SimpleNamespace(tokens=(10, 11, 12))
+        prefix_cache.prepare_store.return_value = prepared_entry
+
+        def commit_prepared(_entry, **kwargs):
+            store_started.set()
+            assert release_store.wait(timeout=5)
+            with kwargs["commit_lock"]:
+                return kwargs["commit_guard"]()
+
+        prefix_cache.commit_prepared.side_effect = commit_prepared
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.prefix_cache = prefix_cache
+        generator.prefill_step_size = 32
+        generator._think_suffix_len = 2
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator._prefix_checkpoint_lock = threading.Lock()
+        generator._request_prefix_checkpoints = {}
+        request_id = "hybrid-prefill"
+
+        prefill_errors = []
+
+        def run_prefill():
+            try:
+                generator._publish_prefill_checkpoint(request_id, prepared_entry)
+            except Exception as exc:
+                prefill_errors.append(exc)
+
+        prefill = threading.Thread(target=run_prefill)
+        prefill.start()
+        assert store_started.wait(timeout=5)
+        abort = threading.Thread(
+            target=generator.abort_prefill,
+            args=(request_id,),
+        )
+        abort.start()
+        release_store.set()
+        prefill.join(timeout=5)
+        abort.join(timeout=5)
+
+        assert not prefill.is_alive()
+        assert not abort.is_alive()
+        assert len(prefill_errors) == 1
+        assert type(prefill_errors[0]).__name__ == "PrefillAbortedError"
+        assert prefix_cache.commit_prepared.call_count == 1
+        assert request_id not in generator._request_prefix_checkpoints
 
 
 if __name__ == "__main__":

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -698,6 +698,10 @@ class TestMLLMCompletionCacheStore:
 
 
 class TestMLLMHybridPrefillCheckpoint:
+    @pytest.fixture(autouse=True)
+    def _require_full_mlx_runtime(self):
+        pytest.importorskip("mlx.nn")
+
     class _HybridCache:
         def __init__(self, position=0):
             self.position = position

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1394,7 +1394,11 @@ class MemoryAwarePrefixCache:
         commit_lock: Any = None,
         commit_guard: Callable[[], bool] | None = None,
     ) -> bool:
-        """Atomically publish an entry returned by :meth:`prepare_store`."""
+        """Atomically publish an entry returned by :meth:`prepare_store`.
+
+        ``commit_lock`` is acquired inside ``_memory_lock``. Callers must not
+        call cache methods while holding the caller-supplied ``commit_lock``.
+        """
         tokens_key = entry.tokens
         commit_context = commit_lock if commit_lock is not None else nullcontext()
         try:

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -30,8 +30,9 @@ import logging
 import math
 import threading
 from collections import OrderedDict
+from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -303,15 +304,24 @@ class _CacheEntry:
     tokens: tuple[int, ...]
     cache: list[Any]
     memory_bytes: int
+    auxiliary: dict[str, Any] | None = None
 
     @classmethod
-    def create(cls, tokens: list[int], cache: list[Any]) -> _CacheEntry:
+    def create(
+        cls,
+        tokens: list[int],
+        cache: list[Any],
+        auxiliary: dict[str, Any] | None = None,
+    ) -> _CacheEntry:
         """Create a cache entry with memory estimation."""
         memory = estimate_kv_cache_memory(cache)
+        if auxiliary:
+            memory += sum(getattr(value, "nbytes", 0) for value in auxiliary.values())
         return cls(
             tokens=tuple(tokens),
             cache=cache,
             memory_bytes=memory,
+            auxiliary=auxiliary,
         )
 
 
@@ -1059,8 +1069,10 @@ class MemoryAwarePrefixCache:
         matches, and longest-common-prefix (LCP) matches.  Uses a sorted key
         index for O(log N) lookup instead of scanning all entries.
 
-        Returns the cached KV state directly (no copy) since MLX arrays
-        are immutable and safe to share.
+        Returns the independently owned stored state directly. Callers must
+        clone its cache wrappers before replay because some MLX cache buffers
+        support in-place updates even though the stored backing is detached
+        from the request that created it.
 
         Args:
             tokens: Input token sequence.
@@ -1288,68 +1300,38 @@ class MemoryAwarePrefixCache:
 
         return None, tokens
 
-    def store(
-        self, tokens: list[int], cache: list[Any], evict_prefixes: bool = True
-    ) -> bool:
-        """
-        Store KV cache for future reuse.
+    def prepare_store(
+        self,
+        tokens: list[int],
+        cache: list[Any],
+        auxiliary: dict[str, Any] | None = None,
+    ) -> _CacheEntry | None:
+        """Detach and account an entry without publishing it.
 
-        The entry is snapshotted before storage: every MLX array is
-        detached into a freshly allocated, evaluated copy (with optional
-        quantization applied first), so the stored entry never aliases the
-        caller's cache objects or retains their lazy graphs.  Entries whose
-        projected size exceeds the memory limit are rejected before
-        anything is materialized.  If the memory limit is exceeded by the
-        new entry, LRU entries are evicted until there's room.
-
-        This method does not raise: any failure while building or storing
-        the snapshot rejects the entry (returns False) with a warning.
-
-        Args:
-            tokens: Token sequence that was processed.
-            cache: The computed KV cache to store.
-            evict_prefixes: If True, evict existing entries whose token
-                sequence is a strict prefix of ``tokens``.  Set to False
-                when storing prompt+output entries to preserve prompt-only
-                entries created by prompt_cache_save (those are the entries
-                that future requests will actually match).
-
-        Returns:
-            True if stored successfully, False if rejected.
+        Hybrid recurrent caches cannot be rewound after generation starts,
+        while ordinary ``KVCache`` buffers are updated in place.  Callers can
+        therefore prepare an immutable entry at the exact prefill boundary,
+        continue the request, and publish that already-detached entry only
+        after the remaining prefill succeeds.
         """
         if not tokens or not cache:
-            return False
+            return None
         if len(tokens) < self._config.min_prefix_tokens:
             logger.debug(
                 "[cache_store] skipped short prefix: tokens=%s min_prefix_tokens=%s",
                 len(tokens),
                 self._config.min_prefix_tokens,
             )
-            return False
+            return None
 
         tokens_key = tuple(tokens)
-
-        # Fast path: already cached — just refresh LRU order.
         with self._memory_lock:
-            if tokens_key in self._entries:
-                self._entries.move_to_end(tokens_key)
-                return True
+            existing = self._entries.get(tokens_key)
+            if existing is not None:
+                return existing
 
-        # Build the snapshot outside _memory_lock: trim (lazy) -> quantize
-        # (lazy) -> preflight (shape-based, no eval) -> detach (the one
-        # entry-sized GPU copy+eval).  Holding _memory_lock across the eval
-        # would serialize try_reserve_memory / remove / clear for the full
-        # copy duration; fetch() is lock-free either way.  store() never
-        # raises: any failure in the pipeline rejects the entry instead.
         try:
-            # Trim oversized KV arrays to actual used size (lazy slices).
             cache = _trim_to_offset(cache)
-
-            # Quantize BEFORE detaching so the detached, evaluated arrays
-            # are the final stored representation.  Quantizing after
-            # detachment would build new lazy quantized arrays on top of
-            # the evaluated full-precision snapshot and retain it as graph
-            # inputs, so resident memory would exceed the accounting.
             if (
                 self._config.kv_quantize
                 and len(tokens) >= self._config.kv_min_quantize_tokens
@@ -1357,12 +1339,6 @@ class MemoryAwarePrefixCache:
                 cache = _quantize_cache(
                     cache, self._config.kv_bits, self._config.kv_group_size
                 )
-
-            # Preflight: reject oversized entries BEFORE materializing
-            # anything.  shape×dtype pricing needs no evaluation, and both
-            # trim and quantize above are lazy, so an over-limit entry is
-            # refused without incurring an entry-sized allocation (which
-            # could itself hit Metal resource/memory limits).
             projected_bytes = estimate_kv_cache_memory(cache)
             if projected_bytes > self._max_memory:
                 self._stats.store_rejections += 1
@@ -1371,36 +1347,76 @@ class MemoryAwarePrefixCache:
                     f"{projected_bytes / _BYTES_PER_MB:.1f}MB "
                     f"exceeds limit {self._max_memory / _BYTES_PER_MB:.1f}MB"
                 )
-                return False
+                return None
 
-            # Detach from live batch buffers and lazy graphs so the stored
-            # entry owns its data (prevents aliasing + Metal handle leak).
-            # Fail-closed: an entry that cannot be detached is rejected —
-            # storing it by reference would reintroduce the leak.  The
-            # copy lock keeps concurrent stores from materializing
-            # entry-sized copies simultaneously (N-fold peak), without
-            # blocking _memory_lock users.
             with self._copy_lock:
                 cache = _detach_cache_for_storage(cache)
-            # Create entry and account the final (detached) representation
-            entry = _CacheEntry.create(tokens, cache)
+                detached_auxiliary = None
+                if auxiliary:
+                    import mlx.core as mx
 
-            with self._memory_lock:
-                # Re-check under the lock: a concurrent store() may have won
-                # the race while we were detaching.  Keep theirs (drop our
-                # copy) and refresh LRU order.
+                    detached_auxiliary = {
+                        key: value + 0 if isinstance(value, mx.array) else value
+                        for key, value in auxiliary.items()
+                    }
+                    mx.eval(
+                        *(
+                            value
+                            for value in detached_auxiliary.values()
+                            if isinstance(value, mx.array)
+                        )
+                    )
+            entry = _CacheEntry.create(tokens, cache, detached_auxiliary)
+            if entry.memory_bytes > self._max_memory:
+                self._stats.store_rejections += 1
+                logger.warning(
+                    "Cache entry too large after auxiliary accounting: "
+                    "%.1fMB exceeds limit %.1fMB",
+                    entry.memory_bytes / _BYTES_PER_MB,
+                    self._max_memory / _BYTES_PER_MB,
+                )
+                return None
+            return entry
+        except UndetachableCacheError as e:
+            self._stats.store_rejections += 1
+            logger.warning("[cache_store] rejecting entry: %s", e)
+            return None
+        except Exception as e:
+            self._stats.store_rejections += 1
+            logger.warning("[cache_store] rejecting entry: %s: %s", type(e).__name__, e)
+            return None
+
+    def commit_prepared(
+        self,
+        entry: _CacheEntry,
+        evict_prefixes: bool = True,
+        *,
+        commit_lock: Any = None,
+        commit_guard: Callable[[], bool] | None = None,
+    ) -> bool:
+        """Atomically publish an entry returned by :meth:`prepare_store`."""
+        tokens_key = entry.tokens
+        commit_context = commit_lock if commit_lock is not None else nullcontext()
+        try:
+            with self._memory_lock, commit_context:
+                if commit_guard is not None and not commit_guard():
+                    return False
+                if entry.memory_bytes > self._max_memory:
+                    self._stats.store_rejections += 1
+                    logger.warning(
+                        "[cache_store] rejecting oversized prepared entry: "
+                        "%.1fMB exceeds limit %.1fMB",
+                        entry.memory_bytes / _BYTES_PER_MB,
+                        self._max_memory / _BYTES_PER_MB,
+                    )
+                    return False
                 if tokens_key in self._entries:
                     self._entries.move_to_end(tokens_key)
                     return True
 
-                # Prefix-subset eviction: remove entries whose token sequence
-                # is a strict prefix of the new entry.  Uses sorted index for
-                # O(log N + K) lookup instead of O(N) scan.
                 if evict_prefixes and self._sorted_keys:
                     to_remove = []
                     idx = bisect.bisect_left(self._sorted_keys, tokens_key)
-                    # Scan backwards — prefixes of tokens_key are immediately
-                    # before idx
                     for i in range(idx - 1, -1, -1):
                         key = self._sorted_keys[i]
                         klen = len(key)
@@ -1416,49 +1432,70 @@ class MemoryAwarePrefixCache:
                         self._stats.evictions += 1
                         self._remove_from_sorted(key)
                         logger.debug(
-                            f"[prefix_evict] removed {len(key)} tokens, "
-                            f"freed {old.memory_bytes / _BYTES_PER_MB:.2f}MB, "
-                            f"new_entry={len(tokens_key)} tokens"
+                            "[prefix_evict] removed %s tokens, freed %.2fMB, "
+                            "new_entry=%s tokens",
+                            len(key),
+                            old.memory_bytes / _BYTES_PER_MB,
+                            len(tokens_key),
                         )
-                    if to_remove:
-                        self._stats.entry_count = len(self._entries)
-                        self._stats.current_memory_bytes = self._current_memory
 
-                # Evict until we have room
                 while (
                     self._current_memory + entry.memory_bytes > self._max_memory
                     or len(self._entries) >= self._config.max_entries
                 ) and self._entries:
                     self._evict_lru()
 
-                # Store entry
                 self._entries[tokens_key] = entry
                 self._current_memory += entry.memory_bytes
                 bisect.insort(self._sorted_keys, tokens_key)
                 self._stats.entry_count = len(self._entries)
                 self._stats.current_memory_bytes = self._current_memory
-        except UndetachableCacheError as e:
-            self._stats.store_rejections += 1
-            logger.warning("[cache_store] rejecting entry: %s", e)
-            return False
         except Exception as e:
-            # Anything else — malformed input to trim/quantize (e.g.
-            # head_dim not divisible by the quantization group size), or an
-            # eviction-path failure such as an SSD spill hook raising a
-            # stream-affinity RuntimeError — must not crash the caller.
-            # Several call sites have no enclosing try; a rejected store
-            # only costs a cache miss.
             self._stats.store_rejections += 1
-            logger.warning("[cache_store] rejecting entry: %s: %s", type(e).__name__, e)
+            logger.warning(
+                "[cache_store] rejecting commit: %s: %s", type(e).__name__, e
+            )
             return False
 
         logger.debug(
-            f"Stored cache: {len(tokens)} tokens, "
+            f"Stored cache: {len(tokens_key)} tokens, "
             f"{entry.memory_bytes / _BYTES_PER_MB:.2f}MB, "
             f"total={self._current_memory / _BYTES_PER_MB:.1f}MB"
         )
-
         return True
+
+    def clone_for_replay(self, cache: list[Any]) -> list[Any] | None:
+        """Return independently owned backing for a mutating model replay."""
+        try:
+            with self._copy_lock:
+                return _detach_cache_for_storage(cache)
+        except Exception as exc:
+            logger.warning(
+                "[cache_fetch] replay clone rejected: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    def fetch_exact_auxiliary(self, tokens: list[int]) -> dict[str, Any] | None:
+        """Return auxiliary data only when an exact resident entry owns it."""
+        with self._memory_lock:
+            entry = self._entries.get(tuple(tokens))
+            if entry is None or entry.auxiliary is None:
+                return None
+            return dict(entry.auxiliary)
+
+    def store(
+        self,
+        tokens: list[int],
+        cache: list[Any],
+        evict_prefixes: bool = True,
+    ) -> bool:
+        """Detach, account, and atomically publish a reusable cache entry."""
+        entry = self.prepare_store(tokens, cache)
+        if entry is None:
+            return False
+        return self.commit_prepared(entry, evict_prefixes=evict_prefixes)
 
     def _remove_from_sorted(self, key: tuple[int, ...]) -> None:
         """Remove a key from the sorted index using bisect for O(log N)."""

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -225,6 +225,12 @@ class MLLMBatchRequest:
     num_tokens: int = 0  # Tokens generated so far
     output_tokens: List[int] = field(default_factory=list)
 
+    # Request-local Qwen mRoPE continuation state. The language model also
+    # keeps a process-global copy, but continuous batching cannot safely use
+    # one request's value for another request or for a restored prefix.
+    rope_deltas: Optional[mx.array] = None
+    prompt_position_ids: Optional[mx.array] = None
+
     # Vision state (populated after initial VLM forward pass)
     vision_encoded: bool = False
     cross_attention_states: Optional[Any] = None  # For models that use cross-attention
@@ -290,7 +296,6 @@ class MLLMBatch:
             self.logits_processors = [self.logits_processors[k] for k in keep_idx]
         if self.samplers is not None:
             self.samplers = [self.samplers[k] for k in keep_idx]
-
         keep_idx_array = mx.array(keep_idx, mx.int32)
         self.y = self.y[keep_idx_array]
 
@@ -560,6 +565,10 @@ class MLLMBatchGenerator:
         # Set operations are GIL-protected, safe across event-loop and
         # executor threads.
         self._aborted_request_ids: set = set()
+        # Metadata-only synchronization between checkpoint publication and
+        # cancellation. The lock is never held across MLX evaluation.
+        self._prefix_checkpoint_lock = threading.Lock()
+        self._request_prefix_checkpoints: Dict[str, Dict[str, Any]] = {}
 
         # Deferred removal queue — UIDs scheduled for removal from another
         # thread (typically the event loop on client disconnect).  The
@@ -759,10 +768,22 @@ class MLLMBatchGenerator:
 
         Called from the event loop thread when a client disconnects.
         The prefill loop checks this set between chunks and raises
-        PrefillAbortedError to exit early.
+        PrefillAbortedError to exit early. An abort that wins the checkpoint
+        commit lock prevents publication. Once the complete prompt boundary
+        has been committed successfully, the entry is valid independent of
+        the request and may remain reusable after a later disconnect.
         """
-        self._aborted_request_ids.add(request_id)
+        with self._prefix_checkpoint_lock:
+            self._aborted_request_ids.add(request_id)
+            state = self._request_prefix_checkpoints.pop(request_id, None)
+            if state is not None:
+                state["cancelled"] = True
         logger.info(f"[abort_prefill] Marked {request_id} for prefill abort")
+
+    def _discard_prefill_checkpoint(self, request_id: str) -> None:
+        """Forget request-local checkpoint publication state."""
+        with self._prefix_checkpoint_lock:
+            self._request_prefix_checkpoints.pop(request_id, None)
 
     def schedule_removal(self, uids: List[int]) -> None:
         """Thread-safe deferred removal of UIDs from the batch.
@@ -1097,6 +1118,13 @@ class MLLMBatchGenerator:
             logger.warning("Prefix cache copy rejected: %s", exc)
             return None
 
+    def _clone_prefix_for_replay(self, cache_list):
+        """Clone cached backing so replay cannot mutate the stored entry."""
+        clone = getattr(self.prefix_cache, "clone_for_replay", None)
+        if callable(clone):
+            return clone(cache_list)
+        return self._copy_prefix_cache(cache_list)
+
     @classmethod
     def _cache_leaves(cls, cache_list) -> Iterator[Any]:
         """Yield cache leaves from a possibly nested CacheList topology."""
@@ -1199,6 +1227,140 @@ class MLLMBatchGenerator:
                 return None
         return copied
 
+    @classmethod
+    def _needs_prefill_checkpoint(cls, cache_list) -> bool:
+        """Return whether any cache leaf cannot be rewound after generation.
+
+        Hybrid models such as Qwen3.5 mix ordinary KV caches with recurrent
+        ``ArraysCache`` state.  The recurrent state is safe to snapshot and
+        resume, but it cannot be rewound after output tokens have advanced it.
+        Such models must therefore store their reusable prompt state while
+        prefill is still at the cache-key boundary.
+        """
+        for cache in cls._cache_leaves(cache_list):
+            is_trimmable = getattr(cache, "is_trimmable", None)
+            if not callable(is_trimmable) or not is_trimmable():
+                return True
+        return False
+
+    def _derive_request_rope_deltas(
+        self, request: MLLMBatchRequest
+    ) -> Optional[mx.array]:
+        """Derive request-local mRoPE continuation state from the full prompt."""
+        get_rope_index = getattr(type(self.language_model), "get_rope_index", None)
+        if not callable(get_rope_index):
+            return None
+        input_ids = request.input_ids
+        if input_ids is None:
+            raise RuntimeError("cannot derive rope_deltas without input_ids")
+        if input_ids.ndim == 1:
+            input_ids = input_ids[None, :]
+        video_grid_thw = request.extra_kwargs.get("video_grid_thw")
+        position_ids, rope_deltas = get_rope_index(
+            self.language_model,
+            input_ids,
+            request.image_grid_thw,
+            video_grid_thw,
+            request.attention_mask,
+        )
+        if position_ids.ndim not in (2, 3):
+            raise RuntimeError(
+                f"position_ids must be rank 2 or 3, got rank {position_ids.ndim}"
+            )
+        if rope_deltas is None:
+            return mx.zeros((input_ids.shape[0], 1), dtype=mx.int32)
+        if rope_deltas.ndim == 0:
+            rope_deltas = rope_deltas.reshape(1, 1)
+        elif rope_deltas.ndim == 1:
+            rope_deltas = rope_deltas[:, None]
+        if rope_deltas.shape[0] != input_ids.shape[0]:
+            raise RuntimeError(
+                f"rope_deltas batch {rope_deltas.shape[0]} does not match "
+                f"request batch {input_ids.shape[0]}"
+            )
+        request.prompt_position_ids = position_ids
+        return rope_deltas
+
+    @staticmethod
+    def _language_model_kwargs(
+        request: MLLMBatchRequest,
+        position_start: Optional[int] = None,
+        position_end: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        rope_deltas = getattr(request, "rope_deltas", None)
+        kwargs = {} if rope_deltas is None else {"rope_deltas": rope_deltas}
+        position_ids = getattr(request, "prompt_position_ids", None)
+        if (
+            position_ids is not None
+            and position_start is not None
+            and position_end is not None
+        ):
+            if position_ids.ndim == 2:
+                kwargs["position_ids"] = position_ids[:, position_start:position_end]
+            else:
+                kwargs["position_ids"] = position_ids[:, :, position_start:position_end]
+        return kwargs
+
+    @staticmethod
+    def _batch_rope_deltas(
+        requests: List[MLLMBatchRequest],
+    ) -> Optional[mx.array]:
+        deltas = [getattr(request, "rope_deltas", None) for request in requests]
+        if not deltas or all(delta is None for delta in deltas):
+            return None
+        if any(delta is None for delta in deltas):
+            raise RuntimeError("Cannot batch mixed mRoPE and non-mRoPE requests")
+        return mx.concatenate(deltas, axis=0)
+
+    def _prefill_checkpoint_plan(self, input_ids, cache_list):
+        """Return ``(token_count, key)`` for a non-rewindable prompt cache."""
+        if self.prefix_cache is None or not self._needs_prefill_checkpoint(cache_list):
+            return None, None
+        # Hybrid recurrent state cannot be replayed from a numerically exact
+        # mid-prompt split on every backend. Store the full prompt state and
+        # its final logits instead; exact hits can then start generation
+        # without replaying or rewinding recurrent state.
+        return None, None
+
+    def _publish_prefill_checkpoint(
+        self, request_id: str, checkpoint_entry: Any
+    ) -> bool:
+        """Publish one checkpoint without racing cancellation ownership."""
+        if checkpoint_entry is None:
+            return False
+        checkpoint_key = list(checkpoint_entry.tokens)
+        checkpoint_state: Dict[str, Any] = {
+            "key": checkpoint_key,
+            "cancelled": False,
+        }
+        with self._prefix_checkpoint_lock:
+            if request_id in self._aborted_request_ids:
+                self._aborted_request_ids.discard(request_id)
+                raise PrefillAbortedError(request_id)
+            self._request_prefix_checkpoints[request_id] = checkpoint_state
+
+        def _commit_allowed() -> bool:
+            return (
+                self._request_prefix_checkpoints.get(request_id) is checkpoint_state
+                and not checkpoint_state["cancelled"]
+            )
+
+        stored = self.prefix_cache.commit_prepared(
+            checkpoint_entry,
+            evict_prefixes=False,
+            commit_lock=self._prefix_checkpoint_lock,
+            commit_guard=_commit_allowed,
+        )
+
+        with self._prefix_checkpoint_lock:
+            current = self._request_prefix_checkpoints.get(request_id)
+            if current is checkpoint_state:
+                self._request_prefix_checkpoints.pop(request_id, None)
+        if checkpoint_state["cancelled"]:
+            self._aborted_request_ids.discard(request_id)
+            raise PrefillAbortedError(request_id)
+        return stored
+
     def _run_chunked_text_prefill(
         self, request: MLLMBatchRequest, cache: List[Any]
     ) -> mx.array:
@@ -1219,29 +1381,19 @@ class MLLMBatchGenerator:
         total = input_ids.shape[1]
         step = self.prefill_step_size
 
-        # Short prompt — process in one shot (no chunking overhead)
-        if total <= step:
-            self._prefill_progress[request.request_id] = (total, total)
-            output = self.language_model(input_ids, cache=cache)
-            request.vision_encoded = True
-            # Release preprocessed inputs after encoding (issue #442)
-            request.pixel_values = None
-            request.attention_mask = None
-            request.image_grid_thw = None
-            request.extra_kwargs.clear()
-            if hasattr(output, "logits"):
-                return output.logits
-            return output
+        checkpoint_at, checkpoint_key = self._prefill_checkpoint_plan(input_ids, cache)
 
-        logger.info(
-            f"[chunked_prefill] Starting {request.request_id[:12]}: "
-            f"{total} tokens, step={step}"
-        )
+        if total > step or checkpoint_at is not None:
+            logger.info(
+                f"[chunked_prefill] Starting {request.request_id[:12]}: "
+                f"{total} tokens, step={step}"
+            )
 
-        # Process all chunks except the last
         processed = 0
         chunk_count = 0
-        while processed + step < total:
+        output = None
+        checkpoint_entry = None
+        while processed < total:
             # Check for abort between chunks (client disconnect)
             if request.request_id in self._aborted_request_ids:
                 self._aborted_request_ids.discard(request.request_id)
@@ -1251,16 +1403,51 @@ class MLLMBatchGenerator:
                 )
                 raise PrefillAbortedError(request.request_id)
 
-            chunk = input_ids[:, processed : processed + step]
-            self.language_model(chunk, cache=cache)
+            end = min(processed + step, total)
+            if checkpoint_at is not None and processed < checkpoint_at < end:
+                end = checkpoint_at
+
+            chunk = input_ids[:, processed:end]
+            output = self.language_model(
+                chunk,
+                cache=cache,
+                **self._language_model_kwargs(request, processed, end),
+            )
+            processed = end
+            chunk_count += 1
+
+            if checkpoint_at is not None and processed == checkpoint_at:
+                # KVCache writes suffix tokens into preallocated arrays in
+                # place. Materialize the active state before detaching it so
+                # the cold continuation and the restored continuation start
+                # from the same realized recurrent/KV state. Publish only
+                # after the remaining prefill succeeds.
+                _eval_prompt_cache(cache)
+                checkpoint_snapshot = self._rewind_prefix_cache(cache, 0)
+                if checkpoint_snapshot is not None:
+                    checkpoint_entry = self.prefix_cache.prepare_store(
+                        checkpoint_key, checkpoint_snapshot
+                    )
+                    if checkpoint_entry is not None:
+                        continuation = self._clone_prefix_for_replay(
+                            checkpoint_entry.cache
+                        )
+                        if continuation is None or not self._prepare_rotating_caches(
+                            continuation
+                        ):
+                            checkpoint_entry = None
+                        else:
+                            cache[:] = continuation
+
+            if processed == total:
+                break
+
             # Eval ALL cache types to break the lazy graph between chunks.
             # ArraysCache (e.g. GatedDeltaNet) has .state; KVCache (full
             # attention) has .keys/.values. Hybrid models like Qwen3.5 use
             # both. Skipping either type lets the computation graph grow
             # across chunks → OOM on long prompts.
             _eval_prompt_cache(cache)
-            processed += step
-            chunk_count += 1
             self._prefill_progress[request.request_id] = (processed, total)
 
             # Log progress every 10 chunks so operators can see prefill
@@ -1278,9 +1465,23 @@ class MLLMBatchGenerator:
             if chunk_count % 4 == 0:
                 mx.clear_cache()
 
-        # Last chunk — return logits for sampling
-        last_chunk = input_ids[:, processed:]
-        output = self.language_model(last_chunk, cache=cache)
+        final_output = output.logits if hasattr(output, "logits") else output
+
+        # A disconnect may arrive while the final suffix is executing.  Do
+        # not let an aborted or failed prefill populate or evict shared cache
+        # state merely because its checkpoint was reached.
+        if checkpoint_entry is not None:
+            # The final suffix forward is lazy. Complete both its logits and
+            # cache-state writes before the publication guard can declare the
+            # prompt checkpoint valid. Ordinary rewindable prefill retains its
+            # existing lazy sampling path.
+            _eval_prompt_cache(cache)
+            mx.eval(final_output)
+            self._publish_prefill_checkpoint(request.request_id, checkpoint_entry)
+        elif request.request_id in self._aborted_request_ids:
+            self._aborted_request_ids.discard(request.request_id)
+            raise PrefillAbortedError(request.request_id)
+
         request.vision_encoded = True
         # Release preprocessed inputs after encoding (issue #442)
         request.pixel_values = None
@@ -1289,15 +1490,13 @@ class MLLMBatchGenerator:
         request.extra_kwargs.clear()
         self._prefill_progress[request.request_id] = (total, total)
 
-        if chunk_count > 0:
+        if chunk_count > 1:
             logger.info(
                 f"[chunked_prefill] Completed {request.request_id[:12]}: "
-                f"{total} tokens in {chunk_count + 1} chunks"
+                f"{total} tokens in {chunk_count} chunks"
             )
 
-        if hasattr(output, "logits"):
-            return output.logits
-        return output
+        return final_output
 
     def _run_vision_encoding(
         self, request: MLLMBatchRequest, cache: Optional[List[Any]] = None
@@ -1376,6 +1575,7 @@ class MLLMBatchGenerator:
         for req in requests:
             try:
                 self._preprocess_request(req)
+                req.rope_deltas = self._derive_request_rope_deltas(req)
             except Exception as e:
                 logger.error(
                     f"Failed to preprocess request {req.request_id}: "
@@ -1498,17 +1698,30 @@ class MLLMBatchGenerator:
                 # running them through the language model alone.
                 cached_kv = None
                 remaining_ids = None
+                cached_last_logits = None
                 if self.prefix_cache is not None and req.input_ids is not None:
                     input_ids_list = req.input_ids.reshape(-1).tolist()
-                    # Strip think suffix from lookup key so stored entries
-                    # (also stripped) match as clean PREFIX.
-                    S = self._think_suffix_len
-                    lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
-                    cached_kv, remaining_ids = self.prefix_cache.fetch(lookup_ids)
-                    # Append think suffix back to remaining so the model
-                    # sees the full generation prompt (<think>\n).
-                    if cached_kv is not None and S > 0:
-                        remaining_ids = list(remaining_ids) + input_ids_list[-S:]
+                    fetch_auxiliary = getattr(
+                        self.prefix_cache, "fetch_exact_auxiliary", None
+                    )
+                    exact_aux = (
+                        fetch_auxiliary(input_ids_list)
+                        if callable(fetch_auxiliary)
+                        else None
+                    )
+                    if exact_aux is not None and "last_logits" in exact_aux:
+                        cached_kv, remaining_ids = self.prefix_cache.fetch(
+                            input_ids_list
+                        )
+                        cached_last_logits = exact_aux["last_logits"]
+                    else:
+                        # Ordinary rewindable caches retain historical prefix
+                        # matching by stripping the generated think suffix.
+                        S = self._think_suffix_len
+                        lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
+                        cached_kv, remaining_ids = self.prefix_cache.fetch(lookup_ids)
+                        if cached_kv is not None and S > 0:
+                            remaining_ids = list(remaining_ids) + input_ids_list[-S:]
 
                     # If remaining tokens contain image placeholders, the
                     # language-model-only path cannot handle them — clear the
@@ -1535,8 +1748,16 @@ class MLLMBatchGenerator:
                     remaining_ids = None
 
                 prepared_cache = None
-                if cached_kv is not None and remaining_ids:
-                    prepared_cache = self._copy_prefix_cache(cached_kv)
+                if cached_kv is not None and cached_last_logits is not None:
+                    prepared_cache = self._clone_prefix_for_replay(cached_kv)
+                    if prepared_cache is None or not self._prepare_rotating_caches(
+                        prepared_cache
+                    ):
+                        cached_kv = None
+                        cached_last_logits = None
+                        prepared_cache = None
+                elif cached_kv is not None and remaining_ids:
+                    prepared_cache = self._clone_prefix_for_replay(cached_kv)
                     if prepared_cache is None or not self._prepare_rotating_caches(
                         prepared_cache
                     ):
@@ -1549,7 +1770,12 @@ class MLLMBatchGenerator:
                         remaining_ids = None
                         prepared_cache = None
                 elif cached_kv is not None and not remaining_ids:
-                    prepared_cache = self._rewind_prefix_cache(cached_kv, 1)
+                    isolated_cache = self._clone_prefix_for_replay(cached_kv)
+                    prepared_cache = (
+                        None
+                        if isolated_cache is None
+                        else self._rewind_prefix_cache(isolated_cache, 1)
+                    )
                     if prepared_cache is None:
                         logger.debug(
                             "Prefix cache exact hit for %s cannot be rewound "
@@ -1558,7 +1784,19 @@ class MLLMBatchGenerator:
                         )
                         cached_kv = None
 
-                if cached_kv is not None and remaining_ids:
+                if cached_kv is not None and cached_last_logits is not None:
+                    request_cache = prepared_cache
+                    last_logits = cached_last_logits
+                    sampled, logprobs = _sample_first_token(req, last_logits)
+                    first_tokens.append(sampled.item())
+                    all_logprobs.append(logprobs.squeeze(0))
+                    per_request_caches.append(request_cache)
+                    req.vision_encoded = True
+                    self._prefill_progress[req.request_id] = (
+                        len(input_ids_list),
+                        len(input_ids_list),
+                    )
+                elif cached_kv is not None and remaining_ids:
                     # Prefix/LCP match — run language model on remaining tokens.
                     # The prepared cache is an isolated recursive copy.
                     request_cache = prepared_cache
@@ -1575,7 +1813,13 @@ class MLLMBatchGenerator:
                                 total_tokens,
                                 total_tokens,
                             )
-                            logits = self.language_model(remaining, cache=request_cache)
+                            logits = self.language_model(
+                                remaining,
+                                cache=request_cache,
+                                **self._language_model_kwargs(
+                                    req, cached_count, total_tokens
+                                ),
+                            )
                         else:
                             # Chunked prefill on remaining tokens
                             self._prefill_progress[req.request_id] = (
@@ -1595,7 +1839,15 @@ class MLLMBatchGenerator:
                                     raise PrefillAbortedError(req.request_id)
 
                                 chunk = remaining[:, processed : processed + step]
-                                self.language_model(chunk, cache=request_cache)
+                                self.language_model(
+                                    chunk,
+                                    cache=request_cache,
+                                    **self._language_model_kwargs(
+                                        req,
+                                        cached_count + processed,
+                                        cached_count + processed + chunk.shape[1],
+                                    ),
+                                )
                                 # Eval ALL cache types (see _run_chunked_text_prefill)
                                 _eval_prompt_cache(request_cache)
                                 processed += step
@@ -1608,7 +1860,15 @@ class MLLMBatchGenerator:
                                     mx.clear_cache()
                             # Last chunk — return logits
                             remaining = remaining[:, processed:]
-                            logits = self.language_model(remaining, cache=request_cache)
+                            logits = self.language_model(
+                                remaining,
+                                cache=request_cache,
+                                **self._language_model_kwargs(
+                                    req,
+                                    cached_count + processed,
+                                    total_tokens,
+                                ),
+                            )
                             self._prefill_progress[req.request_id] = (
                                 total_tokens,
                                 total_tokens,
@@ -1647,7 +1907,13 @@ class MLLMBatchGenerator:
                     )
 
                     with mx.stream(MLLMBatchGenerator._stream):
-                        logits = self.language_model(last_token, cache=request_cache)
+                        logits = self.language_model(
+                            last_token,
+                            cache=request_cache,
+                            **self._language_model_kwargs(
+                                req, total_tokens - 1, total_tokens
+                            ),
+                        )
                         if hasattr(logits, "logits"):
                             logits = logits.logits
 
@@ -1685,6 +1951,36 @@ class MLLMBatchGenerator:
                         # Extract last token logits
                         last_logits = logits[:, -1, :]
 
+                        if (
+                            self.prefix_cache is not None
+                            and self._needs_prefill_checkpoint(request_cache)
+                            and callable(
+                                getattr(self.prefix_cache, "prepare_store", None)
+                            )
+                        ):
+                            entry = self.prefix_cache.prepare_store(
+                                req.input_ids.reshape(-1).tolist(),
+                                request_cache,
+                                auxiliary={"last_logits": last_logits},
+                            )
+                            if entry is not None:
+                                self._publish_prefill_checkpoint(req.request_id, entry)
+                                continuation = self._clone_prefix_for_replay(
+                                    entry.cache
+                                )
+                                if (
+                                    continuation is None
+                                    or not self._prepare_rotating_caches(continuation)
+                                ):
+                                    raise RuntimeError(
+                                        "Cannot continue from stored hybrid prompt state"
+                                    )
+                                request_cache[:] = continuation
+                                if entry.auxiliary is not None:
+                                    stored_logits = entry.auxiliary.get("last_logits")
+                                    if stored_logits is not None:
+                                        last_logits = stored_logits
+
                         sampled, logprobs = _sample_first_token(req, last_logits)
 
                         first_tokens.append(sampled.item())
@@ -1694,6 +1990,7 @@ class MLLMBatchGenerator:
 
             except PrefillAbortedError:
                 aborted_requests.append(req)
+                self._discard_prefill_checkpoint(req.request_id)
                 self._prefill_progress.pop(req.request_id, None)
                 self._pending_error_responses.append(
                     MLLMBatchResponse(
@@ -1784,6 +2081,7 @@ class MLLMBatchGenerator:
             req.attention_mask = None
             req.image_grid_thw = None
             req.extra_kwargs.clear()
+            req.prompt_position_ids = None
 
         return MLLMBatch(
             uids=[req.uid for req in requests],
@@ -1805,6 +2103,7 @@ class MLLMBatchGenerator:
         logits_processors: Optional[List[Optional[List[Callable]]]] = None,
         output_tokens: Optional[List[List[int]]] = None,
         samplers: Optional[List[Optional[Callable]]] = None,
+        rope_deltas: Optional[mx.array] = None,
     ) -> Tuple[mx.array, List[mx.array]]:
         """
         Run one generation step through the language model.
@@ -1824,7 +2123,8 @@ class MLLMBatchGenerator:
             input_tokens = input_tokens[:, None]
 
         # Run language model only (not full VLM)
-        output = self.language_model(input_tokens, cache=cache)
+        model_kwargs = {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
+        output = self.language_model(input_tokens, cache=cache, **model_kwargs)
 
         # Handle LanguageModelOutput or plain tensor
         if hasattr(output, "logits"):
@@ -1912,6 +2212,7 @@ class MLLMBatchGenerator:
                     r for r in self.unprocessed_requests if r.uid not in requested_uids
                 ]
                 for req in requests:
+                    self._discard_prefill_checkpoint(req.request_id)
                     self._pending_error_responses.append(
                         MLLMBatchResponse(
                             uid=req.uid,
@@ -1958,6 +2259,7 @@ class MLLMBatchGenerator:
                         if r.uid not in processed_uids
                     ]
                     for req in text_only:
+                        self._discard_prefill_checkpoint(req.request_id)
                         self._pending_error_responses.append(
                             MLLMBatchResponse(
                                 uid=req.uid,
@@ -1987,12 +2289,15 @@ class MLLMBatchGenerator:
                 list(req.output_tokens) + [token]
                 for req, token in zip(batch.requests, y_list)
             ]
+        rope_deltas = self._batch_rope_deltas(batch.requests)
+        step_kwargs = {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
         batch.y, batch.logprobs = self._step(
             y[:, None],
             batch.cache,
             batch.logits_processors,
             output_tokens,
             batch.samplers,
+            **step_kwargs,
         )
         mx.async_eval(batch.y, batch.logprobs)
 
@@ -2116,6 +2421,8 @@ class MLLMBatchGenerator:
         trim_by: int,
         request_id: str,
         source: str,
+        *,
+        evict_prefixes: bool = True,
     ) -> bool:
         """Store an isolated, key-aligned cache snapshot when rewind is safe."""
         if self.prefix_cache is None:
@@ -2130,8 +2437,13 @@ class MLLMBatchGenerator:
                 trim_by,
             )
             return False
-        self.prefix_cache.store(cache_key, snapshot)
-        return True
+        return bool(
+            self.prefix_cache.store(
+                cache_key,
+                snapshot,
+                evict_prefixes=evict_prefixes,
+            )
+        )
 
     def _maybe_store_prefix_cache(
         self, batch: MLLMBatch, end_indices: List[int]
@@ -2145,6 +2457,7 @@ class MLLMBatchGenerator:
         for i in end_indices:
             req = batch.requests[i]
             if req.input_ids is not None:
+                self._discard_prefill_checkpoint(req.request_id)
                 try:
                     extracted = batch.extract_cache(i)
                     input_ids_list = req.input_ids.reshape(-1).tolist()
@@ -2324,9 +2637,11 @@ def install_mtp_mllm(
         logits_processors: Optional[List[Optional[List[Callable]]]] = None,
         output_tokens: Optional[List[List[int]]] = None,
         samplers: Optional[List[Optional[Callable]]] = None,
+        rope_deltas: Optional[mx.array] = None,
     ) -> Tuple[mx.array, List[mx.array]]:
         """Extended _step with MTP always-advance strategy."""
         batch_size = input_tokens.shape[0]
+        model_kwargs = {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
         active_requests = (
             list(batch_gen.active_batch.requests)
             if batch_gen.active_batch is not None
@@ -2340,9 +2655,14 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
+        mrope_media_bypass = external_drafter and any(
+            getattr(request, "images", None) or getattr(request, "videos", None)
+            for request in active_requests
+        )
         assistant_not_requested_bypass = external_drafter and (
             not active_requests
             or not all(request.mllm_draft for request in active_requests)
+            or mrope_media_bypass
         )
         if (
             prefill_bypass
@@ -2366,8 +2686,16 @@ def install_mtp_mllm(
                 if assistant_not_requested_bypass:
                     _bypass_counts["assistant_not_requested"] += 1
             _skip_state_by_uid.clear()
+            original_step_kwargs = (
+                {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
+            )
             return _orig_step(
-                input_tokens, cache, logits_processors, output_tokens, samplers
+                input_tokens,
+                cache,
+                logits_processors,
+                output_tokens,
+                samplers,
+                **original_step_kwargs,
             )
 
         current_uids = list(batch_gen.active_batch.uids)
@@ -2393,11 +2721,21 @@ def install_mtp_mllm(
             )
         else:
             # Normal forward with return_hidden
-            model_output = language_model(input_tokens, cache=cache, return_hidden=True)
+            model_output = language_model(
+                input_tokens, cache=cache, return_hidden=True, **model_kwargs
+            )
             logits, hidden_states = _model_parts(model_output)
             if hidden_states is None:
+                original_step_kwargs = (
+                    {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
+                )
                 return _orig_step(
-                    input_tokens, cache, logits_processors, output_tokens, samplers
+                    input_tokens,
+                    cache,
+                    logits_processors,
+                    output_tokens,
+                    samplers,
+                    **original_step_kwargs,
                 )
             logits = logits[:, -1, :]
 
@@ -2508,7 +2846,7 @@ def install_mtp_mllm(
                 [primary_tokens[:, None], draft_tokens[:, None]], axis=1
             )
             verify_output = language_model(
-                verify_input, cache=cache, return_hidden=True
+                verify_input, cache=cache, return_hidden=True, **model_kwargs
             )
             verify_logits, verify_hidden = _model_parts(verify_output)
 
@@ -2631,6 +2969,7 @@ def install_mtp_mllm(
                         (replay_tokens if sampled_reject else primary_tokens[:, None]),
                         cache=cache,
                         return_hidden=True,
+                        **model_kwargs,
                     )
                     rerun_logits, rerun_hidden = _model_parts(rerun_out)
                     if rerun_hidden is not None:
@@ -2662,6 +3001,7 @@ def install_mtp_mllm(
                             residual_tokens[:, None],
                             cache=cache,
                             return_hidden=True,
+                            **model_kwargs,
                         )
                         if isinstance(rerun_out, tuple) or hasattr(rerun_out, "logits"):
                             rerun_logits, rerun_hidden = _model_parts(rerun_out)
@@ -2911,12 +3251,15 @@ def install_chunked_prefill_mllm(
             if batch.logits_processors
             else None
         )
+        rope_deltas = batch_gen._batch_rope_deltas(batch.requests)
+        step_kwargs = {"rope_deltas": rope_deltas} if rope_deltas is not None else {}
         batch.y, batch.logprobs = batch_gen._step(
             y[:, None],
             batch.cache,
             batch.logits_processors,
             output_tokens,
             batch.samplers,
+            **step_kwargs,
         )
         # Synchronous eval — must have results before context switch
         mx.eval(batch.y, batch.logprobs)
@@ -3014,15 +3357,54 @@ def install_chunked_prefill_mllm(
             step = batch_gen._chunked_prefill_budget
             remaining = partial["remaining_ids"]
             remaining_count = remaining.shape[1]
+            take = min(step, remaining_count)
+            checkpoint_at = partial.get("checkpoint_at")
+            current_position = partial["cached_count"] + partial["processed"]
+            if (
+                checkpoint_at is not None
+                and current_position < checkpoint_at < current_position + take
+            ):
+                take = checkpoint_at - current_position
 
-            if remaining_count > step:
+            if remaining_count > take:
                 # Process ONE chunk
                 tic = time.perf_counter()
-                batch_gen.language_model(remaining[:, :step], cache=partial["cache"])
+                batch_gen.language_model(
+                    remaining[:, :take],
+                    cache=partial["cache"],
+                    **batch_gen._language_model_kwargs(
+                        req, current_position, current_position + take
+                    ),
+                )
                 _eval_prompt_cache(partial["cache"])
-                partial["remaining_ids"] = remaining[:, step:]
-                partial["processed"] += step
+                partial["remaining_ids"] = remaining[:, take:]
+                partial["processed"] += take
                 partial["chunk_count"] += 1
+                if (
+                    checkpoint_at is not None
+                    and partial["cached_count"] + partial["processed"] == checkpoint_at
+                ):
+                    checkpoint_snapshot = batch_gen._rewind_prefix_cache(
+                        partial["cache"], 0
+                    )
+                    if checkpoint_snapshot is not None:
+                        partial["checkpoint_entry"] = (
+                            batch_gen.prefix_cache.prepare_store(
+                                partial["checkpoint_key"], checkpoint_snapshot
+                            )
+                        )
+                        checkpoint_entry = partial["checkpoint_entry"]
+                        if checkpoint_entry is not None:
+                            continuation = batch_gen._clone_prefix_for_replay(
+                                checkpoint_entry.cache
+                            )
+                            if (
+                                continuation is None
+                                or not batch_gen._prepare_rotating_caches(continuation)
+                            ):
+                                partial["checkpoint_entry"] = None
+                            else:
+                                partial["cache"][:] = continuation
                 batch_gen._prefill_progress[req.request_id] = (
                     partial["cached_count"] + partial["processed"],
                     partial["total"],
@@ -3084,10 +3466,48 @@ def install_chunked_prefill_mllm(
             else:
                 # Last chunk — finalize prefill
                 tic = time.perf_counter()
-                logits = batch_gen.language_model(remaining, cache=partial["cache"])
+                logits = batch_gen.language_model(
+                    remaining,
+                    cache=partial["cache"],
+                    **batch_gen._language_model_kwargs(
+                        req, current_position, current_position + remaining_count
+                    ),
+                )
                 if hasattr(logits, "logits"):
                     logits = logits.logits
                 last_logits = logits[:, -1, :]
+
+                if (
+                    getattr(batch_gen, "prefix_cache", None) is not None
+                    and batch_gen._needs_prefill_checkpoint(partial["cache"])
+                    and req.input_ids is not None
+                ):
+                    checkpoint_entry = batch_gen.prefix_cache.prepare_store(
+                        req.input_ids.reshape(-1).tolist(),
+                        partial["cache"],
+                        auxiliary={"last_logits": last_logits},
+                    )
+                    if checkpoint_entry is not None:
+                        batch_gen._publish_prefill_checkpoint(
+                            req.request_id, checkpoint_entry
+                        )
+                        continuation = batch_gen._clone_prefix_for_replay(
+                            checkpoint_entry.cache
+                        )
+                        if (
+                            continuation is None
+                            or not batch_gen._prepare_rotating_caches(continuation)
+                        ):
+                            raise RuntimeError(
+                                "Cannot continue from stored hybrid prompt state"
+                            )
+                        partial["cache"][:] = continuation
+                        if checkpoint_entry.auxiliary is not None:
+                            stored_logits = checkpoint_entry.auxiliary.get(
+                                "last_logits"
+                            )
+                            if stored_logits is not None:
+                                last_logits = stored_logits
 
                 # Apply logits processors for first token
                 if getattr(req, "logits_processors", None):
@@ -3100,6 +3520,27 @@ def install_chunked_prefill_mllm(
                 )
                 sampled = batch_gen.sampler(logprobs)
                 mx.eval(sampled, logprobs)
+
+                checkpoint_entry = partial.get("checkpoint_entry")
+                if checkpoint_entry is not None:
+                    try:
+                        batch_gen._publish_prefill_checkpoint(
+                            req.request_id, checkpoint_entry
+                        )
+                    except PrefillAbortedError:
+                        batch_gen._partial = None
+                        batch_gen._prefill_progress.pop(req.request_id, None)
+                        batch_gen._pending_error_responses.append(
+                            MLLMBatchResponse(
+                                uid=req.uid,
+                                request_id=req.request_id,
+                                token=0,
+                                logprobs=mx.zeros(1),
+                                finish_reason="abort",
+                            )
+                        )
+                        mx.clear_cache()
+                        return _generation_step()
 
                 batch_gen._prefill_progress[req.request_id] = (
                     partial["total"],
@@ -3189,7 +3630,11 @@ def install_chunked_prefill_mllm(
                     batch_gen.active_batch = new_batch
 
                 # Store in prefix cache (prompt-only)
-                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                if (
+                    checkpoint_entry is None
+                    and batch_gen.prefix_cache is not None
+                    and req.input_ids is not None
+                ):
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
                         S = batch_gen._think_suffix_len
@@ -3216,6 +3661,7 @@ def install_chunked_prefill_mllm(
                     f"for {req.request_id[:12]}: "
                     f"{partial['total']} tokens in {partial['chunk_count']} chunks"
                 )
+                req.prompt_position_ids = None
                 batch_gen._partial = None
                 mx.clear_cache()
                 return _generation_step()
@@ -3242,6 +3688,9 @@ def install_chunked_prefill_mllm(
                 try:
                     # Preprocess to get input_ids
                     batch_gen._preprocess_request(text_only_req)
+                    text_only_req.rope_deltas = batch_gen._derive_request_rope_deltas(
+                        text_only_req
+                    )
                 except Exception as e:
                     logger.error(
                         f"Failed to preprocess request "
@@ -3271,6 +3720,18 @@ def install_chunked_prefill_mllm(
 
                 if batch_gen.prefix_cache is not None:
                     input_ids_list = input_ids.reshape(-1).tolist()
+                    fetch_auxiliary = getattr(
+                        batch_gen.prefix_cache, "fetch_exact_auxiliary", None
+                    )
+                    if callable(fetch_auxiliary) and fetch_auxiliary(input_ids_list):
+                        batch_gen.unprocessed_requests.remove(text_only_req)
+                        new_batch = batch_gen._process_prompts([text_only_req])
+                        if new_batch is not None:
+                            if batch_gen.active_batch is not None:
+                                batch_gen.active_batch.extend(new_batch)
+                            else:
+                                batch_gen.active_batch = new_batch
+                        return _generation_step()
                     S = batch_gen._think_suffix_len
                     lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
                     cached_kv, remaining_ids = batch_gen.prefix_cache.fetch(lookup_ids)
@@ -3286,7 +3747,7 @@ def install_chunked_prefill_mllm(
 
                 prepared_cache = None
                 if cached_kv is not None and remaining_ids:
-                    prepared_cache = batch_gen._copy_prefix_cache(cached_kv)
+                    prepared_cache = batch_gen._clone_prefix_for_replay(cached_kv)
                     if (
                         prepared_cache is None
                         or not batch_gen._prepare_rotating_caches(prepared_cache)
@@ -3295,7 +3756,12 @@ def install_chunked_prefill_mllm(
                         remaining_ids = None
                         prepared_cache = None
                 elif cached_kv is not None and not remaining_ids:
-                    prepared_cache = batch_gen._rewind_prefix_cache(cached_kv, 1)
+                    isolated_cache = batch_gen._clone_prefix_for_replay(cached_kv)
+                    prepared_cache = (
+                        None
+                        if isolated_cache is None
+                        else batch_gen._rewind_prefix_cache(isolated_cache, 1)
+                    )
                     if prepared_cache is None:
                         cached_kv = None
 
@@ -3322,6 +3788,13 @@ def install_chunked_prefill_mllm(
                     cached_count = 0
                     remaining_count = total_tokens
 
+                checkpoint_at = None
+                checkpoint_key = None
+                if cached_count == 0:
+                    checkpoint_at, checkpoint_key = batch_gen._prefill_checkpoint_plan(
+                        input_ids, request_cache
+                    )
+
                 # Decide: interleave or immediate
                 if remaining_count > batch_gen._chunked_prefill_budget:
                     # LONG prompt — start partial (interleaved) prefill
@@ -3339,20 +3812,56 @@ def install_chunked_prefill_mllm(
                         "total": total_tokens,
                         "cached_count": cached_count,
                         "chunk_count": 0,
+                        "checkpoint_at": checkpoint_at,
+                        "checkpoint_key": checkpoint_key,
+                        "checkpoint_entry": None,
                     }
                     batch_gen.unprocessed_requests.remove(text_only_req)
                     text_only_req.vision_encoded = True
 
                     # Process first chunk immediately
                     step = batch_gen._chunked_prefill_budget
+                    take = min(step, remaining_count)
+                    if checkpoint_at is not None and checkpoint_at < take:
+                        take = checkpoint_at
                     tic = time.perf_counter()
-                    batch_gen.language_model(remaining[:, :step], cache=request_cache)
+                    batch_gen.language_model(
+                        remaining[:, :take],
+                        cache=request_cache,
+                        **batch_gen._language_model_kwargs(
+                            text_only_req, cached_count, cached_count + take
+                        ),
+                    )
                     _eval_prompt_cache(request_cache)
-                    batch_gen._partial["remaining_ids"] = remaining[:, step:]
-                    batch_gen._partial["processed"] = step
+                    batch_gen._partial["remaining_ids"] = remaining[:, take:]
+                    batch_gen._partial["processed"] = take
                     batch_gen._partial["chunk_count"] = 1
+                    if checkpoint_at is not None and take == checkpoint_at:
+                        checkpoint_snapshot = batch_gen._rewind_prefix_cache(
+                            request_cache, 0
+                        )
+                        if checkpoint_snapshot is not None:
+                            batch_gen._partial["checkpoint_entry"] = (
+                                batch_gen.prefix_cache.prepare_store(
+                                    checkpoint_key, checkpoint_snapshot
+                                )
+                            )
+                            checkpoint_entry = batch_gen._partial["checkpoint_entry"]
+                            if checkpoint_entry is not None:
+                                continuation = batch_gen._clone_prefix_for_replay(
+                                    checkpoint_entry.cache
+                                )
+                                if (
+                                    continuation is None
+                                    or not batch_gen._prepare_rotating_caches(
+                                        continuation
+                                    )
+                                ):
+                                    batch_gen._partial["checkpoint_entry"] = None
+                                else:
+                                    request_cache[:] = continuation
                     batch_gen._prefill_progress[text_only_req.request_id] = (
-                        cached_count + step,
+                        cached_count + take,
                         total_tokens,
                     )
                     batch_gen._stats.prompt_time += time.perf_counter() - tic

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1951,6 +1951,12 @@ class MLLMBatchGenerator:
                         # Extract last token logits
                         last_logits = logits[:, -1, :]
 
+                        # Keep the cold request's first-token path identical
+                        # whether or not a prompt snapshot will be published.
+                        # prepare_store() materializes a detached cache-wide
+                        # copy, so sampling must complete before that barrier.
+                        sampled, logprobs = _sample_first_token(req, last_logits)
+
                         if (
                             self.prefix_cache is not None
                             and self._needs_prefill_checkpoint(request_cache)
@@ -1965,23 +1971,6 @@ class MLLMBatchGenerator:
                             )
                             if entry is not None:
                                 self._publish_prefill_checkpoint(req.request_id, entry)
-                                continuation = self._clone_prefix_for_replay(
-                                    entry.cache
-                                )
-                                if (
-                                    continuation is None
-                                    or not self._prepare_rotating_caches(continuation)
-                                ):
-                                    raise RuntimeError(
-                                        "Cannot continue from stored hybrid prompt state"
-                                    )
-                                request_cache[:] = continuation
-                                if entry.auxiliary is not None:
-                                    stored_logits = entry.auxiliary.get("last_logits")
-                                    if stored_logits is not None:
-                                        last_logits = stored_logits
-
-                        sampled, logprobs = _sample_first_token(req, last_logits)
 
                         first_tokens.append(sampled.item())
                         all_logprobs.append(logprobs.squeeze(0))
@@ -3475,39 +3464,17 @@ def install_chunked_prefill_mllm(
                 )
                 if hasattr(logits, "logits"):
                     logits = logits.logits
-                last_logits = logits[:, -1, :]
+                prompt_last_logits = logits[:, -1, :]
+                last_logits = prompt_last_logits
 
-                if (
-                    getattr(batch_gen, "prefix_cache", None) is not None
-                    and batch_gen._needs_prefill_checkpoint(partial["cache"])
-                    and req.input_ids is not None
-                ):
-                    checkpoint_entry = batch_gen.prefix_cache.prepare_store(
-                        req.input_ids.reshape(-1).tolist(),
-                        partial["cache"],
-                        auxiliary={"last_logits": last_logits},
-                    )
-                    if checkpoint_entry is not None:
-                        batch_gen._publish_prefill_checkpoint(
-                            req.request_id, checkpoint_entry
-                        )
-                        continuation = batch_gen._clone_prefix_for_replay(
-                            checkpoint_entry.cache
-                        )
-                        if (
-                            continuation is None
-                            or not batch_gen._prepare_rotating_caches(continuation)
-                        ):
-                            raise RuntimeError(
-                                "Cannot continue from stored hybrid prompt state"
-                            )
-                        partial["cache"][:] = continuation
-                        if checkpoint_entry.auxiliary is not None:
-                            stored_logits = checkpoint_entry.auxiliary.get(
-                                "last_logits"
-                            )
-                            if stored_logits is not None:
-                                last_logits = stored_logits
+                from mlx_lm.sample_utils import make_sampler
+
+                req_sampler = make_sampler(
+                    temp=req.temperature,
+                    top_p=req.top_p,
+                    top_k=req.top_k,
+                    min_p=req.min_p,
+                )
 
                 # Apply logits processors for first token
                 if getattr(req, "logits_processors", None):
@@ -3518,8 +3485,41 @@ def install_chunked_prefill_mllm(
                 logprobs = last_logits - mx.logsumexp(
                     last_logits, axis=-1, keepdims=True
                 )
-                sampled = batch_gen.sampler(logprobs)
+                sampled = req_sampler(logprobs)
                 mx.eval(sampled, logprobs)
+
+                # Snapshot only after first-token sampling has materialized.
+                # The stored auxiliary remains the raw prompt logits, before
+                # request-local processors are applied.
+                if (
+                    getattr(batch_gen, "prefix_cache", None) is not None
+                    and batch_gen._needs_prefill_checkpoint(partial["cache"])
+                    and req.input_ids is not None
+                ):
+                    full_prompt_entry = batch_gen.prefix_cache.prepare_store(
+                        req.input_ids.reshape(-1).tolist(),
+                        partial["cache"],
+                        auxiliary={"last_logits": prompt_last_logits},
+                    )
+                    if full_prompt_entry is not None:
+                        try:
+                            batch_gen._publish_prefill_checkpoint(
+                                req.request_id, full_prompt_entry
+                            )
+                        except PrefillAbortedError:
+                            batch_gen._partial = None
+                            batch_gen._prefill_progress.pop(req.request_id, None)
+                            batch_gen._pending_error_responses.append(
+                                MLLMBatchResponse(
+                                    uid=req.uid,
+                                    request_id=req.request_id,
+                                    token=0,
+                                    logprobs=mx.zeros(1),
+                                    finish_reason="abort",
+                                )
+                            )
+                            mx.clear_cache()
+                            return _generation_step()
 
                 checkpoint_entry = partial.get("checkpoint_entry")
                 if checkpoint_entry is not None:
@@ -3549,7 +3549,7 @@ def install_chunked_prefill_mllm(
                 batch_gen._stats.prompt_time += time.perf_counter() - tic
 
                 # Build single-request batch
-                from mlx_lm.sample_utils import make_logits_processors, make_sampler
+                from mlx_lm.sample_utils import make_logits_processors
 
                 req_lp = []
                 need_rep = req.repetition_penalty and req.repetition_penalty != 1.0
@@ -3564,15 +3564,6 @@ def install_chunked_prefill_mllm(
                 if req.logits_processors:
                     req_lp.extend(req.logits_processors)
 
-                req_sampler = None
-                if req.top_k != 0 or req.min_p != 0.0:
-                    req_sampler = make_sampler(
-                        temp=req.temperature,
-                        top_p=req.top_p,
-                        top_k=req.top_k,
-                        min_p=req.min_p,
-                    )
-
                 new_batch = MLLMBatch(
                     uids=[req.uid],
                     request_ids=[req.request_id],
@@ -3583,7 +3574,7 @@ def install_chunked_prefill_mllm(
                     cache=partial["cache"],
                     requests=[req],
                     logits_processors=[req_lp] if req_lp else None,
-                    samplers=[req_sampler] if req_sampler else None,
+                    samplers=[req_sampler],
                 )
 
                 # Extend active batch or set as new


### PR DESCRIPTION

### Summary

This fixes prefix-cache ownership and replay on the `MLLMScheduler` text path
for hybrid models that combine ordinary KV caches with recurrent cache state.

### Problem

Hybrid prompt state cannot be treated like an ordinary rewindable KV cache.
The previous path could retain request-owned lazy arrays, omit auxiliary prompt
logits from memory accounting, publish an entry after cancellation, or
materialize a cache snapshot before the cold request sampled its first token.
Interleaved prefill could also finish with the generator sampler instead of the
request-local sampling configuration.

These failures made ownership and memory use ambiguous and could make enabled
cold, disabled cold, and warm replay produce different output.

### Changes

- Prepare detached, materialized cache entries outside the publication lock,
  then commit them under a cancellation guard.
- Account for owned cache backing and auxiliary prompt logits before admitting
  an entry. Oversized entries fail closed as normal cache misses.
- Store nonrewindable hybrid state at the prompt boundary and clone owned state
  for replay instead of advancing a stored snapshot with the live request.
- Preserve prompt-final logits, request-local mRoPE state, and request-local
  sampling parameters across ordinary and interleaved prefill.
- Sample and evaluate the cold request before snapshot materialization so
  enabling the cache does not change first-token execution order.
- Prevent cancelled prefill from publishing and release partial request state.

### Verification

The complete repository suite on the final three-commit tree passed:

- 2,976 passed
- 25 skipped
- 27 deselected
- Black and Ruff passed on all five changed files

I also qualified the exact path on an M2 Ultra with Qwen3.8-27B 8-bit,
continuous batching, native-target MTP, a 2,048-token prefill chunk, and a
6,144 MB prefix-cache budget. Each fixture generated a fixed greedy response.

| Fixture | Cache disabled cold | Cache enabled cold | Cache enabled warm | Warm reduction |
|---|---:|---:|---:|---:|
| 2K | 12,160.85 ms | 11,915.68 ms | 583.27 ms | 95.11% |
| 6K | 32,116.78 ms | 32,535.50 ms | 589.34 ms | 98.19% |
| 12K | 67,381.15 ms | 68,253.42 ms | 620.24 ms | 99.09% |
| mRoPE, thinking off | 11,751.55 ms | 11,806.67 ms | 432.97 ms | 96.33% |
| mRoPE, thinking on | 14,866.90 ms | 14,723.32 ms | 3,124.39 ms | 78.78% |

For every fixture, cache-enabled cold output matched cache-disabled cold output,
and warm output matched cache-enabled cold output. The thinking comparison
included reasoning content. MTP completed with zero errors. Cancellation did
not leave an extra entry, and explicit clear returned the cache to zero entries
and zero owned bytes.

These are fixed-workload qualification measurements, not a broad throughput or
concurrency claim.

### Scope and fallback

- Prefix caching remains opt-in.
- Unsupported or oversized cache state is rejected and follows the ordinary
  prefill path.
- Media-request caching remains excluded by the existing request guard.
- Growing chat histories whose tokenized form diverges before the stored prompt
  boundary remain cold misses for hybrid recurrent state. Supporting that reuse
  requires a separately owned stable conversation-boundary checkpoint. This pull
  request does not rewind recurrent cache leaves.
- This does not add SSD or restart restoration, change default routing, or add a
  TextModel override for VLM artifacts.
- This does not qualify external-drafter behavior.

### Related work

Package 1 supersedes #731's hybrid rewind-gate approach. It intentionally keeps
strict rewind rejection for recurrent or non-position-indexed leaves and uses
detached prompt-boundary snapshots with final prompt logits for exact reuse.
Merging #731 independently would change that contract, so please treat #731 as
superseded by this implementation.

PRs #726 and #728 address media-request isolation and overlap parts of the same
generator file. Media caching remains excluded here. Those PRs require separate
reconciliation and should not be folded into this ownership patch without their
own tests. PRs #694, #708, #713, and #732 are also open around adjacent MLLM or
cache behavior; they are not claims or dependencies of this pull request.