### PR TITLE
Add Eagle3 as a distinct MLLM speculative draft kind

### DIFF
--- a/docs/guides/continuous-batching.md
+++ b/docs/guides/continuous-batching.md
@@ -57,6 +57,20 @@ assistant drafters currently require `--mllm-draft-kind mtp`. `/v1/status`
 shows the configured model and default after startup. In continuous-batching
 mode, it also adds runtime acceptance counters as requests run.
 
+Eagle3 is a SimpleEngine-only draft implementation. It cannot be combined
+with `--continuous-batching` or its paged batching caches. It is also not
+supported in model registry mode or with lifecycle residency. If these options
+are combined, startup fails with:
+
+```
+Error: Eagle3 uses SimpleEngine and cannot use continuous batching
+```
+
+Use the SimpleEngine command in the multimodal guide instead. Do not infer
+runtime support from successful model construction alone. Startup checks the
+Eagle3 checkpoint identity and target capabilities, including the rollback
+API, capture layers, layer bounds, and compatible hidden and vocabulary sizes.
+
 Injected Qwen3.5 and Qwen3.6 MTP checkpoints use the established post-norm
 backbone state by default. A checkpoint qualified for pre-norm input can opt in
 by setting `mtp_hidden_state_mode` to `pre_norm` in its `text_config`. Leave the

--- a/docs/guides/multimodal.md
+++ b/docs/guides/multimodal.md
@@ -22,6 +22,65 @@ vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
 Models with "VL", "Vision", or "mllm" in the name are auto-detected as multimodal.
 
+## Eagle3 Draft Decoding
+
+Eagle3 uses `SimpleEngine` for multimodal speculative decoding. Configure the
+target and Eagle3 checkpoint together, with an optional draft block size:
+
+```bash
+vllm-mlx serve TARGET_MODEL \
+  --mllm \
+  --mllm-draft-model EAGLE3_CHECKPOINT \
+  --mllm-draft-kind eagle3 \
+  --mllm-draft-block-size 4
+```
+
+When `--mllm-draft-block-size` is omitted, mlx-vlm applies its default
+behavior. When set, Eagle3 requires a value of at least `2`. Eagle3 does not
+support continuous batching, paged batching caches,
+model registry mode, or lifecycle residency. Do not add
+`--continuous-batching`; the CLI rejects it with
+`Error: Eagle3 uses SimpleEngine and cannot use continuous batching`.
+
+At startup, vllm-mlx checks that the requested checkpoint resolves to Eagle3
+and that the target exposes the required rollback and capture-layer
+capabilities. It also checks capture-layer bounds and compatible target hidden
+and vocabulary sizes. Successful model construction by itself is not proof
+that the target is supported at runtime.
+
+The engine status and public `/v1/status` endpoint identify this configuration
+under `speculative` with
+`implementation: "mlx_vlm_eagle3"`, `draft_kind: "eagle3"`, and
+`continuous_batching_supported: false`; `/v1/status` keeps its existing `mtp`
+field. The endpoint also reports Metal memory under `metal`, including
+`peak_memory_gb`.
+
+### Apple Silicon Validation Protocol
+
+Hardware results for Eagle3 are pending. Do not assume a speedup until this
+protocol has been completed on the target Apple Silicon machine:
+
+1. Use the same fixed prompts, media inputs, generation limits, and random
+   seed for target-only and Eagle3 runs. Record exact model and checkpoint
+   revisions.
+2. Run greedy target-only generation and greedy Eagle3 generation. Compare the
+   complete generated token-ID sequences exactly, not only decoded text.
+3. Read the checkpoint default block size from its config. If it differs from
+   mlx-vlm's no-override behavior, pass that value explicitly with
+   `--mllm-draft-block-size`. Warm up each mode, then collect at least 20
+   measured runs per mode for block sizes `2`, `4`, and that checkpoint value.
+4. Record median and p95 latency, output throughput, drafted tokens, accepted
+   tokens, acceptance rate, mean accepted length, process RSS, and peak Metal
+   allocation. Read the latter from `/v1/status` as `metal.peak_memory_gb` and
+   keep raw status samples with the benchmark output.
+5. If the deployment intends to set `max_kv_size`, test its boundary with a
+   bounded sweep. Include the largest prompt and generation combination that
+   fits, the first one that exceeds the bound, and the resulting error or
+   fallback behavior.
+
+Report parity, resource use, and performance separately. Mark every hardware
+result pending until the measurements and exact token-ID comparison pass.
+
 ## Image Analysis
 
 ### Via OpenAI SDK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -136,6 +138,103 @@ def test_serve_parser_accepts_registered_step3p5_tool_parser():
     )
 
     assert args.tool_call_parser == "step3p5"
+
+
+def test_serve_parser_accepts_eagle3_mllm_draft_kind():
+    """Eagle3 must be selectable as a distinct mlx-vlm draft algorithm."""
+    from vllm_mlx import cli
+
+    args = cli.create_parser().parse_args(
+        [
+            "serve",
+            "--model",
+            "local-test-model",
+            "--mllm-draft-kind",
+            "eagle3",
+        ]
+    )
+
+    assert args.mllm_draft_kind == "eagle3"
+
+
+def test_serve_command_rejects_eagle3_batching_before_download(monkeypatch, capsys):
+    """Eagle3 cannot reach model download when continuous batching is requested."""
+    import vllm_mlx
+    from vllm_mlx import cli
+    from vllm_mlx.utils import download
+
+    fake_server = types.ModuleType("vllm_mlx.server")
+    fake_server.RateLimiter = object
+    fake_server.app = object()
+    fake_server._metrics = SimpleNamespace(configure=lambda **kwargs: None)
+    fake_server.load_model = lambda *args, **kwargs: None
+    fake_server.load_model_registry = lambda *args, **kwargs: None
+    fake_registry = types.ModuleType("vllm_mlx.model_registry")
+    fake_registry.RegistryServeDefaults = object
+    monkeypatch.setitem(sys.modules, "vllm_mlx.server", fake_server)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.model_registry", fake_registry)
+    monkeypatch.setattr(vllm_mlx, "server", fake_server, raising=False)
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+
+    monkeypatch.setattr(
+        download,
+        "ensure_model_downloaded",
+        lambda *args, **kwargs: pytest.fail("model download must not start"),
+    )
+
+    with pytest.raises(SystemExit):
+        cli.serve_command(
+            _serve_args(
+                mllm=True,
+                mllm_draft_model="eagle3-drafter",
+                mllm_draft_kind="eagle3",
+                continuous_batching=True,
+            )
+        )
+
+    assert (
+        "Eagle3 uses SimpleEngine and cannot use continuous batching"
+        in capsys.readouterr().out
+    )
+
+
+def test_serve_command_rejects_eagle3_block_size_below_two_before_download(
+    monkeypatch, capsys
+):
+    """Eagle3 block size one must fail before a model download begins."""
+    import vllm_mlx
+    from vllm_mlx import cli
+    from vllm_mlx.utils import download
+
+    fake_server = types.ModuleType("vllm_mlx.server")
+    fake_server.RateLimiter = object
+    fake_server.app = object()
+    fake_server._metrics = SimpleNamespace(configure=lambda **kwargs: None)
+    fake_server.load_model = lambda *args, **kwargs: None
+    fake_server.load_model_registry = lambda *args, **kwargs: None
+    fake_registry = types.ModuleType("vllm_mlx.model_registry")
+    fake_registry.RegistryServeDefaults = object
+    monkeypatch.setitem(sys.modules, "vllm_mlx.server", fake_server)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.model_registry", fake_registry)
+    monkeypatch.setattr(vllm_mlx, "server", fake_server, raising=False)
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        download,
+        "ensure_model_downloaded",
+        lambda *args, **kwargs: pytest.fail("model download must not start"),
+    )
+
+    with pytest.raises(SystemExit):
+        cli.serve_command(
+            _serve_args(
+                mllm=True,
+                mllm_draft_model="eagle3-drafter",
+                mllm_draft_kind="eagle3",
+                mllm_draft_block_size=1,
+            )
+        )
+
+    assert "Eagle3 draft block size must be at least 2" in capsys.readouterr().out
 
 
 def test_memory_budget_help_describes_scope_and_limitations(capsys):

--- a/tests/test_eagle3_server_validation.py
+++ b/tests/test_eagle3_server_validation.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""No-MLX regression coverage for Eagle3 server validation."""
+
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from unittest.mock import patch
+
+import pytest
+
+
+def _install_mlx_stubs(monkeypatch) -> None:
+    """Install the import-time MLX surface needed by the engine modules."""
+    core = types.ModuleType("mlx.core")
+    core.__spec__ = ModuleSpec("mlx.core", loader=None)
+
+    class Array:
+        pass
+
+    core.array = Array
+    core.Stream = type("Stream", (), {})
+    mlx = types.ModuleType("mlx")
+    mlx.__spec__ = ModuleSpec("mlx", loader=None, is_package=True)
+    mlx.__path__ = []
+    mlx.core = core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", core)
+    mlx_lm = types.ModuleType("mlx_lm")
+    mlx_lm.__spec__ = ModuleSpec("mlx_lm", loader=None, is_package=True)
+    mlx_lm.__path__ = []
+    generate = types.ModuleType("mlx_lm.generate")
+    generate.BatchGenerator = type("BatchGenerator", (), {})
+    sample_utils = types.ModuleType("mlx_lm.sample_utils")
+    sample_utils.make_logits_processors = lambda *args, **kwargs: []
+    sample_utils.make_sampler = lambda *args, **kwargs: None
+    tokenizer_utils = types.ModuleType("mlx_lm.tokenizer_utils")
+    tokenizer_utils.NaiveStreamingDetokenizer = type(
+        "NaiveStreamingDetokenizer", (), {}
+    )
+    cache = types.ModuleType("mlx_lm.models.cache")
+    cache.ArraysCache = type("ArraysCache", (), {})
+    mlx_lm.generate = generate
+    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.generate", generate)
+    monkeypatch.setitem(sys.modules, "mlx_lm.sample_utils", sample_utils)
+    monkeypatch.setitem(sys.modules, "mlx_lm.tokenizer_utils", tokenizer_utils)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.cache", cache)
+
+
+def test_load_model_rejects_eagle3_continuous_batching(monkeypatch):
+    """The server must defend against Eagle3 batching outside the CLI."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx import server
+
+    with pytest.raises(ValueError, match="Eagle3 uses SimpleEngine"):
+        server.load_model(
+            "gemma4",
+            use_batching=True,
+            force_mllm=True,
+            mllm_draft_model="eagle3-drafter",
+            mllm_draft_kind="eagle3",
+        )
+
+
+def test_load_model_rejects_eagle3_block_size_below_two(monkeypatch):
+    """Eagle3 block size one must fail before SimpleEngine construction."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx import server
+
+    class FakeSimpleEngine:
+        is_mllm = True
+
+        async def start(self):
+            pass
+
+    with patch.object(
+        server, "SimpleEngine", return_value=FakeSimpleEngine()
+    ) as simple_engine:
+        with pytest.raises(ValueError, match="Eagle3.*at least 2"):
+            server.load_model(
+                "gemma4",
+                force_mllm=True,
+                mllm_draft_model="eagle3-drafter",
+                mllm_draft_kind="eagle3",
+                mllm_draft_block_size=1,
+            )
+
+    simple_engine.assert_not_called()
+
+
+def test_load_model_accepts_eagle3_block_size_two(monkeypatch):
+    """Eagle3's smallest usable block size reaches SimpleEngine unchanged."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx import server
+
+    class FakeSimpleEngine:
+        is_mllm = True
+
+        async def start(self):
+            pass
+
+    fake_engine = FakeSimpleEngine()
+    monkeypatch.setattr(server, "_engine", None)
+    monkeypatch.setattr(server, "_residency_manager", None)
+    monkeypatch.setattr(server, "_lifespan_active", False)
+
+    with patch.object(
+        server, "SimpleEngine", return_value=fake_engine
+    ) as simple_engine:
+        server.load_model(
+            "gemma4",
+            force_mllm=True,
+            mllm_draft_model="eagle3-drafter",
+            mllm_draft_kind="eagle3",
+            mllm_draft_block_size=2,
+        )
+
+    assert simple_engine.call_args.kwargs["mllm_draft_block_size"] == 2
+
+
+def test_load_model_keeps_mtp_block_size_one_valid(monkeypatch):
+    """MTP retains its existing positive block-size contract."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx import server
+
+    class FakeSimpleEngine:
+        is_mllm = True
+
+        async def start(self):
+            pass
+
+    fake_engine = FakeSimpleEngine()
+    monkeypatch.setattr(server, "_engine", None)
+    monkeypatch.setattr(server, "_residency_manager", None)
+    monkeypatch.setattr(server, "_lifespan_active", False)
+
+    with patch.object(
+        server, "SimpleEngine", return_value=fake_engine
+    ) as simple_engine:
+        server.load_model(
+            "gemma4",
+            force_mllm=True,
+            mllm_draft_model="assistant",
+            mllm_draft_kind="mtp",
+            mllm_draft_block_size=1,
+        )
+
+    assert simple_engine.call_args.kwargs["mllm_draft_block_size"] == 1
+
+
+def test_simple_engine_uses_resolved_eagle3_kind_and_reports_speculative(monkeypatch):
+    """SimpleEngine status must expose the loaded Eagle3 algorithm, not only config."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx.engine.simple import SimpleEngine
+    from vllm_mlx.models import mllm
+
+    class FakeMLLM:
+        def __init__(self, *args, **kwargs):
+            self.draft_kind = "eagle3"
+
+        def load(self):
+            pass
+
+    monkeypatch.setattr(mllm, "MLXMultimodalLM", FakeMLLM)
+    engine = SimpleEngine(
+        "target",
+        force_mllm=True,
+        mllm_draft_model="eagle3-drafter",
+        mllm_draft_kind="eagle3",
+        mllm_draft_block_size=4,
+        default_mllm_draft=True,
+    )
+    engine.prepare_for_start()
+
+    assert engine._mllm_draft_kind == "eagle3"
+    assert engine.get_stats()["speculative"] == {
+        "enabled": True,
+        "implementation": "mlx_vlm_eagle3",
+        "draft_model": "eagle3-drafter",
+        "draft_kind": "eagle3",
+        "draft_block_size": 4,
+        "default_enabled": True,
+        "continuous_batching_supported": False,
+    }
+
+
+@pytest.mark.anyio
+async def test_status_projects_eagle3_speculative_configuration(monkeypatch):
+    """The public status payload must retain the active Eagle3 configuration."""
+    _install_mlx_stubs(monkeypatch)
+    from vllm_mlx import server
+
+    class Eagle3Engine:
+        def get_stats(self):
+            return {
+                "running": True,
+                "uptime_seconds": 1,
+                "steps_executed": 0,
+                "num_running": 0,
+                "num_waiting": 0,
+                "num_requests_processed": 0,
+                "total_prompt_tokens": 0,
+                "total_completion_tokens": 0,
+                "requests": [],
+                "speculative": {
+                    "enabled": True,
+                    "implementation": "mlx_vlm_eagle3",
+                    "draft_model": "eagle3-drafter",
+                    "draft_kind": "eagle3",
+                    "draft_block_size": 2,
+                    "default_enabled": True,
+                    "continuous_batching_supported": False,
+                },
+            }
+
+    monkeypatch.setattr(server, "_engine", Eagle3Engine())
+    monkeypatch.setattr(server, "_model_manager", None)
+    monkeypatch.setattr(server, "_model_name", "target")
+    monkeypatch.setattr(server, "_residency_manager", None)
+    monkeypatch.setattr(server, "_default_model_key", None)
+
+    result = await server.status()
+
+    assert result["mtp"] == {"enabled": False}
+    assert result["speculative"]["draft_kind"] == "eagle3"
+    assert result["speculative"]["draft_block_size"] == 2

--- a/tests/test_mllm_assistant_drafter.py
+++ b/tests/test_mllm_assistant_drafter.py
@@ -2,9 +2,232 @@
 """Tests for MLLM assistant-drafter speculative wiring."""
 
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
+
+
+def _install_eagle3_loader(monkeypatch, *, resolved_kind="eagle3", drafter=None):
+    drafter = drafter or _upstream_eagle3_drafter()
+    calls = []
+    speculative = ModuleType("mlx_vlm.speculative")
+
+    def load_drafter(path, kind):
+        calls.append((path, kind))
+        return drafter, resolved_kind
+
+    speculative.load_drafter = load_drafter
+    drafters = ModuleType("mlx_vlm.speculative.drafters")
+    drafters.validate_drafter_compatibility = lambda *args: calls.append(args)
+    mlx_vlm = ModuleType("mlx_vlm")
+    mlx_vlm.__path__ = []
+    mlx_vlm.speculative = speculative
+    speculative.drafters = drafters
+    utils = ModuleType("mlx_vlm.utils")
+    utils.load = lambda path: pytest.fail("Eagle3 must not load a drafter processor")
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative", speculative)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative.drafters", drafters)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", utils)
+    return calls
+
+
+def _upstream_eagle3_drafter(
+    *,
+    capture_layer_ids=(0, 1, 2),
+    target_layer_ids=(0, 1, 2),
+    target_hidden_size=8,
+    target_vocab_size=10,
+    internal_hidden_size=4,
+):
+    """Match mlx-vlm 0.6.5 Eagle3's config and model metadata layout."""
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            capture_layer_ids=capture_layer_ids,
+            target_layer_ids=target_layer_ids,
+            target_hidden_size=target_hidden_size,
+            transformer_layer_config=SimpleNamespace(
+                hidden_size=internal_hidden_size,
+                vocab_size=target_vocab_size,
+            ),
+        ),
+        target_hidden_size=target_hidden_size,
+        target_vocab_size=target_vocab_size,
+    )
+
+
+def _eagle3_target(*, rollback=True, layer_count=4, hidden_size=8, vocab_size=10):
+    language_model = SimpleNamespace(
+        layers=[object()] * layer_count,
+        config=SimpleNamespace(hidden_size=hidden_size, vocab_size=vocab_size),
+    )
+    if rollback:
+        language_model.rollback_speculative_cache = lambda *args: None
+    return SimpleNamespace(language_model=language_model)
+
+
+def test_eagle3_loader_uses_model_only_drafter_and_retains_resolved_kind(monkeypatch):
+    """A separate processor load would wrongly bind Eagle3 to a second tokenizer."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    calls = _install_eagle3_loader(monkeypatch)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target()
+
+    assert model._load_draft_model() is not None
+    assert model.draft_kind == "eagle3"
+    assert calls[0] == ("eagle3-drafter", "eagle3")
+    assert calls[1][0] is model.model
+    assert calls[1][2] == "eagle3"
+
+
+def test_eagle3_preflight_reads_capture_layers_from_upstream_drafter(monkeypatch):
+    """Gemma targets do not retain capture layers after their forward call."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    drafter = _upstream_eagle3_drafter(capture_layer_ids=(0, 1, 3))
+    _install_eagle3_loader(monkeypatch, drafter=drafter)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target(layer_count=4)
+
+    assert model._load_draft_model() is not None
+
+
+def test_eagle3_preflight_falls_back_to_drafter_target_layers(monkeypatch):
+    """Drafters without explicit capture layers use their target-layer fallback."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    drafter = _upstream_eagle3_drafter(
+        capture_layer_ids=None, target_layer_ids=(0, 1, 3)
+    )
+    _install_eagle3_loader(monkeypatch, drafter=drafter)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target(layer_count=4)
+
+    assert model._load_draft_model() is not None
+
+
+def test_eagle3_explicit_kind_mismatch_fails_at_startup(monkeypatch):
+    """Serving a resolved algorithm other than the requested algorithm is unsafe."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    _install_eagle3_loader(monkeypatch, resolved_kind="other")
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target()
+
+    with pytest.raises(
+        ValueError, match="requested 'eagle3'.*resolved 'other'.*eagle3-drafter"
+    ):
+        model._load_draft_model()
+
+
+@pytest.mark.parametrize("resolved_kind", ["mtp", "dflash"])
+def test_eagle3_kind_mismatch_keeps_requested_kind_for_retry(
+    monkeypatch, resolved_kind
+):
+    """A failed resolution must retry the Eagle3 loader, never another kind."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    calls = _install_eagle3_loader(monkeypatch, resolved_kind=resolved_kind)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target()
+
+    for _ in range(2):
+        with pytest.raises(
+            ValueError, match=f"requested 'eagle3'.*resolved '{resolved_kind}'"
+        ):
+            model._load_draft_model()
+        assert model.draft_kind == "eagle3"
+
+    assert calls == [
+        ("eagle3-drafter", "eagle3"),
+        ("eagle3-drafter", "eagle3"),
+    ]
+
+
+def test_eagle3_preflight_rejects_missing_rollback(monkeypatch):
+    """Eagle3 must fail before generation without target cache rollback."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    _install_eagle3_loader(monkeypatch)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target(rollback=False)
+
+    with pytest.raises(ValueError, match="rollback_speculative_cache"):
+        model._load_draft_model()
+
+
+@pytest.mark.parametrize(
+    ("drafter", "property"),
+    [
+        (_upstream_eagle3_drafter(capture_layer_ids=()), "capture_layer_ids"),
+        (_upstream_eagle3_drafter(capture_layer_ids=(0, 0)), "capture_layer_ids"),
+        (_upstream_eagle3_drafter(capture_layer_ids=(-1,)), "capture_layer_ids"),
+        (_upstream_eagle3_drafter(capture_layer_ids=(4,)), "capture_layer_ids"),
+        (_upstream_eagle3_drafter(capture_layer_ids=(0, 1)), "capture_layer_ids"),
+        (
+            _upstream_eagle3_drafter(capture_layer_ids=(0, 1, 2, 3)),
+            "capture_layer_ids",
+        ),
+    ],
+)
+def test_eagle3_preflight_rejects_invalid_target_contract(
+    monkeypatch, drafter, property
+):
+    """Eagle3 must fail before generation when its target contract is incomplete."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    _install_eagle3_loader(monkeypatch, drafter=drafter)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = _eagle3_target()
+
+    with pytest.raises(ValueError, match=property):
+        model._load_draft_model()
+
+
+@pytest.mark.parametrize(
+    ("target", "drafter", "property"),
+    [
+        (
+            _eagle3_target(hidden_size=8),
+            _upstream_eagle3_drafter(target_hidden_size=9),
+            "hidden_size",
+        ),
+        (
+            _eagle3_target(vocab_size=10),
+            _upstream_eagle3_drafter(target_vocab_size=11),
+            "vocab_size",
+        ),
+    ],
+)
+def test_eagle3_preflight_rejects_incompatible_drafter_metadata(
+    monkeypatch, target, drafter, property
+):
+    """Comparable target and drafter metadata must agree before Eagle3 starts."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    _install_eagle3_loader(monkeypatch, drafter=drafter)
+    model = MLXMultimodalLM("target", draft_model="eagle3-drafter", draft_kind="eagle3")
+    model.model = target
+
+    with pytest.raises(ValueError, match=property):
+        model._load_draft_model()
+
+
+def test_eagle3_generation_kwargs_forward_resolved_kind():
+    """Generation must use mlx-vlm's resolved Eagle3 kind and configured block size."""
+    from vllm_mlx.models.mllm import MLXMultimodalLM
+
+    model = MLXMultimodalLM(
+        "target", draft_model="eagle3-drafter", draft_kind="eagle3", draft_block_size=4
+    )
+    model._draft_model = SimpleNamespace(accept_lens=[])
+
+    assert model._draft_generation_kwargs({"mllm_draft": True}) == {
+        "draft_model": model._draft_model,
+        "draft_kind": "eagle3",
+        "draft_block_size": 4,
+    }
 
 
 def test_mllm_chat_forwards_configured_assistant_drafter(monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -114,11 +114,22 @@ def serve_command(args):
     if default_mllm_draft and not mllm_draft_model:
         print("Error: --default-mllm-draft requires --mllm-draft-model")
         sys.exit(1)
+    if mllm_draft_model and args.continuous_batching and mllm_draft_kind == "eagle3":
+        print("Error: Eagle3 uses SimpleEngine and cannot use continuous batching")
+        sys.exit(1)
     if mllm_draft_model and args.continuous_batching and mllm_draft_kind != "mtp":
         print(
             "Error: --mllm-draft-model with --continuous-batching "
             "requires --mllm-draft-kind mtp"
         )
+        sys.exit(1)
+    if (
+        mllm_draft_model
+        and mllm_draft_kind == "eagle3"
+        and mllm_draft_block_size is not None
+        and mllm_draft_block_size < 2
+    ):
+        print("Error: Eagle3 draft block size must be at least 2")
         sys.exit(1)
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         print("Error: --mllm-draft-block-size must be a positive integer")
@@ -1363,8 +1374,11 @@ Examples:
         "--mllm-draft-kind",
         type=str,
         default=None,
-        choices=["mtp"],
-        help="mlx-vlm draft kind for --mllm-draft-model.",
+        choices=["mtp", "eagle3"],
+        help=(
+            "mlx-vlm draft kind for --mllm-draft-model. Eagle3 uses "
+            "SimpleEngine and cannot use continuous batching."
+        ),
     )
     serve_parser.add_argument(
         "--mllm-draft-block-size",

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -796,6 +796,9 @@ class SimpleEngine(BaseEngine):
             )
 
         self._model.load()
+        if self._is_mllm and self._mllm_draft_model_path is not None:
+            assert self._model is not None
+            self._mllm_draft_kind = self._model.draft_kind
 
     def _uses_default_prepare_for_start(self) -> bool:
         """Return True when prepare_for_start is the class implementation."""
@@ -3427,15 +3430,26 @@ class SimpleEngine(BaseEngine):
             }
 
         if self._mllm_draft_model_path is not None:
-            stats["mtp"] = {
-                "enabled": True,
-                "implementation": "mlx_vlm_assistant",
-                "draft_model": self._mllm_draft_model_path,
-                "draft_kind": self._mllm_draft_kind,
-                "draft_block_size": self._mllm_draft_block_size,
-                "default_enabled": self._default_mllm_draft,
-                "continuous_batching_supported": True,
-            }
+            if self._mllm_draft_kind == "eagle3":
+                stats["speculative"] = {
+                    "enabled": True,
+                    "implementation": "mlx_vlm_eagle3",
+                    "draft_model": self._mllm_draft_model_path,
+                    "draft_kind": self._mllm_draft_kind,
+                    "draft_block_size": self._mllm_draft_block_size,
+                    "default_enabled": self._default_mllm_draft,
+                    "continuous_batching_supported": False,
+                }
+            else:
+                stats["mtp"] = {
+                    "enabled": True,
+                    "implementation": "mlx_vlm_assistant",
+                    "draft_model": self._mllm_draft_model_path,
+                    "draft_kind": self._mllm_draft_kind,
+                    "draft_block_size": self._mllm_draft_block_size,
+                    "default_enabled": self._default_mllm_draft,
+                    "continuous_batching_supported": True,
+                }
 
         # System KV cache stats (LRU over multiple system prefixes)
         if self._system_kv_cache:

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -458,6 +458,109 @@ def load_gemma4_assistant_drafter(model_path: str):
     return model
 
 
+def _eagle3_metadata_value(model, name: str):
+    """Return comparable model metadata when the model exposes it."""
+    config = getattr(model, "config", None)
+    candidates = (model, config, getattr(config, "text_config", None))
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        value = (
+            candidate.get(name)
+            if isinstance(candidate, dict)
+            else getattr(candidate, name, None)
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _eagle3_config_value(config, name: str):
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _eagle3_drafter_target_metadata_value(drafter, name: str):
+    """Return Eagle3 metadata that describes the target, not the drafter."""
+    target_name = f"target_{name}"
+    config = getattr(drafter, "config", None)
+    for candidate in (drafter, config):
+        value = _eagle3_config_value(candidate, target_name)
+        if value is not None:
+            return value
+    transformer_config = _eagle3_config_value(config, "transformer_layer_config")
+    return _eagle3_config_value(transformer_config, name)
+
+
+def _validate_eagle3_target(target, drafter) -> None:
+    """Validate the target capabilities required by mlx-vlm Eagle3."""
+    language_model = getattr(target, "language_model", target)
+    rollback = getattr(language_model, "rollback_speculative_cache", None)
+    if not callable(rollback):
+        raise ValueError(
+            "Eagle3 target is incompatible: language model must provide "
+            "callable rollback_speculative_cache"
+        )
+
+    drafter_config = getattr(drafter, "config", None)
+    capture_layer_ids = _eagle3_config_value(drafter_config, "capture_layer_ids")
+    if capture_layer_ids is None:
+        capture_layer_ids = _eagle3_config_value(drafter_config, "target_layer_ids")
+    if not capture_layer_ids or not all(
+        isinstance(layer_id, int) and not isinstance(layer_id, bool)
+        for layer_id in capture_layer_ids
+    ):
+        raise ValueError(
+            "Eagle3 target is incompatible: capture_layer_ids must be a non-empty "
+            "sequence of integers"
+        )
+    if len(capture_layer_ids) != 3:
+        raise ValueError(
+            "Eagle3 target is incompatible: capture_layer_ids must contain exactly "
+            "three layer IDs"
+        )
+    if len(set(capture_layer_ids)) != len(capture_layer_ids):
+        raise ValueError(
+            "Eagle3 target is incompatible: capture_layer_ids must not contain duplicates"
+        )
+    if any(layer_id < 0 for layer_id in capture_layer_ids):
+        raise ValueError(
+            "Eagle3 target is incompatible: capture_layer_ids must not contain "
+            "negative values"
+        )
+
+    layers = getattr(language_model, "layers", None)
+    layer_count = None
+    if layers is not None:
+        try:
+            layer_count = len(layers)
+        except TypeError:
+            pass
+    if layer_count is None:
+        layer_count = _eagle3_metadata_value(language_model, "num_hidden_layers")
+    if layer_count is not None and any(
+        layer_id >= layer_count for layer_id in capture_layer_ids
+    ):
+        raise ValueError(
+            "Eagle3 target is incompatible: capture_layer_ids contains a layer "
+            "outside the target layer count"
+        )
+
+    for property_name in ("hidden_size", "vocab_size"):
+        target_value = _eagle3_metadata_value(language_model, property_name)
+        drafter_value = _eagle3_drafter_target_metadata_value(drafter, property_name)
+        if (
+            target_value is not None
+            and drafter_value is not None
+            and target_value != drafter_value
+        ):
+            raise ValueError(
+                f"Eagle3 target is incompatible: {property_name} differs "
+                f"(target={target_value}, drafter={drafter_value})"
+            )
+
+
 _DRAFT_KWARG_NAMES = ("draft_model", "draft_kind", "draft_block_size")
 
 
@@ -1404,6 +1507,25 @@ class MLXMultimodalLM:
     def _load_draft_model(self):
         if self.draft_kind == "mtp":
             return load_gemma4_assistant_drafter(self.draft_model_path)
+
+        if self.draft_kind == "eagle3":
+            from mlx_vlm.speculative import load_drafter
+            from mlx_vlm.speculative.drafters import validate_drafter_compatibility
+
+            requested_kind = self.draft_kind
+            draft_model, resolved_kind = load_drafter(
+                self.draft_model_path, kind="eagle3"
+            )
+            if requested_kind != resolved_kind:
+                raise ValueError(
+                    "MLLM draft kind mismatch: requested "
+                    f"'{requested_kind}', resolved '{resolved_kind}' for checkpoint "
+                    f"'{self.draft_model_path}'"
+                )
+            _validate_eagle3_target(self.model, draft_model)
+            validate_drafter_compatibility(self.model, draft_model, resolved_kind)
+            self.draft_kind = resolved_kind
+            return draft_model
 
         from mlx_vlm.utils import load
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3570,10 +3570,19 @@ def load_model(
         raise ValueError("MLLM draft models require force_mllm/--mllm")
     if default_mllm_draft and not mllm_draft_model:
         raise ValueError("default_mllm_draft requires an MLLM draft model")
+    if mllm_draft_model and use_batching and mllm_draft_kind == "eagle3":
+        raise ValueError("Eagle3 uses SimpleEngine and cannot use continuous batching")
     if mllm_draft_model and use_batching and mllm_draft_kind != "mtp":
         raise ValueError(
             "Continuous-batching MLLM draft models require mllm_draft_kind='mtp'"
         )
+    if (
+        mllm_draft_model
+        and mllm_draft_kind == "eagle3"
+        and mllm_draft_block_size is not None
+        and mllm_draft_block_size < 2
+    ):
+        raise ValueError("Eagle3 draft block size must be at least 2")
     if mllm_draft_block_size is not None and mllm_draft_block_size <= 0:
         raise ValueError("MLLM draft block size must be a positive integer")
     if mllm_draft_model and (auto_unload_idle_seconds > 0 or lazy_load_model):
@@ -3912,7 +3921,7 @@ async def status():
     # Extract batch_generator throughput when available (MLLM scheduler).
     bg = stats.get("batch_generator", {})
 
-    return {
+    payload = {
         "status": "running" if stats.get("running") else "stopped",
         "model": _model_name,
         "residency": lifecycle,
@@ -3937,6 +3946,9 @@ async def status():
         "mtp": stats.get("mtp") or {"enabled": False},
         "requests": stats.get("requests", []),
     }
+    if "speculative" in stats:
+        payload["speculative"] = stats["speculative"]
+    return payload
 
 
 @app.get("/v1/cache/stats", dependencies=[Depends(verify_api_key)])
@@ -7308,8 +7320,11 @@ Examples:
         "--mllm-draft-kind",
         type=str,
         default=None,
-        choices=["mtp"],
-        help="mlx-vlm draft kind for --mllm-draft-model.",
+        choices=["mtp", "eagle3"],
+        help=(
+            "mlx-vlm draft kind for --mllm-draft-model. Eagle3 uses "
+            "SimpleEngine and cannot use continuous batching."
+        ),
     )
     parser.add_argument(
         "--mllm-draft-block-size",


### PR DESCRIPTION
## Summary

This PR adds Eagle3 as an explicit multimodal speculative decoding mode backed by the native implementation introduced in `mlx-vlm>=0.6.5`.

It provides:

- Explicit `eagle3` selection through `--mllm-draft-kind`.
- Eagle3 drafter loading through `mlx_vlm.speculative.load_drafter`.
- Startup validation of the target and drafter contract.
- Early rejection of unsupported batching and block-size configurations.
- Eagle3 configuration reporting through engine statistics and `/v1/status`.
- Regression coverage for loading, validation, configuration forwarding, retries, status reporting, and MTP compatibility.
- Documentation for usage, limitations, and the required Apple Silicon validation protocol.

Closes #762.

> [!IMPORTANT]
> This PR is intentionally a draft. The implementation and Linux-safe regression coverage are complete, but generation parity and performance still require validation on real Apple Silicon hardware before the PR is ready to merge.

## Context

`mlx-vlm` 0.6.5 introduced a dedicated Eagle3 drafter architecture and generation path. Previously, vllm-mlx only exposed `mtp` through `--mllm-draft-kind`.

Treating an Eagle3 checkpoint as MTP is not sufficient because:

- mlx-vlm resolves Eagle3 checkpoints to `draft_kind="eagle3"`.
- Eagle3 uses its own proposal and verification behavior.
- The target model must expose speculative cache rollback.
- The drafter expects hidden states captured from exactly three target layers.
- Target and drafter hidden and vocabulary dimensions must be compatible.
- The existing continuous-batching proposer is MTP-specific and does not implement Eagle3 rollback or hidden-state capture.

The implementation therefore keeps Eagle3 as a separate algorithm rather than extending or overloading the existing MTP path.

Related work remains separate:

- #724 covers architecture-aware MTP loading.
- #502 and #699 track DFlash.
- This PR does not replace or refactor those implementations.

## Implementation details

### Eagle3 loading and algorithm resolution

When an MLLM drafter is configured with `draft_kind="eagle3"`, `MLXMultimodalLM` now:

1. Loads the checkpoint through the public `mlx_vlm.speculative.load_drafter` API.
2. Requests the explicit `eagle3` kind.
3. Retains the draft kind resolved by mlx-vlm.
4. Rejects a checkpoint if its resolved kind differs from the requested kind.
5. Runs local target-capability validation.
6. Runs mlx-vlm's `validate_drafter_compatibility`.
7. Stores the resolved kind only after every validation succeeds.

The drafter is loaded without requiring target tokenizer or processor files.

The resolved kind is assigned after validation so that a failed startup attempt does not mutate loader state and change the behavior of a retry.

### Target compatibility preflight

Eagle3 startup now validates the contract required by mlx-vlm before the server begins accepting requests.

The preflight checks:

- The target language model exposes a callable `rollback_speculative_cache`.
- Capture-layer metadata exists on the drafter configuration.
- `target_layer_ids` remains supported as a fallback metadata name.
- Capture-layer IDs are integers and not booleans.
- Exactly three capture-layer IDs are provided.
- Capture-layer IDs are unique.
- Capture-layer IDs are nonnegative.
- Every capture-layer ID is inside the target model's layer count when that information is available.
- Target hidden size matches the drafter's target hidden-size metadata.
- Target vocabulary size matches the drafter's target vocabulary-size metadata.

Errors are raised during startup with an actionable compatibility message rather than being deferred until the first generation request.

### Engine routing and batching boundary

Eagle3 is restricted to `SimpleEngine`.

The CLI and direct server loader both reject Eagle3 when continuous batching is enabled:

```text
Eagle3 uses SimpleEngine and cannot use continuous batching
```

This check happens before model download or engine construction.

The custom continuous-batching scheduler remains unchanged because it currently installs an MTP-specific proposer and does not implement the auxiliary hidden-state capture and cache rollback required by Eagle3.

Model registry mode and lifecycle residency remain unsupported because they rely on the continuous-batching engine.

### Draft block-size validation

Eagle3 accepts:

- An omitted block size, which preserves mlx-vlm's no-override behavior.
- Explicit block sizes greater than or equal to `2`.

Explicit Eagle3 block sizes below `2` fail before model construction:

```text
Eagle3 draft block size must be at least 2
```

This restriction is Eagle3-specific. MTP retains its existing behavior and continues to accept a block size of `1`.

### Generation configuration

Once loaded, the resolved `eagle3` kind remains attached to the configured MLLM drafter and is forwarded through the existing mlx-vlm generation path.

Existing request-level behavior is preserved:

- A configured drafter can remain enabled by default.
- Individual requests can opt out.
- The resolved draft kind and configured block size are forwarded only when draft generation is enabled.
- Target-only requests continue through the existing path.

### Status reporting

`SimpleEngine.get_stats()` reports active Eagle3 configuration under:

```json
{
  "speculative": {
    "enabled": true,
    "implementation": "mlx_vlm_eagle3",
    "draft_model": "EAGLE3_CHECKPOINT",
    "draft_kind": "eagle3",
    "draft_block_size": 4,
    "default_enabled": true,
    "continuous_batching_supported": false
  }
}
```

The public `/v1/status` endpoint forwards this `speculative` object.

The existing `mtp` status field is preserved for compatibility. MTP configurations continue using their original `mtp` status representation.

## Behavior matrix

| Configuration | Result |
| --- | --- |
| Eagle3 with `SimpleEngine` | Accepted |
| Eagle3 with continuous batching | Rejected before model loading |
| Eagle3 without explicit block size | Uses mlx-vlm's no-override behavior |
| Eagle3 with block size `1` | Rejected before model construction |
| Eagle3 with block size `2` or greater | Accepted |
| Eagle3 checkpoint resolving to another kind | Rejected during startup |
| Target without speculative rollback | Rejected during startup |
| Invalid or out-of-range capture layers | Rejected during startup |
| Incompatible target hidden or vocabulary size | Rejected during startup |
| MTP with block size `1` | Existing behavior preserved |
| DFlash | Existing path unchanged |

## Type of change

- New feature
- Documentation

## Surface touched

- CLI / serve command
- OpenAI API endpoints
- Scheduler / batching support gates
- Multimodal model loading
- Speculative decoding configuration
- Engine status reporting
- Tests and documentation

## Regression coverage

The new and updated tests cover:

- CLI parser acceptance of `--mllm-draft-kind eagle3`.
- CLI rejection of Eagle3 continuous batching before model download.
- CLI rejection of Eagle3 block size `1` before model download.
- Direct server-loader rejection of unsupported batching.
- Direct server-loader rejection of block size `1`.
- Acceptance and forwarding of block size `2`.
- Preservation of MTP block size `1`.
- Use of the public mlx-vlm drafter loader.
- Loading the drafter without processor arguments.
- Retention of the resolved Eagle3 kind.
- Startup rejection when requested and resolved kinds differ.
- Preservation of requested kind after a failed load so retries remain correct.
- Capture-layer metadata from the upstream drafter configuration.
- Fallback from `capture_layer_ids` to `target_layer_ids`.
- Missing rollback support.
- Invalid capture-layer types.
- Duplicate, negative, out-of-range, two-layer, and four-layer capture configurations.
- Hidden-size and vocabulary-size incompatibility.
- Forwarding of the resolved kind into generation arguments.
- Engine-level speculative status.
- Public `/v1/status` projection.
- Existing MTP status and request opt-out behavior.

## Test plan

### Linux-safe regression suite

```bash
pytest -q \
  tests/test_cli.py::test_serve_parser_accepts_eagle3_mllm_draft_kind \
  tests/test_cli.py::test_serve_command_rejects_eagle3_batching_before_download \
  tests/test_cli.py::test_serve_command_rejects_eagle3_block_size_below_two_before_download \
  tests/test_eagle3_server_validation.py \
  tests/test_mllm_assistant_drafter.py \
  -k eagle3 \
  tests/test_mllm_assistant_drafter.py::test_simple_engine_reports_configured_mllm_drafter_status \
  tests/test_mllm_assistant_drafter.py::test_mllm_drafter_defaults_on_and_request_can_opt_out
```

### Static checks

```bash
ruff check \
  vllm_mlx/models/mllm.py \
  vllm_mlx/engine/simple.py \
  vllm_mlx/cli.py \
  vllm_mlx/server.py \
  tests/test_cli.py \
  tests/test_mllm_assistant_drafter.py \
  tests/test_eagle3_server_validation.py \
  --select E,F,W \
  --ignore E402,E501,E731,F811,F841

black --check vllm_mlx/ tests/

python -m py_compile \
  vllm_mlx/models/mllm.py \
  vllm_mlx/engine/simple.py \
  vllm_mlx/cli.py \
  vllm_mlx/server.py \
  tests/test_cli.py \
  tests/test_mllm_assistant_drafter.py \
  tests/test_eagle3_server_validation.py

git diff --check
```

## Test results

Linux verification completed:

- Eagle3 regression suite: `25 passed, 12 deselected`
- Changed-file Ruff: passed
- Full Black: `253 files would be left unchanged`
- Python compilation: passed
- `git diff --check`: passed
- Multi-agent scoped review: all reported findings addressed
- Final fix review: no new critical, important, or minor findings

Repository-wide checks have existing limitations:

- Full Ruff reports three `E721` diagnostics in untouched tests:
  - `tests/test_memory_cache_mlx.py:725`
  - `tests/test_prefix_cache_untrimmable.py:254`
  - `tests/test_prefix_cache_untrimmable.py:332`
- Repository-wide Mypy reports diagnostics outside the changed lines.
- Tests importing the real MLX runtime cannot run on this Linux host.

## Apple Silicon validation required

Before moving this PR out of draft, validate it on a real Apple Silicon machine using exact target and drafter revisions.

### Correctness

1. Run greedy target-only generation.
2. Run greedy Eagle3 generation with identical prompts, media, seed, and generation limits.
3. Compare complete generated token-ID sequences exactly.
4. Repeat across short, medium, and long prompts.
5. Include text-only and multimodal inputs supported by the selected target.
6. Exercise request-level drafter opt-out.
7. Verify startup errors with an incompatible target or checkpoint.

### Block-size sweep

Test:

- Block size `2`
- Block size `4`
- The value declared by the selected checkpoint configuration
- No explicit override

If the checkpoint value differs from mlx-vlm's no-override behavior, test both independently.

### Performance

After warmup, collect at least 20 measured runs for target-only and every Eagle3 block-size configuration.

Record:

- Median latency
- p95 latency
- Output tokens per second
- Drafted tokens
- Accepted tokens
- Acceptance rate
- Mean accepted draft length
- Process RSS
- Peak Metal allocation
- Prompt and completion token counts

Use `/v1/status` samples to record `metal.peak_memory_gb` and the active speculative configuration.

### Cache boundaries

If `max_kv_size` is used:

1. Find the largest prompt and generation combination that fits.
2. Test the first combination that exceeds the configured bound.
3. Record whether generation fails, falls back, or remains correct.
4. Repeat after the cache has reached capacity to exercise rollback behavior.

## Performance impact

Performance is pending Apple Silicon measurements.

This PR intentionally makes no speedup claim. Earlier Eagle3 experiments referenced by #57 did not establish a reliable Apple Silicon improvement, so support should remain draft until current mlx-vlm measurements are available.

- Hardware: TBD
- Target model and quantization: TBD
- Eagle3 checkpoint and revision: TBD
- Baseline metrics: TBD
- Eagle3 metrics: TBD
- Delta versus main: TBD

Correctness, resource consumption, and performance must be reported separately.

## Output parity

Exact greedy token-ID parity is pending Apple Silicon validation.

The Linux tests verify configuration and dispatch behavior but do not execute MLX kernels or prove generation parity.

Any token divergence must be investigated before the PR is marked ready for review.

## Compatibility

- Requires the existing `mlx-vlm>=0.6.5` dependency floor.
- Adds `eagle3` to the existing CLI choice set.
- Does not change the default draft kind.
- Does not enable Eagle3 automatically.
- Does not change MTP checkpoint loading.
- Does not change DFlash loading.
- Does not add Eagle3 to continuous batching.
- Preserves the existing `mtp` status field.
- Adds the optional `speculative` status field only when Eagle3 is configured.

## Risk notes

The main runtime risks are upstream contract changes and Apple-specific behavior that cannot be reproduced on Linux.

Reviewers should focus on:

- Whether mlx-vlm continues to require exactly three capture layers.
- Whether all intended target architectures expose rollback through `language_model`.
- Whether hidden-size and vocabulary metadata names remain stable across Eagle3 checkpoints.
- Whether cache rollback remains correct after bounded caches reach capacity.
- Whether forwarding the resolved kind covers every multimodal generation route.
- Whether the public status representation is sufficiently stable for clients.
- Whether real acceptance rates justify enabling Eagle3 for the selected checkpoints.

The implementation minimizes these risks by delegating the generation loop to mlx-vlm, validating compatibility during startup, and keeping Eagle3 out of the custom batched scheduler.
