### PR TITLE
Validate vllm-mlx as a local backend for seven coding agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           pip install ruff black
 
       - name: Run ruff
-        run: ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841
+        run: ruff check vllm_mlx/ tests/ scripts/client_acceptance/ --select E,F,W --ignore E402,E501,E731,F811,F841
 
       - name: Run black
-        run: black --check vllm_mlx/ tests/
+        run: black --check vllm_mlx/ tests/ scripts/client_acceptance/
 
   type-check:
     runs-on: ubuntu-latest
@@ -68,6 +68,9 @@ jobs:
       - name: Run unit tests (no MLX required)
         run: |
           pytest \
+            tests/test_client_acceptance_runner.py \
+            tests/test_client_acceptance_clients.py \
+            tests/test_client_acceptance_observe.py \
             tests/test_mcp_security.py \
             tests/test_structured_output.py \
             tests/test_reasoning_parser.py \

--- a/.github/workflows/client-acceptance.yml
+++ b/.github/workflows/client-acceptance.yml
@@ -1,0 +1,85 @@
+name: Client acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Exact model ID advertised by the prepared local server
+        required: true
+        type: string
+      model_revision:
+        description: Immutable model revision or sha256 digest
+        required: true
+        type: string
+      server_revision:
+        description: Commit of the prepared vllm-mlx server
+        required: true
+        type: string
+      clients:
+        description: Space-separated installed clients
+        default: opencode pi codex claude copilot cline openclaw
+        type: string
+      versions:
+        description: Space-separated CLIENT=VERSION pins, one per selected client
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: client-acceptance
+  cancel-in-progress: false
+
+jobs:
+  acceptance:
+    # Never dispatch arbitrary PR code onto the prepared model host.
+    if: github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, macOS, ARM64, client-acceptance]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify Apple Silicon host
+        run: |
+          python3 -c "import platform; assert platform.system() == 'Darwin' and platform.machine() == 'arm64'"
+
+      - name: Run installed clients against the prepared local server
+        env:
+          ACCEPTANCE_MODEL: ${{ inputs.model }}
+          ACCEPTANCE_MODEL_REVISION: ${{ inputs.model_revision }}
+          ACCEPTANCE_SERVER_REVISION: ${{ inputs.server_revision }}
+          ACCEPTANCE_CLIENTS: ${{ inputs.clients }}
+          ACCEPTANCE_VERSIONS: ${{ inputs.versions }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          from scripts.client_acceptance.runner import main
+
+          clients = os.environ['ACCEPTANCE_CLIENTS'].split()
+          versions = os.environ['ACCEPTANCE_VERSIONS'].split()
+          if not clients or {item.partition('=')[0] for item in versions} != set(clients):
+              raise SystemExit('Provide one version pin for every selected client')
+          args = [
+              '--clients', *clients,
+              '--model', os.environ['ACCEPTANCE_MODEL'],
+              '--model-revision', os.environ['ACCEPTANCE_MODEL_REVISION'],
+              '--server-revision', os.environ['ACCEPTANCE_SERVER_REVISION'],
+              '--report', str(Path(os.environ['RUNNER_TEMP']) / 'client-acceptance.json'),
+          ]
+          for version in versions:
+              args.extend(['--expect-version', version])
+          raise SystemExit(main(args))
+          PY
+
+      - name: Upload acceptance results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-acceptance
+          path: ${{ runner.temp }}/client-acceptance.json
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Browse the complete documentation at [vllm-mlx.is-a.dev](https://vllm-mlx.is-a.d
 
 - **Getting started**: [Installation](docs/getting-started/installation.md) · [Quick Start](docs/getting-started/quickstart.md)
 - **Servers & APIs**: [OpenAI server](docs/guides/server.md) · [Anthropic Messages API](docs/guides/server.md#anthropic-messages-api) · [Python API](docs/guides/python-api.md)
+- **Client compatibility**: [Run coding-client acceptance checks](docs/guides/client-acceptance.md)
 - **Features**: [Multimodal](docs/guides/multimodal.md) · [Audio](docs/guides/audio.md) · [Embeddings](docs/guides/embeddings.md) · [Reasoning](docs/guides/reasoning.md) · [MCP & Tool Calling](docs/guides/mcp-tools.md) · [Tool Parsers](docs/guides/tool-calling.md)
 - **Performance**: [Continuous Batching](docs/guides/continuous-batching.md) · [Multi-Model Serving](docs/guides/model-registry.md) · [Warm Prompts](docs/guides/warm-prompts.md) · [MoE Top-K](docs/guides/moe-top-k.md)
 - **Reference**: [CLI](docs/reference/cli.md) · [Models](docs/reference/models.md) · [Configuration](docs/reference/configuration.md)

--- a/docs/guides/client-acceptance.md
+++ b/docs/guides/client-acceptance.md
@@ -60,13 +60,15 @@ for your own model using the [tool-calling guide](tool-calling.md).
 Run the initial pair:
 
 ```bash
+mkdir -p tmp/client-acceptance
+export TMPDIR="$PWD/tmp/client-acceptance"
 python -m scripts.client_acceptance \
   --clients opencode pi \
   --base-url http://127.0.0.1:8000/v1 \
   --model acceptance-model \
   --model-revision MODEL_COMMIT_OR_SHA256 \
   --server-revision SERVER_COMMIT \
-  --report /tmp/client-acceptance.json
+  --report tmp/client-acceptance/report.json
 ```
 
 Replace the revision placeholders with immutable 40-digit commit hashes,
@@ -94,9 +96,9 @@ upstream server has no key, client configurations receive an inert local key.
 
 Each client receives a private temporary home, configuration directories, and
 workspace. The workspace contains an input file holding a random token and an
-output file containing `pending`. The prompt asks the client to read the input,
-copy its token to the output, and answer with the token. The token is absent
-from the prompt.
+output file containing `pending`. The prompt asks the client to read both files,
+replace `pending` with the input token while preserving the final newline, and
+answer with the token. The token is absent from the prompt.
 
 A loopback proxy observes the client's API requests and streams upstream
 responses through unchanged. A passing run requires all of the following:
@@ -104,7 +106,7 @@ responses through unchanged. A passing run requires all of the following:
 - A matching result for every model-issued tool call, with at least one result carrying the token.
 - At least two inference requests through the expected API, using the selected model.
 - A completed streamed model response containing the token.
-- An actual output file containing the token on one line, with the input unchanged.
+- Exact output bytes: the token followed by one LF newline, with the input unchanged.
 - Successful client exit, no timeout, and no observed protocol errors.
 
 The runner rejects symlink or non-regular fixture files. Reports contain
@@ -128,6 +130,11 @@ configured sandbox and tool restrictions. Run acceptance on a dedicated trusted
 host. Client model traffic goes through the local proxy, but this does not by
 itself block unrelated client startup traffic. Install any required provider
 packages beforehand and verify client-specific offline behavior where needed.
+
+Codex's command tools receive the system executable search path while other
+operator environment variables remain excluded. OpenClaw's startup respawning
+and Node compile cache are disabled so the runner can terminate its process
+group before removing the temporary profile.
 
 ## CI and platform coverage
 

--- a/docs/guides/client-acceptance.md
+++ b/docs/guides/client-acceptance.md
@@ -1,0 +1,153 @@
+# Client acceptance
+
+The opt-in acceptance runner checks installed coding clients against a running
+vllm-mlx server. It checks a complete tool interaction and a file edit through
+the client's normal API adapter. It requires Python 3.10 or later on macOS or
+Linux and uses only the Python standard library.
+
+Run it from a repository checkout:
+
+```bash
+python -m scripts.client_acceptance --help
+```
+
+## Client matrix
+
+| Client executable | API exercised | Coverage |
+| --- | --- | --- |
+| `opencode` | Chat Completions | Custom OpenAI-compatible provider |
+| `pi` | Chat Completions | Custom provider configured in `models.json` |
+| `codex` | Responses | Custom provider with the Responses transport |
+| `claude` | Anthropic Messages | Local Anthropic-compatible gateway |
+| `copilot` | Chat Completions | BYOK local provider with offline mode |
+| `cline` | Chat Completions | CLI with isolated provider configuration |
+| `openclaw` | Responses | Embedded `agent exec`, without messaging channels |
+
+These are implemented test targets, not a claim that every client or model has
+passed. Each run records its actual results and installed versions. Cline CLI
+coverage does not establish editor-extension behavior, and OpenClaw embedded
+coverage does not establish gateway or channel behavior.
+
+OpenClaw uses Responses because that transport preserves standard tool-call
+IDs through its replay path. Its Chat Completions path rewrites IDs, which
+would prevent the runner from verifying exact call/result matches.
+
+Continue and Aider are follow-up candidates. Cursor's native agent is outside
+this local test matrix because its documented BYOK requests pass through Cursor
+infrastructure. See [Cursor's BYOK documentation](https://cursor.com/help/models-and-usage/api-keys).
+
+## Prepare the server and clients
+
+Install the desired clients separately, using explicit versions. The runner
+never installs packages or reuses your client login. It discovers executables
+on `PATH`, probes `--version`, and can reject any version that differs from an
+explicit `--expect-version CLIENT=VERSION` pin. A client release that lacks the
+required flags or provider contract will fail its run.
+
+Start vllm-mlx on Apple Silicon with a pinned local model snapshot and the tool
+parser appropriate for that model. For example:
+
+```bash
+vllm-mlx serve /absolute/path/to/model-snapshot \
+  --served-model-name acceptance-model \
+  --host 127.0.0.1 --port 8000 \
+  --enable-auto-tool-choice --tool-call-parser qwen3_xml
+```
+
+The parser in this example is for a compatible Qwen model. Choose the parser
+for your own model using the [tool-calling guide](tool-calling.md).
+
+Run the initial pair:
+
+```bash
+python -m scripts.client_acceptance \
+  --clients opencode pi \
+  --base-url http://127.0.0.1:8000/v1 \
+  --model acceptance-model \
+  --model-revision MODEL_COMMIT_OR_SHA256 \
+  --server-revision SERVER_COMMIT \
+  --report /tmp/client-acceptance.json
+```
+
+Replace the revision placeholders with immutable 40-digit commit hashes,
+64-digit digests, or `sha256:` followed by 64 digits. These values describe the
+server and model you actually launched. They are recorded as operator-provided
+provenance; the runner cannot independently attest to a running server's source
+or model weights. The model ID must match `/v1/models` exactly.
+
+Select the full matrix with:
+
+```text
+--clients opencode pi codex claude copilot cline openclaw
+```
+
+Add `--expect-version` once per client for reproducible comparisons and adjust
+`--timeout` for the model's speed. The default budget is 180 seconds per client.
+For an authenticated local server, set `VLLM_MLX_API_KEY` in the runner's
+environment, or select another variable with `--api-key-env`. The upstream key
+is held by the proxy. Each run gets a separate proxy credential, passed through
+private client configuration files or environment variables, never command-line
+arguments. The proxy checks that credential before forwarding requests. When the
+upstream server has no key, client configurations receive an inert local key.
+
+## What a passing run establishes
+
+Each client receives a private temporary home, configuration directories, and
+workspace. The workspace contains an input file holding a random token and an
+output file containing `pending`. The prompt asks the client to read the input,
+copy its token to the output, and answer with the token. The token is absent
+from the prompt.
+
+A loopback proxy observes the client's API requests and streams upstream
+responses through unchanged. A passing run requires all of the following:
+
+- A matching result for every model-issued tool call, with at least one result carrying the token.
+- At least two inference requests through the expected API, using the selected model.
+- A completed streamed model response containing the token.
+- An actual output file containing the token on one line, with the input unchanged.
+- Successful client exit, no timeout, and no observed protocol errors.
+
+The runner rejects symlink or non-regular fixture files. Reports contain
+structured evidence counts and reason codes, without raw prompts, responses,
+client transcripts, tokens, or authentication headers.
+
+| Result | Meaning | Process exit |
+| --- | --- | --- |
+| `passed` | Every acceptance condition was observed | `0` only when all selected clients pass |
+| `failed` | Launch/setup, process, protocol, or fixture validation failed | `1` if any client fails |
+| `unavailable` | Missing executable, version mismatch/probe failure, or unavailable server/model | `2` when no client fails but some are unavailable |
+
+Unselected clients are untested and omitted from the report. Unavailable
+clients are never counted as passes. Reason codes and API evidence distinguish
+missing prerequisites from unsuccessful tool execution; transcripts are not
+retained, so detailed client debugging requires a separate manual reproduction.
+
+Temporary directories and environment isolation are not an operating-system
+sandbox. Clients retain their executable's host permissions, subject to their
+configured sandbox and tool restrictions. Run acceptance on a dedicated trusted
+host. Client model traffic goes through the local proxy, but this does not by
+itself block unrelated client startup traffic. Install any required provider
+packages beforehand and verify client-specific offline behavior where needed.
+
+## CI and platform coverage
+
+Ordinary Linux CI runs portable runner, configuration, and HTTP/SSE fixture
+tests. Those tests verify the harness; they do not establish MLX model or
+installed-client acceptance.
+
+The manually dispatched **Client acceptance** workflow runs only from `main`
+on a trusted Apple Silicon self-hosted runner with the `client-acceptance`
+label. Prepare the installed clients and a local server on port 8000 before
+dispatch. Provide the exact server/model revisions and one version pin per
+selected client. The workflow has no pull-request trigger, runs clients
+sequentially, and uploads the structured report even after a failed run. It
+does not install packages, start a model server, or connect messaging accounts.
+
+Current provider contracts:
+[OpenCode](https://opencode.ai/docs/providers/#custom-provider),
+[pi](https://pi.dev/),
+[Codex](https://developers.openai.com/codex/config-advanced),
+[Claude Code](https://code.claude.com/docs/en/llm-gateway),
+[Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models),
+[Cline](https://docs.cline.bot/cli/cli-reference),
+[OpenClaw](https://docs.openclaw.ai/providers/vllm).

--- a/scripts/client_acceptance/__init__.py
+++ b/scripts/client_acceptance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-client acceptance utilities, independent of the MLX runtime."""

--- a/scripts/client_acceptance/__main__.py
+++ b/scripts/client_acceptance/__main__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Entry point: python -m scripts.client_acceptance."""
+
+from .runner import main
+
+raise SystemExit(main())

--- a/scripts/client_acceptance/clients.py
+++ b/scripts/client_acceptance/clients.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare isolated, noninteractive clients for a loopback acceptance proxy.
+
+These adapters target the documented CLI contracts checked in September 2026.
+Unsupported flags must fail visibly on older clients. The caller owns process
+timeouts, an allowlisted environment, isolated HOME/XDG directories, and cleanup.
+Preparing a plan never launches a client or reads an existing client profile.
+"""
+
+import ipaddress
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+CLIENT_NAMES = ("opencode", "pi", "codex", "claude", "copilot", "cline", "openclaw")
+LOCAL_KEY = "local-test"
+
+
+@dataclass(frozen=True)
+class ClientPlan:
+    name: str
+    protocol: str
+    argv: list[str]
+    env: dict[str, str]
+
+
+def _write_json(path: Path, value: dict) -> str:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+    path.chmod(0o600)
+    return str(path)
+
+
+def prepare_client(
+    name: str,
+    executable: str,
+    root: Path,
+    base_url: str,
+    model: str,
+    prompt: str,
+    timeout: int,
+    *,
+    api_key: str = LOCAL_KEY,
+) -> ClientPlan:
+    """Write private configuration and return argv without executing commands."""
+    if name not in CLIENT_NAMES:
+        raise ValueError("Unknown acceptance client")
+    if not Path(executable).is_absolute():
+        raise ValueError("Client executable must be an absolute path")
+    if not model.strip() or timeout <= 0:
+        raise ValueError("A model and positive timeout are required")
+    parsed = urlsplit(base_url)
+    try:
+        loopback = (
+            parsed.hostname == "localhost"
+            or ipaddress.ip_address(parsed.hostname or "").is_loopback
+        )
+        port = parsed.port
+    except ValueError:
+        loopback, port = False, None
+    if (
+        parsed.scheme != "http"
+        or not loopback
+        or port is None
+        or parsed.path != "/v1"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Client endpoint must be a loopback HTTP /v1 proxy URL")
+
+    root = root.resolve()
+    workspace = str(root / "workspace")
+    state = root / name
+    state.mkdir(mode=0o700, exist_ok=True)
+    env: dict[str, str] = {}
+    protocol = "chat"
+
+    if name == "opencode":
+        config = _write_json(
+            state / "opencode.json",
+            {
+                "model": f"vllm-mlx/{model}",
+                "small_model": f"vllm-mlx/{model}",
+                "enabled_providers": ["vllm-mlx"],
+                "provider": {
+                    "vllm-mlx": {
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {"baseURL": base_url, "apiKey": api_key},
+                        "models": {
+                            model: {
+                                "name": model,
+                                "limit": {"context": 32768, "output": 4096},
+                            }
+                        },
+                    }
+                },
+                "permission": {"*": "deny", "read": "allow", "edit": "allow"},
+                # Title generation otherwise makes a separate tools-free model
+                # request before the fixture task. Keep this run task-focused.
+                "agent": {"title": {"disable": True}},
+                "compaction": {"auto": False, "prune": False},
+                "share": "disabled",
+                "autoupdate": False,
+                "snapshot": False,
+                "formatter": False,
+                "lsp": False,
+                "plugin": [],
+                "mcp": {},
+                "instructions": [],
+            },
+        )
+        env = {
+            "OPENCODE_CONFIG": config,
+            "OPENCODE_CONFIG_DIR": str(state),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        }
+        argv = [
+            executable,
+            "run",
+            "--pure",
+            "--model",
+            f"vllm-mlx/{model}",
+            "--format",
+            "json",
+            "--dir",
+            workspace,
+            prompt,
+        ]
+    elif name == "pi":
+        _write_json(
+            state / "models.json",
+            {
+                "providers": {
+                    "vllm-mlx": {
+                        "baseUrl": base_url,
+                        "api": "openai-completions",
+                        "apiKey": api_key,
+                        "models": [
+                            {
+                                "id": model,
+                                "reasoning": False,
+                                "contextWindow": 32768,
+                                "maxTokens": 4096,
+                            }
+                        ],
+                    }
+                }
+            },
+        )
+        env = {"PI_CODING_AGENT_DIR": str(state), "PI_OFFLINE": "1"}
+        argv = [
+            executable,
+            "--print",
+            "--mode",
+            "json",
+            "--provider",
+            "vllm-mlx",
+            "--model",
+            model,
+            "--tools",
+            "read,edit,write",
+            "--thinking",
+            "off",
+            "--no-session",
+            "--no-extensions",
+            "--no-skills",
+            "--no-context-files",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-approve",
+            prompt,
+        ]
+    elif name == "codex":
+        protocol = "responses"
+        env = {"CODEX_HOME": str(state), "VLLM_MLX_CLIENT_KEY": api_key}
+        argv = [
+            executable,
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--skip-git-repo-check",
+            "--sandbox",
+            "workspace-write",
+            "--cd",
+            workspace,
+            "--model",
+            model,
+        ]
+        # Codex's normal file-read workflow uses its command tool. Preserve the
+        # OS sandbox rather than disabling that tool or bypassing permissions.
+        config = {
+            "model_provider": "vllm-mlx",
+            "model_providers.vllm-mlx.name": "Local acceptance proxy",
+            "model_providers.vllm-mlx.base_url": base_url,
+            "model_providers.vllm-mlx.wire_api": "responses",
+            "model_providers.vllm-mlx.env_key": "VLLM_MLX_CLIENT_KEY",
+            "model_providers.vllm-mlx.requires_openai_auth": False,
+            "model_providers.vllm-mlx.request_max_retries": 0,
+            "model_providers.vllm-mlx.stream_max_retries": 0,
+            "model_providers.vllm-mlx.stream_idle_timeout_ms": timeout * 1000,
+            "approval_policy": "never",
+            "sandbox_workspace_write.network_access": False,
+            "allow_login_shell": False,
+            "shell_environment_policy.inherit": "none",
+            "project_doc_max_bytes": 0,
+            "web_search": "disabled",
+            "features.apps": False,
+            "features.plugins": False,
+            "features.hooks": False,
+            "features.multi_agent": False,
+            "features.remote_models": False,
+            "features.skip_host_skill_discovery": True,
+        }
+        for key, value in config.items():
+            argv.extend(["-c", f"{key}={json.dumps(value, ensure_ascii=False)}"])
+        argv.append(prompt)
+    elif name == "claude":
+        protocol = "anthropic"
+        env = {
+            "CLAUDE_CONFIG_DIR": str(state),
+            # Anthropic's SDK appends /v1/messages to an origin base URL.
+            "ANTHROPIC_BASE_URL": base_url.removesuffix("/v1"),
+            "ANTHROPIC_API_KEY": api_key,
+            "ANTHROPIC_MODEL": model,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": model,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "API_TIMEOUT_MS": str(timeout * 1000),
+        }
+        argv = [
+            executable,
+            "--print",
+            "--bare",
+            "--restricted",
+            "--setting-sources",
+            "",
+            "--strict-mcp-config",
+            "--mcp-config",
+            '{"mcpServers":{}}',
+            "--tools",
+            "Read,Edit,Write",
+            "--allowedTools",
+            "Read,Edit,Write",
+            "--permission-mode",
+            "acceptEdits",
+            "--no-session-persistence",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            model,
+            "--",
+            prompt,
+        ]
+    elif name == "copilot":
+        env = {
+            "COPILOT_HOME": str(state),
+            "COPILOT_PROVIDER_BASE_URL": base_url,
+            "COPILOT_PROVIDER_TYPE": "openai",
+            "COPILOT_PROVIDER_API_KEY": api_key,
+            "COPILOT_MODEL": model,
+            "COPILOT_OFFLINE": "true",
+            "COPILOT_AUTO_UPDATE": "false",
+        }
+        argv = [
+            executable,
+            "--output-format=json",
+            "--available-tools=view,edit,create,apply_patch",
+            "--allow-tool=read",
+            "--allow-tool=write",
+            "--deny-tool=shell",
+            "--disable-builtin-mcps",
+            "--no-custom-instructions",
+            "--no-auto-update",
+            "--no-bash-env",
+            "--no-remote",
+            "--no-remote-export",
+            "--no-ask-user",
+            "--prompt",
+            prompt,
+        ]
+    elif name == "cline":
+        env = {
+            "CLINE_COMMAND_PERMISSIONS": json.dumps({"deny": ["*"]}),
+            "CLINE_SESSION_BACKEND_MODE": "local",
+        }
+        # Cline 3.0.61 reads this store beneath the root command's --data-dir.
+        # Writing it directly keeps the proxy credential out of auth's argv.
+        _write_json(
+            state / "settings" / "providers.json",
+            {
+                "version": 1,
+                "lastUsedProvider": "openai-compatible",
+                "modes": {},
+                "providers": {
+                    "openai-compatible": {
+                        "settings": {
+                            "provider": "openai-compatible",
+                            "apiKey": api_key,
+                            "model": model,
+                            "baseUrl": base_url,
+                        },
+                        "updatedAt": datetime.now(timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z"),
+                        "tokenSource": "manual",
+                    }
+                },
+            },
+        )
+        argv = [
+            executable,
+            "--data-dir",
+            str(state),
+            "--cwd",
+            workspace,
+            "--provider",
+            "openai-compatible",
+            "--model",
+            model,
+            "--json",
+            "--timeout",
+            str(timeout),
+            "--auto-approve",
+            "true",
+            "--",
+            prompt,
+        ]
+    else:  # openclaw
+        # OpenClaw's Chat replay policy rewrites call IDs. Its Responses
+        # transport preserves standard call_ IDs for exact round-trip checks.
+        protocol = "responses"
+        config = _write_json(
+            state / "openclaw.json",
+            {
+                "models": {
+                    "providers": {
+                        "vllm": {
+                            "baseUrl": base_url,
+                            "apiKey": api_key,
+                            "api": "openai-responses",
+                            "timeoutSeconds": timeout,
+                            "models": [
+                                {
+                                    "id": model,
+                                    "name": model,
+                                    "reasoning": False,
+                                    "input": ["text"],
+                                    "contextWindow": 32768,
+                                    "maxTokens": 4096,
+                                    "cost": {
+                                        "input": 0,
+                                        "output": 0,
+                                        "cacheRead": 0,
+                                        "cacheWrite": 0,
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                },
+                "agents": {
+                    "defaults": {
+                        "workspace": workspace,
+                        "model": {"primary": f"vllm/{model}", "fallbacks": []},
+                    }
+                },
+                "tools": {
+                    "allow": ["read", "edit", "write"],
+                    "fs": {"workspaceOnly": True},
+                },
+                "plugins": {"allow": ["vllm"], "slots": {"memory": "none"}},
+            },
+        )
+        env = {"OPENCLAW_STATE_DIR": str(state)}
+        # --auth-env-only rejects --config. Empty HOME and explicit state keep
+        # this pinned provider independent of existing CLI credential stores.
+        argv = [
+            executable,
+            "agent",
+            "exec",
+            "--config",
+            config,
+            "--cwd",
+            workspace,
+            "--model",
+            f"vllm/{model}",
+            "--code-mode",
+            "direct",
+            "--json",
+            "--timeout",
+            str(timeout),
+            "--",
+            prompt,
+        ]
+
+    return ClientPlan(name, protocol, argv, env)

--- a/scripts/client_acceptance/clients.py
+++ b/scripts/client_acceptance/clients.py
@@ -9,6 +9,7 @@ Preparing a plan never launches a client or reads an existing client profile.
 
 import ipaddress
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -210,6 +211,7 @@ def prepare_client(
             "sandbox_workspace_write.network_access": False,
             "allow_login_shell": False,
             "shell_environment_policy.inherit": "none",
+            "shell_environment_policy.set.PATH": os.defpath,
             "project_doc_max_bytes": 0,
             "web_search": "disabled",
             "features.apps": False,
@@ -381,7 +383,13 @@ def prepare_client(
                 "plugins": {"allow": ["vllm"], "slots": {"memory": "none"}},
             },
         )
-        env = {"OPENCLAW_STATE_DIR": str(state)}
+        env = {
+            "OPENCLAW_STATE_DIR": str(state),
+            # Keep startup in the runner's process group so its timeout can
+            # reap the CLI before the temporary profile is removed.
+            "OPENCLAW_NO_RESPAWN": "1",
+            "NODE_DISABLE_COMPILE_CACHE": "1",
+        }
         # --auth-env-only rejects --config. Empty HOME and explicit state keep
         # this pinned provider independent of existing CLI credential stores.
         argv = [

--- a/scripts/client_acceptance/observe.py
+++ b/scripts/client_acceptance/observe.py
@@ -1,0 +1,567 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded loopback proxy collecting protocol evidence without payload reports."""
+
+import http.client
+import json
+import math
+import secrets
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+MAX_REQUEST_BYTES = 2 * 1024 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_REQUESTS = 128
+_PATHS = {
+    "chat": "/v1/chat/completions",
+    "responses": "/v1/responses",
+    "anthropic": "/v1/messages",
+}
+
+
+def _objects(value):
+    return (
+        [item for item in value if isinstance(item, dict)]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _text(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_text(item) for item in value)
+    if isinstance(value, dict):
+        return _text(value.get("text", value.get("content", "")))
+    return ""
+
+
+class Evidence:
+    """Keep bounded in-memory evidence; summaries contain only counts and flags."""
+
+    def __init__(self, protocol):
+        self.protocol = protocol
+        self.requests = 0
+        self.streamed = False
+        self.completed = False
+        self._answer = ""
+        self._issued = set()
+        self._results = {}
+        self._errors = []
+        self._lock = threading.RLock()
+
+    def error(self, code):
+        with self._lock:
+            if code not in self._errors:
+                self._errors.append(code)
+
+    def begin(self, body):
+        with self._lock:
+            self.requests += 1
+            self.completed = False
+            self._answer = ""
+            if self.requests > MAX_REQUESTS:
+                self.error("request_limit")
+                return False
+            if body.get("stream") is not True:
+                self.error("stream_required")
+            results = []
+            if self.protocol == "responses":
+                results = [
+                    (item.get("call_id"), item.get("output"))
+                    for item in _objects(body.get("input"))
+                    if item.get("type") == "function_call_output"
+                ]
+            else:
+                for message in _objects(body.get("messages")):
+                    if self.protocol == "chat" and message.get("role") == "tool":
+                        results.append(
+                            (message.get("tool_call_id"), message.get("content"))
+                        )
+                    elif self.protocol == "anthropic" and message.get("role") == "user":
+                        for item in _objects(message.get("content")):
+                            if item.get("type") == "tool_result":
+                                if item.get("is_error"):
+                                    self.error("tool_result_error")
+                                results.append(
+                                    (item.get("tool_use_id"), item.get("content"))
+                                )
+            for call_id, result in results:
+                if isinstance(call_id, str) and call_id in self._issued:
+                    # Retain one bounded payload per observed call, not repeated history.
+                    self._results.setdefault(call_id, _text(result))
+            return True
+
+    def finish(self, stream):
+        with self._lock:
+            stream.end()
+            if not stream.completed:
+                self.error("incomplete_stream")
+            for code in stream.errors:
+                self.error(code)
+            if stream.completed and not stream.errors:
+                self.streamed = True
+                for call_id in stream.calls:
+                    if call_id in self._issued:
+                        self.error("duplicate_tool_call_id")
+                    self._issued.add(call_id)
+                self.completed = not stream.calls and stream.final
+                if self.completed and self._issued.difference(self._results):
+                    self.error("missing_tool_results")
+                    self.completed = False
+                self._answer = stream.answer if self.completed else ""
+
+    def summary(self, token):
+        with self._lock:
+            return {
+                "requests": self.requests,
+                "streamed": self.streamed,
+                "tool_calls": len(self._issued),
+                "tool_results": sum(
+                    bool(token) and token in result for result in self._results.values()
+                ),
+                "completed": self.completed,
+                "answer_matches": bool(token) and token in self._answer,
+                "errors": list(self._errors),
+            }
+
+    def passed(self, token):
+        with self._lock:
+            report = self.summary(token)
+            return bool(
+                report["requests"] >= 2
+                and report["streamed"]
+                and report["completed"]
+                and report["answer_matches"]
+                and not report["errors"]
+                and any(token in result for result in self._results.values())
+            )
+
+
+class _Stream:
+    """Parse SSE incrementally, accepting only server-emitted calls and text."""
+
+    def __init__(self, protocol):
+        self.protocol = protocol
+        self.completed = False
+        self.final = False
+        self.answer = ""
+        self.calls = set()
+        self.errors = set()
+        self._buffer = b""
+        self._data = []
+        self._stop = None
+        self._chat_calls = {}
+
+    def feed(self, chunk):
+        self._buffer += chunk
+        while b"\n" in self._buffer:
+            line, self._buffer = self._buffer.split(b"\n", 1)
+            line = line.rstrip(b"\r")
+            if not line:
+                if self._data:
+                    self._event(b"\n".join(self._data))
+                self._data = []
+            elif line.startswith(b"data:"):
+                self._data.append(line[5:].lstrip(b" "))
+
+    def end(self):
+        if self._buffer.strip() or self._data:
+            self.errors.add("incomplete_sse_event")
+
+    def _event(self, raw):
+        if raw == b"[DONE]":
+            if self.protocol == "chat":
+                self.completed = self._stop in ("stop", "tool_calls")
+                self.final = self._stop == "stop"
+                for call in self._chat_calls.values():
+                    try:
+                        valid = (
+                            call.get("id")
+                            and call.get("name")
+                            and isinstance(json.loads(call.get("arguments", "")), dict)
+                        )
+                    except (ValueError, TypeError):
+                        valid = False
+                    if valid:
+                        self.calls.add(call["id"])
+                    else:
+                        self.errors.add("invalid_tool_call")
+            return
+        try:
+            event = json.loads(raw)
+        except (ValueError, UnicodeError):
+            self.errors.add("invalid_sse_json")
+            return
+        if not isinstance(event, dict):
+            self.errors.add("invalid_sse_event")
+            return
+        if event.get("error") or event.get("type") in (
+            "error",
+            "response.failed",
+            "response.incomplete",
+        ):
+            self.errors.add("upstream_error_event")
+            return
+        if self.completed:
+            self.errors.add("event_after_completion")
+            return
+        if self.protocol == "chat":
+            self._chat(event)
+        elif self.protocol == "responses":
+            self._responses(event)
+        else:
+            self._anthropic(event)
+
+    def _chat(self, event):
+        for choice in _objects(event.get("choices")):
+            if choice.get("index", 0) != 0:
+                self.errors.add("multiple_choices")
+                continue
+            delta = choice.get("delta") or {}
+            if not isinstance(delta, dict):
+                self.errors.add("invalid_sse_event")
+                continue
+            self.answer += _text(delta.get("content"))
+            for part in _objects(delta.get("tool_calls")):
+                index = part.get("index")
+                if not isinstance(index, int):
+                    self.errors.add("invalid_tool_call")
+                    continue
+                call = self._chat_calls.setdefault(index, {})
+                function = part.get("function") or {}
+                if not isinstance(function, dict):
+                    self.errors.add("invalid_tool_call")
+                    continue
+                for key, value in (
+                    ("id", part.get("id")),
+                    ("name", function.get("name")),
+                    ("arguments", function.get("arguments")),
+                ):
+                    if isinstance(value, str):
+                        call[key] = call.get(key, "") + value
+            if choice.get("finish_reason"):
+                self._stop = choice["finish_reason"]
+
+    def _responses(self, event):
+        kind = event.get("type")
+        if kind == "response.output_text.delta":
+            self.answer += _text(event.get("delta"))
+        elif kind in ("response.output_item.added", "response.output_item.done"):
+            self._response_call(event.get("item"))
+        elif kind == "response.completed":
+            response = event.get("response")
+            if (
+                not isinstance(response, dict)
+                or response.get("status") != "completed"
+                or response.get("error")
+            ):
+                self.errors.add("response_not_completed")
+                return
+            output = _objects(response.get("output"))
+            # The completed response is authoritative, even when earlier deltas differed.
+            self.answer = "".join(
+                _text(item.get("content"))
+                for item in output
+                if item.get("type") == "message" and item.get("role") == "assistant"
+            )
+            for item in output:
+                self._response_call(item)
+            self.completed = True
+            self.final = not self.calls
+
+    def _response_call(self, item):
+        if isinstance(item, dict) and item.get("type") == "function_call":
+            call_id = item.get("call_id")
+            if isinstance(call_id, str) and call_id and item.get("name"):
+                self.calls.add(call_id)
+            else:
+                self.errors.add("invalid_tool_call")
+
+    def _anthropic(self, event):
+        kind = event.get("type")
+        if kind == "content_block_start":
+            block = event.get("content_block") or {}
+            if isinstance(block, dict):
+                if block.get("type") == "tool_use":
+                    call_id = block.get("id")
+                    if isinstance(call_id, str) and call_id and block.get("name"):
+                        self.calls.add(call_id)
+                    else:
+                        self.errors.add("invalid_tool_call")
+                elif block.get("type") == "text":
+                    self.answer += _text(block.get("text"))
+        elif kind == "content_block_delta":
+            delta = event.get("delta") or {}
+            if isinstance(delta, dict) and delta.get("type") == "text_delta":
+                self.answer += _text(delta.get("text"))
+        elif kind == "message_delta":
+            delta = event.get("delta") or {}
+            if isinstance(delta, dict):
+                self._stop = delta.get("stop_reason")
+        elif kind == "message_stop":
+            self.completed = self._stop in ("end_turn", "stop_sequence", "tool_use")
+            self.final = self._stop in ("end_turn", "stop_sequence")
+
+
+class RecordingProxy:
+    """Forward only selected inference and model discovery to literal loopback."""
+
+    def __init__(self, upstream_url, model, protocol, api_key="", timeout=60):
+        url = urlsplit(upstream_url)
+        try:
+            port = url.port or 80
+        except ValueError:
+            raise ValueError("Invalid upstream port") from None
+        if (
+            url.scheme != "http"
+            or url.hostname not in ("127.0.0.1", "localhost", "::1")
+            or url.username is not None
+            or url.password is not None
+            or url.path.rstrip("/") != "/v1"
+            or url.query
+            or url.fragment
+        ):
+            raise ValueError("Upstream must be an HTTP loopback /v1 base URL")
+        if protocol not in _PATHS or not isinstance(model, str) or not model:
+            raise ValueError("Invalid protocol or model")
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("Timeout must be finite and positive")
+        self.model = model
+        self.protocol = protocol
+        self.timeout = timeout
+        # Resolve the permitted localhost spelling directly, without trusting DNS.
+        self._host = "127.0.0.1" if url.hostname == "localhost" else url.hostname
+        self._port = port
+        self._api_key = api_key
+        # Preserve the upstream authentication boundary without sharing its key
+        # with client processes or exposing a key in command-line arguments.
+        self.client_key = secrets.token_urlsafe(32) if api_key else ""
+        self.evidence = Evidence(protocol)
+        self._serial = threading.Lock()
+        self._server = None
+        self._thread = None
+
+    def __enter__(self):
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def setup(self):
+                super().setup()
+                self.connection.settimeout(owner.timeout)
+
+            def log_message(self, *args):
+                pass
+
+            def do_GET(self):
+                self._dispatch()
+
+            def do_POST(self):
+                self._dispatch()
+
+            def _reject(self, status, code, *, record=True):
+                if record:
+                    self._error(code)
+                self.close_connection = True
+                payload = json.dumps(
+                    {"error": {"message": code, "type": "acceptance_proxy_error"}}
+                ).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def _error(self, code):
+                if not (self.command == "GET" and self.path == "/v1/models"):
+                    owner.evidence.error(code)
+
+            def _dispatch(self):
+                if owner.client_key:
+                    credentials = [("Authorization", "Bearer " + owner.client_key)]
+                    if owner.protocol == "anthropic":
+                        credentials.append(("x-api-key", owner.client_key))
+                    authorized = any(
+                        len(self.headers.get_all(name, [])) == 1
+                        and secrets.compare_digest(
+                            self.headers[name].encode("utf-8"), expected.encode("ascii")
+                        )
+                        for name, expected in credentials
+                    )
+                    if not authorized:
+                        self._reject(401, "authentication_required", record=False)
+                        return
+                allowed = self.command == "GET" and self.path == "/v1/models"
+                # The Anthropic SDK's beta Messages resource adds this exact
+                # query for create/stream and countTokens. No other query is
+                # needed by the acceptance clients.
+                inference_paths = {_PATHS[owner.protocol]}
+                if owner.protocol == "anthropic":
+                    inference_paths.add("/v1/messages?beta=true")
+                inference = self.command == "POST" and self.path in inference_paths
+                count_tokens = (
+                    owner.protocol == "anthropic"
+                    and self.command == "POST"
+                    and self.path
+                    in {
+                        "/v1/messages/count_tokens",
+                        "/v1/messages/count_tokens?beta=true",
+                    }
+                )
+                if not (allowed or inference or count_tokens):
+                    self._reject(404, "path_rejected")
+                    return
+                if (
+                    self.headers.get("Transfer-Encoding")
+                    or len(self.headers.get_all("Content-Length", [])) > 1
+                ):
+                    self._reject(400, "invalid_request_framing")
+                    return
+                try:
+                    length = int(self.headers.get("Content-Length", "0"))
+                except ValueError:
+                    self._reject(400, "invalid_content_length")
+                    return
+                if length < 0 or length > MAX_REQUEST_BYTES:
+                    self._reject(413, "request_too_large")
+                    return
+                try:
+                    raw = self.rfile.read(length)
+                    if len(raw) != length:
+                        self._reject(400, "incomplete_request")
+                        return
+                    body = json.loads(raw) if self.command == "POST" else {}
+                except (ValueError, UnicodeError, RecursionError, OSError):
+                    self._reject(400, "invalid_request_body")
+                    return
+                if self.command == "POST" and (
+                    not isinstance(body, dict) or body.get("model") != owner.model
+                ):
+                    self._reject(400, "model_rejected")
+                    return
+                # SDKs can send the next tool result as soon as they receive a
+                # terminal SSE event, before the preceding HTTP stream closes.
+                # Wait until its issuance evidence is finalized before begin().
+                if not owner._serial.acquire(timeout=owner.timeout):
+                    self._reject(504, "request_queue_timeout")
+                    return
+                try:
+                    if inference and not owner.evidence.begin(body):
+                        self._reject(429, "request_limit")
+                        return
+                    self._forward(raw, inference)
+                finally:
+                    owner._serial.release()
+
+            def _forward(self, raw, inference):
+                deadline = time.monotonic() + owner.timeout
+                connection = http.client.HTTPConnection(
+                    owner._host, owner._port, timeout=owner.timeout
+                )
+                headers = {
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream" if inference else "application/json",
+                    "Accept-Encoding": "identity",
+                }
+                if owner._api_key:
+                    headers["Authorization"] = "Bearer " + owner._api_key
+                    if owner.protocol == "anthropic":
+                        headers["x-api-key"] = owner._api_key
+                if owner.protocol == "anthropic":
+                    headers["anthropic-version"] = "2023-06-01"
+                stream = _Stream(owner.protocol) if inference else None
+                started = False
+                self.close_connection = True
+                try:
+                    connection.request(
+                        self.command, self.path, body=raw or None, headers=headers
+                    )
+                    response = connection.getresponse()
+                    if response.status != 200:
+                        self._reject(502, "upstream_http_error")
+                        return
+                    content_type = response.getheader("Content-Type", "")
+                    if (
+                        inference
+                        and content_type.split(";", 1)[0].strip().lower()
+                        != "text/event-stream"
+                    ):
+                        self._reject(502, "stream_required")
+                        return
+                    if (
+                        response.getheader("Content-Encoding", "identity").lower()
+                        != "identity"
+                    ):
+                        self._reject(502, "unsupported_content_encoding")
+                        return
+                    self.send_response(200)
+                    self.send_header(
+                        "Content-Type",
+                        "text/event-stream" if inference else "application/json",
+                    )
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    started = True
+                    size = 0
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise TimeoutError
+                        # HTTPConnection may relinquish a closing response socket.
+                        if connection.sock is not None:
+                            connection.sock.settimeout(remaining)
+                        elif response.fp is not None:
+                            response.fp.raw._sock.settimeout(remaining)
+                        chunk = response.read1(min(4096, MAX_RESPONSE_BYTES - size + 1))
+                        if not chunk:
+                            break
+                        size += len(chunk)
+                        if size > MAX_RESPONSE_BYTES:
+                            self._error("response_too_large")
+                            break
+                        if stream:
+                            stream.feed(chunk)
+                        self.wfile.write(chunk)
+                        self.wfile.flush()
+                except (TimeoutError, socket.timeout):
+                    self._error("upstream_timeout")
+                    if not started:
+                        self._reject(504, "upstream_timeout")
+                except (OSError, http.client.HTTPException, ValueError, RecursionError):
+                    self._error("upstream_io_error")
+                    if not started:
+                        self._reject(502, "upstream_io_error")
+                finally:
+                    connection.close()
+                    if stream:
+                        owner.evidence.finish(stream)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        self._thread.start()
+        self.base_url = f"http://127.0.0.1:{self._server.server_port}/v1"
+        return self
+
+    def wait_for_idle(self, timeout: float) -> bool:
+        """Wait for active forwarding and evidence collection within the budget."""
+        if not self._serial.acquire(timeout=max(0.0, timeout)):
+            self.evidence.error("stream_finalize_timeout")
+            return False
+        self._serial.release()
+        return True
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=1)

--- a/scripts/client_acceptance/observe.py
+++ b/scripts/client_acceptance/observe.py
@@ -236,8 +236,15 @@ class _Stream:
                 if not isinstance(function, dict):
                     self.errors.add("invalid_tool_call")
                     continue
+                # Qwen XML repeats a complete stable ID on argument deltas.
+                # The client returns that ID once, not its concatenated copies.
+                call_id = part.get("id")
+                if isinstance(call_id, str) and call_id:
+                    if call.get("id") and call["id"] != call_id:
+                        self.errors.add("invalid_tool_call")
+                    else:
+                        call["id"] = call_id
                 for key, value in (
-                    ("id", part.get("id")),
                     ("name", function.get("name")),
                     ("arguments", function.get("arguments")),
                 ):
@@ -342,11 +349,47 @@ class RecordingProxy:
         self.client_key = secrets.token_urlsafe(32) if api_key else ""
         self.evidence = Evidence(protocol)
         self._serial = threading.Lock()
+        self._connections_lock = threading.Lock()
+        self._connections = set()
+        self._closing = False
         self._server = None
         self._thread = None
 
+    def _track_connection(self, connection):
+        with self._connections_lock:
+            if self._closing:
+                raise OSError("Proxy is closing")
+            self._connections.add(connection)
+
+    def _untrack_connection(self, connection):
+        with self._connections_lock:
+            self._connections.discard(connection)
+
     def __enter__(self):
         owner = self
+
+        class Server(ThreadingHTTPServer):
+            # server_close joins the handlers after their sockets are cancelled.
+            daemon_threads = False
+
+            def process_request(self, request, client_address):
+                try:
+                    owner._track_connection(request)
+                    super().process_request(request, client_address)
+                except Exception:
+                    owner._untrack_connection(request)
+                    self.shutdown_request(request)
+                    raise
+
+            def process_request_thread(self, request, client_address):
+                try:
+                    super().process_request_thread(request, client_address)
+                finally:
+                    owner._untrack_connection(request)
+
+            def handle_error(self, request, client_address):
+                if not owner._closing:
+                    super().handle_error(request, client_address)
 
         class Handler(BaseHTTPRequestHandler):
             protocol_version = "HTTP/1.1"
@@ -365,6 +408,9 @@ class RecordingProxy:
                 self._dispatch()
 
             def _reject(self, status, code, *, record=True):
+                if owner._closing:
+                    self.close_connection = True
+                    return
                 if record:
                     self._error(code)
                 self.close_connection = True
@@ -452,6 +498,8 @@ class RecordingProxy:
                     self._reject(504, "request_queue_timeout")
                     return
                 try:
+                    if owner._closing:
+                        return
                     if inference and not owner.evidence.begin(body):
                         self._reject(429, "request_limit")
                         return
@@ -478,7 +526,18 @@ class RecordingProxy:
                 stream = _Stream(owner.protocol) if inference else None
                 started = False
                 self.close_connection = True
+                upstream = None
                 try:
+                    # Register the socket before connect(), so shutdown can also
+                    # cancel connection establishment. Keep this reference when
+                    # HTTPConnection relinquishes a Connection: close socket.
+                    family = socket.AF_INET6 if owner._host == "::1" else socket.AF_INET
+                    upstream = socket.socket(family, socket.SOCK_STREAM)
+                    upstream.settimeout(owner.timeout)
+                    upstream.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    connection.sock = upstream
+                    owner._track_connection(upstream)
+                    upstream.connect((owner._host, owner._port))
                     connection.request(
                         self.command, self.path, body=raw or None, headers=headers
                     )
@@ -520,6 +579,10 @@ class RecordingProxy:
                             response.fp.raw._sock.settimeout(remaining)
                         chunk = response.read1(min(4096, MAX_RESPONSE_BYTES - size + 1))
                         if not chunk:
+                            # read1() permits EOF with Content-Length bytes still
+                            # outstanding; terminal SSE alone is insufficient.
+                            if response.length not in (None, 0):
+                                self._error("incomplete_http_response")
                             break
                         size += len(chunk)
                         if size > MAX_RESPONSE_BYTES:
@@ -539,11 +602,13 @@ class RecordingProxy:
                         self._reject(502, "upstream_io_error")
                 finally:
                     connection.close()
+                    if upstream is not None:
+                        upstream.close()
+                        owner._untrack_connection(upstream)
                     if stream:
                         owner.evidence.finish(stream)
 
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-        self._server.daemon_threads = True
+        self._server = Server(("127.0.0.1", 0), Handler)
         self._thread = threading.Thread(
             target=self._server.serve_forever,
             kwargs={"poll_interval": 0.05},
@@ -562,6 +627,17 @@ class RecordingProxy:
         return True
 
     def __exit__(self, exc_type, exc_value, traceback):
+        with self._connections_lock:
+            self._closing = True
+            connections = tuple(self._connections)
+        # shutdown() wakes handlers blocked in buffered HTTP reads; close()
+        # alone cannot reliably interrupt a read holding a makefile reference.
+        for connection in connections:
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            connection.close()
         self._server.shutdown()
         self._server.server_close()
         self._thread.join(timeout=1)

--- a/scripts/client_acceptance/runner.py
+++ b/scripts/client_acceptance/runner.py
@@ -1,0 +1,372 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run installed coding clients against an explicitly selected local model."""
+
+import argparse
+import json
+import os
+import re
+import secrets
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http.client import HTTPConnection, HTTPException
+from pathlib import Path
+from urllib.parse import urlsplit
+
+PROMPT = (
+    "Read input.txt in the current workspace using a tool. "
+    "Copy its token to output.txt as one line. Leave input.txt unchanged. "
+    "Reply with that token after writing the file. Work only with those two files. "
+    "Do not use the network."
+)
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    returncode: int
+    timed_out: bool
+    version: str | None = None
+
+
+def isolated_environment(root: Path) -> dict[str, str]:
+    """Build a child environment without operator credentials or client profiles."""
+    directories = {
+        "HOME": root / "home",
+        "XDG_CONFIG_HOME": root / "config",
+        "XDG_DATA_HOME": root / "data",
+        "XDG_CACHE_HOME": root / "cache",
+        "XDG_STATE_HOME": root / "state",
+        "TMPDIR": root / "tmp",
+    }
+    for directory in directories.values():
+        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return {
+        **{name: str(path) for name, path in directories.items()},
+        "PATH": os.environ.get("PATH", os.defpath),
+        "LANG": "en_US.UTF-8",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "NO_COLOR": "1",
+        "TERM": "dumb",
+    }
+
+
+def run_process(
+    argv: list[str],
+    env: dict[str, str],
+    cwd: Path,
+    timeout: float,
+    *,
+    capture_version: bool = False,
+) -> ProcessResult:
+    """Bound the process lifetime and terminate descendants on every exit path.
+
+    Client transcripts are discarded. Only a numeric version is extracted when
+    explicitly probing --version; arbitrary subprocess output never enters reports.
+    """
+    with tempfile.TemporaryFile() as output:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=output if capture_version else subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        timed_out = False
+        try:
+            process.wait(timeout=max(0.01, timeout))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+        finally:
+            # Also stop helpers left behind by a successfully exited CLI.
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+        version = None
+        if capture_version and not timed_out and process.returncode == 0:
+            output.seek(0)
+            match = re.search(
+                rb"\b\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?\b", output.read(8192)
+            )
+            if match:
+                version = match.group().decode("ascii")
+        return ProcessResult(process.returncode, timed_out, version)
+
+
+def _file_matches(path: Path, expected: bytes) -> bool:
+    """Inspect a bounded regular file without following a final symlink or FIFO."""
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        with os.fdopen(fd, "rb") as file:
+            if not stat.S_ISREG(os.fstat(file.fileno()).st_mode):
+                return False
+            return file.read(len(expected) + 1) == expected
+    except OSError:
+        return False
+
+
+def evaluate_run(
+    returncode: int,
+    timed_out: bool,
+    workspace: Path,
+    token: str,
+    proof: dict,
+) -> list[str]:
+    reasons = []
+    if timed_out:
+        reasons.append("client_timeout")
+    if returncode != 0:
+        reasons.append("client_exit_nonzero")
+    if not (
+        proof.get("requests", 0) >= 2
+        and proof.get("streamed")
+        and proof.get("tool_calls", 0) > 0
+        and proof.get("tool_results", 0) > 0
+        and proof.get("completed")
+        and proof.get("answer_matches")
+        and not proof.get("errors")
+    ):
+        reasons.append("incomplete_protocol_evidence")
+    expected = (token + "\n").encode("ascii")
+    if not _file_matches(workspace / "input.txt", expected):
+        reasons.append("input_modified")
+    if not _file_matches(workspace / "output.txt", expected):
+        reasons.append("incorrect_file_edit")
+    return reasons
+
+
+def _model_available(
+    base_url: str, model: str, timeout: float, client_key: str
+) -> bool:
+    """Probe through the same proxy used by the client, without redirect handling."""
+    url = urlsplit(base_url)
+    connection = HTTPConnection(url.hostname, url.port, timeout=timeout)
+    try:
+        headers = {"Authorization": "Bearer " + client_key} if client_key else {}
+        connection.request("GET", url.path + "/models", headers=headers)
+        response = connection.getresponse()
+        data = response.read(1_048_577)
+        if response.status != 200 or len(data) > 1_048_576:
+            return False
+        body = json.loads(data)
+        return isinstance(body, dict) and any(
+            isinstance(item, dict) and item.get("id") == model
+            for item in body.get("data", [])
+        )
+    except (OSError, ValueError, TypeError, RecursionError, HTTPException):
+        return False
+    finally:
+        connection.close()
+
+
+def run_client(
+    name: str,
+    base_url: str,
+    model: str,
+    timeout: int,
+    api_key: str = "",
+    expected_version: str | None = None,
+) -> dict:
+    from .clients import LOCAL_KEY, prepare_client
+    from .observe import RecordingProxy
+
+    result = {
+        "client": name,
+        "status": "unavailable",
+        "version": None,
+        "expected_version": expected_version,
+        "reasons": [],
+        "evidence": {},
+    }
+    executable = shutil.which(name)
+    if not executable:
+        result["reasons"] = ["executable_missing"]
+        return result
+    executable = str(Path(executable).absolute())
+    url = urlsplit(base_url)
+    host = f"[{url.hostname}]" if url.hostname == "::1" else url.hostname
+    base_url = f"http://{host}:{url.port or 80}/v1"
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="vllm-mlx-acceptance-") as directory:
+        root = Path(directory)
+        env = isolated_environment(root)
+        workspace = root / "workspace"
+        workspace.mkdir()
+        token = secrets.token_hex(16)
+        (workspace / "input.txt").write_text(token + "\n")
+        (workspace / "output.txt").write_text("pending\n")
+        try:
+            # Preparing before the probe also isolates client-specific version startup.
+            plan = prepare_client(
+                name, executable, root, base_url, model, PROMPT, timeout
+            )
+            env.update(plan.env)
+            version = run_process(
+                [executable, "--version"],
+                env,
+                workspace,
+                min(timeout, 10),
+                capture_version=True,
+            )
+            result["version"] = version.version
+            result["protocol"] = plan.protocol
+            if version.version is None:
+                result["reasons"] = ["version_probe_failed"]
+                return result
+            if expected_version and version.version != expected_version:
+                result["reasons"] = ["client_version_mismatch"]
+                return result
+            with RecordingProxy(
+                base_url,
+                model,
+                plan.protocol,
+                api_key=api_key,
+                timeout=max(0.01, timeout - (time.monotonic() - started)),
+            ) as proxy:
+                if not _model_available(
+                    proxy.base_url, model, min(timeout, 5), proxy.client_key
+                ):
+                    result["reasons"] = ["server_or_model_unavailable"]
+                    return result
+                plan = prepare_client(
+                    name,
+                    executable,
+                    root,
+                    proxy.base_url,
+                    model,
+                    PROMPT,
+                    timeout,
+                    api_key=proxy.client_key or LOCAL_KEY,
+                )
+                env.update(plan.env)
+                result["status"] = "failed"
+                process = run_process(
+                    plan.argv,
+                    env,
+                    workspace,
+                    timeout - (time.monotonic() - started),
+                )
+                drained = proxy.wait_for_idle(
+                    max(0.0, timeout - (time.monotonic() - started))
+                )
+                proof = proxy.evidence.summary(token)
+                result["evidence"] = proof
+                result["returncode"] = process.returncode
+                result["reasons"] = evaluate_run(
+                    process.returncode, process.timed_out, workspace, token, proof
+                )
+                if not drained:
+                    result["reasons"].append("proxy_drain_timeout")
+                if not result["reasons"]:
+                    result["status"] = "passed"
+        except (OSError, ValueError) as exc:
+            # Exception messages can contain subprocess output or credentials.
+            result["status"] = "failed"
+            result["reasons"] = ["runner_error"]
+            result["error_type"] = type(exc).__name__
+        finally:
+            result["duration_seconds"] = round(time.monotonic() - started, 3)
+    return result
+
+
+def _revision(value: str) -> str:
+    if not re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})", value):
+        raise argparse.ArgumentTypeError(
+            "use an immutable 40/64-digit revision or sha256 digest"
+        )
+    return value
+
+
+def _positive_timeout(value: str) -> int:
+    timeout = int(value)
+    if not 1 <= timeout <= 3600:
+        raise argparse.ArgumentTypeError("timeout must be between 1 and 3600 seconds")
+    return timeout
+
+
+def main(argv: list[str] | None = None) -> int:
+    from .clients import CLIENT_NAMES
+    from .observe import RecordingProxy
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--clients", nargs="+", choices=CLIENT_NAMES, default=["opencode", "pi"]
+    )
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
+    parser.add_argument(
+        "--model", required=True, help="Exact ID advertised by /v1/models"
+    )
+    parser.add_argument("--model-revision", required=True, type=_revision)
+    parser.add_argument("--server-revision", required=True, type=_revision)
+    parser.add_argument(
+        "--expect-version", action="append", default=[], metavar="CLIENT=VERSION"
+    )
+    parser.add_argument(
+        "--timeout", type=_positive_timeout, default=180, help="Seconds per client"
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default="VLLM_MLX_API_KEY",
+        help="Environment variable holding the upstream server key",
+    )
+    parser.add_argument(
+        "--report", required=True, type=Path, help="Destination JSON report"
+    )
+    args = parser.parse_args(argv)
+    if os.name != "posix":
+        parser.error("the client runner requires macOS or Linux process groups")
+    if not args.model.strip() or any(ord(char) < 32 for char in args.model):
+        parser.error("model must be a nonempty printable ID")
+    versions = {}
+    for item in args.expect_version:
+        name, separator, version = item.partition("=")
+        if (
+            not separator
+            or name not in args.clients
+            or not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?", version)
+        ):
+            parser.error("--expect-version requires a selected CLIENT=VERSION")
+        versions[name] = version
+    try:
+        # Validate even when every requested executable is missing.
+        RecordingProxy(args.base_url, args.model, "chat")
+    except ValueError:
+        parser.error("base URL must be an HTTP loopback endpoint ending in /v1")
+    key = os.environ.get(args.api_key_env, "")
+    results = [
+        run_client(
+            name, args.base_url, args.model, args.timeout, key, versions.get(name)
+        )
+        for name in dict.fromkeys(args.clients)
+    ]
+    report = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "model": args.model,
+        "model_revision": args.model_revision,
+        "server_revision": args.server_revision,
+        "revision_source": "operator_provided",
+        "results": results,
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2) + "\n")
+    for item in results:
+        reasons = ", ".join(item["reasons"]) or "tool loop and file edit verified"
+        print(f"{item['client']}: {item['status']} ({reasons})")
+    if any(item["status"] == "failed" for item in results):
+        return 1
+    return 0 if all(item["status"] == "passed" for item in results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/client_acceptance/runner.py
+++ b/scripts/client_acceptance/runner.py
@@ -21,9 +21,11 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 PROMPT = (
-    "Read input.txt in the current workspace using a tool. "
-    "Copy its token to output.txt as one line. Leave input.txt unchanged. "
-    "Reply with that token after writing the file. Work only with those two files. "
+    "Read input.txt and output.txt in the current workspace using tools. "
+    "Replace the word pending in output.txt with the token from input.txt, "
+    "keeping the final newline. Leave input.txt unchanged. "
+    "Reply with that token after editing the file. "
+    "Work only with those two files. "
     "Do not use the network."
 )
 

--- a/scripts/client_acceptance/runner.py
+++ b/scripts/client_acceptance/runner.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -71,36 +72,66 @@ def run_process(
     explicitly probing --version; arbitrary subprocess output never enters reports.
     """
     with tempfile.TemporaryFile() as output:
-        process = subprocess.Popen(
-            argv,
-            cwd=cwd,
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=output if capture_version else subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
+        process = None
         timed_out = False
+        cleaning_up = False
+        termination = None
+
+        def terminate(signum, frame):
+            nonlocal termination
+            termination = signum
+            # Defer a signal during Popen until its PID is available, and do
+            # not let a second signal interrupt process-group cleanup.
+            if process is not None and not cleaning_up:
+                raise SystemExit(128 + signum)
+
+        handle_sigterm = (
+            threading.current_thread() is threading.main_thread()
+            and signal.getsignal(signal.SIGTERM) == signal.SIG_DFL
+        )
+        if handle_sigterm:
+            signal.signal(signal.SIGTERM, terminate)
         try:
-            process.wait(timeout=max(0.01, timeout))
-        except subprocess.TimeoutExpired:
-            timed_out = True
-        finally:
-            # Also stop helpers left behind by a successfully exited CLI.
             try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            process.wait()
-        version = None
-        if capture_version and not timed_out and process.returncode == 0:
-            output.seek(0)
-            match = re.search(
-                rb"\b\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?\b", output.read(8192)
-            )
-            if match:
-                version = match.group().decode("ascii")
-        return ProcessResult(process.returncode, timed_out, version)
+                if termination is not None:
+                    raise SystemExit(128 + termination)
+                process = subprocess.Popen(
+                    argv,
+                    cwd=cwd,
+                    env=env,
+                    stdin=subprocess.DEVNULL,
+                    stdout=output if capture_version else subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                if termination is not None:
+                    raise SystemExit(128 + termination)
+                process.wait(timeout=max(0.01, timeout))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+            finally:
+                cleaning_up = True
+                if process is not None:
+                    # Stop helpers even when the CLI already exited normally.
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait()
+            version = None
+            if capture_version and not timed_out and process.returncode == 0:
+                output.seek(0)
+                match = re.search(
+                    rb"\b\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.]+)?\b", output.read(8192)
+                )
+                if match:
+                    version = match.group().decode("ascii")
+            return ProcessResult(process.returncode, timed_out, version)
+        finally:
+            if handle_sigterm:
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            if termination is not None:
+                raise SystemExit(128 + termination)
 
 
 def _file_matches(path: Path, expected: bytes) -> bool:

--- a/tests/test_client_acceptance_clients.py
+++ b/tests/test_client_acceptance_clients.py
@@ -2,6 +2,7 @@
 """Check the local configuration passed across each real client boundary."""
 
 import json
+import shutil
 import stat
 from datetime import datetime
 from pathlib import Path
@@ -172,6 +173,24 @@ def test_codex_selects_responses_and_preserves_sandbox(tmp_path):
     assert Path(plan.env["CODEX_HOME"]).is_relative_to(tmp_path)
 
 
+def test_codex_shell_can_find_system_tools_without_inheriting_operator_path(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PATH", "/operator/private/bin")
+    plan = prepare(tmp_path, "codex")
+    overrides = {
+        plan.argv[index + 1].split("=", 1)[0]: json.loads(
+            plan.argv[index + 1].split("=", 1)[1]
+        )
+        for index, value in enumerate(plan.argv)
+        if value == "-c"
+    }
+    path = overrides.get("shell_environment_policy.set.PATH", "")
+    assert shutil.which("cat", path=path) is not None
+    assert "/operator/private/bin" not in path
+    assert overrides["shell_environment_policy.inherit"] == "none"
+
+
 def test_claude_uses_messages_origin_and_api_key_only_bare_mode(tmp_path):
     plan = prepare(tmp_path, "claude")
     assert plan.protocol == "anthropic"
@@ -237,6 +256,8 @@ def test_openclaw_pins_config_in_embedded_exec_without_channel_delivery(tmp_path
     assert "--deliver" not in plan.argv
     assert "--auth-env-only" not in plan.argv  # Incompatible with --config upstream.
     assert Path(plan.env["OPENCLAW_STATE_DIR"]).is_relative_to(tmp_path)
+    assert plan.env.get("OPENCLAW_NO_RESPAWN") == "1"
+    assert plan.env.get("NODE_DISABLE_COMPILE_CACHE") == "1"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client_acceptance_clients.py
+++ b/tests/test_client_acceptance_clients.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Check the local configuration passed across each real client boundary."""
+
+import json
+import stat
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.client_acceptance.clients import prepare_client
+
+CLIENTS = ("opencode", "pi", "codex", "claude", "copilot", "cline", "openclaw")
+BASE_URL = "http://127.0.0.1:8123/v1"
+MODEL = 'org/model-"quoted"-Ω'
+PROMPT = "Read input.txt, copy its token to output.txt, and reply with it."
+
+
+def prepare(tmp_path, name, **overrides):
+    (tmp_path / "workspace").mkdir(exist_ok=True)
+    (tmp_path / "home").mkdir(exist_ok=True)
+    kwargs = dict(
+        name=name,
+        executable="/opt/client bin/agent",
+        root=tmp_path,
+        base_url=BASE_URL,
+        model=MODEL,
+        prompt=PROMPT,
+        timeout=90,
+    )
+    kwargs.update(overrides)
+    return prepare_client(**kwargs)
+
+
+def read_json(path):
+    return json.loads(Path(path).read_text())
+
+
+@pytest.mark.parametrize("name", CLIENTS)
+def test_preparation_preserves_arguments_without_reading_ambient_credentials(
+    tmp_path, monkeypatch, name
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-secret-must-not-be-copied")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-secret-must-not-be-copied")
+    plan = prepare(tmp_path, name)
+    assert plan.name == name
+    assert plan.argv[0] == "/opt/client bin/agent"
+    assert PROMPT in plan.argv
+    serialized = json.dumps([plan.argv, plan.env])
+    serialized += "".join(
+        path.read_text() for path in tmp_path.rglob("*") if path.is_file()
+    )
+    assert "ambient-secret-must-not-be-copied" not in serialized
+    assert "local-test" in serialized
+    assert not (tmp_path / "workspace" / ".git").exists()
+
+
+@pytest.mark.parametrize("name", CLIENTS)
+def test_preparing_again_replaces_the_proxy_endpoint(tmp_path, name):
+    prepare(tmp_path, name)
+    plan = prepare(tmp_path, name, base_url="http://127.0.0.1:9123/v1")
+    serialized = json.dumps([plan.argv, plan.env])
+    serialized += "".join(
+        path.read_text() for path in tmp_path.rglob("*") if path.is_file()
+    )
+    assert "http://127.0.0.1:8123" not in serialized
+    assert "http://127.0.0.1:9123" in serialized
+
+
+@pytest.mark.parametrize("name", CLIENTS)
+def test_per_run_credential_reaches_private_config_without_process_arguments(
+    tmp_path, name
+):
+    credential = "inert-per-run-proxy-credential"
+    plan = prepare(tmp_path, name, api_key=credential)
+    assert credential not in json.dumps(plan.argv)
+    env_keys = {
+        "codex": "VLLM_MLX_CLIENT_KEY",
+        "claude": "ANTHROPIC_API_KEY",
+        "copilot": "COPILOT_PROVIDER_API_KEY",
+    }
+    config_keys = {
+        "opencode": ("opencode.json", ("provider", "vllm-mlx", "options", "apiKey")),
+        "pi": ("models.json", ("providers", "vllm-mlx", "apiKey")),
+        "cline": (
+            "settings/providers.json",
+            ("providers", "openai-compatible", "settings", "apiKey"),
+        ),
+        "openclaw": ("openclaw.json", ("models", "providers", "vllm", "apiKey")),
+    }
+    if name in env_keys:
+        assert plan.env[env_keys[name]] == credential
+    else:
+        filename, keys = config_keys[name]
+        path = tmp_path / name / filename
+        value = read_json(path)
+        for key in keys:
+            value = value[key]
+        assert value == credential
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+
+def test_opencode_pins_chat_endpoint_and_denies_non_file_tools(tmp_path):
+    plan = prepare(tmp_path, "opencode")
+    config = read_json(plan.env["OPENCODE_CONFIG"])
+    provider = config["provider"]["vllm-mlx"]
+    assert plan.protocol == "chat"
+    assert provider["npm"] == "@ai-sdk/openai-compatible"
+    assert provider["options"]["baseURL"] == BASE_URL
+    assert MODEL in provider["models"]
+    assert config["model"] == config["small_model"] == f"vllm-mlx/{MODEL}"
+    assert config["enabled_providers"] == ["vllm-mlx"]
+    assert config["permission"]["*"] == "deny"
+    assert config["permission"]["read"] == "allow"
+    assert config["permission"]["edit"] == "allow"
+    assert config["share"] == "disabled"
+    assert plan.env["OPENCODE_DISABLE_PROJECT_CONFIG"] == "1"
+    assert plan.env["OPENCODE_DISABLE_MODELS_FETCH"] == "1"
+    assert "--pure" in plan.argv
+
+
+def test_opencode_disables_title_requests_and_automatic_compaction(tmp_path):
+    plan = prepare(tmp_path, "opencode")
+    config = read_json(plan.env["OPENCODE_CONFIG"])
+    assert config["agent"]["title"]["disable"] is True
+    assert config["compaction"]["auto"] is False
+    assert config["compaction"]["prune"] is False
+    assert config["small_model"] == f"vllm-mlx/{MODEL}"
+    assert config["snapshot"] is False
+
+
+def test_pi_uses_custom_provider_with_discovery_disabled(tmp_path):
+    plan = prepare(tmp_path, "pi")
+    config = read_json(Path(plan.env["PI_CODING_AGENT_DIR"]) / "models.json")
+    provider = config["providers"]["vllm-mlx"]
+    assert plan.protocol == "chat"
+    assert provider["api"] == "openai-completions"
+    assert provider["baseUrl"] == BASE_URL
+    assert provider["models"][0]["id"] == MODEL
+    assert "--api-key" not in plan.argv
+    assert plan.argv[plan.argv.index("--tools") + 1] == "read,edit,write"
+    assert plan.env["PI_OFFLINE"] == "1"
+    for flag in (
+        "--no-extensions",
+        "--no-skills",
+        "--no-context-files",
+        "--no-prompt-templates",
+        "--no-session",
+    ):
+        assert flag in plan.argv
+
+
+def test_codex_selects_responses_and_preserves_sandbox(tmp_path):
+    plan = prepare(tmp_path, "codex")
+    overrides = {
+        plan.argv[index + 1].split("=", 1)[0]: plan.argv[index + 1].split("=", 1)[1]
+        for index, value in enumerate(plan.argv)
+        if value == "-c"
+    }
+    assert plan.protocol == "responses"
+    assert json.loads(overrides["model_providers.vllm-mlx.base_url"]) == BASE_URL
+    assert json.loads(overrides["model_providers.vllm-mlx.wire_api"]) == "responses"
+    assert overrides["model_providers.vllm-mlx.requires_openai_auth"] == "false"
+    assert overrides["sandbox_workspace_write.network_access"] == "false"
+    assert overrides["project_doc_max_bytes"] == "0"
+    assert plan.argv[plan.argv.index("--model") + 1] == MODEL
+    assert plan.argv[plan.argv.index("--sandbox") + 1] == "workspace-write"
+    assert "--ignore-user-config" in plan.argv
+    assert "--ignore-rules" in plan.argv
+    assert "--dangerously-bypass-approvals-and-sandbox" not in plan.argv
+    assert Path(plan.env["CODEX_HOME"]).is_relative_to(tmp_path)
+
+
+def test_claude_uses_messages_origin_and_api_key_only_bare_mode(tmp_path):
+    plan = prepare(tmp_path, "claude")
+    assert plan.protocol == "anthropic"
+    assert plan.env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8123"
+    assert plan.env["ANTHROPIC_API_KEY"] == "local-test"
+    assert "--bare" in plan.argv
+    assert "--restricted" in plan.argv
+    assert "--strict-mcp-config" in plan.argv
+    assert plan.argv[plan.argv.index("--setting-sources") + 1] == ""
+    assert plan.argv[plan.argv.index("--tools") + 1] == "Read,Edit,Write"
+    assert plan.argv[plan.argv.index("--model") + 1] == MODEL
+
+
+def test_copilot_uses_offline_byok_and_file_tool_allowlist(tmp_path):
+    plan = prepare(tmp_path, "copilot")
+    assert plan.protocol == "chat"
+    assert plan.env["COPILOT_PROVIDER_BASE_URL"] == BASE_URL
+    assert plan.env["COPILOT_PROVIDER_TYPE"] == "openai"
+    assert plan.env["COPILOT_MODEL"] == MODEL
+    assert plan.env["COPILOT_OFFLINE"] == "true"
+    assert "--available-tools=view,edit,create,apply_patch" in plan.argv
+    assert "--deny-tool=shell" in plan.argv
+    assert "--disable-builtin-mcps" in plan.argv
+    assert "--no-custom-instructions" in plan.argv
+
+
+def test_cline_run_consumes_private_provider_configuration(tmp_path):
+    plan = prepare(tmp_path, "cline")
+    assert plan.protocol == "chat"
+    state = Path(plan.argv[plan.argv.index("--data-dir") + 1])
+    config = read_json(state / "settings" / "providers.json")
+    assert config["version"] == 1
+    assert config["lastUsedProvider"] == "openai-compatible"
+    assert config["modes"] == {}
+    provider = config["providers"]["openai-compatible"]
+    assert provider["settings"] == {
+        "provider": "openai-compatible",
+        "apiKey": "local-test",
+        "model": MODEL,
+        "baseUrl": BASE_URL,
+    }
+    assert provider["tokenSource"] == "manual"
+    assert datetime.fromisoformat(provider["updatedAt"].replace("Z", "+00:00")).tzinfo
+    assert plan.argv[plan.argv.index("--provider") + 1] == "openai-compatible"
+    assert plan.argv[plan.argv.index("--model") + 1] == MODEL
+    assert plan.argv[plan.argv.index("--timeout") + 1] == "90"
+    assert json.loads(plan.env["CLINE_COMMAND_PERMISSIONS"])["deny"] == ["*"]
+
+
+def test_openclaw_pins_config_in_embedded_exec_without_channel_delivery(tmp_path):
+    plan = prepare(tmp_path, "openclaw")
+    config = read_json(plan.argv[plan.argv.index("--config") + 1])
+    provider = config["models"]["providers"]["vllm"]
+    assert plan.protocol == "responses"
+    assert plan.argv[1:3] == ["agent", "exec"]
+    assert provider["baseUrl"] == BASE_URL
+    assert provider["api"] == "openai-responses"
+    assert provider["models"][0]["id"] == MODEL
+    assert config["agents"]["defaults"]["model"]["primary"] == f"vllm/{MODEL}"
+    assert config["tools"]["allow"] == ["read", "edit", "write"]
+    assert config["tools"]["fs"]["workspaceOnly"] is True
+    assert config["plugins"]["allow"] == ["vllm"]
+    assert "--deliver" not in plan.argv
+    assert "--auth-env-only" not in plan.argv  # Incompatible with --config upstream.
+    assert Path(plan.env["OPENCLAW_STATE_DIR"]).is_relative_to(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"name": "unknown"},
+        {"executable": "relative-client"},
+        {"model": ""},
+        {"timeout": 0},
+        {"base_url": "https://example.com/v1"},
+        {"base_url": "http://user:secret@127.0.0.1:8000/v1"},
+        {"base_url": "http://127.0.0.1:8000/v1?secret=value"},
+    ],
+)
+def test_invalid_launch_inputs_fail_before_writing_configuration(tmp_path, overrides):
+    overrides = dict(overrides)
+    with pytest.raises(ValueError):
+        prepare(tmp_path, overrides.pop("name", "pi"), **overrides)
+    assert not any(path.is_file() for path in tmp_path.rglob("*"))

--- a/tests/test_client_acceptance_observe.py
+++ b/tests/test_client_acceptance_observe.py
@@ -1,0 +1,859 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Harness verification with scripted HTTP peers, not MLX acceptance evidence."""
+
+import importlib
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from contextlib import contextmanager
+from http.client import HTTPConnection
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+import pytest
+
+
+def observer():
+    # Keep the initial missing implementation a behavioral assertion failure.
+    try:
+        return importlib.import_module("scripts.client_acceptance.observe")
+    except ModuleNotFoundError:
+        pytest.fail("The client acceptance recording proxy is not implemented")
+
+
+def sse(*events):
+    return b"".join(
+        b"data: "
+        + (event if isinstance(event, bytes) else json.dumps(event).encode())
+        + b"\n\n"
+        for event in events
+    )
+
+
+TOKEN = "fixture-7d1849-secret"
+PATHS = {
+    "chat": "/chat/completions",
+    "responses": "/responses",
+    "anthropic": "/messages",
+}
+
+
+def exchange(protocol, *, result_id="call_1", answer=TOKEN):
+    """Literal wire fixtures for one model read call and its client result."""
+    if protocol == "chat":
+        call = sse(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "read",
+                                        "arguments": '{"path":"fixture.txt"}',
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
+            b"[DONE]",
+        )
+        result = {
+            "messages": [{"role": "tool", "tool_call_id": result_id, "content": TOKEN}]
+        }
+        final = sse(
+            {
+                "choices": [
+                    {"index": 0, "delta": {"content": answer}, "finish_reason": None}
+                ]
+            },
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+            b"[DONE]",
+        )
+    elif protocol == "responses":
+        item = {
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "read",
+            "arguments": '{"path":"fixture.txt"}',
+            "status": "completed",
+        }
+        call = sse(
+            {
+                "type": "response.output_item.added",
+                "item": {**item, "status": "in_progress"},
+            },
+            {"type": "response.output_item.done", "item": item},
+            {
+                "type": "response.completed",
+                "response": {"id": "resp_1", "status": "completed", "output": [item]},
+            },
+        )
+        result = {
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": result_id,
+                    "output": [{"type": "input_text", "text": TOKEN}],
+                }
+            ]
+        }
+        final = sse(
+            {"type": "response.output_text.delta", "delta": answer},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_2",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{"type": "output_text", "text": answer}],
+                        }
+                    ],
+                },
+            },
+        )
+    else:
+        call = sse(
+            {
+                "type": "message_start",
+                "message": {"id": "msg_1", "role": "assistant", "content": []},
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "read",
+                    "input": {},
+                },
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": '{"path":"fixture.txt"}',
+                },
+            },
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}},
+            {"type": "message_stop"},
+        )
+        result = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": result_id,
+                            "content": [{"type": "text", "text": TOKEN}],
+                        }
+                    ],
+                }
+            ]
+        }
+        final = sse(
+            {
+                "type": "message_start",
+                "message": {"id": "msg_2", "role": "assistant", "content": []},
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": answer},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+            {"type": "message_stop"},
+        )
+    return call, result, final
+
+
+@contextmanager
+def upstream(replies):
+    received = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            received.append((self.path, dict(self.headers), body))
+            status, headers, payload = replies.pop(0)
+            self.send_response(status)
+            for name, value in headers.items():
+                self.send_header(name, value)
+            self.send_header("Connection", "close")
+            if not callable(payload):
+                self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if callable(payload):
+                payload(self.wfile)
+            else:
+                self.wfile.write(payload)
+
+        do_GET = do_POST
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(
+        target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+    )
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1", received
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def post(base, path, payload, headers=None):
+    url = urlsplit(base)
+    conn = HTTPConnection(url.hostname, url.port, timeout=3)
+    conn.request(
+        "POST",
+        url.path + path,
+        json.dumps(payload),
+        {"Content-Type": "application/json", **(headers or {})},
+    )
+    response = conn.getresponse()
+    status, body = response.status, response.read()
+    conn.close()
+    return status, body
+
+
+def reply(payload, status=200):
+    return status, {"Content-Type": "text/event-stream"}, payload
+
+
+@pytest.mark.parametrize(
+    "protocol,method,path",
+    [
+        ("chat", "GET", "/models"),
+        ("chat", "POST", "/chat/completions"),
+        ("responses", "POST", "/responses"),
+        ("anthropic", "POST", "/messages?beta=true"),
+        ("anthropic", "POST", "/messages/count_tokens?beta=true"),
+    ],
+)
+@pytest.mark.parametrize("credential", [None, "incorrect", "upstream-secret"])
+def test_protected_proxy_requires_its_own_key_without_recording_rejected_requests(
+    protocol, method, path, credential
+):
+    with upstream([]) as (url, received):
+        with observer().RecordingProxy(
+            url, "test-model", protocol, api_key="upstream-secret"
+        ) as proxy:
+            address = urlsplit(proxy.base_url)
+            connection = HTTPConnection(address.hostname, address.port, timeout=3)
+            headers = {"Authorization": "Bearer " + credential} if credential else {}
+            connection.request(method, address.path + path, headers=headers)
+            response = connection.getresponse()
+            assert response.status == 401
+            response.read()
+            connection.close()
+            assert received == []
+            assert proxy.evidence.summary(TOKEN)["errors"] == []
+            assert proxy.evidence.summary(TOKEN)["requests"] == 0
+
+
+def test_proxy_keys_are_private_to_each_authenticated_run():
+    first = observer().RecordingProxy(
+        "http://127.0.0.1:8000/v1", "test-model", "chat", api_key="upstream-secret"
+    )
+    second = observer().RecordingProxy(
+        "http://127.0.0.1:8000/v1", "test-model", "chat", api_key="upstream-secret"
+    )
+    assert first.client_key != second.client_key
+    assert len(first.client_key) >= 32
+    assert first.client_key != "upstream-secret"
+    assert first.client_key not in json.dumps(first.evidence.summary(TOKEN))
+
+
+@pytest.mark.parametrize(
+    "path,method", [("/models", "GET"), ("/messages/count_tokens", "POST")]
+)
+def test_authenticated_discovery_and_token_count_use_proxy_key(path, method):
+    with upstream([(200, {"Content-Type": "application/json"}, b"{}")]) as (
+        url,
+        received,
+    ):
+        with observer().RecordingProxy(
+            url, "test-model", "anthropic", api_key="upstream-secret"
+        ) as proxy:
+            address = urlsplit(proxy.base_url)
+            connection = HTTPConnection(address.hostname, address.port, timeout=3)
+            connection.request(
+                method,
+                address.path + path,
+                json.dumps({"model": "test-model"}) if method == "POST" else None,
+                {"x-api-key": proxy.client_key},
+            )
+            response = connection.getresponse()
+            assert response.status == 200
+            response.read()
+            connection.close()
+        assert received[0][1]["Authorization"] == "Bearer upstream-secret"
+
+
+@pytest.mark.parametrize("protocol", PATHS)
+def test_observes_real_streamed_tool_round_trip_without_leaking_payload(protocol):
+    call, result, final = exchange(protocol)
+    with upstream([reply(call), reply(final)]) as (url, received):
+        with observer().RecordingProxy(
+            url, "test-model", protocol, api_key="upstream-secret"
+        ) as proxy:
+            first = post(
+                proxy.base_url,
+                PATHS[protocol],
+                {"model": "test-model", "stream": True},
+                {
+                    "Authorization": "Bearer " + proxy.client_key,
+                    "Cookie": "private=cookie",
+                    "x-api-key": "client-key",
+                },
+            )
+            second = post(
+                proxy.base_url,
+                PATHS[protocol],
+                {"model": "test-model", "stream": True, **result},
+                (
+                    {"x-api-key": proxy.client_key}
+                    if protocol == "anthropic"
+                    else {"Authorization": "Bearer " + proxy.client_key}
+                ),
+            )
+            assert first == (200, call)
+            assert second == (200, final)
+            assert proxy.evidence.passed(TOKEN)
+            summary = proxy.evidence.summary(TOKEN)
+            assert summary == {
+                "requests": 2,
+                "streamed": True,
+                "tool_calls": 1,
+                "tool_results": 1,
+                "completed": True,
+                "answer_matches": True,
+                "errors": [],
+            }
+            serialized = json.dumps(summary)
+            assert TOKEN not in serialized and "secret" not in serialized
+        headers = {k.lower(): v for k, v in received[0][1].items()}
+        assert headers["authorization"] == "Bearer upstream-secret"
+        assert "cookie" not in headers
+        assert headers.get("x-api-key") == (
+            "upstream-secret" if protocol == "anthropic" else None
+        )
+
+
+@pytest.mark.parametrize("protocol", PATHS)
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "unmatched_result",
+        "replayed_call",
+        "truncated",
+        "later_response",
+        "error_event",
+        "token_outside_result",
+    ],
+)
+def test_does_not_accept_replayed_or_incomplete_evidence(protocol, failure):
+    call, result, final = exchange(
+        protocol, result_id="other" if failure == "unmatched_result" else "call_1"
+    )
+    if failure == "replayed_call":
+        call = exchange(protocol, answer="not the fixture")[2]
+        # Historical assistant messages are client data, not issuance evidence.
+        result["history"] = {"tool_calls": [{"id": "call_1"}]}
+    if failure == "truncated":
+        final = final[: final.rfind(b"data:")]
+    if failure == "error_event":
+        final += sse({"type": "error", "error": {"message": "secret backend error"}})
+    if failure == "token_outside_result":
+        result = json.loads(json.dumps(result).replace(TOKEN, "other text"))
+        result["metadata"] = {"token": TOKEN}
+    replies = [reply(call), reply(final)]
+    if failure == "later_response":
+        replies.append(reply(exchange(protocol, answer="wrong final answer")[2]))
+    with upstream(replies) as (url, _):
+        with observer().RecordingProxy(url, "test-model", protocol) as proxy:
+            post(
+                proxy.base_url, PATHS[protocol], {"model": "test-model", "stream": True}
+            )
+            post(
+                proxy.base_url,
+                PATHS[protocol],
+                {"model": "test-model", "stream": True, **result},
+            )
+            if failure == "later_response":
+                post(
+                    proxy.base_url,
+                    PATHS[protocol],
+                    {"model": "test-model", "stream": True},
+                )
+            assert not proxy.evidence.passed(TOKEN)
+            assert "secret backend error" not in json.dumps(
+                proxy.evidence.summary(TOKEN)
+            )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/v1",
+        "http://example.org/v1",
+        "http://127.0.0.2/v1",
+        "http://127.0.0.1/v1?key=secret",
+        "http://user:secret@localhost/v1",
+        "http://localhost/other",
+        "http://localhost/v1#fragment",
+    ],
+)
+def test_rejects_non_loopback_or_ambiguous_upstream(url):
+    with pytest.raises(ValueError):
+        observer().RecordingProxy(url, "test-model", "chat")
+
+
+@pytest.mark.parametrize(
+    "path,payload",
+    [
+        ("/responses", {"model": "test-model"}),
+        ("/chat/completions?x=1", {"model": "test-model"}),
+        ("/chat/completions", {"model": "wrong-model"}),
+    ],
+)
+def test_rejects_wrong_path_or_model_without_forwarding(path, payload):
+    with upstream([]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            status, _ = post(proxy.base_url, path, payload)
+            assert status in (400, 404)
+            assert received == []
+            assert not proxy.evidence.passed(TOKEN)
+
+
+@pytest.mark.parametrize("status", [302, 401, 500])
+def test_upstream_failures_are_not_followed_and_are_sanitized(status):
+    with upstream(
+        [
+            (
+                status,
+                {"Location": "http://example.org/private"},
+                b"private backend secret",
+            )
+        ]
+    ) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            _, body = post(
+                proxy.base_url, PATHS["chat"], {"model": "test-model", "stream": True}
+            )
+            assert b"private backend secret" not in body
+            assert not proxy.evidence.passed(TOKEN)
+            assert proxy.evidence.summary(TOKEN)["errors"]
+        assert len(received) == 1
+
+
+def test_request_and_response_capture_are_bounded(monkeypatch):
+    module = observer()
+    monkeypatch.setattr(module, "MAX_REQUEST_BYTES", 256)
+    monkeypatch.setattr(module, "MAX_RESPONSE_BYTES", 256)
+    with upstream([reply(b"x" * 1024)]) as (url, received):
+        with module.RecordingProxy(url, "test-model", "chat") as proxy:
+            status, _ = post(
+                proxy.base_url,
+                PATHS["chat"],
+                {"model": "test-model", "padding": "x" * 300},
+            )
+            assert status == 413
+            _, body = post(
+                proxy.base_url, PATHS["chat"], {"model": "test-model", "stream": True}
+            )
+            assert len(body) <= 256
+            assert not proxy.evidence.passed(TOKEN)
+            assert proxy.evidence.summary(TOKEN)["errors"]
+        assert len(received) == 1
+
+
+def test_summary_only_counts_matching_results_containing_fixture_token():
+    call, result, final = exchange("chat")
+    result["messages"][0]["content"] = "a successful result without the fixture"
+    with upstream([reply(call), reply(final)]) as (url, _):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            post(proxy.base_url, PATHS["chat"], {"model": "test-model", "stream": True})
+            post(
+                proxy.base_url,
+                PATHS["chat"],
+                {"model": "test-model", "stream": True, **result},
+            )
+            assert proxy.evidence.summary(TOKEN)["tool_results"] == 0
+
+
+def test_discovery_failure_does_not_poison_later_inference_evidence():
+    call, result, final = exchange("chat")
+    with upstream([(404, {}, b"discovery unavailable"), reply(call), reply(final)]) as (
+        url,
+        _,
+    ):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            parsed = urlsplit(proxy.base_url)
+            connection = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+            connection.request("GET", "/v1/models")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+            post(proxy.base_url, PATHS["chat"], {"model": "test-model", "stream": True})
+            post(
+                proxy.base_url,
+                PATHS["chat"],
+                {"model": "test-model", "stream": True, **result},
+            )
+            assert proxy.evidence.passed(TOKEN)
+            assert proxy.evidence.summary(TOKEN)["requests"] == 2
+
+
+def test_unterminated_event_after_completion_does_not_pass():
+    call, result, final = exchange("chat")
+    with upstream([reply(call), reply(final + b'data: {"error":')]) as (url, _):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            post(proxy.base_url, PATHS["chat"], {"model": "test-model", "stream": True})
+            post(
+                proxy.base_url,
+                PATHS["chat"],
+                {"model": "test-model", "stream": True, **result},
+            )
+            assert not proxy.evidence.passed(TOKEN)
+
+
+def test_proxy_streams_before_upstream_finishes_and_times_out_stalled_stream():
+    release = threading.Event()
+    prefix = b'data: {"choices":[{"index":0,"delta":{"content":"ready"}}]}\n\n'
+
+    def stalled(wfile):
+        wfile.write(prefix)
+        wfile.flush()
+        release.wait(timeout=2)
+
+    started = time.monotonic()
+    with upstream([reply(stalled)]) as (url, _):
+        with observer().RecordingProxy(url, "test-model", "chat", timeout=0.2) as proxy:
+            parsed = urlsplit(proxy.base_url)
+            connection = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+            connection.request(
+                "POST",
+                "/v1/chat/completions",
+                json.dumps({"model": "test-model", "stream": True}),
+            )
+            response = connection.getresponse()
+            assert response.read(len(prefix)) == prefix
+            assert not release.is_set()
+            response.read()
+            connection.close()
+            assert "upstream_timeout" in proxy.evidence.summary(TOKEN)["errors"]
+            assert not proxy.evidence.passed(TOKEN)
+        release.set()
+    assert time.monotonic() - started < 1.5
+
+
+@pytest.mark.parametrize("query", ["", "?beta=true"])
+def test_anthropic_sdk_beta_query_preserves_tool_round_trip(query):
+    call, result, final = exchange("anthropic")
+    path = "/messages" + query
+    with upstream([reply(call), reply(final)]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "anthropic") as proxy:
+            assert post(
+                proxy.base_url, path, {"model": "test-model", "stream": True}
+            ) == (200, call)
+            assert post(
+                proxy.base_url, path, {"model": "test-model", "stream": True, **result}
+            ) == (200, final)
+            assert proxy.evidence.passed(TOKEN)
+        assert [entry[0] for entry in received] == ["/v1/messages" + query] * 2
+
+
+@pytest.mark.parametrize("query", ["", "?beta=true"])
+def test_anthropic_sdk_beta_token_count_is_not_an_inference(query):
+    payload = b'{"input_tokens": 12}'
+    with upstream([(200, {"Content-Type": "application/json"}, payload)]) as (
+        url,
+        received,
+    ):
+        with observer().RecordingProxy(url, "test-model", "anthropic") as proxy:
+            assert post(
+                proxy.base_url,
+                "/messages/count_tokens" + query,
+                {"model": "test-model", "messages": []},
+            ) == (200, payload)
+            assert proxy.evidence.summary(TOKEN)["requests"] == 0
+        assert received[0][0] == "/v1/messages/count_tokens" + query
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/messages?beta=false",
+        "/messages?beta=true&api_key=secret",
+        "/messages?api_key=secret",
+        "/messages?beta=true&beta=true",
+        "/messages/count_tokens?beta=false",
+        "/models?beta=true",
+        "/messages/batches?beta=true",
+    ],
+)
+def test_anthropic_query_allowlist_rejects_unrelated_parameters_and_paths(path):
+    with upstream([]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "anthropic") as proxy:
+            status, body = post(
+                proxy.base_url, path, {"model": "test-model", "stream": True}
+            )
+            assert status == 404
+            assert b"secret" not in body
+            assert received == []
+
+
+def test_anthropic_beta_query_keeps_model_validation():
+    with upstream([]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "anthropic") as proxy:
+            status, _ = post(
+                proxy.base_url,
+                "/messages?beta=true",
+                {"model": "other-model", "stream": True},
+            )
+            assert status == 400
+            assert received == []
+
+
+@pytest.mark.parametrize("protocol", PATHS)
+def test_continuation_waits_for_terminal_stream_eof(protocol):
+    call, result, final = exchange(protocol)
+    release = threading.Event()
+
+    def delayed_eof(wfile):
+        wfile.write(call)
+        wfile.flush()
+        release.wait(timeout=2)
+
+    with upstream([reply(delayed_eof), reply(final)]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", protocol, timeout=2) as proxy:
+            parsed = urlsplit(proxy.base_url)
+            connection = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+            connection.request(
+                "POST",
+                "/v1" + PATHS[protocol],
+                json.dumps({"model": "test-model", "stream": True}),
+            )
+            response = connection.getresponse()
+            assert response.read(len(call)) == call
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                continuation = executor.submit(
+                    post,
+                    proxy.base_url,
+                    PATHS[protocol],
+                    {"model": "test-model", "stream": True, **result},
+                )
+                try:
+                    # The next request must wait until issuance evidence is final.
+                    with pytest.raises(FutureTimeout):
+                        continuation.result(timeout=0.1)
+                finally:
+                    release.set()
+                    response.read()
+                    connection.close()
+                assert continuation.result(timeout=2) == (200, final)
+            assert proxy.evidence.passed(TOKEN)
+            assert len(received) == 2
+
+
+def test_request_queue_wait_is_bounded():
+    with upstream([]) as (url, received):
+        with observer().RecordingProxy(url, "test-model", "chat", timeout=0.1) as proxy:
+            # Hold the same lock used by an unfinished upstream exchange.
+            proxy._serial.acquire()
+            try:
+                started = time.monotonic()
+                status, body = post(
+                    proxy.base_url,
+                    PATHS["chat"],
+                    {"model": "test-model", "stream": True},
+                )
+                elapsed = time.monotonic() - started
+                assert status == 504
+                assert json.loads(body)["error"]["message"] == "request_queue_timeout"
+                assert 0.08 <= elapsed < 1
+                assert received == []
+                assert not proxy.evidence.passed(TOKEN)
+            finally:
+                proxy._serial.release()
+
+
+def parallel_calls(protocol):
+    """Two complete server-issued calls sharing one model response."""
+    call, _, _ = exchange(protocol)
+    events = []
+    second_blocks = []
+    for line in call.splitlines():
+        if not line.startswith(b"data: "):
+            continue
+        if line == b"data: [DONE]":
+            events.append(b"[DONE]")
+            continue
+        event = json.loads(line[6:])
+        second = json.loads(json.dumps(event).replace("call_1", "call_2"))
+        if protocol == "chat":
+            delta = event["choices"][0]["delta"]
+            if "tool_calls" in delta:
+                other = second["choices"][0]["delta"]["tool_calls"][0]
+                other["index"] = 1
+                delta["tool_calls"].append(other)
+        elif protocol == "responses":
+            if event["type"] in (
+                "response.output_item.added",
+                "response.output_item.done",
+            ):
+                second["item"]["id"] = "fc_2"
+                events.extend([event, second])
+                continue
+            if event["type"] == "response.completed":
+                other = second["response"]["output"][0]
+                other["id"] = "fc_2"
+                event["response"]["output"].append(other)
+        elif event["type"].startswith("content_block_"):
+            second["index"] = 1
+            events.append(event)
+            second_blocks.append(second)
+            if event["type"] == "content_block_stop":
+                events.extend(second_blocks)
+                second_blocks = []
+            continue
+        events.append(event)
+    return sse(*events)
+
+
+@pytest.mark.parametrize("protocol", PATHS)
+@pytest.mark.parametrize("parallel", [False, True], ids=["sequential", "parallel"])
+@pytest.mark.parametrize("missing_result", [False, True], ids=["complete", "missing"])
+def test_final_completion_requires_results_for_every_call(
+    protocol, parallel, missing_result
+):
+    call, first_result, final = exchange(protocol)
+    second_call = call.replace(b"call_1", b"call_2")
+    _, second_result, _ = exchange(protocol, result_id="call_2")
+    second_result = json.loads(json.dumps(second_result).replace(TOKEN, "file written"))
+    key = "input" if protocol == "responses" else "messages"
+    final_results = {
+        key: first_result[key] + ([] if missing_result else second_result[key])
+    }
+    replies = (
+        [reply(parallel_calls(protocol)), reply(final)]
+        if parallel
+        else [reply(call), reply(second_call), reply(final)]
+    )
+    with upstream(replies) as (url, _):
+        with observer().RecordingProxy(url, "test-model", protocol) as proxy:
+            post(
+                proxy.base_url, PATHS[protocol], {"model": "test-model", "stream": True}
+            )
+            if not parallel:
+                post(
+                    proxy.base_url,
+                    PATHS[protocol],
+                    {"model": "test-model", "stream": True, **first_result},
+                )
+            post(
+                proxy.base_url,
+                PATHS[protocol],
+                {"model": "test-model", "stream": True, **final_results},
+            )
+            assert proxy.evidence.passed(TOKEN) is (not missing_result)
+            summary = proxy.evidence.summary(TOKEN)
+            assert summary["completed"] is (not missing_result)
+            assert summary["tool_calls"] == 2
+            assert summary["tool_results"] == 1
+            if missing_result:
+                assert "missing_tool_results" in summary["errors"]
+            else:
+                assert summary["errors"] == []
+
+
+@pytest.mark.parametrize("protocol", PATHS)
+@pytest.mark.parametrize(
+    "release_before_timeout", [True, False], ids=["drained", "timeout"]
+)
+def test_idle_wait_finalizes_terminal_response_evidence(
+    protocol, release_before_timeout
+):
+    call, result, final = exchange(protocol)
+    release = threading.Event()
+
+    def delayed_eof(wfile):
+        wfile.write(final)
+        wfile.flush()
+        release.wait(timeout=2)
+
+    with upstream([reply(call), reply(delayed_eof)]) as (url, _):
+        with observer().RecordingProxy(url, "test-model", protocol, timeout=2) as proxy:
+            post(
+                proxy.base_url, PATHS[protocol], {"model": "test-model", "stream": True}
+            )
+            parsed = urlsplit(proxy.base_url)
+            connection = HTTPConnection(parsed.hostname, parsed.port, timeout=3)
+            connection.request(
+                "POST",
+                "/v1" + PATHS[protocol],
+                json.dumps({"model": "test-model", "stream": True, **result}),
+            )
+            response = connection.getresponse()
+            assert response.read(len(final)) == final
+            try:
+                wait_for_idle = getattr(proxy, "wait_for_idle", None)
+                assert callable(wait_for_idle)
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    idle = executor.submit(wait_for_idle, 0.3)
+                    if release_before_timeout:
+                        with pytest.raises(FutureTimeout):
+                            idle.result(timeout=0.05)
+                        release.set()
+                        assert idle.result(timeout=1) is True
+                        assert proxy.evidence.passed(TOKEN)
+                    else:
+                        assert idle.result(timeout=1) is False
+                        assert (
+                            "stream_finalize_timeout"
+                            in proxy.evidence.summary(TOKEN)["errors"]
+                        )
+                        assert not proxy.evidence.passed(TOKEN)
+            finally:
+                release.set()
+                response.read()
+                connection.close()
+
+
+def test_idle_wait_supports_an_exhausted_client_budget():
+    proxy = observer().RecordingProxy("http://127.0.0.1:8000/v1", "test-model", "chat")
+    wait_for_idle = getattr(proxy, "wait_for_idle", None)
+    assert callable(wait_for_idle)
+    assert wait_for_idle(0) is True
+    with proxy._serial:
+        assert wait_for_idle(0) is False
+    assert proxy.evidence.summary(TOKEN)["errors"] == ["stream_finalize_timeout"]

--- a/tests/test_client_acceptance_observe.py
+++ b/tests/test_client_acceptance_observe.py
@@ -857,3 +857,136 @@ def test_idle_wait_supports_an_exhausted_client_budget():
     with proxy._serial:
         assert wait_for_idle(0) is False
     assert proxy.evidence.summary(TOKEN)["errors"] == ["stream_finalize_timeout"]
+
+
+@pytest.mark.parametrize("later_id", ["call_1", "different_call"])
+def test_chat_repeated_stable_id_matches_results_but_conflicts_fail(later_id):
+    call = sse(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "function": {"name": "read", "arguments": '{"path":'},
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": later_id,
+                                "function": {"arguments": '"input.txt"}'},
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        b"[DONE]",
+    )
+    _, result, final = exchange("chat")
+    with upstream([reply(call), reply(final)]) as (url, _):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            body = {"model": "test-model", "stream": True}
+            post(proxy.base_url, PATHS["chat"], body)
+            post(proxy.base_url, PATHS["chat"], {**body, **result})
+            assert proxy.wait_for_idle(1)
+            assert proxy.evidence.passed(TOKEN) is (later_id == "call_1")
+
+
+def test_terminal_sse_with_truncated_content_length_is_not_accepted():
+    call, result, final = exchange("chat")
+
+    def truncated(wfile):
+        wfile.write(final)
+        wfile.flush()
+
+    replies = [
+        reply(call),
+        (
+            200,
+            {
+                "Content-Type": "text/event-stream",
+                "Content-Length": str(len(final) + 100),
+            },
+            truncated,
+        ),
+    ]
+    with upstream(replies) as (url, _):
+        with observer().RecordingProxy(url, "test-model", "chat") as proxy:
+            body = {"model": "test-model", "stream": True}
+            post(proxy.base_url, PATHS["chat"], body)
+            post(proxy.base_url, PATHS["chat"], {**body, **result})
+            assert proxy.wait_for_idle(1)
+            assert not proxy.evidence.passed(TOKEN)
+            assert "incomplete_http_response" in proxy.evidence.summary(TOKEN)["errors"]
+
+
+@pytest.mark.parametrize("send_headers", [False, True], ids=["headers", "body"])
+def test_proxy_exit_disconnects_upstream_and_joins_handlers(send_headers):
+    request_seen = threading.Event()
+    peer_closed = threading.Event()
+
+    class Peer(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers["Content-Length"]))
+            if send_headers:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(b": waiting\n\n")
+                self.wfile.flush()
+            request_seen.set()
+            self.connection.settimeout(2)
+            if self.connection.recv(1) == b"":
+                peer_closed.set()
+
+        def log_message(self, *args):
+            pass
+
+    peer = ThreadingHTTPServer(("127.0.0.1", 0), Peer)
+    thread = threading.Thread(
+        target=peer.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+    )
+    thread.start()
+    client = None
+    try:
+        with observer().RecordingProxy(
+            f"http://127.0.0.1:{peer.server_port}/v1", "test-model", "chat", timeout=1
+        ) as proxy:
+            address = urlsplit(proxy.base_url)
+            client = HTTPConnection(address.hostname, address.port, timeout=2)
+            client.request(
+                "POST",
+                "/v1/chat/completions",
+                json.dumps({"model": "test-model", "stream": True}),
+            )
+            assert request_seen.wait(1)
+            if send_headers:
+                response = client.getresponse()
+                assert response.read(len(b": waiting\n\n")) == b": waiting\n\n"
+                response.close()
+            client.close()
+            assert not proxy.wait_for_idle(0)
+        assert peer_closed.wait(0.15), "upstream survived proxy context exit"
+        proof = proxy.evidence.summary(TOKEN)
+        time.sleep(0.05)
+        assert proxy.evidence.summary(TOKEN) == proof
+    finally:
+        if client is not None:
+            client.close()
+        peer.shutdown()
+        peer.server_close()
+        thread.join(timeout=2)

--- a/tests/test_client_acceptance_runner.py
+++ b/tests/test_client_acceptance_runner.py
@@ -3,9 +3,11 @@
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -127,6 +129,59 @@ def test_process_timeout_kills_descendant_before_delayed_write(tmp_path):
     assert result.timed_out
     time.sleep(1.1)
     assert not marker.exists()
+
+
+def test_sigterm_runner_kills_client_before_delayed_write(tmp_path):
+    ready = tmp_path / "client.pid"
+    marker = tmp_path / "orphan.txt"
+    client = (
+        "import os,time; from pathlib import Path; "
+        f"Path({str(ready)!r}).write_text(str(os.getpid())); "
+        f"time.sleep(0.6); Path({str(marker)!r}).touch(); time.sleep(30)"
+    )
+    program = (
+        "from pathlib import Path; import sys; "
+        "from scripts.client_acceptance.runner import run_process, isolated_environment; "
+        f"root=Path({str(tmp_path)!r}); "
+        f"run_process([sys.executable,'-c',{client!r}],isolated_environment(root),root,30)"
+    )
+    outer = subprocess.Popen(
+        [sys.executable, "-c", program],
+        env=isolated_environment(tmp_path),
+        cwd=Path(__file__).resolve().parents[1],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    child_pid = None
+    try:
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ready.exists()
+        child_pid = int(ready.read_text())
+        outer.terminate()
+        outer.wait(timeout=3)
+        assert outer.returncode != 0
+        time.sleep(0.8)
+        assert not marker.exists()
+    finally:
+        if outer.poll() is None:
+            outer.kill()
+            outer.wait(timeout=3)
+        if child_pid is not None:
+            try:
+                os.killpg(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def test_process_restores_sigterm_handler(tmp_path):
+    original = signal.getsignal(signal.SIGTERM)
+    result = run_process(
+        [sys.executable, "-c", "pass"], isolated_environment(tmp_path), tmp_path, 5
+    )
+    assert result.returncode == 0
+    assert signal.getsignal(signal.SIGTERM) == original
 
 
 def test_process_output_is_not_retained_in_result(tmp_path):

--- a/tests/test_client_acceptance_runner.py
+++ b/tests/test_client_acceptance_runner.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Portable runner checks. These do not establish real-model acceptance."""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from scripts.client_acceptance.runner import (
+    evaluate_run,
+    isolated_environment,
+    main,
+    run_client,
+    run_process,
+)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    work = tmp_path / "workspace"
+    work.mkdir()
+    (work / "input.txt").write_text("fixture-token\n")
+    (work / "output.txt").write_text("fixture-token\n")
+    return work
+
+
+@pytest.fixture
+def proof():
+    return {
+        "requests": 3,
+        "streamed": True,
+        "tool_calls": 2,
+        "tool_results": 2,
+        "completed": True,
+        "answer_matches": True,
+        "errors": [],
+    }
+
+
+def test_pass_requires_protocol_evidence_and_actual_edit(workspace, proof):
+    assert evaluate_run(0, False, workspace, "fixture-token", proof) == []
+    (workspace / "output.txt").write_text("pending\n")
+    assert "incorrect_file_edit" in evaluate_run(
+        0, False, workspace, "fixture-token", proof
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("requests", 1),
+        ("streamed", False),
+        ("tool_calls", 0),
+        ("tool_results", 0),
+        ("completed", False),
+        ("answer_matches", False),
+        ("errors", ["upstream_error"]),
+    ],
+)
+def test_successful_exit_cannot_replace_protocol_proof(workspace, proof, field, value):
+    proof[field] = value
+    assert "incomplete_protocol_evidence" in evaluate_run(
+        0, False, workspace, "fixture-token", proof
+    )
+
+
+def test_timeout_and_nonzero_exit_fail_even_after_correct_edit(workspace, proof):
+    reasons = evaluate_run(7, True, workspace, "fixture-token", proof)
+    assert "client_timeout" in reasons
+    assert "client_exit_nonzero" in reasons
+
+
+def test_changed_input_and_symlink_output_are_rejected(workspace, proof, tmp_path):
+    (workspace / "input.txt").write_text("changed\n")
+    target = tmp_path / "outside.txt"
+    target.write_text("fixture-token\n")
+    (workspace / "output.txt").unlink()
+    (workspace / "output.txt").symlink_to(target)
+    reasons = evaluate_run(0, False, workspace, "fixture-token", proof)
+    assert "input_modified" in reasons
+    assert "incorrect_file_edit" in reasons
+
+
+def test_non_regular_output_is_rejected_without_blocking(workspace, proof):
+    (workspace / "output.txt").unlink()
+    os.mkfifo(workspace / "output.txt")
+    assert "incorrect_file_edit" in evaluate_run(
+        0, False, workspace, "fixture-token", proof
+    )
+
+
+def test_child_environment_excludes_ambient_secrets_and_profiles(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "inert-parent-sentinel")
+    monkeypatch.setenv("GITHUB_TOKEN", "inert-parent-sentinel")
+    monkeypatch.setenv("HTTP_PROXY", "http://unwanted.invalid")
+    monkeypatch.setenv("NODE_OPTIONS", "--require=unwanted.js")
+    env = isolated_environment(tmp_path)
+    output = subprocess.check_output(
+        [sys.executable, "-c", "import json, os; print(json.dumps(dict(os.environ)))"],
+        env=env,
+        text=True,
+    )
+    child = json.loads(output)
+    for name in ("ANTHROPIC_API_KEY", "GITHUB_TOKEN", "HTTP_PROXY", "NODE_OPTIONS"):
+        assert name not in child
+    assert child["HOME"] == str(tmp_path / "home")
+    assert child["XDG_CONFIG_HOME"].startswith(str(tmp_path))
+    assert child["TMPDIR"] == str(tmp_path / "tmp")
+
+
+def test_process_timeout_kills_descendant_before_delayed_write(tmp_path):
+    marker = tmp_path / "escaped.txt"
+    child = f"import time; from pathlib import Path; time.sleep(1); Path({str(marker)!r}).touch()"
+    parent = (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(30)"
+    )
+    result = run_process(
+        [sys.executable, "-c", parent],
+        isolated_environment(tmp_path),
+        tmp_path,
+        timeout=0.15,
+    )
+    assert result.timed_out
+    time.sleep(1.1)
+    assert not marker.exists()
+
+
+def test_process_output_is_not_retained_in_result(tmp_path):
+    result = run_process(
+        [sys.executable, "-c", "print('inert-output-sentinel')"],
+        isolated_environment(tmp_path),
+        tmp_path,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert "inert-output-sentinel" not in repr(result)
+
+
+def test_missing_clients_produce_report_and_nonzero_exit(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    report_path = tmp_path / "report.json"
+    result = main(
+        [
+            "--clients",
+            "pi",
+            "opencode",
+            "--model",
+            "served-model",
+            "--model-revision",
+            "a" * 40,
+            "--server-revision",
+            "b" * 40,
+            "--report",
+            str(report_path),
+        ]
+    )
+    assert result == 2
+    report = json.loads(report_path.read_text())
+    assert [item["status"] for item in report["results"]] == [
+        "unavailable",
+        "unavailable",
+    ]
+    assert all(item["reasons"] == ["executable_missing"] for item in report["results"])
+    assert report["model_revision"] == "a" * 40
+    assert report["revision_source"] == "operator_provided"
+
+
+def test_mutable_model_revision_is_rejected_before_launch(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "--model",
+                "served-model",
+                "--model-revision",
+                "main",
+                "--server-revision",
+                "b" * 40,
+                "--report",
+                str(tmp_path / "r.json"),
+            ]
+        )
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("failure", ["version_mismatch", "nested_discovery"])
+def test_unavailable_prerequisites_preserve_report_without_running_task(
+    tmp_path, monkeypatch, failure
+):
+    from tests.test_client_acceptance_observe import upstream
+
+    marker = tmp_path / "task-started"
+    executable = tmp_path / "pi"
+    executable.write_text(
+        f"#!{sys.executable}\nimport sys\nfrom pathlib import Path\n"
+        "if '--version' in sys.argv:\n    print('pi 1.2.3')\n"
+        f"else:\n    Path({str(marker)!r}).touch()\n"
+    )
+    executable.chmod(0o700)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    nesting = 10_000
+    body = b'{"data":[],"extra":' + b"[" * nesting + b"0" + b"]" * nesting + b"}"
+    report_path = tmp_path / "report.json"
+    with upstream([(200, {"Content-Type": "application/json"}, body)]) as (
+        url,
+        received,
+    ):
+        status = main(
+            [
+                "--clients",
+                "pi",
+                "--base-url",
+                url,
+                "--model",
+                "served-model",
+                "--model-revision",
+                "a" * 40,
+                "--server-revision",
+                "b" * 40,
+                "--expect-version",
+                "pi=9.9.9" if failure == "version_mismatch" else "pi=1.2.3",
+                "--report",
+                str(report_path),
+            ]
+        )
+    assert status == 2
+    result = json.loads(report_path.read_text())["results"][0]
+    assert result["status"] == "unavailable"
+    assert result["reasons"] == [
+        (
+            "client_version_mismatch"
+            if failure == "version_mismatch"
+            else "server_or_model_unavailable"
+        )
+    ]
+    assert not marker.exists()
+    assert len(received) == (0 if failure == "version_mismatch" else 1)
+
+
+def _scripted_tool_loop(
+    tmp_path,
+    monkeypatch,
+    *,
+    timeout=10,
+    final_delay=0,
+    inference_elapsed=0,
+    client_returncode=0,
+    api_key="",
+):
+    """Exercise the real runner using a scripted client and HTTP model peer."""
+    from tests.test_client_acceptance_observe import exchange, sse, upstream
+
+    token = "fixture-7d1849-secret"
+    monkeypatch.setattr(
+        "scripts.client_acceptance.runner.secrets.token_hex", lambda _: token
+    )
+    executable = tmp_path / "pi"
+    executable.write_text(f"#!{sys.executable}\n" + """
+import json, os, sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+if '--version' in sys.argv:
+    print('pi 1.2.3')
+    raise SystemExit(0)
+provider = json.loads((Path(os.environ['PI_CODING_AGENT_DIR']) / 'models.json').read_text())['providers']['vllm-mlx']
+messages = [{'role': 'user', 'content': sys.argv[-1]}]
+for turn in range(3):
+    body = {'model': provider['models'][0]['id'], 'stream': True, 'messages': messages,
+            'metadata': {'workspace': os.getcwd()}}
+    request = Request(provider['baseUrl'] + '/chat/completions', data=json.dumps(body).encode(),
+                      headers={'Content-Type': 'application/json',
+                               'Authorization': 'Bearer ' + provider['apiKey']})
+    with urlopen(request, timeout=5) as response:
+        events = []
+        for raw in response:
+            line = raw.decode().strip()
+            if line.startswith('data: {'):
+                events.append(json.loads(line[6:]))
+            if turn == 2 and line == 'data: [DONE]':
+                break
+    calls = [call for event in events for choice in event.get('choices', [])
+             for call in choice.get('delta', {}).get('tool_calls', [])]
+    if not calls:
+        raise SystemExit(CLIENT_RETURN_CODE)
+    call = calls[0]
+    args = json.loads(call['function']['arguments'])
+    if call['function']['name'] == 'read':
+        output = Path(args['path']).read_text()
+    else:
+        Path(args['path']).write_text(args['content'])
+        output = 'file written'
+    messages.extend([{'role': 'assistant', 'tool_calls': [call]},
+                     {'role': 'tool', 'tool_call_id': call['id'], 'content': output}])
+raise SystemExit(1)
+""".replace("CLIENT_RETURN_CODE", str(client_returncode)))
+    executable.chmod(0o700)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    read_call, _, final = exchange("chat")
+    read_call = read_call.replace(b"fixture.txt", b"input.txt")
+    write_call = sse(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_write",
+                                "type": "function",
+                                "function": {
+                                    "name": "write",
+                                    "arguments": json.dumps(
+                                        {"path": "output.txt", "content": token + "\n"}
+                                    ),
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
+        b"[DONE]",
+    )
+    replies = [
+        (200, {"Content-Type": "application/json"}, b'{"data":[{"id":"served-model"}]}')
+    ]
+    if inference_elapsed:
+        from types import SimpleNamespace
+
+        from scripts.client_acceptance import observe
+
+        # Advance only the observer's clock to exercise a slow model without a
+        # minute-long test. Real processes, sockets, and parsing still execute.
+        clock = [time.monotonic()]
+        monkeypatch.setattr(
+            observe, "time", SimpleNamespace(monotonic=lambda: clock[0])
+        )
+
+        def first_response(wfile):
+            clock[0] += inference_elapsed
+            wfile.write(read_call)
+            wfile.flush()
+
+    else:
+        first_response = read_call
+
+    def final_response(wfile):
+        wfile.write(final)
+        wfile.flush()
+        time.sleep(final_delay)
+
+    replies += [
+        (200, {"Content-Type": "text/event-stream"}, body)
+        for body in (first_response, write_call, final_response)
+    ]
+    with upstream(replies) as (base_url, received):
+        result = run_client(
+            "pi",
+            base_url,
+            "served-model",
+            timeout,
+            api_key=api_key,
+            expected_version="1.2.3",
+        )
+    return result, received, token
+
+
+def test_runner_uses_private_proxy_credential_for_authenticated_server(
+    tmp_path, monkeypatch
+):
+    key = "inert-upstream-sentinel"
+    result, received, token = _scripted_tool_loop(tmp_path, monkeypatch, api_key=key)
+    assert result["status"] == "passed", result
+    assert len(received) == 4
+    assert all(
+        headers["Authorization"] == "Bearer " + key for _, headers, _ in received
+    )
+    assert key not in json.dumps(result)
+    assert token not in json.dumps(result)
+
+
+def test_runner_executes_tool_loop_through_proxy_and_removes_workspace(
+    tmp_path, monkeypatch
+):
+    """A scripted executable verifies runner integration, not any installed client."""
+    from pathlib import Path
+
+    result, received, token = _scripted_tool_loop(tmp_path, monkeypatch)
+    assert result["status"] == "passed", result
+    assert result["evidence"]["tool_results"] == 1
+    assert result["evidence"]["requests"] == 3
+    assert result["version"] == "1.2.3"
+    workspace = Path(json.loads(received[1][2])["metadata"]["workspace"])
+    assert not workspace.parent.exists()
+    assert token not in json.dumps(result)
+
+
+def test_inference_can_exceed_sixty_seconds_within_requested_client_budget(
+    tmp_path, monkeypatch
+):
+    result, _, _ = _scripted_tool_loop(
+        tmp_path, monkeypatch, timeout=180, inference_elapsed=65
+    )
+    assert result["status"] == "passed", result
+
+
+def test_runner_waits_for_final_stream_evidence_after_client_exits(
+    tmp_path, monkeypatch
+):
+    result, _, _ = _scripted_tool_loop(tmp_path, monkeypatch, final_delay=0.2)
+    assert result["status"] == "passed", result
+    assert result["evidence"]["completed"] is True
+
+
+@pytest.mark.parametrize("returncode", [0, 7])
+def test_final_stream_drain_stops_at_client_budget_and_keeps_exit_failure(
+    tmp_path, monkeypatch, returncode
+):
+    started = time.monotonic()
+    result, _, _ = _scripted_tool_loop(
+        tmp_path,
+        monkeypatch,
+        timeout=1,
+        final_delay=2,
+        client_returncode=returncode,
+    )
+    assert result["status"] == "failed", result
+    assert "proxy_drain_timeout" in result["reasons"]
+    assert ("client_exit_nonzero" in result["reasons"]) == bool(returncode)
+    assert time.monotonic() - started < 1.5

--- a/tests/test_normalize_messages.py
+++ b/tests/test_normalize_messages.py
@@ -7,6 +7,8 @@ consecutive same-role messages before chat template application. This prevents
 crashes from Qwen 3.5 and Llama templates that require alternating roles.
 """
 
+import pytest
+
 
 class TestNormalizeMessages:
     """Test _normalize_messages() for handling real-world client formats."""
@@ -172,3 +174,34 @@ class TestNormalizeMessages:
         assert len(result) == 2
         assert "Part 1" in result[0]["content"]
         assert "Part 3" in result[0]["content"]
+
+    def test_consecutive_tool_results_preserve_call_ids_and_contents(self):
+        from vllm_mlx.server import _normalize_messages
+
+        messages = [
+            {"role": "tool", "tool_call_id": "read-input", "content": "token\n"},
+            {"role": "tool", "tool_call_id": "read-output", "content": "pending\n"},
+        ]
+        result = _normalize_messages(messages)
+        assert result == messages
+        assert [item["tool_call_id"] for item in result] == [
+            "read-input",
+            "read-output",
+        ]
+
+    @pytest.mark.parametrize("call_index", [0, 1])
+    def test_assistant_tool_calls_are_not_merged_into_text(self, call_index):
+        from vllm_mlx.server import _normalize_messages
+
+        messages = [
+            {"role": "assistant", "content": "First"},
+            {"role": "assistant", "content": "Second"},
+        ]
+        messages[call_index]["tool_calls"] = [
+            {
+                "id": "read-input",
+                "type": "function",
+                "function": {"name": "read", "arguments": '{"path":"input.txt"}'},
+            }
+        ]
+        assert _normalize_messages(messages) == messages

--- a/tests/test_tool_parsers.py
+++ b/tests/test_tool_parsers.py
@@ -273,6 +273,36 @@ class TestQwenToolParser:
         assert not result.tools_called
 
 
+class TestQwenStreamingCallIdentity:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            '<tool_call>{"name":"read","arguments":{"path":"input.txt"}}</tool_call>',
+            '[Calling tool: read({"path":"input.txt"})]',
+        ],
+    )
+    def test_completed_calls_are_emitted_once_across_trailing_chunks(self, call):
+        parser = QwenToolParser()
+        text = ""
+        calls = []
+        # Two identical calls are distinct invocations. Include a split closing
+        # marker, trailing whitespace, and the engine's final empty delta.
+        for chunk in [call[:-2], call[-2:], "\n", "", call, "\n", ""]:
+            previous = text
+            text += chunk
+            delta = parser.extract_tool_calls_streaming(previous, text, chunk)
+            calls.extend((delta or {}).get("tool_calls", []))
+        assert [item["index"] for item in calls] == [0, 1]
+        assert len({item["id"] for item in calls}) == 2
+        for item in calls:
+            assert item["function"]["name"] == "read"
+            assert json.loads(item["function"]["arguments"]) == {"path": "input.txt"}
+
+        parser.reset()
+        delta = parser.extract_tool_calls_streaming("", call, call)
+        assert [item["index"] for item in delta["tool_calls"]] == [0]
+
+
 class TestLlamaToolParser:
     """Test the Llama tool parser."""
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -5543,6 +5543,7 @@ def _normalize_messages(messages: list[dict]) -> list[dict]:
 
     Only merges when both messages have string content. Messages with list
     content (multimodal) are left as-is to preserve image/video attachments.
+    Tool results and assistant tool calls retain their individual identities.
 
     Args:
         messages: List of message dicts with 'role' and 'content' keys.
@@ -5565,6 +5566,9 @@ def _normalize_messages(messages: list[dict]) -> list[dict]:
         role = _ROLE_MAP.get(msg["role"], msg["role"])
         if (
             role == prev["role"]
+            and role in ("system", "user", "assistant")
+            and not prev.get("tool_calls")
+            and not msg.get("tool_calls")
             and isinstance(prev.get("content"), str)
             and isinstance(msg.get("content"), str)
         ):

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -333,10 +333,17 @@ class QwenToolParser(ToolParser):
             # Tool call complete, parse the whole thing
             result = self.extract_tool_calls(current_text)
             if result.tools_called:
+                # Trailing whitespace and the final engine delta still contain
+                # every completed call. Emit only newly completed invocations.
+                first_new = self.current_tool_id + 1
+                new_calls = result.tool_calls[first_new:]
+                if not new_calls:
+                    return None
+                self.current_tool_id = len(result.tool_calls) - 1
                 return {
                     "tool_calls": [
                         {
-                            "index": i,
+                            "index": first_new + i,
                             "id": tc["id"],
                             "type": "function",
                             "function": {
@@ -344,7 +351,7 @@ class QwenToolParser(ToolParser):
                                 "arguments": tc["arguments"],
                             },
                         }
-                        for i, tc in enumerate(result.tool_calls)
+                        for i, tc in enumerate(new_calls)
                     ]
                 }
 


### PR DESCRIPTION
## Summary

Add an isolated acceptance runner for **OpenCode, pi, Codex, Claude Code, GitHub Copilot CLI, Cline CLI, and OpenClaw** using vllm-mlx as their local inference backend. The task requires real model-issued tool calls, a file edit, returned tool results, and a completed answer containing a token that was absent from the prompt.

**Real-model validation: all seven clients completed acceptance with Qwen3-8B-6bit on an Apple M5 Max.** These were installed clients talking to actual MLX inference, with private profiles and one client at a time. The final seven-client run used the same source revision and exact client-version pins.

The validated follow-up fixes are published in [`00dbf22`](https://github.com/waybarrios/vllm-mlx/commit/00dbf22d6f64fdd64cf4ed99cb64525ba042aed2), signed by Wayner Barrios with a GitHub-verified SSH signature. [Real-model logs and source provenance](https://github.com/waybarrios/vllm-mlx/pull/774#issuecomment-5557174863) document all seven runs.

### Changes

- Add private client adapters, a bounded HTTP/SSE observation proxy, a process runner, structured JSON reports, portable tests, documentation, and a manual Apple Silicon workflow.
- Preserve stable streamed tool-call IDs, reject truncated HTTP bodies, close active proxy connections, and clean up process groups on timeout or SIGTERM.
- Fix the `qwen` streaming parser so trailing whitespace and final engine chunks cannot emit an already-completed call again with a different ID.
- Preserve individual tool results and assistant tool calls during message normalization, including their call IDs and contents.
- Give Codex command tools the standard system executable path without inheriting the operator's environment. Native sandboxing stays enabled.
- Disable OpenClaw startup respawning and the Node compile cache so its execution stays within the runner's process group through cleanup.
- Make the fixture task explicit: read both files, replace `pending` with the input token, preserve the final newline, and answer with the token. Exact-byte acceptance requirements are unchanged.

### Acceptance contract

Each client receives private HOME/XDG/configuration directories and a workspace containing a random token in `input.txt` and `pending` in `output.txt`. A pass requires the selected model/API, at least two inference requests, completed streaming, model-issued calls with matching returned results, a result and final answer containing the token, exact output bytes, unchanged input bytes, and successful client exit without protocol errors or timeout. Symlinks and non-regular fixture files are rejected.

The runner uses Python's standard library, supports macOS/Linux with Python 3.10+, discovers installed clients on `PATH`, and supports exact version pins. OpenCode and pi are its default targets. Reports distinguish `passed`, `failed`, and `unavailable`; connecting or exiting 0 alone is insufficient.

The proxy restricts upstream traffic to a loopback HTTP endpoint and the selected API. It bounds requests/responses, validates model and framing, and separates upstream credentials from per-run client credentials. JSON reports omit raw prompts, transcripts, fixture tokens, and credentials. Revision metadata is operator-provided.

## Type of change

- New feature
- Bug fix
- Documentation

## Surface touched

- Acceptance CLI and client configuration under `scripts/client_acceptance/`.
- OpenAI Chat Completions/Responses and Anthropic Messages coverage.
- Production `qwen` streaming tool parsing and message normalization before chat-template rendering.
- Portable and Apple Silicon regression tests, CI test selection, documentation, and a dispatch-only acceptance workflow.

Model weights, tokenization, sampling, kernels, scheduling, and cache implementations are unchanged.

## Test plan

From a checkout with isolated dependencies:

```bash
mkdir -p tmp/client-acceptance
export TMPDIR="$PWD/tmp/client-acceptance"
python -m pytest \
  tests/test_client_acceptance_clients.py \
  tests/test_client_acceptance_observe.py \
  tests/test_client_acceptance_runner.py \
  tests/test_tool_parsers.py \
  tests/test_normalize_messages.py \
  tests/test_native_tool_format.py \
  tests/test_chat_template_safety.py \
  tests/test_server.py \
  tests/test_responses_api.py \
  -q -m 'not slow' -k 'not Integration'
```

The three acceptance test modules run without loading a model. Server tests require the project runtime. New regressions reproduce duplicate Qwen calls, loss of tool-message identity, and missing system commands in Codex's isolated shell. The OpenClaw adapter test also covers its startup isolation settings.

For real-model acceptance, use `docs/guides/client-acceptance.md`, a pinned local model snapshot, exact installed-client versions, and a private loopback port. Keep one model and one client active at a time.

## Test results

### Actual MLX inference

Host: **Apple M5 Max, 128 GiB RAM, macOS 26.5.1**. Isolated runtime: Python 3.12.14, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17. Existing cached **Qwen3-8B-6bit**, snapshot `35a99712f90d6c2c9a2407a3857e104a46edd9e6`, parser `qwen`, thinking disabled, default temperature 0, and default max tokens 512. Client-specified token limits may override that default.

| Client | Pinned version | API | Actual-model acceptance | Seconds |
| --- | --- | --- | --- | ---: |
| pi | `0.83.0` | Chat Completions | Passed | 3.892 |
| OpenCode | `1.18.25` | Chat Completions | Passed | 7.783 |
| Claude Code | `2.1.252` | Anthropic Messages | Passed | 5.394 |
| Codex | `0.153.4` | Responses | Passed | 16.538 |
| GitHub Copilot CLI | `1.0.83` | Chat Completions | Passed | 6.974 |
| Cline CLI | `3.0.61` | Chat Completions | Passed | 9.908 |
| OpenClaw | `2026.9.2` | Responses | Passed | 5.976 |

The final run verified exact files, returned tool results, completed answers, and client exit 0 for every client, with a 60-second per-client budget. This establishes observed compatibility for these versions/model/settings, not universal compatibility or a benchmark pass rate.

The smaller Qwen3-4B-8bit snapshot `0348ad770d2ae658ca47b0579b2d2c37b20bbcac` was also rechecked after the follow-up fixes: OpenCode passed; pi completed protocol evidence but failed the exact file edit. Earlier 0.6B/4B failures remain historical diagnostic results and are not reclassified as passes.

### Automated checks

```text
Targeted acceptance/server/parser suite: 542 passed, 3 deselected (16.46s)
Acceptance modules within that suite: 160 passed
Scoped Ruff: passed
Scoped Black: passed (7 files)
git diff --check: passed
```

The six new regression cases failed before their respective fixes and passed afterward. [All 10 GitHub checks completed successfully for the published head `00dbf22`](https://github.com/waybarrios/vllm-mlx/actions/runs/34013859070). The existing advisory mypy step uses `continue-on-error`: it reports the same 481 errors as parent `7cd72c2`, with no added or removed error paths/messages/counts after accounting for line-number shifts. A clean full-project mypy run is not claimed.

### Optional workflow

The workflow is dispatch-only from `main` on `[self-hosted, macOS, ARM64, client-acceptance]`, with a 30-minute budget, serialized runs, read-only repository permissions, no persisted checkout credentials, and 14-day JSON artifact retention. It expects preinstalled clients and an already-running server; it does not run arbitrary PR code on the model host. This optional automation has not been exercised; the live acceptance results above were obtained directly with the CLI.

## Performance impact

The acceptance runner is opt-in tooling. The production fixes affect tool-call streaming and message normalization. No throughput, TTFT, or greedy-generation performance comparison is claimed. Server RSS sampled during the 8B runs was approximately 6.8–6.9 GiB; these are samples, not peak-memory measurements. Test servers and clients were stopped after each run.

## Output parity

Tool-call output intentionally changes: completed Qwen calls are emitted once, and separate tool results retain their identities. Generation parameters and model weights are unchanged. Exact fixture bytes are checked; general byte-for-byte generation parity was not measured.

## Risk notes

- Client/model compatibility depends on exact versions, tool schemas, parser, and model capability. Smaller-model failures remain visible above.
- Private profiles isolate configuration; host permissions and client-specific sandbox/tool restrictions still apply. Local inference routing does not guarantee complete network isolation.
- OpenClaw coverage is embedded `agent exec`, not gateways or messaging channels. Cline coverage is its CLI, not its editor extension. Cursor, Continue, and Aider are outside this PR's targets.
- Message normalization now preserves tool exchanges instead of merging them into ordinary same-role text. Existing normalization tests and server/Responses tests pass.
- Reports contain bounded evidence and operator-supplied revision metadata; deeper diagnosis uses separate isolated reproductions.
