### PR TITLE
fix(cli): resolve MLLM/LLM routing from config.json before engine selection

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -8,10 +8,13 @@ from vllm_mlx/api/utils.py. No MLX dependency.
 
 import json
 
+import pytest
+
 from vllm_mlx.api.models import ContentPart, ImageUrl, Message
 from vllm_mlx.api.utils import (
     MLLM_PATTERNS,
     SPECIAL_TOKENS_PATTERN,
+    MllmRouteUndetermined,
     _check_legacy_string_patterns,
     _config_indicates_vlm,
     _content_to_text,
@@ -20,6 +23,7 @@ from vllm_mlx.api.utils import (
     extract_multimodal_content,
     is_mllm_model,
     is_vlm_model,
+    resolve_mllm_route,
 )
 
 
@@ -318,6 +322,100 @@ class TestIsMllmModelConfigPriority:
 
     def test_config_indicates_vlm_handles_non_list_architectures(self):
         assert _config_indicates_vlm({"architectures": "Qwen3ForCausalLM"}) is False
+
+
+class TestResolveMllmRoute:
+    """Tests for resolve_mllm_route, the config-json-first routing decision
+    used ahead of engine construction on the single-model CLI path.
+
+    Regression coverage for issue #748: a bare HF repo id (no local
+    directory to inspect yet) used to bypass config.json inspection
+    entirely and fall straight to the legacy substring matcher, so a model
+    like "mlx-community/Qwen3.8-27B-8bit" (declares vision_config, but
+    matches no MLLM_PATTERNS entry) silently routed to the text-only
+    engine. resolve_mllm_route is meant to be called with an
+    already-resolved local snapshot path (e.g. from
+    ensure_model_downloaded()) so this same repo id gets authoritative
+    config.json inspection instead.
+    """
+
+    @staticmethod
+    def _write_config(tmp_path, name, payload):
+        model_dir = tmp_path / name
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps(payload))
+        return model_dir
+
+    def test_explicit_override_wins_regardless_of_config(self, tmp_path):
+        model_dir = self._write_config(
+            tmp_path,
+            "text-model",
+            {"architectures": ["Qwen3ForCausalLM"]},
+        )
+        route = resolve_mllm_route(
+            "mlx-community/text-model", str(model_dir), force_mllm=True
+        )
+        assert route.is_mllm is True
+        assert route.source == "explicit"
+
+    def test_bare_repo_id_with_resolved_vlm_config_routes_mllm(self, tmp_path):
+        # "Qwen3.8" matches nothing in MLLM_PATTERNS (the exact #748 repro),
+        # but its resolved config.json declares vision_config.
+        model_dir = self._write_config(
+            tmp_path,
+            "Qwen3.8-27B-8bit",
+            {"model_type": "qwen3_8", "vision_config": {"hidden_size": 1024}},
+        )
+        assert _check_legacy_string_patterns("mlx-community/Qwen3.8-27B-8bit") is False
+
+        route = resolve_mllm_route("mlx-community/Qwen3.8-27B-8bit", str(model_dir))
+
+        assert route.is_mllm is True
+        assert route.source == "config"
+
+    def test_bare_repo_id_with_resolved_text_only_config_routes_llm(self, tmp_path):
+        # An ordinary text-only repo: resolved config.json has no VLM
+        # markers, and the name matches no legacy pattern either.
+        model_dir = self._write_config(
+            tmp_path,
+            "Qwen3.8-27B-8bit",
+            {"model_type": "qwen3_8", "architectures": ["Qwen3ForCausalLM"]},
+        )
+
+        route = resolve_mllm_route("mlx-community/Qwen3.8-27B-8bit", str(model_dir))
+
+        assert route.is_mllm is False
+        assert route.source == "config"
+
+    def test_resolved_snapshot_missing_config_fails_closed(self, tmp_path):
+        # Resolution genuinely produced a snapshot directory (as
+        # ensure_model_downloaded() would), but it has no config.json and
+        # the repo id matches no legacy pattern either: refuse to guess.
+        model_dir = tmp_path / "mystery-repo"
+        model_dir.mkdir()
+
+        with pytest.raises(MllmRouteUndetermined):
+            resolve_mllm_route("someorg/mystery-repo", str(model_dir))
+
+    def test_resolved_snapshot_missing_config_but_name_matches_pattern(self, tmp_path):
+        model_dir = tmp_path / "llava-mystery"
+        model_dir.mkdir()
+
+        route = resolve_mllm_route("someorg/llava-mystery", str(model_dir))
+
+        assert route.is_mllm is True
+        assert route.source == "pattern"
+
+    def test_no_resolved_path_falls_back_to_pattern_like_before(self):
+        # Mirrors is_mllm_model()'s existing behaviour for callers that
+        # never resolved anything (e.g. bare repo id, no download step).
+        route = resolve_mllm_route("mlx-community/Qwen3-VL-4B-Instruct-3bit", None)
+        assert route.is_mllm is True
+        assert route.source == "pattern"
+
+        route = resolve_mllm_route("mlx-community/Qwen3-8B-4bit", None)
+        assert route.is_mllm is False
+        assert route.source == "pattern"
 
 
 class TestExtractMultimodalContent:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -109,6 +110,12 @@ def test_continuous_batching_forwards_prefill_step_size_to_scheduler_config(
     api = ModuleType("vllm_mlx.api")
     api_utils = ModuleType("vllm_mlx.api.utils")
     api_utils.is_mllm_model = lambda model: False
+    api_utils.MllmRouteUndetermined = RuntimeError
+    api_utils.resolve_mllm_route = (
+        lambda model_name, resolved_path=None, force_mllm=False: SimpleNamespace(
+            is_mllm=force_mllm, source="explicit" if force_mllm else "pattern"
+        )
+    )
 
     utils = ModuleType("vllm_mlx.utils")
     download = ModuleType("vllm_mlx.utils.download")
@@ -289,3 +296,150 @@ models:
 
     assert server._model_manager is not None
     assert server._model_manager.memory_budget_bytes == int(6.5 * (1024**3))
+
+
+class TestServeCommandMllmRouting:
+    """Regression coverage for issue #748, bound at the real single-model
+    CLI call site (cli.serve_command), not just the lower-level detection
+    helper.
+
+    Before the fix, is_mllm_model() only inspected config.json for inputs
+    that were already local directories, so a bare HF repo id like
+    "mlx-community/Qwen3.8-27B-8bit" always fell through to
+    MLLM_PATTERNS substring matching (which has no "Qwen3.8" entry) and
+    silently loaded the text-only engine. serve_command now resolves the
+    model first (reusing ensure_model_downloaded's own result) and
+    decides routing from that resolved snapshot's config.json before
+    calling load_model().
+    """
+
+    @staticmethod
+    def _write_config(tmp_path, name, payload):
+        model_dir = tmp_path / name
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps(payload))
+        return model_dir
+
+    def test_cached_bare_repo_id_routes_via_config_not_pattern(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """(a) A cached bare repo ID whose name matches no MLLM_PATTERNS
+        entry, but whose resolved config.json declares vision_config,
+        must route to the MLLM engine — with the decision attributed to
+        config, not pattern matching."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.utils import download
+
+        model_dir = self._write_config(
+            tmp_path,
+            "Qwen3.8-27B-8bit",
+            {"model_type": "qwen3_8", "vision_config": {"hidden_size": 1024}},
+        )
+        loaded = {}
+        monkeypatch.setattr(
+            download, "ensure_model_downloaded", lambda *a, **k: model_dir
+        )
+        monkeypatch.setattr(
+            server,
+            "load_model",
+            lambda *a, **k: loaded.update({"args": a, "kwargs": k}),
+        )
+        monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
+
+        with caplog.at_level("INFO"):
+            cli.serve_command(_serve_args(model="mlx-community/Qwen3.8-27B-8bit"))
+
+        assert loaded["args"][0] == str(model_dir)
+        assert loaded["kwargs"]["force_mllm"] is True
+        assert loaded["kwargs"]["served_model_name"] == "mlx-community/Qwen3.8-27B-8bit"
+        assert "MLLM" in caplog.text
+        assert "source=config" in caplog.text
+
+    def test_uncached_metadata_failure_fails_closed(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """(b) Resolution succeeds (a snapshot directory exists) but its
+        config.json is unreadable/missing, and the repo id matches no
+        legacy pattern either. Must refuse to silently default to the
+        text-only engine — load_model must never be called."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.utils import download
+
+        model_dir = tmp_path / "mystery-repo"
+        model_dir.mkdir()  # resolved, but no config.json inside
+        called = {}
+        monkeypatch.setattr(
+            download, "ensure_model_downloaded", lambda *a, **k: model_dir
+        )
+        monkeypatch.setattr(
+            server, "load_model", lambda *a, **k: called.setdefault("load_model", True)
+        )
+        monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
+
+        with pytest.raises(SystemExit) as exc:
+            cli.serve_command(_serve_args(model="someorg/mystery-repo"))
+
+        assert exc.value.code == 1
+        assert "someorg/mystery-repo" in capsys.readouterr().out
+        assert "load_model" not in called
+
+    def test_ordinary_text_only_repo_routes_llm(self, tmp_path, monkeypatch, caplog):
+        """(c) An ordinary text-only repo, resolved config.json has no
+        VLM markers and the name matches no legacy pattern: routes to the
+        LLM engine, decision attributed to config."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.utils import download
+
+        model_dir = self._write_config(
+            tmp_path,
+            "Qwen3.8-27B-8bit",
+            {"model_type": "qwen3_8", "architectures": ["Qwen3ForCausalLM"]},
+        )
+        loaded = {}
+        monkeypatch.setattr(
+            download, "ensure_model_downloaded", lambda *a, **k: model_dir
+        )
+        monkeypatch.setattr(
+            server,
+            "load_model",
+            lambda *a, **k: loaded.update({"args": a, "kwargs": k}),
+        )
+        monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
+
+        with caplog.at_level("INFO"):
+            cli.serve_command(_serve_args(model="mlx-community/Qwen3.8-27B-8bit"))
+
+        assert loaded["kwargs"]["force_mllm"] is False
+        assert "LLM" in caplog.text
+        assert "source=config" in caplog.text
+
+    def test_explicit_mllm_flag_short_circuits_config(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """--mllm still forces the MLLM route, and is reported as
+        "explicit" rather than "config", even when a resolved config.json
+        disagrees."""
+        from vllm_mlx import cli, server
+        from vllm_mlx.utils import download
+
+        model_dir = self._write_config(
+            tmp_path,
+            "text-model",
+            {"architectures": ["Qwen3ForCausalLM"]},
+        )
+        loaded = {}
+        monkeypatch.setattr(
+            download, "ensure_model_downloaded", lambda *a, **k: model_dir
+        )
+        monkeypatch.setattr(
+            server,
+            "load_model",
+            lambda *a, **k: loaded.update({"args": a, "kwargs": k}),
+        )
+        monkeypatch.setattr("uvicorn.run", lambda *a, **k: None)
+
+        with caplog.at_level("INFO"):
+            cli.serve_command(_serve_args(model="mlx-community/text-model", mllm=True))
+
+        assert loaded["kwargs"]["force_mllm"] is True
+        assert "source=explicit" in caplog.text

--- a/vllm_mlx/api/utils.py
+++ b/vllm_mlx/api/utils.py
@@ -6,6 +6,7 @@ Utility functions for text processing and model detection.
 import json
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 from .models import Message
@@ -495,6 +496,88 @@ def is_mllm_model(model_name: str) -> bool:
 
 # Backwards compatibility alias
 is_vlm_model = is_mllm_model
+
+
+class MllmRouteUndetermined(RuntimeError):
+    """Raised when MLLM/LLM routing cannot be determined from a resolved
+    model snapshot and no known name pattern or explicit override applies.
+
+    This is a fail-closed guard: it only fires when a config.json was
+    supposed to be available (the caller already resolved/downloaded the
+    model) but could not be read, and the model's name also matches
+    nothing in ``MLLM_PATTERNS``. Silently defaulting to the text-only
+    engine in that situation is exactly the bug this guards against.
+    """
+
+
+@dataclass(frozen=True)
+class MllmRoute:
+    """The outcome of an MLLM/LLM routing decision, and how it was made."""
+
+    is_mllm: bool
+    # "explicit": caller passed --mllm.
+    # "config": decided from a resolved snapshot's config.json.
+    # "pattern": config.json was unavailable; decided via MLLM_PATTERNS.
+    source: str
+
+
+def resolve_mllm_route(
+    model_name: str,
+    resolved_path: str | Path | None = None,
+    *,
+    force_mllm: bool = False,
+) -> MllmRoute:
+    """Determine MLLM/LLM routing from an already-resolved local snapshot.
+
+    Unlike ``is_mllm_model()``, which only inspects config.json for inputs
+    that are already local directories, this is meant to be called with
+    ``resolved_path`` set to a snapshot that a caller has just downloaded
+    (e.g. via ``ensure_model_downloaded()``) — so a bare HF repo id gets
+    the same authoritative config.json inspection a local path does,
+    without a second network lookup.
+
+    Args:
+        model_name: the original CLI/user-facing model identifier (bare
+            repo id or path). Used only for the legacy pattern fallback.
+        resolved_path: a local directory already resolved for
+            ``model_name`` (e.g. the return value of
+            ``ensure_model_downloaded()``), if one is available.
+        force_mllm: explicit user override (e.g. ``--mllm``).
+
+    Returns:
+        The routing decision and which signal produced it.
+
+    Raises:
+        MllmRouteUndetermined: ``resolved_path`` was given but its
+            config.json could not be read, and ``model_name`` matches no
+            entry in ``MLLM_PATTERNS`` either.
+    """
+    if force_mllm:
+        return MllmRoute(True, "explicit")
+
+    config = (
+        _try_read_config_json(str(resolved_path)) if resolved_path is not None else None
+    )
+    if config is not None:
+        return MllmRoute(_config_indicates_vlm(config), "config")
+
+    if _check_legacy_string_patterns(model_name):
+        return MllmRoute(True, "pattern")
+
+    # Only fail closed when resolution genuinely produced a snapshot
+    # directory whose config.json we still couldn't read — that's a real
+    # metadata failure. A resolved_path that isn't an actual directory
+    # (e.g. resolution wasn't really performed) has nothing more to go
+    # on than the pattern check already ran, so fall through like before.
+    if resolved_path is not None and Path(resolved_path).is_dir():
+        raise MllmRouteUndetermined(
+            f"Cannot determine whether '{model_name}' is a multimodal "
+            f"model: its resolved config.json at '{resolved_path}' could "
+            "not be read, and its name matches no known multimodal "
+            "pattern. Pass --mllm explicitly if this model is multimodal."
+        )
+
+    return MllmRoute(False, "pattern")
 
 
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -240,8 +240,12 @@ def serve_command(args):
     )
     print("=" * 60)
 
-    # Pre-download model with retry/timeout
-    from .api.utils import is_mllm_model
+    # Pre-download model with retry/timeout, and resolve the MLLM/LLM
+    # routing decision from that same resolved snapshot's config.json
+    # (rather than filename heuristics) before engine construction. This
+    # reuses the download's own resolution, so a bare HF repo id gets an
+    # authoritative check with no second network lookup.
+    from .api.utils import MllmRouteUndetermined, is_mllm_model, resolve_mllm_route
     from .utils.download import DownloadConfig, ensure_model_downloaded
 
     download_config = DownloadConfig(
@@ -249,11 +253,30 @@ def serve_command(args):
         max_retries=args.download_retries,
         offline=getattr(args, "offline", False),
     )
+    resolved_model_path = None
+    mllm_route = None
     if model_arg:
-        ensure_model_downloaded(
+        resolved = ensure_model_downloaded(
             model_arg,
             config=download_config,
+            # This guess only selects which files to fetch; the actual
+            # MLLM/LLM routing decision is made below from the resolved
+            # snapshot's config.json.
             is_mllm=is_mllm_model(model_arg),
+        )
+        resolved_model_path = str(resolved) if resolved is not None else None
+        try:
+            mllm_route = resolve_mllm_route(
+                model_arg,
+                resolved_model_path,
+                force_mllm=getattr(args, "mllm", False),
+            )
+        except MllmRouteUndetermined as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+        logger.info(
+            f"Model route: {'MLLM' if mllm_route.is_mllm else 'LLM'} "
+            f"(source={mllm_route.source})"
         )
         if args.lazy_load_model:
             print(f"Registering model for lazy load: {model_arg}")
@@ -419,17 +442,22 @@ def serve_command(args):
             memory_budget_gb=memory_budget_gb,
         )
     else:
-        # Load model with unified server
+        # Load model with unified server. Pass the already-resolved local
+        # snapshot (not the raw repo id) so loaders don't re-resolve it,
+        # and force the routing decision made above so it can't silently
+        # disagree with a second, independent is_mllm_model() re-check.
         load_model(
-            model_arg,
+            resolved_model_path or model_arg,
             use_batching=args.continuous_batching,
             scheduler_config=scheduler_config,
             stream_interval=args.stream_interval if args.continuous_batching else 1,
             max_tokens=args.max_tokens,
             max_request_tokens=max_request_tokens,
-            force_mllm=getattr(args, "mllm", False),
+            force_mllm=(
+                mllm_route.is_mllm if mllm_route else getattr(args, "mllm", False)
+            ),
             gpu_memory_utilization=args.gpu_memory_utilization,
-            served_model_name=args.served_model_name,
+            served_model_name=args.served_model_name or model_arg,
             trust_remote_code=trust_remote_code,
             mtp=args.enable_mtp,
             prefill_step_size=args.prefill_step_size,


### PR DESCRIPTION
## Summary

Fixes #748. `is_mllm_model()` only inspects `config.json` for inputs that are already local directories. A bare HF repo id passed to the single-model `serve` CLI (e.g. `mlx-community/Qwen3.8-27B-8bit`) is never a local directory before its weights are downloaded, so detection always fell straight to `MLLM_PATTERNS` substring matching — which has no `"Qwen3.8"` entry — and silently loaded the text-only engine even though the model's own `config.json` declares `vision_config`.

**Shape implemented: (1), resolve-before-route, reusing the existing download resolution.** This was fully feasible: `serve_command` already calls `ensure_model_downloaded()` to pre-fetch the model before `load_model()`, but discarded the resolved local snapshot path it returned. This PR captures it instead.

### What changed

- `vllm_mlx/api/utils.py`: new `resolve_mllm_route(model_name, resolved_path, *, force_mllm)` — inspects the *resolved* snapshot's `config.json` (authoritative), falling back to the legacy `MLLM_PATTERNS` matcher only when `config.json` can't be read, and raising `MllmRouteUndetermined` (fail-closed, shape 2) in the residual case where a snapshot directory was genuinely resolved but its config is unreadable/missing *and* the name matches nothing in the pattern list either. `is_mllm_model()` itself is untouched — every existing caller (registry path, tokenizer fallback, etc.) is unaffected.
- `vllm_mlx/cli.py` (`serve_command`, the single-model CLI call site): captures the `Path` `ensure_model_downloaded()` already returns, calls `resolve_mllm_route()` against it, and threads the *resolved snapshot path* (not the raw repo id) into `load_model()` along with the resolved `force_mllm` decision — so the engine's own loader doesn't re-resolve the model a second time over the network, and can't silently re-derive a different answer via its own internal `is_mllm_model()` call. `served_model_name` now defaults to the original repo id so API-facing model names (`/v1/models`, etc.) are unaffected by loading from a local path.
- The routing decision and its source are now logged at startup: `Model route: MLLM (source=config)` / `... (source=explicit)` / `... (source=pattern)`.

No second network lookup is introduced — the pre-download that already happened is what's being reused.

## Test plan

Per the maintainer's acceptance criteria, tests bind the real single-model CLI call site (`cli.serve_command`), not just the lower-level helper:

- [x] `tests/test_cli.py::TestServeCommandMllmRouting::test_cached_bare_repo_id_routes_via_config_not_pattern` — (a) a bare repo id whose name matches no `MLLM_PATTERNS` entry but whose resolved `config.json` declares `vision_config` routes to MLLM, attributed to `source=config`.
- [x] `tests/test_cli.py::TestServeCommandMllmRouting::test_uncached_metadata_failure_fails_closed` — (b) a resolved snapshot with no readable `config.json` and a non-matching name fails closed (`SystemExit(1)`, actionable message, `load_model` never called) instead of silently defaulting to the text-only engine.
- [x] `tests/test_cli.py::TestServeCommandMllmRouting::test_ordinary_text_only_repo_routes_llm` — (c) an ordinary text-only repo (no VLM markers, no pattern match) still correctly routes to LLM.
- [x] `tests/test_cli.py::TestServeCommandMllmRouting::test_explicit_mllm_flag_short_circuits_config` — `--mllm` still overrides and is reported as `source=explicit`.
- [x] `tests/test_api_utils.py::TestResolveMllmRoute` — unit coverage for `resolve_mllm_route()` itself (explicit / config-true / config-false / fail-closed / pattern-fallback-without-resolution).
- [x] Updated the two existing `test_cli.py`/mocked-module tests that stub `vllm_mlx.api.utils` wholesale, so they expose the new `resolve_mllm_route`/`MllmRouteUndetermined` names.

Ran:
```
python -m pytest tests/test_api_utils.py tests/test_cli.py tests/test_lifecycle_cli.py tests/test_simple_engine.py tests/test_batched_engine.py tests/test_server.py -q
# 382 passed, 3 deselected

ruff check vllm_mlx/ tests/
# All checks passed!
```
No model inference or benchmark run, per the issue's scope note. The registry (`--models-config`) path is untouched, as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd2MuriqTy1XruWLGtjZak