### PR TITLE
fix(mllm): route vision-cache clears through batch_generator.vision_cache

### DIFF
--- a/tests/test_mllm_scheduler_cache_clear.py
+++ b/tests/test_mllm_scheduler_cache_clear.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #759.
+
+``MLLMScheduler.clear_runtime_caches()`` / ``.reset()`` used to reference a
+nonexistent ``self.vision_cache`` instead of the real generator-owned
+``self.batch_generator.vision_cache``, raising ``AttributeError`` (caught and
+masked as a soft error by the server). These tests build a bare scheduler via
+``__new__`` (no model/processor needed) with a fake batch generator, so they
+run without any model weights.
+"""
+
+from collections import deque
+
+from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+
+class FakeCache:
+    def __init__(self):
+        self.clear_calls = 0
+
+    def clear(self) -> None:
+        self.clear_calls += 1
+
+
+class FakeBatchGenerator:
+    def __init__(self, vision_cache, prefix_cache, call_order=None):
+        self.vision_cache = vision_cache
+        self.prefix_cache = prefix_cache
+        self._call_order = call_order if call_order is not None else []
+        self.closed = False
+
+    def close(self) -> None:
+        self._call_order.append("close")
+        self.closed = True
+
+
+def _bare_scheduler() -> MLLMScheduler:
+    """Build an MLLMScheduler without running __init__ (no model needed)."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.requests = {}
+    scheduler.waiting = deque()
+    scheduler.running = {}
+    scheduler.finished_req_ids = set()
+    scheduler.request_id_to_uid = {}
+    scheduler.uid_to_request_id = {}
+    scheduler._detokenizer_pool = {}
+    scheduler.batch_generator = None
+    return scheduler
+
+
+def test_clear_runtime_caches_clears_both_vision_and_prefix_caches():
+    scheduler = _bare_scheduler()
+    vision_cache = FakeCache()
+    prefix_cache = FakeCache()
+    scheduler.batch_generator = FakeBatchGenerator(vision_cache, prefix_cache)
+
+    cleared = scheduler.clear_runtime_caches()
+
+    assert cleared == {"vision_cache": True, "prefix_cache": True}
+    assert vision_cache.clear_calls == 1
+    assert prefix_cache.clear_calls == 1
+
+
+def test_reset_clears_vision_cache_before_generator_close():
+    scheduler = _bare_scheduler()
+    call_order: list = []
+    vision_cache = FakeCache()
+
+    real_clear = vision_cache.clear
+
+    def tracked_clear():
+        call_order.append("vision_clear")
+        real_clear()
+
+    vision_cache.clear = tracked_clear
+    prefix_cache = FakeCache()
+    generator = FakeBatchGenerator(vision_cache, prefix_cache, call_order=call_order)
+    scheduler.batch_generator = generator
+
+    # Must not raise AttributeError on a nonexistent scheduler.vision_cache.
+    scheduler.reset()
+
+    assert vision_cache.clear_calls == 1
+    assert call_order == ["vision_clear", "close"]
+    assert scheduler.batch_generator is None

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1295,8 +1295,11 @@ class MLLMScheduler:
             "vision_cache": False,
             "prefix_cache": False,
         }
-        if self.vision_cache:
-            self.vision_cache.clear()
+        if (
+            self.batch_generator is not None
+            and self.batch_generator.vision_cache is not None
+        ):
+            self.batch_generator.vision_cache.clear()
             cleared["vision_cache"] = True
         if (
             self.batch_generator is not None
@@ -1321,8 +1324,7 @@ class MLLMScheduler:
         self._detokenizer_pool.clear()
 
         if self.batch_generator is not None:
+            if self.batch_generator.vision_cache is not None:
+                self.batch_generator.vision_cache.clear()
             self.batch_generator.close()
             self.batch_generator = None
-
-        if self.vision_cache:
-            self.vision_cache.clear()


### PR DESCRIPTION
Fixes #759

## Scope

Narrow fix per maintainer request on #759: `MLLMScheduler.clear_runtime_caches()` and `.reset()` referenced a nonexistent `self.vision_cache`, raising `AttributeError` (caught and masked as a soft error by `server.py`'s `clear_cache()`, so `DELETE /v1/cache` reported `"status":"cleared"` while nothing was actually cleared for MLLM-routed models). The real vision cache lives on `self.batch_generator.vision_cache`, set in `MLLMBatchGenerator.__init__` (`mllm_batch_generator.py:576`). Registry routing (#760) is kept strictly out of scope.

## Changes

- `vllm_mlx/mllm_scheduler.py`:
  - `clear_runtime_caches()` (`:1298`): replaced `self.vision_cache` with the same guarded `self.batch_generator is not None` pattern already used by the adjacent `prefix_cache` clear three lines below, reaching `self.batch_generator.vision_cache`.
  - `reset()` (`:1326`): per the maintainer's correction on #759 — `reset()` calls `self.batch_generator.close()` and sets `self.batch_generator = None` *before* the old vision-cache block, so a naive in-place attribute swap would make the vision clear unreachable. The fix clears `self.batch_generator.vision_cache` first, inside the same `if self.batch_generator is not None:` guard, before `close()`/nulling.
- `tests/test_mllm_scheduler_cache_clear.py`: two new focused fake-generator tests, as scoped by the maintainer (no model run needed):
  - `test_clear_runtime_caches_clears_both_vision_and_prefix_caches` — asserts both generator-owned caches are cleared and both keys in the returned dict report `True`.
  - `test_reset_clears_vision_cache_before_generator_close` — asserts the vision-cache clear happens before `batch_generator.close()` (via call-order tracking) and that `reset()` never touches a nonexistent `self.vision_cache` (the bare scheduler fixture genuinely lacks that attribute, so a regression would fail with the original `AttributeError`).

  Both tests build a bare `MLLMScheduler` via `__new__` with a fake batch generator — no model/processor weights required.

## Type of change

- Bug fix

## Surface touched

- MLLM scheduler cache-clear paths (`clear_runtime_caches()`, `reset()`)

## Test plan

```
pytest tests/test_mllm_scheduler_cache_clear.py tests/test_prefix_cache_scheduler_parity.py tests/test_scheduler_max_kv_size.py tests/test_server_cache_controls.py -v
ruff check vllm_mlx/mllm_scheduler.py tests/test_mllm_scheduler_cache_clear.py
ruff format --check vllm_mlx/mllm_scheduler.py tests/test_mllm_scheduler_cache_clear.py
```

## Test results

```
$ pytest tests/test_mllm_scheduler_cache_clear.py tests/test_prefix_cache_scheduler_parity.py tests/test_scheduler_max_kv_size.py tests/test_server_cache_controls.py -v
42 passed in 1.61s

$ ruff check vllm_mlx/mllm_scheduler.py tests/test_mllm_scheduler_cache_clear.py
All checks passed!

$ ruff format --check vllm_mlx/mllm_scheduler.py tests/test_mllm_scheduler_cache_clear.py
2 files already formatted
```

Also confirmed both new tests reproduce the exact reported `AttributeError: 'MLLMScheduler' object has no attribute 'vision_cache'` when run against pre-fix `mllm_scheduler.py` (`git stash` sanity check), and pass with the fix applied.

## Risk notes

Two-line-shape fix scoped to the two call sites named in #759, mirroring the pattern already used for `prefix_cache` clearing right next to each. No behavior change to registry routing (#760, out of scope) or any other scheduler path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PujPZVZSFQZrqcHodd7qVR