### PR TITLE
fix(mtp): attribute per-request draft/accept counts on the LLM path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
             tests/test_prefix_cache_untrimmable.py \
             tests/test_scheduler_max_kv_size.py \
             tests/test_qwen35_mtp_patch.py \
+            tests/test_llm_mtp_per_request_counters.py \
             tests/test_batched_engine_mllm_config.py \
             tests/test_mllm_continuous_batching.py \
             tests/test_mllm_cache.py \

--- a/tests/test_llm_mtp_per_request_counters.py
+++ b/tests/test_llm_mtp_per_request_counters.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic coverage for per-request MTP counters on the plain-text
+LLM path (scheduler.py) -- the sibling gap to mllm_scheduler.py's
+mtp_drafts/mtp_accepted, which is already wired end-to-end.
+
+Covers:
+- _install_mtp's per-UID attempt/accept delta tracking, driven through the
+  real _mtp_step/_mtp_next closures with a small deterministic fake model
+  (3-token vocab, no real weights) -- including a UID joining mid-stream,
+  to prove drafts attributed to one request don't leak onto another.
+- Scheduler._process_batch_responses correctly attributes drained deltas
+  to the right Request and copies them onto RequestOutput, applying each
+  UID's delta at most once per call.
+"""
+
+from collections import namedtuple
+
+import pytest
+
+try:
+    import mlx.core as mx
+    from mlx_lm.sample_utils import make_sampler
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+_Response = namedtuple(
+    "_Response", ["uid", "token", "logprobs", "finish_reason", "cache_out"]
+)
+
+
+class _FakeActiveBatch:
+    def __init__(self, uids, cache):
+        self.uids = uids
+        self.cache = cache
+
+    def filter(self, keep_indices):
+        self.uids = [self.uids[i] for i in keep_indices]
+
+
+class _FakeMTPModel:
+    """Deterministic 3-token-vocab model: primary always predicts token 0,
+    the MTP head always drafts token 1. ``accept`` controls whether the
+    verify pass's own prediction agrees with the draft (accept) or not
+    (reject) -- vocab index 1 vs. index 0 at verify position 0.
+    """
+
+    def __init__(self, accept: bool):
+        self._accept = accept
+
+    def __call__(self, tokens, cache, return_hidden=True):
+        batch, seq = tokens.shape
+        if seq == 1:
+            logits = mx.array([[[10.0, 0.0, 0.0]]] * batch)
+            hidden = mx.zeros((batch, 1, 1))
+            return logits, hidden
+        # 2-token verify pass (primary, draft): position 0's argmax is
+        # compared against the draft token to decide accept/reject.
+        row0 = [0.0, 10.0, 0.0] if self._accept else [10.0, 0.0, 0.0]
+        verify_logits = mx.array([[row0, [10.0, 0.0, 0.0]]] * batch)
+        verify_hidden = mx.zeros((batch, 1, 1))
+        return verify_logits, verify_hidden
+
+    def mtp_forward(self, hidden, primary_tokens, mtp_cache=None):
+        batch = primary_tokens.shape[0]
+        return mx.array([[[0.0, 10.0, 0.0]]] * batch)
+
+
+class _FakeBatchGenerator:
+    """Minimal stand-in for mlx_lm's real BatchGenerator: just enough
+    surface for _install_mtp to patch. ``_next`` mimics the real one's
+    contract of advancing one primary token per active UID via
+    ``self._step`` -- which _install_mtp replaces with ``_mtp_step``.
+    """
+
+    Response = _Response
+
+    def __init__(self, uids, cache, stop_tokens=frozenset({1})):
+        self.active_batch = _FakeActiveBatch(list(uids), cache)
+        self.sampler = make_sampler(temp=0.0)
+        self.stop_tokens = stop_tokens
+
+    def _step(self, *args, **kwargs):
+        raise NotImplementedError("replaced by _install_mtp")
+
+    def _next(self):
+        if self.active_batch is None:
+            return []
+        uids = list(self.active_batch.uids)
+        input_tokens = mx.zeros((len(uids), 1), dtype=mx.int32)
+        primary_tokens, logprobs = self._step(
+            input_tokens, self.active_batch.cache, [None] * len(uids), None, None
+        )
+        primary_list = primary_tokens.tolist()
+        return [
+            self.Response(uid, primary_list[i], logprobs[i], None, None)
+            for i, uid in enumerate(uids)
+        ]
+
+
+class TestInstallMtpPerUidDeltas:
+    """_install_mtp's closure-level per-UID attempt/accept bookkeeping."""
+
+    def test_attempt_recorded_even_when_verify_rejects(self):
+        from vllm_mlx.scheduler import _install_mtp
+
+        cache = []
+        batch_gen = _FakeBatchGenerator(uids=[7], cache=cache)
+        _install_mtp(batch_gen, model=_FakeMTPModel(accept=False), num_draft_tokens=1)
+
+        batch_gen._next()
+        drafts, accepted = batch_gen.drain_mtp_uid_deltas()
+
+        assert drafts == {7: 1}
+        assert accepted == {}
+
+    def test_accept_only_recorded_once_draft_is_actually_emitted(self):
+        from vllm_mlx.scheduler import _install_mtp
+
+        cache = []
+        batch_gen = _FakeBatchGenerator(uids=[1], cache=cache)
+        _install_mtp(batch_gen, model=_FakeMTPModel(accept=True), num_draft_tokens=1)
+
+        # Step 1: the draft is verified-accepted (deferred), not yet
+        # surfaced as an output token -- accepted delta must stay empty.
+        batch_gen._next()
+        drafts_1, accepted_1 = batch_gen.drain_mtp_uid_deltas()
+        assert drafts_1 == {1: 1}
+        assert accepted_1 == {}
+
+        # Step 2: the deferred draft from step 1 is emitted.
+        batch_gen._next()
+        drafts_2, accepted_2 = batch_gen.drain_mtp_uid_deltas()
+        assert accepted_2 == {1: 1}
+
+    def test_uid_joining_mid_stream_does_not_inherit_another_uids_count(self):
+        """A UID joining mid-stream must not inherit an earlier UID's
+        accepted-draft count, and must start accumulating its own drafts
+        only from the step it actually joins."""
+        from vllm_mlx.scheduler import _install_mtp
+
+        cache = []
+        batch_gen = _FakeBatchGenerator(uids=[1], cache=cache)
+        _install_mtp(batch_gen, model=_FakeMTPModel(accept=True), num_draft_tokens=1)
+
+        # Step 1: only uid 1 present.
+        batch_gen._next()
+        drafts_1, accepted_1 = batch_gen.drain_mtp_uid_deltas()
+        assert drafts_1 == {1: 1}
+        assert accepted_1 == {}
+
+        # Step 2: uid 2 joins. Both attempt a draft this step; only uid 1's
+        # step-1 draft is due for emission (uid 2 has no prior deferred
+        # draft of its own yet).
+        batch_gen.active_batch.uids.append(2)
+        batch_gen._next()
+        drafts_2, accepted_2 = batch_gen.drain_mtp_uid_deltas()
+
+        assert drafts_2 == {1: 1, 2: 1}
+        assert accepted_2 == {1: 1}
+        assert 2 not in accepted_2
+
+
+def _make_scheduler():
+    """Mirrors the mock_model/mock_tokenizer Scheduler-construction idiom
+    used across test_batching.py/test_memory_stability.py."""
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    model = MagicMock()
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda x: list(range(len(x.split())))
+    tokenizer.eos_token_id = 0
+    return Scheduler(model, tokenizer, SchedulerConfig(enable_prefix_cache=False))
+
+
+class TestProcessBatchResponsesAttributesMtpDeltas:
+    """Scheduler._process_batch_responses must attribute drained per-UID
+    MTP deltas to the correct Request and copy them onto RequestOutput.
+    """
+
+    def test_deltas_land_on_the_right_request_and_output(self):
+        from vllm_mlx.request import Request, SamplingParams
+
+        scheduler = _make_scheduler()
+
+        req_a = Request(request_id="a", prompt="hi", sampling_params=SamplingParams())
+        req_b = Request(request_id="b", prompt="yo", sampling_params=SamplingParams())
+        req_a.output_token_ids = [1]  # skip _store_prompt_only_cache
+        req_b.output_token_ids = [1]
+        scheduler.running = {"a": req_a, "b": req_b}
+        scheduler.uid_to_request_id = {1: "a", 2: "b"}
+
+        class FakeBatchGenerator:
+            def drain_mtp_uid_deltas(self):
+                return {1: 2, 2: 1}, {1: 1}
+
+        scheduler.batch_generator = FakeBatchGenerator()
+
+        responses = [
+            _Response(
+                uid=1, token=5, logprobs=None, finish_reason="stop", cache_out=None
+            ),
+            _Response(
+                uid=2, token=6, logprobs=None, finish_reason="stop", cache_out=None
+            ),
+        ]
+
+        outputs, finished_ids = scheduler._process_batch_responses(responses)
+
+        assert req_a.mtp_drafts == 2
+        assert req_a.mtp_accepted == 1
+        assert req_b.mtp_drafts == 1
+        assert req_b.mtp_accepted == 0
+
+        by_request = {o.request_id: o for o in outputs}
+        assert by_request["a"].mtp_drafts == 2
+        assert by_request["a"].mtp_accepted == 1
+        assert by_request["b"].mtp_drafts == 1
+        assert by_request["b"].mtp_accepted == 0
+
+    def test_no_mtp_installed_leaves_counters_at_zero(self):
+        """No batch_generator.drain_mtp_uid_deltas attribute (MTP not
+        installed) must not crash and must leave counters at their
+        dataclass default of 0."""
+        from vllm_mlx.request import Request, SamplingParams
+
+        scheduler = _make_scheduler()
+        req = Request(request_id="a", prompt="hi", sampling_params=SamplingParams())
+        req.output_token_ids = [1]
+        scheduler.running = {"a": req}
+        scheduler.uid_to_request_id = {1: "a"}
+
+        class PlainBatchGenerator:
+            pass
+
+        scheduler.batch_generator = PlainBatchGenerator()
+
+        responses = [
+            _Response(
+                uid=1, token=5, logprobs=None, finish_reason="stop", cache_out=None
+            )
+        ]
+
+        outputs, _ = scheduler._process_batch_responses(responses)
+
+        assert outputs[0].mtp_drafts == 0
+        assert outputs[0].mtp_accepted == 0

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -143,6 +143,13 @@ class Request:
         None  # Type of cache hit: exact/prefix/supersequence/lcp/miss
     )
 
+    # MTP (multi-token prediction) per-request counters, mirroring
+    # MLLMRequest.mtp_drafts/mtp_accepted (mllm_scheduler.py). Attributed by
+    # UID in Scheduler._process_batch_responses from the deltas
+    # _install_mtp's closures accumulate per step (see scheduler.py).
+    mtp_drafts: int = 0
+    mtp_accepted: int = 0
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -826,6 +826,17 @@ def _install_mtp(
     # Format: {uid: {'token': int, 'logprobs': mx.array}}
     _deferred_drafts = {}
 
+    # Per-UID MTP attempt/accept deltas accumulated since the last drain,
+    # keyed by UID the same way _deferred_drafts is. _mtp_stats above only
+    # tracks batch-global totals; these let the scheduler attribute a
+    # step's attempted/accepted events to the specific requests whose UID
+    # was actually part of the batch when they happened, mirroring
+    # MLLMRequest.mtp_drafts/mtp_accepted (mllm_scheduler.py). Drained (read
+    # + cleared) once per Scheduler.step() call so a later UID reuse can't
+    # inherit a finished request's stale counts.
+    _mtp_drafts_by_uid: Dict[int, int] = {}
+    _mtp_accepted_by_uid: Dict[int, int] = {}
+
     # Scheduler-created generators share one state so sampler-driven generator
     # replacement does not reset the operator-facing counters.
     if stats_state is None:
@@ -859,6 +870,18 @@ def _install_mtp(
         }
 
     batch_gen.get_mtp_stats = _get_mtp_stats
+
+    def _drain_mtp_uid_deltas() -> Tuple[Dict[int, int], Dict[int, int]]:
+        """Return and clear the per-UID attempt/accept deltas accumulated
+        since the last call. Meant to be drained exactly once per
+        Scheduler.step() call."""
+        drafts = dict(_mtp_drafts_by_uid)
+        accepted = dict(_mtp_accepted_by_uid)
+        _mtp_drafts_by_uid.clear()
+        _mtp_accepted_by_uid.clear()
+        return drafts, accepted
+
+    batch_gen.drain_mtp_uid_deltas = _drain_mtp_uid_deltas
 
     def _mtp_bypass_reasons(input_tokens, prompt_cache):
         reasons = []
@@ -981,6 +1004,13 @@ def _install_mtp(
         try:
             with _mtp_stats_lock:
                 _mtp_stats["attempted"] += 1
+            # Every UID currently in the batch had a draft attempted this
+            # step (num_draft_tokens is always 1 in the batched path -- see
+            # the warning below), regardless of the eventual accept/reject
+            # outcome, which is why this increments unconditionally here
+            # rather than in the accept-only branches below.
+            for uid in current_uids:
+                _mtp_drafts_by_uid[uid] = _mtp_drafts_by_uid.get(uid, 0) + 1
             # Draft: predict token n+2 from hidden states + primary (n+1)
             draft_logits = model.mtp_forward(
                 hidden_states[:, -1:, :],
@@ -1207,6 +1237,11 @@ def _install_mtp(
             # Emit deferred draft AFTER its primary
             if uid in prev_deferred:
                 draft_info = prev_deferred.pop(uid)
+                # The draft is only really "accepted" once it's actually
+                # surfaced as an output token here, not when _mtp_step
+                # merely predicted an accept -- mirrors MLLM's from_draft
+                # response flag, which is likewise set at emission time.
+                _mtp_accepted_by_uid[uid] = _mtp_accepted_by_uid.get(uid, 0) + 1
                 if "token" in draft_info:
                     draft_t = draft_info["token"]
                 else:
@@ -2758,6 +2793,18 @@ class Scheduler:
         outputs = []
         finished_ids = set()
 
+        # Per-UID MTP deltas accumulated by _install_mtp's closures since
+        # the last drain (no-op {}/{} when MTP isn't installed). Applied at
+        # most once per UID below so a UID with both a primary and a
+        # deferred-draft response this step (see _mtp_next) doesn't have
+        # the same step's deltas counted twice.
+        mtp_drafts_delta: Dict[int, int] = {}
+        mtp_accepted_delta: Dict[int, int] = {}
+        drain_mtp = getattr(self.batch_generator, "drain_mtp_uid_deltas", None)
+        if drain_mtp is not None:
+            mtp_drafts_delta, mtp_accepted_delta = drain_mtp()
+        mtp_delta_applied: Set[int] = set()
+
         for response in responses:
             request_id = self.uid_to_request_id.get(response.uid)
             if request_id is None:
@@ -2766,6 +2813,12 @@ class Scheduler:
             request = self.running.get(request_id)
             if request is None:
                 continue
+
+            uid = response.uid
+            if uid not in mtp_delta_applied:
+                mtp_delta_applied.add(uid)
+                request.mtp_drafts += mtp_drafts_delta.get(uid, 0)
+                request.mtp_accepted += mtp_accepted_delta.get(uid, 0)
 
             # Snapshot the cache while it still covers exactly the prompt, i.e.
             # before the first generated token is appended. Storing that under
@@ -2809,6 +2862,8 @@ class Scheduler:
                 output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                mtp_drafts=request.mtp_drafts,
+                mtp_accepted=request.mtp_accepted,
             )
 
             # Check if finished


### PR DESCRIPTION
Refs #756

## Problem

`RequestOutput.mtp_drafts`/`mtp_accepted` (consumed generically by `server.py`'s `has_mtp_activity`/usage builder) were wired end-to-end on the MLLM path (`mllm_scheduler.py`) but never set on the plain-text LLM path: `scheduler.py`'s `RequestOutput` construction never passed them, the shared `Request` class had no such fields at all, and the LLM path's own MTP loop (`_install_mtp`/`_mtp_step`/`_mtp_next`) tracked accept/attempt only as **batch-global** counters (`_mtp_stats`), with no per-UID attribution. Net effect: a client hitting the text-completion endpoint on an MTP-enabled model always got `has_mtp_activity == False`, while the MLLM/VLM endpoint reported real per-response numbers.

Went with option (a) from #756 (wire it up) rather than (b) (just document the gap) — the per-UID attribution below is genuinely useful (distinguishing "this request was part of the batch when MTP ran" from "it wasn't"), and mirrors an idiom (`_deferred_drafts`, keyed by UID) already present in the same function.

## Changes

- `vllm_mlx/request.py`: adds `Request.mtp_drafts`/`mtp_accepted` (default `0`), mirroring `MLLMRequest`.
- `vllm_mlx/scheduler.py`, `_install_mtp`:
  - Adds `_mtp_drafts_by_uid`/`_mtp_accepted_by_uid`, closure-scoped dicts keyed by UID the same way `_deferred_drafts` already is.
  - **Drafts**: incremented in `_mtp_step` for every UID in the active batch whenever an attempt happens, regardless of the eventual accept/reject outcome — mirrors `_mtp_stats["attempted"]`'s existing batch-wide semantics, just attributed per-UID instead of only summed globally.
  - **Accepted**: incremented in `_mtp_next`, only when a deferred draft is *actually emitted* as an output token — not merely predicted-accepted at verify time in `_mtp_step`. This mirrors the MLLM side precisely: `MLLMBatchResponse.from_draft` is likewise set at emission time, not at the verify step.
  - Exposed via `batch_gen.drain_mtp_uid_deltas()` (mirrors the existing `batch_gen.get_mtp_stats` pattern), which returns-and-clears the accumulated deltas. Drained exactly once per `Scheduler.step()` call so a later UID reuse (once a request finishes and its UID is recycled) can't inherit a finished request's stale counts.
  - `Scheduler._process_batch_responses` applies each UID's drained delta **at most once per call** — a UID can legitimately appear twice in one step's `responses` list (its own primary response, plus a deferred draft from the *previous* step emitted alongside it) — then copies the running cumulative totals onto the constructed `RequestOutput`, exactly like the MLLM side does.

### An honest caveat, called out in #756 too

The plain-LLM path's accept/reject decision is currently a **single batch-wide boolean per step** (`all_accepted = pred_list == draft_list`, a Python list-equality comparison across every sequence in the active batch), not a per-sequence verify. So "per-request attribution" here means *"was this UID part of the batch when the step's shared outcome was decided,"* not an independently-verified per-request result the way MLLM's genuinely-per-response `mtp_attempted`/`from_draft` flags are. That's still a real improvement (a request joining the batch late no longer inherits an earlier request's count, and gets `0` until it's actually participated), just a coarser signal than MLLM's. Documented in the code comments at both increment sites.

## Tests

New `tests/test_llm_mtp_per_request_counters.py`, mapped into the Apple-Silicon CI job only (100% MLX-gated — needs `mlx.core` to import `vllm_mlx.scheduler` — matching `test_mllm_continuous_batching.py`'s existing single-job precedent for a fully MLX-gated file):

- `TestInstallMtpPerUidDeltas` drives the *real* `_mtp_step`/`_mtp_next` closures (via `_install_mtp`) through a small deterministic 3-token-vocab fake model (no real weights — a hand-crafted logits spike controls accept vs. reject deterministically):
  - an attempt is recorded even when the verify step rejects;
  - an accept is recorded only once the deferred draft is actually emitted in the *next* step, not at verify time;
  - a UID joining mid-stream does not inherit an earlier UID's accepted-draft count, and only starts accumulating drafts from the step it actually joins.
- `TestProcessBatchResponsesAttributesMtpDeltas` verifies `Scheduler._process_batch_responses` attributes drained deltas to the correct `Request`/`RequestOutput` (two concurrent requests, distinct deltas, no cross-contamination), and that a scheduler with no MTP installed leaves counters at their dataclass default of `0`.

Verified these are real regression guards, not vacuously green: reverted both source changes locally and confirmed 4 of 5 new tests fail (`AttributeError: no attribute 'drain_mtp_uid_deltas'` / `'Request' object has no attribute 'mtp_drafts'`).

Also confirmed the consumer side needs no new test: `test_no_final_content_watchdog.py::test_generation_metadata_includes_mllm_mtp_counters_without_thinking_processor` (existing, unrelated to this PR) already proves `server.py`'s `_generation_metadata`/usage builder is generic and duck-typed — it was only ever missing real values to read from the LLM path, which is exactly what this PR supplies.

### Test results (isolated `uv venv`, this branch's head, no model download/serving)

- `tests/test_llm_mtp_per_request_counters.py`: 5/5 passed
- Mapped Apple-job subset (`test_qwen35_mtp_patch.py`, `test_llm_mtp_per_request_counters.py`, `test_batched_engine_mllm_config.py`): 22 passed
- Full suite vs. `origin/main` baseline: baseline 2965 passed/13 skipped/27 deselected → this branch 2970 passed/13 skipped/27 deselected (exactly the 5 new tests; no regressions)
- `ruff check` / `black --check`: clean

## Live evidence: not possible within bounded effort — unit-level verification only

Investigated briefly per the mission's bound. `_install_mtp` on the plain-LLM path only fires when `model.mtp is not None` (`scheduler.py`) — a **native MTP head baked into the model's weights**. Per this repo's own `vllm_mlx/patches/qwen3_5_mtp.py` docstring, those weights are added via a separate `scripts/add_mtp_weights_qwen35.py` injection step against a genuine trained base checkpoint — they are not part of any stock public release I could find, and no small (<5GB) MTP-native text-only checkpoint is documented anywhere in this repo's README/docs. The only MTP weight-generation this project's own history (`[[qwen38-mtp-and-flag-tests]]`) has ever exercised targeted the *MLLM* checkpoint (`mlx-community/Qwen3.8-27B-8bit`, 849MB additive), not the plain-text path this PR touches. Producing a live run would require either downloading a large (multi-GB, likely >5GB) unquantized base model to run the injection script against, or locating a pre-built MTP-native text checkpoint that doesn't appear to be published — both out of scope for this bound.

**I am not claiming live evidence I don't have.** Verification here is unit-level only, driving the actual production `_mtp_step`/`_mtp_next` closures with a hand-crafted deterministic model (not a mock of my own new code — a fake of the *model* the real code calls), mirroring the semantics #749 established for the sibling MLLM-side fix.
