### PR TITLE
fix(server): route DELETE /v1/cache(/prefix) through _model_manager in registry mode

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -153,6 +153,70 @@ class TestMetricsEndpoint:
 
         assert response.status_code == 404
 
+    def test_metrics_endpoint_reports_dead_gauges_without_engine_or_manager(
+        self, metrics_client
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+        assert server._engine is None
+        assert server._model_manager is None
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 0.0" in response.text
+        assert "vllm_mlx_scheduler_waiting_requests 0.0" in response.text
+
+    def test_metrics_endpoint_scrapes_registry_mode_engine(
+        self, metrics_client, monkeypatch
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+
+        class FakeModelManager:
+            def __init__(self, engine):
+                self._engine = engine
+
+            def get_metrics_engine(self):
+                return self._engine
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(server, "_model_manager", FakeModelManager(FakeEngine()))
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 1.0" in response.text
+        assert "vllm_mlx_scheduler_waiting_requests 2.0" in response.text
+        assert (
+            'vllm_mlx_cache_type{cache_type="memory_aware_cache"} 1.0' in response.text
+        )
+
+    def test_metrics_endpoint_registry_mode_dead_gauges_when_idle(
+        self, metrics_client, monkeypatch
+    ):
+        client, server, collector = metrics_client
+
+        collector.configure(enabled=True)
+
+        class FakeModelManager:
+            def get_metrics_engine(self):
+                return None
+
+            async def shutdown(self):
+                return None
+
+        monkeypatch.setattr(server, "_model_manager", FakeModelManager())
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert "vllm_mlx_model_loaded 0.0" in response.text
+
     def test_metrics_endpoint_scrapes_runtime_stats(self, metrics_client, monkeypatch):
         client, server, collector = metrics_client
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -339,6 +339,65 @@ def test_preempt_policy_cancels_active_request_and_loads_waiting_model(tmp_path)
     asyncio.run(_run())
 
 
+def test_get_metrics_engine_returns_none_when_idle(tmp_path):
+    registry = _registry(tmp_path, {"alpha": 4})
+    manager = ModelManager(
+        _manager_config(budget_gb=8),
+        registry,
+        _defaults(),
+        engine_factory=lambda config: FakeEngine(config),
+    )
+
+    assert manager.get_metrics_engine() is None
+
+
+def test_get_metrics_engine_returns_sole_loaded_engine(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=8),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease = await manager.acquire("alpha")
+
+        assert manager.get_metrics_engine() is manager._loaded["alpha"].engine
+
+        await lease.release()
+
+    asyncio.run(_run())
+
+
+def test_get_metrics_engine_returns_most_recently_used_when_multiple_loaded(tmp_path):
+    async def _run():
+        registry = _registry(tmp_path, {"alpha": 4, "beta": 4})
+        manager = ModelManager(
+            _manager_config(budget_gb=9),
+            registry,
+            _defaults(),
+            engine_factory=lambda config: FakeEngine(config),
+        )
+
+        lease_a = await manager.acquire("alpha")
+        await lease_a.release()
+        await asyncio.sleep(0.01)  # ensure last_used_at ordering is unambiguous
+        lease_b = await manager.acquire("beta")
+        await lease_b.release()
+
+        assert manager.get_metrics_engine() is manager._loaded["beta"].engine
+
+        # Touching alpha again makes it the most recently used.
+        await asyncio.sleep(0.01)
+        lease_a = await manager.acquire("alpha")
+        await lease_a.release()
+
+        assert manager.get_metrics_engine() is manager._loaded["alpha"].engine
+
+    asyncio.run(_run())
+
+
 def test_non_local_registry_entry_requires_explicit_memory_estimate():
     async def _run():
         registry = {

--- a/tests/test_server_cache_controls.py
+++ b/tests/test_server_cache_controls.py
@@ -82,3 +82,93 @@ def test_clear_cache_clears_engine_managed_runtime_caches(monkeypatch):
             sys.modules["mlx_vlm.utils"] = original_module
         else:
             sys.modules.pop("mlx_vlm.utils", None)
+
+
+def test_clear_prefix_cache_routes_through_model_manager_in_registry_mode(monkeypatch):
+    """Regression: in registry mode (--models-config) the module-global
+    _engine is never populated (_sync_engine_from_residency only syncs from
+    _residency_manager, which is None in registry mode), so the endpoint
+    must resolve the live engine via _model_manager.get_metrics_engine() --
+    the same pattern /metrics already uses -- instead of silently returning
+    {"status": "no_engine"} while _engine stays None.
+    """
+    import vllm_mlx.server as server
+
+    calls = {"cleared": 0}
+
+    class DummyEngine:
+        def clear_prefix_cache(self):
+            calls["cleared"] += 1
+
+    class FakeModelManager:
+        def __init__(self, engine):
+            self._engine = engine
+
+        def get_metrics_engine(self):
+            return self._engine
+
+    original_engine = server._engine
+    original_model_manager = server._model_manager
+    original_api_key = server._api_key
+    try:
+        server._engine = None  # registry mode: global engine stays unset
+        server._model_manager = FakeModelManager(DummyEngine())
+        server._api_key = None
+        client = TestClient(server.app)
+
+        response = client.delete("/v1/cache/prefix")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "cleared"
+        assert calls["cleared"] == 1
+    finally:
+        server._engine = original_engine
+        server._model_manager = original_model_manager
+        server._api_key = original_api_key
+
+
+def test_clear_cache_routes_through_model_manager_in_registry_mode(monkeypatch):
+    """Same registry-mode fix as clear_prefix_cache, for DELETE /v1/cache."""
+    import vllm_mlx.server as server
+
+    calls = {"cleared": 0}
+    fake_utils = types.ModuleType("mlx_vlm.utils")
+    fake_utils.clear_multimodal_kv_cache = lambda: None
+    fake_utils.clear_pixel_values_cache = lambda: None
+
+    class DummyEngine:
+        def clear_runtime_caches(self):
+            calls["cleared"] += 1
+            return {"prefix_cache": True}
+
+    class FakeModelManager:
+        def __init__(self, engine):
+            self._engine = engine
+
+        def get_metrics_engine(self):
+            return self._engine
+
+    original_engine = server._engine
+    original_model_manager = server._model_manager
+    original_api_key = server._api_key
+    original_module = sys.modules.get("mlx_vlm.utils")
+    try:
+        server._engine = None  # registry mode: global engine stays unset
+        server._model_manager = FakeModelManager(DummyEngine())
+        server._api_key = None
+        sys.modules["mlx_vlm.utils"] = fake_utils
+        client = TestClient(server.app)
+
+        response = client.delete("/v1/cache")
+
+        assert response.status_code == 200
+        assert response.json()["engine_cache"] == {"prefix_cache": True}
+        assert calls["cleared"] == 1
+    finally:
+        server._engine = original_engine
+        server._model_manager = original_model_manager
+        server._api_key = original_api_key
+        if original_module is not None:
+            sys.modules["mlx_vlm.utils"] = original_module
+        else:
+            sys.modules.pop("mlx_vlm.utils", None)

--- a/vllm_mlx/model_registry.py
+++ b/vllm_mlx/model_registry.py
@@ -736,6 +736,21 @@ class ModelManager:
             )
         return data
 
+    def get_metrics_engine(self) -> BaseEngine | None:
+        """Return the engine to source Prometheus gauges from, or None if idle.
+
+        The gauges this feeds (``/metrics``) are unlabeled scalars with no
+        ``model=`` dimension, so they can only ever describe one engine at a
+        time. With a single resident model that engine is the obvious and
+        exact choice. With more than one resident, there is no way to report
+        all of them without a schema change, so this reports the most
+        recently used one as a representative sample rather than reporting
+        nothing.
+        """
+        if not self._loaded:
+            return None
+        return max(self._loaded.values(), key=lambda loaded: loaded.last_used_at).engine
+
     async def preload(self) -> None:
         """Preload any entries marked preload=true."""
         for entry in self._registry.values():

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3666,8 +3666,11 @@ async def metrics():
     if not _metrics.enabled:
         raise HTTPException(status_code=404, detail="Metrics endpoint is disabled")
 
+    engine = (
+        _model_manager.get_metrics_engine() if _model_manager is not None else _engine
+    )
     payload, content_type = _metrics.render_metrics(
-        engine=_engine,
+        engine=engine,
         mcp_manager=_mcp_manager,
     )
     return Response(content=payload, headers={"Content-Type": content_type})

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3843,10 +3843,14 @@ async def cache_stats():
 @app.delete("/v1/cache", dependencies=[Depends(verify_api_key)])
 async def clear_cache():
     """Clear all caches."""
+    # In registry mode (--models-config) the module-global _engine is never
+    # populated (_sync_engine_from_residency only syncs from _residency_manager,
+    # which is None here) -- resolve the live engine the same way /metrics does.
+    engine = _model_manager.get_metrics_engine() if _model_manager is not None else _engine
     cleared_engine = None
-    if _engine is not None and hasattr(_engine, "clear_runtime_caches"):
+    if engine is not None and hasattr(engine, "clear_runtime_caches"):
         try:
-            cleared_engine = _engine.clear_runtime_caches()
+            cleared_engine = engine.clear_runtime_caches()
         except Exception as exc:
             logger.warning("Failed to clear engine caches: %s", exc, exc_info=True)
             cleared_engine = {"error": str(exc)}
@@ -3881,12 +3885,18 @@ async def clear_prefix_cache():
     hits the cache. Response returns immediately without waiting for
     the re-warm to finish.
     """
-    if _engine is None:
+    # In registry mode (--models-config) the module-global _engine is never
+    # populated (_sync_engine_from_residency only syncs from _residency_manager,
+    # which is None here) -- resolve the live engine the same way /metrics does.
+    # Without this, the endpoint returns HTTP 200 with {"status": "no_engine"}
+    # and silently clears nothing.
+    engine = _model_manager.get_metrics_engine() if _model_manager is not None else _engine
+    if engine is None:
         return {"status": "no_engine"}
     cleared = False
-    if hasattr(_engine, "clear_prefix_cache"):
+    if hasattr(engine, "clear_prefix_cache"):
         try:
-            _engine.clear_prefix_cache()
+            engine.clear_prefix_cache()
             cleared = True
         except Exception as e:
             logger.warning(
@@ -3896,7 +3906,7 @@ async def clear_prefix_cache():
 
     # Auto re-warm in background if warm-prompts was configured.
     rewarm_scheduled = False
-    if cleared and _warm_prompts_path and hasattr(_engine, "stream_chat"):
+    if cleared and _warm_prompts_path and hasattr(engine, "stream_chat"):
 
         async def _rewarm():
             try:
@@ -3906,7 +3916,7 @@ async def clear_prefix_cache():
                 )
 
                 prompts = load_warmup_file(_warm_prompts_path)
-                result = await warm_prefix_cache(_engine, prompts)
+                result = await warm_prefix_cache(engine, prompts)
                 logger.info(
                     "[clear_prefix_cache] re-warm done: %d completed, %d skipped, %.1fs",
                     result["count"],


### PR DESCRIPTION
Refs #758

## Scope

This PR makes `DELETE /v1/cache/prefix` and `DELETE /v1/cache` actually clear the resident engine's caches in registry mode (`--models-config`), instead of silently returning HTTP 200 while touching nothing.

**Not covered by this PR**: #759, a separate bug this PR's fix incidentally surfaces (`MLLMScheduler.clear_runtime_caches()`/`.reset()` reference a nonexistent `self.vision_cache` — the real attribute lives on `self.batch_generator.vision_cache`). Different root cause, kept out of this PR's diff; `clear_cache()` in this PR catches and reports it as a soft error (`engine_cache: {"error": "..."}`) rather than crashing the request, matching existing behavior for other `clear_runtime_caches()` failures.

**Prerequisite included, not yet upstream**: this branch is built on `origin/main`, which doesn't yet have `ModelManager.get_metrics_engine()` (#738/#739, open/unmerged as of this writing) — the same accessor this fix reuses. Commit 1 here (`dc77dc0`) is #739's exact fix, cherry-picked as a prerequisite so this PR is self-contained and mergeable independently. If #739 merges first, this branch will need a trivial rebase dropping the now-duplicate commit 1; the actual fix (commit 2) doesn't change either way.

## Summary

Both cache-clear endpoints read the module-level `_engine` global (`server.py:191`), which `load_model_registry()` (the `--models-config` path) never populates — it routes everything through `_model_manager` instead, exactly the split #738 already documented for `/metrics`. Verified live before this fix: `DELETE /v1/cache/prefix` against a resident model with ~769MB of real prefix-cache entries returned `{"status":"no_engine"}` and `vllm_mlx_cache_memory_bytes` stayed byte-for-byte unchanged.

## Changes

- `vllm_mlx/model_registry.py`: adds `ModelManager.get_metrics_engine()` (from #739, included here as a prerequisite — see Scope above).
- `vllm_mlx/server.py`:
  - `/metrics` resolves its engine via `_model_manager.get_metrics_engine() if _model_manager is not None else _engine` (from #739).
  - `clear_cache()` (`DELETE /v1/cache`) and `clear_prefix_cache()` (`DELETE /v1/cache/prefix`) now resolve the engine the same way, at the top of each handler, replacing every subsequent read of the bare `_engine` (including the auto-rewarm closure inside `clear_prefix_cache()`, which previously captured the stale global too).
- `tests/test_server_cache_controls.py`: two new regression tests, `test_clear_prefix_cache_routes_through_model_manager_in_registry_mode` and `test_clear_cache_routes_through_model_manager_in_registry_mode`, using the same `FakeModelManager` convention #739 established in `test_metrics.py`. Both assert the endpoint reaches the fake engine's clear method and returns a real `"cleared"` status with `server._engine` left `None` throughout — proving the fix routes through `_model_manager`, not a coincidental fallback.

## Type of change

- Bug fix

## Surface touched

- Model registry / multi-model manager
- Cache control endpoints (`DELETE /v1/cache`, `DELETE /v1/cache/prefix`)

## Test plan

```
pytest tests/test_server_cache_controls.py tests/test_metrics.py tests/test_model_registry.py -v
pytest tests/ -q
```

## Test results

```
$ pytest tests/test_server_cache_controls.py -v
4 passed in 2.37s
```

```
$ pytest tests/ -q
2961 passed, 25 skipped, 27 deselected in 27.14s
```
(`origin/main` baseline @ `22efb47`: 2953 passed per #739's own reported baseline, +6 from #739's cherry-picked commit, +2 new here = 2961; 0 regressed.)

## Live end-to-end verification

- Hardware: Apple M5 Max, 128GB unified memory
- Model: `mlx-community/Qwen3.8-27B-8bit` (MLLM-routed), single-entry registry, `--continuous-batching --enable-prefix-cache --enable-metrics`

Before (registry mode, 3 distinct >128-token prompts warmed into the prefix cache):
```
$ curl -s http://localhost:8091/metrics | grep vllm_mlx_cache_memory_bytes
vllm_mlx_cache_memory_bytes 7.69130496e+08

$ curl -s -X DELETE http://localhost:8091/v1/cache/prefix
{"status":"no_engine"}

$ curl -s http://localhost:8091/metrics | grep vllm_mlx_cache_memory_bytes
vllm_mlx_cache_memory_bytes 7.69130496e+08   # unchanged
```

After (same server/config, this patch applied, restarted, model re-warmed with the same 3 prompts):
```
$ curl -s -X DELETE http://localhost:8091/v1/cache/prefix
{"status":"cleared","rewarm_scheduled":false}

$ curl -s http://localhost:8091/metrics | grep -E "vllm_mlx_cache_memory_bytes|vllm_mlx_cache_entry_count"
vllm_mlx_cache_entry_count 0.0
vllm_mlx_cache_memory_bytes 0.0
```

Also verified `DELETE /v1/cache` now reaches a real engine too (previously always `engine_cache: null`); for this MLLM-routed model it now surfaces #759 instead (see Scope) rather than silently no-op'ing — a strictly more honest failure mode, and outside this PR's diff to fix.

## Risk notes

Scoped to two call-sites plus the shared accessor from #739. No behavior change for the non-registry serving path (`_model_manager is None`, both endpoints fall back to `_engine` exactly as before). No behavior change to `metrics.py`, `model_registry.py`'s existing methods, or request handling.
