### PR TITLE
fix(mllm): media requests must not use the prompt prefix cache

### DIFF
--- a/tests/test_mllm_prefix_cache_media.py
+++ b/tests/test_mllm_prefix_cache_media.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""D15 regression: media requests must never touch the prompt prefix cache.
+
+The prefix cache is keyed on token IDs alone, and every image/audio clip
+occupies identical placeholder IDs — so a media request stored or fetched
+under a token-only key replays a DIFFERENT image's KV for any later request
+with the same prompt text. Found live: 67 distinct document pages through
+an MLLM serve produced 2 distinct transcriptions.
+
+These tests pin the fixed contract at the seams:
+  1. ``_maybe_store_prefix_cache`` stores text-only requests and skips media.
+  2. ``MLLMBatchRequest.is_text_only`` defaults False — an unpreprocessed request
+     is treated as media, so the safe direction is cache bypass.
+"""
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+
+from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchRequest
+
+
+def _bare_generator(prefix_cache) -> MLLMBatchGenerator:
+    gen = object.__new__(MLLMBatchGenerator)
+    gen.prefix_cache = prefix_cache
+    gen._think_suffix_len = 0
+    return gen
+
+
+def _finished_batch(req: MLLMBatchRequest):
+    batch = MagicMock()
+    batch.requests = [req]
+    batch.num_tokens = [4]
+    batch.extract_cache.return_value = []
+    return batch
+
+
+def _request(*, text_only: bool, images=None) -> MLLMBatchRequest:
+    req = MLLMBatchRequest(
+        uid=1,
+        request_id="r1",
+        prompt="Transcribe this page.",
+        images=images,
+    )
+    req.input_ids = mx.array([1, 2, 3, 4, 5])
+    req.is_text_only = text_only
+    return req
+
+
+def test_media_request_is_never_stored():
+    prefix_cache = MagicMock()
+    gen = _bare_generator(prefix_cache)
+    req = _request(text_only=False, images=["data:image/png;base64,AAAA"])
+
+    gen._maybe_store_prefix_cache(_finished_batch(req), end_indices=[0])
+
+    prefix_cache.store.assert_not_called()
+
+
+def test_text_only_request_is_still_stored():
+    prefix_cache = MagicMock()
+    gen = _bare_generator(prefix_cache)
+    req = _request(text_only=True)
+
+    gen._maybe_store_prefix_cache(_finished_batch(req), end_indices=[0])
+
+    assert prefix_cache.store.call_count == 1
+    stored_key = prefix_cache.store.call_args.args[0]
+    assert stored_key == [1, 2, 3, 4, 5]
+
+
+def test_is_text_only_defaults_to_media():
+    # Safe-direction check: before preprocessing runs, a request must count
+    # as media so it can never be served another request's cached KV.
+    req = MLLMBatchRequest(uid=2, request_id="r2", prompt="hello")
+    assert req.is_text_only is False

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -1498,7 +1498,25 @@ class MLLMBatchGenerator:
                 # running them through the language model alone.
                 cached_kv = None
                 remaining_ids = None
-                if self.prefix_cache is not None and req.input_ids is not None:
+                # The prefix cache is keyed on token IDs alone, and every
+                # image/audio clip occupies identical placeholder IDs — so for
+                # media requests "same prompt text" is a full-prefix hit that
+                # replays a DIFFERENT image's KV (the existing image-token
+                # check below only inspects the REMAINING ids, which a full
+                # hit leaves empty). Only text-only requests may touch the
+                # prompt prefix cache; media requests still benefit from
+                # VisionEmbeddingCache, which hashes image bytes.
+                if (
+                    self.prefix_cache is not None
+                    and req.input_ids is not None
+                    # getattr with a permissive default: request-like objects that
+                    # predate this flag (test doubles, external callers) keep the old
+                    # behaviour, so this change only ever RESTRICTS caching for a
+                    # request that explicitly reports media. The real Request dataclass
+                    # defaults the field to False, so a request that never reached
+                    # _process_prompts is still treated as media here.
+                    and getattr(req, "is_text_only", True)
+                ):
                     input_ids_list = req.input_ids.reshape(-1).tolist()
                     # Strip think suffix from lookup key so stored entries
                     # (also stripped) match as clean PREFIX.
@@ -1927,8 +1945,15 @@ class MLLMBatchGenerator:
         elif self.unprocessed_requests and getattr(
             self, "_allow_mid_batch_extend", True
         ):
+            # Audio counts as media too: an audio request selected here would reach
+            # the prompt prefix cache with placeholder-only token keys, which is the
+            # same image-blindness this commit fixes.
             text_only = self._compatible_pending_requests(
-                [r for r in self.unprocessed_requests if not r.images and not r.videos],
+                [
+                    r
+                    for r in self.unprocessed_requests
+                    if not r.images and not r.videos and not r.audio
+                ],
                 self.completion_batch_size,
             )
 
@@ -2144,7 +2169,10 @@ class MLLMBatchGenerator:
             return
         for i in end_indices:
             req = batch.requests[i]
-            if req.input_ids is not None:
+            # Text-only KV only: a media request's KV stored under a
+            # token-only key would be replayed for any other media with the
+            # same prompt text (the docstring above always said text-only).
+            if req.input_ids is not None and getattr(req, "is_text_only", True):
                 try:
                     extracted = batch.extract_cache(i)
                     input_ids_list = req.input_ids.reshape(-1).tolist()
@@ -3188,8 +3216,13 @@ def install_chunked_prefill_mllm(
                     new_batch.cache = merged_cache
                     batch_gen.active_batch = new_batch
 
-                # Store in prefix cache (prompt-only)
-                if batch_gen.prefix_cache is not None and req.input_ids is not None:
+                # Store in prefix cache (prompt-only). Text-only requests
+                # only — see _maybe_store_prefix_cache.
+                if (
+                    batch_gen.prefix_cache is not None
+                    and req.input_ids is not None
+                    and getattr(req, "is_text_only", True)
+                ):
                     try:
                         input_ids_list = req.input_ids.reshape(-1).tolist()
                         S = batch_gen._think_suffix_len
@@ -3234,7 +3267,9 @@ def install_chunked_prefill_mllm(
                 len(batch_gen.unprocessed_requests),
             )
             for r in compatible_pending:
-                if not r.images and not r.videos:
+                # Audio counts as media too: an audio request here would reach the
+                # prefix cache with placeholder-only token keys.
+                if not r.images and not r.videos and not r.audio:
                     text_only_req = r
                     break
 


### PR DESCRIPTION
**Symptom.** Serving a vision model with `--mllm --continuous-batching`
(prefix cache enabled, its default), sending N different images with the
same prompt text at temperature 0 returns the FIRST image's transcription
for all N requests. Reproduced with Qwen2.5-VL-7B-Instruct-8bit: 67
distinct document pages, one transcription prompt, only 2 distinct
outputs. A degenerate garbage response on the first request after model
load comes from the same path.

**Cause.** The prompt prefix cache is keyed on token IDs alone. Every
image occupies identical placeholder token IDs, so for media requests
"same prompt text" is a full-prefix hit and the engine replays another
image's KV wholesale. The existing safeguard in `_process_prompts` only
scans the *remaining* (uncached) ids for `image_token_index`, and a
full-prefix hit leaves `remaining_ids` empty, so it never fires. The
store side (`_maybe_store_prefix_cache`) has a docstring saying
"text-only requests" but no code enforcing it. Two text-only interleave
selections also admit audio requests (`not r.images and not r.videos`),
which walks the same bug in an audio costume.

**Fix.** `is_text_only`, whose field comment has always said "eligible
for prefix cache", now gates every prefix-cache fetch and store, and the
interleave selections exclude audio. Text-only requests keep the cache
unchanged. Repeated identical images still benefit from
`VisionEmbeddingCache`, which hashes image bytes correctly. The default
`is_text_only=False` fails safe: an unpreprocessed request can never be
served another request's KV.

An alternative considered and deliberately not done here: salting the
cache key with an images hash (e.g. `compute_images_hash`) would let
identical-image requests share prompt KV, but pseudo-token keys break the
cache's offset==key-length invariant. Happy to discuss that as a
follow-up.

**Tests.** `tests/test_mllm_prefix_cache_media.py`: media requests are
never stored; text-only requests still are; `is_text_only` defaults to
the safe direction. Full suite on the rebased branch (2026-09-04, on top
of f2d3ad3): 3016 passed / 24 skipped.

Fixes the media half of the behavior confirmed by review in #736.
