### PR TITLE
Report request-owned cached prompt tokens in Chat usage

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -41,6 +41,7 @@ from vllm_mlx.api.models import (
     Message,
     ModelInfo,
     ModelsResponse,
+    PromptTokensDetails,
     ResponseFormat,
     ResponseFormatJsonSchema,
     StreamOptions,
@@ -370,15 +371,26 @@ class TestChatCompletion:
         assert choice.finish_reason == "stop"
 
     def test_usage(self):
-        usage = Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=4),
+        )
         assert usage.prompt_tokens == 10
         assert usage.total_tokens == 30
+        assert usage.model_dump()["prompt_tokens_details"] == {"cached_tokens": 4}
+        assert usage.model_dump(include={"prompt_tokens"}) == {"prompt_tokens": 10}
+        assert "prompt_tokens_details" not in usage.model_dump(
+            exclude={"prompt_tokens_details"}
+        )
 
     def test_usage_defaults(self):
         usage = Usage()
         assert usage.prompt_tokens == 0
         assert usage.completion_tokens == 0
         assert usage.total_tokens == 0
+        assert "prompt_tokens_details" not in usage.model_dump()
 
     def test_chat_completion_response(self):
         resp = ChatCompletionResponse(

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -30,6 +30,7 @@ class TestBatchedEngineGenerate:
         prompt_tokens=10,
         completion_tokens=3,
         finish_reason="stop",
+        cached_tokens=None,
     ):
         """Build a mock RequestOutput (as returned by AsyncEngineCore)."""
         mock = MagicMock()
@@ -40,6 +41,7 @@ class TestBatchedEngineGenerate:
         mock.prompt_tokens = prompt_tokens
         mock.completion_tokens = completion_tokens
         mock.finish_reason = finish_reason
+        mock.cached_tokens = cached_tokens
         return mock
 
     @pytest.mark.anyio
@@ -83,6 +85,7 @@ class TestBatchedEngineGenerate:
             prompt_tokens=7,
             completion_tokens=1,
             finish_reason="stop",
+            cached_tokens=4,
         )
 
         mock_engine = MagicMock()
@@ -95,6 +98,7 @@ class TestBatchedEngineGenerate:
         assert result.prompt_tokens == 7
         assert result.completion_tokens == 1
         assert result.finish_reason == "stop"
+        assert result.cached_tokens == 4
 
 
 class TestBatchedEngineCacheRestore:

--- a/tests/test_batched_engine_mllm_config.py
+++ b/tests/test_batched_engine_mllm_config.py
@@ -175,9 +175,10 @@ def test_generate_forwards_mllm_draft_opt_in():
     scheduler = SimpleNamespace(generate=AsyncMock(return_value=_generation_output()))
     engine = _batched_mllm_engine(scheduler)
 
-    asyncio.run(engine.generate("hello", mllm_draft=True))
+    output = asyncio.run(engine.generate("hello", mllm_draft=True))
 
     assert scheduler.generate.await_args.kwargs["mllm_draft"] is True
+    assert output.cached_tokens is None
 
 
 def test_generate_uses_configured_mllm_draft_default():
@@ -232,6 +233,7 @@ def test_stream_generate_uses_configured_mllm_draft_default():
     outputs = asyncio.run(consume_stream())
 
     assert outputs[0].text == "ok"
+    assert outputs[0].cached_tokens is None
     assert scheduler.add_request_async.await_args.kwargs["mllm_draft"] is True
 
 

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -2103,6 +2103,7 @@ class TestChunkedPrefillCacheHandling:
         gen._next()
 
         assert rewind_calls == [1]
+        assert req.cached_tokens == 4
 
     def test_saturated_rotating_exact_hit_falls_back(self, monkeypatch):
         from mlx_lm.models.cache import CacheList, RotatingKVCache
@@ -2145,6 +2146,7 @@ class TestChunkedPrefillCacheHandling:
         make_cache.assert_called_once()
         original_next.assert_called_once()
         assert [child.offset for child in stored[0].caches] == [6, 6]
+        assert request.cached_tokens == 0
 
     def test_partial_hit_uses_copy_prefix_cache(self, monkeypatch):
         """A partial hit clones storage and does not use exact-hit rewind."""
@@ -2190,6 +2192,7 @@ class TestChunkedPrefillCacheHandling:
             1
         ], f"Expected _copy_prefix_cache called once, got {copy_calls}"
         assert rewind_calls == []
+        assert req.cached_tokens == 3
 
     def test_abort_cleans_up_partial_prefill(self):
         """Aborting a request during chunked prefill must clean up _partial."""

--- a/tests/test_mllm_mtp_routing.py
+++ b/tests/test_mllm_mtp_routing.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for MLLM + MTP per-request routing."""
 
+import pytest
+
 
 def test_has_media_content_text_only():
     from vllm_mlx.api.utils import has_media_content as _has_media_content
@@ -221,7 +223,8 @@ def test_mllm_mtp_attempt_metadata_only_marks_real_attempts():
     assert attempted == {}
 
 
-def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs():
+@pytest.mark.parametrize("cached_tokens", [3, 0, None, "3", True])
+def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs(cached_tokens):
     from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
     from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
 
@@ -248,6 +251,7 @@ def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs():
                 logprobs=None,
                 mtp_attempted=True,
                 mtp_attempted_count=1,
+                cached_tokens=cached_tokens,
             ),
             MLLMBatchResponse(
                 uid=7,
@@ -256,6 +260,7 @@ def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs():
                 logprobs=None,
                 finish_reason="stop",
                 from_draft=True,
+                cached_tokens=cached_tokens,
             ),
         ]
     )
@@ -263,6 +268,8 @@ def test_mllm_scheduler_exposes_mtp_attempts_and_accepts_on_outputs():
     assert finished == {"req-7"}
     assert outputs[-1].mtp_drafts == 1
     assert outputs[-1].mtp_accepted == 1
+    expected = cached_tokens if type(cached_tokens) is int else None
+    assert outputs[-1].cached_tokens == expected
 
 
 def test_get_language_model():

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -467,9 +467,20 @@ class TestRequestOutput:
         assert usage["completion_tokens"] == 20
         assert usage["total_tokens"] == 30
 
+    def test_usage_reports_request_owned_cached_tokens(self):
+        output = RequestOutput(
+            request_id="test-1",
+            prompt_tokens=10,
+            completion_tokens=20,
+            cached_tokens=4,
+        )
+
+        assert output.usage["prompt_tokens_details"] == {"cached_tokens": 4}
+
     def test_usage_defaults(self):
         output = RequestOutput(request_id="test-1")
         usage = output.usage
         assert usage["prompt_tokens"] == 0
         assert usage["completion_tokens"] == 0
         assert usage["total_tokens"] == 0
+        assert "prompt_tokens_details" not in usage

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1613,6 +1613,7 @@ class TestMaxTokensLimit:
                     prompt_tokens=5,
                     completion_tokens=2,
                     finish_reason="stop",
+                    cached_tokens=4,
                 )
 
         fake_engine = FakeEngine()
@@ -1663,6 +1664,8 @@ class TestMaxTokensLimit:
         assert all(call == ("fake", user_stop) for call in helper_calls)
         assert captured["kwargs"]["stop"] == expected_stop
         assert response.choices[0].message.content == "ok"
+        assert response.usage.prompt_tokens == 5
+        assert response.usage.prompt_tokens_details.cached_tokens == 4
 
     @pytest.mark.anyio
     async def test_create_anthropic_message_rejects_over_limit_before_engine_lookup(
@@ -3203,6 +3206,7 @@ class TestStreamChatCompletion:
                     finish_reason=None,
                     prompt_tokens=3,
                     completion_tokens=1,
+                    cached_tokens=2,
                 )
 
         monkeypatch.setattr(server, "_model_name", "served-model")
@@ -3239,6 +3243,7 @@ class TestStreamChatCompletion:
             "prompt_tokens": 3,
             "completion_tokens": 1,
             "total_tokens": 4,
+            "prompt_tokens_details": {"cached_tokens": 2},
         }
 
     @pytest.mark.anyio

--- a/tests/test_streaming_latency.py
+++ b/tests/test_streaming_latency.py
@@ -254,6 +254,7 @@ async def test_output_collector():
             output_token_ids=[1, 2],
             output_text="Hello World",
             finished=False,
+            cached_tokens=4,
         )
     )
 
@@ -261,6 +262,7 @@ async def test_output_collector():
     assert merged is not None
     assert merged.new_text == "Hello World"
     assert merged.new_token_ids == [1, 2]
+    assert merged.cached_tokens == 4
     print("  [PASS] Output aggregation")
 
     # Test async get

--- a/vllm_mlx/api/__init__.py
+++ b/vllm_mlx/api/__init__.py
@@ -32,6 +32,7 @@ from .models import (
     CompletionChoice,
     CompletionResponse,
     # Common
+    PromptTokensDetails,
     Usage,
     ModelInfo,
     ModelsResponse,
@@ -94,6 +95,7 @@ from .tool_calling import (
 )
 
 __all__ = [
+    "PromptTokensDetails",
     # Models
     "ImageUrl",
     "VideoUrl",

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -252,12 +252,27 @@ class ChatCompletionChoice(BaseModel):
     finish_reason: str | None = "stop"
 
 
+class PromptTokensDetails(BaseModel):
+    """Optional request-owned prompt cache usage."""
+
+    cached_tokens: int
+
+
 class Usage(BaseModel):
     """Token usage statistics."""
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    prompt_tokens_details: PromptTokensDetails | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        """Omit cache details when request-level accounting is unavailable."""
+        data = handler(self)
+        if self.prompt_tokens_details is None:
+            data.pop("prompt_tokens_details", None)
+        return data
 
 
 class GenerationMetadata(BaseModel):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -36,6 +36,9 @@ class GenerationOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Request-owned prompt positions supplied by a validated cache. None means
+    # the engine did not provide request-level cache accounting.
+    cached_tokens: int | None = None
 
 
 class EngineBusy(RuntimeError):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -796,6 +796,7 @@ class BatchedEngine(BaseEngine):
                 finish_reason=output.finish_reason,
                 mtp_drafts=output.mtp_drafts,
                 mtp_accepted=output.mtp_accepted,
+                cached_tokens=getattr(output, "cached_tokens", None),
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -826,6 +827,7 @@ class BatchedEngine(BaseEngine):
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
+            cached_tokens=getattr(output, "cached_tokens", None),
         )
 
     async def stream_generate(
@@ -888,6 +890,7 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     mtp_drafts=output.mtp_drafts,
                     mtp_accepted=output.mtp_accepted,
+                    cached_tokens=getattr(output, "cached_tokens", None),
                 )
             return
 
@@ -923,6 +926,7 @@ class BatchedEngine(BaseEngine):
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,
                 finish_reason=output.finish_reason,
+                cached_tokens=getattr(output, "cached_tokens", None),
             )
 
     async def chat(

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -229,6 +229,8 @@ class MLLMBatchRequest:
     vision_encoded: bool = False
     cross_attention_states: Optional[Any] = None  # For models that use cross-attention
     encoder_outputs: Optional[Any] = None  # For encoder-decoder models
+    # Prompt positions actually supplied from a validated prefix cache.
+    cached_tokens: int = 0
 
 
 @dataclass
@@ -248,6 +250,7 @@ class MLLMBatchResponse:
     from_draft: bool = False  # True when this response is an accepted MTP draft
     mtp_attempted: bool = False  # True when the primary step attempted MTP
     mtp_attempted_count: int = 0  # Number of draft tokens attempted
+    cached_tokens: int | None = None  # Request-owned cached prompt positions
 
 
 @dataclass
@@ -1484,6 +1487,8 @@ class MLLMBatchGenerator:
 
         aborted_requests = []
         for req in requests:
+            # Request objects may be reused after a failed or aborted prefill.
+            req.cached_tokens = 0
             try:
                 # Check abort before starting prefill
                 if req.request_id in self._aborted_request_ids:
@@ -1625,6 +1630,7 @@ class MLLMBatchGenerator:
                         all_logprobs.append(logprobs.squeeze(0))
 
                     per_request_caches.append(request_cache)
+                    req.cached_tokens = cached_count
                     req.vision_encoded = True
                     logger.debug(
                         f"Prefix cache hit for {req.request_id}: "
@@ -1641,6 +1647,7 @@ class MLLMBatchGenerator:
                     request_cache = prepared_cache
                     last_token = req.input_ids[:, -1:]
                     total_tokens = len(input_ids_list)
+                    cached_count = total_tokens - 1
                     self._prefill_progress[req.request_id] = (
                         total_tokens,
                         total_tokens,
@@ -1659,10 +1666,11 @@ class MLLMBatchGenerator:
                         all_logprobs.append(logprobs.squeeze(0))
 
                     per_request_caches.append(request_cache)
+                    req.cached_tokens = cached_count
                     req.vision_encoded = True
                     logger.debug(
                         f"Prefix cache exact hit for {req.request_id}: "
-                        f"all {total_tokens} tokens cached"
+                        f"cached={cached_count}, last token replayed"
                     )
 
                 else:
@@ -2073,6 +2081,7 @@ class MLLMBatchGenerator:
                     logprobs=logprobs[i],
                     finish_reason=finish_reason,
                     prompt_cache=cache_fn,
+                    cached_tokens=req.cached_tokens,
                 )
             )
 
@@ -2792,6 +2801,7 @@ def install_mtp_mllm(
                                 logprobs=draft_lp,
                                 finish_reason="stop",
                                 from_draft=from_draft,
+                                cached_tokens=r.cached_tokens,
                             )
                         )
                         draft_end_uids.add(uid)
@@ -2816,6 +2826,7 @@ def install_mtp_mllm(
                                 logprobs=draft_lp,
                                 finish_reason=draft_finish,
                                 from_draft=from_draft,
+                                cached_tokens=r.cached_tokens,
                             )
                         )
 
@@ -2970,6 +2981,7 @@ def install_chunked_prefill_mllm(
                         if finish_reason is not None
                         else None
                     ),
+                    cached_tokens=req.cached_tokens,
                 )
             )
 
@@ -3216,6 +3228,7 @@ def install_chunked_prefill_mllm(
                     f"for {req.request_id[:12]}: "
                     f"{partial['total']} tokens in {partial['chunk_count']} chunks"
                 )
+                req.cached_tokens = partial["cached_count"]
                 batch_gen._partial = None
                 mx.clear_cache()
                 return _generation_step()
@@ -3239,6 +3252,7 @@ def install_chunked_prefill_mllm(
                     break
 
             if text_only_req is not None:
+                text_only_req.cached_tokens = 0
                 try:
                     # Preprocess to get input_ids
                     batch_gen._preprocess_request(text_only_req)
@@ -3322,6 +3336,10 @@ def install_chunked_prefill_mllm(
                     cached_count = 0
                     remaining_count = total_tokens
 
+                # The validated lookup determines the request-owned count;
+                # a later abort or fallback must not retain a prior result.
+                text_only_req.cached_tokens = cached_count
+
                 # Decide: interleave or immediate
                 if remaining_count > batch_gen._chunked_prefill_budget:
                     # LONG prompt — start partial (interleaved) prefill
@@ -3375,7 +3393,9 @@ def install_chunked_prefill_mllm(
 
     def _patched_remove(uids: List[int]) -> None:
         if batch_gen._partial is not None:
-            if batch_gen._partial["request"].uid in set(uids):
+            partial_request = batch_gen._partial["request"]
+            if partial_request.uid in set(uids):
+                partial_request.cached_tokens = 0
                 batch_gen._partial = None
                 mx.clear_cache()
         _orig_remove(uids)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -128,6 +128,8 @@ class MLLMRequest:
 
     # Timing
     first_token_time: Optional[float] = None
+    # Request-owned prompt positions supplied from a validated cache.
+    cached_tokens: int | None = 0
 
 
 @dataclass
@@ -498,6 +500,8 @@ class MLLMScheduler:
         if request is None:
             return False
 
+        request.cached_tokens = 0
+
         # Signal batch generator to abort any in-progress prefill for this
         # request.  The prefill loop checks _aborted_request_ids between
         # chunks and raises PrefillAbortedError to exit early.
@@ -661,6 +665,7 @@ class MLLMScheduler:
 
             # Handle error responses from failed preprocessing
             if response.finish_reason == "error":
+                request.cached_tokens = 0
                 output = RequestOutput(
                     request_id=request_id,
                     new_token_ids=[],
@@ -670,6 +675,7 @@ class MLLMScheduler:
                     completion_tokens=0,
                     finished=True,
                     finish_reason="error",
+                    cached_tokens=0,
                 )
                 request.status = RequestStatus.FINISHED_ABORTED
                 request.output_text = ""
@@ -681,6 +687,10 @@ class MLLMScheduler:
                 continue
 
             # Append token to request
+            cached_tokens = getattr(response, "cached_tokens", None)
+            if type(cached_tokens) is not int:
+                cached_tokens = None
+            request.cached_tokens = cached_tokens
             request.output_tokens.append(response.token)
             request.num_output_tokens = len(request.output_tokens)
             if response.mtp_attempted:
@@ -713,6 +723,7 @@ class MLLMScheduler:
                 completion_tokens=request.num_output_tokens,
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
+                cached_tokens=request.cached_tokens,
             )
 
             # Check if finished
@@ -874,6 +885,7 @@ class MLLMScheduler:
                             completion_tokens=request.num_output_tokens,
                             mtp_drafts=request.mtp_drafts,
                             mtp_accepted=request.mtp_accepted,
+                            cached_tokens=None,
                         )
                     )
                 except asyncio.QueueFull:
@@ -1185,7 +1197,7 @@ class MLLMScheduler:
                     "tokens_per_second": None,
                     "ttft_s": None,
                     "cache_hit_type": None,
-                    "cached_tokens": 0,
+                    "cached_tokens": req.cached_tokens,
                 }
             )
 
@@ -1230,7 +1242,7 @@ class MLLMScheduler:
                     "tokens_per_second": tok_s,
                     "ttft_s": ttft,
                     "cache_hit_type": None,
-                    "cached_tokens": 0,
+                    "cached_tokens": req.cached_tokens,
                 }
             )
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -690,6 +690,7 @@ class MLLMScheduler:
             cached_tokens = getattr(response, "cached_tokens", None)
             if type(cached_tokens) is not int:
                 cached_tokens = None
+            # Error responses continue above; normal token responses carry cache usage.
             request.cached_tokens = cached_tokens
             request.output_tokens.append(response.token)
             request.num_output_tokens = len(request.output_tokens)

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -160,6 +160,7 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            cached_tokens=new.cached_tokens,
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -217,12 +217,17 @@ class RequestOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Request-owned prompt positions supplied by a validated cache.
+    cached_tokens: int | None = None
 
     @property
-    def usage(self) -> Dict[str, int]:
+    def usage(self) -> Dict[str, Any]:
         """Return usage statistics compatible with OpenAI API."""
-        return {
+        usage: Dict[str, Any] = {
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.prompt_tokens + self.completion_tokens,
         }
+        if self.cached_tokens is not None:
+            usage["prompt_tokens_details"] = {"cached_tokens": self.cached_tokens}
+        return usage

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2824,6 +2824,7 @@ class Scheduler:
                 output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                cached_tokens=request.cached_tokens,
             )
 
             # Check if finished

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -99,6 +99,7 @@ from .api.models import (
     Message,  # noqa: F401
     ModelInfo,  # noqa: F401
     ModelsResponse,
+    PromptTokensDetails,
     RerankRequest,
     RerankResponse,
     RerankResult,
@@ -3785,10 +3786,16 @@ def get_usage(output: GenerationOutput) -> Usage:
     total_completion_tokens = (
         output.completion_tokens if hasattr(output, "completion_tokens") else 0
     )
+    cached_tokens = getattr(output, "cached_tokens", None)
     return Usage(
         prompt_tokens=total_prompt_tokens,
         completion_tokens=total_completion_tokens,
         total_tokens=total_prompt_tokens + total_completion_tokens,
+        prompt_tokens_details=(
+            PromptTokensDetails(cached_tokens=cached_tokens)
+            if cached_tokens is not None
+            else None
+        ),
     )
 
 
@@ -5520,11 +5527,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                     finish_reason=finish_reason,
                 )
             ],
-            usage=Usage(
-                prompt_tokens=output.prompt_tokens,
-                completion_tokens=output.completion_tokens,
-                total_tokens=output.prompt_tokens + output.completion_tokens,
-            ),
+            usage=get_usage(output),
             generation_metadata=_generation_metadata(
                 prepared.thinking_processor, output
             ),
@@ -6583,6 +6586,7 @@ async def stream_chat_completion(
     # Track token counts for usage reporting
     prompt_tokens = 0
     completion_tokens = 0
+    cached_tokens: int | None = None
     last_output = None
 
     # Response-format streaming filter — strip markdown code fences from
@@ -6619,6 +6623,9 @@ async def stream_chat_completion(
                 prompt_tokens = output.prompt_tokens
             if hasattr(output, "completion_tokens") and output.completion_tokens:
                 completion_tokens = output.completion_tokens
+            output_cached_tokens = getattr(output, "cached_tokens", None)
+            if output_cached_tokens is not None:
+                cached_tokens = output_cached_tokens
 
             # Use reasoning parser if enabled (skip when enable_thinking=False
             # is set either on the request or via the resolved chat template
@@ -7025,6 +7032,11 @@ async def stream_chat_completion(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=prompt_tokens + completion_tokens,
+                    prompt_tokens_details=(
+                        PromptTokensDetails(cached_tokens=cached_tokens)
+                        if cached_tokens is not None
+                        else None
+                    ),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json()}\n\n"


### PR DESCRIPTION
## Summary

I traced cached-prompt reporting through the schedulers and found that the
request's reused prefix count was not carried into Chat usage. This adds the
optional OpenAI-compatible `prompt_tokens_details.cached_tokens` field to
non-streaming responses and the final streaming usage chunk.

- Preserve the full `prompt_tokens` and `total_tokens` values.
- Forward the Text scheduler's existing request count. Track MLLM partial
  reuse from the validated lookup; exact hits report N-1 because the last
  prompt token is replayed.
- Report zero for a known miss and omit the optional details when accounting
  is unavailable. Aggregate cache lookup counters are not used.

This changes reporting, not cache policy, model computation, or generation
settings. It is based directly on main and contains no persistence or cache
ownership prerequisites.

## Verification

The new request-usage regression fails on the clean base. Tests cover partial
reuse, exact-hit rewind, unsafe-cache fallback, scheduler/collector/engine
propagation, unknown-field omission, and streaming/non-streaming usage.

- Focused: 407 passed, 7 deselected.
- Full repository: 3,069 passed, 25 skipped, 27 deselected.
- Black, Ruff, and diff checks pass.

These are source/API contract checks, not a performance benchmark or a
model-wide cache qualification.
