### PR TITLE
fix(mllm): reconcile stateful MTP batch lifecycles

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2394,7 +2394,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         ):
             install_mtp_mllm(generator, object(), draft_model=drafter)
 
-    @pytest.mark.parametrize("marker", [None, "false", 1])
+    @pytest.mark.parametrize("marker", ["false", 1])
     def test_external_mtp_reconciliation_marker_fails_closed(self, marker):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
 
@@ -2408,6 +2408,38 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         with pytest.raises(TypeError, match="literal boolean"):
             install_mtp_mllm(generator, object(), draft_model=drafter)
+
+    @pytest.mark.parametrize("declared", ["absent", None, True, False])
+    @pytest.mark.parametrize("hooks", ["absent", "callable", "partial", "noncallable"])
+    def test_external_mtp_selects_released_lifecycle_contract(self, declared, hooks):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        # v0.6.5/v0.6.6 Gemma has neither hook; Qwen3.5/DeepSeek/Eagle
+        # have both. This is an attribute/lifecycle fixture, not weight loading.
+        drafter = SimpleNamespace(reset=MagicMock())
+        if declared != "absent":
+            drafter.requires_verified_token_reconciliation = declared
+        if hooks != "absent":
+            drafter.accept_verified_tokens_batch = MagicMock()
+        if hooks == "callable":
+            drafter.filter_batch = MagicMock()
+        elif hooks == "noncallable":
+            drafter.filter_batch = None
+        batch = SimpleNamespace(_row_filter_hook=None)
+        generator = SimpleNamespace(
+            model=object(), active_batch=batch, _step=MagicMock(), _next=MagicMock()
+        )
+        invalid = declared is True and hooks != "callable"
+        invalid |= declared in ("absent", None) and hooks in ("partial", "noncallable")
+        if invalid:
+            with pytest.raises(TypeError, match="lifecycle hook"):
+                install_mtp_mllm(generator, object(), draft_model=drafter)
+            drafter.reset.assert_not_called()
+        else:
+            install_mtp_mllm(generator, object(), draft_model=drafter)
+            drafter.reset.assert_called_once_with(generator.model)
+            stateful = declared is not False and hooks == "callable"
+            assert callable(batch._row_filter_hook) is stateful
 
     def test_stateful_external_mtp_filter_failure_clears_lifecycle(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
@@ -3312,45 +3344,99 @@ def test_external_mtp_drafts_mixed_position_rows_independently():
     assert draft_model.set_calls[-1]["kv_offset"] == 10377
 
 
-def test_scheduler_step_error_fails_every_request_once():
-    """A poisoned shared batch must not be retried behind SSE heartbeats."""
-    import inspect
+@pytest.mark.parametrize("cleanup_fails", [False, True])
+def test_scheduler_loop_verification_error_and_cleanup_boundary(
+    monkeypatch, cleanup_fails
+):
+    """Characterize fanout and the existing unhandled cleanup-error boundary."""
+    import threading
+    from collections import deque
 
-    from vllm_mlx.mllm_scheduler import MLLMScheduler
+    import vllm_mlx.mllm_scheduler as scheduler_mod
+    from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, RequestStatus
 
-    scheduler = MLLMScheduler.__new__(MLLMScheduler)
-    scheduler.requests = {
-        request_id: SimpleNamespace(
-            output_tokens=[1, 2],
-            output_text="partial",
-            num_prompt_tokens=10327,
-            num_output_tokens=2,
-            mtp_drafts=10,
-            mtp_accepted=6,
+    monkeypatch.setattr(scheduler_mod, "bind_generation_streams", lambda: None)
+
+    async def run():
+        scheduler = MLLMScheduler.__new__(MLLMScheduler)
+        scheduler._running = True
+        scheduler.requests = {
+            request_id: SimpleNamespace(
+                request_id=request_id,
+                status=status,
+                output_tokens=[1],
+                output_text="partial",
+                num_prompt_tokens=3,
+                num_output_tokens=1,
+                mtp_drafts=1,
+                mtp_accepted=0,
+            )
+            for request_id, status in (
+                ("active", RequestStatus.RUNNING),
+                ("waiting", RequestStatus.WAITING),
+            )
+        }
+        scheduler.running = {"active": scheduler.requests["active"]}
+        scheduler.waiting = deque([scheduler.requests["waiting"]])
+        scheduler.request_id_to_uid = {"active": 7}
+        scheduler.uid_to_request_id = {7: "active"}
+        scheduler.finished_req_ids = set()
+        scheduler._detokenizer_pool = {}
+        scheduler.total_completion_tokens = scheduler.total_prompt_tokens = 0
+        scheduler.output_queues = {key: asyncio.Queue() for key in scheduler.requests}
+        scheduler._schedule_waiting = lambda: []
+        drained = asyncio.Event()
+
+        def notify_removed():
+            drained.set()
+            if cleanup_fails:
+                raise RuntimeError("cleanup callback failed")
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._old_wired_limit = None
+        generator._pending_removal_lock = threading.Lock()
+        generator._pending_removal_uids = set()
+        generator._aborted_request_ids = set()
+        generator.unprocessed_requests = []
+        generator.active_batch = SimpleNamespace(
+            uids=[7], notify_all_rows_removed=notify_removed
         )
-        for request_id in ("older", "joining")
-    }
-    scheduler.output_queues = {
-        request_id: asyncio.Queue() for request_id in scheduler.requests
-    }
-    scheduler.batch_generator = SimpleNamespace(process_pending_removals=MagicMock())
+        poisoned_batch = generator.active_batch
+        calls = []
 
-    def abort(request_id):
-        scheduler.requests.pop(request_id, None)
-        return True
+        def failed_verify():
+            calls.append("verify")
+            raise RuntimeError("target cache may have advanced")
 
-    scheduler.abort_request = MagicMock(side_effect=abort)
-    scheduler._fail_requests_after_step_error(ValueError("negative dimensions"))
+        generator.next = failed_verify
+        scheduler.batch_generator = generator
+        task = asyncio.create_task(scheduler._process_loop())
+        try:
+            await asyncio.wait_for(drained.wait(), timeout=1)
+            if cleanup_fails:
+                with pytest.raises(RuntimeError, match="cleanup callback failed"):
+                    await asyncio.wait_for(task, timeout=1)
+                # Existing limitation: cleanup escapes the loop and retains the
+                # poisoned batch. This is not a recovery/reusability assertion.
+                assert generator.active_batch is poisoned_batch
+            else:
+                assert not task.done()
+                assert generator.active_batch is None
+        finally:
+            scheduler._running = False
+            if not task.done():
+                await asyncio.wait_for(task, timeout=1)
+        assert calls == ["verify"]
+        assert scheduler.requests == scheduler.running == {}
+        assert not scheduler.waiting
+        assert not scheduler.request_id_to_uid and not scheduler.uid_to_request_id
+        assert generator._aborted_request_ids == {"active", "waiting"}
+        for queue in scheduler.output_queues.values():
+            output = queue.get_nowait()
+            assert output.finished and output.finish_reason == "error"
+            assert output.output_text == "partial"
+            assert queue.get_nowait() is None
+            assert queue.empty()
 
-    assert scheduler.requests == {}
-    assert scheduler.abort_request.call_count == 2
-    scheduler.batch_generator.process_pending_removals.assert_called_once_with()
-    for queue in scheduler.output_queues.values():
-        output = queue.get_nowait()
-        assert output.finished is True
-        assert output.finish_reason == "error"
-        assert output.output_text == "partial"
-
-    assert "_fail_requests_after_step_error(e)" in inspect.getsource(
-        MLLMScheduler._process_loop
-    )
+    asyncio.run(run())

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1470,6 +1470,118 @@ class TestMLLMBatchGeneratorMTPGuards:
             batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
         )
 
+    def test_external_media_mtp_bypass_preserves_target_mrope(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_mtp_mllm,
+        )
+
+        rope_deltas = mx.array([[21]], dtype=mx.int32)
+        expected = (mx.array([2]), [mx.zeros((4,))])
+        original_step = MagicMock(return_value=expected)
+        request = MLLMBatchRequest(
+            uid=1,
+            request_id="media",
+            prompt="prompt",
+            images=["image"],
+            mllm_draft=True,
+            rope_deltas=rope_deltas,
+        )
+        batch_gen = SimpleNamespace(
+            model=object(),
+            _step=original_step,
+            _next=lambda: [],
+            active_batch=SimpleNamespace(uids=[1], requests=[request]),
+            sampler=lambda scores: mx.argmax(scores, axis=-1),
+        )
+        language_model = MagicMock()
+        draft_model = MagicMock()
+        draft_model.requires_verified_token_reconciliation = False
+        install_mtp_mllm(batch_gen, language_model, draft_model=draft_model)
+
+        result = batch_gen._step(
+            mx.array([[1]]),
+            [],
+            rope_deltas=rope_deltas,
+        )
+
+        assert result is expected
+        original_step.assert_called_once()
+        assert original_step.call_args.kwargs["rope_deltas"].tolist() == [[21]]
+        language_model.assert_not_called()
+        assert (
+            batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
+        )
+
+    def test_external_mtp_filters_drafter_when_batch_rows_retire(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, install_mtp_mllm
+
+        draft_model = MagicMock()
+        draft_model.requires_verified_token_reconciliation = False
+        active_batch = SimpleNamespace(
+            uids=[11, 22],
+            requests=[],
+        )
+
+        class FakeBatchGen:
+            def __init__(self):
+                self.model = object()
+                self.active_batch = active_batch
+                self._step = MagicMock()
+                self.sampler = MagicMock()
+                self.stop_tokens = set()
+                self._maybe_store_prefix_cache = MagicMock()
+
+                def retire_first_row():
+                    self.active_batch.uids = [22]
+                    return [
+                        MLLMBatchResponse(
+                            uid=11,
+                            request_id="retired",
+                            token=1,
+                            logprobs=mx.zeros(2),
+                            finish_reason="stop",
+                        ),
+                        MLLMBatchResponse(
+                            uid=22,
+                            request_id="active",
+                            token=2,
+                            logprobs=mx.zeros(2),
+                        ),
+                    ]
+
+                self._next = retire_first_row
+
+        batch_gen = FakeBatchGen()
+        install_mtp_mllm(batch_gen, MagicMock(), draft_model=draft_model)
+
+        batch_gen._next()
+
+        draft_model.filter_batch.assert_called_once_with([1])
+
+    def test_external_mtp_resets_drafter_before_a_new_batch(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        draft_model = MagicMock()
+        draft_model.requires_verified_token_reconciliation = False
+
+        class FakeBatchGen:
+            def __init__(self):
+                self.model = object()
+                self.active_batch = None
+                self._step = MagicMock()
+                self._next = MagicMock(return_value=[])
+                self.sampler = MagicMock()
+                self.stop_tokens = set()
+                self._maybe_store_prefix_cache = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        install_mtp_mllm(batch_gen, MagicMock(), draft_model=draft_model)
+
+        batch_gen._next()
+
+        assert draft_model.reset.call_count == 2
+
     def test_positive_temperature_is_stochastic_without_sampling_filters(self):
         from vllm_mlx.mllm_batch_generator import _request_uses_stochastic_sampling
 

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1628,6 +1628,74 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert [response.uid for response in responses] == [11, 22]
         assert draft_model.reset.call_count == 1
 
+    def test_stateless_external_mtp_all_row_retirement_resets_once(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, install_mtp_mllm
+
+        _patch_external_mtp_metadata(monkeypatch)
+        monkeypatch.setattr(
+            "vllm_mlx.mllm_batch_generator._draft_external_mtp_active_batch",
+            lambda *args, **kwargs: mx.array([2], dtype=mx.uint32),
+        )
+        request = SimpleNamespace(
+            uid=11,
+            request_id="retire-all",
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            mllm_draft=True,
+        )
+
+        class LanguageModel:
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                del cache, return_hidden
+                seq_len = input_tokens.shape[1]
+                logits = mx.full((1, seq_len, 4), -1000.0)
+                logits[:, 0, 1 if seq_len == 1 else 2] = 0.0
+                if seq_len == 2:
+                    logits[:, 1, 3] = 0.0
+                return logits, mx.zeros((1, seq_len, 2))
+
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=SimpleNamespace(uids=[11], requests=[request]),
+            _step=MagicMock(side_effect=AssertionError("must not bypass MTP")),
+            sampler=lambda scores: mx.argmax(scores, axis=-1),
+            stop_tokens=set(),
+            _maybe_store_prefix_cache=MagicMock(),
+        )
+
+        def retire_all():
+            if generator.active_batch is None:
+                return []
+            generator.active_batch = None
+            return [
+                MLLMBatchResponse(
+                    uid=11,
+                    request_id="retire-all",
+                    token=1,
+                    logprobs=mx.zeros(4),
+                    finish_reason="stop",
+                )
+            ]
+
+        generator._next = retire_all
+        drafter = SimpleNamespace(
+            requires_verified_token_reconciliation=False,
+            reset=MagicMock(),
+            set_shared_kv=MagicMock(),
+            accept_lens=[],
+            draft_lens=[],
+        )
+        install_mtp_mllm(generator, LanguageModel(), draft_model=drafter)
+
+        generator._step(mx.array([[0]], dtype=mx.uint32), [], None, None, None)
+        generator._next()
+        generator._next()
+
+        # One reset at installation and one when the active batch retires.
+        assert drafter.reset.call_count == 2
+
     def test_positive_temperature_is_stochastic_without_sampling_filters(self):
         from vllm_mlx.mllm_batch_generator import _request_uses_stochastic_sampling
 
@@ -1864,6 +1932,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
+            rope_deltas=rope_deltas,
         )
 
         assert model.mtp_calls == 1
@@ -1999,13 +2068,23 @@ class TestMLLMBatchGeneratorMTPGuards:
                 raise AssertionError("sampled MTP must not take the bypass path")
 
         class LanguageModel:
+            def __init__(self):
+                self.calls = []
+
             def mtp_forward(self, hidden_states, next_token_ids, mtp_cache=None):
                 del hidden_states, next_token_ids, mtp_cache
                 # Draft is confident in token 1.
                 return mx.array([[[0.0, 5.0, 1.0, -3.0]]])
 
-            def __call__(self, input_tokens, cache=None, return_hidden=False):
+            def __call__(
+                self,
+                input_tokens,
+                cache=None,
+                return_hidden=False,
+                rope_deltas=None,
+            ):
                 del cache, return_hidden
+                self.calls.append((input_tokens.shape[1], rope_deltas.tolist()))
                 if input_tokens.shape[1] == 2:
                     # Verify pass: target is confident in token 2, not the
                     # draft's token 1, so the sampled draft is rejected and
@@ -2023,6 +2102,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         model = LanguageModel()
         install_mtp_mllm(generator, model)
         cache = [TrimmableCache()]
+        rope_deltas = mx.array([[13]], dtype=mx.int32)
 
         generator._step(
             mx.array([[0]], dtype=mx.uint32),
@@ -2030,8 +2110,10 @@ class TestMLLMBatchGeneratorMTPGuards:
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
+            rope_deltas=rope_deltas,
         )
         assert generator.get_mtp_stats()["rejected"] == 1
+        assert model.calls == [(1, [[13]]), (2, [[13]]), (1, [[13]])]
 
         # A second decode step must not crash: the skip-state entry populated
         # by the residual replay above must be rank-2 (batch, vocab), not a
@@ -2042,6 +2124,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
+            rope_deltas=rope_deltas,
         )
         mx.eval(tokens)
         assert tokens.shape == (1,)
@@ -2487,6 +2570,127 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         assert generator.active_batch is None
         assert drafter.reset_calls == 2
+
+    def test_stateful_external_mtp_filters_normal_generator_retirement_once(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+            install_mtp_mllm,
+        )
+
+        requests = [
+            MLLMBatchRequest(uid=uid, request_id=name, prompt="prompt")
+            for uid, name in ((1, "retire"), (2, "keep"))
+        ]
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.model = object()
+        generator.active_batch = MLLMBatch(
+            uids=[1, 2],
+            request_ids=["retire", "keep"],
+            y=mx.array([5, 6], dtype=mx.uint32),
+            logprobs=[mx.zeros(8), mx.zeros(8)],
+            max_tokens=[8, 8],
+            num_tokens=[0, 0],
+            cache=[],
+            requests=requests,
+        )
+        generator._step = MagicMock(
+            return_value=(
+                mx.array([7, 7], dtype=mx.uint32),
+                [mx.zeros(8), mx.zeros(8)],
+            )
+        )
+        generator.sampler = MagicMock()
+        generator.stop_tokens = {5}
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator._stats = MLLMBatchStats()
+        generator._maybe_store_prefix_cache = MagicMock()
+        drafter = _RecordingStatefulDrafter(rows=["retire", "keep"])
+
+        install_mtp_mllm(generator, object(), draft_model=drafter)
+        generator._step = MagicMock(
+            return_value=(
+                mx.array([7, 7], dtype=mx.uint32),
+                [mx.zeros(8), mx.zeros(8)],
+            )
+        )
+        responses = generator._next()
+
+        assert [response.finish_reason for response in responses] == ["stop", None]
+        assert generator.active_batch.uids == [2]
+        assert drafter.filter_calls == [[1]]
+
+    def test_stateful_external_mtp_filters_chunked_generation_retirement_once(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchRequest,
+            MLLMBatchStats,
+            install_chunked_prefill_mllm,
+            install_mtp_mllm,
+        )
+
+        requests = [
+            MLLMBatchRequest(uid=uid, request_id=name, prompt="prompt")
+            for uid, name in ((1, "retire"), (2, "keep"))
+        ]
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.model = object()
+        generator.active_batch = MLLMBatch(
+            uids=[1, 2],
+            request_ids=["retire", "keep"],
+            y=mx.array([5, 6], dtype=mx.uint32),
+            logprobs=[mx.zeros(8), mx.zeros(8)],
+            max_tokens=[8, 8],
+            num_tokens=[0, 0],
+            cache=[],
+            requests=requests,
+        )
+        generator._step = MagicMock()
+        generator.sampler = MagicMock()
+        generator.stop_tokens = {5}
+        generator.unprocessed_requests = []
+        generator._pending_error_responses = []
+        generator._aborted_request_ids = set()
+        generator._prefill_progress = {}
+        generator.prefix_cache = None
+        generator.max_kv_size = 0
+        generator._stats = MLLMBatchStats()
+        generator._maybe_store_prefix_cache = MagicMock()
+        generator._language_model_kwargs = lambda *args: {}
+        generator.language_model = MagicMock(return_value=mx.zeros((1, 1, 8)))
+        partial_request = SimpleNamespace(uid=99, request_id="partial")
+        drafter = _RecordingStatefulDrafter(rows=["retire", "keep"])
+
+        install_chunked_prefill_mllm(generator, budget=1)
+        install_mtp_mllm(generator, object(), draft_model=drafter)
+        generator._partial = {
+            "request": partial_request,
+            "cache": [],
+            "remaining_ids": mx.array([[1, 2]], dtype=mx.uint32),
+            "processed": 0,
+            "total": 2,
+            "cached_count": 0,
+            "chunk_count": 0,
+            "checkpoint_at": None,
+        }
+        generator._step = MagicMock(
+            return_value=(
+                mx.array([7, 7], dtype=mx.uint32),
+                [mx.zeros(8), mx.zeros(8)],
+            )
+        )
+
+        responses = generator._next()
+
+        assert [response.finish_reason for response in responses] == ["stop", None]
+        assert generator.active_batch.uids == [2]
+        assert drafter.filter_calls == [[1]]
 
     def test_stateful_external_mtp_reconciles_on_next_target_primary(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1470,49 +1470,6 @@ class TestMLLMBatchGeneratorMTPGuards:
             batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
         )
 
-    def test_external_media_mtp_bypass_preserves_target_mrope(self):
-        from vllm_mlx.mllm_batch_generator import (
-            MLLMBatchRequest,
-            install_mtp_mllm,
-        )
-
-        rope_deltas = mx.array([[21]], dtype=mx.int32)
-        expected = (mx.array([2]), [mx.zeros((4,))])
-        original_step = MagicMock(return_value=expected)
-        request = MLLMBatchRequest(
-            uid=1,
-            request_id="media",
-            prompt="prompt",
-            images=["image"],
-            mllm_draft=True,
-            rope_deltas=rope_deltas,
-        )
-        batch_gen = SimpleNamespace(
-            model=object(),
-            _step=original_step,
-            _next=lambda: [],
-            active_batch=SimpleNamespace(uids=[1], requests=[request]),
-            sampler=lambda scores: mx.argmax(scores, axis=-1),
-        )
-        language_model = MagicMock()
-        draft_model = MagicMock()
-        draft_model.requires_verified_token_reconciliation = False
-        install_mtp_mllm(batch_gen, language_model, draft_model=draft_model)
-
-        result = batch_gen._step(
-            mx.array([[1]]),
-            [],
-            rope_deltas=rope_deltas,
-        )
-
-        assert result is expected
-        original_step.assert_called_once()
-        assert original_step.call_args.kwargs["rope_deltas"].tolist() == [[21]]
-        language_model.assert_not_called()
-        assert (
-            batch_gen.get_mtp_stats()["bypass_counts"]["assistant_not_requested"] == 1
-        )
-
     def test_external_mtp_filters_drafter_when_batch_rows_retire(self):
         from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, install_mtp_mllm
 
@@ -2067,23 +2024,13 @@ class TestMLLMBatchGeneratorMTPGuards:
                 raise AssertionError("sampled MTP must not take the bypass path")
 
         class LanguageModel:
-            def __init__(self):
-                self.calls = []
-
             def mtp_forward(self, hidden_states, next_token_ids, mtp_cache=None):
                 del hidden_states, next_token_ids, mtp_cache
                 # Draft is confident in token 1.
                 return mx.array([[[0.0, 5.0, 1.0, -3.0]]])
 
-            def __call__(
-                self,
-                input_tokens,
-                cache=None,
-                return_hidden=False,
-                rope_deltas=None,
-            ):
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
                 del cache, return_hidden
-                self.calls.append((input_tokens.shape[1], rope_deltas.tolist()))
                 if input_tokens.shape[1] == 2:
                     # Verify pass: target is confident in token 2, not the
                     # draft's token 1, so the sampled draft is rejected and
@@ -2101,18 +2048,14 @@ class TestMLLMBatchGeneratorMTPGuards:
         model = LanguageModel()
         install_mtp_mllm(generator, model)
         cache = [TrimmableCache()]
-        rope_deltas = mx.array([[13]], dtype=mx.int32)
-
         generator._step(
             mx.array([[0]], dtype=mx.uint32),
             cache=cache,
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
-            rope_deltas=rope_deltas,
         )
         assert generator.get_mtp_stats()["rejected"] == 1
-        assert model.calls == [(1, [[13]]), (2, [[13]]), (1, [[13]])]
 
         # A second decode step must not crash: the skip-state entry populated
         # by the residual replay above must be rank-2 (batch, vocab), not a
@@ -2123,7 +2066,6 @@ class TestMLLMBatchGeneratorMTPGuards:
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
-            rope_deltas=rope_deltas,
         )
         mx.eval(tokens)
         assert tokens.shape == (1,)
@@ -2841,14 +2783,13 @@ class TestMLLMBatchGeneratorMTPGuards:
             hidden_states,
             positions,
             sampler,
-            token_dtype,
         ):
             nonlocal draft_round
             del draft_model, hidden_states, positions, sampler
             tokens = [5, 6] if draft_round == 0 else [7]
             draft_round += 1
             assert len(tokens) == primary_tokens.shape[0]
-            return mx.array(tokens, dtype=token_dtype)
+            return mx.array(tokens, dtype=primary_tokens.dtype)
 
         monkeypatch.setattr(
             "vllm_mlx.mllm_batch_generator._draft_external_mtp_active_batch",

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -35,6 +35,81 @@ except ImportError:
 pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 
 
+class _RecordingStatefulDrafter:
+    requires_verified_token_reconciliation = True
+
+    def __init__(self, rows=None):
+        self.accept_lens = []
+        self.draft_lens = []
+        self.rows = list(rows or [])
+        self.filter_calls = []
+        self.reconciliations = []
+        self.reset_calls = 0
+        self.events = []
+
+    def reset(self, model):
+        self.model = model
+        self.reset_calls += 1
+        self.events.append("reset")
+
+    def set_shared_kv(self, *args, **kwargs):
+        self.last_shared_kv = (args, kwargs)
+        self.events.append("set_shared_kv")
+
+    def accept_verified_tokens_batch(
+        self,
+        verify_hidden,
+        draft_tokens,
+        accepted,
+        new_tokens,
+        sampler,
+        token_dtype,
+        greedy,
+    ):
+        self.events.append("reconcile")
+        self.reconciliations.append(
+            {
+                "rows": list(self.rows),
+                "hidden_shape": tuple(verify_hidden.shape),
+                "draft_tokens": draft_tokens.tolist(),
+                "accepted": list(accepted),
+                "new_tokens": [list(row) for row in new_tokens],
+                "token_dtype": token_dtype,
+                "greedy": greedy,
+            }
+        )
+
+    def filter_batch(self, keep):
+        keep = keep.tolist()
+        self.events.append("filter_batch")
+        self.filter_calls.append(keep)
+        if self.rows:
+            self.rows = [self.rows[index] for index in keep]
+
+
+def _patch_external_mtp_metadata(monkeypatch):
+    import mlx_vlm.speculative.common as speculative_common
+    import mlx_vlm.speculative.mtp as speculative_mtp
+
+    monkeypatch.setattr(
+        speculative_common, "_batch_cache_left_padding", lambda cache: None
+    )
+    monkeypatch.setattr(
+        speculative_mtp,
+        "_mtp_shared_kv_from_prompt_cache",
+        lambda model, cache: {"shared": object()},
+    )
+    monkeypatch.setattr(
+        speculative_mtp,
+        "_mtp_cache_positions",
+        lambda cache, batch_size: (10, [10] * batch_size),
+    )
+    monkeypatch.setattr(
+        speculative_mtp, "_mtp_draft_position", lambda positions: positions
+    )
+    return speculative_mtp
+
+
 # Test image (small PNG)
 TEST_IMAGE_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
@@ -1118,6 +1193,7 @@ class TestMLLMBatchGeneratorMTPGuards:
         expected_logprobs = [mx.array([0.1, 0.9]), mx.array([0.2, 0.8])]
         original_step = MagicMock(return_value=(expected_tokens, expected_logprobs))
         draft_model = MagicMock()
+        draft_model.requires_verified_token_reconciliation = False
 
         class FakeBatchGen:
             def __init__(self):
@@ -1165,30 +1241,12 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert _request_uses_stochastic_sampling(request) is True
 
     def test_external_stochastic_rejection_replays_sampled_target(self, monkeypatch):
-        import mlx_vlm.speculative.common as speculative_common
-        import mlx_vlm.speculative.mtp as speculative_mtp
-
         from vllm_mlx.mllm_batch_generator import (
             MLLMBatchResponse,
             install_mtp_mllm,
         )
 
-        monkeypatch.setattr(
-            speculative_common, "_batch_cache_left_padding", lambda cache: None
-        )
-        monkeypatch.setattr(
-            speculative_mtp,
-            "_mtp_shared_kv_from_prompt_cache",
-            lambda model, cache: {"shared": object()},
-        )
-        monkeypatch.setattr(
-            speculative_mtp,
-            "_mtp_cache_positions",
-            lambda cache, batch_size: (10, [10] * batch_size),
-        )
-        monkeypatch.setattr(
-            speculative_mtp, "_mtp_draft_position", lambda positions: positions
-        )
+        speculative_mtp = _patch_external_mtp_metadata(monkeypatch)
         monkeypatch.setattr(
             speculative_mtp,
             "_mtp_draft_block_active",
@@ -1240,17 +1298,6 @@ class TestMLLMBatchGeneratorMTPGuards:
             def trim(self, count):
                 self.trim_calls.append(count)
 
-        class DraftModel:
-            def __init__(self):
-                self.accept_lens = []
-                self.draft_lens = []
-
-            def reset(self, model):
-                self.model = model
-
-            def set_shared_kv(self, *args, **kwargs):
-                return None
-
         class LanguageModel:
             def __init__(self):
                 self.inputs = []
@@ -1267,7 +1314,7 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         generator = Generator()
         language_model = LanguageModel()
-        draft_model = DraftModel()
+        draft_model = _RecordingStatefulDrafter()
         cache = TrimmableCache()
         install_mtp_mllm(generator, language_model, draft_model=draft_model)
 
@@ -1287,6 +1334,25 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert int(mx.argmax(responses[1].logprobs).item()) == 3
         assert draft_model.accept_lens == [0]
         assert generator.get_mtp_stats()["rejected"] == 1
+        assert draft_model.reconciliations[0]["accepted"] == [0]
+        assert draft_model.reconciliations[0]["draft_tokens"] == [[]]
+        assert draft_model.reconciliations[0]["new_tokens"] == [[1]]
+        assert draft_model.reconciliations[1]["accepted"] == [0]
+        assert draft_model.reconciliations[1]["draft_tokens"] == [[2]]
+        assert draft_model.reconciliations[1]["new_tokens"] == [[3]]
+
+        generator._step(
+            mx.array([[1]], dtype=mx.uint32),
+            cache=[cache],
+            logits_processors=None,
+            output_tokens=None,
+            samplers=[lambda logprobs: mx.array([1], dtype=mx.uint32)],
+        )
+
+        assert draft_model.reconciliations[2]["accepted"] == [0]
+        assert draft_model.reconciliations[2]["draft_tokens"] == [[]]
+        assert draft_model.reconciliations[2]["new_tokens"] == [[1]]
+        assert draft_model.reconciliations[2]["hidden_shape"] == (1, 1, 2)
 
     def test_uniform_draft_batches_remove_only_selected_requests(self):
         from vllm_mlx.mllm_batch_generator import (
@@ -1890,6 +1956,321 @@ class TestMLLMBatchGeneratorMTPGuards:
         assert len(responses) == 1
         assert generator.active_batch is not None
         assert generator.active_batch.logits_processors == [None]
+
+    def test_stateful_external_mtp_requires_batch_lifecycle_hooks(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        generator = SimpleNamespace(
+            model=object(),
+            _step=MagicMock(),
+            _next=MagicMock(),
+        )
+        drafter = SimpleNamespace(
+            requires_verified_token_reconciliation=True,
+            reset=MagicMock(),
+        )
+
+        with pytest.raises(
+            TypeError, match="accept_verified_tokens_batch, filter_batch"
+        ):
+            install_mtp_mllm(generator, object(), draft_model=drafter)
+
+    @pytest.mark.parametrize("marker", [None, "false", 1])
+    def test_external_mtp_reconciliation_marker_fails_closed(self, marker):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        generator = SimpleNamespace(
+            model=object(), _step=MagicMock(), _next=MagicMock()
+        )
+        drafter = SimpleNamespace(
+            requires_verified_token_reconciliation=marker,
+            reset=MagicMock(),
+        )
+
+        with pytest.raises(TypeError, match="literal boolean"):
+            install_mtp_mllm(generator, object(), draft_model=drafter)
+
+    def test_stateful_external_mtp_filter_failure_clears_lifecycle(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        request = SimpleNamespace(mllm_draft=True)
+        active_batch = SimpleNamespace(
+            uids=[1, 2], requests=[request, request], _row_filter_hook=None
+        )
+        original_step = MagicMock(return_value=(mx.array([3, 4]), [mx.zeros(1)] * 2))
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=active_batch,
+            _step=original_step,
+            _next=MagicMock(),
+            sampler=MagicMock(),
+        )
+        drafter = _RecordingStatefulDrafter(rows=["a", "b"])
+        drafter.filter_batch = MagicMock(side_effect=RuntimeError("filter failed"))
+        install_mtp_mllm(generator, object(), draft_model=drafter)
+
+        generator._step(mx.array([[1], [2]]), [], [[MagicMock()]], None, None)
+        with pytest.raises(RuntimeError, match="filter failed"):
+            active_batch._row_filter_hook([1, 2], [2])
+
+        assert drafter.reset_calls == 2
+
+    def test_stateful_external_mtp_reconciles_on_next_target_primary(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        speculative_mtp = _patch_external_mtp_metadata(monkeypatch)
+        drafter = _RecordingStatefulDrafter()
+        drafter.draft_round = 0
+
+        def fake_draft_block(*args, **kwargs):
+            del args, kwargs
+            tokens = ([20, 21], [22, 23], [24, 25])[drafter.draft_round]
+            drafter.draft_round += 1
+            return mx.array(tokens, dtype=mx.uint32)[:, None]
+
+        monkeypatch.setattr(
+            speculative_mtp, "_mtp_draft_block_active", fake_draft_block
+        )
+
+        requests = [
+            SimpleNamespace(
+                uid=uid,
+                request_id=f"row-{uid}",
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                mllm_draft=True,
+            )
+            for uid in (7, 8)
+        ]
+
+        class LanguageModel:
+            def __init__(self):
+                self.verify_round = 0
+
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                del cache, return_hidden
+                seq_len = input_tokens.shape[1]
+                logits = mx.full((2, seq_len, 32), -1000.0)
+                if seq_len == 1:
+                    targets = [10, 11]
+                    for row, target in enumerate(targets):
+                        logits[row, 0, target] = 0.0
+                else:
+                    verify_targets = ([20, 21], [29, 28], [24, 25])[self.verify_round]
+                    bonus_targets = ([12, 13], [14, 15], [16, 17])[self.verify_round]
+                    self.verify_round += 1
+                    for row, target in enumerate(verify_targets):
+                        logits[row, 0, target] = 0.0
+                    for row, target in enumerate(bonus_targets):
+                        logits[row, 1, target] = 0.0
+                return logits, mx.zeros((2, seq_len, 4))
+
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=SimpleNamespace(uids=[7, 8], requests=requests),
+            _step=MagicMock(side_effect=AssertionError("must not bypass MTP")),
+            _next=MagicMock(return_value=[]),
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+        )
+        install_mtp_mllm(generator, LanguageModel(), draft_model=drafter)
+
+        first, _ = generator._step(
+            mx.array([[0], [0]], dtype=mx.uint32), [], None, None, None
+        )
+        second, _ = generator._step(
+            mx.array([[10], [11]], dtype=mx.uint32), [], None, None, None
+        )
+        third, _ = generator._step(
+            mx.array([[12], [13]], dtype=mx.uint32), [], None, None, None
+        )
+
+        assert first.tolist() == [10, 11]
+        assert second.tolist() == [12, 13]
+        assert third.tolist() == [29, 28]
+        assert drafter.events[:3] == ["reset", "set_shared_kv", "reconcile"]
+        assert [call["accepted"] for call in drafter.reconciliations[:3]] == [
+            [0, 0],
+            [1, 1],
+            [0, 0],
+        ]
+        assert [call["draft_tokens"] for call in drafter.reconciliations[:3]] == [
+            [[], []],
+            [[20], [21]],
+            [[22], [23]],
+        ]
+        assert [call["new_tokens"] for call in drafter.reconciliations[:3]] == [
+            [[10], [11]],
+            [[20, 12], [21, 13]],
+            [[29], [28]],
+        ]
+        assert [call["hidden_shape"] for call in drafter.reconciliations[:3]] == [
+            (2, 1, 4),
+            (2, 2, 4),
+            (2, 2, 4),
+        ]
+        assert all(
+            call["token_dtype"] == mx.uint32 for call in drafter.reconciliations[:3]
+        )
+        assert all(call["greedy"] is True for call in drafter.reconciliations)
+
+    @pytest.mark.parametrize(
+        ("stop_tokens", "num_tokens", "max_tokens", "expected_finish"),
+        [
+            ({5}, [0, 0], [8, 8], "stop"),
+            (set(), [1, 0], [2, 8], "length"),
+        ],
+    )
+    def test_stateful_external_mtp_filters_deferred_draft_retirement(
+        self,
+        monkeypatch,
+        stop_tokens,
+        num_tokens,
+        max_tokens,
+        expected_finish,
+    ):
+        import mlx_vlm.speculative.common as speculative_common
+        import mlx_vlm.speculative.mtp as speculative_mtp
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            MLLMBatchResponse,
+            install_mtp_mllm,
+        )
+
+        monkeypatch.setattr(
+            speculative_common, "_batch_cache_left_padding", lambda cache: None
+        )
+        monkeypatch.setattr(
+            speculative_mtp,
+            "_mtp_shared_kv_from_prompt_cache",
+            lambda model, cache: {"shared": object()},
+        )
+        monkeypatch.setattr(
+            speculative_mtp,
+            "_mtp_cache_positions",
+            lambda cache, batch_size: (10, [10] * batch_size),
+        )
+        monkeypatch.setattr(
+            speculative_mtp, "_mtp_draft_position", lambda positions: positions
+        )
+
+        draft_round = 0
+
+        def fake_draft_block(
+            draft_model,
+            primary_tokens,
+            hidden_states,
+            positions,
+            sampler,
+            token_dtype,
+        ):
+            nonlocal draft_round
+            del draft_model, hidden_states, positions, sampler
+            tokens = [5, 6] if draft_round == 0 else [7]
+            draft_round += 1
+            assert len(tokens) == primary_tokens.shape[0]
+            return mx.array(tokens, dtype=token_dtype)
+
+        monkeypatch.setattr(
+            "vllm_mlx.mllm_batch_generator._draft_external_mtp_active_batch",
+            fake_draft_block,
+        )
+
+        requests = [
+            SimpleNamespace(
+                uid=uid,
+                request_id=name,
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                mllm_draft=True,
+                output_tokens=[],
+            )
+            for uid, name in ((1, "a"), (2, "b"))
+        ]
+        batch = MLLMBatch(
+            uids=[1, 2],
+            request_ids=["a", "b"],
+            y=mx.array([0, 0], dtype=mx.uint32),
+            logprobs=[mx.zeros(16), mx.zeros(16)],
+            max_tokens=list(max_tokens),
+            num_tokens=list(num_tokens),
+            cache=[],
+            requests=requests,
+        )
+
+        class LanguageModel:
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                del cache, return_hidden
+                batch_size, seq_len = input_tokens.shape
+                logits = mx.full((batch_size, seq_len, 16), -1000.0)
+                if seq_len == 1:
+                    targets = [10, 11][:batch_size]
+                else:
+                    targets = ([5, 6] if batch_size == 2 else [7])[:batch_size]
+                for row, target in enumerate(targets):
+                    logits[row, 0, target] = 0.0
+                if seq_len == 2:
+                    logits[:, 1, 8] = 0.0
+                return logits, mx.zeros((batch_size, seq_len, 4))
+
+        primary_responses = [
+            MLLMBatchResponse(
+                uid=uid,
+                request_id=name,
+                token=token,
+                logprobs=mx.zeros(16),
+            )
+            for uid, name, token in ((1, "a", 10), (2, "b", 11))
+        ]
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=batch,
+            _step=MagicMock(side_effect=AssertionError("must not bypass MTP")),
+            _next=MagicMock(return_value=primary_responses),
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+            stop_tokens=stop_tokens,
+            _maybe_store_prefix_cache=MagicMock(),
+            unprocessed_requests=[],
+        )
+        drafter = _RecordingStatefulDrafter(rows=["a", "b"])
+        install_mtp_mllm(generator, LanguageModel(), draft_model=drafter)
+
+        generator._step(mx.array([[0], [0]], dtype=mx.uint32), [], None, None, None)
+        responses = generator._next()
+
+        assert [response.token for response in responses] == [10, 5, 11, 6]
+        assert responses[1].finish_reason == expected_finish
+        assert responses[3].finish_reason is None
+        assert generator.active_batch.uids == [2]
+        assert drafter.filter_calls == [[1]]
+        assert drafter.rows == ["b"]
+
+        generator._step(mx.array([[11]], dtype=mx.uint32), [], None, None, None)
+        assert [call["rows"] for call in drafter.reconciliations[:2]] == [
+            ["a", "b"],
+            ["b"],
+        ]
+        assert [call["draft_tokens"] for call in drafter.reconciliations[:2]] == [
+            [[], []],
+            [[6]],
+        ]
+        assert [call["accepted"] for call in drafter.reconciliations[:2]] == [
+            [0, 0],
+            [1],
+        ]
+        assert [call["new_tokens"] for call in drafter.reconciliations[:2]] == [
+            [[10], [11]],
+            [[6, 8]],
+        ]
+
+        MLLMBatchGenerator.remove(generator, [2])
+        assert generator.active_batch is None
+        assert drafter.reset_calls == 2
 
 
 class TestBatchedMLLMConfigWiring:

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1559,7 +1559,7 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         draft_model.filter_batch.assert_called_once_with([1])
 
-    def test_external_mtp_resets_drafter_before_a_new_batch(self):
+    def test_stateless_external_mtp_skips_redundant_idle_reset(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
 
         draft_model = MagicMock()
@@ -1580,7 +1580,53 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         batch_gen._next()
 
-        assert draft_model.reset.call_count == 2
+        assert draft_model.reset.call_count == 1
+
+    def test_stateless_external_mtp_without_row_filter_retires_cleanly(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse, install_mtp_mllm
+
+        draft_model = SimpleNamespace(
+            requires_verified_token_reconciliation=False,
+            reset=MagicMock(),
+        )
+        active_batch = SimpleNamespace(uids=[11, 22], requests=[])
+
+        class FakeBatchGen:
+            def __init__(self):
+                self.model = object()
+                self.active_batch = active_batch
+                self._step = MagicMock()
+                self.sampler = MagicMock()
+                self.stop_tokens = set()
+                self._maybe_store_prefix_cache = MagicMock()
+
+                def retire_first_row():
+                    self.active_batch.uids = [22]
+                    return [
+                        MLLMBatchResponse(
+                            uid=11,
+                            request_id="retired",
+                            token=1,
+                            logprobs=mx.zeros(2),
+                            finish_reason="stop",
+                        ),
+                        MLLMBatchResponse(
+                            uid=22,
+                            request_id="active",
+                            token=2,
+                            logprobs=mx.zeros(2),
+                        ),
+                    ]
+
+                self._next = retire_first_row
+
+        batch_gen = FakeBatchGen()
+        install_mtp_mllm(batch_gen, MagicMock(), draft_model=draft_model)
+
+        responses = batch_gen._next()
+
+        assert [response.uid for response in responses] == [11, 22]
+        assert draft_model.reset.call_count == 1
 
     def test_positive_temperature_is_stochastic_without_sampling_filters(self):
         from vllm_mlx.mllm_batch_generator import _request_uses_stochastic_sampling

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2252,6 +2252,84 @@ class TestMLLMBatchGeneratorMTPGuards:
 
         assert drafter.reset_calls == 2
 
+    def test_stateful_external_mtp_binds_existing_batch_before_first_step(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            install_mtp_mllm,
+        )
+
+        request = SimpleNamespace(uid=1, request_id="existing", mllm_draft=True)
+        batch = MLLMBatch(
+            uids=[1],
+            request_ids=["existing"],
+            y=mx.array([0], dtype=mx.uint32),
+            logprobs=[mx.zeros(4)],
+            max_tokens=[8],
+            num_tokens=[0],
+            cache=[],
+            requests=[request],
+        )
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=batch,
+            unprocessed_requests=[],
+            _step=MagicMock(),
+            _next=MagicMock(return_value=[]),
+            sampler=MagicMock(),
+            stop_tokens=set(),
+            _maybe_store_prefix_cache=MagicMock(),
+        )
+        drafter = _RecordingStatefulDrafter(rows=["existing"])
+
+        install_mtp_mllm(generator, object(), draft_model=drafter)
+        MLLMBatchGenerator.remove(generator, [1])
+
+        assert generator.active_batch is None
+        assert drafter.reset_calls == 2
+
+    def test_stateful_external_mtp_binds_batch_created_by_wrapped_next(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatch,
+            MLLMBatchGenerator,
+            install_mtp_mllm,
+        )
+
+        request = SimpleNamespace(uid=1, request_id="created", mllm_draft=True)
+        batch = MLLMBatch(
+            uids=[1],
+            request_ids=["created"],
+            y=mx.array([0], dtype=mx.uint32),
+            logprobs=[mx.zeros(4)],
+            max_tokens=[8],
+            num_tokens=[0],
+            cache=[],
+            requests=[request],
+        )
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=None,
+            unprocessed_requests=[],
+            _step=MagicMock(),
+            sampler=MagicMock(),
+            stop_tokens=set(),
+            _maybe_store_prefix_cache=MagicMock(),
+        )
+
+        def create_batch():
+            generator.active_batch = batch
+            return []
+
+        generator._next = create_batch
+        drafter = _RecordingStatefulDrafter(rows=["created"])
+
+        install_mtp_mllm(generator, object(), draft_model=drafter)
+        generator._next()
+        MLLMBatchGenerator.remove(generator, [1])
+
+        assert generator.active_batch is None
+        assert drafter.reset_calls == 2
+
     def test_stateful_external_mtp_reconciles_on_next_target_primary(self, monkeypatch):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm
 

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1164,6 +1164,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             "concurrent_batch": 0,
             "logits_processors": 0,
             "assistant_not_requested": 0,
+            "hidden_state_unavailable": 0,
         }
 
         logits_processor = MagicMock()
@@ -1185,6 +1186,242 @@ class TestMLLMBatchGeneratorMTPGuards:
         stats = batch_gen.get_mtp_stats()
         assert stats["attempted"] == 0
         assert stats["bypass_counts"]["logits_processors"] == 1
+
+    @pytest.mark.parametrize("mode", ["native", "stateless_external"])
+    def test_mtp_missing_hidden_uses_first_target_logits_once(self, mode):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        requests = [
+            SimpleNamespace(
+                uid=uid,
+                request_id=f"hidden-none-{uid}",
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                min_p=0.0,
+                mllm_draft=True,
+            )
+            for uid in (7, 8)
+        ]
+
+        class TrackingCache:
+            position = 0
+
+        cache = [TrackingCache()]
+
+        def hiddenless_logits(input_tokens):
+            logits = mx.full((2, input_tokens.shape[1], 8), -10.0)
+            logits[0, -1, 4] = 2.0
+            logits[1, -1, 5] = 3.0
+            return logits
+
+        class HiddenlessTarget:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                self.calls.append(return_hidden)
+                cache[0].position += input_tokens.shape[1]
+                return hiddenless_logits(input_tokens)
+
+        target = HiddenlessTarget()
+
+        def faithful_original_step(
+            input_tokens,
+            cache,
+            logits_processors=None,
+            output_tokens=None,
+            samplers=None,
+        ):
+            del logits_processors, output_tokens
+            logits = target(input_tokens, cache=cache, return_hidden=False)[:, -1, :]
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            tokens = mx.concatenate(
+                [
+                    sampler(logprobs[row : row + 1])
+                    for row, sampler in enumerate(samplers)
+                ]
+            )
+            return tokens, list(logprobs)
+
+        original_step = MagicMock(side_effect=faithful_original_step)
+        fallback_sampler = MagicMock(
+            side_effect=AssertionError("per-request samplers must be preserved")
+        )
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=SimpleNamespace(uids=[7, 8], requests=requests),
+            _step=original_step,
+            _next=MagicMock(return_value=[]),
+            sampler=fallback_sampler,
+        )
+        draft_model = None
+        if mode == "stateless_external":
+            draft_model = SimpleNamespace(
+                requires_verified_token_reconciliation=False,
+                reset=MagicMock(),
+            )
+        install_mtp_mllm(generator, target, draft_model=draft_model)
+
+        row_samplers = [
+            MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+            MagicMock(return_value=mx.array([2], dtype=mx.uint32)),
+        ]
+        primary, logprobs = generator._step(
+            mx.array([[1], [2]], dtype=mx.uint32),
+            cache,
+            None,
+            None,
+            row_samplers,
+        )
+
+        expected_logits = hiddenless_logits(mx.array([[1], [2]], dtype=mx.uint32))[
+            :, -1, :
+        ]
+        expected_logprobs = expected_logits - mx.logsumexp(
+            expected_logits, axis=-1, keepdims=True
+        )
+
+        assert primary.tolist() == [1, 2]
+        assert target.calls == [True]
+        assert cache[0].position == 1
+        assert all(
+            mx.allclose(actual, expected).item()
+            for actual, expected in zip(logprobs, expected_logprobs)
+        )
+        assert all(sampler.call_count == 1 for sampler in row_samplers)
+        fallback_sampler.assert_not_called()
+        assert generator.get_mtp_stats()["attempted"] == 0
+        assert (
+            generator.get_mtp_stats()["bypass_counts"]["hidden_state_unavailable"] == 1
+        )
+        original_step.assert_not_called()
+
+    def test_stateful_external_mtp_missing_hidden_fails_closed(self):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        request = SimpleNamespace(
+            uid=7,
+            request_id="hidden-none",
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            mllm_draft=True,
+        )
+
+        class HiddenlessTarget:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                self.calls.append(return_hidden)
+                cache[0].position += input_tokens.shape[1]
+                logits = mx.full((1, input_tokens.shape[1], 8), -1000.0)
+                logits[:, -1, 4] = 0.0
+                return logits
+
+        class TrackingCache:
+            position = 0
+
+        cache = [TrackingCache()]
+        target = HiddenlessTarget()
+
+        def faithful_original_step(
+            input_tokens,
+            cache,
+            logits_processors=None,
+            output_tokens=None,
+            samplers=None,
+        ):
+            del logits_processors, output_tokens, samplers
+            logits = target(input_tokens, cache=cache, return_hidden=False)[:, -1, :]
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            return mx.argmax(logprobs, axis=-1), list(logprobs)
+
+        original_step = MagicMock(side_effect=faithful_original_step)
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=SimpleNamespace(uids=[7], requests=[request]),
+            _step=original_step,
+            _next=MagicMock(return_value=[]),
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+        )
+        drafter = _RecordingStatefulDrafter(rows=["hidden-none"])
+        install_mtp_mllm(generator, target, draft_model=drafter)
+
+        with pytest.raises(RuntimeError, match="requires target hidden states"):
+            generator._step(mx.array([[1]], dtype=mx.uint32), cache, None, None, None)
+
+        assert target.calls == [True]
+        assert cache[0].position == 1
+        assert drafter.reset_calls == 2
+        assert generator.get_mtp_stats()["errors"] == 1
+        original_step.assert_not_called()
+
+    @pytest.mark.parametrize("mode", ["native", "stateless_external"])
+    def test_mtp_verify_failure_aborts_every_mode(self, monkeypatch, mode):
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        request = SimpleNamespace(
+            uid=7,
+            request_id="verify-failure",
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            mllm_draft=True,
+        )
+        generator = SimpleNamespace(
+            model=object(),
+            active_batch=SimpleNamespace(uids=[7], requests=[request]),
+            _step=MagicMock(side_effect=AssertionError("must not fall through")),
+            _next=MagicMock(return_value=[]),
+            sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+        )
+
+        class TrackingCache:
+            position = 0
+
+        cache = [TrackingCache()]
+
+        class FailingVerifyTarget:
+            def mtp_forward(self, hidden_states, next_token_ids, mtp_cache=None):
+                del hidden_states, next_token_ids, mtp_cache
+                logits = mx.full((1, 1, 8), -1000.0)
+                logits[:, :, 5] = 0.0
+                return logits
+
+            def __call__(self, input_tokens, cache=None, return_hidden=False):
+                cache[0].position += input_tokens.shape[1]
+                if input_tokens.shape[1] == 2:
+                    raise ValueError("verify failed")
+                logits = mx.full((1, 1, 8), -1000.0)
+                logits[:, :, 4] = 0.0
+                return logits, mx.zeros((1, 1, 4))
+
+        target = FailingVerifyTarget()
+        draft_model = None
+        if mode == "stateless_external":
+            _patch_external_mtp_metadata(monkeypatch)
+            monkeypatch.setattr(
+                "vllm_mlx.mllm_batch_generator._draft_external_mtp_active_batch",
+                lambda *args, **kwargs: mx.array([5], dtype=mx.uint32),
+            )
+            draft_model = SimpleNamespace(
+                requires_verified_token_reconciliation=False,
+                reset=MagicMock(),
+                set_shared_kv=MagicMock(),
+                accept_lens=[],
+                draft_lens=[],
+            )
+        install_mtp_mllm(generator, target, draft_model=draft_model)
+
+        with pytest.raises(RuntimeError, match="target cache may have advanced"):
+            generator._step(mx.array([[1]], dtype=mx.uint32), cache, None, None, None)
+
+        assert cache[0].position == 3
+        assert generator.get_mtp_stats()["errors"] == 1
 
     def test_external_mtp_requires_every_active_request_to_opt_in(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1932,7 +1932,6 @@ class TestMLLMBatchGeneratorMTPGuards:
             logits_processors=None,
             output_tokens=None,
             samplers=[lambda logprobs: mx.argmax(logprobs, axis=-1)],
-            rope_deltas=rope_deltas,
         )
 
         assert model.mtp_calls == 1

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -269,6 +269,7 @@ class MLLMBatch:
     requests: List[MLLMBatchRequest]  # Full request data
     logits_processors: Optional[List[Optional[List[Callable]]]] = None
     samplers: Optional[List[Optional[Callable]]] = None
+    _row_filter_hook: Optional[Callable[[List[int], List[int]], None]] = None
 
     def __len__(self) -> int:
         return len(self.uids)
@@ -280,6 +281,7 @@ class MLLMBatch:
         Args:
             keep_idx: Indices of requests to keep
         """
+        previous_uids = list(self.uids)
         self.uids = [self.uids[k] for k in keep_idx]
         self.request_ids = [self.request_ids[k] for k in keep_idx]
         self.logprobs = [self.logprobs[k] for k in keep_idx]
@@ -298,6 +300,14 @@ class MLLMBatch:
         for c in self.cache:
             if hasattr(c, "filter"):
                 c.filter(keep_idx_array)
+
+        if self._row_filter_hook is not None:
+            self._row_filter_hook(previous_uids, list(self.uids))
+
+    def notify_all_rows_removed(self) -> None:
+        """Notify an attached lifecycle owner before this batch is discarded."""
+        if self._row_filter_hook is not None and self.uids:
+            self._row_filter_hook(list(self.uids), [])
 
     def extend(self, other: "MLLMBatch") -> None:
         """
@@ -852,6 +862,7 @@ class MLLMBatchGenerator:
             if keep_idx:
                 self.active_batch.filter(keep_idx)
             else:
+                self.active_batch.notify_all_rows_removed()
                 self.active_batch = None
 
         # Remove from unprocessed
@@ -2084,6 +2095,7 @@ class MLLMBatchGenerator:
             if keep_idx:
                 batch.filter(keep_idx)
             else:
+                batch.notify_all_rows_removed()
                 self.active_batch = None
 
         self._stats.generation_tokens += len(responses)
@@ -2245,9 +2257,31 @@ def install_mtp_mllm(
     _orig_step = batch_gen._step
     _draft_sampler = make_sampler(temp=0.0)
     external_drafter = draft_model is not None
+    reconciliation_marker = (
+        getattr(draft_model, "requires_verified_token_reconciliation", None)
+        if external_drafter
+        else False
+    )
+    if external_drafter and type(reconciliation_marker) is not bool:
+        raise TypeError(
+            "Assistant drafter must declare "
+            "requires_verified_token_reconciliation as a literal boolean"
+        )
+    stateful_external_drafter = reconciliation_marker is True
     if external_drafter:
         batch_gen._require_uniform_mllm_draft = True
         batch_gen._allow_mid_batch_extend = False
+        if stateful_external_drafter:
+            missing_hooks = [
+                name
+                for name in ("accept_verified_tokens_batch", "filter_batch")
+                if not callable(getattr(draft_model, name, None))
+            ]
+            if missing_hooks:
+                raise TypeError(
+                    "Stateful assistant drafter is missing required continuous-"
+                    f"batching lifecycle hook(s): {', '.join(missing_hooks)}"
+                )
         draft_model.reset(batch_gen.model)
 
     def _model_parts(output: Any) -> Tuple[mx.array, Optional[mx.array]]:
@@ -2277,6 +2311,139 @@ def install_mtp_mllm(
     # Deferred drafts keyed by UID
     _deferred_drafts: Dict[int, dict] = {}
     _attempted_drafts_by_uid: Dict[int, int] = {}
+    _pending_external_sync: Optional[Dict[str, Any]] = None
+    _external_batch_active = False
+    _external_drafter_initialized = False
+
+    def _reset_external_drafter() -> None:
+        nonlocal _pending_external_sync, _external_batch_active
+        nonlocal _external_drafter_initialized
+        _pending_external_sync = None
+        _external_batch_active = False
+        _external_drafter_initialized = False
+        if external_drafter:
+            draft_model.reset(batch_gen.model)
+
+    def _reconcile_external_drafter(
+        verify_hidden: mx.array,
+        draft_tokens: mx.array,
+        accepted: List[int],
+        new_tokens: List[List[int]],
+        token_dtype: mx.Dtype,
+    ) -> None:
+        if not stateful_external_drafter:
+            return
+        draft_model.accept_verified_tokens_batch(
+            verify_hidden,
+            draft_tokens,
+            accepted,
+            new_tokens,
+            _draft_sampler,
+            token_dtype,
+            True,
+        )
+
+    def _sync_external_drafter_before_draft(
+        current_uids: List[int],
+        primary_tokens: mx.array,
+        hidden_states: mx.array,
+    ) -> None:
+        nonlocal _pending_external_sync, _external_drafter_initialized
+        pending = _pending_external_sync
+        if not stateful_external_drafter:
+            return
+        primary = [int(token) for token in primary_tokens.tolist()]
+        if pending is None:
+            if not _external_drafter_initialized:
+                # The serving loop does not retain full-prompt hidden states.
+                # Cold-start the owned drafter cache from the first decoded
+                # target hidden/token pair instead of drafting from an empty,
+                # prompt-independent state.
+                empty_drafts = mx.zeros(
+                    (len(current_uids), 0), dtype=primary_tokens.dtype
+                )
+                _reconcile_external_drafter(
+                    hidden_states,
+                    empty_drafts,
+                    [0] * len(current_uids),
+                    [[token] for token in primary],
+                    primary_tokens.dtype,
+                )
+                _external_drafter_initialized = True
+            return
+        if pending["uids"] != current_uids:
+            raise RuntimeError(
+                "Assistant drafter rows changed before verified state was filtered"
+            )
+
+        if pending["kind"] == "verified_round":
+            new_tokens = [
+                list(committed) + [token]
+                for committed, token in zip(pending["committed"], primary)
+            ]
+            _reconcile_external_drafter(
+                pending["verify_hidden"],
+                pending["draft_tokens"],
+                pending["accepted"],
+                new_tokens,
+                primary_tokens.dtype,
+            )
+        elif pending["kind"] == "advance_after_residual":
+            empty_drafts = mx.zeros((len(current_uids), 0), dtype=primary_tokens.dtype)
+            _reconcile_external_drafter(
+                hidden_states,
+                empty_drafts,
+                [0] * len(current_uids),
+                [[token] for token in primary],
+                primary_tokens.dtype,
+            )
+        else:
+            raise RuntimeError(
+                f"Unknown assistant drafter sync kind: {pending['kind']!r}"
+            )
+        _pending_external_sync = None
+        _external_drafter_initialized = True
+
+    def _filter_external_drafter_rows(
+        previous_uids: List[int], keep_uids: List[int]
+    ) -> None:
+        if not stateful_external_drafter or previous_uids == keep_uids:
+            return
+        removed_uids = set(previous_uids) - set(keep_uids)
+        for uid in removed_uids:
+            _skip_state_by_uid.pop(uid, None)
+            _deferred_drafts.pop(uid, None)
+            _attempted_drafts_by_uid.pop(uid, None)
+        if not keep_uids:
+            _reset_external_drafter()
+            return
+
+        index_by_uid = {uid: idx for idx, uid in enumerate(previous_uids)}
+        try:
+            keep = [index_by_uid[uid] for uid in keep_uids]
+        except KeyError as exc:
+            raise RuntimeError(
+                "Target batch introduced an unknown row while filtering the drafter"
+            ) from exc
+        keep_array = mx.array(keep, dtype=mx.int32)
+        try:
+            draft_model.filter_batch(keep_array)
+
+            pending = _pending_external_sync
+            if pending is None:
+                return
+            if pending["uids"] != previous_uids:
+                raise RuntimeError(
+                    "Pending assistant drafter state does not match target batch rows"
+                )
+            pending["uids"] = list(keep_uids)
+            pending["verify_hidden"] = pending["verify_hidden"][keep_array]
+            pending["draft_tokens"] = pending["draft_tokens"][keep_array]
+            pending["accepted"] = [pending["accepted"][idx] for idx in keep]
+            pending["committed"] = [pending["committed"][idx] for idx in keep]
+        except Exception:
+            _reset_external_drafter()
+            raise
 
     # MTP stats. These are intentionally exposed through get_mtp_stats() so
     # /v1/status can distinguish "weights injected" from useful draft work.
@@ -2326,12 +2493,15 @@ def install_mtp_mllm(
         samplers: Optional[List[Optional[Callable]]] = None,
     ) -> Tuple[mx.array, List[mx.array]]:
         """Extended _step with MTP always-advance strategy."""
+        nonlocal _pending_external_sync, _external_batch_active
         batch_size = input_tokens.shape[0]
         active_requests = (
             list(batch_gen.active_batch.requests)
             if batch_gen.active_batch is not None
             else []
         )
+        if stateful_external_drafter and batch_gen.active_batch is not None:
+            batch_gen.active_batch._row_filter_hook = _filter_external_drafter_rows
         # Prefill and request-local logits processors remain non-speculative.
         # Sampling and concurrent batches are supported below with per-request
         # distributions and UID-keyed verified state.
@@ -2366,6 +2536,8 @@ def install_mtp_mllm(
                 if assistant_not_requested_bypass:
                     _bypass_counts["assistant_not_requested"] += 1
             _skip_state_by_uid.clear()
+            if stateful_external_drafter and _pending_external_sync is not None:
+                _reset_external_drafter()
             return _orig_step(
                 input_tokens, cache, logits_processors, output_tokens, samplers
             )
@@ -2426,15 +2598,10 @@ def install_mtp_mllm(
             primary_tokens = batch_gen.sampler(logprobs)
 
         # MTP draft + always-advance verify
+        target_verify_started = False
         try:
-            with _mtp_stats_lock:
-                _mtp_stats["attempted"] += 1
-            sampled_rows = [
-                _request_uses_stochastic_sampling(request)
-                for request in active_requests
-            ]
-            uses_stochastic_sampling = any(sampled_rows)
             if external_drafter:
+                _external_batch_active = True
                 from mlx_vlm.speculative.common import _batch_cache_left_padding
                 from mlx_vlm.speculative.mtp import _mtp_draft_position
 
@@ -2451,6 +2618,17 @@ def install_mtp_mllm(
                     kv_valid_len=mx.array(positions),
                     left_padding=_batch_cache_left_padding(cache),
                 )
+            _sync_external_drafter_before_draft(
+                current_uids, primary_tokens, hidden_states
+            )
+            with _mtp_stats_lock:
+                _mtp_stats["attempted"] += 1
+            sampled_rows = [
+                _request_uses_stochastic_sampling(request)
+                for request in active_requests
+            ]
+            uses_stochastic_sampling = any(sampled_rows)
+            if external_drafter:
                 # Sample-and-compare preserves the target distribution here only
                 # because the external draft is a point mass. Changing greedy=True
                 # requires a rejection-sampling verifier that accounts for q(x).
@@ -2507,6 +2685,7 @@ def install_mtp_mllm(
             verify_input = mx.concatenate(
                 [primary_tokens[:, None], draft_tokens[:, None]], axis=1
             )
+            target_verify_started = True
             verify_output = language_model(
                 verify_input, cache=cache, return_hidden=True
             )
@@ -2595,6 +2774,15 @@ def install_mtp_mllm(
                 if external_drafter:
                     draft_model.accept_lens.append(1)
                     draft_model.draft_lens.append(1)
+                if stateful_external_drafter:
+                    _pending_external_sync = {
+                        "kind": "verified_round",
+                        "uids": list(current_uids),
+                        "verify_hidden": verify_hidden,
+                        "draft_tokens": draft_tokens[:, None],
+                        "accepted": [1] * batch_size,
+                        "committed": [[int(token)] for token in draft_list],
+                    }
 
             else:
                 # A batch cache cannot roll back an individual row. On a mixed
@@ -2605,6 +2793,35 @@ def install_mtp_mllm(
                 sampled_reject = uses_stochastic_sampling and bool(
                     residual_tokens_by_uid
                 )
+                if stateful_external_drafter:
+                    if sampled_reject:
+                        residual_rows = [
+                            [int(residual_tokens_by_uid[uid])] for uid in current_uids
+                        ]
+                        _reconcile_external_drafter(
+                            verify_hidden,
+                            draft_tokens[:, None],
+                            [0] * batch_size,
+                            residual_rows,
+                            primary_tokens.dtype,
+                        )
+                        _pending_external_sync = {
+                            "kind": "advance_after_residual",
+                            "uids": list(current_uids),
+                            "verify_hidden": verify_hidden,
+                            "draft_tokens": draft_tokens[:, None],
+                            "accepted": [0] * batch_size,
+                            "committed": residual_rows,
+                        }
+                    else:
+                        _pending_external_sync = {
+                            "kind": "verified_round",
+                            "uids": list(current_uids),
+                            "verify_hidden": verify_hidden,
+                            "draft_tokens": draft_tokens[:, None],
+                            "accepted": [0] * batch_size,
+                            "committed": [[] for _ in current_uids],
+                        }
                 replay_tokens = primary_tokens
                 if sampled_reject:
                     residual_tokens = mx.array(
@@ -2709,8 +2926,16 @@ def install_mtp_mllm(
         except Exception as e:
             logger.warning(f"[MTP-MLLM] draft/verify failed: {e}")
             _skip_state_by_uid.clear()
+            if stateful_external_drafter:
+                _reset_external_drafter()
             with _mtp_stats_lock:
                 _mtp_stats["errors"] += 1
+            if stateful_external_drafter and target_verify_started:
+                raise RuntimeError(
+                    "Stateful assistant verification failed after the target cache "
+                    "may have advanced; aborting the batch instead of continuing "
+                    "with unverified cache state"
+                ) from e
 
         # Log MTP stats every 50 steps
         with _mtp_stats_lock:
@@ -2732,10 +2957,13 @@ def install_mtp_mllm(
 
     def _mtp_next() -> List[MLLMBatchResponse]:
         """Wrapper around _next that emits deferred MTP draft tokens."""
+        nonlocal _pending_external_sync
         if batch_gen.active_batch is None:
             _skip_state_by_uid.clear()
             _deferred_drafts.clear()
             _attempted_drafts_by_uid.clear()
+            if _external_batch_active:
+                _reset_external_drafter()
 
         # `_inner_next` may extend a text-only request into an active batch
         # before the next `_mtp_step` call. That's fine: `_mtp_step` itself
@@ -2836,7 +3064,9 @@ def install_mtp_mllm(
                 if keep:
                     batch_gen.active_batch.filter(keep)
                 else:
+                    batch_gen.active_batch.notify_all_rows_removed()
                     batch_gen.active_batch = None
+                    _pending_external_sync = None
 
         active_uids = (
             set(batch_gen.active_batch.uids)
@@ -2981,6 +3211,7 @@ def install_chunked_prefill_mllm(
             if keep_idx:
                 batch.filter(keep_idx)
             else:
+                batch.notify_all_rows_removed()
                 batch_gen.active_batch = None
 
         batch_gen._stats.generation_tokens += len(responses)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2445,6 +2445,14 @@ def install_mtp_mllm(
             _reset_external_drafter()
             raise
 
+    def _attach_external_lifecycle_hook() -> None:
+        if stateful_external_drafter and batch_gen.active_batch is not None:
+            batch_gen.active_batch._row_filter_hook = _filter_external_drafter_rows
+
+    # Installation can occur with a pre-existing batch in tests or embedded
+    # callers. Bind lifecycle ownership before any public removal can mutate it.
+    _attach_external_lifecycle_hook()
+
     # MTP stats. These are intentionally exposed through get_mtp_stats() so
     # /v1/status can distinguish "weights injected" from useful draft work.
     _mtp_stats_lock = threading.Lock()
@@ -2531,8 +2539,7 @@ def install_mtp_mllm(
             if batch_gen.active_batch is not None
             else []
         )
-        if stateful_external_drafter and batch_gen.active_batch is not None:
-            batch_gen.active_batch._row_filter_hook = _filter_external_drafter_rows
+        _attach_external_lifecycle_hook()
         # Prefill and request-local logits processors remain non-speculative.
         # Sampling and concurrent batches are supported below with per-request
         # distributions and UID-keyed verified state.
@@ -2981,6 +2988,7 @@ def install_mtp_mllm(
     def _mtp_next() -> List[MLLMBatchResponse]:
         """Wrapper around _next that emits deferred MTP draft tokens."""
         nonlocal _pending_external_sync
+        _attach_external_lifecycle_hook()
         if batch_gen.active_batch is None:
             _skip_state_by_uid.clear()
             _deferred_drafts.clear()
@@ -3004,6 +3012,9 @@ def install_mtp_mllm(
                     prev_deferred[uid] = _deferred_drafts.pop(uid)
 
         responses = batch_gen._inner_next()
+        # Prompt or chunked-prefill work may have created a new active batch.
+        # Bind its lifecycle before control returns to public remove/abort paths.
+        _attach_external_lifecycle_hook()
 
         if responses:
             _mark_mtp_attempts_on_primary_responses(responses, _attempted_drafts_by_uid)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -269,7 +269,9 @@ class MLLMBatch:
     requests: List[MLLMBatchRequest]  # Full request data
     logits_processors: Optional[List[Optional[List[Callable]]]] = None
     samplers: Optional[List[Optional[Callable]]] = None
-    _row_filter_hook: Optional[Callable[[List[int], List[int]], None]] = None
+    _row_filter_hook: Optional[Callable[[List[int], List[int]], None]] = field(
+        default=None, repr=False
+    )
 
     def __len__(self) -> int:
         return len(self.uids)
@@ -2262,13 +2264,28 @@ def install_mtp_mllm(
         if external_drafter
         else False
     )
-    if external_drafter and type(reconciliation_marker) is not bool:
+    if reconciliation_marker is not None and type(reconciliation_marker) is not bool:
         raise TypeError(
             "Assistant drafter must declare "
             "requires_verified_token_reconciliation as a literal boolean"
         )
     stateful_external_drafter = reconciliation_marker is True
     if external_drafter:
+        if reconciliation_marker is None:
+            # Released drafters predate the declaration. These hooks identify
+            # state reconciliation, not numerical continuous-batching support.
+            absent = object()
+            hooks = [
+                getattr(draft_model, name, absent)
+                for name in ("accept_verified_tokens_batch", "filter_batch")
+            ]
+            if all(callable(hook) for hook in hooks):
+                stateful_external_drafter = True
+            elif not all(hook is absent for hook in hooks):
+                raise TypeError(
+                    "Assistant drafter must provide both callable lifecycle hooks "
+                    "accept_verified_tokens_batch and filter_batch, or neither"
+                )
         batch_gen._require_uniform_mllm_draft = True
         batch_gen._allow_mid_batch_extend = False
         if stateful_external_drafter:

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -3123,7 +3123,9 @@ def install_mtp_mllm(
             ]
             if len(keep) != len(prior_active_uids):
                 if keep:
-                    draft_model.filter_batch(keep)
+                    filter_batch = getattr(draft_model, "filter_batch", None)
+                    if callable(filter_batch):
+                        filter_batch(keep)
                 else:
                     draft_model.reset(batch_gen.model)
         for uid in list(_skip_state_by_uid):

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2455,7 +2455,38 @@ def install_mtp_mllm(
         "concurrent_batch": 0,
         "logits_processors": 0,
         "assistant_not_requested": 0,
+        "hidden_state_unavailable": 0,
     }
+
+    def _sample_primary_logits(
+        logits: mx.array,
+        logits_processors: Optional[List[Optional[List[Callable]]]],
+        output_tokens: Optional[List[List[int]]],
+        samplers: Optional[List[Optional[Callable]]],
+    ) -> Tuple[mx.array, List[mx.array]]:
+        """Sample one target token from logits already backed by the live cache."""
+        if logits_processors and output_tokens and any(logits_processors):
+            processed_logits = []
+            for row in range(logits.shape[0]):
+                sample_logits = logits[row : row + 1]
+                if logits_processors[row]:
+                    for processor in logits_processors[row]:
+                        sample_logits = processor(
+                            mx.array(output_tokens[row]), sample_logits
+                        )
+                processed_logits.append(sample_logits)
+            logits = mx.concatenate(processed_logits, axis=0)
+
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        if samplers and any(samplers):
+            sampled = []
+            for row in range(logprobs.shape[0]):
+                sampler = samplers[row] if samplers[row] else batch_gen.sampler
+                sampled.append(sampler(logprobs[row : row + 1]))
+            primary_tokens = mx.concatenate(sampled, axis=0)
+        else:
+            primary_tokens = batch_gen.sampler(logprobs)
+        return primary_tokens, list(logprobs)
 
     def _get_mtp_stats() -> Dict[str, Any]:
         with _mtp_stats_lock:
@@ -2567,35 +2598,27 @@ def install_mtp_mllm(
             # Normal forward with return_hidden
             model_output = language_model(input_tokens, cache=cache, return_hidden=True)
             logits, hidden_states = _model_parts(model_output)
-            if hidden_states is None:
-                return _orig_step(
-                    input_tokens, cache, logits_processors, output_tokens, samplers
-                )
             logits = logits[:, -1, :]
+            if hidden_states is None:
+                _skip_state_by_uid.clear()
+                if stateful_external_drafter:
+                    _reset_external_drafter()
+                    with _mtp_stats_lock:
+                        _mtp_stats["errors"] += 1
+                    raise RuntimeError(
+                        "Stateful assistant MTP requires target hidden states; "
+                        "aborting after the single target forward instead of "
+                        "replaying against an advanced cache"
+                    )
+                with _mtp_stats_lock:
+                    _bypass_counts["hidden_state_unavailable"] += 1
+                return _sample_primary_logits(
+                    logits, logits_processors, output_tokens, samplers
+                )
 
-        # Apply logits processors before sampling
-        if logits_processors and output_tokens and any(logits_processors):
-            processed_logits = []
-            for e in range(batch_size):
-                sample_logits = logits[e : e + 1]
-                if logits_processors[e]:
-                    for processor in logits_processors[e]:
-                        sample_logits = processor(
-                            mx.array(output_tokens[e]), sample_logits
-                        )
-                processed_logits.append(sample_logits)
-            logits = mx.concatenate(processed_logits, axis=0)
-
-        # Sample primary (use per-request sampler if available)
-        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
-        if samplers and any(samplers):
-            sampled_list = []
-            for e in range(logprobs.shape[0]):
-                s = samplers[e] if samplers[e] else batch_gen.sampler
-                sampled_list.append(s(logprobs[e : e + 1]))
-            primary_tokens = mx.concatenate(sampled_list, axis=0)
-        else:
-            primary_tokens = batch_gen.sampler(logprobs)
+        primary_tokens, logprobs = _sample_primary_logits(
+            logits, logits_processors, output_tokens, samplers
+        )
 
         # MTP draft + always-advance verify
         target_verify_started = False
@@ -2930,11 +2953,11 @@ def install_mtp_mllm(
                 _reset_external_drafter()
             with _mtp_stats_lock:
                 _mtp_stats["errors"] += 1
-            if stateful_external_drafter and target_verify_started:
+            if target_verify_started:
                 raise RuntimeError(
-                    "Stateful assistant verification failed after the target cache "
-                    "may have advanced; aborting the batch instead of continuing "
-                    "with unverified cache state"
+                    "MTP verification failed after the target cache may have "
+                    "advanced; aborting the batch instead of continuing with "
+                    "unverified cache state"
                 ) from e
 
         # Log MTP stats every 50 steps

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -3127,7 +3127,7 @@ def install_mtp_mllm(
                     if callable(filter_batch):
                         filter_batch(keep)
                 else:
-                    draft_model.reset(batch_gen.model)
+                    _reset_external_drafter()
         for uid in list(_skip_state_by_uid):
             if uid not in active_uids:
                 _skip_state_by_uid.pop(uid, None)

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2989,6 +2989,11 @@ def install_mtp_mllm(
         """Wrapper around _next that emits deferred MTP draft tokens."""
         nonlocal _pending_external_sync
         _attach_external_lifecycle_hook()
+        prior_active_uids = (
+            list(batch_gen.active_batch.uids)
+            if batch_gen.active_batch is not None
+            else []
+        )
         if batch_gen.active_batch is None:
             _skip_state_by_uid.clear()
             _deferred_drafts.clear()
@@ -3107,6 +3112,20 @@ def install_mtp_mllm(
             if batch_gen.active_batch is not None
             else set()
         )
+        # Stateful drafters are synchronized by MLLMBatch._row_filter_hook.
+        # Preserve the legacy positional lifecycle only for stateless external
+        # drafters, which intentionally do not install that hook.
+        if external_drafter and not stateful_external_drafter and prior_active_uids:
+            keep = [
+                index
+                for index, uid in enumerate(prior_active_uids)
+                if uid in active_uids
+            ]
+            if len(keep) != len(prior_active_uids):
+                if keep:
+                    draft_model.filter_batch(keep)
+                else:
+                    draft_model.reset(batch_gen.model)
         for uid in list(_skip_state_by_uid):
             if uid not in active_uids:
                 _skip_state_by_uid.pop(uid, None)


### PR DESCRIPTION
## Summary
- Reconcile stateful external drafters after verified tokens and keep row ownership aligned through lifecycle callbacks.
- Honor explicit lifecycle declarations; use the released callable hook pair when the declaration is absent or `None`. This selects reconciliation behavior, not numerical batching support.
- Avoid a second target forward when hidden states are unavailable: stateless fallback samples the existing logits; stateful drafting fails instead of replaying an advanced cache.

## Failure boundary
The MLLM scheduler catches verification errors and attempts to fail every tracked request, including waiting requests. Cleanup can itself raise and end that processing task. This PR does not guarantee general failure atomicity or recovery; a process restart or model reload is not established by these tests.

## Verification
- Local affected suite: 93 passed; four existing model-required tests excluded by the repository defaults. Python 3.12, mlx-vlm 0.7.0rc0; source-bound execution with no weights loaded.
- Tests cover lifecycle selection using released drafter attribute shapes, reconciliation/row filtering, single-forward fallback, and the actual async loop with normal and failing cleanup.
- All 10 GitHub checks pass on `fcd730e`, including both Apple Silicon jobs. No new hardware qualification claimed.
