### PR TITLE
Report declared drafter batch capability without changing startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             tests/test_platform.py \
             tests/test_llm.py \
             tests/test_mllm.py \
+            tests/test_mllm_assistant_drafter.py \
             tests/test_server.py \
             tests/test_paged_cache.py \
             tests/test_prefix_cache_untrimmable.py \

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -543,6 +543,7 @@ Response fields:
 | `metal.peak_memory_gb` | Peak Metal GPU memory usage (GB) |
 | `metal.cache_memory_gb` | Metal cache memory usage (GB) |
 | `cache` | Cache statistics (type, entries, hit rate, memory usage) |
+| `mtp.continuous_batching_supported` | Drafter-declared batching capability: `true` (supported), `false` (unsupported), or `null` (undeclared or invalid/unknown). This reporting field does not block startup. |
 | `requests` | List of active requests with per-request details |
 
 Per-request fields in `requests`:

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -1,6 +1,7 @@
 """BatchedEngine MLLM scheduler configuration wiring tests.
 
-These tests avoid model loading and MLX imports. They validate that CLI-level
+These tests avoid model loading; importing the real loader may import MLX.
+They validate that CLI-level
 SchedulerConfig fields survive the BatchedEngine -> MLLMSchedulerConfig bridge.
 """
 
@@ -87,18 +88,30 @@ def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch)
 
 def _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter):
     from vllm_mlx.engine.batched import BatchedEngine
+    import vllm_mlx.models.mllm as mllm_mod
 
     captured = {}
 
+    def load_released_gemma_fixture(model_path):
+        captured["loader_path"] = model_path
+        return loaded_drafter
+
+    monkeypatch.setattr(
+        mllm_mod, "load_gemma4_assistant_drafter", load_released_gemma_fixture
+    )
+
     class FakeMLXMultimodalLM:
+        _load_draft_model = mllm_mod.MLXMultimodalLM._load_draft_model
+
         def __init__(self, model_name, trust_remote_code=True, **kwargs):
             captured["model_kwargs"] = kwargs
             self.model = object()
             self.processor = object()
-            self._draft_model = loaded_drafter
+            self.draft_kind = kwargs["draft_kind"]
+            self.draft_model_path = kwargs["draft_model"]
 
         def load(self):
-            return None
+            self._draft_model = self._load_draft_model()
 
     class FakeMLLMSchedulerConfig:
         def __init__(self, **kwargs):
@@ -110,6 +123,9 @@ def _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter):
 
         async def start(self):
             return None
+
+        def get_stats(self):
+            return {}
 
     import vllm_mlx.engine.batched as batched_mod
 
@@ -133,13 +149,22 @@ def _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter):
         mllm_draft_block_size=6,
     )
     asyncio.run(engine._start_mllm())
+    captured["stats"] = engine.get_stats()
     return captured
 
 
 def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
-    loaded_drafter = SimpleNamespace(supports_continuous_batching=True)
+    # Released mlx-vlm v0.6.5 (84f43753) and v0.6.6 (c9e27b08):
+    # gemma4_assistant.Gemma4AssistantDraftModel has no capability marker.
+    # This models that attribute contract only; no weights are loaded and no
+    # numerical Gemma support is certified by this fixture.
+    class ReleasedGemmaDrafter:
+        pass
+
+    loaded_drafter = ReleasedGemmaDrafter()
     captured = _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter)
 
+    assert captured["loader_path"] == "assistant"
     assert captured["model_kwargs"]["draft_model"] == "assistant"
     assert captured["model_kwargs"]["draft_kind"] == "mtp"
     assert captured["model_kwargs"]["draft_block_size"] == 6
@@ -148,6 +173,8 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
         "draft_kind": "mtp",
         "draft_block_size": 6,
     }
+    assert captured["stats"]["mtp"]["continuous_batching_supported"] is None
+    assert not hasattr(loaded_drafter, "supports_continuous_batching")
 
 
 @pytest.mark.parametrize(
@@ -160,9 +187,11 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
         SimpleNamespace(supports_continuous_batching=False),
     ],
 )
-def test_start_mllm_rejects_unqualified_external_drafter(monkeypatch, loaded_drafter):
-    with pytest.raises(ValueError, match="explicitly declares"):
-        _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter)
+def test_capability_reporting_does_not_change_startup_admission(
+    monkeypatch, loaded_drafter
+):
+    captured = _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter)
+    assert captured["scheduler_kwargs"]["draft_model"] is loaded_drafter
 
 
 def _generation_output():

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -10,6 +10,8 @@ import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 
 def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch):
     from vllm_mlx.engine.batched import BatchedEngine
@@ -83,11 +85,10 @@ def test_start_mllm_forwards_prefix_cache_disable_to_mllm_scheduler(monkeypatch)
     assert captured["config_kwargs"]["ssd_cache_max_gb"] == 10.0
 
 
-def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
+def _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter):
     from vllm_mlx.engine.batched import BatchedEngine
 
     captured = {}
-    loaded_drafter = object()
 
     class FakeMLXMultimodalLM:
         def __init__(self, model_name, trust_remote_code=True, **kwargs):
@@ -132,6 +133,12 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
         mllm_draft_block_size=6,
     )
     asyncio.run(engine._start_mllm())
+    return captured
+
+
+def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
+    loaded_drafter = SimpleNamespace(supports_continuous_batching=True)
+    captured = _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter)
 
     assert captured["model_kwargs"]["draft_model"] == "assistant"
     assert captured["model_kwargs"]["draft_kind"] == "mtp"
@@ -141,6 +148,21 @@ def test_start_mllm_forwards_external_assistant_drafter(monkeypatch):
         "draft_kind": "mtp",
         "draft_block_size": 6,
     }
+
+
+@pytest.mark.parametrize(
+    "loaded_drafter",
+    [
+        None,
+        object(),
+        SimpleNamespace(supports_continuous_batching=None),
+        SimpleNamespace(supports_continuous_batching="false"),
+        SimpleNamespace(supports_continuous_batching=False),
+    ],
+)
+def test_start_mllm_rejects_unqualified_external_drafter(monkeypatch, loaded_drafter):
+    with pytest.raises(ValueError, match="explicitly declares"):
+        _run_start_mllm_with_external_drafter(monkeypatch, loaded_drafter)
 
 
 def _generation_output():
@@ -168,6 +190,9 @@ def _batched_mllm_engine(scheduler, *, default_mllm_draft=False):
     )
     engine._loaded = True
     engine._mllm_scheduler = scheduler
+    engine._mllm_instance = SimpleNamespace(
+        _draft_model=SimpleNamespace(supports_continuous_batching=True)
+    )
     return engine
 
 
@@ -252,6 +277,19 @@ def test_idle_stats_report_configured_mllm_draft_default():
         "default_enabled": True,
         "continuous_batching_supported": True,
     }
+
+
+@pytest.mark.parametrize("reported", [False, None, "false"])
+def test_batched_stats_preserve_scheduler_batch_capability(reported):
+    engine = _batched_mllm_engine(
+        SimpleNamespace(
+            get_stats=lambda: {"mtp": {"continuous_batching_supported": reported}}
+        )
+    )
+
+    assert engine.get_stats()["mtp"]["continuous_batching_supported"] is (
+        reported if type(reported) is bool else None
+    )
 
 
 def _run_start_mllm(monkeypatch, scheduler_config):

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -7,6 +7,31 @@ from types import SimpleNamespace
 import pytest
 
 
+@pytest.mark.parametrize(
+    ("drafter", "expected"),
+    [
+        (SimpleNamespace(supports_continuous_batching=True), True),
+        (SimpleNamespace(supports_continuous_batching=False), False),
+        (SimpleNamespace(supports_continuous_batching=None), None),
+        (SimpleNamespace(supports_continuous_batching="false"), None),
+        (SimpleNamespace(), None),
+    ],
+)
+def test_simple_engine_reports_explicit_drafter_batch_capability(drafter, expected):
+    from vllm_mlx.engine.simple import SimpleEngine
+
+    engine = SimpleEngine(
+        "qwen4-exp",
+        force_mllm=True,
+        mllm_draft_model="assistant",
+        mllm_draft_kind="mtp",
+    )
+    engine._loaded = True
+    engine._model = SimpleNamespace(_draft_model=drafter)
+
+    assert engine.get_stats()["mtp"]["continuous_batching_supported"] is expected
+
+
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):
     from vllm_mlx.models.mllm import MLXMultimodalLM
 
@@ -281,7 +306,7 @@ def test_simple_engine_reports_configured_mllm_drafter_status():
         "draft_kind": "mtp",
         "draft_block_size": 4,
         "default_enabled": True,
-        "continuous_batching_supported": True,
+        "continuous_batching_supported": None,
     }
 
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -487,14 +487,8 @@ class BatchedEngine(BaseEngine):
         # Create and start MLLM scheduler
         scheduler_kwargs = {}
         if self._mllm_draft_model is not None:
-            loaded_drafter = getattr(self._mllm_instance, "_draft_model", None)
-            if continuous_batching_capability(loaded_drafter) is not True:
-                raise ValueError(
-                    "Continuous batching requires an MLLM MTP drafter that "
-                    "explicitly declares supports_continuous_batching=True"
-                )
             scheduler_kwargs = {
-                "draft_model": loaded_drafter,
+                "draft_model": getattr(self._mllm_instance, "_draft_model", None),
                 "draft_kind": self._mllm_draft_kind,
                 "draft_block_size": self._mllm_draft_block_size,
             }

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -31,6 +31,10 @@ from .base import (
     run_blocking_startup_work,
 )
 from .chat_template_safety import normalize_messages_for_chat_template
+from .drafter_capabilities import (
+    continuous_batching_capability,
+    explicit_bool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -483,8 +487,14 @@ class BatchedEngine(BaseEngine):
         # Create and start MLLM scheduler
         scheduler_kwargs = {}
         if self._mllm_draft_model is not None:
+            loaded_drafter = getattr(self._mllm_instance, "_draft_model", None)
+            if continuous_batching_capability(loaded_drafter) is not True:
+                raise ValueError(
+                    "Continuous batching requires an MLLM MTP drafter that "
+                    "explicitly declares supports_continuous_batching=True"
+                )
             scheduler_kwargs = {
-                "draft_model": getattr(self._mllm_instance, "_draft_model", None),
+                "draft_model": loaded_drafter,
                 "draft_kind": self._mllm_draft_kind,
                 "draft_block_size": self._mllm_draft_block_size,
             }
@@ -1247,13 +1257,20 @@ class BatchedEngine(BaseEngine):
                 mtp_stats = stats.setdefault("mtp", {})
                 mtp_stats.setdefault("enabled", True)
                 mtp_stats.setdefault("implementation", "external_assistant")
+                if "continuous_batching_supported" in mtp_stats:
+                    batch_capability = explicit_bool(
+                        mtp_stats["continuous_batching_supported"]
+                    )
+                else:
+                    loaded_drafter = getattr(self._mllm_instance, "_draft_model", None)
+                    batch_capability = continuous_batching_capability(loaded_drafter)
                 mtp_stats.update(
                     {
                         "draft_model": self._mllm_draft_model,
                         "draft_kind": self._mllm_draft_kind,
                         "draft_block_size": self._mllm_draft_block_size,
                         "default_enabled": self._default_mllm_draft,
-                        "continuous_batching_supported": True,
+                        "continuous_batching_supported": batch_capability,
                     }
                 )
             # MLLM engine is always "running" once loaded

--- a/vllm_mlx/engine/drafter_capabilities.py
+++ b/vllm_mlx/engine/drafter_capabilities.py
@@ -1,0 +1,13 @@
+"""Capability normalization for external speculative drafters."""
+
+from typing import Any
+
+
+def explicit_bool(value: Any) -> bool | None:
+    """Return only literal Boolean capability declarations."""
+    return value if type(value) is bool else None
+
+
+def continuous_batching_capability(drafter: Any) -> bool | None:
+    """Return an external drafter's explicit CB capability, if declared."""
+    return explicit_bool(getattr(drafter, "supports_continuous_batching", None))

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -46,6 +46,7 @@ from .chat_template_safety import (
     build_system_prompt_cache_prefix,
     normalize_messages_for_chat_template,
 )
+from .drafter_capabilities import continuous_batching_capability
 from ..mlx_streams import (
     bind_generation_streams,
     restore_generation_streams,
@@ -3427,6 +3428,7 @@ class SimpleEngine(BaseEngine):
             }
 
         if self._mllm_draft_model_path is not None:
+            loaded_drafter = getattr(self._model, "_draft_model", None)
             stats["mtp"] = {
                 "enabled": True,
                 "implementation": "mlx_vlm_assistant",
@@ -3434,7 +3436,9 @@ class SimpleEngine(BaseEngine):
                 "draft_kind": self._mllm_draft_kind,
                 "draft_block_size": self._mllm_draft_block_size,
                 "default_enabled": self._default_mllm_draft,
-                "continuous_batching_supported": True,
+                "continuous_batching_supported": continuous_batching_capability(
+                    loaded_drafter
+                ),
             }
 
         # System KV cache stats (LRU over multiple system prefixes)


### PR DESCRIPTION
## Summary

- Report literal drafter capability as true/false and missing or invalid declarations as null.
- Preserve scheduler-reported capability instead of overwriting it with true.
- Leave startup admission unchanged, including released Gemma assistant drafters without a declaration.

## Verification

- At `c63e1f8`, 33 focused tests passed with no exclusions.
- The startup regression follows the real draft-loader routing boundary with a marker-absent return shape matching released Gemma. Weight loading is substituted; this is not numerical Gemma qualification.
- Tests retain explicit/unknown capability reporting and scheduler-precedence coverage. All 10 GitHub checks pass on `c63e1f8`, including both Apple Silicon jobs.
