### PR TITLE
docs: provide a release-bound first-response path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@
 
 A vLLM-style inference server for Apple Silicon Macs. Unlike `Ollama` or `mlx-lm` used directly, it ships **continuous batching, paged KV cache, prefix caching, and SSD-tiered cache**, and exposes **both OpenAI `/v1/*` and Anthropic `/v1/messages`** from a single process. Run LLMs, vision models, audio, and embeddings on Metal with unified memory, no conversion step.
 
-## Quick start (30 seconds)
+## Quick start
+
+New users: follow the [isolated release install](docs/getting-started/installation.md#install-a-release)
+and [first-response check](docs/getting-started/quickstart.md#first-response).
+The example below assumes that environment is activated. Initial model
+download/loading time depends on the machine and connection.
 
 ```bash
-pip install vllm-mlx
-vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous-batching
+python -m pip install 'vllm-mlx==0.4.1'
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --host 127.0.0.1 --port 8000
 ```
 
 **OpenAI SDK:**
@@ -29,7 +34,7 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 ```python
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
-r = client.chat.completions.create(model="default", messages=[{"role": "user", "content": "Hi!"}])
+r = client.chat.completions.create(model="mlx-community/Llama-3.2-3B-Instruct-4bit", messages=[{"role": "user", "content": "Hi!"}])
 print(r.choices[0].message.content)
 ```
 
@@ -64,13 +69,13 @@ claude
 - **STT**: Whisper family with RTF up to 197x on M4 Max
 
 ### Reasoning & advanced
-- **Reasoning extraction**: Qwen3, DeepSeek-R1, DeepSeek-V4 (`--reasoning-parser`)
+- **Reasoning extraction**: Qwen3 and DeepSeek-R1 parsers (`--reasoning-parser`)
 - **MoE expert reduction**: `--moe-top-k` for +7-16% on Qwen3-30B-A3B
-- **Speculative decoding**: `--mtp` for Qwen3-Next
-- **Sparse prefill**: attention-based `--spec-prefill` for TTFT reduction
+- **Speculative decoding**: `--enable-mtp` for supported models
+- **Sparse prefill**: attention-based `--specprefill` for supported model/draft combinations
 
 ### Observability
-- **Prometheus metrics**: `/metrics` endpoint with `--metrics`
+- **Prometheus metrics**: `/metrics` endpoint with `--enable-metrics`
 - **Built-in benchmarker**: `vllm-mlx bench-serve` for prompt sweeps with CSV/JSON output
 
 ### Native GPU acceleration
@@ -116,7 +121,7 @@ vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 
 ```python
 r = client.chat.completions.create(
-    model="default",
+    model="mlx-community/Qwen3-8B-4bit",
     messages=[{"role": "user", "content": "What is 17 * 23?"}],
 )
 print("Thinking:", r.choices[0].message.reasoning)
@@ -131,7 +136,7 @@ vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
 ```python
 r = client.chat.completions.create(
-    model="default",
+    model="mlx-community/Qwen3-VL-4B-Instruct-3bit",
     messages=[{"role": "user", "content": [
         {"type": "text", "text": "What is in this image?"},
         {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
@@ -141,9 +146,11 @@ r = client.chat.completions.create(
 
 ### Structured output (JSON Schema)
 
+With the text server from the quick start:
+
 ```python
 r = client.chat.completions.create(
-    model="default",
+    model="mlx-community/Llama-3.2-3B-Instruct-4bit",
     messages=[{"role": "user", "content": "List 3 colors."}],
     response_format={
         "type": "json_schema",
@@ -218,40 +225,23 @@ vllm-mlx model convert meta-llama/Llama-3.2-3B-Instruct --output ./models/llama-
 ### Prometheus metrics
 
 ```bash
-vllm-mlx serve <model> --metrics
+vllm-mlx serve <model> --enable-metrics
 curl http://localhost:8000/metrics
 ```
 
 ## Installation
 
-**Using uv (recommended):**
+Use the [release walkthrough](docs/getting-started/installation.md#install-a-release)
+for an isolated environment and a pinned server version. If you already manage
+CLI tools with uv, its isolated equivalent is:
 
 ```bash
-uv tool install vllm-mlx                 # CLI, system-wide
-# or in a project
-uv pip install vllm-mlx
+uv tool install 'vllm-mlx==0.4.1'
 ```
 
-**Using pip:**
-
-```bash
-pip install vllm-mlx
-
-# Audio extras
-pip install vllm-mlx[audio]
-brew install espeak-ng
-python -m spacy download en_core_web_sm
-```
-
-**From source:**
-
-```bash
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
-pip install -e .
-```
-
-See [Installation Guide](docs/getting-started/installation.md) for full options.
+Keep [development checkouts](docs/getting-started/installation.md#development-checkout)
+separate. See the [Installation Guide](docs/getting-started/installation.md) for
+optional extras and [Audio Guide](docs/guides/audio.md) for audio setup.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --host 127.0.0.1 --port 
 
 **OpenAI SDK:**
 
+Install `openai` in your Python client environment first; it is not installed
+by the server package. See the [client setup](docs/getting-started/quickstart.md#option-1-openai-compatible-server).
+
 ```python
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ and [first-response check](docs/getting-started/quickstart.md#first-response).
 The example below assumes that environment is activated. Initial model
 download/loading time depends on the machine and connection.
 
+The version below is this walkthrough's pinned reference release, not an
+automatically updated latest version.
+
 ```bash
 python -m pip install 'vllm-mlx==0.4.1'
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --host 127.0.0.1 --port 8000
 ```
+
+After the first response, restart with `--continuous-batching` to try
+[continuous batching and its cache options](docs/guides/continuous-batching.md).
+The minimal command above uses the default engine without that flag.
 
 **OpenAI SDK:**
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,42 +5,73 @@
 - macOS on Apple Silicon (M1/M2/M3/M4/M5)
 - Python 3.10+
 
-## Install with uv (Recommended)
+## Install a release
+
+For a first run, use a fresh environment rather than an editable checkout.
+This walkthrough targets [v0.4.1](https://github.com/waybarrios/vllm-mlx/releases/tag/v0.4.1).
+Changes merged into `main` after that release are not included just because
+their PR is closed. Check the release containing a required fix before choosing
+a model or enabling an advanced feature.
+
+Use an Apple Silicon-native Python installation (`arm64`), not a terminal or
+Python running under Rosetta. The example uses Python 3.12; install it first
+if that command is unavailable.
+
+```bash
+python3.12 -c 'import platform; print(platform.system(), platform.machine())'
+# Expected: Darwin arm64
+mkdir vllm-mlx-demo
+cd vllm-mlx-demo
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install 'vllm-mlx==0.4.1'
+python -m pip check
+python -c 'from importlib.metadata import version; print(version("vllm-mlx"))'
+# Expected: 0.4.1
+```
+
+The version pin fixes the server release, not every transitive dependency.
+After a successful run, retain `python -m pip freeze` output when reporting a
+problem or reproducing the environment. Do not install this walkthrough into
+an environment managed by another application or running inference service.
+
+Continue to [your first response](quickstart.md#first-response). Model download
+and loading time are additional; installation is not a model compatibility or
+memory-capacity check.
+
+## Development checkout
+
+Use this path when contributing or when a specific unreleased fix is required.
+It follows source, not the release walkthrough above. Record `git rev-parse
+HEAD` with any test or issue report. Use a separate environment; do not mix the
+editable checkout into the release environment.
 
 ```bash
 git clone https://github.com/waybarrios/vllm-mlx.git
 cd vllm-mlx
-
-uv pip install -e .
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e '.[dev]'
 ```
 
-## Install with pip
+## Optional release extras
 
-```bash
-git clone https://github.com/waybarrios/vllm-mlx.git
-cd vllm-mlx
+Run these commands in the release environment, not the development checkout.
+Contributors use the corresponding editable extras instead.
 
-pip install -e .
-```
-
-### Optional: Vision Support
+### Vision Support
 
 For video processing with transformers:
 
 ```bash
-pip install -e ".[vision]"
+python -m pip install 'vllm-mlx[vision]==0.4.1'
 ```
 
-### Optional: Audio Support (STT/TTS)
+### Audio Support (STT/TTS)
 
 ```bash
-pip install mlx-audio
-```
-
-### Optional: Embeddings
-
-```bash
-pip install mlx-embeddings
+python -m pip install 'vllm-mlx[audio]==0.4.1'
 ```
 
 ## What Gets Installed
@@ -51,7 +82,7 @@ pip install mlx-embeddings
 - `gradio` - Chat UI
 - `psutil` - Resource monitoring
 - `mlx-audio` (optional) - Speech-to-Text and Text-to-Speech
-- `mlx-embeddings` (optional) - Text embeddings
+- `mlx-embeddings` - Text embeddings
 
 ## Verify Installation
 
@@ -60,10 +91,10 @@ pip install mlx-embeddings
 vllm-mlx --help
 vllm-mlx-bench --help
 vllm-mlx-chat --help
-
-# Test with a small model
-vllm-mlx-bench --model mlx-community/Llama-3.2-1B-Instruct-4bit --prompts 1
 ```
+
+Use the [first-response check](quickstart.md#first-response) before benchmarks,
+tools, multimodal inputs, or concurrent clients.
 
 ## Troubleshooting
 
@@ -78,7 +109,7 @@ uname -m  # Should output "arm64"
 
 Check your internet connection and HuggingFace access. Some models require authentication:
 ```bash
-huggingface-cli login
+hf auth login
 ```
 
 You can inspect and stage models before serving:
@@ -89,6 +120,11 @@ vllm-mlx model acquire mlx-community/Llama-3.2-3B-Instruct-4bit \
 ```
 
 ### Out of memory
+
+Stop the server with Ctrl-C before trying a smaller model. Close other model
+servers and reduce the requested context before adding cache or speculative
+features. A weight download fitting on disk does not prove the runtime fits
+in unified memory. See [artifact and profile choices](quickstart.md#artifact-and-profile-choices).
 
 Use a smaller quantized model:
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,6 +9,10 @@
 
 For a first run, use a fresh environment rather than an editable checkout.
 This walkthrough targets [v0.4.1](https://github.com/waybarrios/vllm-mlx/releases/tag/v0.4.1).
+This is a pinned reference release, not a promise to install the latest version.
+When updating this walkthrough for a release, update the pins and expected
+version in the README and this page together, and recheck the quickstart's
+CLI flags and first-response request against that release.
 Changes merged into `main` after that release are not included just because
 their PR is closed. Check the release containing a required fix before choosing
 a model or enabling an advanced feature.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -75,6 +75,13 @@ vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000 --continuous
 
 Use with OpenAI Python SDK:
 
+Leave the server running. In another terminal, install the SDK in your Python
+client environment (the server package does not install `openai`):
+
+```bash
+python -m pip install openai
+```
+
 ```python
 from openai import OpenAI
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,11 +1,72 @@
 # Quick Start
 
+## First response
+
+Complete the [isolated release install](installation.md#install-a-release)
+first. Keep its environment activated. This starts one small text model with
+the default engine; advanced features and coding clients come afterward.
+The first launch downloads the model if it is not already cached. Keep this
+terminal open until the server reports it is ready.
+
+```bash
+vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --host 127.0.0.1 --port 8000
+```
+
+In a second terminal, check readiness and the served model before sending work:
+
+```bash
+curl --fail --show-error http://127.0.0.1:8000/health
+curl --fail --show-error http://127.0.0.1:8000/v1/models
+curl --fail --show-error http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"mlx-community/Llama-3.2-3B-Instruct-4bit","messages":[{"role":"user","content":"Say hello in one sentence."}],"max_tokens":64}'
+```
+
+Success is a nonempty answer in `choices[0].message.content`, not just a
+listening port. Check `/v1/models` again if a client reports a model mismatch.
+If port 8000 is occupied, choose a free port and change it in every URL; do not
+terminate an unfamiliar process. Keep the host on loopback for local use.
+Stop the server with Ctrl-C before starting a different model.
+
+If a CLI flag is unrecognized, check `vllm-mlx serve --help` in the same
+environment and the installed release. Do not copy options from newer source
+documentation into an older wheel. Download/authentication failures belong to
+model acquisition; unsupported architecture/parser errors require a supported
+model and dependency combination, not guessed flags. Include the exact model
+repository/revision, command, server error and package versions in a report.
+
+## Artifact and profile choices
+
+Choose an artifact first, then settings supported by that artifact and the
+installed server version. The example above uses a community 4-bit MLX
+conversion, not the vendor's original weights.
+
+| Choice | What to preserve and disclose |
+|---|---|
+| Vendor-documented artifact/settings | Exact vendor revision, tokenizer, template, sampling and architecture requirements. Confirm that the artifact format and model implementation are supported by MLX; a vendor CUDA command is not a Mac launch recipe. |
+| Lower-memory converted artifact | Conversion source/revision, quantization and any changed storage method, plus the tested context and feature limits. Label it as a derivative; do not claim weight or quality equivalence to the vendor artifact. |
+
+Weight quantization, KV-cache quantization, and SSD prefix-cache persistence
+are different choices. A prefix cache on SSD does not make model weights
+SSD-streamed. External quantized embedding storage likewise does not establish
+support for generic expert offloading or a larger context. Use only documented
+combinations; MTP, SpecPrefill and cache features are not universally composable.
+Leave untested combinations off rather than inheriting another model's flags.
+
+After the first response, use the existing SDK or chat UI examples below.
+The [coding-client validation work](https://github.com/waybarrios/vllm-mlx/pull/774)
+tracks client-specific setup and evidence; check its merge/release status
+before treating those results as coverage for your installation.
+Test one client and its required tool/reasoning contract before
+adding concurrent workloads. Basic chat success alone does not qualify tools,
+vision, structured output or long context.
+
 ## Option 1: OpenAI-Compatible Server
 
 Start the server:
 
 ```bash
-# Simple mode - maximum throughput for single user
+# Simple mode
 vllm-mlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
 
 # Continuous batching - for multiple concurrent users
@@ -31,7 +92,7 @@ Or with curl:
 ```bash
 curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model": "default", "messages": [{"role": "user", "content": "Hello!"}]}'
+  -d '{"model": "mlx-community/Llama-3.2-3B-Instruct-4bit", "messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
 ## Option 2: Direct Python API
@@ -69,7 +130,7 @@ vllm-mlx serve mlx-community/Qwen3-VL-4B-Instruct-3bit --port 8000
 
 ```python
 response = client.chat.completions.create(
-    model="default",
+    model="mlx-community/Qwen3-VL-4B-Instruct-3bit",
     messages=[{
         "role": "user",
         "content": [
@@ -91,7 +152,7 @@ vllm-mlx serve mlx-community/Qwen3-8B-4bit --reasoning-parser qwen3
 
 ```python
 response = client.chat.completions.create(
-    model="default",
+    model="mlx-community/Qwen3-8B-4bit",
     messages=[{"role": "user", "content": "What is 17 × 23?"}]
 )
 print(response.choices[0].message.content)  # Final answer

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,6 +28,12 @@ If port 8000 is occupied, choose a free port and change it in every URL; do not
 terminate an unfamiliar process. Keep the host on loopback for local use.
 Stop the server with Ctrl-C before starting a different model.
 
+The minimal command uses the default engine without continuous batching.
+After the first response, stop it and add `--continuous-batching` to the same
+serve command to try that engine. See the
+[continuous-batching guide](../guides/continuous-batching.md) for its cache
+options and supported configurations.
+
 If a CLI flag is unrecognized, check `vllm-mlx serve --help` in the same
 environment and the installed release. Do not copy options from newer source
 documentation into an older wheel. Download/authentication failures belong to


### PR DESCRIPTION
## Summary

Give first-time users one isolated, version-pinned install-to-response path before introducing advanced features. Keep editable development installs separate and remove the 30-second setup claim.

The existing examples also used three unrecognized flags and an unconfigured `default` model alias. This corrects those against the published 0.4.1 wheel, adds health/model-ID checks, and distinguishes vendor artifacts from lower-memory derivatives without claiming equivalent quality or universal feature support. It links the existing coding-client work in #774 rather than adding another client setup system.

## Validation

- Checked the published wheel hash against PyPI, CLI flag definitions and health/model/chat routes.
- Executed the wheel's isolated model-name validator: unconfigured `default` returns 404; the example's actual served ID is accepted.
- Dependency resolution dry-run passes in an isolated Python 3.12 environment.
- Shell examples pass syntax checks; relative file links and `git diff --check` pass.

Documentation only. No fresh model download, model smoke test, inference-suite run, or performance/quality qualification is claimed. The server version pin is not a lock of every transitive dependency.
