### PR TITLE
fix(shutdown): exit the serve process before MLX's thread-local teardown segfaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
             tests/test_chat_template_safety.py \
             tests/test_simple_engine_thread_pinning.py \
             tests/test_engine_base.py \
+            tests/test_shutdown_decision.py \
             tests/test_harmony_parsers.py \
             tests/test_endpoint_model_policies.py \
             tests/test_truncation.py \
@@ -201,6 +202,8 @@ jobs:
             tests/test_harmony_render.py \
             tests/test_embeddings.py \
             tests/test_rerank.py \
+            tests/test_shutdown_decision.py \
+            tests/test_shutdown_exit.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -126,6 +126,7 @@ Create `mcp.json`:
 | Variable | Description |
 |----------|-------------|
 | `VLLM_MLX_TEST_MODEL` | Default model for tests |
+| `VLLM_MLX_CLEAN_EXIT` | Set to `0` to keep normal interpreter finalization on shutdown. Default `1`: the serve process exits at the end of lifespan shutdown, once every request is served and caches are persisted, because MLX's thread-local compile cache segfaults during CPython teardown. Only affects the `serve` entry points, never library use. |
 | `HF_TOKEN` | HuggingFace authentication token |
 | `OPENAI_API_KEY` | Set to any value for SDK compatibility |
 

--- a/tests/test_shutdown_decision.py
+++ b/tests/test_shutdown_decision.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Portable coverage for the clean-exit policy (vllm_mlx.shutdown).
+
+The policy decides whether the serve process may skip CPython finalization at
+the end of lifespan shutdown (the MLX thread-local teardown segfault
+workaround). The decision module imports no engine code, so these tests run
+in the standard no-MLX CI job on every platform. The os._exit/lifespan wiring
+itself — driving the real server through startup and shutdown — remains in
+tests/test_shutdown_exit.py, which needs MLX and runs on Apple Silicon.
+
+vllm_mlx.server and vllm_mlx.cli cannot be imported without MLX, so the tests
+that pin their call sites read the source instead: an AST assertion fails the
+same way a broken import would, without needing the platform.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.shutdown import (
+    clean_exit_enabled,
+    exit_without_finalizing,
+    should_exit_without_finalizing,
+)
+
+PACKAGE = Path(__file__).resolve().parent.parent / "vllm_mlx"
+
+
+# ---------------------------------------------------------------------------
+# The decision predicate
+# ---------------------------------------------------------------------------
+
+
+def test_clean_shutdown_with_optin_exits():
+    assert should_exit_without_finalizing(None, None, True, env={}) is True
+
+
+def test_primary_failure_never_exits():
+    """A failed serving phase must propagate and exit non-zero."""
+    assert (
+        should_exit_without_finalizing(RuntimeError("boom"), None, True, env={})
+        is False
+    )
+
+
+def test_cleanup_failure_never_exits():
+    """A failed cleanup phase is a failed shutdown, not a success."""
+    assert (
+        should_exit_without_finalizing(None, RuntimeError("boom"), True, env={})
+        is False
+    )
+
+
+def test_both_failures_never_exit():
+    assert (
+        should_exit_without_finalizing(
+            RuntimeError("a"), RuntimeError("b"), True, env={}
+        )
+        is False
+    )
+
+
+def test_env_disable_keeps_normal_finalization():
+    """VLLM_MLX_CLEAN_EXIT=0 restores ordinary interpreter teardown."""
+    env = {"VLLM_MLX_CLEAN_EXIT": "0"}
+    assert should_exit_without_finalizing(None, None, True, env=env) is False
+    assert clean_exit_enabled(env) is False
+
+
+def test_env_default_is_enabled():
+    assert clean_exit_enabled({}) is True
+    assert clean_exit_enabled({"VLLM_MLX_CLEAN_EXIT": "1"}) is True
+
+
+def test_embedded_use_never_exits():
+    """Library/embedded use never opts in: exiting the host process is not
+
+    ours to do. The opt-in flag is threaded through explicitly, so with it
+    false the decision is false no matter how clean the shutdown was.
+    """
+    assert should_exit_without_finalizing(None, None, False, env={}) is False
+    assert (
+        should_exit_without_finalizing(None, None, False, env={"VLLM_MLX_CLEAN_EXIT": "1"})
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# The exit mechanics (os._exit monkeypatched — nothing here kills pytest)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_exit(monkeypatch):
+    calls: list[int] = []
+    monkeypatch.setattr("vllm_mlx.shutdown.os._exit", calls.append)
+    return calls
+
+
+def test_exit_forwards_status_and_flushes(fake_exit, monkeypatch):
+    monkeypatch.delenv("VLLM_MLX_CLEAN_EXIT", raising=False)
+    exit_without_finalizing(3)
+    assert fake_exit == [3]
+
+
+def test_exit_default_status_is_zero(fake_exit, monkeypatch):
+    monkeypatch.delenv("VLLM_MLX_CLEAN_EXIT", raising=False)
+    exit_without_finalizing()
+    assert fake_exit == [0]
+
+
+def test_exit_respects_env_disable(fake_exit, monkeypatch):
+    monkeypatch.setenv("VLLM_MLX_CLEAN_EXIT", "0")
+    exit_without_finalizing(0)
+    assert fake_exit == []
+
+
+def test_exit_survives_temp_cleanup_failure(fake_exit, monkeypatch):
+    """The temp-file sweep is best-effort; its failure must not stop the exit."""
+    import sys
+    import types
+
+    monkeypatch.delenv("VLLM_MLX_CLEAN_EXIT", raising=False)
+    broken = types.ModuleType("vllm_mlx.models.mllm")
+
+    def _raise():
+        raise OSError("disk went away")
+
+    broken.cleanup_all_temp_files = _raise
+    monkeypatch.setitem(sys.modules, "vllm_mlx.models.mllm", broken)
+    exit_without_finalizing(0)
+    assert fake_exit == [0]
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring (source-level: server/cli import MLX, so importing them is
+# exactly what this file must not do)
+# ---------------------------------------------------------------------------
+
+
+def _assignments_to(tree: ast.AST, attr: str) -> list[ast.Assign]:
+    """Assign statements whose target is ``<something>.attr`` or ``attr``."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            name = None
+            if isinstance(target, ast.Attribute):
+                name = target.attr
+            elif isinstance(target, ast.Name):
+                name = target.id
+            if name == attr:
+                found.append(node)
+    return found
+
+
+def test_module_default_is_no_exit():
+    """server.py must default the opt-in flag to False for embedded use."""
+    tree = ast.parse((PACKAGE / "server.py").read_text())
+    defaults = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_exit_process_after_shutdown"
+    ]
+    assert defaults, "module-level _exit_process_after_shutdown declaration missing"
+    assert isinstance(defaults[0].value, ast.Constant)
+    assert defaults[0].value.value is False
+
+
+def test_both_launcher_call_sites_opt_in():
+    """Both serve entry points — `vllm-mlx serve` (cli.py) and
+    `python -m vllm_mlx.server` (server.py main) — must set the flag True
+    before uvicorn.run, or the guard silently never fires on that path.
+    """
+    for module in ("cli.py", "server.py"):
+        tree = ast.parse((PACKAGE / module).read_text())
+        assigns = _assignments_to(tree, "_exit_process_after_shutdown")
+        true_assigns = [
+            a
+            for a in assigns
+            if isinstance(a.value, ast.Constant) and a.value.value is True
+        ]
+        assert true_assigns, f"{module}: no `_exit_process_after_shutdown = True` call site"
+
+
+def test_lifespan_consults_the_shared_predicate():
+    """The guard in server.py must route through vllm_mlx.shutdown, so the
+    behavior standard CI verifies is the behavior the server runs.
+    """
+    source = (PACKAGE / "server.py").read_text()
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "should_exit_without_finalizing"
+    ]
+    assert calls, "lifespan does not call should_exit_without_finalizing"
+    args = calls[0].args
+    assert len(args) == 3, "predicate must receive primary_exc, cleanup_exc, opt-in flag"

--- a/tests/test_shutdown_decision.py
+++ b/tests/test_shutdown_decision.py
@@ -83,7 +83,9 @@ def test_embedded_use_never_exits():
     """
     assert should_exit_without_finalizing(None, None, False, env={}) is False
     assert (
-        should_exit_without_finalizing(None, None, False, env={"VLLM_MLX_CLEAN_EXIT": "1"})
+        should_exit_without_finalizing(
+            None, None, False, env={"VLLM_MLX_CLEAN_EXIT": "1"}
+        )
         is False
     )
 
@@ -186,7 +188,9 @@ def test_both_launcher_call_sites_opt_in():
             for a in assigns
             if isinstance(a.value, ast.Constant) and a.value.value is True
         ]
-        assert true_assigns, f"{module}: no `_exit_process_after_shutdown = True` call site"
+        assert (
+            true_assigns
+        ), f"{module}: no `_exit_process_after_shutdown = True` call site"
 
 
 def test_lifespan_consults_the_shared_predicate():
@@ -204,4 +208,6 @@ def test_lifespan_consults_the_shared_predicate():
     ]
     assert calls, "lifespan does not call should_exit_without_finalizing"
     args = calls[0].args
-    assert len(args) == 3, "predicate must receive primary_exc, cleanup_exc, opt-in flag"
+    assert (
+        len(args) == 3
+    ), "predicate must receive primary_exc, cleanup_exc, opt-in flag"

--- a/tests/test_shutdown_exit.py
+++ b/tests/test_shutdown_exit.py
@@ -53,10 +53,21 @@ def server(monkeypatch):
 
 @pytest.fixture
 def exit_calls(monkeypatch):
-    """Record calls to the exit helper instead of ending the test process."""
+    """Record calls to the exit helper instead of ending the test process.
+
+    The lifespan guard calls vllm_mlx.shutdown.exit_without_finalizing (the
+    cli name is a kept alias for other callers), so that is what gets patched:
+    patching the alias would let the real os._exit(0) end the pytest process
+    mid-run — silently, since the status is 0.
+    """
     calls: list[tuple] = []
     monkeypatch.setattr(
-        "vllm_mlx.cli._exit_without_finalizing",
+        "vllm_mlx.server.exit_without_finalizing",
+        lambda *args, **kwargs: calls.append(args),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.shutdown.exit_without_finalizing",
         lambda *args, **kwargs: calls.append(args),
     )
     return calls

--- a/tests/test_shutdown_exit.py
+++ b/tests/test_shutdown_exit.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lifecycle tests for the clean-exit guard.
+
+The guard skips CPython finalization at the end of lifespan shutdown, because
+MLX's thread-local compile cache deallocates Python objects from a dying thread
+and segfaults. Skipping finalization is only defensible when the shutdown
+itself succeeded: if it exits on a failed cleanup, a broken shutdown is
+reported as a clean one and the exception that would have said otherwise is
+never raised. These tests pin that boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+# vllm_mlx.server and vllm_mlx.cli both import mlx transitively, so these run
+# where MLX does — Apple Silicon — like the project's other server-level tests.
+# The ubuntu CI job installs no MLX and selects tests explicitly, so this file
+# skips there rather than failing.
+pytest.importorskip("mlx")
+
+
+@pytest.fixture
+def server(monkeypatch):
+    """vllm_mlx.server with every optional subsystem disabled.
+
+    Startup is entirely conditional on these globals, so nulling them makes
+    lifespan cheap enough to drive in a unit test — no model, no event loop
+    state, no disk.
+    """
+    import vllm_mlx.server as srv
+
+    for name in (
+        "_engine",
+        "_mcp_manager",
+        "_model_manager",
+        "_lifecycle_task",
+        "_registry_idle_reaper_task",
+        "_residency_manager",
+        "_default_model_key",
+        "_warm_prompts_path",
+    ):
+        monkeypatch.setattr(srv, name, None, raising=False)
+    monkeypatch.setattr(srv, "_lifespan_active", False, raising=False)
+    return srv
+
+
+@pytest.fixture
+def exit_calls(monkeypatch):
+    """Record calls to the exit helper instead of ending the test process."""
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        "vllm_mlx.cli._exit_without_finalizing",
+        lambda *args, **kwargs: calls.append(args),
+    )
+    return calls
+
+
+async def _run_lifespan(srv):
+    # lifespan is a bare async generator; FastAPI is what wraps it. Do the same
+    # here rather than reaching into the app.
+    async with asynccontextmanager(srv.lifespan)(object()):
+        pass
+
+
+def test_clean_shutdown_skips_finalization(server, exit_calls, monkeypatch):
+    """The whole point: a shutdown that raised nothing exits early."""
+    monkeypatch.setattr(server, "_exit_process_after_shutdown", True, raising=False)
+
+    asyncio.run(_run_lifespan(server))
+
+    assert len(exit_calls) == 1
+
+
+def test_cleanup_failure_is_raised_not_swallowed(server, exit_calls, monkeypatch):
+    """A failed cleanup must surface, not be reported as a clean exit.
+
+    This is the regression that matters. Exiting inside the finally block on a
+    cleanup failure makes the `raise cleanup_exc` below it unreachable, so a
+    cache-save or engine-stop failure would leave the process claiming success.
+    """
+    monkeypatch.setattr(server, "_exit_process_after_shutdown", True, raising=False)
+    monkeypatch.setattr(server, "_engine", MagicMock(), raising=False)
+
+    def boom():
+        raise RuntimeError("cache save failed")
+
+    monkeypatch.setattr(server, "_save_prefix_cache_to_disk", boom, raising=False)
+
+    with pytest.raises(RuntimeError, match="cache save failed"):
+        asyncio.run(_run_lifespan(server))
+
+    assert exit_calls == [], "must not exit early when cleanup failed"
+
+
+def test_serving_failure_is_raised_not_swallowed(server, exit_calls, monkeypatch):
+    """An exception from the serving phase must propagate too."""
+    monkeypatch.setattr(server, "_exit_process_after_shutdown", True, raising=False)
+
+    async def run_and_fail():
+        async with asynccontextmanager(server.lifespan)(object()):
+            raise RuntimeError("request handling exploded")
+
+    with pytest.raises(RuntimeError, match="request handling exploded"):
+        asyncio.run(run_and_fail())
+
+    assert exit_calls == [], "must not exit early when serving failed"
+
+
+def test_library_use_never_exits(server, exit_calls, monkeypatch):
+    """Importing the app must not give it the right to end the host process."""
+    monkeypatch.setattr(server, "_exit_process_after_shutdown", False, raising=False)
+
+    asyncio.run(_run_lifespan(server))
+
+    assert exit_calls == []
+
+
+def test_flag_defaults_off():
+    """The default has to be off, or embedding vllm_mlx exits its host."""
+    source = inspect.getsource(__import__("vllm_mlx.server", fromlist=["x"]))
+    assert "_exit_process_after_shutdown: bool = False" in source
+
+
+def test_both_launchers_arm_the_flag():
+    """Serving from either entry point should get the same behaviour."""
+    import vllm_mlx.cli as cli
+    import vllm_mlx.server as srv
+
+    assert "_exit_process_after_shutdown = True" in inspect.getsource(cli.serve_command)
+    assert "_exit_process_after_shutdown = True" in inspect.getsource(srv.main)
+
+
+def test_env_var_disables_the_guard(monkeypatch):
+    """VLLM_MLX_CLEAN_EXIT=0 restores normal finalization for debugging."""
+    import vllm_mlx.cli as cli
+
+    monkeypatch.setenv("VLLM_MLX_CLEAN_EXIT", "0")
+    exits: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exits.append(code))
+
+    cli._exit_without_finalizing()
+
+    assert exits == [], "with the guard disabled the process must finalize normally"
+
+
+def test_exit_runs_owned_atexit_work_first(monkeypatch):
+    """Skipping finalization skips atexit, so our own handler runs explicitly.
+
+    Temp files from decoded video and rendered document pages are the only
+    atexit work this package owns; leaking them on every shutdown would fill
+    the temp directory.
+    """
+    import vllm_mlx.cli as cli
+
+    monkeypatch.delenv("VLLM_MLX_CLEAN_EXIT", raising=False)
+    cleaned: list[bool] = []
+    monkeypatch.setattr(
+        "vllm_mlx.models.mllm.cleanup_all_temp_files",
+        lambda: cleaned.append(True),
+    )
+    exits: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exits.append(code))
+
+    cli._exit_without_finalizing()
+
+    assert cleaned == [True], "temp files must be cleaned before exiting"
+    assert exits == [0]
+
+
+def test_exit_survives_cleanup_errors(monkeypatch):
+    """A failure in our own cleanup must not stop the exit it precedes."""
+    import vllm_mlx.cli as cli
+
+    monkeypatch.delenv("VLLM_MLX_CLEAN_EXIT", raising=False)
+
+    def boom():
+        raise OSError("temp dir vanished")
+
+    monkeypatch.setattr("vllm_mlx.models.mllm.cleanup_all_temp_files", boom)
+    exits: list[int] = []
+    monkeypatch.setattr(os, "_exit", lambda code: exits.append(code))
+
+    cli._exit_without_finalizing()
+
+    assert exits == [0]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -14,6 +14,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 
 from .cli_arg_types import (
@@ -44,6 +45,46 @@ def _add_tool_calling_args(serve_parser: argparse.ArgumentParser) -> None:
         choices=_TOOL_PARSER_CHOICES,
         help=_TOOL_PARSER_HELP,
     )
+
+
+def _exit_without_finalizing(status: int = 0) -> None:
+    """Leave the serve process without running interpreter finalization.
+
+    ``uvicorn.run()`` returns only after a graceful shutdown: the socket is
+    closed, lifespan shutdown has run (engine stopped, caches persisted, MCP
+    stopped) and no request is in flight. All that is left is CPython teardown,
+    which joins the non-daemon threads that have touched MLX - and MLX keeps
+    its compile cache in thread-local storage whose entries own Python objects.
+    When such a thread exits, dyld runs the TLS destructor, which calls
+    _Py_Dealloc without a thread state or the GIL:
+
+        _pthread_exit -> _pthread_tsd_cleanup
+          -> dyld::ThreadLocalVariables::finalizeList
+            -> mlx::core::detail::CompileCache::CacheEntry::~CacheEntry()
+              -> _Py_Dealloc            EXC_BAD_ACCESS at 0x350
+
+    Six identical crash reports, on both the pinned generation worker
+    (``simple-generate_0``) and the default executor thread that lifespan
+    shutdown itself creates for cache persistence (``asyncio_0``). MLX exposes
+    no way to clear that cache from Python - ``clear_streams`` covers streams
+    and ``clear_cache`` covers memory - so the crash cannot be prevented, only
+    outrun. Every request has already been served by this point; the only thing
+    lost is cleanup the OS does anyway.
+
+    Run the one atexit handler we own first. Set VLLM_MLX_CLEAN_EXIT=0 to keep
+    normal finalization when debugging.
+    """
+    if os.environ.get("VLLM_MLX_CLEAN_EXIT", "1") == "0":
+        return
+    try:
+        from .models.mllm import cleanup_all_temp_files
+
+        cleanup_all_temp_files()
+    except Exception:
+        pass
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(status)
 
 
 def serve_command(args):
@@ -451,6 +492,11 @@ def serve_command(args):
 
     # Start server
     print(f"Starting server at http://{args.host}:{args.port}")
+    # Exit is handled at the end of lifespan shutdown (see
+    # server._exit_process_after_shutdown): uvicorn.run() joins the
+    # asyncio default-executor threads inside itself, so a guard placed
+    # after it runs too late to matter.
+    server._exit_process_after_shutdown = True
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -73,18 +73,13 @@ def _exit_without_finalizing(status: int = 0) -> None:
 
     Run the one atexit handler we own first. Set VLLM_MLX_CLEAN_EXIT=0 to keep
     normal finalization when debugging.
-    """
-    if os.environ.get("VLLM_MLX_CLEAN_EXIT", "1") == "0":
-        return
-    try:
-        from .models.mllm import cleanup_all_temp_files
 
-        cleanup_all_temp_files()
-    except Exception:
-        pass
-    sys.stdout.flush()
-    sys.stderr.flush()
-    os._exit(status)
+    The decision policy and exit mechanics live in ``vllm_mlx.shutdown`` so
+    they are testable without MLX; this name is kept for its call sites.
+    """
+    from .shutdown import exit_without_finalizing
+
+    exit_without_finalizing(status)
 
 
 def serve_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -14,7 +14,6 @@ Usage:
 
 import argparse
 import json
-import os
 import sys
 
 from .cli_arg_types import (

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1655,13 +1655,16 @@ async def lifespan(app: FastAPI):
         # process has to exit non-zero. Exiting here on a cleanup failure would
         # report a failed shutdown as a success and make the raise below
         # unreachable — reintroducing, in the fix, exactly the silent-failure
-        # class this change set exists to remove.
-        clean = primary_exc is None and cleanup_exc is None
-        if _exit_process_after_shutdown and clean:
-            from .cli import _exit_without_finalizing
+        # class this change set exists to remove. The predicate lives in
+        # vllm_mlx.shutdown, which imports no engine code, so standard CI
+        # exercises it on every platform.
+        from .shutdown import exit_without_finalizing, should_exit_without_finalizing
 
+        if should_exit_without_finalizing(
+            primary_exc, cleanup_exc, _exit_process_after_shutdown
+        ):
             logger.info("Shutdown complete")
-            _exit_without_finalizing()
+            exit_without_finalizing()
 
     if primary_exc is not None:
         if cleanup_exc is not None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1522,6 +1522,14 @@ async def _release_default_engine(*, count_activity: bool = True) -> None:
     _sync_engine_from_residency()
 
 
+# Set by the serve entry points. When true, the process exits at the end of
+# lifespan shutdown instead of returning into asyncio's loop teardown, which
+# joins threads that have touched MLX and crashes in its thread-local compile
+# cache destructor. Left false for library/embedded use, where exiting the
+# host process would be indefensible.
+_exit_process_after_shutdown: bool = False
+
+
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
     global _engine, _mcp_manager, _model_manager, _lifecycle_task, _lifespan_active
@@ -1641,6 +1649,11 @@ async def lifespan(app: FastAPI):
     finally:
         _get_idle_unload_event().set()
         _lifespan_active = False
+        if _exit_process_after_shutdown and primary_exc is None:
+            from .cli import _exit_without_finalizing
+
+            logger.info("Shutdown complete")
+            _exit_without_finalizing()
 
     if primary_exc is not None:
         if cleanup_exc is not None:
@@ -7108,6 +7121,9 @@ def main():
     # Start server with TCP keepalive for fast dead-client detection.
     # Without this, abrupt client disconnects (power-off, network loss) take
     # 2+ hours to detect via default TCP keepalive, wasting GPU cycles.
+    # Same guard the CLI serve path uses; see the module flag above.
+    global _exit_process_after_shutdown
+    _exit_process_after_shutdown = True
     uvicorn.run(
         app,
         host=args.host,

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1649,7 +1649,15 @@ async def lifespan(app: FastAPI):
     finally:
         _get_idle_unload_event().set()
         _lifespan_active = False
-        if _exit_process_after_shutdown and primary_exc is None:
+        # Only a shutdown that raised nothing may skip finalization. If either
+        # the request-serving phase or the cleanup phase failed, fall through
+        # and let the exception propagate: the caller has to see it, and the
+        # process has to exit non-zero. Exiting here on a cleanup failure would
+        # report a failed shutdown as a success and make the raise below
+        # unreachable — reintroducing, in the fix, exactly the silent-failure
+        # class this change set exists to remove.
+        clean = primary_exc is None and cleanup_exc is None
+        if _exit_process_after_shutdown and clean:
             from .cli import _exit_without_finalizing
 
             logger.info("Shutdown complete")

--- a/vllm_mlx/shutdown.py
+++ b/vllm_mlx/shutdown.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Process-exit policy for the serve entry points.
+
+This module holds the *decision* of whether the process may exit at the end of
+lifespan shutdown without running CPython finalization, separated from the
+MLX-heavy modules so it can be tested on any platform. The mechanics of the
+exit itself (``exit_without_finalizing``) live here too; only its optional
+temp-file sweep imports an engine module, and lazily.
+
+Background: finalization joins non-daemon threads that have touched MLX, and
+MLX keeps its compile cache in thread-local storage whose destructor calls
+``_Py_Dealloc`` without a thread state or the GIL — EXC_BAD_ACCESS at teardown,
+after every request has already been served. The full write-up lives on
+``exit_without_finalizing``'s original home, ``cli._exit_without_finalizing``,
+which now delegates here.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+
+__all__ = [
+    "clean_exit_enabled",
+    "should_exit_without_finalizing",
+    "exit_without_finalizing",
+]
+
+
+def clean_exit_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Whether the early-exit workaround is enabled (VLLM_MLX_CLEAN_EXIT).
+
+    Defaults to enabled; ``VLLM_MLX_CLEAN_EXIT=0`` restores normal interpreter
+    finalization for debugging the teardown crash itself.
+    """
+    if env is None:
+        env = os.environ
+    return env.get("VLLM_MLX_CLEAN_EXIT", "1") != "0"
+
+
+def should_exit_without_finalizing(
+    primary_exc: BaseException | None,
+    cleanup_exc: BaseException | None,
+    exit_process_after_shutdown: bool,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Decide whether lifespan shutdown may skip CPython finalization.
+
+    Only a shutdown that raised nothing may skip finalization, and only when a
+    serve entry point opted in. If either the request-serving phase or the
+    cleanup phase failed, the caller has to see the exception and the process
+    has to exit non-zero — exiting early would report a failed shutdown as a
+    success. Embedded/library use never opts in
+    (``exit_process_after_shutdown`` stays false), because exiting the host
+    process would be indefensible.
+    """
+    if not exit_process_after_shutdown:
+        return False
+    if primary_exc is not None or cleanup_exc is not None:
+        return False
+    return clean_exit_enabled(env)
+
+
+def exit_without_finalizing(status: int = 0) -> None:
+    """Leave the process without running interpreter finalization.
+
+    Runs the one cleanup we own (multimodal temp files), flushes stdio, and
+    calls ``os._exit``. Honors ``VLLM_MLX_CLEAN_EXIT=0`` as a final guard for
+    direct callers; the lifespan path has already consulted
+    ``should_exit_without_finalizing``.
+    """
+    if not clean_exit_enabled():
+        return
+    try:
+        from .models.mllm import cleanup_all_temp_files
+
+        cleanup_all_temp_files()
+    except Exception:
+        pass
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(status)


### PR DESCRIPTION
Split out of #733 at review request. This is a process-wide lifecycle change and does not belong in a video PR.

## The crash

Stopping the server segfaults **after** it has finished serving. macOS recorded six identical crash reports:

```
EXC_BAD_ACCESS (SIGSEGV), KERN_INVALID_ADDRESS at 0x350
  _pthread_exit -> _pthread_tsd_cleanup
    -> dyld::ThreadLocalVariables::finalizeList
      -> mlx::core::detail::CompileCache::CacheEntry::~CacheEntry()
        -> _Py_Dealloc
```

MLX keeps its compile cache in thread-local storage and the entries own Python objects. When a thread that ran compiled MLX work exits, dyld runs the TLS destructor, which deallocates Python objects with no thread state and no GIL.

It is **not thread-specific**: five reports fault on `asyncio_0`, one on `simple-generate_0` (the pinned MLX worker), so rerouting work between executors does not help. It is **not video-specific** either: `asyncio_0` is the default-executor thread that lifespan shutdown itself creates via `_run_blocking_engine_cache_io()` to persist the prefix cache. Shutdown spawns a thread, touches MLX from it, and lets it die.

This is an upstream MLX bug. vllm-mlx cannot clear that cache from Python — `clear_streams()` covers streams, `clear_cache()` covers memory, nothing covers the compile cache — so the crash can only be outrun.

## The change

Once lifespan shutdown has finished there is nothing left but teardown, so the serve process exits instead of returning into it.

Placement matters and was got wrong first: a guard after `uvicorn.run()` still crashed, because `uvicorn.run` calls `asyncio.run`, which joins the default-executor threads **inside itself**. The exit has to happen at the end of lifespan shutdown, which runs earlier.

**Finalization is skipped only when both phases raised nothing.** An earlier revision of this checked `primary_exc` but not `cleanup_exc`, so a failure in cache-save, engine-stop, MCP or model-manager shutdown was captured and then `os._exit(0)` ran anyway, making `raise cleanup_exc` unreachable — a broken shutdown reporting success. That was caught in review of #733 and is fixed here. If either phase failed, the guard stands aside and the exception propagates with a non-zero exit; a teardown segfault on that path is the better trade, since a process that already has an error to report should report it loudly rather than exit silently and clean.

The one `atexit` handler this package owns (temp-file cleanup) is invoked explicitly, and streams are flushed. Gated on `server._exit_process_after_shutdown`, set only by the two serve entry points, so importing the app as a library never exits the host process. `VLLM_MLX_CLEAN_EXIT=0` restores normal finalization.

## Tests

`tests/test_shutdown_exit.py`, driving `lifespan` directly with the optional subsystems nulled:

| behaviour | test |
|---|---|
| clean shutdown | `test_clean_shutdown_skips_finalization` |
| cleanup exception | `test_cleanup_failure_is_raised_not_swallowed` |
| serving exception | `test_serving_failure_is_raised_not_swallowed` |
| embedded/library use | `test_library_use_never_exits`, `test_flag_defaults_off` |
| both launchers | `test_both_launchers_arm_the_flag` |
| `VLLM_MLX_CLEAN_EXIT=0` | `test_env_var_disables_the_guard` |
| owned atexit work | `test_exit_runs_owned_atexit_work_first`, `test_exit_survives_cleanup_errors` |

The regression test discriminates: restoring the old guard makes `test_cleanup_failure_is_raised_not_swallowed` fail; the fix makes it pass.

These skip without MLX, since `vllm_mlx.server` and `vllm_mlx.cli` both import it transitively — the same reason `tests/test_lifecycle_server.py` is not in the `ubuntu-latest` job. They need an Apple Silicon runner to execute. Say the word if you would rather they were restructured to run without MLX; it would mean extracting the guard's decision into a module that does not pull in the engines.

## Not resolved

No standalone reproducer for the MLX defect yet, so nothing has been filed upstream. `mx.compile` on a worker thread that then exits does not reproduce it on its own, nor does adding a per-thread GPU stream and a surviving array. Reported here with the crash reports rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)