### PR TITLE
Fix Qwen SpecPrefill dispatch and MTP-off continuation

### DIFF
--- a/tests/test_simple_engine.py
+++ b/tests/test_simple_engine.py
@@ -2113,7 +2113,8 @@ class TestSimpleEngineConcurrency:
         assert seen["tokens"] == [10, 11, 12, 13]
 
     @pytest.mark.anyio
-    async def test_specprefill_success_preserves_mtp_path(self):
+    @pytest.mark.parametrize("mtp", [False, True])
+    async def test_specprefill_success_preserves_mtp_path(self, mtp):
         """Successful sparse prefill should continue through the normal MTP path."""
         from types import SimpleNamespace
 
@@ -2148,13 +2149,13 @@ class TestSimpleEngineConcurrency:
         )
 
         text_model = MagicMock()
-        text_model.mtp = object()
+        text_model.mtp = object() if mtp else None
         text_model.make_mtp_cache.return_value = ["mtp-cache"]
 
         engine = SimpleEngine(
             "test-model",
             force_mllm=True,
-            mtp=True,
+            mtp=mtp,
             mtp_num_draft_tokens=4,
             specprefill_enabled=True,
             specprefill_threshold=1,
@@ -2209,8 +2210,12 @@ class TestSimpleEngineConcurrency:
             "min_p": 0.0,
         }
         assert captured["prompt"] == [17]
-        assert captured["kwargs"]["mtp"] is True
-        assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
+        if mtp:
+            assert captured["kwargs"]["mtp"] is True
+            assert captured["kwargs"]["prompt_cache"] == ["backbone-cache", "mtp-cache"]
+        else:
+            assert "mtp" not in captured["kwargs"]
+            assert captured["kwargs"]["prompt_cache"] == ["backbone-cache"]
         assert captured["kwargs"]["max_tokens"] == 3
         assert captured["kwargs"]["logits_processors"] is None
         assert captured["select_chunks_kwargs"]["backbone_pct"] == 0.25

--- a/tests/test_specprefill_query_dispatch.py
+++ b/tests/test_specprefill_query_dispatch.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import mlx.nn as nn
+import pytest
+
+from vllm_mlx import specprefill
+
+
+def test_empty_rope_module_is_preserved():
+    rope = nn.RoPE(16)
+    assert not rope
+    assert specprefill._get_rope(SimpleNamespace(rope=rope)) is rope
+
+
+@pytest.mark.parametrize("identity", ["model_type", "config"])
+def test_score_tokens_selects_qwen_gated_queries(monkeypatch, identity):
+    attention = SimpleNamespace(
+        rope=nn.RoPE(16), num_attention_heads=2, num_key_value_heads=1
+    )
+    model = SimpleNamespace(layers=[SimpleNamespace(self_attn=attention)])
+    if identity == "config":
+        model.config = SimpleNamespace(model_type="qwen3_5")
+    else:
+        model.model_type = "qwen3_5"
+    monkeypatch.setattr(
+        specprefill, "_find_attention_layers", lambda _: [(0, model.layers[0])]
+    )
+    monkeypatch.setattr(specprefill, "make_prompt_cache", lambda _: [])
+    monkeypatch.setattr(specprefill, "_prefill_draft", lambda *args, **kwargs: None)
+
+    class CaptureReached(Exception):
+        pass
+
+    def capture(model, query_buffer, query_extractor):
+        assert query_extractor is specprefill._qwen35_extract_queries
+        raise CaptureReached
+
+    monkeypatch.setattr(specprefill, "_patch_attention_for_capture", capture)
+    with pytest.raises(CaptureReached):
+        specprefill.score_tokens(model, [1, 2, 3])

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -3245,7 +3245,7 @@ class SimpleEngine(BaseEngine):
                     prefill_step_size=self._prefill_step_size,
                     logits_processors=seeded_processors,
                     prompt_cache=prompt_cache,
-                    mtp=use_mtp,
+                    **({"mtp": True} if use_mtp else {}),
                 ):
                     if abort_event.is_set():
                         logger.info(

--- a/vllm_mlx/specprefill.py
+++ b/vllm_mlx/specprefill.py
@@ -328,7 +328,9 @@ def score_tokens(
     # Auto-detect query extractor from model_type (explicit registry, not
     # attribute sniffing -- avoids silent misclassification on new models).
     if query_extractor is None:
-        model_type = getattr(getattr(model, "config", None), "model_type", "")
+        model_type = getattr(model, "model_type", None) or getattr(
+            getattr(model, "config", None), "model_type", ""
+        )
         _EXTRACTOR_REGISTRY = {
             "qwen3_5": _qwen35_extract_queries,
             "qwen3_5_moe": _qwen35_extract_queries,
@@ -644,7 +646,8 @@ def _get_rope(attn):
 
     mlx_lm models use ``self.rope``; mlx_vlm models use ``self.rotary_emb``.
     """
-    return getattr(attn, "rope", None) or getattr(attn, "rotary_emb", None)
+    rope = getattr(attn, "rope", None)
+    return rope if rope is not None else getattr(attn, "rotary_emb", None)
 
 
 def _set_rope(attn, rope_module):


### PR DESCRIPTION
## Summary

Fix three compatibility checks that made Qwen draft-backed SpecPrefill fall
back to dense generation:

- Read `model.model_type` as well as the existing config-based identity, so
  mlx-lm's Qwen draft selects the gated Qwen query extractor.
- Check RoPE presence with `is not None`. An empty `nn.RoPE` module is falsey
  but still supplies positional encoding.
- Omit `mtp` from sparse continuation when MTP is off. Passing `mtp=False`
  reaches an unsupported `generate_step` keyword on mlx-lm 0.31.3.

The MTP-on call remains unchanged. No model allowlist, default, dependency,
token selection, or cache policy changes.

## Verification

74 focused SimpleEngine, cancellation, query-dispatch, and rotating-cache
tests pass on this branch. The dispatch/RoPE regressions and MTP-off
continuation assertion failed before the fixes. Black and diff checks pass.

Separately, a local Runtime composition with these changes completed one
Qwen3.6-35B / Qwen3.5-2B text retrieval canary: 2,277 of 11,237 prompt tokens
selected, all three keys correct, normal completion, no fallback. Before the
fixes, the correct answer came only from dense fallback. This is not an
upstream-head hardware qualification, speed claim, or coverage for media,
continuous batching, MTP coexistence, Qwen27, or Qwen Next.
