### PR TITLE
fix(mllm): make generator request ownership transactional

### DIFF
--- a/tests/test_mllm_generator_ownership.py
+++ b/tests/test_mllm_generator_ownership.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused generator request-ownership regressions."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+def _assert_same_error(action, error, *args):
+    with pytest.raises(type(error)) as exc_info:
+        action(*args)
+    assert exc_info.value is error
+
+
+def _make_insert_generator():
+    from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator.uid_counter = 0
+    generator.unprocessed_requests = []
+    return generator
+
+
+def _make_chunked_generator():
+    from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator, MLLMBatchStats
+
+    generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+    generator._next = lambda: []
+    generator._pending_error_responses = []
+    generator._aborted_request_ids = set()
+    generator._aborted_request_uids = set()
+    generator._prefill_progress = {}
+    generator.active_batch = None
+    generator.unprocessed_requests = []
+    generator.prefix_cache = None
+    generator.language_model = MagicMock()
+    generator._stats = MLLMBatchStats()
+    generator._think_suffix_len = 0
+    generator.max_kv_size = 0
+    return generator
+
+
+class TestMLLMPendingRemovalOwnership:
+    def test_process_pending_removals_requeues_failed_removal(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        removal_error = RuntimeError("remove failed")
+
+        class FailingActiveBatch:
+            uids = [7, 8]
+            requests = [
+                SimpleNamespace(uid=7, request_id="same"),
+                SimpleNamespace(uid=8, request_id="other"),
+            ]
+
+            def __init__(self):
+                self.fail = True
+
+            def filter(self, keep_idx):
+                if self.fail:
+                    self.fail = False
+                    raise removal_error
+                self.uids = [self.uids[index] for index in keep_idx]
+                self.requests = [self.requests[index] for index in keep_idx]
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator._pending_removal_lock = threading.Lock()
+        generator._pending_removal_uids = {7}
+        generator._aborted_request_ids = {"same"}
+        generator._aborted_request_uids = {7}
+        generator._prefill_progress = {"same": (2, 5)}
+        generator.unprocessed_requests = []
+        generator.active_batch = FailingActiveBatch()
+
+        _assert_same_error(generator.process_pending_removals, removal_error)
+        assert generator._pending_removal_uids == {7}
+        assert generator._aborted_request_ids == {"same"}
+        assert generator._aborted_request_uids == {7}
+        assert generator._prefill_progress == {"same": (2, 5)}
+
+        generator.process_pending_removals()
+        assert generator._pending_removal_uids == set()
+        assert generator.active_batch.uids == [8]
+        assert generator._aborted_request_ids == set()
+        assert generator._aborted_request_uids == set()
+        assert generator._prefill_progress == {}
+
+    def test_generator_removal_retires_abort_marker_for_exact_uid(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchGenerator
+
+        class FakeActiveBatch:
+            def __init__(self):
+                self.uids = [92, 95]
+                self.requests = [
+                    SimpleNamespace(uid=92, request_id="same"),
+                    SimpleNamespace(uid=95, request_id="other"),
+                ]
+
+            def filter(self, keep_idx):
+                self.uids = [self.uids[index] for index in keep_idx]
+                self.requests = [self.requests[index] for index in keep_idx]
+
+        generator = MLLMBatchGenerator.__new__(MLLMBatchGenerator)
+        generator.active_batch = FakeActiveBatch()
+        generator.unprocessed_requests = [SimpleNamespace(uid=91, request_id="same")]
+        generator._aborted_request_ids = {"same", "other"}
+        generator._aborted_request_uids = {91, 92, 93}
+        generator._prefill_progress = {
+            "same": (2, 4),
+            "other": (1, 3),
+        }
+
+        generator.remove([91, 92])
+        assert generator.unprocessed_requests == []
+        assert generator.active_batch.uids == [95]
+        assert [request.request_id for request in generator.active_batch.requests] == [
+            "other"
+        ]
+        assert generator._aborted_request_ids == {"other"}
+        assert generator._aborted_request_uids == {93}
+        assert generator._prefill_progress == {"other": (1, 3)}
+
+        generator.abort_prefill("same", 93)
+        replacement = SimpleNamespace(uid=94, request_id="same")
+        retired = SimpleNamespace(uid=93, request_id="same")
+        assert generator._consume_prefill_abort(replacement) is False
+        assert generator._consume_prefill_abort(retired) is True
+
+
+class TestMLLMGeneratorInsertOwnership:
+    def test_generator_insert_metadata_failure_is_atomic(self):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        class FailingMetadataRequest:
+            uid = 33
+            request_id = "bad"
+            videos = audio = None
+
+            @property
+            def images(self):
+                raise RuntimeError("metadata failed")
+
+        generator = _make_insert_generator()
+        generator.uid_counter = 8
+        existing = MLLMBatchRequest(uid=7, request_id="old", prompt="old")
+        generator.unprocessed_requests = [existing]
+        original_queue = generator.unprocessed_requests
+        first = MLLMBatchRequest(uid=21, request_id="first", prompt="first")
+        second = MLLMBatchRequest(uid=22, request_id="second", prompt="second")
+        bad_request = FailingMetadataRequest()
+        requests = [first, second, bad_request]
+        original_uids = [request.uid for request in requests]
+
+        with pytest.raises(RuntimeError, match="metadata failed"):
+            generator.insert(requests)
+
+        assert generator.uid_counter == 8
+        assert [request.uid for request in requests] == original_uids
+        assert generator.unprocessed_requests is original_queue
+        assert [request.uid for request in original_queue] == [7]
+
+    @pytest.mark.parametrize("mode", ["unprocessed", "active", "partial"])
+    def test_generator_insert_rejects_live_uid_overlap_without_mutation(self, mode):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        generator = _make_insert_generator()
+        generator.uid_counter = 4
+        live = MLLMBatchRequest(uid=4, request_id="live", prompt="live")
+        request = MLLMBatchRequest(uid=99, request_id="new", prompt="new")
+
+        if mode == "unprocessed":
+            generator.unprocessed_requests = [live]
+        elif mode == "active":
+            generator.active_batch = SimpleNamespace(uids=[4], requests=[live])
+        else:
+            generator._partial = {"request": live}
+
+        original_queue = generator.unprocessed_requests
+        with pytest.raises(RuntimeError, match="overlaps live"):
+            generator.insert([request])
+
+        assert request.uid == 99
+        assert generator.uid_counter == 4
+        assert generator.unprocessed_requests is original_queue
+        assert live.uid == 4
+
+
+class TestMLLMPrefillAbortPolling:
+    def test_run_chunked_text_prefill_aborts_before_model_call(self):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            PrefillAbortedError,
+        )
+
+        generator = _make_chunked_generator()
+        generator.prefill_step_size = 2
+        request = MLLMBatchRequest(uid=1, request_id="same", prompt="long text")
+        request.input_ids = mx.array([[1, 2, 3, 4, 5]])
+        generator.abort_prefill(request.request_id, request.uid)
+        replacement = MLLMBatchRequest(
+            uid=2, request_id=request.request_id, prompt="replacement"
+        )
+
+        assert generator._consume_prefill_abort(replacement) is False
+        with pytest.raises(PrefillAbortedError, match="same"):
+            generator._run_chunked_text_prefill(request, cache=[])
+
+        generator.language_model.assert_not_called()
+        assert generator._aborted_request_ids == set()
+        assert generator._aborted_request_uids == set()
+
+    def test_process_prompts_entry_poll_consumes_uid_abort(self, monkeypatch):
+        import vllm_mlx.mllm_batch_generator as batch_module
+        from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
+
+        generator = _make_chunked_generator()
+        generator.prefill_step_size = 2
+        generator.sampler = MagicMock()
+        generator.model = SimpleNamespace(
+            config=SimpleNamespace(image_token_index=None)
+        )
+        generator._preprocess_request = lambda request: None
+        monkeypatch.setattr(
+            "mlx_lm.models.cache.make_prompt_cache",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_logits_processors",
+            lambda **kwargs: [],
+        )
+        monkeypatch.setattr(
+            "mlx_lm.sample_utils.make_sampler",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(batch_module.mx, "clear_cache", lambda: None)
+
+        request = MLLMBatchRequest(uid=11, request_id="same", prompt="prompt")
+        request.input_ids = mx.array([[1, 2, 3]])
+        request.is_text_only = True
+        generator.abort_prefill(request.request_id, request.uid)
+        replacement = MLLMBatchRequest(
+            uid=12, request_id=request.request_id, prompt="replacement"
+        )
+        assert generator._consume_prefill_abort(replacement) is False
+
+        assert generator._process_prompts([request]) is None
+        generator.language_model.assert_not_called()
+        assert len(generator._pending_error_responses) == 1
+        assert generator._pending_error_responses[0].finish_reason == "abort"
+        assert generator._aborted_request_ids == set()
+        assert generator._aborted_request_uids == set()
+
+
+class TestMLLMChunkedOwnership:
+    def test_chunked_polling_consumes_uid_abort_and_cleans_partial(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        generator = _make_chunked_generator()
+        install_chunked_prefill_mllm(generator, budget=2)
+        monkeypatch.setattr(mx, "clear_cache", lambda: None)
+
+        request = MLLMBatchRequest(uid=3, request_id="same", prompt="long text")
+        generator._partial = {
+            "request": request,
+            "cache": [],
+            "remaining_ids": mx.array([[3, 4]]),
+            "processed": 2,
+            "total": 4,
+            "cached_count": 0,
+            "chunk_count": 1,
+        }
+        generator._prefill_progress[request.request_id] = (2, 4)
+        generator.abort_prefill(request.request_id, request.uid)
+
+        replacement = MLLMBatchRequest(
+            uid=4, request_id=request.request_id, prompt="replacement"
+        )
+        assert generator._consume_prefill_abort(replacement) is False
+
+        responses = generator._next()
+
+        abort_responses = [
+            response for response in responses if response.finish_reason == "abort"
+        ]
+        assert len(abort_responses) == 1
+        assert abort_responses[0].uid == request.uid
+        assert abort_responses[0].request_id == request.request_id
+        assert generator._partial is None
+        assert request.request_id not in generator._prefill_progress
+        assert request.uid not in generator._aborted_request_uids
+
+    def test_successful_partial_removal_retires_marker_and_progress(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        class ActiveBatch:
+            def __init__(self):
+                self.uids = [4, 9]
+                self.requests = [
+                    SimpleNamespace(uid=4, request_id="active"),
+                    SimpleNamespace(uid=9, request_id="keep"),
+                ]
+
+            def filter(self, keep_idx):
+                self.uids = [self.uids[index] for index in keep_idx]
+                self.requests = [self.requests[index] for index in keep_idx]
+
+        generator = _make_chunked_generator()
+        install_chunked_prefill_mllm(generator, budget=2)
+        clear_cache = MagicMock()
+        monkeypatch.setattr(mx, "clear_cache", clear_cache)
+        partial_request = MLLMBatchRequest(
+            uid=3, request_id="partial", prompt="long text"
+        )
+        generator._partial = {"request": partial_request}
+        generator.active_batch = ActiveBatch()
+        generator._aborted_request_ids = {"partial", "active", "keep"}
+        generator._aborted_request_uids = {3, 4, 9}
+        generator._prefill_progress = {
+            "partial": (2, 5),
+            "active": (1, 2),
+            "keep": (1, 3),
+        }
+
+        generator.remove([3, 4])
+
+        assert generator._partial is None
+        assert generator.active_batch.uids == [9]
+        assert generator._aborted_request_ids == {"keep"}
+        assert generator._aborted_request_uids == {9}
+        assert generator._prefill_progress == {"keep": (1, 3)}
+        clear_cache.assert_called_once_with()
+
+    def test_failed_partial_removal_preserves_ownership_for_retry(self, monkeypatch):
+        from vllm_mlx.mllm_batch_generator import (
+            MLLMBatchRequest,
+            install_chunked_prefill_mllm,
+        )
+
+        class FailingActiveBatch:
+            def __init__(self):
+                self.uids = [4, 9]
+                self.requests = [
+                    SimpleNamespace(uid=4, request_id="active"),
+                    SimpleNamespace(uid=9, request_id="keep"),
+                ]
+                self.fail = True
+
+            def filter(self, keep_idx):
+                if self.fail:
+                    self.fail = False
+                    raise RuntimeError("filter failed")
+                self.uids = [self.uids[index] for index in keep_idx]
+                self.requests = [self.requests[index] for index in keep_idx]
+
+        generator = _make_chunked_generator()
+        install_chunked_prefill_mllm(generator, budget=2)
+        clear_cache = MagicMock()
+        monkeypatch.setattr(mx, "clear_cache", clear_cache)
+        partial_request = MLLMBatchRequest(
+            uid=3, request_id="partial", prompt="long text"
+        )
+        partial = {"request": partial_request}
+        generator._partial = partial
+        generator.active_batch = FailingActiveBatch()
+        generator._aborted_request_ids = {"partial", "active"}
+        generator._aborted_request_uids = {3, 4}
+        generator._prefill_progress = {
+            "partial": (2, 5),
+            "active": (1, 2),
+        }
+
+        with pytest.raises(RuntimeError, match="filter failed"):
+            generator.remove([3, 4])
+        assert generator._partial is partial
+        assert generator.active_batch.uids == [4, 9]
+        assert generator._aborted_request_ids == {"partial", "active"}
+        assert generator._aborted_request_uids == {3, 4}
+        assert generator._prefill_progress == {
+            "partial": (2, 5),
+            "active": (1, 2),
+        }
+        clear_cache.assert_not_called()
+
+        generator.remove([3, 4])
+        assert generator._partial is None
+        assert generator.active_batch.uids == [9]
+        assert generator._aborted_request_ids == set()
+        assert generator._aborted_request_uids == set()
+        assert generator._prefill_progress == {}
+        clear_cache.assert_called_once_with()
+
+
+class TestMLLMBatchFilterOwnership:
+    def test_filter_is_atomic_across_nested_cache_failure(self):
+        from copy import deepcopy
+
+        from vllm_mlx.mllm_batch_generator import MLLMBatch, MLLMBatchRequest
+
+        class OwnerCache:
+            def __init__(self, label, owners, *, fail):
+                self.label = label
+                self.owners = list(owners)
+                self.values = [f"{label}-{owner}" for owner in owners]
+                self.state = {
+                    "owners": list(owners),
+                    "values": list(self.values),
+                    "metadata": {"owner_uids": list(owners)},
+                }
+                self.fail = fail
+                self.filter_calls = 0
+
+            def filter(self, keep_idx):
+                indices = [int(index) for index in keep_idx.tolist()]
+                self.filter_calls += 1
+                self.owners = [self.owners[index] for index in indices]
+                self.values = [self.values[index] for index in indices]
+                self.state["owners"] = [
+                    self.state["owners"][index] for index in indices
+                ]
+                self.state["values"] = [
+                    self.state["values"][index] for index in indices
+                ]
+                self.state["metadata"]["owner_uids"] = [
+                    self.state["metadata"]["owner_uids"][index] for index in indices
+                ]
+                self.state["staged"] = True
+                if self.fail:
+                    raise RuntimeError("nested cache filter failed")
+
+        class CacheListLike:
+            def __init__(self, *caches):
+                self.caches = tuple(caches)
+                self.container_state = {
+                    "owners": (41, 42),
+                    "filter_generation": 0,
+                }
+
+            def filter(self, keep_idx):
+                indices = [int(index) for index in keep_idx.tolist()]
+                self.container_state["owners"] = tuple(
+                    self.container_state["owners"][index] for index in indices
+                )
+                self.container_state["filter_generation"] += 1
+                for cache in self.caches:
+                    cache.filter(keep_idx)
+
+        requests = [
+            MLLMBatchRequest(uid=41, request_id="owner-a", prompt="a"),
+            MLLMBatchRequest(uid=42, request_id="owner-b", prompt="b"),
+        ]
+        owner_by_uid = {request.uid: request.request_id for request in requests}
+        failing_cache = OwnerCache("failing", [41, 42], fail=True)
+        stable_cache = OwnerCache("stable", [41, 42], fail=False)
+        cache_group = CacheListLike(failing_cache, stable_cache)
+        batch = MLLMBatch(
+            uids=[41, 42],
+            request_ids=["owner-a", "owner-b"],
+            y=mx.array([410, 420]),
+            logprobs=["logprob-a", "logprob-b"],
+            max_tokens=[128, 256],
+            num_tokens=[3, 5],
+            cache=[cache_group],
+            requests=requests,
+            logits_processors=[["processor-a"], ["processor-b"]],
+            samplers=["sampler-a", "sampler-b"],
+        )
+
+        original_lists = {
+            field: getattr(batch, field)
+            for field in (
+                "uids",
+                "request_ids",
+                "logprobs",
+                "max_tokens",
+                "num_tokens",
+                "requests",
+                "logits_processors",
+                "samplers",
+            )
+        }
+        original_list_values = {
+            field: deepcopy(value) for field, value in original_lists.items()
+        }
+        original_y = batch.y
+        original_y_value = batch.y.tolist()
+        original_cache_list = batch.cache
+        original_cache_group = cache_group
+        original_cache_children = cache_group.caches
+        original_failing_state = failing_cache.state
+        original_stable_state = stable_cache.state
+        original_cache_snapshot = deepcopy(
+            {
+                "group": cache_group.container_state,
+                "failing": failing_cache.__dict__,
+                "stable": stable_cache.__dict__,
+            }
+        )
+        original_owner_inputs = [
+            (request.uid, request.request_id) for request in requests
+        ]
+
+        with pytest.raises(RuntimeError, match="nested cache filter failed"):
+            batch.filter([1])
+
+        for field, original in original_lists.items():
+            assert getattr(batch, field) is original
+            assert getattr(batch, field) == original_list_values[field]
+        assert batch.y is original_y
+        assert batch.y.tolist() == original_y_value
+        assert batch.cache is original_cache_list
+        assert batch.cache[0] is original_cache_group
+        assert batch.cache[0].caches is original_cache_children
+        assert failing_cache.state is original_failing_state
+        assert stable_cache.state is original_stable_state
+        assert {
+            "group": cache_group.container_state,
+            "failing": failing_cache.__dict__,
+            "stable": stable_cache.__dict__,
+        } == original_cache_snapshot
+        assert owner_by_uid == {41: "owner-a", 42: "owner-b"}
+        assert [
+            (request.uid, request.request_id) for request in requests
+        ] == original_owner_inputs
+
+        failing_cache.fail = False
+        batch.filter([1])
+
+        assert batch.uids == [42]
+        assert batch.request_ids == ["owner-b"]
+        assert batch.logprobs == ["logprob-b"]
+        assert batch.max_tokens == [256]
+        assert batch.num_tokens == [5]
+        assert batch.requests == [requests[1]]
+        assert batch.logits_processors == [["processor-b"]]
+        assert batch.samplers == ["sampler-b"]
+        assert batch.y.tolist() == [420]
+        assert dict(zip(batch.uids, batch.request_ids)) == {42: "owner-b"}
+
+        published_group = batch.cache[0]
+        assert isinstance(published_group.caches, tuple)
+        assert published_group.container_state == {
+            "owners": (42,),
+            "filter_generation": 1,
+        }
+        for cache in published_group.caches:
+            assert cache.owners == [42]
+            assert cache.values == [f"{cache.label}-42"]
+            assert cache.state == {
+                "owners": [42],
+                "values": [f"{cache.label}-42"],
+                "metadata": {"owner_uids": [42]},
+                "staged": True,
+            }
+            assert cache.filter_calls == 1

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -16,6 +16,7 @@ Architecture:
 3. Language model generation is batched using BatchKVCache (like LLM batching)
 """
 
+import copy
 import logging
 import math
 import os
@@ -273,6 +274,51 @@ class MLLMBatch:
     def __len__(self) -> int:
         return len(self.uids)
 
+    @staticmethod
+    def _copy_cache_container(container: Any, clone_item: Callable[[Any], Any]) -> Any:
+        """Copy a cache container while preserving its list/tuple type."""
+        if isinstance(container, list):
+            copied = copy.copy(container)
+            copied[:] = [clone_item(item) for item in container]
+            return copied
+        if isinstance(container, tuple):
+            items = tuple(clone_item(item) for item in container)
+            if type(container) is tuple:
+                return items
+            if hasattr(container, "_fields"):
+                return type(container)(*items)
+            return type(container)(items)
+        return container
+
+    @classmethod
+    def _copy_cache_state(cls, value: Any) -> Any:
+        """Copy mutable Python containers without copying MLX array storage."""
+        if isinstance(value, (list, tuple)):
+            return cls._copy_cache_container(value, cls._copy_cache_state)
+        if isinstance(value, dict):
+            copied = copy.copy(value)
+            copied.clear()
+            copied.update(
+                (key, cls._copy_cache_state(item)) for key, item in value.items()
+            )
+            return copied
+        return value
+
+    @classmethod
+    def _copy_cache_for_filter(cls, cache: Any) -> Any:
+        """Shallow-copy a cache and its mutable filter-owned containers."""
+        if not hasattr(cache, "filter"):
+            return cache
+
+        copied = copy.copy(cache)
+        for name, value in getattr(cache, "__dict__", {}).items():
+            if name == "caches":
+                value = cls._copy_cache_container(value, cls._copy_cache_for_filter)
+            elif isinstance(value, (list, tuple, dict)):
+                value = cls._copy_cache_state(value)
+            setattr(copied, name, value)
+        return copied
+
     def filter(self, keep_idx: List[int]) -> None:
         """
         Filter batch to keep only requests at specified indices.
@@ -280,24 +326,53 @@ class MLLMBatch:
         Args:
             keep_idx: Indices of requests to keep
         """
-        self.uids = [self.uids[k] for k in keep_idx]
-        self.request_ids = [self.request_ids[k] for k in keep_idx]
-        self.logprobs = [self.logprobs[k] for k in keep_idx]
-        self.max_tokens = [self.max_tokens[k] for k in keep_idx]
-        self.num_tokens = [self.num_tokens[k] for k in keep_idx]
-        self.requests = [self.requests[k] for k in keep_idx]
-        if self.logits_processors is not None:
-            self.logits_processors = [self.logits_processors[k] for k in keep_idx]
-        if self.samplers is not None:
-            self.samplers = [self.samplers[k] for k in keep_idx]
-
         keep_idx_array = mx.array(keep_idx, mx.int32)
-        self.y = self.y[keep_idx_array]
+        staged_y = self.y[keep_idx_array]
+        staged_uids = [self.uids[k] for k in keep_idx]
+        staged_request_ids = [self.request_ids[k] for k in keep_idx]
+        staged_logprobs = [self.logprobs[k] for k in keep_idx]
+        staged_max_tokens = [self.max_tokens[k] for k in keep_idx]
+        staged_num_tokens = [self.num_tokens[k] for k in keep_idx]
+        staged_requests = [self.requests[k] for k in keep_idx]
 
-        # Filter cache entries
-        for c in self.cache:
-            if hasattr(c, "filter"):
-                c.filter(keep_idx_array)
+        staged_logits_processors = None
+        if self.logits_processors is not None:
+            staged_logits_processors = [self.logits_processors[k] for k in keep_idx]
+
+        staged_samplers = None
+        if self.samplers is not None:
+            staged_samplers = [self.samplers[k] for k in keep_idx]
+
+        staged_cache = self._copy_cache_container(
+            self.cache, self._copy_cache_for_filter
+        )
+        for cache in staged_cache:
+            if hasattr(cache, "filter"):
+                cache.filter(keep_idx_array)
+
+        (
+            self.uids,
+            self.request_ids,
+            self.y,
+            self.logprobs,
+            self.max_tokens,
+            self.num_tokens,
+            self.cache,
+            self.requests,
+            self.logits_processors,
+            self.samplers,
+        ) = (
+            staged_uids,
+            staged_request_ids,
+            staged_y,
+            staged_logprobs,
+            staged_max_tokens,
+            staged_num_tokens,
+            staged_cache,
+            staged_requests,
+            staged_logits_processors,
+            staged_samplers,
+        )
 
     def extend(self, other: "MLLMBatch") -> None:
         """
@@ -560,6 +635,7 @@ class MLLMBatchGenerator:
         # Set operations are GIL-protected, safe across event-loop and
         # executor threads.
         self._aborted_request_ids: set = set()
+        self._aborted_request_uids: set = set()
 
         # Deferred removal queue — UIDs scheduled for removal from another
         # thread (typically the event loop on client disconnect).  The
@@ -754,15 +830,39 @@ class MLLMBatchGenerator:
             mx.set_wired_limit(self._old_wired_limit)
             self._old_wired_limit = None
 
-    def abort_prefill(self, request_id: str) -> None:
+    def abort_prefill(self, request_id: str, uid: Optional[int] = None) -> None:
         """Signal that a request's prefill should be aborted.
 
         Called from the event loop thread when a client disconnects.
         The prefill loop checks this set between chunks and raises
         PrefillAbortedError to exit early.
         """
-        self._aborted_request_ids.add(request_id)
+        if uid is None:
+            # Backward-compatible diagnostic path. Scheduler-owned requests
+            # always provide the internal UID so an external ID can be reused
+            # without inheriting stale abort ownership.
+            aborted_ids = getattr(self, "_aborted_request_ids", None)
+            if aborted_ids is None:
+                aborted_ids = self._aborted_request_ids = set()
+            aborted_ids.add(request_id)
+        else:
+            aborted_uids = getattr(self, "_aborted_request_uids", None)
+            if aborted_uids is None:
+                aborted_uids = self._aborted_request_uids = set()
+            aborted_uids.add(uid)
         logger.info(f"[abort_prefill] Marked {request_id} for prefill abort")
+
+    def _consume_prefill_abort(self, request: MLLMBatchRequest) -> bool:
+        """Consume an abort owned by this exact request instance."""
+        aborted_uids = getattr(self, "_aborted_request_uids", set())
+        aborted_ids = getattr(self, "_aborted_request_ids", set())
+        by_uid = request.uid in aborted_uids
+        by_legacy_id = request.request_id in aborted_ids
+        if not (by_uid or by_legacy_id):
+            return False
+        aborted_uids.discard(request.uid)
+        aborted_ids.discard(request.request_id)
+        return True
 
     def schedule_removal(self, uids: List[int]) -> None:
         """Thread-safe deferred removal of UIDs from the batch.
@@ -777,6 +877,11 @@ class MLLMBatchGenerator:
         """
         with self._pending_removal_lock:
             self._pending_removal_uids.update(uids)
+
+    def has_pending_removals(self) -> bool:
+        """Return whether scheduler-thread removal work is queued."""
+        with self._pending_removal_lock:
+            return bool(self._pending_removal_uids)
 
     def process_pending_removals(self) -> None:
         """Remove any UIDs enqueued via :meth:`schedule_removal`.
@@ -795,7 +900,15 @@ class MLLMBatchGenerator:
             self._pending_removal_uids = set()
 
         uids = list(pending)
-        self.remove(uids)
+        try:
+            self.remove(uids)
+        except Exception:
+            # Preserve failed ownership for a later safe-boundary retry. A
+            # failed removal must never silently drop the only record of ghost
+            # generator work.
+            with self._pending_removal_lock:
+                self._pending_removal_uids.update(uids)
+            raise
 
     def __del__(self):
         try:
@@ -816,21 +929,65 @@ class MLLMBatchGenerator:
         Returns:
             List of UIDs assigned to requests
         """
-        uids = []
-        for req in requests:
-            req.uid = self.uid_counter
-            self.uid_counter += 1
-            self.unprocessed_requests.append(req)
-            uids.append(req.uid)
+        first_uid = self.uid_counter
+        if type(first_uid) is not int or first_uid < 0:
+            raise ValueError("MLLM UID counter must be a nonnegative integer")
 
-        # Sort by estimated complexity (no images = simpler)
-        self.unprocessed_requests = sorted(
-            self.unprocessed_requests,
-            key=lambda x: (
-                0 if not x.images and not x.videos and not x.audio else 1,
-                len(x.images or []) + len(x.videos or []) + len(x.audio or []),
-            ),
-        )
+        request_ids = [id(request) for request in requests]
+        if len(set(request_ids)) != len(request_ids):
+            raise ValueError("Cannot insert the same MLLM request object twice")
+
+        active_batch = getattr(self, "active_batch", None)
+        partial = getattr(self, "_partial", None)
+        owned_requests = list(self.unprocessed_requests)
+        if active_batch is not None:
+            owned_requests.extend(active_batch.requests)
+        if partial is not None:
+            owned_requests.append(partial["request"])
+        if set(request_ids).intersection(id(request) for request in owned_requests):
+            raise ValueError("Cannot insert an MLLM request that is already owned")
+
+        original_uids = [request.uid for request in requests]
+        try:
+            # The exact-class contract assigns only this internally generated,
+            # consecutive range.  Check for collisions before publishing it.
+            uids = list(range(first_uid, first_uid + len(requests)))
+            owned_uids = {request.uid for request in self.unprocessed_requests}
+            if active_batch is not None:
+                owned_uids.update(active_batch.uids)
+            if partial is not None:
+                owned_uids.add(partial["request"].uid)
+            if owned_uids.intersection(uids):
+                raise RuntimeError("MLLM UID counter overlaps live generator work")
+
+            for request, uid in zip(requests, uids):
+                request.uid = uid
+
+            # Stage ordering before publishing either the queue or UID counter.
+            # If request metadata raises while computing complexity, callers
+            # can retry without ghost work or consumed identities.
+            pending = sorted(
+                [*self.unprocessed_requests, *requests],
+                key=lambda request: (
+                    (
+                        0
+                        if not request.images
+                        and not request.videos
+                        and not request.audio
+                        else 1
+                    ),
+                    len(request.images or [])
+                    + len(request.videos or [])
+                    + len(request.audio or []),
+                ),
+            )
+        except Exception:
+            for request, uid in zip(requests, original_uids):
+                request.uid = uid
+            raise
+
+        self.unprocessed_requests = pending
+        self.uid_counter = first_uid + len(requests)
 
         logger.debug(f"Inserted {len(requests)} requests, UIDs: {uids}")
         return uids
@@ -843,6 +1000,21 @@ class MLLMBatchGenerator:
             uids: List of UIDs to remove
         """
         uid_set = set(uids)
+
+        # Abort markers are keyed by external request ID for chunked-prefill
+        # polling. Retire markers owned by the exact UIDs being removed so a
+        # later request that reuses the same external ID cannot inherit them.
+        removed_request_ids = {
+            request.request_id
+            for request in self.unprocessed_requests
+            if request.uid in uid_set
+        }
+        if self.active_batch is not None:
+            removed_request_ids.update(
+                request.request_id
+                for request in self.active_batch.requests
+                if request.uid in uid_set
+            )
 
         # Remove from active batch
         if self.active_batch is not None:
@@ -858,6 +1030,18 @@ class MLLMBatchGenerator:
         self.unprocessed_requests = [
             r for r in self.unprocessed_requests if r.uid not in uid_set
         ]
+
+        # Publish abort-marker retirement only after generator ownership was
+        # removed successfully. If active-batch filtering raises, the pending
+        # removal retry must retain the abort signal as well as the UID.
+        aborted_ids = getattr(self, "_aborted_request_ids", set())
+        aborted_uids = getattr(self, "_aborted_request_uids", set())
+        prefill_progress = getattr(self, "_prefill_progress", None)
+        for request_id in removed_request_ids:
+            aborted_ids.discard(request_id)
+            if prefill_progress is not None:
+                prefill_progress.pop(request_id, None)
+        aborted_uids.difference_update(uid_set)
 
     def _compatible_pending_requests(
         self,
@@ -1243,8 +1427,7 @@ class MLLMBatchGenerator:
         chunk_count = 0
         while processed + step < total:
             # Check for abort between chunks (client disconnect)
-            if request.request_id in self._aborted_request_ids:
-                self._aborted_request_ids.discard(request.request_id)
+            if self._consume_prefill_abort(request):
                 logger.info(
                     f"[chunked_prefill] Aborted {request.request_id} at "
                     f"{processed}/{total} tokens"
@@ -1486,8 +1669,7 @@ class MLLMBatchGenerator:
         for req in requests:
             try:
                 # Check abort before starting prefill
-                if req.request_id in self._aborted_request_ids:
-                    self._aborted_request_ids.discard(req.request_id)
+                if self._consume_prefill_abort(req):
                     raise PrefillAbortedError(req.request_id)
 
                 # Try prefix cache for all requests (text-only and multimodal).
@@ -1586,8 +1768,7 @@ class MLLMBatchGenerator:
                             chunk_count = 0
                             while processed + step < remaining_count:
                                 # Check for abort between chunks
-                                if req.request_id in self._aborted_request_ids:
-                                    self._aborted_request_ids.discard(req.request_id)
+                                if self._consume_prefill_abort(req):
                                     logger.info(
                                         f"[chunked_prefill] Aborted {req.request_id} "
                                         f"at {cached_count + processed}/{total_tokens} tokens"
@@ -2995,8 +3176,7 @@ def install_chunked_prefill_mllm(
             req = partial["request"]
 
             # Abort check
-            if req.request_id in batch_gen._aborted_request_ids:
-                batch_gen._aborted_request_ids.discard(req.request_id)
+            if batch_gen._consume_prefill_abort(req):
                 batch_gen._partial = None
                 mx.clear_cache()
                 batch_gen._prefill_progress.pop(req.request_id, None)
@@ -3374,11 +3554,28 @@ def install_chunked_prefill_mllm(
     _orig_remove = batch_gen.remove
 
     def _patched_remove(uids: List[int]) -> None:
-        if batch_gen._partial is not None:
-            if batch_gen._partial["request"].uid in set(uids):
-                batch_gen._partial = None
-                mx.clear_cache()
+        partial = batch_gen._partial
+        partial_request = partial["request"] if partial is not None else None
+        partial_uid = partial_request.uid if partial_request is not None else None
+        partial_request_id = (
+            partial_request.request_id if partial_request is not None else None
+        )
+        uid_set = set(uids)
+
+        # Remove published queue/batch ownership first. If that operation
+        # fails, preserve the partial request, both abort-marker sets, and
+        # progress so deferred removal remains a complete retry.
         _orig_remove(uids)
+        if partial_uid in uid_set:
+            batch_gen._partial = None
+            prefill_progress = getattr(batch_gen, "_prefill_progress", None)
+            if prefill_progress is not None:
+                prefill_progress.pop(partial_request_id, None)
+            aborted_ids = getattr(batch_gen, "_aborted_request_ids", set())
+            aborted_uids = getattr(batch_gen, "_aborted_request_uids", set())
+            aborted_ids.discard(partial_request_id)
+            aborted_uids.discard(partial_uid)
+            mx.clear_cache()
 
     batch_gen.remove = _patched_remove
     batch_gen._next = _chunked_next


### PR DESCRIPTION
I add the generator-side UID and transaction substrate for MLLM request ownership.

Batch filtering now stages row and cache mutations before publication. The generator gains an exact-UID prefill-abort path, failed deferred removals remain observable and retryable, successful removal retires owned abort/progress state, and insertion rolls back without consuming ownership after metadata or live-UID collision failures.

This is intentionally the first of two scoped changes. Scheduler call-site adoption and response/cleanup serialization will follow in a dependent PR; this PR does not claim end-to-end scheduler ownership or cancellation completion. Admission policy, stream shutdown, and cache policy are also outside this change.

Validation on Apple Silicon:
- 12 focused generator ownership cases passed
- 56 adjacent MLLM continuous-batching cases passed; 4 existing slow real-model cases were deselected
- Black, Ruff, and diff checks passed