### PR TITLE
fix(mllm): load registered MTP drafters safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             tests/test_platform.py \
             tests/test_llm.py \
             tests/test_mllm.py \
+            tests/test_mllm_assistant_drafter.py \
             tests/test_server.py \
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,7 +33,7 @@ vllm-mlx serve --models-config <yaml> [options]
 | `--timeout` | Request timeout in seconds | 300 |
 | `--enable-metrics` | Expose Prometheus metrics on `/metrics` | False |
 | `--continuous-batching` | Enable batching for multi-user | False |
-| `--mllm-draft-model` | Configured mlx-vlm assistant/draft model path. Requires `--mllm`. | None |
+| `--mllm-draft-model` | Local path or Hugging Face repo ID for an mlx-vlm assistant/draft model. Requires `--mllm`. | None |
 | `--mllm-draft-kind` | Assistant drafter kind. Use `mtp` for continuous batching. | None |
 | `--mllm-draft-block-size` | Speculative block size passed to mlx-vlm. | None |
 | `--default-mllm-draft` | Enable the configured assistant by default. Requests can override with `mllm_draft`. | False |

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -1,10 +1,173 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for MLLM assistant-drafter speculative wiring."""
 
+import json
 import sys
 from types import SimpleNamespace
 
 import pytest
+
+
+def _write_drafter_config(tmp_path, config):
+    text = config if isinstance(config, str) else json.dumps(config)
+    (tmp_path / "config.json").write_text(text, encoding="utf-8")
+    return str(tmp_path)
+
+
+def _drafter_module(load_result, validate=lambda *args: None):
+    return SimpleNamespace(
+        load_drafter=lambda *args, **kwargs: load_result,
+        validate_drafter_compatibility=validate,
+    )
+
+
+def _install_fake_mlx_vlm(monkeypatch, drafter_module):
+    target = SimpleNamespace(config=SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules, "mlx_vlm", SimpleNamespace(load=lambda path: (target, object()))
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.utils",
+        SimpleNamespace(load_config=lambda path: {"model_type": "qwen4_exp"}),
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative.drafters", drafter_module)
+    return target
+
+
+def test_registered_mtp_drafter_resolves_repo_id_without_network(monkeypatch, tmp_path):
+    from vllm_mlx.models.mllm import load_mtp_drafter
+
+    _write_drafter_config(tmp_path, {"model_type": "qwen4_exp_mtp"})
+    captured = {}
+
+    def resolve(repo_id):
+        captured["repo_id"] = repo_id
+        return tmp_path
+
+    monkeypatch.setitem(
+        sys.modules, "mlx_vlm.utils", SimpleNamespace(get_model_path=resolve)
+    )
+    drafter = object()
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.speculative.drafters",
+        _drafter_module((drafter, "mtp")),
+    )
+
+    assert load_mtp_drafter("owner/qwen4-exp-mtp") is drafter
+    assert captured["repo_id"] == "owner/qwen4-exp-mtp"
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"model_type": "gemma4_assistant"},
+        {"model_type": "GEMMA4_UNIFIED_ASSISTANT"},
+        {"model_type": "gemma4", "text_config": {"model_type": "gemma4_assistant"}},
+    ],
+)
+def test_mtp_drafter_preserves_supported_gemma_loader_shapes(
+    monkeypatch, tmp_path, config
+):
+    from vllm_mlx.models import mllm
+
+    path = _write_drafter_config(tmp_path, config)
+    expected = object()
+    monkeypatch.setattr(mllm, "load_gemma4_assistant_drafter", lambda path: expected)
+
+    assert mllm.load_mtp_drafter(path) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (None, "must be a JSON object"),
+        ([], "must be a JSON object"),
+        ({}, "has no valid model_type"),
+        ("{not-json", "Invalid MTP drafter config JSON"),
+        (
+            {
+                "model_type": "qwen4_exp_mtp",
+                "text_config": {"model_type": "gemma4_assistant"},
+            },
+            "conflicting model types",
+        ),
+    ],
+)
+def test_mtp_drafter_rejects_invalid_config(tmp_path, config, message):
+    from vllm_mlx.models.mllm import load_mtp_drafter
+
+    path = _write_drafter_config(tmp_path, config)
+    with pytest.raises(ValueError, match=message):
+        load_mtp_drafter(path)
+
+
+@pytest.mark.parametrize("source", ["text_config", "speculators_model_type"])
+def test_mtp_drafter_prefers_nested_drafter_model_type(tmp_path, source):
+    from vllm_mlx.models.mllm import _read_mtp_drafter_model_type
+
+    config = {"model_type": "qwen4_exp"}
+    config[source] = (
+        {"model_type": "qwen4_exp_mtp"} if source == "text_config" else "qwen4_exp_mtp"
+    )
+    _write_drafter_config(tmp_path, config)
+
+    assert _read_mtp_drafter_model_type(tmp_path / "config.json") == "qwen4_exp_mtp"
+
+
+@pytest.mark.parametrize(
+    ("loaded", "message"),
+    [
+        (None, "must return"),
+        ((None, "mtp"), "returned no model"),
+        ((object(), "dflash"), "unsupported kind"),
+        ((object(), "mtp", "extra"), "must return"),
+    ],
+)
+def test_mtp_drafter_rejects_invalid_loader_return(
+    monkeypatch, tmp_path, loaded, message
+):
+    from vllm_mlx.models.mllm import load_mtp_drafter
+
+    path = _write_drafter_config(tmp_path, {"model_type": "qwen4_exp_mtp"})
+    monkeypatch.setitem(
+        sys.modules, "mlx_vlm.speculative.drafters", _drafter_module(loaded)
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_mtp_drafter(path)
+
+
+def test_mllm_load_binds_registered_drafter_and_validates_target(monkeypatch, tmp_path):
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    path = _write_drafter_config(tmp_path, {"model_type": "qwen4_exp_mtp"})
+    drafter = SimpleNamespace()
+    captured = {}
+
+    def validate(target_model, draft_model, draft_kind):
+        captured.update(target=target_model, draft=draft_model, kind=draft_kind)
+
+    target = _install_fake_mlx_vlm(
+        monkeypatch, _drafter_module((drafter, "mtp"), validate)
+    )
+    model = MLXMultimodalLM("target", draft_model=path, draft_kind="mtp")
+    model.load()
+
+    assert model._draft_model is drafter
+    assert captured == {"target": target, "draft": drafter, "kind": "mtp"}
+
+
+def test_mllm_load_preserves_registered_drafter_error(monkeypatch, tmp_path):
+    from vllm_mlx.models.mllm import MLXMultimodalLM, MTPDrafterLoadError
+
+    path = _write_drafter_config(tmp_path, {"model_type": "qwen4_exp_mtp"})
+    _install_fake_mlx_vlm(monkeypatch, SimpleNamespace())
+    model = MLXMultimodalLM("target", draft_model=path, draft_kind="mtp")
+
+    with pytest.raises(MTPDrafterLoadError, match="registered 'qwen4_exp_mtp'"):
+        model.load()
 
 
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -170,6 +170,22 @@ def test_mllm_load_preserves_registered_drafter_error(monkeypatch, tmp_path):
         model.load()
 
 
+def test_registered_mtp_drafter_requires_validator_for_target(monkeypatch, tmp_path):
+    from vllm_mlx.models.mllm import MTPDrafterLoadError, load_mtp_drafter
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen4_exp_mtp"}), encoding="utf-8"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.speculative.drafters",
+        SimpleNamespace(load_drafter=lambda *args, **kwargs: (object(), "mtp")),
+    )
+
+    with pytest.raises(MTPDrafterLoadError, match="registered 'qwen4_exp_mtp'"):
+        load_mtp_drafter(str(tmp_path), target_model=object())
+
+
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
     from vllm_mlx.models.mllm import MLXMultimodalLM
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1356,7 +1356,8 @@ Examples:
         "--mllm-draft-model",
         type=str,
         default=None,
-        help="Path to an mlx-vlm MLLM draft/assistant model. "
+        help="Local path or Hugging Face repo ID for an mlx-vlm MLLM "
+        "draft/assistant model. "
         "For Gemma 4 assistant drafters, use with --mllm-draft-kind mtp.",
     )
     serve_parser.add_argument(

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -538,10 +538,7 @@ def load_mtp_drafter(model_path: str, target_model=None):
         return model
 
     try:
-        from mlx_vlm.speculative.drafters import (
-            load_drafter,
-            validate_drafter_compatibility,
-        )
+        from mlx_vlm.speculative.drafters import load_drafter
     except ImportError as exc:
         raise MTPDrafterLoadError(
             "This MTP drafter requires an mlx-vlm build with the registered "
@@ -570,6 +567,15 @@ def load_mtp_drafter(model_path: str, target_model=None):
             f"Configured MTP drafter resolved to unsupported kind {resolved_kind!r}"
         )
     if target_model is not None:
+        try:
+            from mlx_vlm.speculative.drafters import (
+                validate_drafter_compatibility,
+            )
+        except ImportError as exc:
+            raise MTPDrafterLoadError(
+                "This MTP drafter requires an mlx-vlm build with the registered "
+                f"{model_type!r} architecture."
+            ) from exc
         validate_drafter_compatibility(target_model, model, resolved_kind)
     return model
 

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -458,6 +458,122 @@ def load_gemma4_assistant_drafter(model_path: str):
     return model
 
 
+class MTPDrafterLoadError(RuntimeError):
+    """Raised when a registered MTP drafter architecture is unavailable."""
+
+
+_GEMMA4_ASSISTANT_MODEL_TYPES = {
+    "gemma4_assistant",
+    "gemma4_unified_assistant",
+}
+
+
+def _read_mtp_drafter_model_type(config_path: Path) -> str:
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid MTP drafter config JSON: {config_path}") from exc
+    if not isinstance(config, dict):
+        raise ValueError(f"MTP drafter config must be a JSON object: {config_path}")
+
+    candidates = [config.get("model_type"), config.get("speculators_model_type")]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        candidates.append(text_config.get("model_type"))
+
+    model_types = [
+        value.strip().casefold()
+        for value in candidates
+        if isinstance(value, str) and value.strip()
+    ]
+    drafter_types = {
+        model_type
+        for model_type in model_types
+        if model_type.endswith("_mtp") or model_type in _GEMMA4_ASSISTANT_MODEL_TYPES
+    }
+    if len(drafter_types) > 1:
+        raise ValueError(
+            f"MTP drafter config has conflicting model types: {config_path}"
+        )
+    if drafter_types:
+        return drafter_types.pop()
+    if model_types:
+        return model_types[0]
+    raise ValueError(f"MTP drafter config has no valid model_type: {config_path}")
+
+
+def _resolve_mtp_drafter_path(path_or_repo: str) -> Path:
+    path = Path(path_or_repo)
+    if path.exists():
+        return path
+    try:
+        from mlx_vlm.utils import get_model_path
+    except ImportError as exc:
+        raise MTPDrafterLoadError(
+            "Resolving an MTP drafter repository requires mlx-vlm"
+        ) from exc
+    return Path(get_model_path(path_or_repo))
+
+
+def load_mtp_drafter(model_path: str, target_model=None):
+    """Load a local or Hugging Face MTP drafter without assuming Gemma layout."""
+    resolved_path = _resolve_mtp_drafter_path(model_path)
+    config_path = resolved_path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"MTP drafter config not found: {config_path}")
+    model_type = _read_mtp_drafter_model_type(config_path)
+    if model_type in _GEMMA4_ASSISTANT_MODEL_TYPES:
+        model = load_gemma4_assistant_drafter(str(resolved_path))
+        if target_model is not None:
+            try:
+                from mlx_vlm.speculative.drafters import (
+                    validate_drafter_compatibility,
+                )
+            except ImportError:
+                # Preserve compatibility with mlx-vlm releases that predate
+                # the shared validator; this is the existing Gemma loader.
+                pass
+            else:
+                validate_drafter_compatibility(target_model, model, "mtp")
+        return model
+
+    try:
+        from mlx_vlm.speculative.drafters import (
+            load_drafter,
+            validate_drafter_compatibility,
+        )
+    except ImportError as exc:
+        raise MTPDrafterLoadError(
+            "This MTP drafter requires an mlx-vlm build with the registered "
+            f"{model_type!r} architecture."
+        ) from exc
+
+    logger.info(
+        "Loading registered MTP drafter model_type=%s from %s",
+        model_type,
+        resolved_path,
+    )
+    try:
+        loaded = load_drafter(str(resolved_path), kind="mtp", lazy=False)
+    except ImportError as exc:
+        raise MTPDrafterLoadError(
+            "This MTP drafter requires an mlx-vlm build with the registered "
+            f"{model_type!r} architecture."
+        ) from exc
+    if not isinstance(loaded, tuple) or len(loaded) != 2:
+        raise ValueError("mlx-vlm load_drafter() must return (model, resolved_kind)")
+    model, resolved_kind = loaded
+    if model is None:
+        raise ValueError("mlx-vlm load_drafter() returned no model")
+    if resolved_kind != "mtp":
+        raise ValueError(
+            f"Configured MTP drafter resolved to unsupported kind {resolved_kind!r}"
+        )
+    if target_model is not None:
+        validate_drafter_compatibility(target_model, model, resolved_kind)
+    return model
+
+
 _DRAFT_KWARG_NAMES = ("draft_model", "draft_kind", "draft_block_size")
 
 
@@ -1403,7 +1519,7 @@ class MLXMultimodalLM:
 
     def _load_draft_model(self):
         if self.draft_kind == "mtp":
-            return load_gemma4_assistant_drafter(self.draft_model_path)
+            return load_mtp_drafter(self.draft_model_path, target_model=self.model)
 
         from mlx_vlm.utils import load
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -7170,7 +7170,8 @@ Examples:
         "--mllm-draft-model",
         type=str,
         default=None,
-        help="Path to an mlx-vlm MLLM draft/assistant model.",
+        help="Local path or Hugging Face repo ID for an mlx-vlm MLLM "
+        "draft/assistant model.",
     )
     parser.add_argument(
         "--mllm-draft-kind",


### PR DESCRIPTION
## Summary

- resolve local paths and Hugging Face repo IDs through mlx-vlm before reading drafter metadata
- normalize top-level and nested drafter architecture declarations
- preserve the established Gemma assistant loader while routing registered MTP architectures through mlx-vlm
- validate loader return values and target compatibility without masking architecture-specific errors

Unknown or malformed drafter configurations now fail before serving starts.

## Validation

- focused loader tests: `30 passed`
- full non-slow/non-integration suite: `2937 passed, 17 skipped, 69 deselected`
- Ruff and touched-file Black checks passed
- composed Qwen3.8 Flash-Next serving path passed 64K continuous batching and 128K MTP qualification

