### PR TITLE
fix(memory-cache): do not evict strict-prefix entries of hybrid caches on store

### DIFF
--- a/tests/test_memory_cache.py
+++ b/tests/test_memory_cache.py
@@ -654,3 +654,97 @@ def test_load_rejects_v3_cache_after_rewind_semantics_change(tmp_path, caplog):
     ):
         assert cache.load_from_disk(str(tmp_path)) == 0
     assert "version mismatch: disk=3 current=4" in caplog.text
+
+
+class _TrimmableKV(MockKVCache):
+    """KV-style layer that reports itself rewindable, like KVCache."""
+
+    def __init__(self, nbytes: int):
+        super().__init__(nbytes // 2, nbytes // 2)
+        self.offset = 8
+
+    def is_trimmable(self) -> bool:
+        return True
+
+
+class _RecurrentLayer:
+    """State-container layer without a token dimension, like ArraysCache."""
+
+    def __init__(self, nbytes: int):
+        self.state = [MockArray(nbytes)]
+
+
+class TestPrefixSubsetEvictionHybrid:
+    """store() must not evict strict-prefix entries of a hybrid cache.
+
+    For a rewindable cache the longer entry subsumes the shorter one, so
+    evicting the prefix is a pure win.  A hybrid (recurrent + attention)
+    cache cannot be rewound, fetch() refuses LCP/supersequence reuse for
+    it, and the strict-prefix entry is therefore the only entry a request
+    that branches after it can ever hit.
+    """
+
+    @staticmethod
+    def _cache(max_entries: int = 10, max_memory_mb: float = 1.0):
+        return MemoryAwarePrefixCache(
+            MagicMock(),
+            MemoryCacheConfig(
+                max_memory_mb=max_memory_mb,
+                max_entries=max_entries,
+                min_prefix_tokens=1,
+            ),
+        )
+
+    def test_trimmable_cache_still_evicts_strict_prefix(self):
+        cache = self._cache()
+        assert cache.store([1, 2, 3], [_TrimmableKV(4 * 1024)])
+        assert cache.store([1, 2, 3, 4, 5], [_TrimmableKV(4 * 1024)])
+
+        assert [1, 2, 3] not in cache
+        assert [1, 2, 3, 4, 5] in cache
+        assert cache.get_stats()["evictions"] == 1
+
+    def test_hybrid_cache_keeps_strict_prefix(self):
+        cache = self._cache()
+        prewarmed = [1, 2, 3]
+        turn_a = [1, 2, 3, 4, 5]
+        turn_b = [1, 2, 3, 6, 7]
+        hybrid = lambda: [
+            _TrimmableKV(4 * 1024),
+            _RecurrentLayer(2 * 1024),
+        ]  # noqa: E731
+
+        assert cache.store(prewarmed, hybrid())
+        # request A extends the prewarmed prefix and stores its own entry ...
+        assert cache.store(turn_a, hybrid())
+        # ... which must NOT have evicted the prefix request B needs
+        assert prewarmed in cache
+        assert turn_a in cache
+        assert cache.get_stats()["evictions"] == 0
+
+        assert cache.store(turn_b, hybrid())
+        assert prewarmed in cache
+        assert len(cache) == 3
+
+    def test_hybrid_cache_respects_explicit_evict_prefixes_false(self):
+        # The exemption only ever turns eviction OFF; the explicit opt-out
+        # callers already use keeps working.
+        cache = self._cache()
+        assert cache.store([1, 2], [_TrimmableKV(1024), _RecurrentLayer(512)])
+        assert cache.store(
+            [1, 2, 3], [_TrimmableKV(1024), _RecurrentLayer(512)], evict_prefixes=False
+        )
+        assert [1, 2] in cache and [1, 2, 3] in cache
+
+    def test_hybrid_entries_still_bounded_by_lru(self):
+        # Memory pressure still evicts hybrid entries; only the proactive
+        # prefix deletion is skipped.
+        cache = self._cache(max_entries=100, max_memory_mb=0.5)
+        for i in range(6):
+            tokens = list(range(1, 4 + i))  # each a strict prefix of the next
+            assert cache.store(
+                tokens, [_TrimmableKV(150 * 1024), _RecurrentLayer(50 * 1024)]
+            )
+        assert cache.memory_usage_mb <= 0.5
+        assert cache.get_stats()["evictions"] > 0
+        assert len(cache) < 6

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -1396,6 +1396,29 @@ class MemoryAwarePrefixCache:
                 # Prefix-subset eviction: remove entries whose token sequence
                 # is a strict prefix of the new entry.  Uses sorted index for
                 # O(log N + K) lookup instead of O(N) scan.
+                #
+                # Hybrid caches are exempt.  The eviction assumes the longer
+                # entry subsumes the shorter one, which holds only when the
+                # cache can be trimmed back to the shorter length.  Recurrent
+                # layers cannot be rewound — fetch() refuses LCP and
+                # supersequence reuse for them for exactly that reason — so a
+                # strict-prefix entry is the only one such a model can reuse
+                # for a request that branches after it.  Evicting it makes
+                # each request destroy what the next one needs (measured: a
+                # prewarmed shared system prefix served one hit instead of
+                # two, because the first request's store evicted it).  LRU
+                # eviction under the memory limit is unaffected; this only
+                # stops the proactive deletion of still-usable prefixes.
+                if evict_prefixes and any(
+                    not _is_cache_layer_trimmable(lc) for lc in cache
+                ):
+                    evict_prefixes = False
+                    logger.debug(
+                        "[prefix_evict] skipped for new_entry=%s tokens: "
+                        "non-trimmable cache layers (hybrid model), prefix "
+                        "entries stay reusable",
+                        len(tokens_key),
+                    )
                 if evict_prefixes and self._sorted_keys:
                     to_remove = []
                     idx = bisect.bisect_left(self._sorted_keys, tokens_key)


### PR DESCRIPTION
## The bug

`MemoryAwarePrefixCache.store()` proactively evicts every resident entry whose token sequence is a strict prefix of the entry being stored. That is a pure win for a rewindable cache: the longer entry can be trimmed back to the shorter length, so it serves everything the shorter one served.

It is the wrong call for a hybrid model (recurrent + attention layers, e.g. Qwen3.5/3.6 with GatedDeltaNet). Recurrent state cannot be rewound, and `fetch()` already refuses LCP and supersequence reuse for non-trimmable layers for exactly that reason. For such a model the strict-prefix entry is therefore the **only** entry a request that branches after it can ever hit. Evicting it on store makes each request destroy what the next one needs.

**Measured** (fork, Qwen3.6-35B-A3B, MLLM path, `--enable-prefix-cache`): prewarm a shared system prefix, then send two requests with different user turns. Expected two hits; got one, because request one's store evicted the prewarmed prefix before request two arrived. Both store call sites in `mllm_batch_generator.py` use the default `evict_prefixes=True`, so the guard belongs in `store()` rather than at the call sites.

## The fix

`store()` skips the proactive prefix eviction when any layer of the new entry is non-trimmable, using the same `_is_cache_layer_trimmable` predicate `fetch()` uses. Nothing else changes:

- LRU eviction under the memory limit is untouched, so memory stays bounded.
- The explicit `evict_prefixes=False` opt-out that prompt+output stores already use keeps working.
- Rewindable caches keep the existing behavior.

## Tests

`tests/test_memory_cache.py` (in the CI list), no MLX needed:

- trimmable cache still evicts the strict prefix (pins existing behavior)
- hybrid cache keeps the prewarmed prefix across two branching stores (the measured scenario)
- explicit `evict_prefixes=False` unaffected
- hybrid entries are still bounded by LRU under memory pressure

## Relation to other PRs

Independent of #744 in semantics: #744 changes how hybrid entries are published, this changes whether an existing prefix entry survives a later store. They touch the same region of `store()`, so this will need a trivial rebase once #744 lands; I'll do that. Together with #744 and #764 this is what makes multi-turn agent traffic against a hybrid model hit the prefix cache on every turn rather than re-prefilling the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQAzGiCRR1VocVNa3ngyjw
