### PR TITLE
fix(anthropic): convert image blocks instead of silently dropping them

### DIFF
--- a/tests/test_anthropic_adapter_images.py
+++ b/tests/test_anthropic_adapter_images.py
@@ -1,0 +1,123 @@
+"""Anthropic image blocks must reach the model.
+
+Before this, an image block parsed cleanly and was then dropped, so a vision
+request returned HTTP 200 with a confident text-only answer. vLLM's own
+Anthropic surface converts image blocks, so this was also a parity gap.
+"""
+
+import base64
+
+import pytest
+
+from vllm_mlx.api.anthropic_adapter import _convert_message
+from vllm_mlx.api.anthropic_models import AnthropicMessage
+
+PNG = base64.b64encode(b"\x89PNG\r\n\x1a\nfake").decode()
+
+
+def parts_of(msg):
+    """Normalize content parts to dicts (pydantic coerces them to ContentPart)."""
+    out = []
+    for p in msg.content:
+        out.append(p if isinstance(p, dict) else p.model_dump(exclude_none=True))
+    return out
+
+
+def url_of(part):
+    u = part["image_url"]
+    return u if isinstance(u, str) else u["url"]
+
+
+def _img(media_type="image/png", data=PNG):
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": media_type, "data": data},
+    }
+
+
+def _msg(role, content):
+    return AnthropicMessage(role=role, content=content)
+
+
+def test_image_block_becomes_an_image_url_part():
+    out = _convert_message(_msg("user", [_img()]))
+    assert len(out) == 1
+    parts = parts_of(out[0])
+    assert isinstance(parts, list), "content must be multimodal, not a string"
+    assert parts[0]["type"] == "image_url"
+    assert url_of(parts[0]) == f"data:image/png;base64,{PNG}"
+
+
+def test_media_type_is_preserved_not_assumed_png():
+    parts = parts_of(_convert_message(_msg("user", [_img("image/jpeg")]))[0])
+    assert url_of(parts[0]).startswith("data:image/jpeg;base64,")
+
+
+def test_text_and_image_interleaving_is_preserved():
+    # For document work, "here is the page" vs "now answer this" ordering changes
+    # the task, so order must survive the conversion.
+    out = _convert_message(
+        _msg(
+            "user",
+            [
+                {"type": "text", "text": "before"},
+                _img(),
+                {"type": "text", "text": "after"},
+            ],
+        )
+    )
+    parts = parts_of(out[0])
+    kinds = [p["type"] for p in parts]
+    assert kinds == ["text", "image_url", "text"]
+    assert parts[0]["text"] == "before"
+    assert parts[2]["text"] == "after"
+
+
+def test_url_source_is_supported():
+    out = _convert_message(
+        _msg(
+            "user",
+            [{"type": "image", "source": {"type": "url", "url": "https://x/y.png"}}],
+        )
+    )
+    assert url_of(parts_of(out[0])[0]) == "https://x/y.png"
+
+
+def test_unknown_source_type_raises_rather_than_dropping():
+    # Silent dropping is the exact failure this branch exists to end.
+    with pytest.raises(ValueError, match="unsupported image source type"):
+        _convert_message(_msg("user", [{"type": "image", "source": {"type": "magic"}}]))
+
+
+def test_empty_image_data_raises():
+    with pytest.raises(ValueError, match="no data"):
+        _convert_message(_msg("user", [_img(data="")]))
+
+
+def test_text_only_path_is_unchanged():
+    # The hot path must stay a plain string, not become a one-element list.
+    out = _convert_message(_msg("user", [{"type": "text", "text": "hello"}]))
+    assert out[0].content == "hello"
+    assert _convert_message(_msg("user", "plain"))[0].content == "plain"
+
+
+def test_assistant_images_are_not_dropped():
+    out = _convert_message(_msg("assistant", [_img()]))
+    assert isinstance(out[0].content, list)
+    assert parts_of(out[0])[0]["type"] == "image_url"
+
+
+def test_image_alongside_tool_result_keeps_both():
+    out = _convert_message(
+        _msg(
+            "user",
+            [
+                _img(),
+                {"type": "tool_result", "tool_use_id": "t1", "content": "42"},
+            ],
+        )
+    )
+    roles = [m.role for m in out]
+    assert "user" in roles and "tool" in roles
+    user_msg = next(m for m in out if m.role == "user")
+    assert parts_of(user_msg)[0]["type"] == "image_url"

--- a/tests/test_anthropic_adapter_images.py
+++ b/tests/test_anthropic_adapter_images.py
@@ -121,3 +121,32 @@ def test_image_alongside_tool_result_keeps_both():
     assert "user" in roles and "tool" in roles
     user_msg = next(m for m in out if m.role == "user")
     assert parts_of(user_msg)[0]["type"] == "image_url"
+
+
+def test_assistant_image_with_tool_use_preserves_both():
+    msg = AnthropicMessage(
+        role="assistant",
+        content=[
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": PNG,
+                },
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "zoom",
+                "input": {"region": "top-left"},
+            },
+        ],
+    )
+    (converted,) = _convert_message(msg)
+    assert converted.role == "assistant"
+    assert (
+        converted.tool_calls and converted.tool_calls[0]["function"]["name"] == "zoom"
+    )
+    kinds = [part["type"] for part in parts_of(converted)]
+    assert "image_url" in kinds

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5632,3 +5632,66 @@ class TestDetectImplicitThinking:
         assert engine.calls == 2, "unidentifiable template must not be cached"
         assert server._implicit_thinking_cache == {}
         server._implicit_thinking_cache.clear()
+
+
+class TestAnthropicImageClientErrors:
+    """Invalid image blocks must produce deliberate 400s, not unhandled 500s.
+
+    The adapter raises ValueError for empty/unknown image sources; the route
+    must translate that before engine acquisition, in both modes.
+    """
+
+    @pytest.fixture()
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.server import app
+
+        return TestClient(app)
+
+    def _setup(self, monkeypatch):
+        import vllm_mlx.server as server
+
+        monkeypatch.setattr(server, "_model_name", "test-model")
+        monkeypatch.setattr(server, "_default_timeout", 30.0)
+        monkeypatch.setattr(server, "_default_max_tokens", 128)
+        monkeypatch.setattr(server, "_api_key", None)
+        monkeypatch.setattr(
+            server,
+            "_rate_limiter",
+            server.RateLimiter(requests_per_minute=60, enabled=False),
+        )
+
+    def _payload(self, source, stream=False):
+        return {
+            "model": "test-model",
+            "max_tokens": 16,
+            "stream": stream,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image", "source": source}],
+                }
+            ],
+        }
+
+    def test_empty_image_data_is_400_non_streaming(self, client, monkeypatch):
+        self._setup(monkeypatch)
+        source = {"type": "base64", "media_type": "image/png", "data": ""}
+        response = client.post("/v1/messages", json=self._payload(source))
+        assert response.status_code == 400
+        assert "image" in response.json()["detail"]
+
+    def test_unknown_image_source_is_400_non_streaming(self, client, monkeypatch):
+        self._setup(monkeypatch)
+        source = {"type": "carrier-pigeon", "data": "abc"}
+        response = client.post("/v1/messages", json=self._payload(source))
+        assert response.status_code == 400
+        assert "carrier-pigeon" in response.json()["detail"]
+
+    def test_empty_image_data_is_400_streaming(self, client, monkeypatch):
+        self._setup(monkeypatch)
+        source = {"type": "base64", "media_type": "image/png", "data": ""}
+        response = client.post("/v1/messages", json=self._payload(source, stream=True))
+        assert response.status_code == 400
+        assert "image" in response.json()["detail"]

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -190,10 +190,49 @@ def _convert_message(msg: AnthropicMessage) -> list[Message]:
     text_parts = []
     tool_calls_for_assistant = []
     tool_results = []
+    # Ordered multimodal parts, built in parallel with text_parts. Only used when
+    # the message actually carries media, so the text-only path is byte-identical
+    # to before -- important because that path is the hot one.
+    content_parts: list[dict] = []
+    has_media = False
 
     for block in msg.content:
         if block.type == "text":
             text_parts.append(block.text or "")
+            content_parts.append({"type": "text", "text": block.text or ""})
+
+        elif block.type == "image":
+            # Anthropic image block -> OpenAI image_url part.
+            #
+            # Without this branch the block was parsed (AnthropicContentBlock
+            # carries `source`) and then silently DROPPED, so a vision request
+            # returned HTTP 200 with a confident text-only answer -- the model
+            # never saw the picture. vLLM's own Anthropic surface converts
+            # image blocks, so this was also a parity gap.
+            source = block.source or {}
+            src_type = source.get("type")
+            if src_type == "base64":
+                media_type = source.get("media_type") or "image/png"
+                data = source.get("data") or ""
+                if not data:
+                    # A data URI with an empty payload is worse than an error: the
+                    # request would look well-formed and the model would answer
+                    # about nothing.
+                    raise ValueError("image block carries no data")
+                url = f"data:{media_type};base64,{data}"
+            elif src_type == "url":
+                url = source.get("url") or ""
+            else:
+                # Refuse rather than drop: an unknown source type that silently
+                # vanishes is the exact failure this branch exists to end.
+                raise ValueError(
+                    f"unsupported image source type {src_type!r}; "
+                    "expected 'base64' or 'url'"
+                )
+            if not url:
+                raise ValueError("image block carries no data")
+            content_parts.append({"type": "image_url", "image_url": {"url": url}})
+            has_media = True
 
         elif block.type == "tool_use":
             # Assistant message with tool calls
@@ -243,26 +282,37 @@ def _convert_message(msg: AnthropicMessage) -> list[Message]:
                     tool_calls=tool_calls_for_assistant,
                 )
             )
+        elif has_media:
+            messages.append(Message(role="assistant", content=content_parts))
         elif combined_text is not None:
             messages.append(Message(role="assistant", content=combined_text))
         else:
             messages.append(Message(role="assistant", content=""))
     elif msg.role == "user":
         # User messages: collect text parts, then add tool results separately
-        if text_parts:
+        if has_media:
+            # Preserve the author's text/image interleaving: for document work the
+            # order of "here is the page" vs "now answer this" changes the task.
+            messages.append(Message(role="user", content=content_parts))
+        elif text_parts:
             combined_text = "\n".join(text_parts)
             messages.append(Message(role="user", content=combined_text))
 
         # Tool results become separate tool messages
         messages.extend(tool_results)
 
-        # If no text and no tool results, add empty user message
-        if not text_parts and not tool_results:
+        # If no text, no media and no tool results, add empty user message.
+        # has_media matters: an image-only message has no text_parts, and without
+        # this guard it emitted the image AND a stray empty user message.
+        if not text_parts and not tool_results and not has_media:
             messages.append(Message(role="user", content=""))
     else:
         # Other roles
-        combined_text = "\n".join(text_parts) if text_parts else ""
-        messages.append(Message(role=msg.role, content=combined_text))
+        if has_media:
+            messages.append(Message(role=msg.role, content=content_parts))
+        else:
+            combined_text = "\n".join(text_parts) if text_parts else ""
+            messages.append(Message(role=msg.role, content=combined_text))
 
     return messages
 

--- a/vllm_mlx/api/anthropic_adapter.py
+++ b/vllm_mlx/api/anthropic_adapter.py
@@ -249,6 +249,9 @@ def _convert_message(msg: AnthropicMessage) -> list[Message]:
             )
 
         elif block.type == "tool_result":
+            # Follow-up (out of scope for the image-block fix): images nested
+            # inside tool_result.content still go through this text-only
+            # extraction and are not converted to image_url parts.
             # Tool result → OpenAI tool message
             result_content = block.content
             if isinstance(result_content, list):
@@ -275,10 +278,13 @@ def _convert_message(msg: AnthropicMessage) -> list[Message]:
     if msg.role == "assistant":
         combined_text = "\n".join(text_parts) if text_parts else None
         if tool_calls_for_assistant:
+            # An assistant turn can carry an image alongside a tool call; the
+            # media extraction downstream is role-agnostic, so preserve the
+            # full part list rather than flattening to text and dropping it.
             messages.append(
                 Message(
                     role="assistant",
-                    content=combined_text or "",
+                    content=content_parts if has_media else (combined_text or ""),
                     tool_calls=tool_calls_for_assistant,
                 )
             )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -5827,8 +5827,14 @@ async def create_anthropic_message(
         _sanitize_log_text(last_user_preview, limit=300),
     )
 
-    # Convert Anthropic request -> OpenAI request
-    openai_request = anthropic_to_openai(anthropic_request)
+    # Convert Anthropic request -> OpenAI request. Conversion errors are
+    # client-input errors (e.g. an image block with an empty payload or an
+    # unknown source type) and must surface as 400s before any engine is
+    # acquired, never as unhandled 500s.
+    try:
+        openai_request = anthropic_to_openai(anthropic_request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     total_timeout, deadline = _start_request_budget(None)
     engine = await _acquire_default_engine_for_request(
         request,


### PR DESCRIPTION
**Symptom.** Sending an image through `/v1/messages` returns HTTP 200 with a
confident text-only answer. The model never sees the picture, and nothing in
the response indicates that.

**Cause.** `_convert_message` in `api/anthropic_adapter.py` branches on
`text`, `tool_use` and `tool_result` with no `image` branch and no catch-all.
An image block parses cleanly (`AnthropicContentBlock` carries `source`, and
`test_anthropic_models.py::test_image_block` covers the parsing) and is then
discarded during conversion. vLLM's own Anthropic surface converts image
blocks, so this was also a parity gap.

**Fix.** Convert Anthropic `source` to an OpenAI `image_url` content part:

- `base64` sources become data URIs with the declared `media_type` preserved
  (not assumed PNG); `url` sources pass through.
- Text and image parts keep the author's interleaving order. For document
  work, "here is the page" before "now answer this" is a different task from
  the reverse.
- Unknown source types and empty payloads raise instead of dropping. A data
  URI with an empty payload looks well-formed and makes the model answer
  about nothing, which is the exact failure this change exists to end.
- The text-only path still produces a plain string, so the common path is
  unchanged.
- Also fixes an adjacent latent bug this exposed: the "no text and no tool
  results" guard appended a stray empty user message, which image-only
  requests newly triggered.

`Message.content` already accepts `str | list[ContentPart] | list[dict]`;
the adapter simply never produced the list form.

**Tests.** `tests/test_anthropic_adapter_images.py` (9 tests): base64 with
media_type preserved, url sources, text/image interleaving order, image-only
messages produce no stray empty message, unknown source type raises, empty
payload raises, text-only path still emits a plain string. Full suite:
3074 passed / 24 skipped.
