### PR TITLE
fix(mllm): key the prefix cache on the message boundary, not the think suffix

### DIFF
--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2356,3 +2356,206 @@ def test_scheduler_step_error_fails_every_request_once():
     assert "_fail_requests_after_step_error(e)" in inspect.getsource(
         MLLMScheduler._process_loop
     )
+
+
+class TestPromptBoundaryKeying:
+    """Prefix-cache keys and lookups must cut at the last complete message,
+    independent of the per-request thinking mode, at all four call sites.
+
+    ``_think_suffix_len`` is measured once at startup with
+    ``enable_thinking=True`` (``<think>\\n`` = 2 tokens). A request rendered
+    with ``enable_thinking=False`` carries ``<think>\\n\\n</think>\\n\\n``
+    (4 tokens), so a fixed strip leaves two generation-prompt tokens on the
+    key and the entry is never a strict prefix of the next turn.
+    """
+
+    IM_START, IM_END, ASSISTANT = 6, 7, 8
+    THINK, NL, NLNL, END_THINK = 9, 10, 11, 12
+    BODY = [1, 2, 3, IM_END, 4, 5, IM_END]  # two complete messages
+    SUFFIX_ON = [IM_START, ASSISTANT, THINK, NL]  # enable_thinking=True
+    SUFFIX_OFF = [IM_START, ASSISTANT, THINK, NLNL, END_THINK, NLNL]  # False
+    STARTUP_SUFFIX_LEN = 2  # what _compute_think_suffix_len() measures
+
+    @classmethod
+    def _ids(cls, thinking: bool):
+        return cls.BODY + (cls.SUFFIX_ON if thinking else cls.SUFFIX_OFF)
+
+    @classmethod
+    def _gen(cls):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchStats
+
+        gen = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        gen._stats = MLLMBatchStats()
+        gen._pending_error_responses = []
+        gen._aborted_request_ids = set()
+        gen._prefill_progress = {}
+        gen.active_batch = None
+        gen.stop_tokens = set()
+        gen.unprocessed_requests = []
+        gen.max_kv_size = 0
+        gen._think_suffix_len = cls.STARTUP_SUFFIX_LEN
+        gen._im_end_id = cls.IM_END
+        gen._has_empty_rotating_cache = lambda cache: False
+        return gen
+
+    BOUNDARY = len(BODY)
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_boundary_is_thinking_mode_independent(self, thinking):
+        gen = self._gen()
+        ids = self._ids(thinking)
+        assert gen._prompt_boundary_len(ids) == self.BOUNDARY
+        assert ids[: self.BOUNDARY] == self.BODY
+
+    def test_startup_suffix_strip_is_wrong_for_thinking_off(self):
+        # The pre-fix behavior, kept as the fallback for non-ChatML templates:
+        # right by construction for the mode it was measured in, two tokens
+        # long for the other one.
+        gen = self._gen()
+        gen._im_end_id = None
+        assert gen._prompt_boundary_len(self._ids(True)) == self.BOUNDARY + 2
+        assert gen._prompt_boundary_len(self._ids(False)) == self.BOUNDARY + 4
+        # +2 over the shared prefix: not a strict prefix of the next turn.
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_turn_one_key_is_strict_prefix_of_turn_two(self, thinking):
+        gen = self._gen()
+        turn1 = self._ids(thinking)
+        reply = [20, 21, self.IM_END]
+        turn2 = self.BODY + [self.IM_START, self.ASSISTANT] + reply
+        turn2 += [self.IM_START, 30, 31, self.IM_END]
+        turn2 += self.SUFFIX_ON if thinking else self.SUFFIX_OFF
+        key1 = turn1[: gen._prompt_boundary_len(turn1)]
+        assert turn2[: len(key1)] == key1 and len(turn2) > len(key1)
+
+    # -- canonical (non-chunked) path -----------------------------------------
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_canonical_fetch_looks_up_message_boundary(self, monkeypatch, thinking):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
+
+        class FreshCache:
+            def merge(self, caches):
+                return self
+
+        lookups = []
+
+        class RecordingPrefixCache:
+            def fetch(self, ids):
+                lookups.append(list(ids))
+                return None, list(ids)  # miss
+
+        monkeypatch.setattr(mx, "stream", lambda stream: nullcontext())
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache", lambda *_, **__: [FreshCache()]
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **_: MagicMock(return_value=mx.array([1], dtype=mx.uint32)),
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors", lambda **_: []
+        )
+
+        gen = self._gen()
+        gen.prefix_cache = RecordingPrefixCache()
+        gen.prefill_step_size = 512
+        gen.language_model = object()
+        gen.model = MagicMock()
+        gen.sampler = MagicMock()
+        gen._preprocess_request = lambda req: None
+        gen._run_chunked_text_prefill = MagicMock(
+            return_value=mx.array([[[0.0, 1.0]]], dtype=mx.float32)
+        )
+
+        ids = self._ids(thinking)
+        req = MLLMBatchRequest(uid=1, request_id="canon-fetch", prompt="x")
+        req.input_ids = mx.array([ids])
+        req.is_text_only = True
+
+        MLLMBatchGenerator._process_prompts(gen, [req])
+
+        assert lookups == [self.BODY]
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_canonical_store_keys_message_boundary(self, thinking):
+        from types import SimpleNamespace
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
+
+        gen = self._gen()
+        gen.prefix_cache = object()
+        stores = []
+        gen._store_prefix_snapshot = lambda key, cache, trim, rid, src: (
+            stores.append((list(key), trim)) or True
+        )
+
+        ids = self._ids(thinking)
+        req = MLLMBatchRequest(uid=1, request_id="canon-store", prompt="x")
+        req.input_ids = mx.array([ids])
+        batch = SimpleNamespace(
+            requests=[req],
+            num_tokens=[3],  # three generated tokens
+            extract_cache=lambda i: ["cache"],
+        )
+
+        MLLMBatchGenerator._maybe_store_prefix_cache(gen, batch, [0])
+
+        suffix_len = len(ids) - self.BOUNDARY
+        assert stores == [(self.BODY, 3 + suffix_len)]
+
+    # -- chunked (interleaved) prefill path ----------------------------------
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_chunked_fetch_and_store_use_message_boundary(self, thinking):
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        gen = self._gen()
+        ids = self._ids(thinking)
+
+        lookups, stores = [], []
+        cached = KVCache()
+        cached.update_and_fetch(mx.zeros((1, 1, 3, 4)), mx.zeros((1, 1, 3, 4)))
+        mx.eval(cached.keys, cached.values)
+
+        class RecordingPrefixCache:
+            def fetch(self, lookup):
+                lookups.append(list(lookup))
+                # partial hit on the first three body tokens
+                return [cached], list(lookup)[3:]
+
+        gen.prefix_cache = RecordingPrefixCache()
+        gen._copy_prefix_cache = lambda kv: kv
+        gen._rewind_prefix_cache = lambda kv, n: kv
+        gen._store_prefix_snapshot = lambda key, cache, trim, rid, src: (
+            stores.append((list(key), trim, src)) or True
+        )
+        # Real-shaped logits so the interleaved prefill runs to completion.
+        gen.language_model = lambda x, cache=None: mx.zeros((1, x.shape[1], 16))
+        gen.sampler = lambda logprobs: mx.array([1], dtype=mx.uint32)
+        gen._next = lambda: []
+        # A budget smaller than the uncached remainder keeps the request on
+        # the interleaved path (a remainder that fits in one step is handed
+        # back to the canonical path, which the tests above cover).
+        install_chunked_prefill_mllm(gen, budget=4)
+
+        req = MLLMBatchRequest(uid=2, request_id="chunked", prompt="hello")
+        req.input_ids = mx.array([ids])
+        req.is_text_only = True
+        req.images = None
+        req.videos = None
+        gen.unprocessed_requests.append(req)
+        gen._preprocess_request = lambda r: None
+
+        for _ in range(8):  # fetch, then chunks of 4 until the prefill completes
+            gen._next()
+            if gen._partial is None and stores:
+                break
+
+        assert lookups == [self.BODY]
+        assert stores == [(self.BODY, len(ids) - self.BOUNDARY, "interleaved prefill")]

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -609,6 +609,9 @@ class MLLMBatchGenerator:
         # but next request has actual response at that position).
         # Stripping the suffix from cache keys enables clean PREFIX match.
         self._think_suffix_len = self._compute_think_suffix_len()
+        # Fallback anchor for _prompt_boundary_len().  See that method for why
+        # the think-suffix length alone is not a safe cut point.
+        self._im_end_id = self._resolve_im_end_id()
 
         # Generation stream
         if MLLMBatchGenerator._stream is None:
@@ -685,6 +688,47 @@ class MLLMBatchGenerator:
                 "[prefix_cache] Chat template has last_query_index but "
                 "regex did not match — template may use a different pattern"
             )
+
+    def _resolve_im_end_id(self) -> Optional[int]:
+        """Token id of ``<|im_end|>``, or None for non-ChatML templates."""
+        try:
+            tokenizer = getattr(self.processor, "tokenizer", self.processor)
+            ids = tokenizer.encode("<|im_end|>")
+            if len(ids) == 1:
+                return ids[0]
+        except Exception:
+            pass
+        return None
+
+    def _prompt_boundary_len(self, ids: List[int]) -> int:
+        """Length of the reusable prefix of ``ids`` — the end of the last
+        COMPLETE message.
+
+        Prefix-cache keys must not include the generation prompt.  The next
+        turn of the same conversation replaces it with the assistant's actual
+        reply, so a key that contains it is never a strict prefix of the next
+        turn: it matches only as an LCP with a small ``excess``, which is
+        rejected outright for hybrid (linear-attention) caches because
+        recurrent state cannot be rewound.  The result is a silent loss of
+        prefix reuse — every turn re-prefills the whole conversation.
+
+        ``_think_suffix_len`` is measured ONCE at startup against
+        ``enable_thinking=True``.  That is the wrong length whenever a request
+        renders with ``enable_thinking=False``, which callers select per
+        request via ``chat_template_kwargs``.  For Qwen3.5/3.6 the two suffixes
+        are ``<think>\n`` (2 tokens) and ``<think>\n\n</think>\n\n``
+        (4 tokens), so a fixed strip of 2 leaves ``<think>\n\n`` on the key.
+
+        Anchoring on the last ``<|im_end|>`` is independent of both the
+        thinking mode and the template's generation-prompt shape, and costs
+        only the few tokens of the ``<|im_start|>assistant`` header.
+        """
+        if self._im_end_id is not None:
+            for i in range(len(ids) - 1, -1, -1):
+                if ids[i] == self._im_end_id:
+                    return i + 1
+        S = self._think_suffix_len
+        return len(ids) - S if S > 0 else len(ids)
 
     def _compute_think_suffix_len(self) -> int:
         """Compute how many extra tokens enable_thinking=True adds at the END.
@@ -1502,13 +1546,13 @@ class MLLMBatchGenerator:
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Strip think suffix from lookup key so stored entries
                     # (also stripped) match as clean PREFIX.
-                    S = self._think_suffix_len
-                    lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
+                    boundary = self._prompt_boundary_len(input_ids_list)
+                    lookup_ids = input_ids_list[:boundary]
                     cached_kv, remaining_ids = self.prefix_cache.fetch(lookup_ids)
-                    # Append think suffix back to remaining so the model
-                    # sees the full generation prompt (<think>\n).
-                    if cached_kv is not None and S > 0:
-                        remaining_ids = list(remaining_ids) + input_ids_list[-S:]
+                    # Put the generation prompt back on the remaining tokens
+                    # so the model still sees the full prompt.
+                    if cached_kv is not None and boundary < len(input_ids_list):
+                        remaining_ids = list(remaining_ids) + input_ids_list[boundary:]
 
                     # If remaining tokens contain image placeholders, the
                     # language-model-only path cannot handle them — clear the
@@ -2153,9 +2197,9 @@ class MLLMBatchGenerator:
                     # The exact-match path trims by 1 at fetch time to
                     # re-derive logits for the last prompt token.
                     output_count = batch.num_tokens[i]
-                    S = self._think_suffix_len
-                    total_trim = output_count + S
-                    cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
+                    boundary = self._prompt_boundary_len(input_ids_list)
+                    total_trim = output_count + (len(input_ids_list) - boundary)
+                    cache_key = input_ids_list[:boundary]
                     self._store_prefix_snapshot(
                         cache_key,
                         extracted,
@@ -3192,12 +3236,12 @@ def install_chunked_prefill_mllm(
                 if batch_gen.prefix_cache is not None and req.input_ids is not None:
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
-                        S = batch_gen._think_suffix_len
-                        cache_key = input_ids_list[:-S] if S > 0 else input_ids_list
-                        # Trim output: at store time output_count=0, so
-                        # trim by S only (matching canonical path's
-                        # output_count + S invariant).
-                        trim_amount = S
+                        boundary = batch_gen._prompt_boundary_len(input_ids_list)
+                        cache_key = input_ids_list[:boundary]
+                        # output_count is 0 here (nothing generated yet), so the
+                        # trim is just the generation prompt — the same boundary
+                        # the canonical path uses.
+                        trim_amount = len(input_ids_list) - boundary
                         batch_gen._store_prefix_snapshot(
                             cache_key,
                             partial["cache"],
@@ -3271,11 +3315,11 @@ def install_chunked_prefill_mllm(
 
                 if batch_gen.prefix_cache is not None:
                     input_ids_list = input_ids.reshape(-1).tolist()
-                    S = batch_gen._think_suffix_len
-                    lookup_ids = input_ids_list[:-S] if S > 0 else input_ids_list
+                    boundary = batch_gen._prompt_boundary_len(input_ids_list)
+                    lookup_ids = input_ids_list[:boundary]
                     cached_kv, remaining_ids = batch_gen.prefix_cache.fetch(lookup_ids)
-                    if cached_kv is not None and S > 0:
-                        remaining_ids = list(remaining_ids) + input_ids_list[-S:]
+                    if cached_kv is not None and boundary < len(input_ids_list):
+                        remaining_ids = list(remaining_ids) + input_ids_list[boundary:]
 
                     # Check for empty rotating cache
                     if cached_kv is not None and batch_gen._has_empty_rotating_cache(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -723,11 +723,14 @@ class MLLMBatchGenerator:
         thinking mode and the template's generation-prompt shape, and costs
         only the few tokens of the ``<|im_start|>assistant`` header.
         """
-        if self._im_end_id is not None:
+        # getattr: tests build the generator with __new__ and set only the
+        # attributes they need, so neither field is guaranteed to exist.
+        im_end_id = getattr(self, "_im_end_id", None)
+        if im_end_id is not None:
             for i in range(len(ids) - 1, -1, -1):
-                if ids[i] == self._im_end_id:
+                if ids[i] == im_end_id:
                     return i + 1
-        S = self._think_suffix_len
+        S = getattr(self, "_think_suffix_len", 0)
         return len(ids) - S if S > 0 else len(ids)
 
     def _compute_think_suffix_len(self) -> int:


### PR DESCRIPTION
## The bug

`_compute_think_suffix_len()` measures the generation-prompt suffix **once at startup**, using `enable_thinking=True`. But callers choose the thinking mode **per request** via `chat_template_kwargs`, and the two suffixes are different lengths:

| mode | generation prompt | tokens |
|---|---|---|
| `enable_thinking=True` | `<think>\n` | 2 |
| `enable_thinking=False` | `<think>\n\n</think>\n\n` | 4 |

So for a request rendered with `enable_thinking=False`, `input_ids_list[:-S]` strips 2 of 4 and leaves `<think>\n\n` on the stored key. That entry is 2 tokens longer than the prefix it shares with the next turn, so it falls out of the strict-PREFIX path into LCP — and LCP reuse is correctly refused for hybrid / linear-attention caches, because recurrent state cannot be rewound.

**The failure is silent.** No error, no warning — the prefix cache simply stops hitting for multi-turn clients, and every turn re-prefills the entire conversation.

## Reproduction (tokenizer only, no server)

On `Qwen3.6-35B-A3B`, comparing turn 1 against turn 2 of the same conversation:

```
_think_suffix_len (measured at startup, enable_thinking=True) = 2

enable_thinking=True
  turn-1 prompt         216 tokens
  shared with turn-2    214
  generation prompt     2 tokens  ['<think>', '\n']
  key with -S strip     214   excess over shared = 0   OK
  key at last <|im_end|> 210   excess over shared = -4   OK

enable_thinking=False
  turn-1 prompt         218 tokens
  shared with turn-2    214
  generation prompt     4 tokens  ['<think>', '\n\n', '</think>', '\n\n']
  key with -S strip     216   excess over shared = 2   <-- NOT a strict prefix: reuse lost
  key at last <|im_end|> 210   excess over shared = -4   OK
```

Any thinking-capable ChatML model served to a client that sends `enable_thinking: false` hits this.

## The fix

Anchor the key on the **last `<|im_end|>`** — the end of the last complete message — instead of on a startup-measured suffix length. That point is independent of the thinking mode and of the template's generation-prompt shape, and is a strict prefix of every later turn of the same conversation by construction. The cost is the few tokens of the trailing `<|im_start|>assistant` header.

`_think_suffix_len` is retained as the fallback for non-ChatML templates, so nothing regresses for models without `<|im_end|>`.

Applied at all four sites, so keys and lookups agree — they must, or the miss is silent again: canonical store/fetch and chunked-prefill store/fetch.

## Scope of the standalone claim

On upstream alone this PR fixes the **key**: for rewindable cache types (plain KV, attention-only models) a stored prompt entry now survives as a strict prefix of the next turn in both thinking modes. It does **not** by itself make hybrid (recurrent-state) models reuse prefixes on upstream: `_store_prefix_snapshot()` still rejects the positive trim for non-rewindable leaves via `_can_rewind_prefix_cache()`. Hybrid reuse is #744's job; once it lands this will be rebased onto it and the hybrid claim re-verified on that tree, without duplicating #744's ownership or publication logic.

## Testing

- The reproduction above is deterministic and needs no server.
- `TestPromptBoundaryKeying` (in `tests/test_mllm_continuous_batching.py`, run by the Apple Silicon job) drives all four call sites with `enable_thinking=true` and `false` token layouts and asserts the key and the lookup cut at the last `<|im_end|>`: canonical fetch through `_process_prompts`, canonical store through `_maybe_store_prefix_cache`, and the chunked fetch and store inside `install_chunked_prefill_mllm` (driven to completion with a 4-token budget). It also pins that the turn-1 key is a strict prefix of turn 2, and that the pre-fix startup-suffix strip leaves two extra tokens on the thinking-off key.
- Runtime evidence, for context only: on a fork that additionally carries a hybrid store, this change took a multi-turn agentic client against `Qwen3.6-35B-A3B-6bit` from a full re-prefill every turn to reusing the prefix (**40.3s cold → 0.51s on the following turn**), with a needle 9,000 tokens inside the cached region retrieved intact in both thinking modes. That result is not reproducible on this branch alone; see *Scope* above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
