### PR TITLE
fix(mllm): populate vllm_mlx_engine_steps_executed for MLLM-routed models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,20 +119,30 @@ jobs:
           file: ./coverage.xml
           fail_ci_if_error: false
 
-      - name: Run MLX-stubbed metrics/scheduler tests
+      - name: Run MLX-stubbed scheduler tests
         # Deliberately its own step (fresh process), not merged into "Run
-        # unit tests (no MLX required)" above: these two files install a
-        # MagicMock-backed mlx/mlx_lm stub (tests/_mlx_stub.py) so their
+        # unit tests (no MLX required)" above: this file installs a
+        # MagicMock-backed mlx/mlx_lm stub (tests/_mlx_stub.py) so its
         # mlx.core-importing dependencies load without the real package.
         # Several files in the step above (e.g. test_memory_cache.py,
         # test_prefix_cache.py) have their own real `except ImportError`
         # mlx-optional handling that a stub in the same sys.modules/process
         # would silently break (isinstance() against a MagicMock raises
         # TypeError instead of behaving like "mlx absent") -- see
-        # tests/_mlx_stub.py's docstring. Refs #746 / PR #749 review.
+        # tests/_mlx_stub.py's docstring.
+        #
+        # test_metrics.py is NOT included here: it needs the full
+        # vllm_mlx.server import chain (uvicorn, prometheus-client), neither
+        # of which this job installs, and mlx-stubbing them the same way
+        # broke fixture setup with ModuleNotFoundError. That file stays
+        # Apple-Silicon-only; the one contract it covers that also needed
+        # Linux coverage (get_stats()["steps_executed"] reaching the
+        # vllm_mlx_engine_steps_executed gauge) has a dependency-light
+        # equivalent below, in TestMetricsEngineStepsExecutedGauge, which
+        # calls MetricsCollector directly and needs neither of those.
+        # Refs #746 / PR #749 review.
         run: |
           pytest \
-            tests/test_metrics.py \
             tests/test_mllm_steps_executed_stat.py \
             -v --tb=short
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,23 @@ jobs:
           file: ./coverage.xml
           fail_ci_if_error: false
 
+      - name: Run MLX-stubbed metrics/scheduler tests
+        # Deliberately its own step (fresh process), not merged into "Run
+        # unit tests (no MLX required)" above: these two files install a
+        # MagicMock-backed mlx/mlx_lm stub (tests/_mlx_stub.py) so their
+        # mlx.core-importing dependencies load without the real package.
+        # Several files in the step above (e.g. test_memory_cache.py,
+        # test_prefix_cache.py) have their own real `except ImportError`
+        # mlx-optional handling that a stub in the same sys.modules/process
+        # would silently break (isinstance() against a MagicMock raises
+        # TypeError instead of behaving like "mlx absent") -- see
+        # tests/_mlx_stub.py's docstring. Refs #746 / PR #749 review.
+        run: |
+          pytest \
+            tests/test_metrics.py \
+            tests/test_mllm_steps_executed_stat.py \
+            -v --tb=short
+
   test-python-3-14:
     # Focused job for the CPython 3.14+ asyncio.shield() behavior change
     # that shield_task() (vllm_mlx/engine/base.py) works around -- the
@@ -179,6 +196,7 @@ jobs:
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
             tests/test_mllm_steps_executed_stat.py \
+            tests/test_metrics.py \
             tests/test_optimizations.py \
             tests/test_simple_engine.py \
             tests/test_simple_engine_prefix_trie_cache.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
             tests/test_batched_engine_mllm_config.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \
+            tests/test_mllm_steps_executed_stat.py \
             tests/test_optimizations.py \
             tests/test_simple_engine.py \
             tests/test_simple_engine_prefix_trie_cache.py \

--- a/tests/_mlx_stub.py
+++ b/tests/_mlx_stub.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in mlx/mlx_lm stub for test files that don't need real MLX behavior.
+
+Deliberately NOT wired into conftest.py: conftest.py loads unconditionally
+for every pytest invocation that touches this directory, so a stub
+installed there would leak into ``sys.modules`` for *every* test file
+collected in the same run -- including ones like test_memory_cache.py and
+test_prefix_cache.py, which have their own working ``except ImportError``
+fallback for real mlx_lm absence and break when that import instead
+"succeeds" against a MagicMock (e.g. ``isinstance(x, mock_attr)`` raises
+``TypeError``, not a clean not-mlx result).
+
+Call ``install_if_unavailable()`` at the top of a test file, before any
+``import vllm_mlx...`` line, and keep that file's CI selector in its own
+pytest invocation, separate from files that have their own mlx-optional
+handling (see .github/workflows/ci.yml's dedicated
+"Run MLX-stubbed metrics/scheduler tests" step). A no-op wherever mlx is
+actually installed (the Apple Silicon CI job, or a dev machine with mlx
+present).
+"""
+
+
+def install_if_unavailable() -> None:
+    try:
+        import mlx.core  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    import importlib.machinery
+    import sys
+    from unittest.mock import MagicMock
+
+    for name in (
+        "mlx",
+        "mlx.core",
+        "mlx.nn",
+        "mlx_lm",
+        "mlx_lm.generate",
+        "mlx_lm.models",
+        "mlx_lm.models.cache",
+        "mlx_lm.sample_utils",
+        "mlx_lm.tokenizer_utils",
+    ):
+        if name in sys.modules:
+            continue
+        stub = MagicMock(name=name)
+        # A real ModuleSpec, not None: importlib.util.find_spec() (used by
+        # e.g. transformers' is_mlx_available()) raises ValueError on a
+        # sys.modules entry whose __spec__ is falsy rather than a spec.
+        stub.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        stub.__path__ = []  # let it satisfy submodule imports like a package
+        sys.modules[name] = stub
+        parent, _, child = name.rpartition(".")
+        if parent:
+            setattr(sys.modules[parent], child, stub)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -170,6 +170,10 @@ class TestMetricsEndpoint:
         assert (
             'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
         )
+        # get_stats()["steps_executed"] must reach the gauge -- the
+        # duck-typed read side of #746 (the producer side, MLLMScheduler /
+        # BatchedEngine, is covered by test_mllm_steps_executed_stat.py).
+        assert "vllm_mlx_engine_steps_executed 7.0" in response.text
 
     def test_metrics_collapse_unmatched_paths(self, metrics_client, monkeypatch):
         client, server, collector = metrics_client

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,16 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for Prometheus server metrics."""
+"""Tests for Prometheus server metrics.
 
-import platform
-import sys
+Everything here exercises the metrics endpoint against a FastAPI TestClient
+with a fake/monkeypatched engine -- no real MLX operation runs. It used to
+be gated to Apple Silicon only, but that was never actually about needing
+real MLX: importing ``vllm_mlx.server`` just needs ``mlx.core`` importable,
+which ``_mlx_stub.install_if_unavailable()`` below provides on runners
+without the real package. This file previously wasn't selected by any CI
+job at all (see #746 / PR #749's review) -- it now runs in a dedicated
+Linux-matrix step (kept separate from files with their own real
+``except ImportError`` mlx-optional handling, e.g. test_memory_cache.py --
+see _mlx_stub.py's docstring) and in the Apple job, where mlx is real and
+this stub never engages.
+"""
+
+from tests import _mlx_stub
+
+_mlx_stub.install_if_unavailable()
 
 import pytest
-
-# Skip all tests if not on Apple Silicon
-pytestmark = pytest.mark.skipif(
-    sys.platform != "darwin" or platform.machine() != "arm64",
-    reason="Requires Apple Silicon",
-)
 
 
 class FakeEngine:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,24 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Prometheus server metrics.
 
-Everything here exercises the metrics endpoint against a FastAPI TestClient
-with a fake/monkeypatched engine -- no real MLX operation runs. It used to
-be gated to Apple Silicon only, but that was never actually about needing
-real MLX: importing ``vllm_mlx.server`` just needs ``mlx.core`` importable,
-which ``_mlx_stub.install_if_unavailable()`` below provides on runners
-without the real package. This file previously wasn't selected by any CI
-job at all (see #746 / PR #749's review) -- it now runs in a dedicated
-Linux-matrix step (kept separate from files with their own real
-``except ImportError`` mlx-optional handling, e.g. test_memory_cache.py --
-see _mlx_stub.py's docstring) and in the Apple job, where mlx is real and
-this stub never engages.
+Runs against a real FastAPI TestClient built from vllm_mlx.server, which
+pulls in the full server dependency chain (uvicorn, fastapi, prometheus-client,
+mlx.core). Kept Apple-Silicon-only rather than mlx-stubbed: unlike
+test_mllm_steps_executed_stat.py's mlx.core-only need, this file's import
+chain also needs uvicorn/prometheus-client, neither of which the Linux
+test-matrix job installs (see PR #749's review -- an earlier version of
+this file ran here via tests/_mlx_stub.py and errored at fixture setup
+with ModuleNotFoundError: No module named 'uvicorn'). The one assertion
+that specifically needed Linux coverage (get_stats()["steps_executed"]
+reaching the vllm_mlx_engine_steps_executed gauge) now has a dependency-light
+equivalent in test_mllm_steps_executed_stat.py's
+TestMetricsEngineStepsExecutedGauge, which calls MetricsCollector directly
+and needs neither uvicorn nor a real prometheus_client registry. This file
+still runs in the Apple job for full HTTP-layer integration coverage.
 """
 
-from tests import _mlx_stub
-
-_mlx_stub.install_if_unavailable()
+import platform
+import sys
 
 import pytest
+
+# Skip all tests if not on Apple Silicon
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
 
 
 class FakeEngine:

--- a/tests/test_mllm_steps_executed_stat.py
+++ b/tests/test_mllm_steps_executed_stat.py
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """Deterministic coverage for #746: vllm_mlx_engine_steps_executed is never
-populated for MLLM-routed models. Also covers the PR #749 review fix: a
-step that raises must not be counted (mirrors AsyncEngineCore's
-increment-after-success placement, engine_core.py).
+populated for MLLM-routed models. Also covers two PR #749 review threads:
+a step that raises must not be counted (mirrors AsyncEngineCore's
+increment-after-success placement, engine_core.py), and the
+scheduler->engine->gauge chain must have CI coverage on Linux, not just
+Apple Silicon.
 
-The original #746 gap was two-layered:
+The original #746 gap was three-layered:
 - ``MLLMScheduler.get_stats()`` never produced a ``steps_executed`` key.
 - ``BatchedEngine.get_stats()``'s MLLM promotion allowlist didn't forward
   that key to the top-level stats dict ``metrics.py`` reads even if it did.
+- ``metrics.py``'s ``_update_engine_gauges`` already read it correctly once
+  produced -- no change needed there, but it still needed a test.
 
-These tests lock in both ends with fakes -- no real model/generation --
-mirroring the fake/fixture style used in test_mllm_continuous_batching.py.
+TestMLLMSchedulerStepsExecuted and TestBatchedEngineStepsExecutedPromotion
+lock in the first two with fakes -- no real model/generation -- mirroring
+the fake/fixture style used in test_mllm_continuous_batching.py.
 ``vllm_mlx.mllm_scheduler`` and ``vllm_mlx.engine.batched`` both hard-import
 ``mlx.core`` at module scope. Real MLX is used where available; where it
 isn't (e.g. the Linux CI matrix), ``tests._mlx_stub.install_if_unavailable``
@@ -19,6 +24,11 @@ test is pure Python bookkeeping either way, so it's meaningful coverage in
 both cases. Kept in its own CI step, separate from files with their own
 real ``except ImportError`` mlx-optional handling -- see _mlx_stub.py's
 docstring for why that matters.
+
+TestMetricsEngineStepsExecutedGauge locks in the third: it calls
+``vllm_mlx.metrics.MetricsCollector`` directly, needing neither the mlx
+stub above nor a real prometheus_client registry -- see its own docstring
+for why it isn't in test_metrics.py instead.
 """
 
 from tests import _mlx_stub
@@ -161,3 +171,44 @@ class TestBatchedEngineStepsExecutedPromotion:
         stats = engine.get_stats()
 
         assert "steps_executed" not in stats
+
+
+class TestMetricsEngineStepsExecutedGauge:
+    """get_stats()["steps_executed"] must reach the exported
+    vllm_mlx_engine_steps_executed gauge (metrics.py:_update_engine_gauges).
+
+    This was originally an assertion inside test_metrics.py's HTTP-layer
+    test (a FastAPI TestClient hitting the real /metrics endpoint). Moved
+    here per PR #749's review: that file's import chain needs uvicorn and
+    prometheus-client in addition to mlx.core, and the Linux CI job installs
+    none of the three -- mlx-stubbing them the same way test_mllm_scheduler
+    tests are stubbed broke fixture setup with
+    ``ModuleNotFoundError: No module named 'uvicorn'``.
+
+    vllm_mlx.metrics has no mlx dependency at all, so this needs no stub.
+    Calling MetricsCollector._update_engine_gauges() directly (instead of
+    going through render_metrics()/the HTTP layer) also means it needs no
+    real prometheus_client registry: a defaultdict(MagicMock) stands in for
+    the ``_prom`` dict of real Counter/Gauge/Histogram objects
+    _init_prometheus() would normally build, so every ``self._prom[key]``
+    access _update_engine_gauges makes for gauges this test doesn't care
+    about (engine_type, cache_type, metal_memory_bytes, ...) just resolves
+    to a fresh, harmless mock -- only "engine_steps_executed" is inspected.
+    """
+
+    def test_steps_executed_reaches_the_gauge(self):
+        from collections import defaultdict
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.metrics import MetricsCollector
+
+        class FakeEngine:
+            def get_stats(self):
+                return {"steps_executed": 7, "num_waiting": 0}
+
+        collector = MetricsCollector.__new__(MetricsCollector)
+        collector._prom = defaultdict(MagicMock)
+
+        collector._update_engine_gauges(engine=FakeEngine(), mcp_manager=None)
+
+        collector._prom["engine_steps_executed"].set.assert_called_once_with(7)

--- a/tests/test_mllm_steps_executed_stat.py
+++ b/tests/test_mllm_steps_executed_stat.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic coverage for #746: vllm_mlx_engine_steps_executed is never
+populated for MLLM-routed models.
+
+The gap was two-layered:
+- ``MLLMScheduler.get_stats()`` never produced a ``steps_executed`` key.
+- ``BatchedEngine.get_stats()``'s MLLM promotion allowlist didn't forward
+  that key to the top-level stats dict ``metrics.py`` reads even if it did.
+
+These tests lock in both ends with fakes -- no real model/generation --
+mirroring the fake/fixture style used in test_mllm_continuous_batching.py.
+``vllm_mlx.mllm_scheduler`` and ``vllm_mlx.engine.batched`` both hard-import
+``mlx.core`` at module scope, so the whole file is MLX-only.
+"""
+
+try:
+    import mlx.core as mx  # noqa: F401
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+class TestMLLMSchedulerStepsExecuted:
+    """MLLMScheduler.get_stats() must report a step counter that increments
+    once per step(), mirroring AsyncEngineCore._steps_executed
+    (engine_core.py) for the plain-LLM path.
+    """
+
+    def _make_scheduler(self):
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+        class FakeTokenizer:
+            eos_token_id = None
+
+            def encode(self, text):
+                return [1, 2, 3]
+
+        class FakeProcessor:
+            tokenizer = FakeTokenizer()
+
+        class FakeModel:
+            config = None
+
+        scheduler = MLLMScheduler(model=FakeModel(), processor=FakeProcessor())
+        # step() unconditionally calls _schedule_waiting(), which lazily
+        # builds a real MLLMBatchGenerator from the (fake) model/processor.
+        # The counter contract under test doesn't depend on that machinery,
+        # so replace it with a no-op to keep this deterministic and fast.
+        scheduler._schedule_waiting = lambda: []
+        return scheduler
+
+    def test_get_stats_reports_steps_executed(self):
+        scheduler = self._make_scheduler()
+        assert scheduler.get_stats()["steps_executed"] == 0
+
+    def test_step_increments_steps_executed(self):
+        scheduler = self._make_scheduler()
+
+        scheduler.step()
+        assert scheduler.get_stats()["steps_executed"] == 1
+
+        scheduler.step()
+        scheduler.step()
+        assert scheduler.get_stats()["steps_executed"] == 3
+
+
+class TestBatchedEngineStepsExecutedPromotion:
+    """BatchedEngine.get_stats() must promote steps_executed from the MLLM
+    scheduler's stats dict into the top-level stats dict metrics.py reads.
+    """
+
+    def _make_engine(self, mllm_stats):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        class FakeMLLMScheduler:
+            def get_stats(self):
+                return mllm_stats
+
+        # get_stats() only touches a handful of plain attributes; bypass
+        # BatchedEngine.__init__ (which loads a real model) and set just
+        # those directly.
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._mllm_scheduler = FakeMLLMScheduler()
+        engine._engine = None
+        engine._model_name = "fake-mllm-model"
+        engine._created_at = 0.0
+        engine._is_mllm = True
+        engine._loaded = True
+        engine._stream_interval = 1
+        engine._mllm_draft_model = None
+        return engine
+
+    def test_promotes_steps_executed_to_top_level(self):
+        engine = self._make_engine({"steps_executed": 42, "num_waiting": 0})
+
+        stats = engine.get_stats()
+
+        assert stats["steps_executed"] == 42
+
+    def test_omits_steps_executed_when_scheduler_lacks_it(self):
+        engine = self._make_engine({"num_waiting": 0})
+
+        stats = engine.get_stats()
+
+        assert "steps_executed" not in stats

--- a/tests/test_mllm_steps_executed_stat.py
+++ b/tests/test_mllm_steps_executed_stat.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Deterministic coverage for #746: vllm_mlx_engine_steps_executed is never
-populated for MLLM-routed models.
+populated for MLLM-routed models. Also covers the PR #749 review fix: a
+step that raises must not be counted (mirrors AsyncEngineCore's
+increment-after-success placement, engine_core.py).
 
-The gap was two-layered:
+The original #746 gap was two-layered:
 - ``MLLMScheduler.get_stats()`` never produced a ``steps_executed`` key.
 - ``BatchedEngine.get_stats()``'s MLLM promotion allowlist didn't forward
   that key to the top-level stats dict ``metrics.py`` reads even if it did.
@@ -10,8 +12,18 @@ The gap was two-layered:
 These tests lock in both ends with fakes -- no real model/generation --
 mirroring the fake/fixture style used in test_mllm_continuous_batching.py.
 ``vllm_mlx.mllm_scheduler`` and ``vllm_mlx.engine.batched`` both hard-import
-``mlx.core`` at module scope, so the whole file is MLX-only.
+``mlx.core`` at module scope. Real MLX is used where available; where it
+isn't (e.g. the Linux CI matrix), ``tests._mlx_stub.install_if_unavailable``
+stubs it so this import still succeeds -- the counter/promotion logic under
+test is pure Python bookkeeping either way, so it's meaningful coverage in
+both cases. Kept in its own CI step, separate from files with their own
+real ``except ImportError`` mlx-optional handling -- see _mlx_stub.py's
+docstring for why that matters.
 """
+
+from tests import _mlx_stub
+
+_mlx_stub.install_if_unavailable()
 
 try:
     import mlx.core as mx  # noqa: F401
@@ -22,7 +34,9 @@ except ImportError:
 
 import pytest
 
-pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+pytestmark = pytest.mark.skipif(
+    not HAS_MLX, reason="mlx.core not importable (even as a stub)"
+)
 
 
 class TestMLLMSchedulerStepsExecuted:
@@ -67,6 +81,45 @@ class TestMLLMSchedulerStepsExecuted:
         scheduler.step()
         scheduler.step()
         assert scheduler.get_stats()["steps_executed"] == 3
+
+    def test_step_that_raises_is_not_counted(self):
+        """Regression for the PR #749 review: step() used to increment
+        _steps_executed before any operation that can raise (schedule_waiting,
+        the batch generator's forward pass, response processing), so a step
+        that failed partway through -- and whose requests get terminated by
+        _fail_requests_after_step_error rather than retried, since retrying a
+        partially mutated batch is unsafe -- was still counted as executed.
+        The counter must only advance on the successful-return path, mirroring
+        AsyncEngineCore (engine_core.py), which increments only after
+        self.scheduler.step() returns.
+        """
+        scheduler = self._make_scheduler()
+
+        class ExplodingBatchGenerator:
+            def process_pending_removals(self):
+                pass
+
+            def next(self):
+                raise RuntimeError("simulated forward-pass failure")
+
+        scheduler.batch_generator = ExplodingBatchGenerator()
+        # Any truthy value satisfies step()'s `self.batch_generator is not
+        # None and self.running` gate to reach next() -- get_stats() (which
+        # would need a fully request-shaped fake here) is deliberately not
+        # called in this test; the counter is checked directly below instead.
+        scheduler.running = {"req-exploding": object()}
+
+        with pytest.raises(RuntimeError, match="simulated forward-pass failure"):
+            scheduler.step()
+
+        assert scheduler._steps_executed == 0
+
+        # The counter isn't left in a broken state by the earlier exception --
+        # a subsequent step that actually completes still counts normally.
+        scheduler.batch_generator = None
+        scheduler.running = {}
+        scheduler.step()
+        assert scheduler.get_stats()["steps_executed"] == 1
 
 
 class TestBatchedEngineStepsExecutedPromotion:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1157,6 +1157,7 @@ class BatchedEngine(BaseEngine):
                 "num_requests_processed",
                 "total_prompt_tokens",
                 "total_completion_tokens",
+                "steps_executed",
                 "metal_active_memory_gb",
                 "metal_peak_memory_gb",
                 "metal_cache_memory_gb",

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -790,7 +790,6 @@ class MLLMScheduler:
             MLLMSchedulerOutput with results of this step
         """
         output = MLLMSchedulerOutput()
-        self._steps_executed += 1
 
         # Drain any deferred removals queued from other threads (e.g.
         # the asyncio event loop during client-disconnect aborts).
@@ -844,6 +843,16 @@ class MLLMScheduler:
 
         # Clear finished tracking for next step
         self.finished_req_ids = set()
+
+        # Count only steps that complete without raising, mirroring
+        # AsyncEngineCore._steps_executed (engine_core.py), which increments
+        # after self.scheduler.step() returns successfully rather than
+        # before calling it. A step that raises partway through (e.g. an
+        # unrecoverable forward-pass error -- see
+        # _fail_requests_after_step_error) never did the scheduling/
+        # generation work "steps_executed" is meant to count, so it must
+        # not be counted.
+        self._steps_executed += 1
 
         return output
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -253,6 +253,10 @@ class MLLMScheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # Count of step() calls, mirroring AsyncEngineCore._steps_executed
+        # (engine_core.py) for the plain-LLM path -- surfaced via get_stats()
+        # as vllm_mlx_engine_steps_executed (see #746).
+        self._steps_executed = 0
 
         # Memory management: periodic mx.clear_cache() to free Metal buffers
         self._step_count = 0
@@ -786,6 +790,7 @@ class MLLMScheduler:
             MLLMSchedulerOutput with results of this step
         """
         output = MLLMSchedulerOutput()
+        self._steps_executed += 1
 
         # Drain any deferred removals queued from other threads (e.g.
         # the asyncio event loop during client-disconnect aborts).
@@ -1242,6 +1247,7 @@ class MLLMScheduler:
             "num_requests_processed": self.num_requests_processed,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
+            "steps_executed": self._steps_executed,
             "requests": self.get_running_requests_info(),
         }
 


### PR DESCRIPTION
Refs #746

Implements the full spec from Thump604's 2026-08-30T19:58:47Z comment on #746: deterministic no-real-inference coverage for both the scheduler counter and the `BatchedEngine` promotion/metrics mapping, plus an exact-head Apple Silicon MLLM run showing a positive, increasing gauge. Kept separate from #739's registry-engine-selection fix.

## Update (2026-09-08): review-driven changes since the original head

Two rounds of review on this PR changed the counter's placement and the CI mapping described below. Current state, as of head `ed8f2ca`:

- **Counter placement**: `_steps_executed` now increments on `step()`'s successful-return path (immediately before its single `return output`), not unconditionally at the top of the method — see the "Changes" section below, which describes the current code. A step that raises partway through (schedule_waiting, the batch generator's forward pass, response processing) is no longer counted; its requests get terminated by `_fail_requests_after_step_error` rather than retried, since retrying a partially mutated batch is unsafe. Regression test: `test_step_that_raises_is_not_counted`.
- **CI mapping**: six scheduler/gauge cases in `tests/test_mllm_steps_executed_stat.py` run in the Linux `test-matrix` job (a dedicated "Run MLX-stubbed scheduler tests" step, `tests/_mlx_stub.py` standing in for the real mlx/mlx_lm package) as well as in `test-apple-silicon` (real mlx). The Apple job additionally runs `tests/test_metrics.py`'s HTTP-layer metrics test (5 cases) — that file stays Apple-Silicon-only, since its import chain also needs `uvicorn`/`prometheus-client`, which the Linux job doesn't install. The one gauge-mapping assertion that specifically needed Linux coverage moved to a dependency-light equivalent, `TestMetricsEngineStepsExecutedGauge` (in `test_mllm_steps_executed_stat.py`), which calls `MetricsCollector` directly and needs neither uvicorn, prometheus-client, nor mlx.
- CI is green on `ed8f2ca`: [run 33983587011](https://github.com/waybarrios/vllm-mlx/actions/runs/33983587011), all 10 checks passing.

The **"Tests" and "Apple Silicon evidence" sections below, and their numbers, are exactly as gathered against this PR's original head, `52c947a`** (before either review round) — kept as-is rather than restated, since they're a record of that specific run, not a living description of current head. See the PR comments from 2026-09-04 and 2026-09-05 for the intermediate heads (`e6c81fe`, `ed8f2ca`) and what changed/was verified at each.

## Problem

`vllm_mlx_engine_steps_executed` is permanently `0.0` for any model routed through `BatchedEngine`'s MLLM branch (`self._mllm_scheduler` set) — registry mode or not, and independent of #738/#739. Root cause (verified against `origin/main@22efb47`, unchanged at push time):

- `vllm_mlx/mllm_scheduler.py`'s `MLLMScheduler.get_stats()` never produced a `"steps_executed"` key.
- `vllm_mlx/engine/batched.py`'s `BatchedEngine.get_stats()` MLLM promotion allowlist omitted that key, so even if present it would never reach the top-level stats dict `metrics.py` reads.

The plain-LLM path already has this working via `AsyncEngineCore._steps_executed` (`engine_core.py`), incremented once per `scheduler.step()` call inside the engine loop, itself gated by `scheduler.has_requests()`.

## Changes

- `vllm_mlx/mllm_scheduler.py`: adds `MLLMScheduler._steps_executed`, incremented once per `step()` call on the **successful-return path** — immediately before `step()`'s single `return output`, after every operation in the method that can raise (`process_pending_removals`, `_schedule_waiting`, the batch generator's `next()`, `_process_batch_responses`) has already completed. This mirrors `AsyncEngineCore._steps_executed`'s placement exactly: `AsyncEngineCore` increments only after `self.scheduler.step()` returns, not before calling it. (The first push had this unconditional at the top of the method instead; moved per review — see "Update" above.) Exposed via `get_stats()["steps_executed"]`.
- `vllm_mlx/engine/batched.py`: adds `"steps_executed"` to the MLLM promotion allowlist tuple so it reaches the top-level stats dict.
- `vllm_mlx/metrics.py`: **no change** — `_update_engine_gauges` already duck-types `stats.get("steps_executed")`; it was only ever missing the value to read.

## Tests

`tests/test_mllm_steps_executed_stat.py` (mirrors the fake/fixture style of `test_mllm_continuous_batching.py`; real `mlx.core` on the Apple job, `tests/_mlx_stub.py`'s stub on the Linux `test-matrix` job — see "Update" above for the current CI mapping), six cases across three classes:

- `TestMLLMSchedulerStepsExecuted`: `get_stats()` reports `0` on a fresh scheduler; increments by exactly 1 per `step()` call (batch-generator construction bypassed via a no-op `_schedule_waiting` stub, since the counter contract doesn't depend on it); and `test_step_that_raises_is_not_counted`, added on review, which makes `step()` fail via a batch generator whose `next()` raises and confirms the counter is untouched, then confirms a subsequent successful step still counts normally.
- `TestBatchedEngineStepsExecutedPromotion`: a fake `_mllm_scheduler.get_stats()` dict with `steps_executed` gets promoted to the top level; one without it is correctly omitted (not defaulted to 0/false-positive).
- `TestMetricsEngineStepsExecutedGauge`: added on review as the dependency-light home for the gauge-mapping assertion originally in `test_metrics.py` (see "Update" above) — calls `MetricsCollector._update_engine_gauges()` directly against a `defaultdict(MagicMock)` standing in for the real Prometheus registry, confirming `get_stats()["steps_executed"]` reaches `vllm_mlx_engine_steps_executed`.

Verified these are real regression guards, not vacuously green: reverted both source changes locally and confirmed 3 of 4 (original count, before the two review-added cases) new tests fail with `KeyError: 'steps_executed'`; separately, reverting the counter-placement fix alone makes `test_step_that_raises_is_not_counted` fail (`assert 1 == 0`).

Also added one assertion to the existing `test_metrics.py::test_metrics_endpoint_scrapes_runtime_stats` (already used a `FakeEngine.get_stats()` with `steps_executed=7` but never asserted on it) confirming the gauge renders `vllm_mlx_engine_steps_executed 7.0`. This file is Apple-Silicon-only (see "Update" above for why, and for where its CI mapping stands now).

### Test results as of the original head (`52c947a`) (isolated `uv venv`, no model download/serving)

- `tests/test_mllm_steps_executed_stat.py`: 4/4 passed (the original two classes; `test_step_that_raises_is_not_counted` and `TestMetricsEngineStepsExecutedGauge` were added in later commits — see "Update" above)
- `tests/test_metrics.py` (new assertion included): 5/5 passed
- Mapped Apple-job subset (`test_mllm_continuous_batching.py`, `test_mllm_cache.py`, `test_mllm_steps_executed_stat.py`, `test_optimizations.py`): 98 passed, 5 deselected
- Full suite vs. `origin/main` baseline: baseline 2965 passed/13 skipped/27 deselected → this branch 2969 passed/13 skipped/27 deselected (exactly the 4 new tests; no regressions)
- `ruff check` / `black --check`: clean

For the CI-contract fix (the mlx-stub/uvicorn gap and its resolution), see the 2026-09-04/09-05 PR comments and "Update" above; the exact-head CI run (`ed8f2ca`, [run 33983587011](https://github.com/waybarrios/vllm-mlx/actions/runs/33983587011)) is the current source of truth for whether everything passes together, rather than a further round of local-only numbers.

## Apple Silicon evidence, as of the original head (`52c947a`) (hardware: Apple M5 Max, 128GB)

Built into a disposable `git worktree` + isolated `uv venv`, `pip install -e .` — production's actual serving install/pin untouched throughout. Temporary server on `:8093`, `HOME`-override cache isolation (confirmed: prefix-cache path resolved under the scratch `HOME`, and the shared `~/.cache/vllm-mlx/prefix_cache/` on this machine kept its same 3 pre-existing entries, untouched, before/after).

Registry mode (`--models-config`) was tried first per the original plan, but its `/metrics` still reads only the module-level `_engine` (`None` in registry mode) on this base commit — that's exactly #739's still-unmerged fix, unrelated to #746. To get real evidence for *this* fix uncorrelated with that separate gap, I switched to single-model mode with `--mllm` (bare single-model launch skips MLLM auto-detection for this checkpoint; known gotcha), `--continuous-batching --enable-prefix-cache --enable-metrics`, pointed at the already-downloaded local HF cache snapshot (no network fetch: `Fetching 17 files: 100%` from local cache).

Startup log confirms MLLM routing through `BatchedEngine`:
```
INFO:vllm_mlx.engine.batched:BatchedEngine loaded: mlx-community/Qwen3.8-27B-8bit (mllm=True)
```

Gauge before/after (`_steps_executed` was unconditional-at-top-of-`step()` at this head — see "Update" above for the counter-placement fix made in a later commit; that fix doesn't change these particular numbers, since none of these requests hit the exception path it addresses):
```
# before any request
vllm_mlx_model_loaded 1.0
vllm_mlx_engine_steps_executed 0.0

# after request 1 (max_tokens=10, finish_reason=length)
vllm_mlx_engine_steps_executed 10.0

# after request 2 (max_tokens=20, finish_reason=length)
vllm_mlx_engine_steps_executed 30.0
```

Positive and monotonically increasing, as the issue requires. SIGTERM'd cleanly (`Application shutdown complete`, `BatchedEngine stopped`); `:8093` confirmed free afterward. Production `:8091`/`:8082` (same PIDs throughout) unaffected — `:8091` still answering `200` on `/v1/models` after this run, and the shared prefix-cache directory shows no new entry for this model.

## Test plan for reviewer

- [x] `tests/test_mllm_steps_executed_stat.py` passes (original head `52c947a`: 4/4; current head `ed8f2ca`: 6/6, including the exception-path and gauge-mapping cases added on review)
- [x] Mutation-tested: reverting the counter fix fails the new/moved tests (both the original promotion fix and the later successful-return-placement fix)
- [x] Full suite: no regressions vs. `origin/main`, as of original head `52c947a` (2969 passed vs. baseline 2965)
- [x] Live MLLM run on Apple Silicon: gauge positive and increasing, as of original head `52c947a`
- [x] Production serving untouched, throughout every round of this PR
- [x] CI green on current head `ed8f2ca`: [run 33983587011](https://github.com/waybarrios/vllm-mlx/actions/runs/33983587011), all 10 checks
