### PR TITLE
fix(prefix-cache): prefer superseded prefixes over LRU when evicting

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -428,6 +428,47 @@ class TestMemoryAwarePrefixCache:
         stats = cache.get_stats()
         assert stats["evictions"] > 0
 
+    def test_eviction_prefers_superseded_prefix_over_lru(self, model, mock_kv_cache):
+        """Under pressure, give up a turn another entry subsumes -- not a live one.
+
+        Multi-turn conversations store one entry per turn, each a strict prefix of
+        the next, so the cache fills with superseded turns. Walking strictly
+        oldest-first then evicts conversation A's NEWEST entry -- the one A is
+        about to reuse -- before touching conversation B's already-superseded
+        turns. Preferring superseded entries keeps every live conversation warm.
+        """
+        # ~200KB entries, 1MB budget => 5 resident; 8 stores forces 3 evictions.
+        config = MemoryCacheConfig(
+            max_memory_mb=1.0,
+            max_entries=100,
+            min_prefix_tokens=1,
+        )
+        cache = MemoryAwarePrefixCache(model, config)
+
+        def turns(tag):
+            # three turns, each a strict prefix of the next
+            return [[tag] * (3 * n) for n in (1, 2, 3)]
+
+        a_turns, b_turns = turns(1), turns(2)
+        # evict_prefixes=False mirrors the hybrid-model path, where proactive
+        # prefix eviction is disabled and superseded turns therefore accumulate.
+        for seq in a_turns + b_turns:
+            cache.store(seq, mock_kv_cache(200 * 1024), evict_prefixes=False)
+        # conversation C applies the pressure that forces the discriminating choice
+        for seq in turns(3)[:2]:
+            cache.store(seq, mock_kv_cache(200 * 1024), evict_prefixes=False)
+
+        assert cache.get_stats()["evictions"] >= 3
+
+        # A's live (newest) entry must have survived: strict LRU would have taken
+        # it as the third victim, since A1 and A2 are the two oldest entries.
+        result, _ = cache.fetch(a_turns[-1])
+        assert result is not None, "live entry of the older conversation was evicted"
+
+        # ...and B's live entry too.
+        result_b, _ = cache.fetch(b_turns[-1])
+        assert result_b is not None, "live entry of the newer conversation was evicted"
+
     def test_lru_order_updated_on_fetch(self, small_cache, mock_kv_cache):
         # Store two entries
         tokens1 = [1, 2, 3]

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1466,8 +1466,38 @@ class MemoryAwarePrefixCache:
         if idx < len(self._sorted_keys) and self._sorted_keys[idx] == key:
             self._sorted_keys.pop(idx)
 
+    def _find_superseded_lru(self) -> tuple[int, ...] | None:
+        """Oldest resident entry that is a strict prefix of another resident entry.
+
+        Such an entry is the cheapest thing to give up under memory pressure:
+        anything it could serve, the longer entry serves at least as well, since a
+        strict-prefix hit on the longer key covers everything the shorter key
+        covers and more.
+
+        This matters because multi-turn conversations generate exactly this shape
+        -- one entry per turn, each a strict prefix of the next. Without it the
+        cache fills with superseded turns and plain LRU, walking oldest-first,
+        sacrifices an older conversation's *newest* entry (the one it is about to
+        need) before it touches a newer conversation's already-superseded turns.
+
+        The one case that loses is a conversation branched *below* the longer
+        entry (an edited or retried turn). That request re-prefills -- which is
+        what would have happened anyway had plain LRU chosen it.
+
+        Extensions of a key sort immediately after it, so checking the single
+        successor in ``_sorted_keys`` is sufficient: any key ordered between a key
+        and one of its extensions would itself have to start with that key.
+        """
+        for key in self._entries:  # OrderedDict iterates oldest-first (LRU order)
+            idx = bisect.bisect_right(self._sorted_keys, key)
+            if idx < len(self._sorted_keys):
+                nxt = self._sorted_keys[idx]
+                if len(nxt) > len(key) and nxt[: len(key)] == key:
+                    return key
+        return None
+
     def _evict_lru(self) -> None:
-        """Evict the least recently used entry.
+        """Evict one entry, preferring a superseded prefix over the LRU entry.
 
         If an SSD tier is attached, the entry is spilled to disk instead
         of being discarded.
@@ -1476,8 +1506,18 @@ class MemoryAwarePrefixCache:
             if not self._entries:
                 return
 
-            # popitem(last=False) removes oldest entry (FIFO order = LRU)
-            tokens_key, entry = self._entries.popitem(last=False)
+            # Prefer an entry that another resident entry already subsumes, else
+            # popitem(last=False) (oldest = LRU). This never deletes proactively --
+            # it only chooses the victim once eviction is already required, so the
+            # hybrid-model prefix-eviction exemption in store() is unaffected.
+            superseded = self._find_superseded_lru()
+            if superseded is not None:
+                tokens_key = superseded
+                entry = self._entries.pop(tokens_key)
+                evict_reason = "superseded"
+            else:
+                tokens_key, entry = self._entries.popitem(last=False)
+                evict_reason = "lru"
             self._current_memory -= entry.memory_bytes
             self._remove_from_sorted(tokens_key)
             self._stats.evictions += 1
@@ -1489,7 +1529,7 @@ class MemoryAwarePrefixCache:
             self._ssd_tier.enqueue_spill(tokens_key, entry.cache, entry.memory_bytes)
 
         logger.debug(
-            f"[lru_evict] removed {len(tokens_key)} tokens, "
+            f"[lru_evict:{evict_reason}] removed {len(tokens_key)} tokens, "
             f"freed {entry.memory_bytes / _BYTES_PER_MB:.2f}MB"
             f"{'  (spilled to SSD)' if self._ssd_tier is not None else ''}"
         )


### PR DESCRIPTION
## Problem

Multi-turn conversations store **one prefix-cache entry per turn**, each a strict prefix of the next. `_evict_lru` walks strictly oldest-first, so under memory pressure it sacrifices an older conversation's *newest* entry — the one that conversation is about to reuse — before touching a newer conversation's already-superseded turns.

Concretely, with two conversations of three turns each and pressure from a third:

| policy | victims | live entries killed |
|---|---|---|
| plain LRU | `A1, A2, `**`A3`** | **A3** — conversation A must fully re-prefill |
| this PR | `A1, A2, B1` | none |

This bites hardest on **hybrid / linear-attention models**, and not by coincidence. `store()` already exempts them from proactive prefix eviction (correctly — recurrent state cannot be rewound, so `cache_fetch` blocks LCP and supersequence reuse and strict-PREFIX is the only sound path). That exemption means nothing else ever reclaims superseded turns, so the cache fills with them and LRU is left choosing badly.

## Change

`_find_superseded_lru()` returns, in LRU order, an entry that another resident entry strictly extends. Anything it could serve, the longer entry serves at least as well, so it is the cheapest thing to give up. Eviction falls back to `popitem(last=False)` when nothing is superseded.

This **never deletes proactively** — it only picks the victim once eviction is already required — so the hybrid exemption in `store()` is untouched and the regression that motivated it (a shared system prefix being deleted by the next store) cannot return. A lone shared prefix with no longer resident entry is not superseded, so it is never preferentially evicted; there is a unit test for exactly that.

Extensions of a key sort immediately after it, so testing the single successor in `_sorted_keys` is sufficient and the check stays O(log N).

The one case that loses is a conversation branched *below* the longer entry (an edited or retried turn). It re-prefills — which is what plain LRU would have caused anyway.

## Testing

- `tests/test_memory_cache.py` — **54 passed**. The new test fails on the old policy with `live entry of the older conversation was evicted` and passes on the new one; I verified both directions by stashing the change.
- `tests/test_memory_cache_stream_safety.py`, `tests/test_mllm_cache.py` — 36 passed.

## Measurements

Qwen3.6-35B-A3B 6-bit (hybrid: 30 GatedDeltaNet + 10 full-attention layers) on an M5 Max, served by vllm-mlx, driven through a real Claude Code session (via claude-code-router) that spawned two parallel subagents.

Entry cost averages **~630 MB at ~26k tokens**. One session plus two subagents reached **6 entries / 3776 MB against a 4000 MB budget (94.4%)** before its first eviction — i.e. a single agentic session with two subagents very nearly fills a 4 GB prefix cache on its own.

Three-conversation pressure test (A×3 turns, B×3 turns, then C×3 forcing eviction), after the change:

```
phase 1  A×3, B×3        -> 6 entries, 3391 MB (84.8%)
phase 2  C×3 (pressure)  -> 2 evictions, steady at 7 entries / ~3970 MB
phase 3  AT4  HIT 0.36s   <- A's live entry survived
         BT4  HIT 0.52s   <- B's live entry survived     => 2/2
```

Warm appends run **0.3–0.7 s against 8–10 s cold** on these conversations, so keeping a live entry resident is worth roughly 25× on the next turn.

## What I did not verify

The pressure test above was run only **after** the change; I did not re-run the identical live scenario against unmodified `main` (it needs two more server restarts on a machine that was back in use). The old policy's victim order is therefore established by the unit test — which does fail on `main`'s logic — and by an offline simulation of the same key shapes, not by a second live run.

Only a hybrid model was exercised end-to-end. For non-hybrid models proactive prefix eviction already removes most superseded entries, so `_find_superseded_lru` will usually return `None` and behaviour is unchanged; that path is covered by unit tests rather than live measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BnttGFEAsQ13ULkcktTaY