### PR TITLE
Preserve assistant reasoning when chat history is replayed

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -159,6 +159,35 @@ class TestMessage:
         msg = Message(role="assistant", content=None)
         assert msg.content is None
 
+    @pytest.mark.parametrize("field", ["reasoning_content", "reasoning"])
+    def test_assistant_reasoning_survives_request_validation(self, field):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                {"role": "user", "content": "Question"},
+                {"role": "assistant", "content": "Answer", field: "Exact thought\n"},
+                {"role": "user", "content": "Continue"},
+            ],
+        )
+        history = request.messages[1].model_dump(exclude_none=True)
+        assert history == {
+            "role": "assistant",
+            "content": "Answer",
+            "reasoning_content": "Exact thought\n",
+        }
+
+    def test_returned_assistant_message_can_be_replayed(self):
+        returned = AssistantMessage(content="Answer", reasoning_content="Thought")
+        replayed = Message.model_validate(returned.model_dump())
+        assert replayed.model_dump(exclude_none=True) == returned.model_dump()
+
+    def test_absent_reasoning_does_not_add_template_history(self):
+        msg = Message(role="assistant", content="Answer")
+        assert msg.model_dump(exclude_none=True) == {
+            "role": "assistant",
+            "content": "Answer",
+        }
+
 
 class TestToolCalling:
     """Tests for tool calling models."""

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -78,6 +78,11 @@ class Message(BaseModel):
 
     role: str
     content: str | list[ContentPart] | list[dict] | None = None
+    # Preserve returned reasoning when assistant history is replayed to a template.
+    reasoning_content: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("reasoning_content", "reasoning"),
+    )
     # For assistant messages with tool calls
     tool_calls: list[dict] | None = None
     # For tool response messages (role="tool")


### PR DESCRIPTION
## Summary

I found that replaying an assistant response through Chat Completions drops
its `reasoning_content` during request validation. The response schema already
exposes this field, but the input `Message` schema does not retain it.

This adds the optional field to `Message`, using the same `reasoning` alias
as the response schema. Messages without reasoning remain unchanged. The
tests cover both input names, an assistant-response round trip, and omission
when no reasoning is supplied.

Losing the field can change the rendered history for templates that preserve
reasoning. This PR fixes the schema loss only; it does not change templates,
cache matching, or hybrid-cache rewind behavior, and it does not resolve all
multi-turn cache misses in #730.

## Verification

- Reproduced the dropped field on main `ec8e493` without loading a model.
- All 87 API-model tests pass on this branch.
- Ruff and diff checks pass.
