### PR TITLE
feat(spec-decode): DSpark block speculative decoding for NemotronH (design + spike, refs #699)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
             tests/test_qwen3_xml_registration.py \
             tests/test_qwen3_xml_streaming_chunks.py \
             tests/test_qwen35_mtp_hidden_state_mode.py \
+            tests/test_dspark_spec_decode.py \
             tests/test_streaming_fence_stripper.py \
             tests/test_streaming_think_router.py \
             tests/test_streaming_tool_filter.py \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ claude
 ### Reasoning & advanced
 - **Reasoning extraction**: Qwen3, DeepSeek-R1, DeepSeek-V4 (`--reasoning-parser`)
 - **MoE expert reduction**: `--moe-top-k` for +7-16% on Qwen3-30B-A3B
-- **Speculative decoding**: `--mtp` for Qwen3-Next
+- **Speculative decoding**: `--mtp` for Qwen3-Next; `--spec-draft dspark` block drafting for Nemotron 3.5 Lightning ([design + measurements](docs/guides/speculative-decoding.md))
 - **Sparse prefill**: attention-based `--spec-prefill` for TTFT reduction
 
 ### Observability

--- a/docs/guides/speculative-decoding.md
+++ b/docs/guides/speculative-decoding.md
@@ -48,6 +48,30 @@ prefix. Against a 1-wide greedy run of the same prompt, 199 positions were compa
 divergence, at a position where the 1-wide run's top-1/top-2 logit gap was exactly 0.0000
 (a bf16 tie that a different verify width legitimately breaks the other way).
 
+## Clean run on the rebased tree (2026-09-04, host otherwise idle)
+
+Same build for every row; served with `--continuous-batching --disable-prefix-cache --max-num-seqs 1`, native NVFP4 drafter, greedy, thinking off, one warm-up then three 512-token completions per prompt; medians. M5 Max 128 GB, mlx-lm 0.31.3.
+
+| config | code tok/s | vs plain | accepted / round (per token) | prose tok/s | vs plain | accepted / round (per token) |
+|---|---|---|---|---|---|---|
+| plain greedy | 125.6 | — | — | 118.8 | — | — |
+| DSpark k=4 | 104.1 | 0.83× | 2.98 of 4 (74.6 %) | 65.2 | 0.55× | 1.51 of 4 (37.7 %) |
+| DSpark k=7 | 76.8 | 0.61× | 3.59 of 7 (51.3 %) | 53.6 | 0.45× | 1.88 of 7 (26.9 %) |
+| DSpark k=4, `--spec-draft-margin-tau 1.5` | 109.6 | 0.87× | 2.59 of 2.96 drafted (87.5 %) | 71.1 | 0.60× | 1.17 of 2.22 drafted (52.6 %) |
+
+Counters over the whole run: `errors` 0, `context_disables` 0, `bounded_kv_disables` 0, `despeculations` = one per finished request (the rewind at `extract_cache`). Every config's three runs were byte-identical to each other.
+
+Reading: the ratios match the August measurements (0.7–0.8× then, 0.83–0.87× now on code). Wider blocks lose: k=7 accepts more tokens per round (3.59) but the 8-wide verify costs more than they save. The adaptive cut-off is now the best configuration, because on this tree the cost per drafted position is what it trims. Prose is worse than code at every setting, as the acceptance column predicts.
+
+**Fidelity.** Against the plain run, every DSpark config produced the same two divergences, one per prompt, and all three DSpark configs agree with each other:
+
+| prompt | first divergence | plain chose | DSpark chose | plain-forward logits at that position | gap |
+|---|---|---|---|---|---|
+| code | token 50 of 512 | `\n\n` | `,` | 28.25 vs 28.25 | **0.000** (exact tie) |
+| prose | token 2 of 512 | ` difference` | ` distinction` | 24.125 vs 24.25 | **0.125 = one bf16 ULP** at that magnitude |
+
+The gaps were measured offline with the same weights (the server has no logprobs endpoint): a forward over the prompt plus the common prefix, top-3 logits at the divergence position. In the prose case the wide forward's own argmax is the DSpark token, i.e. the 1-wide run is the one that broke the tie the other way. Both divergences therefore satisfy the acceptance bar proposed in *Greedy versus non-greedy correctness*: every emitted token is an argmax of the target over the emitted prefix, and any difference from a 1-wide run sits at a position whose top-1/top-2 gap is within bf16 resolution.
+
 ## Why it does not win yet: the verify-width curve
 
 Speculative decoding pays for a `(k+1)`-wide verify forward instead of `k+1` single-token
@@ -267,7 +291,7 @@ is a follow-up; the verify forward already produces the full distributions it ne
 | `rounds` | draft/verify rounds attempted |
 | `drafted` / `accepted` | draft tokens proposed / accepted |
 | `acceptance_rate` | `accepted / drafted` (per-token) |
-| `mean_accept_len` | `accepted / rounds`; tokens per round is this + 1 (bonus or corrected token) |
+| `mean_accept_len` | `accepted / rounds`; a round also emits the target's own token after the accepted prefix, so tokens per round is this + 1 after a full block and this + 2 after a partial one (the correction plus the next sample) |
 | `rounds_full` | rounds where the entire block was accepted |
 | `context_disables` | requests where spec turned itself off at the context check |
 | `bounded_kv_disables` | requests where spec turned itself off because the KV cache was no longer trimmable |

--- a/docs/guides/speculative-decoding.md
+++ b/docs/guides/speculative-decoding.md
@@ -1,0 +1,327 @@
+# Block Speculative Decoding (DSpark)
+
+`--spec-draft dspark` adds block-draft speculative decoding for NemotronH targets
+(Nemotron 3.5 Lightning 30B-A3B) on the continuous-batching text path. It drafts up to
+7 tokens per round with NVIDIA's [DSpark](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark)
+drafter and verifies the whole block in one target forward.
+
+This page is the design note and the measurements behind
+[waybarrios/vllm-mlx#699](https://github.com/waybarrios/vllm-mlx/issues/699). Read the
+**Status** section first: the implementation is correct and reaches NVIDIA's acceptance
+figures, but on today's MLX kernels it decodes at 0.7–0.8× plain greedy speed. The
+bottleneck is measured and named below; it is a kernel-level property of MoE verify
+width on MLX, not the drafter.
+
+## Quick start
+
+```bash
+# 1. Drafter weights into the target's model directory (one of two artifacts, see below)
+python scripts/prepare_dspark_weights.py --mlx-model-path <nemotron-6bit-dir>
+
+# 2. Serve. Greedy, single-stream requests engage the drafter; everything else
+#    runs plain decode on the same server.
+vllm-mlx serve <nemotron-6bit-dir> --continuous-batching \
+    --spec-draft dspark --spec-num-draft-tokens 4 --spec-draft-margin-tau 1.5
+
+# 3. Counters
+curl -s localhost:8000/v1/status | jq .spec_decode
+```
+
+A request engages speculative decoding only when `temperature` is `0` (argmax sampling)
+and it is the only sequence in the generation batch. Prefix-cache hits disable it for that
+request (see *Fallbacks*); benchmark with `--disable-prefix-cache`.
+
+## Status (2026-08-13 to 08-15 measurements, M5 Max 128 GB, Lightning 30B-A3B 6-bit)
+
+| | value |
+|---|---|
+| live mean accepted draft tokens / round (code generation) | **3.20** of 7 drafted (NVIDIA reports 3.75) |
+| per-token acceptance at k=4 | 62 % |
+| errors over the measurement runs | 0 |
+| plain greedy decode | 115 tok/s whole-request, 134 tok/s steady-state |
+| DSpark k=7, first working version (BF16 draft) | 66 tok/s |
+| DSpark k=4, tuned (8-bit draft, gathered Markov, sliced head; 86.6 with `--spec-draft-margin-tau 1.5`) | 87–90 tok/s |
+| **net** | **0.7–0.8× plain decode** |
+
+Correctness: every emitted token is an argmax of the target's own logits over the emitted
+prefix. Against a 1-wide greedy run of the same prompt, 199 positions were compared: 1
+divergence, at a position where the 1-wide run's top-1/top-2 logit gap was exactly 0.0000
+(a bf16 tie that a different verify width legitimately breaks the other way).
+
+## Why it does not win yet: the verify-width curve
+
+Speculative decoding pays for a `(k+1)`-wide verify forward instead of `k+1` single-token
+forwards. The whole question is how much a wide forward costs. Measured on the same
+sequence with a warm ~500-token cache (`mx.eval`-timed, 30 iterations):
+
+| verify width | ms / step | × width-1 | marginal ms / extra token |
+|---|---|---|---|
+| 1 | 8.47 | 1.00 | — |
+| 2 | 13.49 | 1.59 | 5.0 |
+| 3 | 15.64 | 1.85 | ~2.2 |
+| 5 | 20.67 | 2.44 | ~2.5 |
+| 8 | 28.13 | 3.32 | ~2.5 |
+
+Two readings, both true:
+
+* **Sublinear**, so block drafting is the right shape: the dense weights (23 Mamba layers,
+  6 attention layers, shared experts, lm_head) are read once per forward regardless of
+  width. Only the routed experts scale with width.
+* **The marginal cost is the ceiling.** Past width 2 every extra verified token costs
+  ~2.5–2.8 ms ≈ 30 % of a full step. That marginal is dominated by per-token routed-expert
+  reads (6 of 128 experts × 23 MoE layers ≈ 0.5 GB per token) that the current
+  `switch_layers` gather in mlx-lm does not batch across positions. It bounds any
+  speculative speedup on this stack at roughly 2×, and reaching 1.5× needs most rounds to
+  accept most of the block.
+
+Per-round arithmetic at k=7: 28 ms verify + ~4 ms draft for a mean of ~4.2 kept tokens is
+~7.6 ms/token *before* the partial-accept re-advance, which adds another wide forward to
+~85 % of rounds. Plain decode is 8.5 ms/token. NVIDIA's numbers work because their fused
+batched-expert kernels put the marginal near 1.1×/k.
+
+The ceiling in closed form, with `r` the fraction of rounds that need the re-advance and
+`k` the block: `1 / (r + (1 - r) / k)` ≈ 1.7× at the measured acceptance. A realistic
+~1.3× on this stack would need a single-forward commit path that hybrid models do not have.
+
+The same curve explains why Lightning's built-in single-token MTP head breaks even here
+(74.5 % acceptance and still 106 vs 115–134 tok/s, see #710 for the equivalent measurement on
+a hybrid Qwen): with verify-2 at 1.59×, one draft per verify cannot amortize.
+
+**Where the 1.5–2× lives:** batching the routed-expert gather across the verify block would
+drop the marginal toward the dense floor (~0.9 ms/token), at which point this exact DSpark
+stack projects to ~180–230 tok/s. That kernel work is the natural next phase, and it speeds
+up plain MoE decode for every model on vllm-mlx, speculative decoding aside.
+
+## Acceptance is at spec; the residual gap to NVIDIA is the metric
+
+Draft precision was eliminated as a cause: the bit-exact native NVFP4 drafter (MLX
+`mode="nvfp4"`) gives identical acceptance to the dequantized BF16→8-bit chain. SPEED-Bench
+(real prompts only — 6 of its 11 categories ship as license placeholders), same harness,
+same n, only the target precision varying:
+
+| category | 6-bit target | BF16 target | NVIDIA (BF16, temp 1.0 / top_p 0.95) |
+|---|---|---|---|
+| coding | 4.40 | 4.11 | 4.38 |
+| multilingual | 2.13 | 1.96 | 4.55 |
+| qa | 2.90 | 3.45 | 3.36 |
+| rag | 4.57 | 5.24 | 4.25 |
+| writing | 2.04 | 1.92 | 2.83 |
+| overall | 3.21 | 3.34 | 3.87 |
+
+Target quantization is a ~4 % effect in mixed directions. coding and rag are at or above
+NVIDIA's numbers at both precisions; qa is at the BF16 target. The deficit concentrates in flat-distribution categories (writing,
+multilingual) and is largely the metric: NVIDIA's acceptance is probabilistic rejection
+sampling at temperature 1.0, ours is exact greedy prefix match, which is strictly harsher
+exactly where the distribution is flat.
+
+## Design
+
+### Target model families and artifact format
+
+* **Targets:** `model_type == "nemotron_h"` only (Lightning 30B-A3B; the hybrid
+  Mamba-2 + attention + latent-MoE layout). The scheduler hook itself is model-agnostic —
+  it needs a drafter that implements the block-draft API below and a target forward that
+  can stash aux hidden states.
+* **Drafter artifacts**, looked up in the target's model directory:
+  1. `dspark-native/model.safetensors` — an MLX-native NVFP4 repack of NVIDIA's checkpoint
+     (bit-exact nibbles, `mode="nvfp4"`, group 16, global scales retained). Loaded at
+     native precision; `markov_w2` is dequantized exactly to BF16 because it is consumed
+     by row gathers.
+  2. `dspark/weights.safetensors` — BF16, produced by `scripts/prepare_dspark_weights.py`
+     from NVIDIA's NVFP4 checkpoint (fp4-e2m1 nibbles × fp8-e4m3 block scales × fp32 global
+     scale). Re-quantized to 8-bit/group-64 at load. DSpark was trained at NVFP4, so 8-bit
+     is finer than its native format; measured acceptance is identical to artifact 1.
+  * `dspark/config.json` (NVIDIA's config) is always required. The draft vocab (131072) is
+    the real tokenizer vocab; the target's 248320 is lm_head padding, so id mapping is the
+    identity and the drafter borrows the target's lm_head sliced to 131072 rows.
+
+### How DSpark drafts
+
+* **EAGLE lineage:** the drafter is conditioned on the target's internal hidden states
+  after layers `[1, 5, 19, 29, 41, 51]`.
+* **DFlash context trick:** the drafter never runs its 6 layers over the context. For each
+  token the target processes, the 6 tapped states are concatenated (6×2688), fused by a
+  learned `fc` to 2688, RMS-normed, and projected through each draft layer's K/V heads
+  directly into that layer's KV cache. Context cost ≈ a few GEMVs per token (~0.6 ms).
+* **One parallel block per round:** the query is `[anchor, mask×N]`, the anchor being the
+  newest sampled target token and the masks (id 990) sitting at the positions they predict.
+  One (1+N)-wide pass through the 6-layer drafter (attention with per-head sink logits and
+  a 1024-token sliding window) yields all N predictions at once.
+* **Markov fix-up:** parallel drafting cannot see intra-block dependencies, so a rank-512
+  head walks left to right adding `markov_w2(markov_w1[prev])` to each position's base
+  logits before the argmax. Scored over the top-64 base candidates only (vLLM's gathered
+  top-k), so the whole chain stays lazy with one sync per round.
+
+### Draft-block API and fallback behavior
+
+A drafter is any object with:
+
+```text
+block_size: int
+context_length: int
+reset_context() -> None
+append_context(aux_cat: [n, num_aux*hidden]) -> None   # positions ctx_len .. ctx_len+n-1
+draft(anchor_id: int, target_lm_head, n_draft: int) -> list[int]   # 1..n_draft ids
+```
+
+`draft` may return fewer than `n_draft` tokens (adaptive block length:
+`--spec-draft-margin-tau` stops at the first position whose Markov-adjusted top-1/top-2
+margin falls below tau; every wasted draft position costs a full routed-expert read in
+the verify).
+
+Fallbacks, all logged and counted in `/v1/status`:
+
+| condition | behavior |
+|---|---|
+| no drafter in the model directory | warning at load, server runs plain decode |
+| request is not greedy (`temperature != 0`) | generator created without the hook |
+| generation batch holds >1 sequence, or logits processors | stock step for that call; hook re-arms when the batch is a single sequence again |
+| another request merges into the batch, or a request's cache is extracted (finish/abort), while verified-but-unemitted tokens are in the cache | the cache is rewound to the emitted prefix first (`despeculations += 1`); speculation stays off for that request |
+| drafter context ≠ target cache at a cycle (prefix-cache hit, another request's prefill, batch change) | spec off for that request, `context_disables += 1` |
+| KV cache no longer trimmable (`--max-kv-size` reached) | spec off for that request, `bounded_kv_disables += 1` |
+| any exception in draft/verify | spec off for that request, `errors += 1`; the cache is rewound to the emitted prefix |
+
+### k-wide verify acceptance semantics
+
+The verify forward runs `[P, d1..dk]` in one call. Position `i` of its logits is what the
+target emits after `[.., P, d1..di]`. With `v[i] = argmax` at position `i`:
+
+* `m` = number of leading positions with `v[i] == d[i+1]` (a prefix: once a position
+  disagrees, nothing after it counts, because it was conditioned on the wrong token).
+* `c = v[m]` is the target's own token at the first disagreement, or the bonus token after
+  a fully accepted block. It is emitted too, so a round nets `m + 1` tokens and a round
+  with `m = 0` still makes progress.
+
+(`vllm_mlx/spec_utils.longest_accepted_prefix`, unit-tested without MLX.)
+
+### KV / recurrent-state rollback
+
+Lightning is 23 Mamba + 23 MoE + 6 attention layers. KV caches can be trimmed to un-process
+rejected tokens; recurrent state cannot be rewound. Per round:
+
+1. Snapshot the Mamba layers' state arrays before the verify. MLX cache updates reassign
+   the state arrays rather than mutating them, so holding the references *is* a snapshot
+   (verified empirically; #710 measures the same kind of snapshot on a hybrid Qwen at
+   1.8 % of a step).
+2. Verify all `k+1` positions (cache advances by `k+1`).
+3. Full accept: nothing to undo. The post-`dk` logits are kept, so the bonus token costs no
+   forward.
+4. Partial accept: trim the KV caches by `k+1`, restore the Mamba snapshots, and re-advance
+   `[P, d1..dm, c]` in one `(m+2)`-wide forward. Both cache types land exactly at the
+   emitted sequence. This re-advance is the hard floor a hybrid model imposes: an
+   attention-only target could keep the accepted prefix in place and trim only the tail.
+
+### Batch membership and mixed-request rules
+
+The hook lives on `GenerationBatch._step` (mlx-lm ≥ 0.31; the older
+`BatchGenerator._step` hook that #737 guards no longer exists). It is single-sequence by
+construction: any step where the generation batch holds more than one sequence, or any
+logits processor, runs the stock step.
+
+Between two steps of a round the cache is *ahead* of what has been emitted (it holds the
+verified-but-unemitted tokens), which stock code must never see. The hook tracks how far
+ahead it is and, before a batch merge (`GenerationBatch.extend`), a cache extraction
+(`extract_cache`, i.e. finish or abort) or an error fallback, rewinds to the pre-verify
+snapshot and re-advances exactly the tokens emitted since. After that the request decodes
+plainly for the rest of its life: its drafter context cannot be reconciled with the cache
+any more, and the context check (run every cycle, not only the first) fails closed. The
+same check catches another request's prefill landing in the aux stash between two steps —
+the taps cannot tell sequences apart, so a request that shares the server with a prefill
+loses speculation rather than drafting against a foreign context.
+
+Concurrent traffic on one server is therefore correct but not accelerated: the hook only
+pays off for stretches where one greedy request has the generator to itself. Generators are
+created per sampling params, so non-greedy requests never see the hook; the one pre-existing
+gap is upstream's rule that a generator is not recreated while requests are running, so a
+non-greedy request inserted into a hooked greedy generator is decoded with the stale sampler
+and speculated (same behavior as MTP today; noted for the maintainers). The MLLM path is
+untouched.
+
+### Greedy versus non-greedy correctness
+
+Greedy only. The install gate is `temperature == 0`, which `make_sampler` maps to a pure
+argmax regardless of `top_p`/`top_k`/`min_p`.
+
+"Byte-identical" is not the right bar, and the definition matters (asked in #699):
+
+* **Guaranteed:** every emitted token id is an argmax of the target's logits over the
+  emitted prefix. This is checkable after the fact by re-scoring the emitted sequence in a
+  plain forward.
+* **Not guaranteed, and not a bug:** identical token ids to a separate 1-wide greedy run.
+  bf16 logits computed at width 8 and width 1 differ in reduction order; where the target's
+  own top-1/top-2 gap is within that noise, the two runs may break the tie differently.
+  Measured: 1 flip in 199 positions, at a gap of exactly 0.0000.
+* Decoded bytes follow from token ids, so the same statements hold for them.
+
+Proposed acceptance test: (a) re-scored argmax agreement at 100 % of emitted positions,
+and (b) any divergence from the 1-wide run must sit at a position whose 1-wide top-1/top-2
+gap is ≤ bf16 epsilon of the logit magnitude. Non-greedy (rejection-sampling) verification
+is a follow-up; the verify forward already produces the full distributions it needs.
+
+### Metrics
+
+`GET /v1/status` → `spec_decode`:
+
+| field | meaning |
+|---|---|
+| `rounds` | draft/verify rounds attempted |
+| `drafted` / `accepted` | draft tokens proposed / accepted |
+| `acceptance_rate` | `accepted / drafted` (per-token) |
+| `mean_accept_len` | `accepted / rounds`; tokens per round is this + 1 (bonus or corrected token) |
+| `rounds_full` | rounds where the entire block was accepted |
+| `context_disables` | requests where spec turned itself off at the context check |
+| `bounded_kv_disables` | requests where spec turned itself off because the KV cache was no longer trimmable |
+| `despeculations` | times the cache was rewound to the emitted prefix ahead of a batch merge or extraction |
+| `errors` | requests where spec turned itself off on an exception |
+| `active` | whether the current request still has spec enabled |
+
+Counters are cumulative across generator replacements (same pattern as the MTP counters).
+
+### Benchmark matrix
+
+What a throughput or output-fidelity claim for this path needs to state:
+
+| dimension | values |
+|---|---|
+| target | Lightning 30B-A3B 6-bit (primary); BF16 (precision control) |
+| drafter artifact | native NVFP4; BF16→8-bit (must agree) |
+| `k` (`--spec-num-draft-tokens`) | 1, 2, 3, 4, 5, 7 |
+| `--spec-draft-margin-tau` | off, 1.0, 1.5, 2.0 |
+| prompts | SPEED-Bench real categories (coding, multilingual, qa, rag, writing) + one fixed 512-token code prompt for steady-state timing |
+| regime | single stream, `temperature 0`, `--disable-prefix-cache`, warm cache (report the depth) |
+| throughput | whole-request tok/s and steady-state decode tok/s, each vs plain greedy on the same server build |
+| acceptance | `mean_accept_len`, `acceptance_rate`, `rounds_full` |
+| fidelity | re-scored argmax agreement; divergence count vs 1-wide run with the 1-wide top-1/top-2 gap at each divergence |
+| verify-width curve | ms/step at widths 1, 2, 3, 5, 8 on the same cache depth (the number that predicts everything else) |
+| environment | chip / memory, `mlx`, `mlx-lm`, vllm-mlx tree |
+
+The measurements on this page: M5 Max 128 GB, mlx-lm 0.31, vllm-mlx at the #699 spike
+tree (fork branch, June 2026 base), 2026-08-13 to 08-15.
+
+## Limitations
+
+* Greedy, single-sequence, NemotronH targets only.
+* Prefix-cache hits disable speculation for that request (no aux states exist for cached
+  tokens). Re-deriving them from a cached prefix is possible but not implemented.
+* A stop or `max_tokens` inside a block wastes the already-verified trailing tokens (the
+  cache handed back at finish is rewound to the emitted prefix, so nothing leaks into the
+  prefix cache).
+* Not profitable on current MLX kernels; see the width curve. Ship-worthy once the routed
+  expert gather batches across the verify block.
+
+## Bugs worth knowing about (each cost real hours)
+
+* **fp8-e4m3 block scales read as integers.** NVFP4 block scales are e4m3 *bit patterns*
+  in a uint8 tensor; `astype(float32)` silently yields 0–255. Teacher-forced agreement was
+  15.6 % with the bug and 29.9 % after decoding the pattern. If a converted checkpoint
+  "mostly works", check the scales first (`vllm_mlx/spec_utils.fp8_e4m3_to_float`).
+* **A BF16 drafter defeats itself.** 967M parameters in BF16 is 1.9 GB; a draft round then
+  reads as many bytes as a target step (~8 ms measured). 8-bit quantization takes the
+  round from 6.1 to ~4 ms with identical agreement, because the drafter was trained at
+  4-bit.
+* **Full-vocab Markov per step.** The naive sequential loop reads a 131k×512 matrix and
+  syncs the GPU 7 times per round. Scoring only the top-64 base candidates makes the whole
+  chain lazy with one sync per round.
+* **Clearing the aux stash on a new request** starved the context check and disabled
+  speculation for every request after the first: at that moment the stash already holds
+  the new request's prompt states.

--- a/docs/guides/speculative-decoding.md
+++ b/docs/guides/speculative-decoding.md
@@ -104,8 +104,10 @@ Per-round arithmetic at k=7: 28 ms verify + ~4 ms draft for a mean of ~4.2 kept 
 batched-expert kernels put the marginal near 1.1×/k.
 
 The ceiling in closed form, with `r` the fraction of rounds that need the re-advance and
-`k` the block: `1 / (r + (1 - r) / k)` ≈ 1.7× at the measured acceptance. A realistic
-~1.3× on this stack would need a single-forward commit path that hybrid models do not have.
+`k` the block: `1 / (r + (1 - r) / k)`, which is ≈ 1.15× at the measured r = 0.85 and k = 7.
+(An earlier revision of this page said 1.7×; that was an arithmetic error.) The
+single-forward commit path that would remove the re-advance does not exist for hybrid
+models, so on this target the measured 0.83–0.87× is the number to plan around.
 
 The same curve explains why Lightning's built-in single-token MTP head breaks even here
 (74.5 % acceptance and still 106 vs 115–134 tok/s, see #710 for the equivalent measurement on

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ vllm-mlx brings native Apple Silicon GPU acceleration to vLLM by integrating:
 - [Tool Calling](guides/tool-calling.md)
 - [MCP & Tool Calling](guides/mcp-tools.md)
 - [Continuous Batching](guides/continuous-batching.md)
+- [Block Speculative Decoding (DSpark)](guides/speculative-decoding.md)
 - [Multi-Model Serving](guides/model-registry.md)
 
 ### Reference

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,6 +37,9 @@ vllm-mlx serve --models-config <yaml> [options]
 | `--mllm-draft-kind` | Assistant drafter kind. Use `mtp` for continuous batching. | None |
 | `--mllm-draft-block-size` | Speculative block size passed to mlx-vlm. | None |
 | `--default-mllm-draft` | Enable the configured assistant by default. Requests can override with `mllm_draft`. | False |
+| `--spec-draft` | Block-draft speculative decoding (`dspark`, NemotronH targets). Requires `--continuous-batching`; greedy single-stream requests only. See [Speculative Decoding](../guides/speculative-decoding.md). | None |
+| `--spec-num-draft-tokens` | Draft tokens per speculative round (max 7 for DSpark). | 7 |
+| `--spec-draft-margin-tau` | Adaptive block length: stop drafting where the draft margin falls below this value. | None |
 | `--cache-memory-mb` | Cache memory limit in MB | Auto |
 | `--cache-memory-percent` | Fraction of RAM for cache | 0.20 |
 | `--no-memory-aware-cache` | Use legacy entry-count cache | False |

--- a/scripts/prepare_dspark_weights.py
+++ b/scripts/prepare_dspark_weights.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Prepare NVIDIA DSpark draft-model weights for MLX (Nemotron 3.5 Lightning).
+
+Downloads nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark (a single
+~1.3 GB safetensors), dequantizes every NVFP4-packed tensor to BF16, and saves
+<model-dir>/dspark/weights.safetensors + dspark/config.json. At serve time
+vllm_mlx/patches/nemotron_dspark.py re-quantizes the drafter to 8-bit (DSpark
+was trained at NVFP4, so 8-bit is finer than its native format).
+
+If you have an MLX-native NVFP4 repack of the same checkpoint, drop it at
+<model-dir>/dspark-native/model.safetensors instead; the loader prefers it
+and runs the drafter at native precision. Only dspark/config.json is needed
+from this script in that case (use --config-only).
+
+NVFP4 (modelopt): weights packed 2 x fp4-e2m1 per uint8, per-16-element block
+scales in fp8-e4m3 (`<name>_scale`), one global fp32 scale (`<name>_scale_2`).
+dequant = fp4_value * block_scale * global_scale. The block scales are e4m3
+BIT PATTERNS stored in a uint8 tensor — decode them, never cast them.
+
+Usage:
+    python prepare_dspark_weights.py --mlx-model-path <nemotron 6bit dir>
+        [--source nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark]
+        [--survey-only]      # just print tensor names/shapes and exit
+        [--config-only]      # write dspark/config.json only
+"""
+
+import argparse
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+# Make the pure-Python decode tables importable when run from a checkout.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vllm_mlx.spec_utils import FP4_E2M1_VALUES, fp8_e4m3_lut  # noqa: E402
+
+SOURCE = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark"
+
+
+def dequantize_nvfp4(packed, scales, global_scale, mx):
+    """Dequantize one modelopt NVFP4 tensor to BF16.
+
+    packed: uint8 [rows, cols/2] (low nibble = even column, high = odd)
+    scales: uint8 [rows, cols/16] holding fp8-e4m3 bit patterns
+    global_scale: fp32 scalar
+    """
+    fp4_lut = mx.array(FP4_E2M1_VALUES, dtype=mx.float32)
+    e4m3_lut = mx.array(fp8_e4m3_lut(), dtype=mx.float32)
+    lo = (packed & 0x0F).astype(mx.uint32)
+    hi = (packed >> 4).astype(mx.uint32)
+    vals = mx.stack([fp4_lut[lo], fp4_lut[hi]], axis=-1)
+    vals = vals.reshape(packed.shape[0], packed.shape[1] * 2)
+    s = e4m3_lut[scales.astype(mx.uint32)]
+    s = mx.repeat(s, 16, axis=-1)[:, : vals.shape[1]]
+    return (vals * s * global_scale).astype(mx.bfloat16)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    ap.add_argument("--mlx-model-path", required=True)
+    ap.add_argument("--source", default=SOURCE)
+    ap.add_argument("--survey-only", action="store_true")
+    ap.add_argument("--config-only", action="store_true")
+    ap.add_argument("--download-dir", default=None)
+    args = ap.parse_args()
+
+    import mlx.core as mx
+
+    mx.set_default_device(mx.cpu)
+
+    model_dir = Path(args.mlx_model_path).expanduser()
+    dl = Path(args.download_dir or (model_dir / "dspark-src"))
+    dl.mkdir(parents=True, exist_ok=True)
+
+    files = (
+        ["config.json"] if args.config_only else ["model.safetensors", "config.json"]
+    )
+    for fn in files:
+        dest = dl / fn
+        if not dest.exists():
+            url = f"https://huggingface.co/{args.source}/resolve/main/{fn}"
+            print(f"downloading {fn} ...")
+            r = subprocess.run(["curl", "-L", "-C", "-", "-o", str(dest), url])
+            if r.returncode != 0:
+                sys.exit(f"download failed: {fn}")
+
+    dst = model_dir / "dspark"
+    dst.mkdir(exist_ok=True)
+    (dst / "config.json").write_text((dl / "config.json").read_text())
+    if args.config_only:
+        print(f"wrote {dst / 'config.json'}")
+        return 0
+
+    raw = mx.load(str(dl / "model.safetensors"))
+    print(f"{len(raw)} tensors in source")
+
+    if args.survey_only:
+        for k in sorted(raw):
+            v = raw[k]
+            print(f"  {k:<70} {tuple(v.shape)} {v.dtype}")
+        return 0
+
+    out: dict = {}
+    n_dq = 0
+    for k in sorted(raw):
+        if k.endswith("_scale") or k.endswith("_scale_2"):
+            continue  # consumed alongside their base tensor
+        w = raw[k]
+        sk, gk = f"{k}_scale", f"{k}_scale_2"
+        if sk in raw:  # NVFP4-packed
+            gscale = raw[gk].astype(mx.float32) if gk in raw else mx.array(1.0)
+            w = dequantize_nvfp4(raw[k], raw[sk], gscale, mx)
+            n_dq += 1
+        elif w.dtype in (mx.float32, mx.float16):
+            w = w.astype(mx.bfloat16)
+        mx.eval(w)
+        out[k] = w
+
+    mx.save_safetensors(str(dst / "weights.safetensors"), out)
+    total = sum(v.nbytes for v in out.values())
+    print(
+        f"wrote {len(out)} tensors ({n_dq} dequantized from NVFP4, "
+        f"{total / 1e6:.0f} MB) -> {dst / 'weights.safetensors'}"
+    )
+
+    # quick sanity: no NaN/Inf, plausible magnitudes
+    for k in list(out)[:3] + list(out)[-3:]:
+        a = out[k].astype(mx.float32)
+        mabs = float(mx.abs(a).max())
+        if math.isnan(mabs) or math.isinf(mabs) or mabs > 1e4:
+            print(f"  WARNING {k}: max|w| = {mabs}")
+        else:
+            print(f"  ok {k}: max|w| = {mabs:.3g}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dspark_scheduler_step.py
+++ b/tests/test_dspark_scheduler_step.py
@@ -1,0 +1,423 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end check of the DSpark scheduler hook on a tiny hybrid NemotronH.
+
+Runs the real mlx-lm ``BatchGenerator`` over a randomly initialised
+Mamba + attention + MLP NemotronH, once plain and once with
+``_install_dspark`` driven by scripted drafters:
+
+* ``oracle``  — proposes exactly what the target will emit (all accepted)
+* ``garbage`` — always wrong (every round is a full rollback + re-advance)
+* ``half``    — right for two positions, then wrong (partial accept)
+
+In every case the speculative path must reproduce the plain greedy token
+sequence. That is the greedy-validity bar; the garbage and half cases
+exercise the KV trim + recurrent-state restore path on real caches. The
+comparison applies the acceptance bar from docs/guides/speculative-decoding.md:
+a divergence is tolerated only at a position where the plain run's own
+top-1/top-2 logit gap is below a tie threshold (a wider verify forward may
+round such a tie the other way). The seed is chosen so no such position
+exists, and generation runs on a CPU stream for determinism.
+The scripted drafters also assert that the anchor handed to them is the
+token they expect at the context position they track, which pins the
+position bookkeeping between the target cache, the aux-state stash and the
+drafter context.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+
+from mlx_lm.generate import BatchGenerator  # noqa: E402
+from mlx_lm.models.nemotron_h import Model, ModelArgs  # noqa: E402
+
+from vllm_mlx.patches.nemotron_dspark import _install_aux_taps  # noqa: E402
+from vllm_mlx.scheduler import _install_dspark, _SpecDecodeStatsState  # noqa: E402
+
+PATTERN = ["M", "*", "M", "-", "*", "M"]
+AUX_LAYERS = [0, 2, 4]
+HIDDEN = 32
+VOCAB = 97
+PROMPT = [3, 17, 5, 88, 41, 2, 9, 60, 33, 12, 7, 45]
+N_TOKENS = 40
+
+
+TIE_TOL = 1e-3  # plain-run top-1/top-2 gap below which a flip is a tie
+
+
+def _tiny_model(seed: int = 1) -> Model:
+    args = ModelArgs(
+        model_type="nemotron_h",
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=len(PATTERN),
+        max_position_embeddings=1024,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        attention_bias=False,
+        mamba_num_heads=4,
+        mamba_head_dim=8,
+        mamba_proj_bias=False,
+        ssm_state_size=8,
+        conv_kernel=4,
+        n_groups=1,
+        mlp_bias=False,
+        layer_norm_epsilon=1e-5,
+        use_bias=False,
+        use_conv_bias=True,
+        hybrid_override_pattern=PATTERN,
+    )
+    mx.random.seed(seed)
+    model = Model(args)
+    mx.eval(model.parameters())
+    return model
+
+
+class _ScriptedDraft:
+    """Stands in for DSparkDraft: same surface, scripted proposals."""
+
+    block_size = 8
+
+    def __init__(self, oracle, mode: str):
+        self.oracle = list(oracle)
+        self.mode = mode
+        self.calls = 0
+        self.diverged_at = None
+        self.reset_context()
+
+    def reset_context(self):
+        self._ctx_len = 0
+
+    @property
+    def context_length(self) -> int:
+        return self._ctx_len
+
+    def append_context(self, aux_cat):
+        assert aux_cat.ndim == 2 and aux_cat.shape[1] == len(AUX_LAYERS) * HIDDEN
+        self._ctx_len += int(aux_cat.shape[0])
+
+    def draft(self, anchor_id: int, target_lm_head, n_draft: int):
+        self.calls += 1
+        pos = self._ctx_len
+        if pos >= len(self.oracle):
+            # The hook drafts one more round after the token that hits
+            # max_tokens (it cannot know the batch is about to finish);
+            # those drafts are never emitted. Any proposal will do.
+            return [(anchor_id + 1) % VOCAB]
+        # The anchor should be the oracle token at the position we think the
+        # cache is at. Record the first mismatch (the test decides whether it
+        # was a tolerated tie or a real fault) and draft dummies from then on.
+        if self.diverged_at is None and self.oracle[pos] != anchor_id:
+            self.diverged_at = pos
+        if self.diverged_at is not None:
+            return [(anchor_id + 1) % VOCAB]
+        truth = self.oracle[pos + 1 : pos + 1 + n_draft]
+        if not truth:
+            return [(anchor_id + 1) % VOCAB]
+        wrong = [(t + 1) % VOCAB for t in truth]
+        if self.mode == "oracle":
+            return truth
+        if self.mode == "garbage":
+            return wrong
+        if self.mode == "half":
+            return truth[:2] + wrong[2:]
+        raise ValueError(self.mode)
+
+
+def _generate(model, install=None):
+    """Run one greedy request; returns (tokens, top1-top2 gap per position)."""
+    bg = BatchGenerator(
+        model,
+        max_tokens=N_TOKENS,
+        sampler=lambda x: mx.argmax(x, axis=-1),
+        prefill_step_size=5,  # several prompt chunks exercise the tap stash
+        stream=mx.new_stream(mx.cpu),  # deterministic, and off the GPU
+    )
+    if install is not None:
+        install(bg)
+    bg.insert([list(PROMPT)])
+    out, gaps = [], []
+    while True:
+        responses = bg.next_generated()
+        if not responses:
+            break
+        for r in responses:
+            out.append(int(r.token))
+            top2 = mx.topk(r.logprobs, 2)  # ascending
+            gaps.append(float(top2[1] - top2[0]))
+            if r.finish_reason is not None:
+                return out, gaps
+    return out, gaps
+
+
+@pytest.fixture(scope="module")
+def model_and_plain():
+    model = _tiny_model()
+    plain, gaps = _generate(model)
+    assert len(plain) == N_TOKENS
+    # A useful oracle must not be degenerate, and must have no near-ties so
+    # the comparison below is exact in practice.
+    assert len(set(plain)) > 3
+    assert min(gaps) > TIE_TOL
+    return model, plain, gaps
+
+
+def _assert_same_greedy_sequence(spec, plain, gaps, label):
+    first = next((i for i, (a, b) in enumerate(zip(spec, plain)) if a != b), None)
+    if first is None:
+        assert len(spec) == len(plain), label
+        return
+    assert gaps[first] < TIE_TOL, (
+        f"{label}: spec decode diverged from plain greedy at position {first} "
+        f"where the plain top-1/top-2 gap was {gaps[first]:.3e} (not a tie)"
+    )
+
+
+@pytest.mark.parametrize("mode", ["oracle", "garbage", "half"])
+def test_spec_decode_reproduces_plain_greedy(model_and_plain, mode):
+    model, plain, gaps = model_and_plain
+    drafter = _ScriptedDraft(PROMPT + plain, mode)
+
+    _install_aux_taps(model, AUX_LAYERS)
+    model.dspark = drafter
+    model._dspark_pending = []
+    model._dspark_collect = True
+    stats_state = _SpecDecodeStatsState()
+    try:
+
+        def _install(bg):
+            assert _install_dspark(
+                bg, model=model, num_draft_tokens=4, stats_state=stats_state
+            )
+
+        spec, _ = _generate(model, install=_install)
+    finally:
+        model._dspark_collect = False
+        model.dspark = None
+
+    _assert_same_greedy_sequence(spec, plain, gaps, mode)
+    assert (
+        drafter.diverged_at is None
+    ), f"{mode}: drafter anchor mismatch at position {drafter.diverged_at}"
+
+    c = stats_state.counters
+    assert c["errors"] == 0
+    assert c["context_disables"] == 0
+    assert c["rounds"] > 0 and drafter.calls == c["rounds"]
+    # The hook drafts one wasted round after the token that hits max_tokens;
+    # the scripted drafter answers it with a deliberately wrong proposal, so
+    # every mode tolerates exactly one rejected tail round.
+    if mode == "oracle":
+        assert c["drafted"] - c["accepted"] <= 1
+        assert c["rounds"] - c["rounds_full"] <= 1
+        # a 4-wide block accepted every round: far fewer rounds than tokens
+        assert c["rounds"] * 5 >= N_TOKENS
+    elif mode == "garbage":
+        assert c["accepted"] == 0
+        assert c["rounds_full"] == 0
+    else:
+        assert 0 < c["accepted"] < c["drafted"]
+        # only a round whose oracle tail is <= 2 tokens can be fully right
+        assert c["rounds_full"] <= 1
+
+
+def test_stats_snapshot_shape(model_and_plain):
+    model, plain, _ = model_and_plain
+    drafter = _ScriptedDraft(PROMPT + plain, "oracle")
+    _install_aux_taps(model, AUX_LAYERS)
+    model.dspark = drafter
+    model._dspark_pending = []
+    model._dspark_collect = True
+    try:
+        holder = {}
+
+        def _install(bg):
+            _install_dspark(bg, model=model, num_draft_tokens=7)
+            holder["bg"] = bg
+
+        _generate(model, install=_install)
+    finally:
+        model._dspark_collect = False
+        model.dspark = None
+
+    stats = holder["bg"].get_spec_decode_stats()
+    assert stats["mode"] == "dspark_block"
+    assert stats["num_draft_tokens"] == 7  # block_size 8 -> at most 7
+    assert stats["enabled"] is True
+    assert 0.0 < stats["acceptance_rate"] <= 1.0
+    assert stats["mean_accept_len"] > 1.0
+
+
+# --- cache invariant under batch changes, errors and extraction -----------------
+
+
+def _generate_schedule(model, schedule, install=None):
+    """Run several requests on one generator.
+
+    ``schedule`` is a list of ``(step_index, prompt)``: each prompt is
+    inserted just before that many ``next()`` calls have run. Returns
+    ``{uid: (tokens, gaps)}``.
+    """
+    bg = BatchGenerator(
+        model,
+        max_tokens=N_TOKENS,
+        sampler=lambda x: mx.argmax(x, axis=-1),
+        prefill_step_size=5,
+        stream=mx.new_stream(mx.cpu),
+    )
+    if install is not None:
+        install(bg)
+    pending = sorted(schedule)
+    out, finished, step = {}, set(), 0
+    while True:
+        while pending and pending[0][0] <= step:
+            _, prompt = pending.pop(0)
+            (uid,) = bg.insert([list(prompt)])
+            out[uid] = ([], [])
+        if not pending and len(finished) == len(out):
+            return out
+        _, responses = bg.next()
+        step += 1
+        assert step < 10_000, "generator never finished"
+        for r in responses:
+            toks, gaps = out[r.uid]
+            toks.append(int(r.token))
+            top2 = mx.topk(r.logprobs, 2)
+            gaps.append(float(top2[1] - top2[0]))
+            if r.finish_reason is not None:
+                finished.add(r.uid)
+
+
+def _arm(model, drafter):
+    _install_aux_taps(model, AUX_LAYERS)
+    model.dspark = drafter
+    model._dspark_pending = []
+    model._dspark_collect = True
+
+
+def _disarm(model):
+    model._dspark_collect = False
+    model.dspark = None
+
+
+PROMPT_B = [61, 4, 90, 15, 2, 33, 71, 8, 19, 50, 27, 44]
+
+
+def test_second_request_joining_mid_round_keeps_both_outputs(model_and_plain):
+    """A second request merging into the batch while the first holds
+    verified-but-unemitted tokens must not corrupt either output. The hook
+    rewinds the cache to the emitted prefix before the merge; both requests
+    then decode plainly and must match a plain run of the same schedule.
+
+    Oracle mode only: with a 7-wide fully accepted block a round spans 8
+    steps, so the merge (which takes ~3 steps of prefill) lands mid-round.
+    With rejected drafts a round is 2 steps and the every-cycle context
+    check switches speculation off before the merge can land.
+    """
+    mode = "oracle"
+    model, _, _ = model_and_plain
+    for n1 in range(2, 14):
+        schedule = [(0, PROMPT), (n1, PROMPT_B)]
+        plain = _generate_schedule(model, schedule)
+        uid_a, uid_b = sorted(plain)
+        drafter = _ScriptedDraft(PROMPT + plain[uid_a][0], mode)
+        stats_state = _SpecDecodeStatsState()
+        _arm(model, drafter)
+        try:
+            spec = _generate_schedule(
+                model,
+                schedule,
+                install=lambda bg: _install_dspark(
+                    bg, model=model, num_draft_tokens=7, stats_state=stats_state
+                ),
+            )
+        finally:
+            _disarm(model)
+        for uid in (uid_a, uid_b):
+            toks, gaps = plain[uid]
+            _assert_same_greedy_sequence(spec[uid][0], toks, gaps, f"{mode} n1={n1}")
+        assert drafter.diverged_at is None
+        c = stats_state.counters
+        assert c["errors"] == 0
+        if c["despeculations"] >= 1:
+            return  # the merge landed mid-round and was handled
+    pytest.fail("no insertion step exercised the de-speculation path")
+
+
+def test_exception_after_verify_rolls_back_and_falls_back(model_and_plain, monkeypatch):
+    """An exception after the verify forward must leave the cache at the
+    emitted prefix; the request then finishes on plain decode, still
+    matching plain greedy."""
+    import vllm_mlx.scheduler as sched
+
+    model, plain, gaps = model_and_plain
+    real = sched.longest_accepted_prefix
+    calls = {"n": 0}
+
+    def flaky(verified, drafted):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("injected after the verify forward")
+        return real(verified, drafted)
+
+    monkeypatch.setattr(sched, "longest_accepted_prefix", flaky)
+    drafter = _ScriptedDraft(PROMPT + plain, "oracle")
+    stats_state = _SpecDecodeStatsState()
+    holder = {}
+
+    def _install(bg):
+        _install_dspark(bg, model=model, num_draft_tokens=4, stats_state=stats_state)
+        holder["bg"] = bg
+
+    _arm(model, drafter)
+    try:
+        spec, _ = _generate(model, install=_install)
+    finally:
+        _disarm(model)
+
+    _assert_same_greedy_sequence(spec, plain, gaps, "injected failure")
+    assert drafter.diverged_at is None
+    c = stats_state.counters
+    assert c["errors"] == 1
+    assert c["rounds"] == 2  # the failing round was the last one attempted
+    assert holder["bg"].get_spec_decode_stats()["active"] is False
+
+
+def test_finished_request_cache_holds_only_emitted_tokens(model_and_plain):
+    """The cache handed back at finish must not carry verified-but-unemitted
+    tokens (it may be stored as a prefix-cache entry)."""
+    model, plain, _ = model_and_plain
+
+    def _run(install=None):
+        bg = BatchGenerator(
+            model,
+            max_tokens=N_TOKENS,
+            sampler=lambda x: mx.argmax(x, axis=-1),
+            prefill_step_size=5,
+            stream=mx.new_stream(mx.cpu),
+        )
+        if install is not None:
+            install(bg)
+        bg.insert([list(PROMPT)])
+        while True:
+            for r in bg.next_generated():
+                if r.finish_reason is not None:
+                    return r
+
+    def _kv_offset(cache):
+        return next(int(c.offset) for c in cache if hasattr(c, "keys"))
+
+    plain_final = _run()
+    assert _kv_offset(plain_final.prompt_cache) == len(PROMPT) + N_TOKENS
+
+    drafter = _ScriptedDraft(PROMPT + plain, "oracle")
+    _arm(model, drafter)
+    try:
+        spec_final = _run(
+            install=lambda bg: _install_dspark(bg, model=model, num_draft_tokens=7)
+        )
+    finally:
+        _disarm(model)
+    assert _kv_offset(spec_final.prompt_cache) == len(PROMPT) + N_TOKENS
+    assert list(spec_final.all_tokens) == list(plain_final.all_tokens)

--- a/tests/test_dspark_spec_decode.py
+++ b/tests/test_dspark_spec_decode.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for DSpark block speculative decoding (--spec-draft dspark).
+
+The first group needs no MLX and runs on every CI host: the acceptance
+semantics that make verified block decoding greedy-valid, and the NVFP4
+decode tables the weight-prep script relies on. The second group exercises
+the scheduler plumbing and is skipped where mlx-lm is not importable.
+"""
+
+import math
+
+import pytest
+
+from vllm_mlx.spec_utils import (
+    FP4_E2M1_VALUES,
+    fp8_e4m3_lut,
+    fp8_e4m3_to_float,
+    longest_accepted_prefix,
+)
+
+# --- acceptance semantics ------------------------------------------------------
+
+
+class TestLongestAcceptedPrefix:
+    def test_full_accept_returns_bonus_token(self):
+        # target agrees with every draft; verified[k] is the bonus token
+        m, correction = longest_accepted_prefix([5, 6, 7, 99], [5, 6, 7])
+        assert (m, correction) == (3, 99)
+
+    def test_first_mismatch_returns_targets_own_token(self):
+        m, correction = longest_accepted_prefix([5, 6, 42, 99], [5, 6, 7])
+        assert (m, correction) == (2, 42)
+
+    def test_zero_accept_still_yields_one_target_token(self):
+        # a "failed" round nets the corrected token, never zero progress
+        m, correction = longest_accepted_prefix([11, 12, 13, 14], [1, 2, 3])
+        assert (m, correction) == (0, 11)
+
+    def test_later_agreement_does_not_rescue_an_earlier_mismatch(self):
+        # acceptance is a prefix: once position 0 disagrees, nothing after
+        # it can be emitted (it was conditioned on the wrong token)
+        m, correction = longest_accepted_prefix([9, 2, 3, 4], [1, 2, 3])
+        assert (m, correction) == (0, 9)
+
+    def test_single_draft(self):
+        assert longest_accepted_prefix([1, 2], [1]) == (1, 2)
+        assert longest_accepted_prefix([3, 2], [1]) == (0, 3)
+
+    def test_length_contract_is_enforced(self):
+        with pytest.raises(ValueError, match="len\\(drafted\\) \\+ 1"):
+            longest_accepted_prefix([1, 2, 3], [1, 2, 3])
+
+
+# --- NVFP4 decode tables -------------------------------------------------------
+
+
+class TestFp8E4m3:
+    @pytest.mark.parametrize(
+        "byte, value",
+        [
+            (0x00, 0.0),
+            (0x38, 1.0),  # e=7 m=0 -> 1.0
+            (0x3C, 1.5),  # e=7 m=4
+            (0x40, 2.0),  # e=8 m=0
+            (0x08, 2.0**-6),  # smallest normal
+            (0x01, 2.0**-9),  # smallest subnormal
+            (0x7E, 448.0),  # largest finite e4m3fn value
+            (0xB8, -1.0),  # sign bit
+            (0xC0, -2.0),
+        ],
+    )
+    def test_known_values(self, byte, value):
+        assert fp8_e4m3_to_float(byte) == pytest.approx(value)
+
+    def test_nan_pattern(self):
+        assert math.isnan(fp8_e4m3_to_float(0x7F))
+        assert math.isnan(fp8_e4m3_to_float(0xFF))
+
+    def test_bit_pattern_is_not_the_integer(self):
+        # The bug this table exists to prevent: treating the byte as an int.
+        lut = fp8_e4m3_lut()
+        assert len(lut) == 256
+        assert lut[0x38] == 1.0 and lut[0x38] != 0x38
+        finite = [v for v in lut if not math.isnan(v)]
+        assert max(finite) == 448.0 and min(finite) == -448.0
+
+    def test_negative_zero_and_symmetry(self):
+        lut = fp8_e4m3_lut()
+        for b in range(0x7F):
+            assert lut[b | 0x80] == pytest.approx(-lut[b])
+
+    def test_out_of_range_rejected(self):
+        with pytest.raises(ValueError):
+            fp8_e4m3_to_float(256)
+
+
+def test_fp4_e2m1_table():
+    assert len(FP4_E2M1_VALUES) == 16
+    assert FP4_E2M1_VALUES[:8] == (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+    for i in range(8):
+        assert FP4_E2M1_VALUES[i + 8] == -FP4_E2M1_VALUES[i]
+
+
+# --- scheduler plumbing (needs mlx-lm) ------------------------------------------
+
+mlx_lm = pytest.importorskip("mlx_lm")
+
+
+def test_scheduler_config_accepts_dspark_and_rejects_bad_values():
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    cfg = SchedulerConfig(spec_draft="dspark", spec_num_draft_tokens=4)
+    assert cfg.spec_draft == "dspark"
+    assert cfg.spec_num_draft_tokens == 4
+    assert cfg.spec_draft_margin_tau is None
+    with pytest.raises(ValueError, match="spec_draft"):
+        SchedulerConfig(spec_draft="eagle")
+    with pytest.raises(ValueError, match="spec_num_draft_tokens"):
+        SchedulerConfig(spec_draft="dspark", spec_num_draft_tokens=0)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SchedulerConfig(spec_draft="dspark", enable_mtp=True)
+
+
+def test_sampling_is_greedy_follows_temperature_only():
+    from vllm_mlx.request import SamplingParams
+    from vllm_mlx.scheduler import _sampling_is_greedy
+
+    # make_sampler(temp=0) is argmax regardless of the other knobs
+    assert _sampling_is_greedy(SamplingParams(temperature=0.0, top_p=0.9))
+    assert _sampling_is_greedy(SamplingParams(temperature=0))
+    assert not _sampling_is_greedy(SamplingParams(temperature=0.2, top_p=1.0))
+    assert not _sampling_is_greedy(object())
+
+
+def test_install_dspark_noops_without_drafter(caplog):
+    import logging
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import _install_dspark
+
+    class _GB:
+        def _step(self):
+            raise AssertionError("must not be called")
+
+    bg = SimpleNamespace(_generation_batch=_GB(), _next=lambda: [])
+    model = SimpleNamespace()  # no .dspark
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+        assert _install_dspark(bg, model=model) is False
+    assert not hasattr(bg, "get_spec_decode_stats")
+    assert bg._next.__name__ == "<lambda>"  # untouched
+    assert any("[DSpark] disabled" in rec.message for rec in caplog.records)
+
+
+def test_install_dspark_noops_without_step_hook(caplog):
+    import logging
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import _install_dspark
+
+    bg = SimpleNamespace(_generation_batch=object(), _next=lambda: [])
+    model = SimpleNamespace(dspark=object())
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+        assert _install_dspark(bg, model=model) is False
+    assert any("_step" in rec.message for rec in caplog.records)
+
+
+def test_scheduler_without_drafter_creates_generator_and_warns(caplog):
+    """Real construction path: --spec-draft dspark with no drafter loaded must
+    warn once and hand back a working generator (plain decode)."""
+    import logging
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import Request, SamplingParams, Scheduler, SchedulerConfig
+
+    model = SimpleNamespace()  # no .dspark
+    tokenizer = SimpleNamespace(
+        encode=lambda text: list(range(len(text.split()))),
+        decode=lambda ids: " ".join(str(i) for i in ids),
+        eos_token_id=0,
+        eos_token_ids={0},
+    )
+    scheduler = Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(enable_prefix_cache=False, spec_draft="dspark"),
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.scheduler"):
+        bg = scheduler._create_batch_generator(SamplingParams(temperature=0.0))
+    assert bg is not None
+    assert not hasattr(bg, "get_spec_decode_stats")
+    assert any("no drafter is loaded" in rec.message for rec in caplog.records)
+    assert "spec_decode" not in scheduler.get_stats()
+
+    scheduler.add_request(
+        Request(
+            request_id="dspark-1",
+            prompt="hello there",
+            sampling_params=SamplingParams(max_tokens=4, temperature=0.0),
+        )
+    )
+    assert scheduler.has_requests()
+
+
+def test_scheduler_skips_dspark_for_non_greedy_requests(caplog):
+    import logging
+    from types import SimpleNamespace
+
+    from vllm_mlx.scheduler import SamplingParams, Scheduler, SchedulerConfig
+
+    model = SimpleNamespace(dspark=object())
+    tokenizer = SimpleNamespace(
+        encode=lambda text: [1, 2, 3],
+        decode=lambda ids: "x",
+        eos_token_id=0,
+        eos_token_ids={0},
+    )
+    scheduler = Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(enable_prefix_cache=False, spec_draft="dspark"),
+    )
+    with caplog.at_level(logging.INFO, logger="vllm_mlx.scheduler"):
+        bg = scheduler._create_batch_generator(SamplingParams(temperature=0.7))
+    assert not hasattr(bg, "get_spec_decode_stats")
+    assert any("not greedy" in rec.message for rec in caplog.records)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -126,6 +126,20 @@ def serve_command(args):
     if mllm_draft_model and (args.auto_unload_idle_seconds > 0 or args.lazy_load_model):
         print("Error: --mllm-draft-model is not supported with lifecycle residency yet")
         sys.exit(1)
+    spec_draft = getattr(args, "spec_draft", None)
+    if spec_draft:
+        if not args.continuous_batching:
+            print("Error: --spec-draft requires --continuous-batching")
+            sys.exit(1)
+        if getattr(args, "mllm", False):
+            print("Error: --spec-draft is not supported with --mllm")
+            sys.exit(1)
+        if args.enable_mtp:
+            print("Error: --spec-draft and --enable-mtp are mutually exclusive")
+            sys.exit(1)
+        if args.spec_num_draft_tokens < 1:
+            print("Error: --spec-num-draft-tokens must be at least 1")
+            sys.exit(1)
 
     # Configure server security settings
     server._api_key = args.api_key
@@ -316,6 +330,10 @@ def serve_command(args):
             enable_mtp=args.enable_mtp,
             mtp_num_draft_tokens=args.mtp_num_draft_tokens,
             mtp_optimistic=args.mtp_optimistic,
+            # Block-draft speculative decoding (DSpark)
+            spec_draft=args.spec_draft,
+            spec_num_draft_tokens=args.spec_num_draft_tokens,
+            spec_draft_margin_tau=args.spec_draft_margin_tau,
             # KV cache quantization
             kv_cache_quantization=args.kv_cache_quantization,
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
@@ -341,6 +359,13 @@ def serve_command(args):
                     "MTP: MLLM path currently uses effective_draft_tokens=1 "
                     "per verify step; inspect /v1/status for attempts and acceptance"
                 )
+        if args.spec_draft:
+            print(
+                f"Speculative decoding: {args.spec_draft} block draft, "
+                f"draft_tokens={args.spec_num_draft_tokens}, "
+                f"margin_tau={args.spec_draft_margin_tau} "
+                "(greedy single-stream requests only; see /v1/status spec_decode)"
+            )
         print(f"Stream interval: {args.stream_interval} tokens")
         if args.use_paged_cache:
             print(
@@ -1284,6 +1309,31 @@ Examples:
         default=False,
         help="Skip MTP acceptance check for maximum speed. "
         "~5-10%% wrong tokens. Best for chat, not for code.",
+    )
+    # Block-draft speculative decoding (DSpark)
+    serve_parser.add_argument(
+        "--spec-draft",
+        choices=["dspark"],
+        default=None,
+        help="Block-draft speculative decoding. 'dspark' uses the NVIDIA DSpark "
+        "drafter: NemotronH targets, requires --continuous-batching and the "
+        "drafter weights in the model dir (see docs/guides/speculative-decoding.md). "
+        "Engages for greedy (temperature 0) single-stream requests only.",
+    )
+    serve_parser.add_argument(
+        "--spec-num-draft-tokens",
+        type=int,
+        default=7,
+        help="Draft tokens per speculative round (max block_size-1 = 7 for DSpark). "
+        "Default: 7",
+    )
+    serve_parser.add_argument(
+        "--spec-draft-margin-tau",
+        type=float,
+        default=None,
+        help="Adaptive block length: stop drafting at the first position whose "
+        "top1-top2 draft margin falls below this value (e.g. 1.5). Default: off "
+        "(always draft the full block).",
     )
     # Prefill step size
     serve_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -137,7 +137,7 @@ def serve_command(args):
         if args.enable_mtp:
             print("Error: --spec-draft and --enable-mtp are mutually exclusive")
             sys.exit(1)
-        if args.spec_num_draft_tokens < 1:
+        if getattr(args, "spec_num_draft_tokens", 7) < 1:
             print("Error: --spec-num-draft-tokens must be at least 1")
             sys.exit(1)
 
@@ -331,9 +331,9 @@ def serve_command(args):
             mtp_num_draft_tokens=args.mtp_num_draft_tokens,
             mtp_optimistic=args.mtp_optimistic,
             # Block-draft speculative decoding (DSpark)
-            spec_draft=args.spec_draft,
-            spec_num_draft_tokens=args.spec_num_draft_tokens,
-            spec_draft_margin_tau=args.spec_draft_margin_tau,
+            spec_draft=getattr(args, "spec_draft", None),
+            spec_num_draft_tokens=getattr(args, "spec_num_draft_tokens", 7),
+            spec_draft_margin_tau=getattr(args, "spec_draft_margin_tau", None),
             # KV cache quantization
             kv_cache_quantization=args.kv_cache_quantization,
             kv_cache_quantization_bits=args.kv_cache_quantization_bits,
@@ -359,11 +359,11 @@ def serve_command(args):
                     "MTP: MLLM path currently uses effective_draft_tokens=1 "
                     "per verify step; inspect /v1/status for attempts and acceptance"
                 )
-        if args.spec_draft:
+        if getattr(args, "spec_draft", None):
             print(
                 f"Speculative decoding: {args.spec_draft} block draft, "
-                f"draft_tokens={args.spec_num_draft_tokens}, "
-                f"margin_tau={args.spec_draft_margin_tau} "
+                f"draft_tokens={getattr(args, 'spec_num_draft_tokens', 7)}, "
+                f"margin_tau={getattr(args, 'spec_draft_margin_tau', None)} "
                 "(greedy single-stream requests only; see /v1/status spec_decode)"
             )
         print(f"Stream interval: {args.stream_interval} tokens")

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -496,6 +496,11 @@ class BatchedEngine(BaseEngine):
             tokenizer_config=tokenizer_config,
         )
 
+        # DSpark block-draft speculative decoding (--spec-draft dspark):
+        # attach the drafter and the aux-hidden-state taps it feeds on.
+        if getattr(self._scheduler_config, "spec_draft", None) == "dspark":
+            self._inject_dspark_drafter()
+
         # Validate MTP support if enabled
         if self._scheduler_config and self._scheduler_config.enable_mtp:
             from ..patches.qwen3_5_mtp import validate_mtp_support as validate_35
@@ -510,6 +515,44 @@ class BatchedEngine(BaseEngine):
                 )
 
         self._configure_metal_memory_limits()
+
+    def _inject_dspark_drafter(self) -> None:
+        """Load the DSpark drafter for a NemotronH text model (--spec-draft dspark).
+
+        Failure is logged and leaves generation unaffected: the scheduler
+        warns and runs plain decode when ``model.dspark`` is absent.
+        """
+        import json
+        from pathlib import Path
+
+        from mlx_lm.utils import _download
+
+        try:
+            model_path = Path(_download(self._model_name))
+            config_path = model_path / "config.json"
+            if not config_path.exists():
+                logger.warning(
+                    "[DSpark] no config.json at %s; not installing", model_path
+                )
+                return
+            with open(config_path) as f:
+                config = json.load(f)
+            if config.get("model_type") != "nemotron_h":
+                logger.warning(
+                    "[DSpark] --spec-draft dspark needs a nemotron_h target, got %r; "
+                    "not installing",
+                    config.get("model_type"),
+                )
+                return
+            from ..patches.nemotron_dspark import inject_dspark_support
+
+            margin_tau = getattr(self._scheduler_config, "spec_draft_margin_tau", None)
+            if inject_dspark_support(
+                self._model, model_path, config, margin_tau=margin_tau
+            ):
+                logger.info("[DSpark] drafter injected")
+        except Exception:
+            logger.exception("[DSpark] drafter injection failed; continuing without it")
 
     def _configure_metal_memory_limits(self) -> None:
         """Make MLX allocation failures graceful during startup."""

--- a/vllm_mlx/patches/nemotron_dspark.py
+++ b/vllm_mlx/patches/nemotron_dspark.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+DSpark block drafter for NemotronH (Nemotron 3.5 Lightning) on MLX.
+
+Port of the DSpark/DFlash semantics from vLLM (``qwen3_dspark.py``,
+``qwen3_dflash.py`` and the DSpark speculator), restricted to the
+single-sequence greedy regime that vllm-mlx's scheduler spec path serves.
+
+How DSpark works (the parts that matter here):
+
+* The draft NEVER runs its own layers over the context. For every token the
+  TARGET processes, the target's hidden states after layers
+  ``target_layer_ids`` ([1, 5, 19, 29, 41, 51] for Lightning) are
+  concatenated (6 x hidden), fused by ``fc`` to hidden, RMS-normed, and
+  projected through each draft layer's K/V heads straight into that layer's
+  context KV cache. Context cost per token is a few GEMVs, not a 6-layer
+  forward. The aux states come from :func:`_install_aux_taps`, which patches
+  the target's forward to stash them (prompt chunks included).
+
+* One draft round is ONE parallel forward of a ``(1 + N)``-token query block
+  ``[anchor, mask * N]`` (``mask_token_id`` = 990, ``N <= block_size - 1``).
+  Masks sit AT the positions they predict (``sample_from_anchor = false``).
+  Attention is causal within the block, sees the context KV through a
+  1024-token sliding window, and every head carries a learned attention-sink
+  logit (an extra softmax column that absorbs mass and is then dropped).
+
+* Sampling is semi-autoregressive: base logits for all N positions come from
+  the single parallel forward (through the TARGET's lm_head — the draft has
+  none), then a low-rank Markov head walks left to right adding a transition
+  bias conditioned on the previously chosen token,
+  ``logits_i = base_i + markov_w2(markov_w1[prev])``, greedy argmax.
+
+* Vocab: the draft speaks the real tokenizer vocab (131072). The target's
+  248320 is lm_head padding, so the draft<->target id mapping is the
+  identity, base logits are the target lm_head's first 131072 rows, and an
+  anchor id >= 131072 (added special tokens) is clamped to the mask id — the
+  round simply drafts poorly and verification cleans up.
+
+Two weight artifacts are accepted, checked in this order:
+
+1. ``<model>/dspark-native/model.safetensors`` — an MLX-native NVFP4 repack
+   of NVIDIA's checkpoint (bit-exact nibbles, ``mode="nvfp4"``, group 16,
+   global scales retained). Loaded at native precision.
+2. ``<model>/dspark/weights.safetensors`` — BF16 produced by
+   ``scripts/prepare_dspark_weights.py``, re-quantized to 8-bit at load.
+   DSpark was trained at NVFP4, so 8-bit is finer than its native format;
+   measured agreement is identical to path 1.
+
+``<model>/dspark/config.json`` (NVIDIA's config) is always required.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, List, Optional, Sequence
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TARGET_LAYER_IDS = (1, 5, 19, 29, 41, 51)
+
+
+class _DSparkAttention(nn.Module):
+    def __init__(self, cfg: dict):
+        super().__init__()
+        h = cfg["hidden_size"]
+        self.n_heads = cfg["num_attention_heads"]
+        self.n_kv = cfg["num_key_value_heads"]
+        self.head_dim = cfg["head_dim"]
+        self.scale = self.head_dim**-0.5
+        q_out = self.n_heads * self.head_dim
+        kv_out = self.n_kv * self.head_dim
+        self.q_proj = nn.Linear(h, q_out, bias=False)
+        self.k_proj = nn.Linear(h, kv_out, bias=False)
+        self.v_proj = nn.Linear(h, kv_out, bias=False)
+        self.o_proj = nn.Linear(q_out, h, bias=False)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=cfg["rms_norm_eps"])
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=cfg["rms_norm_eps"])
+        self.attention_sink_bias = mx.zeros((self.n_heads,))
+        self.rope_theta = cfg.get("rope_theta") or 10000
+
+
+class _DSparkMLP(nn.Module):
+    def __init__(self, cfg: dict):
+        super().__init__()
+        h, i = cfg["hidden_size"], cfg["intermediate_size"]
+        self.gate_proj = nn.Linear(h, i, bias=False)
+        self.up_proj = nn.Linear(h, i, bias=False)
+        self.down_proj = nn.Linear(i, h, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _DSparkLayer(nn.Module):
+    def __init__(self, cfg: dict):
+        super().__init__()
+        self.input_layernorm = nn.RMSNorm(cfg["hidden_size"], eps=cfg["rms_norm_eps"])
+        self.post_attention_layernorm = nn.RMSNorm(
+            cfg["hidden_size"], eps=cfg["rms_norm_eps"]
+        )
+        self.self_attn = _DSparkAttention(cfg)
+        self.mlp = _DSparkMLP(cfg)
+
+
+class _MarkovHead(nn.Module):
+    def __init__(self, vocab: int, rank: int):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(vocab, rank)
+        self.markov_w2 = nn.Linear(rank, vocab, bias=False)
+
+
+class _ScaledModule(nn.Module):
+    """Wrap a bias-free module so its output is multiplied by a constant.
+
+    Used to fold NVFP4 global scales (which MLX's ``nvfp4`` mode does not
+    model) into the module output: ``(g * W) @ x == g * (W @ x)``.
+    """
+
+    def __init__(self, inner, g: float):
+        super().__init__()
+        self.inner = inner
+        self._g = float(g)
+
+    def __call__(self, x):
+        return self.inner(x) * self._g
+
+
+class DSparkDraft(nn.Module):
+    """The drafter plus its single-sequence context KV state."""
+
+    def __init__(self, cfg: dict, margin_tau: Optional[float] = None):
+        super().__init__()
+        self.cfg = cfg
+        h = cfg["hidden_size"]
+        num_aux = int(cfg.get("num_aux_layers") or len(_target_layer_ids(cfg)))
+        self.embed_tokens = nn.Embedding(cfg["vocab_size"], h)
+        self.fc = nn.Linear(num_aux * h, h, bias=False)
+        self.hidden_norm = nn.RMSNorm(h, eps=cfg["rms_norm_eps"])
+        self.layers = [_DSparkLayer(cfg) for _ in range(cfg["num_hidden_layers"])]
+        self.norm = nn.RMSNorm(h, eps=cfg["rms_norm_eps"])
+        rank = cfg.get("markov_rank") or cfg.get("dspark_markov_rank") or 512
+        self.markov_head = _MarkovHead(cfg["vocab_size"], int(rank))
+
+        dflash = cfg.get("dflash_config") or {}
+        self.mask_token_id = int(
+            cfg.get("mask_token_id", dflash.get("mask_token_id", 990))
+        )
+        self.vocab_size = int(cfg["vocab_size"])
+        self.block_size = int(cfg.get("block_size") or 8)
+        self.window = int(
+            cfg.get("sliding_window") or dflash.get("swa_window_size") or 1024
+        )
+        # Adaptive block length: stop drafting at the first position whose
+        # Markov-adjusted top1-top2 margin falls below tau (None = always
+        # draft the full block). Every wasted draft position costs a full
+        # routed-expert read in the verify forward, so this trades a little
+        # acceptance for shorter, cheaper verifies.
+        self.margin_tau = margin_tau
+        self._sliced_lm_head = None
+        self.reset_context()
+
+    # -- context KV ---------------------------------------------------------
+
+    def reset_context(self) -> None:
+        n_l = len(self.layers)
+        self._ctx_k: List[Optional[mx.array]] = [None] * n_l  # [n, n_kv, head_dim]
+        self._ctx_v: List[Optional[mx.array]] = [None] * n_l
+        self._ctx_len = 0  # absolute positions represented so far
+
+    @property
+    def context_length(self) -> int:
+        return self._ctx_len
+
+    def append_context(self, aux_cat: mx.array) -> None:
+        """Append target aux states for positions ``ctx_len .. ctx_len+n-1``.
+
+        ``aux_cat``: ``[n, num_aux_layers * hidden]`` in sequence order.
+        """
+        n = aux_cat.shape[0]
+        ctx = self.hidden_norm(self.fc(aux_cat))  # [n, h]
+        pos0 = self._ctx_len
+        for li, layer in enumerate(self.layers):
+            a = layer.self_attn
+            k = a.k_proj(ctx).reshape(n, a.n_kv, a.head_dim)
+            k = a.k_norm(k)
+            k = mx.fast.rope(
+                k.transpose(1, 0, 2)[None],
+                a.head_dim,
+                traditional=False,
+                base=a.rope_theta,
+                scale=1.0,
+                offset=pos0,
+            )[0].transpose(1, 0, 2)
+            v = a.v_proj(ctx).reshape(n, a.n_kv, a.head_dim)
+            if self._ctx_k[li] is None:
+                self._ctx_k[li], self._ctx_v[li] = k, v
+            else:
+                self._ctx_k[li] = mx.concatenate([self._ctx_k[li], k], axis=0)
+                self._ctx_v[li] = mx.concatenate([self._ctx_v[li], v], axis=0)
+            # Sliding window: only the trailing window is ever attended to.
+            if self._ctx_k[li].shape[0] > self.window:
+                self._ctx_k[li] = self._ctx_k[li][-self.window :]
+                self._ctx_v[li] = self._ctx_v[li][-self.window :]
+        self._ctx_len += n
+        # No eager eval: the next draft/verify sync materializes these.
+
+    # -- draft round --------------------------------------------------------
+
+    def draft(self, anchor_id: int, target_lm_head, n_draft: int) -> List[int]:
+        """One block-draft round.
+
+        The anchor sits at position ``ctx_len``; the ``n_draft`` masks at the
+        following positions ARE the predictions. Returns up to ``n_draft``
+        token ids (greedy, Markov-biased); fewer when ``margin_tau`` cuts the
+        block short.
+        """
+        n_draft = max(1, min(int(n_draft), self.block_size - 1))
+        cfg_pos = self._ctx_len
+        n_q = 1 + n_draft
+        aid = anchor_id if anchor_id < self.vocab_size else self.mask_token_id
+        ids = mx.array([aid] + [self.mask_token_id] * n_draft)
+        x = self.embed_tokens(ids)  # [n_q, h]
+
+        for li, layer in enumerate(self.layers):
+            a = layer.self_attn
+            hn = layer.input_layernorm(x)
+            q = a.q_proj(hn).reshape(n_q, a.n_heads, a.head_dim)
+            k = a.k_proj(hn).reshape(n_q, a.n_kv, a.head_dim)
+            v = a.v_proj(hn).reshape(n_q, a.n_kv, a.head_dim)
+            q = a.q_norm(q)
+            k = a.k_norm(k)
+            q = mx.fast.rope(
+                q.transpose(1, 0, 2)[None],
+                a.head_dim,
+                traditional=False,
+                base=a.rope_theta,
+                scale=1.0,
+                offset=cfg_pos,
+            )[0].transpose(1, 0, 2)
+            k = mx.fast.rope(
+                k.transpose(1, 0, 2)[None],
+                a.head_dim,
+                traditional=False,
+                base=a.rope_theta,
+                scale=1.0,
+                offset=cfg_pos,
+            )[0].transpose(1, 0, 2)
+
+            ck, cv = self._ctx_k[li], self._ctx_v[li]
+            n_ctx = 0 if ck is None else ck.shape[0]
+            keys = k if ck is None else mx.concatenate([ck, k], axis=0)
+            vals = v if cv is None else mx.concatenate([cv, v], axis=0)
+
+            # [heads, n_q, n_ctx + n_q] with GQA repeat
+            rep = a.n_heads // a.n_kv
+            keys_h = mx.repeat(keys.transpose(1, 0, 2), rep, axis=0)
+            vals_h = mx.repeat(vals.transpose(1, 0, 2), rep, axis=0)
+            q_h = q.transpose(1, 0, 2)
+            scores = (q_h @ keys_h.transpose(0, 2, 1)) * a.scale
+
+            # Causal within the block + sliding window over absolute
+            # positions. Context keys hold positions
+            # [ctx_len - n_ctx .. ctx_len - 1]; query i sits at ctx_len + i.
+            q_pos = mx.arange(n_q)[:, None] + self._ctx_len
+            k_pos = mx.concatenate(
+                [
+                    mx.arange(n_ctx) + (self._ctx_len - n_ctx),
+                    mx.arange(n_q) + self._ctx_len,
+                ]
+            )[None, :]
+            visible = (k_pos <= q_pos) & (k_pos > q_pos - self.window)
+            scores = mx.where(visible[None], scores, mx.array(-mx.inf))
+
+            # Attention sink: an extra per-head logit column, dropped after
+            # the softmax (it only steals probability mass).
+            sink = mx.broadcast_to(
+                a.attention_sink_bias[:, None, None], (a.n_heads, n_q, 1)
+            )
+            probs = mx.softmax(
+                mx.concatenate([scores, sink], axis=-1).astype(mx.float32),
+                axis=-1,
+            )[..., :-1].astype(x.dtype)
+            attn = (probs @ vals_h).transpose(1, 0, 2).reshape(n_q, -1)
+            x = x + a.o_proj(attn)
+            x = x + layer.mlp(layer.post_attention_layernorm(x))
+
+        hidden = self.norm(x)[1:]  # mask positions only
+        head = self._sliced_lm_head
+        if head is None:
+            base = target_lm_head(hidden)[..., : self.vocab_size]
+        else:
+            base = head(hidden)  # [N, V_draft]
+
+        # Sequential Markov stage over a gathered top-k (vLLM's
+        # _sample_sequential_topk): the transition bias only ever needs to
+        # break ties among plausible candidates, so restrict each position to
+        # its top-k base logits and gather just those markov_w2 rows
+        # (k x rank) instead of the full vocab x rank head. Everything stays
+        # lazy — ONE eval for the whole block instead of one per draft.
+        k_top = 64
+        top_idx = mx.argpartition(-base, k_top - 1, axis=-1)[:, :k_top]  # [N, k]
+        top_vals = mx.take_along_axis(base, top_idx, axis=-1)  # [N, k]
+        w2 = self.markov_head.markov_w2.weight  # [V, r]
+
+        drafts = []
+        margins = []
+        prev = mx.array([aid])
+        for i in range(n_draft):
+            me = self.markov_head.markov_w1(prev)[0]  # [r]
+            bias_i = (w2[top_idx[i]] * me).sum(axis=-1)  # [k] gathered rows
+            cand = top_vals[i] + bias_i
+            top2 = mx.topk(cand, 2)  # ascending
+            margins.append(top2[1] - top2[0])
+            j = mx.argmax(cand, keepdims=True)
+            tok = mx.take(top_idx[i], j)  # [1]
+            drafts.append(tok)
+            prev = tok
+        out = mx.concatenate(drafts)
+        mg = mx.stack(margins)
+        mx.eval(out, mg)
+        toks = [int(t) for t in out]
+        tau = self.margin_tau
+        if tau is not None:
+            mgl = [float(v) for v in mg]
+            keep = len(toks)
+            for i in range(1, len(toks)):  # always keep at least one draft
+                if mgl[i] < tau:
+                    keep = i
+                    break
+            toks = toks[:keep]
+        return toks
+
+
+# -- loading ------------------------------------------------------------------
+
+
+def _target_layer_ids(cfg: dict) -> List[int]:
+    dflash = cfg.get("dflash_config") or {}
+    ids = dflash.get("target_layer_ids") or cfg.get("target_layer_ids")
+    return [int(i) for i in (ids or DEFAULT_TARGET_LAYER_IDS)]
+
+
+def _load_native_nvfp4(draft: DSparkDraft, native_file: Path) -> int:
+    """Load the MLX-native NVFP4 repack at native precision.
+
+    The quantized modules (fc, the MLPs, markov_w2) run at 4-bit
+    (``mode="nvfp4"``, group 16) — no precision confound against NVIDIA's
+    own checkpoint. The retained global scale folds into the module output
+    (bias-free linears). ``markov_w2`` is the exception: it is consumed via
+    row gathers, which packed quantized storage would scramble, so it is
+    dequantized exactly (f32 math, one uniform global factor) to BF16.
+    """
+    raw = mx.load(str(native_file))
+    quantized = {k[: -len(".global_scale")] for k in raw if k.endswith(".global_scale")}
+
+    def _is_quantized(path, module):
+        return path in quantized and "markov_w2" not in path
+
+    nn.quantize(
+        draft, group_size=16, bits=4, mode="nvfp4", class_predicate=_is_quantized
+    )
+
+    loadable = []
+    for key, value in raw.items():
+        if key.endswith(".global_scale"):
+            continue
+        if key.rsplit(".", 1)[0] == "markov_head.markov_w2":
+            continue  # handled below
+        loadable.append((key, value))
+    w2 = (
+        mx.dequantize(
+            raw["markov_head.markov_w2.weight"],
+            scales=raw["markov_head.markov_w2.scales"],
+            group_size=16,
+            bits=4,
+            mode="nvfp4",
+        ).astype(mx.float32)
+        * raw["markov_head.markov_w2.global_scale"]
+    )
+    loadable.append(("markov_head.markov_w2.weight", w2.astype(mx.bfloat16)))
+    draft.load_weights(loadable, strict=False)
+
+    def _fold(owner, attr, path):
+        setattr(
+            owner,
+            attr,
+            _ScaledModule(getattr(owner, attr), raw[path + ".global_scale"]),
+        )
+
+    _fold(draft, "fc", "fc")
+    for i, layer in enumerate(draft.layers):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            _fold(layer.mlp, proj, f"layers.{i}.mlp.{proj}")
+    mx.eval(draft.parameters())
+    return len(quantized)
+
+
+def _load_bf16_quantize_8bit(draft: DSparkDraft, weights_file: Path) -> None:
+    """Load the BF16 dequant and quantize the drafter to 8-bit (group 64).
+
+    BF16 is 1.9 GB — a full draft round then reads as many bytes as a TARGET
+    forward (~8 ms), destroying the speedup. Unlike an MTP head (trained in
+    BF16, collapses when quantized), DSpark was trained at NVFP4, so 8-bit is
+    strictly finer than its native format. Norms, the sink biases and
+    ``markov_w2`` (row-gathered) stay in floating point.
+    """
+    weights = list(mx.load(str(weights_file)).items())
+    draft.load_weights(weights, strict=False)
+
+    def _is_quantizable(path, module):
+        if "markov_w2" in path:
+            return False
+        if isinstance(module, (nn.Linear, nn.Embedding)):
+            return module.weight.shape[-1] % 64 == 0
+        return False
+
+    nn.quantize(draft, group_size=64, bits=8, class_predicate=_is_quantizable)
+    mx.eval(draft.parameters())
+
+
+def _slice_lm_head(draft: DSparkDraft, model) -> None:
+    """Slice the target's (quantized) lm_head to the draft vocab once.
+
+    Halves the per-round head cost (248320 -> 131072 rows). Quantized storage
+    is row-major, so a row slice stays valid. Falls back to the full head.
+    """
+    try:
+        lh = model.lm_head
+        if hasattr(lh, "scales"):
+            import copy
+
+            sl = copy.copy(lh)
+            sl.weight = lh.weight[: draft.vocab_size]
+            sl.scales = lh.scales[: draft.vocab_size]
+            if hasattr(lh, "biases"):
+                sl.biases = lh.biases[: draft.vocab_size]
+            mx.eval(sl.weight, sl.scales)
+            draft._sliced_lm_head = sl
+            logger.info("[DSpark] sliced lm_head to %d rows", draft.vocab_size)
+    except Exception:
+        logger.exception("[DSpark] lm_head slice failed — using the full head")
+
+
+def _install_aux_taps(model, aux_layer_ids: Sequence[int]) -> None:
+    """Patch the NemotronH model class so every forward can stash aux states.
+
+    While ``model._dspark_collect`` is true, each forward appends the
+    concatenated hidden states after ``aux_layer_ids`` to
+    ``model._dspark_pending`` as one ``[n, num_aux * hidden]`` chunk — prompt
+    chunks and decode steps alike, in sequence order. Only single-sequence
+    forwards are stashed; a multi-sequence forward clears the stash, which
+    makes the scheduler's context check fail closed for that request.
+
+    The forward mirrors ``mlx_lm.models.nemotron_h`` exactly (masks, cache
+    indexing, block dispatch); with the flag off it defers to the original.
+    """
+    model._dspark_aux_layers = [int(i) for i in aux_layer_ids]
+    if getattr(model, "_dspark_taps_installed", False):
+        return
+
+    from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+
+    base_cls = model.__class__
+
+    class _NemotronHWithDSparkTaps(base_cls):  # type: ignore[misc,valid-type]
+        def __call__(self, inputs, cache=None, **kwargs):
+            if not getattr(self, "_dspark_collect", False) or kwargs:
+                return super().__call__(inputs, cache=cache, **kwargs)
+            bb = self.backbone
+            hidden_states = bb.embeddings(inputs)
+            if cache is None:
+                cache = [None] * len(bb.layers)
+            attn_mask = create_attention_mask(hidden_states, cache[bb.fa_idx])
+            ssm_mask = create_ssm_mask(hidden_states, cache[bb.ssm_idx])
+            aux_ids = set(self._dspark_aux_layers)
+            aux = []
+            cache_counter = 0
+            for li, layer in enumerate(bb.layers):
+                if layer.block_type == "M" or layer.block_type == "*":
+                    c = cache[cache_counter]
+                    cache_counter += 1
+                else:
+                    c = None
+                mask = attn_mask if layer.block_type == "*" else ssm_mask
+                hidden_states = layer(hidden_states, mask=mask, cache=c)
+                if li in aux_ids:
+                    aux.append(hidden_states)
+            if aux and inputs.shape[0] == 1:
+                self._dspark_pending.append(mx.concatenate(aux, axis=-1)[0])
+            elif aux:
+                self._dspark_pending.clear()
+            return self.lm_head(bb.norm_f(hidden_states))
+
+    _NemotronHWithDSparkTaps.__name__ = base_cls.__name__ + "WithDSparkTaps"
+    _NemotronHWithDSparkTaps.__qualname__ = _NemotronHWithDSparkTaps.__name__
+    model.__class__ = _NemotronHWithDSparkTaps
+    model._dspark_pending = []
+    model._dspark_collect = False
+    model._dspark_taps_installed = True
+
+
+def inject_dspark_support(
+    model: Any,
+    model_path,
+    target_config: dict,
+    margin_tau: Optional[float] = None,
+) -> bool:
+    """Attach a :class:`DSparkDraft` to a NemotronH model as ``model.dspark``.
+
+    Requires ``<model_path>/dspark/config.json`` plus either the native
+    NVFP4 repack or the BF16 dequant (see the module docstring). Installs
+    the aux-state taps on the target and turns collection on. The
+    scheduler's spec step drives everything else. Returns True on success;
+    a False return leaves the model untouched and generation unaffected.
+    """
+    model_path = Path(model_path)
+    cfile = model_path / "dspark" / "config.json"
+    wfile = model_path / "dspark" / "weights.safetensors"
+    native = model_path / "dspark-native" / "model.safetensors"
+    if not cfile.exists() or not (wfile.exists() or native.exists()):
+        logger.info(
+            "[DSpark] no drafter at %s (need dspark/config.json plus "
+            "dspark-native/model.safetensors or dspark/weights.safetensors)",
+            model_path,
+        )
+        return False
+    if target_config.get("model_type") != "nemotron_h":
+        logger.warning(
+            "[DSpark] target model_type %r is not nemotron_h; not installing",
+            target_config.get("model_type"),
+        )
+        return False
+
+    cfg = json.loads(cfile.read_text())
+    draft = DSparkDraft(cfg, margin_tau=margin_tau)
+
+    if native.exists():
+        n_q = _load_native_nvfp4(draft, native)
+        logger.info("[DSpark] native NVFP4 weights loaded (%d quantized modules)", n_q)
+    else:
+        _load_bf16_quantize_8bit(draft, wfile)
+        logger.info("[DSpark] BF16 weights loaded and quantized to 8-bit")
+
+    # fc must have landed: all-zeros means the key mapping failed.
+    fc_weight = (
+        draft.fc.inner.weight
+        if isinstance(draft.fc, _ScaledModule)
+        else draft.fc.weight
+    )
+    if float(mx.abs(fc_weight.astype(mx.float32)).sum()) == 0.0:
+        logger.error(
+            "[DSpark] fc.weight is all zeros — key mapping failed; not installing"
+        )
+        return False
+
+    _slice_lm_head(draft, model)
+    _install_aux_taps(model, _target_layer_ids(cfg))
+    model.dspark = draft
+    model._dspark_pending = []
+    model._dspark_collect = True
+    logger.info(
+        "[DSpark] drafter ready: %d layers, vocab %d, block %d, aux layers %s, margin_tau=%s",
+        len(draft.layers),
+        draft.vocab_size,
+        draft.block_size,
+        model._dspark_aux_layers,
+        margin_tau,
+    )
+    return True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1736,8 +1736,9 @@ def _install_dspark(
             "errors": c["errors"],
             # per drafted token
             "acceptance_rate": (accepted / drafted) if drafted else 0.0,
-            # accepted drafts per round; each round also emits one target
-            # token (bonus or correction), so tokens/round = this + 1
+            # accepted drafts per round; a round also emits the target's own
+            # token after the accepted prefix (tokens/round = this + 1 after a
+            # full block, + 2 after a partial one: correction + next sample)
             "mean_accept_len": (accepted / rounds) if rounds else 0.0,
         }
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -28,6 +28,7 @@ from .paged_cache import PagedCacheManager
 from .ssd_cache import SSDCacheConfig, SSDCacheTier
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
+from .spec_utils import longest_accepted_prefix
 from .utils.mamba_cache import ensure_mamba_support
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,22 @@ class SchedulerConfig:
     mtp_num_draft_tokens: int = 1  # Number of draft tokens from MTP head
     mtp_optimistic: bool = False  # Skip acceptance check for max speed
 
+    # Block-draft speculative decoding (--spec-draft). Only "dspark" exists:
+    # the NVIDIA DSpark drafter for NemotronH targets, greedy single-sequence
+    # requests only. Mutually exclusive with enable_mtp (the CLI enforces it).
+    spec_draft: Optional[str] = None
+    spec_num_draft_tokens: int = 7  # draft tokens per round (<= block_size - 1)
+    spec_draft_margin_tau: Optional[float] = None  # adaptive block cut-off
+
     def __post_init__(self) -> None:
+        if self.spec_draft not in (None, "dspark"):
+            raise ValueError(
+                f"spec_draft must be None or 'dspark', got {self.spec_draft!r}"
+            )
+        if self.spec_num_draft_tokens < 1:
+            raise ValueError("spec_num_draft_tokens must be >= 1")
+        if self.spec_draft and self.enable_mtp:
+            raise ValueError("spec_draft and enable_mtp are mutually exclusive")
         if self.mllm_prefill_step_size is not None and self.mllm_prefill_step_size <= 0:
             raise ValueError("mllm_prefill_step_size must be > 0 when provided")
 
@@ -1289,6 +1305,457 @@ def _install_mtp(
     )
 
 
+@dataclass
+class _SpecDecodeStatsState:
+    """Cumulative block-spec-decode counters shared across generator instances."""
+
+    counters: Dict[str, int] = field(
+        default_factory=lambda: {
+            "rounds": 0,  # draft/verify rounds attempted
+            "drafted": 0,  # draft tokens proposed
+            "accepted": 0,  # draft tokens accepted
+            "rounds_full": 0,  # rounds where the whole block was accepted
+            "context_disables": 0,  # requests that turned spec off (context gap)
+            "bounded_kv_disables": 0,  # KV cache past --max-kv-size (untrimmable)
+            "despeculations": 0,  # cache rewound to the emitted prefix (batch change)
+            "errors": 0,
+        }
+    )
+    lock: Any = field(default_factory=Lock)
+
+
+def _sampling_is_greedy(sampling_params: Any) -> bool:
+    """True when the request samples by argmax.
+
+    ``mlx_lm.sample_utils.make_sampler(temp=0)`` returns a pure argmax
+    sampler regardless of top_p/top_k/min_p, so temperature alone decides.
+    """
+    temp = getattr(sampling_params, "temperature", None)
+    try:
+        return temp is not None and float(temp) == 0.0
+    except (TypeError, ValueError):
+        return False
+
+
+def _install_dspark(
+    batch_gen: "BatchGenerator",
+    model: Any,
+    num_draft_tokens: int = 7,
+    stats_state: Optional["_SpecDecodeStatsState"] = None,
+) -> bool:
+    """
+    Install DSpark block speculative decoding on an mlx-lm >= 0.31
+    BatchGenerator. Returns True when installed.
+
+    mlx-lm 0.31 moved decode into ``GenerationBatch._step``, which is
+    pipelined: each call RETURNS the token sampled by the PREVIOUS call
+    while advancing the cache by it. The hook keeps that contract and
+    spreads one speculative round over several calls:
+
+      cycle call    forward(t) -> P = argmax; DSpark drafts d1..dk (one
+                    parallel query-block forward + sequential Markov bias);
+                    verify [P, d1..dk] in ONE (k+1)-wide target forward.
+                    m = longest agreeing prefix (see longest_accepted_prefix).
+                    m == k: queue d1..dk; keep the post-dk logits for the
+                            next cycle (the bonus token needs no forward).
+                    m <  k: trim the KV caches by k+1, restore the recurrent
+                            snapshots, re-advance [P, d1..dm, c] in one
+                            forward where c is the verify pass's own
+                            corrected token — a "failed" round still nets
+                            m+1 new tokens; queue d1..dm, c.
+      pending calls emit one queued token each, NO forward.
+      skip call     sample the next P from the stored logits, no forward,
+                    and start the next cycle from there.
+
+    Correctness: every emitted token is an argmax of the target's logits
+    over the emitted prefix. The draft only changes speed. Divergence from
+    a plain 1-wide greedy run can only occur where the target's own top-1 /
+    top-2 logits tie within bf16 reduction-order noise at a different verify
+    width (measured: 1 flip in 199 positions, at a gap of exactly 0.0).
+
+    Hybrid caches: KV layers are trimmed; Mamba/recurrent layers cannot be
+    rewound, so their state arrays are snapshotted before the verify (mlx
+    caches reassign state arrays rather than mutating them, so holding the
+    references is a faithful snapshot) and restored on a partial accept.
+
+    Cache invariant. Between two steps of a round the cache is AHEAD of
+    what has been emitted (it holds the verified-but-not-yet-emitted
+    tokens), which the stock step must never see. The hook therefore
+    tracks how far ahead it is and, before anything that hands the cache to
+    stock code — a batch merge (``extend``), a cache extraction, an
+    exception — rewinds to the pre-verify snapshot and re-advances exactly
+    the tokens emitted since (``_despeculate``). Speculation then stays off
+    for that request, because its drafter context can no longer be
+    reconciled with the cache.
+
+    Gates: single-sequence batches only (any other composition runs the
+    stock step for that call), no logits processors, greedy sampling (the
+    install site only calls this for temperature 0), and trimmable KV
+    caches (a RotatingKVCache past ``--max-kv-size`` cannot be rolled
+    back). If the drafter's context does not line up with the target cache
+    at any cycle — a prefix-cache hit skipped the prompt forward, another
+    request's prefill landed in the aux stash, or the request was
+    de-speculated — spec decode disables itself for that request rather
+    than drafting against a wrong context.
+    """
+    gb0 = getattr(batch_gen, "_generation_batch", None)
+    if gb0 is None or not hasattr(type(gb0), "_step"):
+        logger.warning(
+            "[DSpark] disabled: mlx-lm BatchGenerator has no GenerationBatch._step "
+            "hook (expected mlx-lm >= 0.31). Generation continues without it."
+        )
+        return False
+    draft = getattr(model, "dspark", None)
+    if draft is None:
+        logger.warning("[DSpark] disabled: model has no drafter (model.dspark is None)")
+        return False
+    if stats_state is None:
+        stats_state = _SpecDecodeStatsState()
+    counters = stats_state.counters
+    lock = stats_state.lock
+
+    gb_cls = type(gb0)
+    _gb_cls_step = gb_cls._step  # unbound originals
+    _gb_cls_extend = gb_cls.extend
+    _gb_cls_extract = gb_cls.extract_cache
+    block_size = int(getattr(draft, "block_size", 8))
+    k = max(1, min(int(num_draft_tokens), block_size - 1))
+
+    st: Dict[str, Any] = {
+        "skip": None,  # logits to sample the next P from without a forward
+        "pending": deque(),  # (token, logprobs) already in the cache
+        "uids": None,
+        "installed_on": None,
+        "disabled": False,
+        # how far the cache is ahead of the emitted prefix, and what it
+        # takes to get back there
+        "snaps": {},  # recurrent-state snapshot taken before the verify
+        "advanced": 0,  # tokens fed since that snapshot
+        "emitted_since": [],  # of those, the ones already emitted, in order
+    }
+
+    def _bump(key: str, n: int = 1) -> None:
+        with lock:
+            counters[key] += n
+
+    def _reset() -> None:
+        st["skip"] = None
+        st["pending"].clear()
+        st["uids"] = None
+        st["snaps"] = {}
+        st["advanced"] = 0
+        st["emitted_since"] = []
+
+    def _disable(reason_key: str, msg: str, *args) -> None:
+        logger.warning("[DSpark] " + msg + " — spec decode off for this request", *args)
+        st["disabled"] = True
+        _bump(reason_key)
+
+    def _rnn_snapshot(prompt_cache):
+        """Snapshot every non-trimmable (recurrent) cache before a verify.
+
+        mlx-lm cache updates reassign the state arrays rather than mutating
+        them, so holding the references is a faithful snapshot. ArraysCache
+        also keeps per-sequence ``lengths`` / ``left_padding`` counters that
+        ``advance()`` decrements per processed token; they are captured too
+        so a rollback leaves them consistent.
+        """
+        snaps = {}
+        for ci, c in enumerate(prompt_cache):
+            if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
+                if hasattr(c, "state"):
+                    snaps[ci] = (
+                        list(c.state),
+                        getattr(c, "lengths", None),
+                        getattr(c, "left_padding", None),
+                    )
+        return snaps
+
+    def _rollback(prompt_cache, snaps, n_trim: int) -> None:
+        for c in prompt_cache:
+            if hasattr(c, "is_trimmable") and c.is_trimmable() and hasattr(c, "trim"):
+                c.trim(n_trim)
+        for ci, (state, lengths, left_padding) in snaps.items():
+            c = prompt_cache[ci]
+            c.state = state
+            if hasattr(c, "lengths"):
+                c.lengths = lengths
+            if hasattr(c, "left_padding"):
+                c.left_padding = left_padding
+
+    def _kv_trimmable(prompt_cache) -> bool:
+        for c in prompt_cache:
+            if hasattr(c, "keys") and hasattr(c, "is_trimmable"):
+                if not c.is_trimmable():
+                    return False
+        return True
+
+    def _cache_offset(prompt_cache) -> int:
+        for c in prompt_cache:
+            if hasattr(c, "offset") and hasattr(c, "keys"):
+                return int(c.offset)
+        return -1
+
+    def _drain_aux() -> None:
+        """Move every stashed aux chunk into the drafter's context KV."""
+        pending = model._dspark_pending
+        while pending:
+            draft.append_context(pending.pop(0))
+
+    def _despeculate(gb) -> None:
+        """Rewind the cache to exactly the emitted prefix and drop spec state.
+
+        After this the stock invariant holds: every token in the cache has
+        been emitted and ``gb._next_tokens`` is the next token to feed.
+        """
+        if st["advanced"]:
+            _rollback(gb.prompt_cache, st["snaps"], st["advanced"])
+            emitted = st["emitted_since"]
+            if emitted:
+                model(mx.array([emitted], dtype=mx.uint32), cache=gb.prompt_cache)
+            model._dspark_pending.clear()
+            draft.reset_context()
+            _bump("despeculations")
+        _reset()
+
+    def _finish_step(gb, inputs, primary, logprobs):
+        gb._next_tokens = primary
+        gb._next_logprobs = list(logprobs)
+        mx.async_eval(gb._next_tokens, gb._next_logprobs)
+        mx.eval(inputs, gb._current_logprobs)
+        inputs_l = inputs.tolist()
+        for sti, ti in zip(gb.tokens, inputs_l):
+            sti.append(ti)
+        return inputs_l, gb._current_logprobs
+
+    def _make_step(gb):
+        def _dspark_gb_step():
+            uids = tuple(gb.uids)
+            if len(uids) != 1 or any(gb.logits_processors):
+                if st["advanced"]:
+                    # A merge must have gone through _despeculate first; if
+                    # not, the cache is unreconcilable from here.
+                    logger.error(
+                        "[DSpark] batch changed with speculative state held; "
+                        "disabling for this request"
+                    )
+                    _bump("errors")
+                    st["disabled"] = True
+                _reset()
+                draft.reset_context()
+                return _gb_cls_step(gb)
+            if st["uids"] is not None and st["uids"] != uids:
+                # New request. Reset the draft context and re-enable, but do
+                # NOT clear model._dspark_pending: it already holds the new
+                # request's prompt aux states (the old request's were drained
+                # during its cycles). Clearing it here starves the context
+                # check and disables spec for every request after the first.
+                _reset()
+                draft.reset_context()
+                st["disabled"] = False
+            st["uids"] = uids
+            if st["disabled"]:
+                return _gb_cls_step(gb)
+
+            # ---- pending call: token already in the cache, just emit ----
+            if st["pending"]:
+                tok, lp = st["pending"].popleft()
+                gb._current_tokens = gb._next_tokens
+                gb._current_logprobs = gb._next_logprobs
+                inputs = gb._current_tokens
+                gb._next_tokens = mx.array([tok], dtype=mx.uint32)
+                gb._next_logprobs = [lp]
+                mx.eval(inputs, gb._current_logprobs)
+                inputs_l = inputs.tolist()
+                st["emitted_since"].append(int(inputs_l[0]))
+                for sti, ti in zip(gb.tokens, inputs_l):
+                    sti.append(ti)
+                return inputs_l, gb._current_logprobs
+
+            # ---- cycle call ----
+            gb._current_tokens = gb._next_tokens
+            gb._current_logprobs = gb._next_logprobs
+            inputs = gb._current_tokens
+            # Emitting `inputs` completes the previous round: after this call
+            # the cache holds exactly the emitted prefix again.
+            st["snaps"] = {}
+            st["advanced"] = 0
+            st["emitted_since"] = []
+
+            skip = st["skip"]
+            if skip is not None:
+                st["skip"] = None
+                logits = skip
+            else:
+                out = model(inputs[:, None], cache=gb.prompt_cache)
+                logits = out[:, -1, :]
+
+            # The drafter's context must cover exactly the target cache,
+            # checked every cycle: a prefix-cache hit skips the prompt aux
+            # states, and another request's prefill between two steps adds
+            # foreign ones (the taps cannot tell sequences apart).
+            _drain_aux()
+            if not st["disabled"]:
+                off = _cache_offset(gb.prompt_cache)
+                if off >= 0 and draft.context_length != off:
+                    _disable(
+                        "context_disables",
+                        "drafter context (%d) does not match the target cache (%d): "
+                        "a prefix-cache hit, another request's prefill or a batch "
+                        "change disturbed the aux states",
+                        draft.context_length,
+                        off,
+                    )
+            if not st["disabled"] and not _kv_trimmable(gb.prompt_cache):
+                _disable(
+                    "bounded_kv_disables",
+                    "KV cache is not trimmable (past --max-kv-size); a partial "
+                    "accept could not be rolled back",
+                )
+
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            primary = mx.argmax(logprobs, axis=-1)  # greedy by install gate
+
+            if st["disabled"]:
+                return _finish_step(gb, inputs, primary, logprobs)
+
+            _bump("rounds")
+            try:
+                mx.eval(primary)
+                p_tok = int(primary.item())
+                drafts = draft.draft(p_tok, model.lm_head, k)
+                nd = len(drafts)  # adaptive: may be < k
+                _bump("drafted", nd)
+
+                st["snaps"] = _rnn_snapshot(gb.prompt_cache)
+                verify_in = mx.array([[p_tok] + drafts], dtype=mx.uint32)
+                vlogits = model(verify_in, cache=gb.prompt_cache)
+                st["advanced"] = nd + 1
+                # position i's logits predict the token after input i
+                vpred = mx.argmax(vlogits[0, :, :], axis=-1)
+                mx.eval(vpred)
+                m, correction = longest_accepted_prefix(vpred.tolist(), drafts)
+                _bump("accepted", m)
+
+                vlp = vlogits[0] - mx.logsumexp(vlogits[0], axis=-1, keepdims=True)
+                if m == nd:
+                    _bump("rounds_full")
+                    for i, d in enumerate(drafts):
+                        st["pending"].append((d, vlp[i]))
+                    st["skip"] = vlogits[:, -1, :]
+                    _drain_aux()  # verify aux == accepted tokens
+                else:
+                    # Partial accept: rewind everything the verify advanced,
+                    # then re-advance the accepted prefix plus the target's
+                    # own corrected token in one forward.
+                    model._dspark_pending.clear()  # verify aux is invalid
+                    _rollback(gb.prompt_cache, st["snaps"], nd + 1)
+                    st["advanced"] = 0
+                    readv = mx.array(
+                        [[p_tok] + drafts[:m] + [correction]], dtype=mx.uint32
+                    )
+                    rlogits = model(readv, cache=gb.prompt_cache)
+                    st["advanced"] = m + 2
+                    for i in range(m):
+                        st["pending"].append((drafts[i], vlp[i]))
+                    st["pending"].append((correction, vlp[m]))
+                    st["skip"] = rlogits[:, -1, :]
+                    _drain_aux()  # re-advance aux == kept tokens
+                mx.async_eval(st["skip"])
+            except Exception:
+                logger.exception(
+                    "[DSpark] draft/verify failed — disabling for this request"
+                )
+                _bump("errors")
+                st["disabled"] = True
+                try:
+                    if st["advanced"]:
+                        # nothing past the snapshot has been emitted yet
+                        _rollback(gb.prompt_cache, st["snaps"], st["advanced"])
+                except Exception:
+                    logger.exception("[DSpark] rollback after failure also failed")
+                st["skip"] = None
+                st["pending"].clear()
+                st["snaps"] = {}
+                st["advanced"] = 0
+                st["emitted_since"] = []
+                model._dspark_pending.clear()
+
+            return _finish_step(gb, inputs, primary, logprobs)
+
+        return _dspark_gb_step
+
+    def _make_extend(gb):
+        def _dspark_extend(batch):
+            # Another sequence is joining: hand over a cache that holds
+            # exactly the emitted prefix.
+            _despeculate(gb)
+            return _gb_cls_extend(gb, batch)
+
+        return _dspark_extend
+
+    def _make_extract(gb):
+        def _dspark_extract_cache(idx):
+            # A finished or aborted request must not carry verified-but-
+            # unemitted tokens into a stored prompt cache.
+            _despeculate(gb)
+            return _gb_cls_extract(gb, idx)
+
+        return _dspark_extract_cache
+
+    batch_gen._inner_next = batch_gen._next
+
+    def _dspark_next():
+        gb = batch_gen._generation_batch
+        if st["installed_on"] is not gb:
+            gb._step = _make_step(gb)
+            gb.extend = _make_extend(gb)
+            gb.extract_cache = _make_extract(gb)
+            st["installed_on"] = gb
+            _reset()
+        return batch_gen._inner_next()
+
+    batch_gen._next = _dspark_next
+
+    def _get_spec_decode_stats() -> Dict[str, Any]:
+        with lock:
+            c = dict(counters)
+        rounds, drafted, accepted = c["rounds"], c["drafted"], c["accepted"]
+        return {
+            "enabled": True,
+            "active": not st["disabled"],
+            "mode": "dspark_block",
+            "num_draft_tokens": k,
+            "rounds": rounds,
+            "drafted": drafted,
+            "accepted": accepted,
+            "rounds_full": c["rounds_full"],
+            "context_disables": c["context_disables"],
+            "bounded_kv_disables": c["bounded_kv_disables"],
+            "despeculations": c["despeculations"],
+            "errors": c["errors"],
+            # per drafted token
+            "acceptance_rate": (accepted / drafted) if drafted else 0.0,
+            # accepted drafts per round; each round also emits one target
+            # token (bonus or correction), so tokens/round = this + 1
+            "mean_accept_len": (accepted / rounds) if rounds else 0.0,
+        }
+
+    batch_gen.get_spec_decode_stats = _get_spec_decode_stats
+    logger.info(
+        "[DSpark] installed on GenerationBatch: block spec decode, "
+        f"num_draft_tokens={k} (block_size={block_size})"
+    )
+    return True
+
+
+def _spec_decode_status_snapshot(batch_generator) -> Dict[str, Any]:
+    get_stats = getattr(batch_generator, "get_spec_decode_stats", None)
+    if callable(get_stats):
+        return {"spec_decode": get_stats()}
+    return {}
+
+
 def _mtp_status_snapshot(batch_generator) -> Dict[str, Any]:
     get_mtp_stats = getattr(batch_generator, "get_mtp_stats", None)
     if callable(get_mtp_stats):
@@ -1410,6 +1877,7 @@ class Scheduler:
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
         self._mtp_stats_state = _MTPStatsState()
+        self._spec_stats_state = _SpecDecodeStatsState()
 
         # Memory management: periodic mx.clear_cache() to free Metal command buffers
         # Lower interval = less VRAM spike during generation but slight throughput cost
@@ -1541,6 +2009,28 @@ class Scheduler:
         if not need_chunked and prompt_cache_cb is not None:
             if hasattr(bg, "_process_prompts"):
                 _install_prompt_cache_save(bg, prompt_cache_cb)
+
+        # DSpark block-draft speculative decoding: greedy, single-sequence
+        # NemotronH only. Installed per generator so the greedy gate follows
+        # the sampling params that created it.
+        if self.config.spec_draft == "dspark":
+            if getattr(self.model, "dspark", None) is None:
+                logger.warning(
+                    "[DSpark] --spec-draft dspark is set but no drafter is loaded "
+                    "(model.dspark is None); continuing without it"
+                )
+            elif not _sampling_is_greedy(sampling_params):
+                logger.info(
+                    "[DSpark] skipped: sampling is not greedy (temperature=%s)",
+                    sampling_params.temperature,
+                )
+            else:
+                _install_dspark(
+                    bg,
+                    model=self.model,
+                    num_draft_tokens=self.config.spec_num_draft_tokens,
+                    stats_state=self._spec_stats_state,
+                )
 
         # Install MTP if the model supports it
         if self.config.enable_mtp:
@@ -3350,6 +3840,7 @@ class Scheduler:
             "total_completion_tokens": self.total_completion_tokens,
         }
         stats.update(_mtp_status_snapshot(self.batch_generator))
+        stats.update(_spec_decode_status_snapshot(self.batch_generator))
         # Include Metal memory stats
         try:
             if mx.metal.is_available():

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3935,6 +3935,7 @@ async def status():
         or stats.get("paged_cache")
         or stats.get("prefix_cache"),
         "mtp": stats.get("mtp") or {"enabled": False},
+        "spec_decode": stats.get("spec_decode") or {"enabled": False},
         "requests": stats.get("requests", []),
     }
 

--- a/vllm_mlx/spec_utils.py
+++ b/vllm_mlx/spec_utils.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python helpers for block speculative decoding.
+
+Deliberately free of MLX imports so the acceptance semantics and the NVFP4
+decode tables can be unit-tested on hosts without Apple Silicon.
+"""
+
+from typing import List, Sequence, Tuple
+
+# fp4 e2m1 values indexed by nibble; the high bit is the sign.
+FP4_E2M1_VALUES: Tuple[float, ...] = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def fp8_e4m3_to_float(byte: int) -> float:
+    """Decode one OCP fp8 e4m3fn bit pattern (bias 7, no infinities).
+
+    NVFP4 block scales are e4m3 *bit patterns* stored in a uint8 tensor.
+    Casting that tensor to float gives 0..255 — silently wrong scales that
+    still produce a "mostly working" model (teacher-forced draft agreement
+    dropped from 29.9% to 15.6% with that bug). Decode the pattern instead.
+    """
+    if not 0 <= byte <= 0xFF:
+        raise ValueError(f"fp8 byte out of range: {byte!r}")
+    sign = -1.0 if byte & 0x80 else 1.0
+    exponent = (byte >> 3) & 0x0F
+    mantissa = byte & 0x07
+    if exponent == 0:
+        # subnormal: no implicit leading one, exponent fixed at 1-bias
+        return sign * (mantissa / 8.0) * 2.0**-6
+    if exponent == 0x0F and mantissa == 0x07:
+        return float("nan")
+    return sign * (1.0 + mantissa / 8.0) * 2.0 ** (exponent - 7)
+
+
+def fp8_e4m3_lut() -> List[float]:
+    """All 256 e4m3fn values, indexed by byte."""
+    return [fp8_e4m3_to_float(b) for b in range(256)]
+
+
+def longest_accepted_prefix(
+    verified: Sequence[int], drafted: Sequence[int]
+) -> Tuple[int, int]:
+    """Greedy block-verify acceptance.
+
+    ``drafted`` is the draft block ``[d1..dk]``. ``verified`` holds the
+    target's argmax at every position of the verify forward over
+    ``[P, d1..dk]``: ``verified[i]`` is what the target emits after
+    ``[.., P, d1..di]``, so it has ``k + 1`` entries and ``verified[k]`` is
+    the bonus token that follows a fully accepted block.
+
+    Returns ``(m, correction)``: ``m`` is the number of leading draft tokens
+    the target agrees with, and ``correction`` is the target's own token at
+    the first disagreement (or the bonus token when ``m == k``). Every
+    emitted token is therefore an argmax of the target's logits over the
+    emitted prefix — the draft can only change speed, never the output.
+    """
+    k = len(drafted)
+    if len(verified) != k + 1:
+        raise ValueError(
+            f"verified must have len(drafted) + 1 = {k + 1} entries, "
+            f"got {len(verified)}"
+        )
+    m = 0
+    while m < k and verified[m] == drafted[m]:
+        m += 1
+    return m, verified[m]


### PR DESCRIPTION
This is the spike promised in #699 (steps 1 and 2 of the staged plan proposed there: an approach skeleton plus a flag-gated implementation validated against a correctness bar). It is a draft for design review, not a merge request yet.

## Headline

DSpark block speculative decoding for NemotronH (Nemotron 3.5 Lightning 30B-A3B) on the continuous-batching text path. It is correct and reaches NVIDIA's acceptance figure: 3.20 of 7 drafted tokens accepted per round live (NVIDIA reports 3.75; the gap is the metric, see the guide). It does not yet win: 0.83–0.87x plain greedy on code and 0.55–0.60x on prose at k=4 on this tree today (August spike: 87–90 vs 115–134 tok/s, 0.7–0.8x).

The bottleneck is measured, not guessed. A verify forward of width w costs 8.47 / 13.49 / 15.64 / 20.67 / 28.13 ms at w = 1 / 2 / 3 / 5 / 8. Past width 2 every extra verified token costs ~2.5–2.8 ms, about 30% of a full step, and that marginal is the per-token routed-expert read that the current `switch_layers` gather does not batch across positions. It caps any speculative speedup on this stack near 2x. Batching the expert gather across the verify block would put this same code at a projected ~180–230 tok/s, and would speed up plain MoE decode for every model. Full design, measurements, benchmark matrix and the "byte-identical" definition: `docs/guides/speculative-decoding.md`.

## Run data

(M5 Max 128 GB, Lightning 30B-A3B 6-bit, mlx-lm 0.31, single stream, greedy, `--disable-prefix-cache`, 2026-08-13 to 08-15; full write-up in `docs/guides/speculative-decoding.md`)

Verify-width curve — same sequence, warm ~500-token cache, `mx.eval`-timed, 30 iterations:

| verify width | ms / step | × width-1 | marginal ms / extra token |
|---|---|---|---|
| 1 | 8.47 | 1.00 | — |
| 2 | 13.49 | 1.59 | 5.0 |
| 3 | 15.64 | 1.85 | ~2.2 |
| 5 | 20.67 | 2.44 | ~2.5 |
| 8 | 28.13 | 3.32 | ~2.5 |

Throughput:

| config | tok/s |
|---|---|
| plain greedy | 115 whole-request / 134 steady-state |
| DSpark k=7, BF16 draft, full-vocab Markov (first working build) | 66 |
| DSpark k=4, 8-bit draft, gathered top-64 Markov, sliced lm_head | 90 |
| DSpark k=4 + adaptive block length (`margin_tau` 1.5) | 86.6 |
| Lightning's own MTP head, k=1, 74.5 % acceptance (for comparison) | 106.5 |

Acceptance — mean accepted draft tokens per round at k=7, SPEED-Bench real prompts (6 of its 11 categories ship as license placeholders), greedy exact prefix match:

| category | 6-bit target | BF16 target | NVIDIA (BF16, temp 1.0 rejection sampling) |
|---|---|---|---|
| coding | 4.40 | 4.11 | 4.38 |
| qa | 2.90 | 3.45 | 3.36 |
| rag | 4.57 | 5.24 | 4.25 |
| multilingual | 2.13 | 1.96 | 4.55 |
| writing | 2.04 | 1.92 | 2.83 |

The bit-exact native NVFP4 drafter and the BF16→8-bit chain give identical acceptance, so draft precision is eliminated as a cause of the residual gap; target precision is a ~4 % mixed-direction effect.

Per-round arithmetic at k=7: 28 ms verify + ~4 ms draft (6.1 ms before 8-bit quantization) for a mean of ~4.2 kept tokens ≈ 7.6 ms/token, before the partial-accept re-advance, which adds a second wide forward to ~85 % of rounds. Plain decode is 8.5 ms/token. Feeding the target's aux states into the draft KV costs ~0.6 ms/token.

### Room for improvement, by expected payoff

1. **Batch the routed-expert gather across verify positions** (mlx-lm `switch_layers` as used by `nemotron_h`). The 2.5–2.8 ms marginal is ~0.5 GB of expert reads per position (6 of 128 experts × 23 MoE layers) issued one position at a time. Batching them across the block drops the marginal toward the dense floor (~0.9 ms/token), at which point this exact stack projects to ~180–230 tok/s. It also speeds up plain MoE decode for every model here. This is the only item that flips the sign.
2. **The partial-accept re-advance.** ~85 % of rounds pay a second (m+2)-wide forward because Mamba state cannot be rewound. With that floor the ceiling is 1 / (r + (1 − r) / k), which is ≈ 1.15× at the measured r = 0.85 and k = 7 (corrected: an earlier revision said 1.7×, an arithmetic error). The single-forward commit path that would remove the re-advance does not exist for hybrid targets. An attention-only target keeps the accepted prefix in place and skips this cost entirely.
3. **Host syncs per round.** The round has three `mx.eval` points (primary, draft block, verify argmax). Not measured separately for DSpark; in the MTP port the single per-cycle sync accounted for ~0.2 forward-equivalents per cycle, so overlapping the draft with the verify launch is worth measuring.
4. **Adaptive block length** at `margin_tau` 1.5 measured 86.6 vs 90 at fixed k=4 — no gain at this marginal cost. Worth re-testing only after item 1 changes the cost per verified token.
5. **Prefix-cache hits disable speculation** because no aux states exist for cached tokens. Re-deriving them from the cached prefix with one extra forward would let agentic multi-turn traffic use the drafter at all.

### Clean run on this tree (2026-09-04, host otherwise idle)

Same build for every row; served with `--continuous-batching --disable-prefix-cache --max-num-seqs 1`, native NVFP4 drafter, greedy, thinking off, one warm-up then three 512-token completions per prompt; medians. M5 Max 128 GB, mlx-lm 0.31.3.

| config | code tok/s | vs plain | accepted / round (per token) | prose tok/s | vs plain | accepted / round (per token) |
|---|---|---|---|---|---|---|
| plain greedy | 125.6 | — | — | 118.8 | — | — |
| DSpark k=4 | 104.1 | 0.83× | 2.98 of 4 (74.6 %) | 65.2 | 0.55× | 1.51 of 4 (37.7 %) |
| DSpark k=7 | 76.8 | 0.61× | 3.59 of 7 (51.3 %) | 53.6 | 0.45× | 1.88 of 7 (26.9 %) |
| DSpark k=4, `--spec-draft-margin-tau 1.5` | 109.6 | 0.87× | 2.59 of 2.96 drafted (87.5 %) | 71.1 | 0.60× | 1.17 of 2.22 drafted (52.6 %) |

Counters over the whole run: `errors` 0, `context_disables` 0, `bounded_kv_disables` 0, `despeculations` = one per finished request (the rewind at `extract_cache`). Every config's three runs were byte-identical to each other.

Reading: the ratios match the August measurements (0.7–0.8× then, 0.83–0.87× now on code). Wider blocks lose: k=7 accepts more tokens per round (3.59) but the 8-wide verify costs more than they save. The adaptive cut-off is now the best configuration, because on this tree the cost per drafted position is what it trims. Prose is worse than code at every setting, as the acceptance column predicts.

**Fidelity.** Against the plain run, every DSpark config produced the same two divergences, one per prompt, and all three DSpark configs agree with each other:

| prompt | first divergence | plain chose | DSpark chose | plain-forward logits at that position | gap |
|---|---|---|---|---|---|
| code | token 50 of 512 | `\n\n` | `,` | 28.25 vs 28.25 | **0.000** (exact tie) |
| prose | token 2 of 512 | ` difference` | ` distinction` | 24.125 vs 24.25 | **0.125 = one bf16 ULP** at that magnitude |

The gaps were measured offline with the same weights (the server has no logprobs endpoint): a forward over the prompt plus the common prefix, top-3 logits at the divergence position. In the prose case the wide forward's own argmax is the DSpark token, i.e. the 1-wide run is the one that broke the tie the other way. Both divergences therefore satisfy the acceptance bar proposed below: every emitted token is an argmax of the target over the emitted prefix, and any difference from a 1-wide run sits at a position whose top-1/top-2 gap is within bf16 resolution.

Artifacts (server logs, per-run JSONL with the full completions, status snapshots, the driver and the probe) are kept locally and can be attached on request.

## What is in the PR

- `vllm_mlx/patches/nemotron_dspark.py` — the drafter (DFlash context KV from target aux states, parallel block draft, gathered top-64 Markov fix-up) and the aux-state taps on the NemotronH forward. Loads either an MLX-native NVFP4 repack or the BF16 dequant.
- `vllm_mlx/scheduler.py` — `_install_dspark` on `GenerationBatch._step` (mlx-lm >= 0.31): k-wide verify, longest-prefix accept, KV trim plus recurrent-state restore, re-advance of the accepted prefix plus the target's own corrected token. Config fields and `/v1/status` `spec_decode` counters. `_install_mtp` and the #737 guard are untouched.
- `vllm_mlx/spec_utils.py` — acceptance semantics and fp8-e4m3 / fp4-e2m1 decode tables, MLX-free.
- `scripts/prepare_dspark_weights.py`, `cli.py`, `engine/batched.py`, `server.py`, docs, README, CI test list.

Flags: `--spec-draft dspark`, `--spec-num-draft-tokens` (default 7), `--spec-draft-margin-tau` (adaptive block length). Requires `--continuous-batching`; rejected with `--mllm` or `--enable-mtp`.

Degradation: engages only for temperature-0 single-sequence requests. Multi-sequence steps, logits processors, prefix-cache hits (no aux states for cached tokens), a KV cache past `--max-kv-size`, a missing drafter, or any exception fall back to plain decode for that call or request, logged and counted. Because the cache runs ahead of the emitted tokens inside a round, the hook rewinds it to the emitted prefix before any batch merge, cache extraction (finish/abort) or error fallback, so stock code never sees verified-but-unemitted tokens.

## Tests

- `tests/test_dspark_spec_decode.py` (in CI): acceptance semantics, e4m3/e2m1 tables, config validation, greedy gate, no-op paths through the real `Scheduler._create_batch_generator`.
- `tests/test_dspark_scheduler_step.py`: the real mlx-lm `BatchGenerator` over a tiny random Mamba+attention+MLP NemotronH with scripted oracle / garbage / half-right drafters; the spec path must reproduce plain greedy (tie-tolerant per the definition below; the seed has no ties). Also covers a second request merging mid-round, an exception injected after the verify forward, and the cache handed back at finish, all on real hybrid caches.

## Not in this PR

NemotronH MTP head port, non-greedy (rejection-sampling) verification, re-deriving aux states from a prefix-cache hit, the batched expert-gather kernel.

## Status

Unit and e2e tests pass locally. The clean run above (this tree, idle host) covers load, engagement, throughput against plain on the same build, the counters, and the fidelity bar. Nothing is owed on the measurement side; the open items are the design questions below.

## Questions

1. Flag naming: `--spec-draft` / `--spec-num-draft-tokens` vs. folding into the `--mllm-draft-*` family.
2. Would you take the scheduler hook plus the drafter API (`block_size`, `append_context`, `draft`) behind the flag now, with the DSpark drafter itself as a follow-up, or hold everything until it wins?
3. Is batching the routed-expert gather across the verify block something the project wants?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQAzGiCRR1VocVNa3ngyjw

