### PR TITLE
Forward chat reasoning effort to the template

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -45,6 +45,13 @@ Clients route requests by setting the OpenAI `model` field to one of the configu
 Set server defaults for chat template kwargs. Request-level `chat_template_kwargs`
 values still win per key.
 
+For chat requests, top-level `reasoning_effort` is forwarded verbatim to the
+model's chat template. It overrides the server default; an explicit
+`chat_template_kwargs.reasoning_effort` overrides both. Accepted values and
+fallback behavior are template-specific: OpenAI's `low`/`medium`/`high` values
+are not portable across models. Check the selected model's template before
+choosing a value; a template may ignore the field or use its own fallback.
+
 ```bash
 vllm-mlx serve mlx-community/Qwen3-8B-4bit \
   --reasoning-parser qwen3 \

--- a/tests/test_chat_template_kwargs.py
+++ b/tests/test_chat_template_kwargs.py
@@ -105,6 +105,7 @@ def test_chat_completion_endpoint_forwards_chat_template_kwargs():
                 "model": "test-model",
                 "messages": [{"role": "user", "content": "Reply with ORBIT."}],
                 "max_tokens": 8,
+                "reasoning_effort": "medium",
                 "chat_template_kwargs": {"enable_thinking": False},
             },
         )
@@ -113,8 +114,44 @@ def test_chat_completion_endpoint_forwards_chat_template_kwargs():
         srv._model_name = original_model_name
 
     assert response.status_code == 200
-    assert captured["kwargs"]["chat_template_kwargs"] == {"enable_thinking": False}
+    assert captured["kwargs"]["chat_template_kwargs"] == {
+        "enable_thinking": False,
+        "reasoning_effort": "medium",
+    }
     assert response.json()["choices"][0]["message"]["content"] == "ORBIT"
+
+
+@pytest.mark.parametrize(
+    ("request_effort", "request_kwargs", "expected_effort"),
+    [
+        (None, None, "low"),
+        ("medium", None, "medium"),
+        ("medium", {"reasoning_effort": "high"}, "high"),
+    ],
+)
+def test_chat_completion_preparation_resolves_reasoning_effort_precedence(
+    monkeypatch, request_effort, request_kwargs, expected_effort
+):
+    monkeypatch.setattr(
+        srv,
+        "_default_chat_template_kwargs",
+        {"reasoning_effort": "low", "server_only": True},
+    )
+    request = srv.ChatCompletionRequest(
+        model="test-model",
+        messages=[srv.Message(role="user", content="Hello")],
+        reasoning_effort=request_effort,
+        chat_template_kwargs=request_kwargs,
+    )
+    engine = SimpleNamespace(is_mllm=False, preserve_native_tool_format=False)
+
+    prepared = srv._prepare_chat_completion_invocation(engine, request, 8)
+
+    assert prepared.chat_kwargs["chat_template_kwargs"] == {
+        "reasoning_effort": expected_effort,
+        "server_only": True,
+        **({} if request_kwargs is None else request_kwargs),
+    }
 
 
 def test_chat_completion_endpoint_applies_server_default_chat_template_kwargs():

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -188,6 +188,8 @@ class ChatCompletionRequest(BaseModel):
     response_format: ResponseFormat | dict | None = None
     # OpenAI-compatible token bias map: token id string -> bias value
     logit_bias: dict[str, float] | None = None
+    # Per-request reasoning effort forwarded through chat template kwargs
+    reasoning_effort: str | None = None
     # Extra kwargs forwarded to tokenizer.apply_chat_template
     chat_template_kwargs: dict[str, Any] | None = None
     # MLLM-specific parameters

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -299,11 +299,14 @@ def _resolve_request_max_tokens(requested_value: int | None) -> int:
 
 def _resolve_chat_template_kwargs(
     request_value: dict[str, object] | None,
+    request_reasoning_effort: str | None = None,
 ) -> dict[str, object]:
-    """Resolve chat template kwargs: request > server default > empty dict."""
+    """Resolve chat kwargs: server default < effort < explicit request kwargs."""
     resolved: dict[str, object] = {}
     if _default_chat_template_kwargs:
         resolved.update(_default_chat_template_kwargs)
+    if request_reasoning_effort is not None:
+        resolved["reasoning_effort"] = request_reasoning_effort
     if request_value:
         resolved.update(request_value)
     return resolved
@@ -815,7 +818,8 @@ def _prepare_chat_completion_invocation(
     if specprefill_backbone_pct is not None:
         chat_kwargs["specprefill_backbone_pct"] = specprefill_backbone_pct
     resolved_chat_template_kwargs = _resolve_chat_template_kwargs(
-        request.chat_template_kwargs
+        request.chat_template_kwargs,
+        request_reasoning_effort=getattr(request, "reasoning_effort", None),
     )
     if resolved_chat_template_kwargs:
         chat_kwargs["chat_template_kwargs"] = resolved_chat_template_kwargs


### PR DESCRIPTION
## Summary

I found that a top-level `reasoning_effort` on Chat Completions is silently
dropped by request validation. Clients sending that field therefore do not
override the server's template default.

This retains the optional string and forwards it through the shared chat
preparation path. Precedence is:

1. Server template defaults.
2. A non-null top-level request `reasoning_effort`.
3. Explicit request `chat_template_kwargs`.

Absent or null effort preserves existing behavior. The value is forwarded
unchanged; this does not add model-specific mappings, toggle thinking, or
change the Anthropic/Responses routes. Tests cover the HTTP forwarding path
and the precedence rules.

## Verification

- Reproduced the dropped field on main `ec8e493` without loading a model.
- 274 API-model, template and server tests pass; three existing tests are
  deselected by the repository configuration.
- Ruff and diff checks pass.
