### PR TITLE
feat: OpenAI-compatible logprobs for chat and text completions (continuous batching)

### DIFF
--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -112,6 +112,36 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
+#### Log probabilities
+
+With `--continuous-batching`, chat completions accept `logprobs: true` and
+`top_logprobs` (0-20), and text completions accept `logprobs` (0-5). The
+server then returns OpenAI-format per-token log probabilities, both streaming
+and non-streaming:
+
+```python
+response = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello!"}],
+    logprobs=True,
+    top_logprobs=5,
+)
+for token in response.choices[0].logprobs.content:
+    print(token.token, token.logprob)
+```
+
+Notes:
+
+- Values are taken after logits processors (JSON-schema constraints,
+  `logit_bias`, repetition and presence penalties) and before temperature,
+  top-p, top-k and min-p.
+- They cover every generated token except the final stop token. The server
+  post-processes text for reasoning and tool-call parsing, `response_format`
+  JSON normalization and whitespace trimming, so `message.content` can differ
+  from the concatenated tokens.
+- Requests that ask for logprobs skip speculative (MTP or drafter) decoding.
+- The default simple engine returns HTTP 400 for logprobs requests.
+
 ### Completions
 
 ```bash

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -140,6 +140,9 @@ Notes:
   JSON normalization and whitespace trimming, so `message.content` can differ
   from the concatenated tokens.
 - Requests that ask for logprobs skip speculative (MTP or drafter) decoding.
+- Batched forward passes accumulate floating-point results in a different
+  order from single requests, so values can differ slightly between batched
+  and unbatched runs. At an exact tie this can also flip the greedy token.
 - The default simple engine returns HTTP 400 for logprobs requests.
 
 ### Completions

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -139,7 +139,12 @@ Notes:
   post-processes text for reasoning and tool-call parsing, `response_format`
   JSON normalization and whitespace trimming, so `message.content` can differ
   from the concatenated tokens.
-- Requests that ask for logprobs skip speculative (MTP or drafter) decoding.
+- Requests that ask for logprobs never receive speculatively drafted tokens:
+  they skip multimodal MTP and drafter decoding. The LLM path's MTP hook is
+  inactive with mlx-lm 0.31 and later.
+- `token` and `bytes` come from decoding each token on its own, so a token
+  that is only part of a multi-byte UTF-8 character reports the replacement
+  character (U+FFFD), as in vLLM.
 - Batched forward passes accumulate floating-point results in a different
   order from single requests, so values can differ slightly between batched
   and unbatched runs. At an exact tie this can also flip the greedy token.

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -475,6 +475,19 @@ class TestLogprobs:
                 top_logprobs=21,
             )
 
+    def test_chat_request_accepts_zero_top_logprobs(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            logprobs=True,
+            top_logprobs=0,
+        )
+        assert req.top_logprobs == 0
+
+    def test_completion_request_rejects_negative_logprobs(self):
+        with pytest.raises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hi", logprobs=-1)
+
     def test_completion_request_logprobs_bounds(self):
         req = CompletionRequest(model="test-model", prompt="Hi", logprobs=5)
         assert req.logprobs == 5

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -23,7 +23,10 @@ from vllm_mlx.api.models import (
     ChatCompletionChoice,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChatCompletionTokenLogprob,
+    ChoiceLogprobs,
     CompletionChoice,
+    CompletionLogprobs,
     CompletionRequest,
     CompletionResponse,
     ContentPart,
@@ -46,6 +49,7 @@ from vllm_mlx.api.models import (
     StreamOptions,
     ToolCall,
     ToolDefinition,
+    TopLogprob,
     Usage,
     VideoUrl,
     AudioUrl,
@@ -432,6 +436,94 @@ class TestTextCompletion:
         assert resp.object == "text_completion"
         assert resp.id.startswith("cmpl-")
         assert len(resp.choices) == 1
+
+
+class TestLogprobs:
+    """Tests for OpenAI-compatible logprobs request fields and response models."""
+
+    def test_chat_request_logprobs_default_none(self):
+        req = ChatCompletionRequest(
+            model="test-model", messages=[{"role": "user", "content": "Hi"}]
+        )
+        assert req.logprobs is None
+        assert req.top_logprobs is None
+
+    def test_chat_request_accepts_logprobs_and_top_logprobs(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+            logprobs=True,
+            top_logprobs=20,
+        )
+        assert req.logprobs is True
+        assert req.top_logprobs == 20
+
+    def test_chat_request_rejects_top_logprobs_without_logprobs(self):
+        with pytest.raises(ValidationError, match="logprobs"):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                top_logprobs=3,
+            )
+
+    def test_chat_request_rejects_top_logprobs_above_20(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                logprobs=True,
+                top_logprobs=21,
+            )
+
+    def test_completion_request_logprobs_bounds(self):
+        req = CompletionRequest(model="test-model", prompt="Hi", logprobs=5)
+        assert req.logprobs == 5
+        with pytest.raises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hi", logprobs=6)
+
+    def test_chat_choice_logprobs_default_none(self):
+        choice = ChatCompletionChoice(message=AssistantMessage(content="Hi"))
+        assert choice.model_dump()["logprobs"] is None
+
+    def test_chat_choice_with_token_logprobs(self):
+        token = ChatCompletionTokenLogprob(
+            token="Hi",
+            logprob=-0.25,
+            bytes=[72, 105],
+            top_logprobs=[
+                TopLogprob(token="Hi", logprob=-0.25, bytes=[72, 105]),
+                TopLogprob(token="Hey", logprob=-1.5, bytes=[72, 101, 121]),
+            ],
+        )
+        choice = ChatCompletionChoice(
+            message=AssistantMessage(content="Hi"),
+            logprobs=ChoiceLogprobs(content=[token]),
+        )
+        dumped = choice.model_dump()
+        assert dumped["logprobs"]["content"][0]["token"] == "Hi"
+        assert dumped["logprobs"]["content"][0]["top_logprobs"][1]["logprob"] == -1.5
+        assert dumped["logprobs"]["refusal"] is None
+
+    def test_chunk_choice_carries_logprobs(self):
+        chunk_choice = ChatCompletionChunkChoice(
+            delta=ChatCompletionChunkDelta(content="Hi"),
+            logprobs=ChoiceLogprobs(
+                content=[ChatCompletionTokenLogprob(token="Hi", logprob=-0.1)]
+            ),
+        )
+        assert chunk_choice.logprobs.content[0].top_logprobs == []
+
+    def test_completion_choice_legacy_logprobs(self):
+        choice = CompletionChoice(
+            text=" there",
+            logprobs=CompletionLogprobs(
+                tokens=[" there"],
+                token_logprobs=[-0.5],
+                top_logprobs=[{" there": -0.5, " here": -1.2}],
+                text_offset=[0],
+            ),
+        )
+        assert choice.model_dump()["logprobs"]["token_logprobs"] == [-0.5]
 
 
 class TestModelsEndpoint:

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -74,6 +74,42 @@ class TestBatchedEngineGenerate:
         assert result.tokens == []
 
     @pytest.mark.anyio
+    async def test_logprobs_are_forwarded_and_returned(self):
+        """logprobs travel into SamplingParams and back out on the output."""
+        engine = self._make_engine()
+        mock_output = self._make_mock_request_output()
+        mock_output.output_logprobs = ["entry"]
+
+        mock_engine = MagicMock()
+        mock_engine.generate = AsyncMock(return_value=mock_output)
+        engine._engine = mock_engine
+
+        result = await engine.generate(prompt="test", max_tokens=10, logprobs=3)
+
+        sampling_params = mock_engine.generate.call_args.kwargs["sampling_params"]
+        assert sampling_params.logprobs == 3
+        assert result.logprobs == ["entry"]
+
+    @pytest.mark.anyio
+    async def test_mllm_logprobs_are_forwarded_and_returned(self):
+        """The MLLM route forwards logprobs to the scheduler and returns them."""
+        engine = self._make_engine()
+        engine._is_mllm = True
+        mock_output = self._make_mock_request_output()
+        mock_output.output_logprobs = ["entry"]
+        mock_output.mtp_drafts = 0
+        mock_output.mtp_accepted = 0
+
+        scheduler = MagicMock()
+        scheduler.generate = AsyncMock(return_value=mock_output)
+        engine._mllm_scheduler = scheduler
+
+        result = await engine.generate(prompt="test", max_tokens=10, logprobs=3)
+
+        assert scheduler.generate.call_args.kwargs["logprobs"] == 3
+        assert result.logprobs == ["entry"]
+
+    @pytest.mark.anyio
     async def test_other_output_fields_still_populated(self):
         """Existing fields (text, prompt_tokens, etc.) must remain correct."""
         engine = self._make_engine()

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for per-token logprob extraction and OpenAI formatting."""
+"""Tests for per-token logprob extraction, recording and OpenAI formatting."""
 
 import math
 from types import SimpleNamespace
@@ -13,14 +13,17 @@ from vllm_mlx.logprobs import (  # noqa: E402
     MAX_TOP_LOGPROBS,
     TokenLogprob,
     extract_token_logprob,
-    logprobs_for_step,
+    record_step_logprobs,
     to_chat_logprobs,
     to_completion_logprobs,
 )
+from vllm_mlx.request import RequestOutput, SamplingParams  # noqa: E402
 
 
 class _CharTokenizer:
     """Tokenizer stand-in that decodes token id ``i`` to ``chr(ord('a') + i)``."""
+
+    clean_up_tokenization_spaces = False
 
     def decode(self, ids):
         return "".join(chr(ord("a") + i) for i in ids)
@@ -31,10 +34,14 @@ def _log_softmax(values):
     return logits - mx.logsumexp(logits)
 
 
-def _expected(values, index):
+def _reference_logprob(values, index):
     top = max(values)
     total = sum(math.exp(v - top) for v in values)
     return values[index] - top - math.log(total)
+
+
+def _entry(token_id, token, logprob=-0.5):
+    return TokenLogprob(token_id=token_id, token=token, logprob=logprob)
 
 
 class TestExtractTokenLogprob:
@@ -44,12 +51,13 @@ class TestExtractTokenLogprob:
 
         assert entry.token_id == 2
         assert entry.token == "c"
-        assert entry.logprob == pytest.approx(_expected(values, 2), abs=1e-5)
-        assert [(tid, tok) for tid, tok, _ in entry.top_logprobs] == [
-            (1, "b"),
-            (3, "d"),
-        ]
-        assert entry.top_logprobs[0][2] == pytest.approx(_expected(values, 1), abs=1e-5)
+        assert entry.logprob == pytest.approx(_reference_logprob(values, 2), abs=1e-5)
+        (best_id, best_token, best_logprob), (next_id, next_token, _) = (
+            entry.top_logprobs
+        )
+        assert (best_id, best_token) == (1, "b")
+        assert (next_id, next_token) == (3, "d")
+        assert best_logprob == pytest.approx(_reference_logprob(values, 1), abs=1e-5)
 
     def test_zero_top_reports_only_the_sampled_token(self):
         entry = extract_token_logprob(_log_softmax([0.0, 1.0]), 1, 0, _CharTokenizer())
@@ -60,22 +68,26 @@ class TestExtractTokenLogprob:
         entry = extract_token_logprob(row, 1, 3, _CharTokenizer())
 
         assert entry.logprob == LOGPROB_FLOOR
-        assert all(math.isfinite(lp) for _, _, lp in entry.top_logprobs)
-        assert entry.top_logprobs[-1][2] == LOGPROB_FLOOR
+        top_values = [logprob for _, _, logprob in entry.top_logprobs]
+        assert all(math.isfinite(value) for value in top_values)
+        assert top_values[-1] == LOGPROB_FLOOR
 
     def test_placeholder_row_returns_none(self):
         # Error paths emit ``mx.zeros(1)`` instead of a vocabulary row.
         assert extract_token_logprob(mx.zeros(1), 5, 1, _CharTokenizer()) is None
 
     def test_top_is_capped(self):
-        row = _log_softmax([float(i) for i in range(MAX_TOP_LOGPROBS + 10)])
-        entry = extract_token_logprob(row, 0, 50, _CharTokenizer())
+        vocab_size = MAX_TOP_LOGPROBS + 10
+        row = _log_softmax([float(i) for i in range(vocab_size)])
+        entry = extract_token_logprob(row, 0, MAX_TOP_LOGPROBS + 30, _CharTokenizer())
         assert len(entry.top_logprobs) == MAX_TOP_LOGPROBS
 
 
-class TestLogprobsForStep:
-    def _request(self):
-        return SimpleNamespace(output_logprobs=None)
+class TestRecordStepLogprobs:
+    def _request(self, num_top):
+        return SimpleNamespace(
+            output_logprobs=None, sampling_params=SimpleNamespace(logprobs=num_top)
+        )
 
     def _response(self, token, finish_reason=None):
         return SimpleNamespace(
@@ -85,24 +97,23 @@ class TestLogprobsForStep:
         )
 
     def test_disabled_when_not_requested(self):
-        request = self._request()
-        assert (
-            logprobs_for_step(request, self._response(1), None, _CharTokenizer())
-            is None
-        )
+        request = self._request(None)
+        step = record_step_logprobs(request, self._response(1), _CharTokenizer())
+
+        assert step is None
         assert request.output_logprobs is None
 
     def test_appends_content_tokens(self):
-        request = self._request()
-        step = logprobs_for_step(request, self._response(2), 1, _CharTokenizer())
+        request = self._request(1)
+        step = record_step_logprobs(request, self._response(2), _CharTokenizer())
 
         assert [entry.token for entry in step] == ["c"]
         assert request.output_logprobs == step
 
     def test_stop_token_is_excluded(self):
-        request = self._request()
-        step = logprobs_for_step(
-            request, self._response(0, finish_reason="stop"), 1, _CharTokenizer()
+        request = self._request(1)
+        step = record_step_logprobs(
+            request, self._response(0, finish_reason="stop"), _CharTokenizer()
         )
 
         assert step == []
@@ -140,3 +151,131 @@ class TestFormatting:
         # The legacy format always includes the sampled token among the top ones.
         assert logprobs.top_logprobs[1] == {"!": -0.3}
         assert logprobs.top_logprobs[0] == {"Hé": -0.1, "Hi": -2.5}
+
+
+class TestOutputCollectorMerge:
+    """The collector merges outputs when the producer runs ahead of the consumer."""
+
+    def _merge(self, existing, new):
+        from vllm_mlx.output_collector import RequestOutputCollector
+
+        return RequestOutputCollector()._merge_outputs(existing, new)
+
+    def test_not_requested_stays_none(self):
+        merged = self._merge(RequestOutput("r"), RequestOutput("r"))
+        assert merged.new_logprobs is None
+        assert merged.output_logprobs is None
+
+    def test_step_entries_concatenate_and_latest_cumulative_wins(self):
+        first, second = _entry(0, "a"), _entry(1, "b")
+        existing = RequestOutput("r", new_logprobs=[first], output_logprobs=[first])
+        new = RequestOutput("r", new_logprobs=[second], output_logprobs=[first, second])
+
+        merged = self._merge(existing, new)
+
+        assert merged.new_logprobs == [first, second]
+        assert merged.output_logprobs == [first, second]
+
+    def test_requested_but_empty_is_preserved(self):
+        merged = self._merge(RequestOutput("r"), RequestOutput("r", new_logprobs=[]))
+        assert merged.new_logprobs == []
+
+
+class TestSchedulersRecordLogprobs:
+    """Both schedulers attach this step's entries and the cumulative list."""
+
+    def _mllm_scheduler(self, request):
+        from vllm_mlx.mllm_scheduler import MLLMScheduler
+
+        scheduler = MLLMScheduler.__new__(MLLMScheduler)
+        scheduler._detokenizer_pool = {}
+        scheduler.uid_to_request_id = {0: request.request_id}
+        scheduler.running = {request.request_id: request}
+        scheduler.total_completion_tokens = 0
+        scheduler.num_requests_processed = 0
+        scheduler.processor = SimpleNamespace(tokenizer=_CharTokenizer())
+        return scheduler
+
+    def _mllm_response(self, request, token, finish_reason=None):
+        from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
+
+        return MLLMBatchResponse(
+            uid=0,
+            request_id=request.request_id,
+            token=token,
+            logprobs=_log_softmax([0.0, 1.0, 2.0]),
+            finish_reason=finish_reason,
+        )
+
+    def _mllm_request(self, num_top):
+        from vllm_mlx.mllm_scheduler import MLLMRequest
+
+        return MLLMRequest(
+            request_id="req-1",
+            prompt="p",
+            sampling_params=SamplingParams(logprobs=num_top),
+        )
+
+    def test_mllm_scheduler_records_content_and_skips_stop(self):
+        request = self._mllm_request(1)
+        scheduler = self._mllm_scheduler(request)
+
+        (step,), _ = scheduler._process_batch_responses(
+            [self._mllm_response(request, 2)]
+        )
+        (last,), finished = scheduler._process_batch_responses(
+            [self._mllm_response(request, 0, finish_reason="stop")]
+        )
+
+        assert [entry.token for entry in step.new_logprobs] == ["c"]
+        assert last.new_logprobs == []
+        assert [entry.token for entry in last.output_logprobs] == ["c"]
+        assert finished == {"req-1"}
+
+    def test_mllm_scheduler_leaves_fields_unset_when_not_requested(self):
+        request = self._mllm_request(None)
+        scheduler = self._mllm_scheduler(request)
+
+        (step,), _ = scheduler._process_batch_responses(
+            [self._mllm_response(request, 2)]
+        )
+
+        assert step.new_logprobs is None
+        assert step.output_logprobs is None
+
+    def test_llm_scheduler_records_content_and_skips_stop(self):
+        from vllm_mlx.request import Request
+        from vllm_mlx.scheduler import Scheduler
+
+        request = Request(
+            request_id="req-1",
+            prompt="p",
+            sampling_params=SamplingParams(logprobs=1),
+        )
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._actual_tokenizer = _CharTokenizer()
+        scheduler._detokenizer_pool = {}
+        scheduler.uid_to_request_id = {0: "req-1"}
+        scheduler.running = {"req-1": request}
+        scheduler.block_aware_cache = None
+        scheduler.total_completion_tokens = 0
+        scheduler.num_requests_processed = 0
+        scheduler._store_prompt_only_cache = lambda request, response: None
+
+        def response(token, finish_reason=None):
+            return SimpleNamespace(
+                uid=0,
+                token=token,
+                logprobs=_log_softmax([0.0, 1.0, 2.0]),
+                finish_reason=finish_reason,
+            )
+
+        (step,), _ = scheduler._process_batch_responses([response(2)])
+        (last,), finished = scheduler._process_batch_responses(
+            [response(0, finish_reason="stop")]
+        )
+
+        assert [entry.token for entry in step.new_logprobs] == ["c"]
+        assert last.new_logprobs == []
+        assert [entry.token for entry in last.output_logprobs] == ["c"]
+        assert finished == {"req-1"}

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for per-token logprob extraction and OpenAI formatting."""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.logprobs import (  # noqa: E402
+    LOGPROB_FLOOR,
+    MAX_TOP_LOGPROBS,
+    TokenLogprob,
+    extract_token_logprob,
+    logprobs_for_step,
+    to_chat_logprobs,
+    to_completion_logprobs,
+)
+
+
+class _CharTokenizer:
+    """Tokenizer stand-in that decodes token id ``i`` to ``chr(ord('a') + i)``."""
+
+    def decode(self, ids):
+        return "".join(chr(ord("a") + i) for i in ids)
+
+
+def _log_softmax(values):
+    logits = mx.array(values, dtype=mx.float32)
+    return logits - mx.logsumexp(logits)
+
+
+def _expected(values, index):
+    top = max(values)
+    total = sum(math.exp(v - top) for v in values)
+    return values[index] - top - math.log(total)
+
+
+class TestExtractTokenLogprob:
+    def test_chosen_token_and_sorted_top(self):
+        values = [0.0, 3.0, 1.0, 2.0]
+        entry = extract_token_logprob(_log_softmax(values), 2, 2, _CharTokenizer())
+
+        assert entry.token_id == 2
+        assert entry.token == "c"
+        assert entry.logprob == pytest.approx(_expected(values, 2), abs=1e-5)
+        assert [(tid, tok) for tid, tok, _ in entry.top_logprobs] == [
+            (1, "b"),
+            (3, "d"),
+        ]
+        assert entry.top_logprobs[0][2] == pytest.approx(_expected(values, 1), abs=1e-5)
+
+    def test_zero_top_reports_only_the_sampled_token(self):
+        entry = extract_token_logprob(_log_softmax([0.0, 1.0]), 1, 0, _CharTokenizer())
+        assert entry.top_logprobs == []
+
+    def test_masked_logits_are_clamped_to_floor(self):
+        row = _log_softmax([0.0, -math.inf, 1.0])
+        entry = extract_token_logprob(row, 1, 3, _CharTokenizer())
+
+        assert entry.logprob == LOGPROB_FLOOR
+        assert all(math.isfinite(lp) for _, _, lp in entry.top_logprobs)
+        assert entry.top_logprobs[-1][2] == LOGPROB_FLOOR
+
+    def test_placeholder_row_returns_none(self):
+        # Error paths emit ``mx.zeros(1)`` instead of a vocabulary row.
+        assert extract_token_logprob(mx.zeros(1), 5, 1, _CharTokenizer()) is None
+
+    def test_top_is_capped(self):
+        row = _log_softmax([float(i) for i in range(MAX_TOP_LOGPROBS + 10)])
+        entry = extract_token_logprob(row, 0, 50, _CharTokenizer())
+        assert len(entry.top_logprobs) == MAX_TOP_LOGPROBS
+
+
+class TestLogprobsForStep:
+    def _request(self):
+        return SimpleNamespace(output_logprobs=None)
+
+    def _response(self, token, finish_reason=None):
+        return SimpleNamespace(
+            token=token,
+            logprobs=_log_softmax([0.0, 1.0, 2.0]),
+            finish_reason=finish_reason,
+        )
+
+    def test_disabled_when_not_requested(self):
+        request = self._request()
+        assert (
+            logprobs_for_step(request, self._response(1), None, _CharTokenizer())
+            is None
+        )
+        assert request.output_logprobs is None
+
+    def test_appends_content_tokens(self):
+        request = self._request()
+        step = logprobs_for_step(request, self._response(2), 1, _CharTokenizer())
+
+        assert [entry.token for entry in step] == ["c"]
+        assert request.output_logprobs == step
+
+    def test_stop_token_is_excluded(self):
+        request = self._request()
+        step = logprobs_for_step(
+            request, self._response(0, finish_reason="stop"), 1, _CharTokenizer()
+        )
+
+        assert step == []
+        assert request.output_logprobs == []
+
+
+class TestFormatting:
+    def _entries(self):
+        return [
+            TokenLogprob(
+                token_id=0,
+                token="Hé",
+                logprob=-0.1,
+                top_logprobs=[(0, "Hé", -0.1), (1, "Hi", -2.5)],
+            ),
+            TokenLogprob(token_id=2, token="!", logprob=-0.3),
+        ]
+
+    def test_chat_format(self):
+        logprobs = to_chat_logprobs(self._entries())
+
+        first = logprobs.content[0]
+        assert first.token == "Hé"
+        assert first.bytes == list("Hé".encode("utf-8"))
+        assert [top.token for top in first.top_logprobs] == ["Hé", "Hi"]
+        assert logprobs.content[1].top_logprobs == []
+        assert logprobs.refusal is None
+
+    def test_completion_format(self):
+        logprobs = to_completion_logprobs(self._entries(), text_offset=5)
+
+        assert logprobs.tokens == ["Hé", "!"]
+        assert logprobs.token_logprobs == [-0.1, -0.3]
+        assert logprobs.text_offset == [5, 7]
+        # The legacy format always includes the sampled token among the top ones.
+        assert logprobs.top_logprobs[1] == {"!": -0.3}
+        assert logprobs.top_logprobs[0] == {"Hé": -0.1, "Hi": -2.5}

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1088,6 +1088,7 @@ class TestMLLMBatchGeneratorMTPGuards:
             "no_active_batch": 0,
             "concurrent_batch": 0,
             "logits_processors": 0,
+            "logprobs": 0,
             "assistant_not_requested": 0,
         }
 
@@ -1110,6 +1111,53 @@ class TestMLLMBatchGeneratorMTPGuards:
         stats = batch_gen.get_mtp_stats()
         assert stats["attempted"] == 0
         assert stats["bypass_counts"]["logits_processors"] == 1
+
+    def test_install_mtp_mllm_disables_mtp_when_logprobs_requested(self):
+        """Draft tokens report logprobs from a different distribution, so
+        requests that ask for logprobs must take the non-speculative step."""
+        from vllm_mlx.mllm_batch_generator import install_mtp_mllm
+
+        expected_tokens = mx.array([7])
+        expected_logprobs = [mx.array([0.1, 0.9])]
+        original_step = MagicMock(return_value=(expected_tokens, expected_logprobs))
+
+        class FakeBatchGen:
+            def __init__(self):
+                self._step = original_step
+                self._next = MagicMock(return_value=[])
+                self.active_batch = MagicMock()
+                self.active_batch.__len__.return_value = 1
+                self.active_batch.requests = [
+                    MagicMock(
+                        temperature=0.0,
+                        top_p=1.0,
+                        top_k=0,
+                        min_p=0.0,
+                        logprobs=0,
+                    )
+                ]
+                self.sampler = MagicMock()
+
+        batch_gen = FakeBatchGen()
+        language_model = MagicMock()
+
+        install_mtp_mllm(batch_gen, language_model, num_draft_tokens=4)
+
+        tokens, logprobs = batch_gen._step(
+            mx.array([[123]]),
+            cache=[],
+            logits_processors=None,
+            output_tokens=[[1, 2]],
+            samplers=[None],
+        )
+
+        assert tokens.tolist() == expected_tokens.tolist()
+        original_step.assert_called_once()
+        language_model.mtp_forward.assert_not_called()
+        stats = batch_gen.get_mtp_stats()
+        assert stats["attempted"] == 0
+        assert stats["bypass_counts"]["logprobs"] == 1
+        assert stats["bypass_counts"]["logits_processors"] == 0
 
     def test_external_mtp_requires_every_active_request_to_opt_in(self):
         from vllm_mlx.mllm_batch_generator import install_mtp_mllm

--- a/tests/test_server_logprobs.py
+++ b/tests/test_server_logprobs.py
@@ -31,9 +31,61 @@ def _sse_payloads(chunks):
     return payloads
 
 
+def _streamed_chat_tokens(chunks):
+    return [
+        token["token"]
+        for payload in _sse_payloads(chunks)
+        for choice in payload.get("choices", [])
+        if choice.get("logprobs")
+        for token in choice["logprobs"]["content"]
+    ]
+
+
+class FakeChatEngine:
+    """Chat engine double that records its kwargs and returns canned outputs."""
+
+    model_name = "fake-engine"
+    is_mllm = False
+    preserve_native_tool_format = False
+
+    def __init__(self, result=None, stream=(), supports_logprobs=True):
+        self.result = result
+        self.stream = list(stream)
+        self.supports_logprobs = supports_logprobs
+        self.kwargs = None
+
+    async def chat(self, messages, **kwargs):
+        self.kwargs = kwargs
+        return self.result
+
+    async def stream_chat(self, messages, **kwargs):
+        self.kwargs = kwargs
+        for output in self.stream:
+            yield output
+
+
+class FakeCompletionEngine:
+    """Completion engine double that records its kwargs and returns canned outputs."""
+
+    def __init__(self, result=None, stream=(), supports_logprobs=True):
+        self.result = result
+        self.stream = list(stream)
+        self.supports_logprobs = supports_logprobs
+        self.kwargs = None
+
+    async def generate(self, **kwargs):
+        self.kwargs = kwargs
+        return self.result
+
+    async def stream_generate(self, **kwargs):
+        self.kwargs = kwargs
+        for output in self.stream:
+            yield output
+
+
 @pytest.fixture
 def chat_server(monkeypatch):
-    """Patch server globals so chat handlers run against a fake engine."""
+    """Patch server globals so chat handlers run against ``state["engine"]``."""
     import vllm_mlx.server as server
 
     state = {"engine": None}
@@ -65,229 +117,276 @@ def chat_server(monkeypatch):
     return state
 
 
+@pytest.fixture
+def hides_tag_parser(monkeypatch):
+    """Install a reasoning parser that consumes ``<tag>`` without emitting a chunk."""
+    import vllm_mlx.server as server
+    from vllm_mlx.reasoning import DeltaMessage
+
+    class HidesTagParser:
+        def __init__(self, tokenizer=None):
+            pass
+
+        def reset_state(self, implicit_mode: bool = False):
+            pass
+
+        def extract_reasoning_streaming(self, previous_text, current_text, delta_text):
+            if delta_text == "<tag>":
+                return None
+            return DeltaMessage(content=delta_text)
+
+    monkeypatch.setattr(server, "_reasoning_parser_name", "hides-tag")
+    monkeypatch.setattr(server, "_reasoning_parser", None)
+    monkeypatch.setattr(server, "get_reasoning_parser", lambda name: HidesTagParser)
+
+
+@pytest.fixture
+def completion_server(monkeypatch):
+    """Patch server globals so completion handlers use ``state["engine"]``."""
+    import vllm_mlx.server as server
+
+    state = {"engine": None}
+    monkeypatch.setattr(server, "_model_name", "test-model")
+    monkeypatch.setattr(server, "_model_manager", None)
+    monkeypatch.setattr(server, "_residency_manager", None)
+    monkeypatch.setattr(server, "_default_model_key", None)
+    monkeypatch.setattr(server, "get_engine", lambda: state["engine"])
+    return state
+
+
+def _chat_request(**fields):
+    from vllm_mlx.server import ChatCompletionRequest, Message
+
+    return ChatCompletionRequest(
+        model="served-model",
+        messages=[Message(role="user", content="Hello")],
+        **fields,
+    )
+
+
+async def _stream_chat(engine, request):
+    from vllm_mlx.server import stream_chat_completion
+
+    return [
+        chunk
+        async for chunk in stream_chat_completion(engine, request.messages, request)
+    ]
+
+
 class TestChatCompletionLogprobs:
     @pytest.mark.anyio
     async def test_nonstream_returns_logprobs_and_forwards_top(self, chat_server):
         from vllm_mlx.engine.base import GenerationOutput
-        from vllm_mlx.server import (
-            ChatCompletionRequest,
-            Message,
-            create_chat_completion,
+        from vllm_mlx.server import create_chat_completion
+
+        engine = FakeChatEngine(
+            result=GenerationOutput(
+                text="Hi!",
+                prompt_tokens=3,
+                completion_tokens=2,
+                finish_reason="stop",
+                logprobs=[
+                    _entry(0, "Hi", -0.1, [(0, "Hi", -0.1), (1, "Hey", -2.0)]),
+                    _entry(2, "!", -0.3),
+                ],
+            )
+        )
+        chat_server["engine"] = engine
+
+        response = await create_chat_completion(
+            _chat_request(logprobs=True, top_logprobs=2), raw_request=None
         )
 
-        captured = {}
-
-        class FakeEngine:
-            model_name = "fake-engine"
-            is_mllm = False
-            preserve_native_tool_format = False
-            supports_logprobs = True
-
-            async def chat(self, messages, **kwargs):
-                captured.update(kwargs)
-                return GenerationOutput(
-                    text="Hi!",
-                    prompt_tokens=3,
-                    completion_tokens=2,
-                    finish_reason="stop",
-                    logprobs=[
-                        _entry(0, "Hi", -0.1, [(0, "Hi", -0.1), (1, "Hey", -2.0)]),
-                        _entry(2, "!", -0.3),
-                    ],
-                )
-
-        chat_server["engine"] = FakeEngine()
-        request = ChatCompletionRequest(
-            model="served-model",
-            messages=[Message(role="user", content="Hello")],
-            logprobs=True,
-            top_logprobs=2,
-        )
-
-        response = await create_chat_completion(request, raw_request=None)
-
-        assert captured["logprobs"] == 2
+        assert engine.kwargs["logprobs"] == 2
         content = response.choices[0].logprobs.content
         assert [token.token for token in content] == ["Hi", "!"]
         assert [top.token for top in content[0].top_logprobs] == ["Hi", "Hey"]
-        assert content[1].bytes == [33]
+        assert content[1].bytes == [ord("!")]
 
     @pytest.mark.anyio
     async def test_nonstream_without_logprobs_sends_no_flag(self, chat_server):
         from vllm_mlx.engine.base import GenerationOutput
-        from vllm_mlx.server import (
-            ChatCompletionRequest,
-            Message,
-            create_chat_completion,
+        from vllm_mlx.server import create_chat_completion
+
+        engine = FakeChatEngine(
+            result=GenerationOutput(text="ok", finish_reason="stop"),
+            supports_logprobs=False,
         )
+        chat_server["engine"] = engine
 
-        captured = {}
+        response = await create_chat_completion(_chat_request(), raw_request=None)
 
-        class FakeEngine:
-            model_name = "fake-engine"
-            is_mllm = False
-            preserve_native_tool_format = False
-
-            async def chat(self, messages, **kwargs):
-                captured.update(kwargs)
-                return GenerationOutput(text="ok", finish_reason="stop")
-
-        chat_server["engine"] = FakeEngine()
-        request = ChatCompletionRequest(
-            model="served-model", messages=[Message(role="user", content="Hello")]
-        )
-
-        response = await create_chat_completion(request, raw_request=None)
-
-        assert "logprobs" not in captured
+        assert "logprobs" not in engine.kwargs
         assert response.choices[0].logprobs is None
 
     @pytest.mark.anyio
     async def test_engine_without_support_is_rejected(self, chat_server):
         from fastapi import HTTPException
 
-        from vllm_mlx.server import (
-            ChatCompletionRequest,
-            Message,
-            create_chat_completion,
-        )
+        from vllm_mlx.server import create_chat_completion
 
-        class FakeEngine:
-            model_name = "fake-engine"
-            is_mllm = False
-            preserve_native_tool_format = False
-
-            async def chat(self, messages, **kwargs):
-                raise AssertionError("engine must not be called")
-
-        chat_server["engine"] = FakeEngine()
-        request = ChatCompletionRequest(
-            model="served-model",
-            messages=[Message(role="user", content="Hello")],
-            logprobs=True,
-        )
+        engine = FakeChatEngine(supports_logprobs=False)
+        chat_server["engine"] = engine
 
         with pytest.raises(HTTPException) as excinfo:
-            await create_chat_completion(request, raw_request=None)
+            await create_chat_completion(_chat_request(logprobs=True), raw_request=None)
+
         assert excinfo.value.status_code == 400
         assert "continuous-batching" in excinfo.value.detail
+        assert engine.kwargs is None
 
     @pytest.mark.anyio
     async def test_stream_emits_each_token_logprob_once(self, chat_server):
         from vllm_mlx.engine.base import GenerationOutput
-        from vllm_mlx.server import (
-            ChatCompletionRequest,
-            Message,
-            stream_chat_completion,
-        )
 
-        class FakeEngine:
-            model_name = "fake-engine"
-            supports_logprobs = True
-
-            async def stream_chat(self, messages, **kwargs):
-                yield GenerationOutput(
+        engine = FakeChatEngine(
+            stream=[
+                GenerationOutput(
                     text="",
                     new_text="Hi",
                     finished=False,
-                    logprobs=[_entry(0, "Hi", -0.1)],
-                )
-                yield GenerationOutput(
+                    new_logprobs=[_entry(0, "Hi", -0.1)],
+                ),
+                GenerationOutput(
                     text="",
                     new_text="!",
                     finished=True,
                     finish_reason="stop",
-                    logprobs=[_entry(2, "!", -0.3)],
-                )
-
-        request = ChatCompletionRequest(
-            model="served-model",
-            messages=[Message(role="user", content="Hello")],
-            stream=True,
-            logprobs=True,
+                    new_logprobs=[_entry(2, "!", -0.3)],
+                ),
+            ]
         )
 
-        chunks = [
-            chunk
-            async for chunk in stream_chat_completion(
-                FakeEngine(), request.messages, request
-            )
-        ]
+        chunks = await _stream_chat(engine, _chat_request(stream=True, logprobs=True))
 
-        tokens = [
-            token["token"]
+        assert _streamed_chat_tokens(chunks) == ["Hi", "!"]
+
+    @pytest.mark.anyio
+    async def test_stream_keeps_logprobs_of_a_consumed_final_token(
+        self, chat_server, hides_tag_parser
+    ):
+        """A parser that swallows the finishing output forces the terminal chunk."""
+        from vllm_mlx.engine.base import GenerationOutput
+
+        engine = FakeChatEngine(
+            stream=[
+                GenerationOutput(
+                    text="",
+                    new_text="Hi",
+                    finished=False,
+                    new_logprobs=[_entry(0, "Hi", -0.1)],
+                ),
+                GenerationOutput(
+                    text="",
+                    new_text="<tag>",
+                    finished=True,
+                    finish_reason="stop",
+                    new_logprobs=[_entry(9, "<tag>", -0.2)],
+                ),
+            ]
+        )
+
+        chunks = await _stream_chat(engine, _chat_request(stream=True, logprobs=True))
+
+        assert _streamed_chat_tokens(chunks) == ["Hi", "<tag>"]
+        finishing = [
+            choice
             for payload in _sse_payloads(chunks)
             for choice in payload.get("choices", [])
-            if choice.get("logprobs")
-            for token in choice["logprobs"]["content"]
+            if choice.get("finish_reason")
         ]
-        assert tokens == ["Hi", "!"]
+        assert finishing and finishing[-1]["logprobs"]["content"][0]["token"] == "<tag>"
 
-    def test_pending_logprobs_wait_for_a_chunk_with_choices(self):
+    @pytest.mark.anyio
+    async def test_stream_flushes_consumed_tokens_when_stream_ends_early(
+        self, chat_server, hides_tag_parser
+    ):
+        from vllm_mlx.engine.base import GenerationOutput
+
+        engine = FakeChatEngine(
+            stream=[
+                GenerationOutput(
+                    text="",
+                    new_text="Hi",
+                    finished=False,
+                    new_logprobs=[_entry(0, "Hi", -0.1)],
+                ),
+                GenerationOutput(
+                    text="",
+                    new_text="<tag>",
+                    finished=False,
+                    new_logprobs=[_entry(9, "<tag>", -0.2)],
+                ),
+            ]
+        )
+
+        chunks = await _stream_chat(engine, _chat_request(stream=True, logprobs=True))
+
+        assert _streamed_chat_tokens(chunks) == ["Hi", "<tag>"]
+
+
+class TestAttachPendingLogprobs:
+    def _chunk_with_choice(self):
         from vllm_mlx.api.models import (
             ChatCompletionChunk,
             ChatCompletionChunkChoice,
             ChatCompletionChunkDelta,
         )
+
+        return ChatCompletionChunk(
+            model="m",
+            choices=[
+                ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content="Hi"))
+            ],
+        )
+
+    def test_chunk_without_choices_leaves_entries_pending(self):
+        from vllm_mlx.api.models import ChatCompletionChunk
         from vllm_mlx.server import _attach_pending_logprobs
 
         pending = [_entry(0, "Hi", -0.1)]
+        _attach_pending_logprobs(ChatCompletionChunk(model="m", choices=[]), pending)
 
-        usage_only = _attach_pending_logprobs(
-            ChatCompletionChunk(model="m", choices=[]), pending
-        )
-        assert usage_only.choices == []
         assert len(pending) == 1
 
-        chunk = _attach_pending_logprobs(
-            ChatCompletionChunk(
-                model="m",
-                choices=[
-                    ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(content="Hi")
-                    )
-                ],
-            ),
-            pending,
-        )
+    def test_entries_move_onto_the_next_chunk_with_choices(self):
+        from vllm_mlx.server import _attach_pending_logprobs
+
+        pending = [_entry(0, "Hi", -0.1)]
+        chunk = self._chunk_with_choice()
+        _attach_pending_logprobs(chunk, pending)
+
         assert [t.token for t in chunk.choices[0].logprobs.content] == ["Hi"]
         assert pending == []
 
 
 class TestCompletionLogprobs:
     @pytest.mark.anyio
-    async def test_nonstream_completion_returns_legacy_logprobs(self, monkeypatch):
-        import vllm_mlx.server as server
+    async def test_nonstream_completion_returns_legacy_logprobs(
+        self, completion_server
+    ):
         from vllm_mlx.server import CompletionRequest, create_completion
 
-        captured = {}
+        engine = FakeCompletionEngine(
+            result=SimpleNamespace(
+                text="ab",
+                finish_reason="stop",
+                completion_tokens=2,
+                prompt_tokens=1,
+                logprobs=[
+                    _entry(0, "a", -0.2, [(0, "a", -0.2), (1, "b", -1.9)]),
+                    _entry(1, "b", -0.4),
+                ],
+            )
+        )
+        completion_server["engine"] = engine
 
-        class DummyEngine:
-            supports_logprobs = True
+        response = await create_completion(
+            CompletionRequest(model="test-model", prompt="hello", logprobs=1),
+            raw_request=None,
+        )
 
-            async def generate(self, **kwargs):
-                captured.update(kwargs)
-                return SimpleNamespace(
-                    text="ab",
-                    finish_reason="stop",
-                    completion_tokens=2,
-                    prompt_tokens=1,
-                    logprobs=[
-                        _entry(0, "a", -0.2, [(0, "a", -0.2), (1, "b", -1.9)]),
-                        _entry(1, "b", -0.4),
-                    ],
-                )
-
-        monkeypatch.setattr(server, "_model_name", "test-model")
-        monkeypatch.setattr(server, "_model_manager", None)
-        monkeypatch.setattr(server, "_residency_manager", None)
-        monkeypatch.setattr(server, "_default_model_key", None)
-        monkeypatch.setattr(server, "get_engine", lambda: DummyEngine())
-
-        request = CompletionRequest(model="test-model", prompt="hello", logprobs=1)
-        response = await create_completion(request, raw_request=None)
-
-        assert captured["logprobs"] == 1
+        assert engine.kwargs["logprobs"] == 1
         logprobs = response.choices[0].logprobs
         assert logprobs.tokens == ["a", "b"]
         assert logprobs.token_logprobs == [-0.2, -0.4]
@@ -295,26 +394,24 @@ class TestCompletionLogprobs:
         assert logprobs.top_logprobs[0] == {"a": -0.2, "b": -1.9}
 
     @pytest.mark.anyio
-    async def test_completion_engine_without_support_is_rejected(self, monkeypatch):
+    async def test_completion_engine_without_support_is_rejected(
+        self, completion_server
+    ):
         from fastapi import HTTPException
 
-        import vllm_mlx.server as server
         from vllm_mlx.server import CompletionRequest, create_completion
 
-        class DummyEngine:
-            async def generate(self, **kwargs):
-                raise AssertionError("engine must not be called")
+        engine = FakeCompletionEngine(supports_logprobs=False)
+        completion_server["engine"] = engine
 
-        monkeypatch.setattr(server, "_model_name", "test-model")
-        monkeypatch.setattr(server, "_model_manager", None)
-        monkeypatch.setattr(server, "_residency_manager", None)
-        monkeypatch.setattr(server, "_default_model_key", None)
-        monkeypatch.setattr(server, "get_engine", lambda: DummyEngine())
-
-        request = CompletionRequest(model="test-model", prompt="hello", logprobs=0)
         with pytest.raises(HTTPException) as excinfo:
-            await create_completion(request, raw_request=None)
+            await create_completion(
+                CompletionRequest(model="test-model", prompt="hello", logprobs=0),
+                raw_request=None,
+            )
+
         assert excinfo.value.status_code == 400
+        assert engine.kwargs is None
 
     @pytest.mark.anyio
     async def test_stream_completion_offsets_continue_across_chunks(self):
@@ -322,36 +419,33 @@ class TestCompletionLogprobs:
         from vllm_mlx.engine.base import GenerationOutput
         from vllm_mlx.server import stream_completion
 
-        captured = {}
-
-        class DummyEngine:
-            async def stream_generate(self, **kwargs):
-                captured.update(kwargs)
-                yield GenerationOutput(
+        engine = FakeCompletionEngine(
+            stream=[
+                GenerationOutput(
                     text="",
                     new_text="ab",
                     finished=False,
-                    logprobs=[_entry(0, "ab", -0.5)],
-                )
-                yield GenerationOutput(
+                    new_logprobs=[_entry(0, "ab", -0.5)],
+                ),
+                GenerationOutput(
                     text="",
                     new_text="c",
                     finished=True,
                     finish_reason="stop",
                     completion_tokens=2,
                     prompt_tokens=1,
-                    logprobs=[_entry(2, "c", -0.7)],
-                )
-
+                    new_logprobs=[_entry(2, "c", -0.7)],
+                ),
+            ]
+        )
         request = CompletionRequest(model="test-model", prompt="hello", logprobs=0)
+
         chunks = [
             chunk
-            async for chunk in stream_completion(
-                DummyEngine(), "hello", request, max_tokens=8
-            )
+            async for chunk in stream_completion(engine, "hello", request, max_tokens=8)
         ]
 
-        assert captured["logprobs"] == 0
+        assert engine.kwargs["logprobs"] == 0
         choice_logprobs = [
             payload["choices"][0]["logprobs"] for payload in _sse_payloads(chunks)
         ]

--- a/tests/test_server_logprobs.py
+++ b/tests/test_server_logprobs.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Server tests for OpenAI-compatible logprobs on chat and text completions."""
+
+import json
+import platform
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
+
+
+def _entry(token_id, token, logprob, top=()):
+    from vllm_mlx.logprobs import TokenLogprob
+
+    return TokenLogprob(
+        token_id=token_id, token=token, logprob=logprob, top_logprobs=list(top)
+    )
+
+
+def _sse_payloads(chunks):
+    payloads = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                payloads.append(json.loads(line[len("data: ") :]))
+    return payloads
+
+
+@pytest.fixture
+def chat_server(monkeypatch):
+    """Patch server globals so chat handlers run against a fake engine."""
+    import vllm_mlx.server as server
+
+    state = {"engine": None}
+
+    async def fake_acquire(
+        raw_request,
+        *,
+        total_timeout=None,
+        deadline=None,
+        count_activity=True,
+        model=None,
+    ):
+        return state["engine"]
+
+    async def fake_release(*, count_activity=True):
+        return None
+
+    monkeypatch.setattr(server, "_validate_model_name", lambda _m: None)
+    monkeypatch.setattr(server, "_acquire_default_engine_for_request", fake_acquire)
+    monkeypatch.setattr(server, "_release_default_engine", fake_release)
+    monkeypatch.setattr(server, "_model_name", "served-model")
+    monkeypatch.setattr(server, "_default_max_tokens", 128)
+    monkeypatch.setattr(server, "_default_timeout", 30.0)
+    monkeypatch.setattr(server, "_enable_auto_tool_choice", False)
+    monkeypatch.setattr(server, "_tool_call_parser", None)
+    monkeypatch.setattr(server, "_tool_parser_instance", None)
+    monkeypatch.setattr(server, "_reasoning_parser_name", None)
+    monkeypatch.setattr(server, "_reasoning_parser", None)
+    return state
+
+
+class TestChatCompletionLogprobs:
+    @pytest.mark.anyio
+    async def test_nonstream_returns_logprobs_and_forwards_top(self, chat_server):
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        captured = {}
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+            supports_logprobs = True
+
+            async def chat(self, messages, **kwargs):
+                captured.update(kwargs)
+                return GenerationOutput(
+                    text="Hi!",
+                    prompt_tokens=3,
+                    completion_tokens=2,
+                    finish_reason="stop",
+                    logprobs=[
+                        _entry(0, "Hi", -0.1, [(0, "Hi", -0.1), (1, "Hey", -2.0)]),
+                        _entry(2, "!", -0.3),
+                    ],
+                )
+
+        chat_server["engine"] = FakeEngine()
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Hello")],
+            logprobs=True,
+            top_logprobs=2,
+        )
+
+        response = await create_chat_completion(request, raw_request=None)
+
+        assert captured["logprobs"] == 2
+        content = response.choices[0].logprobs.content
+        assert [token.token for token in content] == ["Hi", "!"]
+        assert [top.token for top in content[0].top_logprobs] == ["Hi", "Hey"]
+        assert content[1].bytes == [33]
+
+    @pytest.mark.anyio
+    async def test_nonstream_without_logprobs_sends_no_flag(self, chat_server):
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        captured = {}
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                captured.update(kwargs)
+                return GenerationOutput(text="ok", finish_reason="stop")
+
+        chat_server["engine"] = FakeEngine()
+        request = ChatCompletionRequest(
+            model="served-model", messages=[Message(role="user", content="Hello")]
+        )
+
+        response = await create_chat_completion(request, raw_request=None)
+
+        assert "logprobs" not in captured
+        assert response.choices[0].logprobs is None
+
+    @pytest.mark.anyio
+    async def test_engine_without_support_is_rejected(self, chat_server):
+        from fastapi import HTTPException
+
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            create_chat_completion,
+        )
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            is_mllm = False
+            preserve_native_tool_format = False
+
+            async def chat(self, messages, **kwargs):
+                raise AssertionError("engine must not be called")
+
+        chat_server["engine"] = FakeEngine()
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Hello")],
+            logprobs=True,
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await create_chat_completion(request, raw_request=None)
+        assert excinfo.value.status_code == 400
+        assert "continuous-batching" in excinfo.value.detail
+
+    @pytest.mark.anyio
+    async def test_stream_emits_each_token_logprob_once(self, chat_server):
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import (
+            ChatCompletionRequest,
+            Message,
+            stream_chat_completion,
+        )
+
+        class FakeEngine:
+            model_name = "fake-engine"
+            supports_logprobs = True
+
+            async def stream_chat(self, messages, **kwargs):
+                yield GenerationOutput(
+                    text="",
+                    new_text="Hi",
+                    finished=False,
+                    logprobs=[_entry(0, "Hi", -0.1)],
+                )
+                yield GenerationOutput(
+                    text="",
+                    new_text="!",
+                    finished=True,
+                    finish_reason="stop",
+                    logprobs=[_entry(2, "!", -0.3)],
+                )
+
+        request = ChatCompletionRequest(
+            model="served-model",
+            messages=[Message(role="user", content="Hello")],
+            stream=True,
+            logprobs=True,
+        )
+
+        chunks = [
+            chunk
+            async for chunk in stream_chat_completion(
+                FakeEngine(), request.messages, request
+            )
+        ]
+
+        tokens = [
+            token["token"]
+            for payload in _sse_payloads(chunks)
+            for choice in payload.get("choices", [])
+            if choice.get("logprobs")
+            for token in choice["logprobs"]["content"]
+        ]
+        assert tokens == ["Hi", "!"]
+
+    def test_pending_logprobs_wait_for_a_chunk_with_choices(self):
+        from vllm_mlx.api.models import (
+            ChatCompletionChunk,
+            ChatCompletionChunkChoice,
+            ChatCompletionChunkDelta,
+        )
+        from vllm_mlx.server import _attach_pending_logprobs
+
+        pending = [_entry(0, "Hi", -0.1)]
+
+        usage_only = _attach_pending_logprobs(
+            ChatCompletionChunk(model="m", choices=[]), pending
+        )
+        assert usage_only.choices == []
+        assert len(pending) == 1
+
+        chunk = _attach_pending_logprobs(
+            ChatCompletionChunk(
+                model="m",
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(content="Hi")
+                    )
+                ],
+            ),
+            pending,
+        )
+        assert [t.token for t in chunk.choices[0].logprobs.content] == ["Hi"]
+        assert pending == []
+
+
+class TestCompletionLogprobs:
+    @pytest.mark.anyio
+    async def test_nonstream_completion_returns_legacy_logprobs(self, monkeypatch):
+        import vllm_mlx.server as server
+        from vllm_mlx.server import CompletionRequest, create_completion
+
+        captured = {}
+
+        class DummyEngine:
+            supports_logprobs = True
+
+            async def generate(self, **kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    text="ab",
+                    finish_reason="stop",
+                    completion_tokens=2,
+                    prompt_tokens=1,
+                    logprobs=[
+                        _entry(0, "a", -0.2, [(0, "a", -0.2), (1, "b", -1.9)]),
+                        _entry(1, "b", -0.4),
+                    ],
+                )
+
+        monkeypatch.setattr(server, "_model_name", "test-model")
+        monkeypatch.setattr(server, "_model_manager", None)
+        monkeypatch.setattr(server, "_residency_manager", None)
+        monkeypatch.setattr(server, "_default_model_key", None)
+        monkeypatch.setattr(server, "get_engine", lambda: DummyEngine())
+
+        request = CompletionRequest(model="test-model", prompt="hello", logprobs=1)
+        response = await create_completion(request, raw_request=None)
+
+        assert captured["logprobs"] == 1
+        logprobs = response.choices[0].logprobs
+        assert logprobs.tokens == ["a", "b"]
+        assert logprobs.token_logprobs == [-0.2, -0.4]
+        assert logprobs.text_offset == [0, 1]
+        assert logprobs.top_logprobs[0] == {"a": -0.2, "b": -1.9}
+
+    @pytest.mark.anyio
+    async def test_completion_engine_without_support_is_rejected(self, monkeypatch):
+        from fastapi import HTTPException
+
+        import vllm_mlx.server as server
+        from vllm_mlx.server import CompletionRequest, create_completion
+
+        class DummyEngine:
+            async def generate(self, **kwargs):
+                raise AssertionError("engine must not be called")
+
+        monkeypatch.setattr(server, "_model_name", "test-model")
+        monkeypatch.setattr(server, "_model_manager", None)
+        monkeypatch.setattr(server, "_residency_manager", None)
+        monkeypatch.setattr(server, "_default_model_key", None)
+        monkeypatch.setattr(server, "get_engine", lambda: DummyEngine())
+
+        request = CompletionRequest(model="test-model", prompt="hello", logprobs=0)
+        with pytest.raises(HTTPException) as excinfo:
+            await create_completion(request, raw_request=None)
+        assert excinfo.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_stream_completion_offsets_continue_across_chunks(self):
+        from vllm_mlx.api.models import CompletionRequest
+        from vllm_mlx.engine.base import GenerationOutput
+        from vllm_mlx.server import stream_completion
+
+        captured = {}
+
+        class DummyEngine:
+            async def stream_generate(self, **kwargs):
+                captured.update(kwargs)
+                yield GenerationOutput(
+                    text="",
+                    new_text="ab",
+                    finished=False,
+                    logprobs=[_entry(0, "ab", -0.5)],
+                )
+                yield GenerationOutput(
+                    text="",
+                    new_text="c",
+                    finished=True,
+                    finish_reason="stop",
+                    completion_tokens=2,
+                    prompt_tokens=1,
+                    logprobs=[_entry(2, "c", -0.7)],
+                )
+
+        request = CompletionRequest(model="test-model", prompt="hello", logprobs=0)
+        chunks = [
+            chunk
+            async for chunk in stream_completion(
+                DummyEngine(), "hello", request, max_tokens=8
+            )
+        ]
+
+        assert captured["logprobs"] == 0
+        choice_logprobs = [
+            payload["choices"][0]["logprobs"] for payload in _sse_payloads(chunks)
+        ]
+        assert [lp["tokens"] for lp in choice_logprobs] == [["ab"], ["c"]]
+        assert [lp["text_offset"] for lp in choice_logprobs] == [[0], [2]]

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -226,7 +226,8 @@ class ChatCompletionRequest(BaseModel):
     response_format: ResponseFormat | dict | None = None
     # OpenAI-compatible token bias map: token id string -> bias value
     logit_bias: dict[str, float] | None = None
-    # OpenAI-compatible log probabilities of the output tokens
+    # OpenAI-compatible log probabilities of the output tokens. The upper bound
+    # matches ``vllm_mlx.logprobs.MAX_TOP_LOGPROBS``.
     logprobs: bool | None = None
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     # Extra kwargs forwarded to tokenizer.apply_chat_template

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -165,6 +165,44 @@ class StreamOptions(BaseModel):
     include_usage: bool = False  # Include usage stats in final chunk
 
 
+# =============================================================================
+# Log Probabilities (OpenAI-compatible)
+# =============================================================================
+
+
+class TopLogprob(BaseModel):
+    """One of the most likely tokens at a position, with its log probability."""
+
+    token: str
+    logprob: float
+    bytes: list[int] | None = None
+
+
+class ChatCompletionTokenLogprob(BaseModel):
+    """Log probability information for one generated token."""
+
+    token: str
+    logprob: float
+    bytes: list[int] | None = None
+    top_logprobs: list[TopLogprob] = Field(default_factory=list)
+
+
+class ChoiceLogprobs(BaseModel):
+    """Log probability information for a chat completion choice."""
+
+    content: list[ChatCompletionTokenLogprob] | None = None
+    refusal: list[ChatCompletionTokenLogprob] | None = None
+
+
+class CompletionLogprobs(BaseModel):
+    """Legacy log probability format for text completions."""
+
+    tokens: list[str] = Field(default_factory=list)
+    token_logprobs: list[float] = Field(default_factory=list)
+    top_logprobs: list[dict[str, float]] | None = None
+    text_offset: list[int] = Field(default_factory=list)
+
+
 class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
@@ -188,6 +226,9 @@ class ChatCompletionRequest(BaseModel):
     response_format: ResponseFormat | dict | None = None
     # OpenAI-compatible token bias map: token id string -> bias value
     logit_bias: dict[str, float] | None = None
+    # OpenAI-compatible log probabilities of the output tokens
+    logprobs: bool | None = None
+    top_logprobs: int | None = Field(default=None, ge=0, le=20)
     # Extra kwargs forwarded to tokenizer.apply_chat_template
     chat_template_kwargs: dict[str, Any] | None = None
     # MLLM-specific parameters
@@ -212,6 +253,12 @@ class ChatCompletionRequest(BaseModel):
     # Thinking token budget: cap reasoning tokens by forcing </think> when
     # budget exhausted (None = no budget, unlimited reasoning)
     thinking_token_budget: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _top_logprobs_requires_logprobs(self) -> "ChatCompletionRequest":
+        if self.top_logprobs is not None and not self.logprobs:
+            raise ValueError("`logprobs` must be true when `top_logprobs` is set")
+        return self
 
 
 class AssistantMessage(BaseModel):
@@ -250,6 +297,7 @@ class ChatCompletionChoice(BaseModel):
     index: int = 0
     message: AssistantMessage
     finish_reason: str | None = "stop"
+    logprobs: ChoiceLogprobs | None = None
 
 
 class Usage(BaseModel):
@@ -299,6 +347,8 @@ class CompletionRequest(BaseModel):
     max_tokens: int | None = Field(default=None, gt=0)
     stream: bool = False
     stop: list[str] | None = None
+    # OpenAI-compatible: number of most likely tokens to return per position
+    logprobs: int | None = Field(default=None, ge=0, le=5)
     # Sampling penalties
     repetition_penalty: float | None = None  # mlx-lm style (>1.0 penalizes)
     # Request timeout in seconds (None = use server default)
@@ -319,6 +369,7 @@ class CompletionChoice(BaseModel):
     index: int = 0
     text: str
     finish_reason: str | None = "stop"
+    logprobs: CompletionLogprobs | None = None
 
 
 class CompletionResponse(BaseModel):
@@ -566,6 +617,7 @@ class ChatCompletionChunkChoice(BaseModel):
     index: int = 0
     delta: ChatCompletionChunkDelta
     finish_reason: str | None = None
+    logprobs: ChoiceLogprobs | None = None
 
 
 class ChatCompletionChunk(BaseModel):

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -10,7 +10,10 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..logprobs import TokenLogprob
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +36,10 @@ class GenerationOutput:
     # For streaming
     new_text: str = ""
     finished: bool = True
-    # Per-token logprobs (``vllm_mlx.logprobs.TokenLogprob``) when requested:
-    # this step's tokens for streaming outputs, all tokens for final outputs.
-    logprobs: list | None = None
+    # Per-token logprobs when requested: all tokens so far (like ``text``)
+    # and this step's tokens (like ``new_text``).
+    logprobs: list["TokenLogprob"] | None = None
+    new_logprobs: list["TokenLogprob"] | None = None
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -33,6 +33,9 @@ class GenerationOutput:
     # For streaming
     new_text: str = ""
     finished: bool = True
+    # Per-token logprobs (``vllm_mlx.logprobs.TokenLogprob``) when requested:
+    # this step's tokens for streaming outputs, all tokens for final outputs.
+    logprobs: list | None = None
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
@@ -269,6 +272,11 @@ class BaseEngine(ABC):
     @preserve_native_tool_format.setter
     def preserve_native_tool_format(self, value: bool) -> None:
         self._preserve_native_tool_format = value
+
+    @property
+    def supports_logprobs(self) -> bool:
+        """Whether generation can return per-token logprobs."""
+        return False
 
     def prepare_for_start(self) -> None:
         """Run blocking startup work before async engine start.

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -897,7 +897,8 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     mtp_drafts=output.mtp_drafts,
                     mtp_accepted=output.mtp_accepted,
-                    logprobs=getattr(output, "new_logprobs", None),
+                    logprobs=getattr(output, "output_logprobs", None),
+                    new_logprobs=getattr(output, "new_logprobs", None),
                 )
             return
 
@@ -934,7 +935,8 @@ class BatchedEngine(BaseEngine):
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,
                 finish_reason=output.finish_reason,
-                logprobs=getattr(output, "new_logprobs", None),
+                logprobs=getattr(output, "output_logprobs", None),
+                new_logprobs=getattr(output, "new_logprobs", None),
             )
 
     async def chat(

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -170,6 +170,10 @@ class BatchedEngine(BaseEngine):
         return self._model_name
 
     @property
+    def supports_logprobs(self) -> bool:
+        return True
+
+    @property
     def is_mllm(self) -> bool:
         """Check if this is a multimodal model."""
         return self._is_mllm
@@ -785,6 +789,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                logprobs=kwargs.pop("logprobs", None),
                 mllm_draft=bool(kwargs.pop("mllm_draft", self._default_mllm_draft)),
             )
 
@@ -796,6 +801,7 @@ class BatchedEngine(BaseEngine):
                 finish_reason=output.finish_reason,
                 mtp_drafts=output.mtp_drafts,
                 mtp_accepted=output.mtp_accepted,
+                logprobs=getattr(output, "output_logprobs", None),
             )
 
         # Use LLM engine for text-only (non-MLLM models)
@@ -811,6 +817,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
             logits_processors=kwargs.pop("logits_processors", None),
+            logprobs=kwargs.pop("logprobs", None),
         )
 
         output = await self._engine.generate(
@@ -826,6 +833,7 @@ class BatchedEngine(BaseEngine):
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             finish_reason=output.finish_reason,
+            logprobs=getattr(output, "output_logprobs", None),
         )
 
     async def stream_generate(
@@ -875,6 +883,7 @@ class BatchedEngine(BaseEngine):
                 presence_penalty=kwargs.pop("presence_penalty", 0.0),
                 repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
                 logits_processors=kwargs.pop("logits_processors", None),
+                logprobs=kwargs.pop("logprobs", None),
                 mllm_draft=bool(kwargs.pop("mllm_draft", self._default_mllm_draft)),
             )
 
@@ -888,6 +897,7 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     mtp_drafts=output.mtp_drafts,
                     mtp_accepted=output.mtp_accepted,
+                    logprobs=getattr(output, "new_logprobs", None),
                 )
             return
 
@@ -904,6 +914,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             stop=stop or [],
             logits_processors=kwargs.pop("logits_processors", None),
+            logprobs=kwargs.pop("logprobs", None),
         )
 
         prefix_boundary = kwargs.pop("prefix_boundary", 0)
@@ -923,6 +934,7 @@ class BatchedEngine(BaseEngine):
                 completion_tokens=output.completion_tokens,
                 finished=output.finished,
                 finish_reason=output.finish_reason,
+                logprobs=getattr(output, "new_logprobs", None),
             )
 
     async def chat(

--- a/vllm_mlx/logprobs.py
+++ b/vllm_mlx/logprobs.py
@@ -12,16 +12,23 @@ values. Call it on the engine thread: MLX arrays must be evaluated on the
 thread that built them, and no MLX arrays should reach the API layer.
 """
 
+import logging
 import math
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import mlx.core as mx
+
+if TYPE_CHECKING:
+    from .api.models import ChoiceLogprobs, CompletionLogprobs
+
+logger = logging.getLogger(__name__)
 
 # OpenAI reports -9999.0 for very unlikely tokens. The same floor replaces the
 # -inf values that masked logits (e.g. JSON-schema constraints) produce, which
 # are not valid JSON.
 LOGPROB_FLOOR = -9999.0
+# OpenAI's limit; ``ChatCompletionRequest.top_logprobs`` enforces the same bound.
 MAX_TOP_LOGPROBS = 20
 
 
@@ -36,7 +43,7 @@ class TokenLogprob:
     top_logprobs: List[Tuple[int, str, float]] = field(default_factory=list)
 
 
-def _finite(value: float) -> float:
+def _clamp_to_floor(value: float) -> float:
     if math.isnan(value) or value < LOGPROB_FLOOR:
         return LOGPROB_FLOOR
     return value
@@ -46,11 +53,14 @@ def _decode_token(tokenizer: Any, token_id: int) -> str:
     try:
         return tokenizer.decode([token_id])
     except Exception:
+        logger.debug(
+            "Could not decode token id %d for logprobs", token_id, exc_info=True
+        )
         return ""
 
 
 def extract_token_logprob(
-    logprobs: mx.array,
+    vocab_logprobs: mx.array,
     token_id: int,
     num_top: int,
     tokenizer: Any,
@@ -58,48 +68,50 @@ def extract_token_logprob(
     """
     Build a ``TokenLogprob`` for ``token_id`` from a vocabulary logprob row.
 
-    Returns ``None`` when ``logprobs`` does not cover ``token_id``, as with the
-    placeholder arrays that error paths emit.
+    Returns ``None`` when ``vocab_logprobs`` does not cover ``token_id``, as
+    with the placeholder arrays that error paths emit.
     """
-    row = logprobs.reshape(-1)
-    vocab = row.shape[0]
-    if token_id < 0 or token_id >= vocab:
+    row = vocab_logprobs.reshape(-1)
+    vocab_size = row.shape[0]
+    if token_id < 0 or token_id >= vocab_size:
         return None
-    num_top = max(0, min(int(num_top), MAX_TOP_LOGPROBS, vocab))
+    num_top = max(0, min(int(num_top), MAX_TOP_LOGPROBS, vocab_size))
     chosen = row[token_id]
     pairs: List[Tuple[int, float]] = []
     if num_top:
         top_ids = mx.argpartition(-row, kth=num_top - 1)[:num_top]
-        top_vals = row[top_ids]
-        mx.eval(chosen, top_ids, top_vals)
+        top_values = row[top_ids]
+        mx.eval(chosen, top_ids, top_values)
         pairs = sorted(
-            zip(top_ids.tolist(), top_vals.tolist()), key=lambda pair: -pair[1]
+            zip(top_ids.tolist(), top_values.tolist()), key=lambda pair: -pair[1]
         )
     else:
         mx.eval(chosen)
     return TokenLogprob(
         token_id=token_id,
         token=_decode_token(tokenizer, token_id),
-        logprob=_finite(chosen.item()),
+        logprob=_clamp_to_floor(chosen.item()),
         top_logprobs=[
-            (tid, _decode_token(tokenizer, tid), _finite(val)) for tid, val in pairs
+            (tid, _decode_token(tokenizer, tid), _clamp_to_floor(value))
+            for tid, value in pairs
         ],
     )
 
 
-def logprobs_for_step(
+def record_step_logprobs(
     request: Any,
     response: Any,
-    num_top: Optional[int],
     tokenizer: Any,
 ) -> Optional[List[TokenLogprob]]:
     """
-    Record the logprob of ``response.token`` on ``request`` when requested.
+    Append the logprob of ``response.token`` to ``request.output_logprobs``.
 
-    Returns ``None`` when the request did not ask for logprobs. Otherwise it
-    returns this step's entries (empty for stop tokens, which are not content)
-    and appends them to ``request.output_logprobs``.
+    Returns ``None`` without touching the request when it did not ask for
+    logprobs (``request.sampling_params.logprobs is None``). Otherwise it
+    creates ``request.output_logprobs`` on first use and returns this step's
+    entries, which are empty for stop tokens because those are not content.
     """
+    num_top = request.sampling_params.logprobs
     if num_top is None:
         return None
     if request.output_logprobs is None:
@@ -117,7 +129,7 @@ def _utf8(token: str) -> List[int]:
     return list(token.encode("utf-8", errors="replace"))
 
 
-def to_chat_logprobs(entries: List[TokenLogprob]) -> Any:
+def to_chat_logprobs(entries: List[TokenLogprob]) -> "ChoiceLogprobs":
     """Format entries as an OpenAI chat ``ChoiceLogprobs``."""
     # Imported here so engine modules can use this file without the API layer.
     from .api.models import ChatCompletionTokenLogprob, ChoiceLogprobs, TopLogprob
@@ -138,7 +150,9 @@ def to_chat_logprobs(entries: List[TokenLogprob]) -> Any:
     )
 
 
-def to_completion_logprobs(entries: List[TokenLogprob], text_offset: int = 0) -> Any:
+def to_completion_logprobs(
+    entries: List[TokenLogprob], text_offset: int = 0
+) -> "CompletionLogprobs":
     """Format entries in the legacy ``/v1/completions`` logprobs shape."""
     from .api.models import CompletionLogprobs
 

--- a/vllm_mlx/logprobs.py
+++ b/vllm_mlx/logprobs.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Per-token log probabilities for OpenAI-compatible ``logprobs``.
+
+The engines already compute ``log_softmax`` over the vocabulary at every
+decode step. That happens after logits processors (JSON-schema masks, logit
+bias, repetition/presence penalties) and before temperature, top-p, top-k and
+min-p, so the values reported here are the processed distribution at T=1.
+
+``extract_token_logprob`` turns one row of that array into plain Python
+values. Call it on the engine thread: MLX arrays must be evaluated on the
+thread that built them, and no MLX arrays should reach the API layer.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import mlx.core as mx
+
+# OpenAI reports -9999.0 for very unlikely tokens. The same floor replaces the
+# -inf values that masked logits (e.g. JSON-schema constraints) produce, which
+# are not valid JSON.
+LOGPROB_FLOOR = -9999.0
+MAX_TOP_LOGPROBS = 20
+
+
+@dataclass
+class TokenLogprob:
+    """Log probability of one generated token and its most likely alternatives."""
+
+    token_id: int
+    token: str
+    logprob: float
+    # (token_id, token, logprob), most likely first
+    top_logprobs: List[Tuple[int, str, float]] = field(default_factory=list)
+
+
+def _finite(value: float) -> float:
+    if math.isnan(value) or value < LOGPROB_FLOOR:
+        return LOGPROB_FLOOR
+    return value
+
+
+def _decode_token(tokenizer: Any, token_id: int) -> str:
+    try:
+        return tokenizer.decode([token_id])
+    except Exception:
+        return ""
+
+
+def extract_token_logprob(
+    logprobs: mx.array,
+    token_id: int,
+    num_top: int,
+    tokenizer: Any,
+) -> Optional[TokenLogprob]:
+    """
+    Build a ``TokenLogprob`` for ``token_id`` from a vocabulary logprob row.
+
+    Returns ``None`` when ``logprobs`` does not cover ``token_id``, as with the
+    placeholder arrays that error paths emit.
+    """
+    row = logprobs.reshape(-1)
+    vocab = row.shape[0]
+    if token_id < 0 or token_id >= vocab:
+        return None
+    num_top = max(0, min(int(num_top), MAX_TOP_LOGPROBS, vocab))
+    chosen = row[token_id]
+    pairs: List[Tuple[int, float]] = []
+    if num_top:
+        top_ids = mx.argpartition(-row, kth=num_top - 1)[:num_top]
+        top_vals = row[top_ids]
+        mx.eval(chosen, top_ids, top_vals)
+        pairs = sorted(
+            zip(top_ids.tolist(), top_vals.tolist()), key=lambda pair: -pair[1]
+        )
+    else:
+        mx.eval(chosen)
+    return TokenLogprob(
+        token_id=token_id,
+        token=_decode_token(tokenizer, token_id),
+        logprob=_finite(chosen.item()),
+        top_logprobs=[
+            (tid, _decode_token(tokenizer, tid), _finite(val)) for tid, val in pairs
+        ],
+    )
+
+
+def logprobs_for_step(
+    request: Any,
+    response: Any,
+    num_top: Optional[int],
+    tokenizer: Any,
+) -> Optional[List[TokenLogprob]]:
+    """
+    Record the logprob of ``response.token`` on ``request`` when requested.
+
+    Returns ``None`` when the request did not ask for logprobs. Otherwise it
+    returns this step's entries (empty for stop tokens, which are not content)
+    and appends them to ``request.output_logprobs``.
+    """
+    if num_top is None:
+        return None
+    if request.output_logprobs is None:
+        request.output_logprobs = []
+    if response.finish_reason == "stop":
+        return []
+    entry = extract_token_logprob(response.logprobs, response.token, num_top, tokenizer)
+    if entry is None:
+        return []
+    request.output_logprobs.append(entry)
+    return [entry]
+
+
+def _utf8(token: str) -> List[int]:
+    return list(token.encode("utf-8", errors="replace"))
+
+
+def to_chat_logprobs(entries: List[TokenLogprob]) -> Any:
+    """Format entries as an OpenAI chat ``ChoiceLogprobs``."""
+    # Imported here so engine modules can use this file without the API layer.
+    from .api.models import ChatCompletionTokenLogprob, ChoiceLogprobs, TopLogprob
+
+    return ChoiceLogprobs(
+        content=[
+            ChatCompletionTokenLogprob(
+                token=entry.token,
+                logprob=entry.logprob,
+                bytes=_utf8(entry.token),
+                top_logprobs=[
+                    TopLogprob(token=token, logprob=logprob, bytes=_utf8(token))
+                    for _, token, logprob in entry.top_logprobs
+                ],
+            )
+            for entry in entries
+        ]
+    )
+
+
+def to_completion_logprobs(entries: List[TokenLogprob], text_offset: int = 0) -> Any:
+    """Format entries in the legacy ``/v1/completions`` logprobs shape."""
+    from .api.models import CompletionLogprobs
+
+    tokens: List[str] = []
+    token_logprobs: List[float] = []
+    top_logprobs: List[dict] = []
+    offsets: List[int] = []
+    offset = text_offset
+    for entry in entries:
+        tokens.append(entry.token)
+        token_logprobs.append(entry.logprob)
+        # The legacy API always includes the sampled token among the top ones.
+        top = {token: logprob for _, token, logprob in entry.top_logprobs}
+        top.setdefault(entry.token, entry.logprob)
+        top_logprobs.append(top)
+        offsets.append(offset)
+        offset += len(entry.token)
+    return CompletionLogprobs(
+        tokens=tokens,
+        token_logprobs=token_logprobs,
+        top_logprobs=top_logprobs,
+        text_offset=offsets,
+    )

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -2345,6 +2345,9 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
+        # ``logprobs`` is Optional[int]. Checking the type rather than
+        # ``is not None`` keeps request doubles without the field (e.g.
+        # ``MagicMock``) from reading as logprobs requests.
         logprobs_bypass = any(
             isinstance(getattr(request, "logprobs", None), int)
             for request in active_requests

--- a/vllm_mlx/mllm_batch_generator.py
+++ b/vllm_mlx/mllm_batch_generator.py
@@ -210,6 +210,10 @@ class MLLMBatchRequest:
     # Merged with built-in repetition/presence penalty processors in
     # ``_prefill_batch``.
     logits_processors: Optional[List[Callable]] = None
+    # Most likely alternatives to report per token; ``None`` disables logprobs.
+    # Requests with logprobs skip speculative drafting, whose draft tokens
+    # report logprobs from a different distribution.
+    logprobs: Optional[int] = None
 
     # Processed inputs (set after vision preprocessing)
     input_ids: Optional[mx.array] = None
@@ -2287,6 +2291,7 @@ def install_mtp_mllm(
         "no_active_batch": 0,
         "concurrent_batch": 0,
         "logits_processors": 0,
+        "logprobs": 0,
         "assistant_not_requested": 0,
     }
 
@@ -2340,6 +2345,10 @@ def install_mtp_mllm(
         logits_processors_bypass = logits_processors is not None and any(
             logits_processors
         )
+        logprobs_bypass = any(
+            isinstance(getattr(request, "logprobs", None), int)
+            for request in active_requests
+        )
         assistant_not_requested_bypass = external_drafter and (
             not active_requests
             or not all(request.mllm_draft for request in active_requests)
@@ -2348,6 +2357,7 @@ def install_mtp_mllm(
             prefill_bypass
             or no_active_batch_bypass
             or logits_processors_bypass
+            or logprobs_bypass
             or assistant_not_requested_bypass
         ):
             # Keep the descriptions near the guards so operator-facing
@@ -2363,6 +2373,8 @@ def install_mtp_mllm(
                     _bypass_counts["no_active_batch"] += 1
                 if logits_processors_bypass:
                     _bypass_counts["logits_processors"] += 1
+                if logprobs_bypass:
+                    _bypass_counts["logprobs"] += 1
                 if assistant_not_requested_bypass:
                     _bypass_counts["assistant_not_requested"] += 1
             _skip_state_by_uid.clear()

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -37,7 +37,7 @@ from .mllm_batch_generator import (
 )
 from .mlx_streams import bind_generation_streams
 from .multimodal_processor import MultimodalProcessor
-from .logprobs import logprobs_for_step
+from .logprobs import TokenLogprob, record_step_logprobs
 from .request import RequestOutput, RequestStatus, SamplingParams
 
 logger = logging.getLogger(__name__)
@@ -120,7 +120,7 @@ class MLLMRequest:
     output_text: str = ""
     output_tokens: List[int] = field(default_factory=list)
     # Per-token logprobs, when requested (see ``vllm_mlx.logprobs``)
-    output_logprobs: Optional[List[Any]] = None
+    output_logprobs: Optional[List[TokenLogprob]] = None
     finish_reason: Optional[str] = None
 
     # Token counts
@@ -708,9 +708,7 @@ class MLLMScheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
-            new_logprobs = logprobs_for_step(
-                request, response, request.sampling_params.logprobs, tokenizer
-            )
+            new_logprobs = record_step_logprobs(request, response, tokenizer)
 
             # Create output
             output = RequestOutput(
@@ -878,6 +876,7 @@ class MLLMScheduler:
                         RequestOutput(
                             request_id=request_id,
                             output_token_ids=list(request.output_tokens),
+                            output_logprobs=getattr(request, "output_logprobs", None),
                             output_text=request.output_text,
                             finished=True,
                             finish_reason="error",

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -37,6 +37,7 @@ from .mllm_batch_generator import (
 )
 from .mlx_streams import bind_generation_streams
 from .multimodal_processor import MultimodalProcessor
+from .logprobs import logprobs_for_step
 from .request import RequestOutput, RequestStatus, SamplingParams
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,8 @@ class MLLMRequest:
     status: RequestStatus = RequestStatus.WAITING
     output_text: str = ""
     output_tokens: List[int] = field(default_factory=list)
+    # Per-token logprobs, when requested (see ``vllm_mlx.logprobs``)
+    output_logprobs: Optional[List[Any]] = None
     finish_reason: Optional[str] = None
 
     # Token counts
@@ -449,6 +452,7 @@ class MLLMScheduler:
             presence_penalty=kwargs.pop("presence_penalty", 0.0),
             repetition_penalty=kwargs.pop("repetition_penalty", 1.0),
             logits_processors=kwargs.pop("logits_processors", None),
+            logprobs=kwargs.pop("logprobs", None),
         )
 
         request = MLLMRequest(
@@ -606,6 +610,7 @@ class MLLMScheduler:
                 presence_penalty=request.sampling_params.presence_penalty,
                 repetition_penalty=request.sampling_params.repetition_penalty,
                 logits_processors=request.sampling_params.logits_processors,
+                logprobs=request.sampling_params.logprobs,
                 mllm_draft=request.mllm_draft,
             )
             batch_requests.append(batch_req)
@@ -703,6 +708,10 @@ class MLLMScheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
+            new_logprobs = logprobs_for_step(
+                request, response, request.sampling_params.logprobs, tokenizer
+            )
+
             # Create output
             output = RequestOutput(
                 request_id=request_id,
@@ -713,6 +722,8 @@ class MLLMScheduler:
                 completion_tokens=request.num_output_tokens,
                 mtp_drafts=request.mtp_drafts,
                 mtp_accepted=request.mtp_accepted,
+                new_logprobs=new_logprobs,
+                output_logprobs=request.output_logprobs,
             )
 
             # Check if finished

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -149,6 +149,11 @@ class RequestOutputCollector:
         # Combine new tokens
         merged_new_token_ids = existing.new_token_ids + new.new_token_ids
         merged_new_text = existing.new_text + new.new_text
+        merged_new_logprobs = None
+        if existing.new_logprobs is not None or new.new_logprobs is not None:
+            merged_new_logprobs = (existing.new_logprobs or []) + (
+                new.new_logprobs or []
+            )
 
         return RequestOutput(
             request_id=new.request_id,
@@ -160,6 +165,8 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            new_logprobs=merged_new_logprobs,
+            output_logprobs=new.output_logprobs,
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -65,6 +65,9 @@ class SamplingParams:
     # decoding via ``lm-format-enforcer``).  These are merged with any
     # built-in processors (repetition/presence penalty) at batch time.
     logits_processors: Optional[List[Callable]] = None
+    # Number of most likely alternatives to report per generated token.
+    # ``None`` disables logprobs; 0 reports only the sampled token.
+    logprobs: Optional[int] = None
 
     def __post_init__(self):
         if self.stop is None:
@@ -108,6 +111,8 @@ class Request:
     num_computed_tokens: int = 0
     output_token_ids: List[int] = field(default_factory=list)
     output_text: str = ""
+    # Per-token logprobs, when requested (see ``vllm_mlx.logprobs``)
+    output_logprobs: Optional[List[Any]] = None
 
     # For BatchGenerator integration
     batch_uid: Optional[int] = None  # UID assigned by BatchGenerator
@@ -217,6 +222,10 @@ class RequestOutput:
     # MTP speculative decoding counters. Zero means no MTP attempt occurred.
     mtp_drafts: int = 0
     mtp_accepted: int = 0
+    # Per-token logprobs when requested: entries for this step's content
+    # tokens (stop tokens excluded) and the cumulative list.
+    new_logprobs: Optional[List[Any]] = None
+    output_logprobs: Optional[List[Any]] = None
 
     @property
     def usage(self) -> Dict[str, int]:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
+    from .logprobs import TokenLogprob
     from .paged_cache import BlockTable
 
 
@@ -112,7 +113,7 @@ class Request:
     output_token_ids: List[int] = field(default_factory=list)
     output_text: str = ""
     # Per-token logprobs, when requested (see ``vllm_mlx.logprobs``)
-    output_logprobs: Optional[List[Any]] = None
+    output_logprobs: Optional[List["TokenLogprob"]] = None
 
     # For BatchGenerator integration
     batch_uid: Optional[int] = None  # UID assigned by BatchGenerator
@@ -224,8 +225,8 @@ class RequestOutput:
     mtp_accepted: int = 0
     # Per-token logprobs when requested: entries for this step's content
     # tokens (stop tokens excluded) and the cumulative list.
-    new_logprobs: Optional[List[Any]] = None
-    output_logprobs: Optional[List[Any]] = None
+    new_logprobs: Optional[List["TokenLogprob"]] = None
+    output_logprobs: Optional[List["TokenLogprob"]] = None
 
     @property
     def usage(self) -> Dict[str, int]:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -27,7 +27,7 @@ from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 from .paged_cache import PagedCacheManager
 from .ssd_cache import SSDCacheConfig, SSDCacheTier
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
-from .logprobs import logprobs_for_step
+from .logprobs import record_step_logprobs
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .utils.mamba_cache import ensure_mamba_support
 
@@ -2817,11 +2817,14 @@ class Scheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
-            new_logprobs = logprobs_for_step(
-                request,
-                response,
-                request.sampling_params.logprobs,
-                self._actual_tokenizer,
+            # LLM-path MTP (``_install_mtp``) is inactive on mlx-lm >= 0.31.3, so no
+
+            # drafted tokens reach here; if it returns, requests with logprobs must
+
+            # bypass it as the MLLM path does.
+
+            new_logprobs = record_step_logprobs(
+                request, response, self._actual_tokenizer
             )
 
             # Create output

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -27,6 +27,7 @@ from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig
 from .paged_cache import PagedCacheManager
 from .ssd_cache import SSDCacheConfig, SSDCacheTier
 from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
+from .logprobs import logprobs_for_step
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .utils.mamba_cache import ensure_mamba_support
 
@@ -2816,6 +2817,13 @@ class Scheduler:
                 detok.add_token(response.token)
                 new_text = detok.last_segment
 
+            new_logprobs = logprobs_for_step(
+                request,
+                response,
+                request.sampling_params.logprobs,
+                self._actual_tokenizer,
+            )
+
             # Create output
             output = RequestOutput(
                 request_id=request_id,
@@ -2824,6 +2832,8 @@ class Scheduler:
                 output_token_ids=request.output_token_ids,
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                new_logprobs=new_logprobs,
+                output_logprobs=request.output_logprobs,
             )
 
             # Check if finished

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -54,6 +54,7 @@ import uuid
 from collections import OrderedDict, defaultdict
 from collections.abc import AsyncIterator
 from contextlib import suppress
+from typing import Any
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
@@ -767,6 +768,54 @@ def _attach_logit_bias_processor(
         chat_kwargs["logits_processors"] = list(existing) + list(processors)
 
 
+def _require_logprobs_support(engine: BaseEngine) -> None:
+    """Reject logprobs requests the active engine cannot serve."""
+    if not getattr(engine, "supports_logprobs", False):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "logprobs require the continuous-batching engine "
+                "(start the server with --continuous-batching)"
+            ),
+        )
+
+
+def _chat_choice_logprobs(output: Any) -> Any:
+    """Format an engine output's per-token logprobs for a chat choice."""
+    entries = getattr(output, "logprobs", None)
+    if entries is None:
+        return None
+    from .logprobs import to_chat_logprobs
+
+    return to_chat_logprobs(entries)
+
+
+def _completion_choice_logprobs(output: Any, text_offset: int = 0) -> Any:
+    """Format an engine output's per-token logprobs for a completion choice."""
+    entries = getattr(output, "logprobs", None)
+    if entries is None:
+        return None
+    from .logprobs import to_completion_logprobs
+
+    return to_completion_logprobs(entries, text_offset=text_offset)
+
+
+def _attach_pending_logprobs(
+    chunk: ChatCompletionChunk, pending: list
+) -> ChatCompletionChunk:
+    """Move buffered per-token logprobs onto the next streaming chunk sent.
+
+    Reasoning and tool parsers may consume tokens without emitting a chunk,
+    so logprobs are buffered until a chunk with choices actually goes out.
+    """
+    if pending and chunk.choices:
+        from .logprobs import to_chat_logprobs
+
+        chunk.choices[0].logprobs = to_chat_logprobs(pending)
+        pending.clear()
+    return chunk
+
+
 def _prepare_chat_completion_invocation(
     engine: BaseEngine,
     request: ChatCompletionRequest,
@@ -796,6 +845,9 @@ def _prepare_chat_completion_invocation(
         "repetition_penalty": _resolve_repetition_penalty(request.repetition_penalty),
     }
     _attach_logit_bias_processor(chat_kwargs, getattr(request, "logit_bias", None))
+    if getattr(request, "logprobs", None):
+        _require_logprobs_support(engine)
+        chat_kwargs["logprobs"] = getattr(request, "top_logprobs", None) or 0
 
     if has_media:
         chat_kwargs["images"] = images if images else None
@@ -5221,6 +5273,8 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     release_on_exit = True
 
     try:
+        if getattr(request, "logprobs", None) is not None:
+            _require_logprobs_support(engine)
         if request.stream:
             response = StreamingResponse(
                 _disconnect_guard(
@@ -5275,6 +5329,8 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             mllm_draft = getattr(request, "mllm_draft", None)
             if mllm_draft is not None:
                 generate_kwargs["mllm_draft"] = mllm_draft
+            if getattr(request, "logprobs", None) is not None:
+                generate_kwargs["logprobs"] = request.logprobs
             try:
                 if raw_request is None:
                     output = await engine.generate(**generate_kwargs)
@@ -5304,6 +5360,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     index=i,
                     text=output.text,
                     finish_reason=output.finish_reason,
+                    logprobs=_completion_choice_logprobs(output),
                 )
             )
             total_completion_tokens += output.completion_tokens
@@ -5518,6 +5575,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         tool_calls=tool_calls,
                     ),
                     finish_reason=finish_reason,
+                    logprobs=_chat_choice_logprobs(output),
                 )
             ],
             usage=Usage(
@@ -6489,6 +6547,9 @@ async def stream_completion(
     mllm_draft = getattr(request, "mllm_draft", None)
     if mllm_draft is not None:
         generate_kwargs["mllm_draft"] = mllm_draft
+    if getattr(request, "logprobs", None) is not None:
+        generate_kwargs["logprobs"] = request.logprobs
+    text_offset = 0
 
     try:
         async for output in engine.stream_generate(**generate_kwargs):
@@ -6504,6 +6565,9 @@ async def stream_completion(
                 if hasattr(output, "completion_tokens")
                 else completion_tokens
             )
+            chunk_logprobs = _completion_choice_logprobs(output, text_offset)
+            if chunk_logprobs is not None:
+                text_offset += sum(len(token) for token in chunk_logprobs.tokens)
             data = {
                 "id": f"cmpl-{uuid.uuid4().hex[:8]}",
                 "object": "text_completion",
@@ -6515,6 +6579,11 @@ async def stream_completion(
                         "text": output.new_text,
                         "finish_reason": (
                             output.finish_reason if output.finished else None
+                        ),
+                        "logprobs": (
+                            chunk_logprobs.model_dump()
+                            if chunk_logprobs is not None
+                            else None
                         ),
                     }
                 ],
@@ -6559,6 +6628,7 @@ async def stream_chat_completion(
     tool_request_context, tools_dict, include_usage = _stream_request_metadata(request)
 
     # First chunk with role
+    pending_logprobs: list = []
     first_chunk = ChatCompletionChunk(
         id=response_id,
         model=_response_model_name(request.model),
@@ -6608,6 +6678,7 @@ async def stream_chat_completion(
     try:
         # Stream content
         async for output in engine.stream_chat(messages=messages, **kwargs):
+            pending_logprobs.extend(getattr(output, "logprobs", None) or [])
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
             delta_text = output.new_text or ""
@@ -6711,7 +6782,7 @@ async def stream_chat_completion(
                                     ],
                                     usage=None,
                                 )
-                                yield f"data: {chunk.model_dump_json()}\n\n"
+                                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
                             continue
 
                         if "tool_calls" in tool_result:
@@ -6742,7 +6813,7 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
-                            yield f"data: {chunk.model_dump_json()}\n\n"
+                            yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
                             )
@@ -6792,7 +6863,7 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
-                yield f"data: {chunk.model_dump_json()}\n\n"
+                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
                 )
@@ -6876,7 +6947,7 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
-                            yield f"data: {chunk.model_dump_json()}\n\n"
+                            yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
                             )
@@ -6925,7 +6996,7 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
-                yield f"data: {chunk.model_dump_json()}\n\n"
+                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
                 )

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -54,7 +54,6 @@ import uuid
 from collections import OrderedDict, defaultdict
 from collections.abc import AsyncIterator
 from contextlib import suppress
-from typing import Any
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
@@ -80,7 +79,9 @@ from .api.models import (
     ChatCompletionChunkDelta,  # noqa: F401
     ChatCompletionRequest,
     ChatCompletionResponse,
+    ChoiceLogprobs,
     CompletionChoice,  # noqa: F401
+    CompletionLogprobs,
     CompletionRequest,
     CompletionResponse,
     ContentPart,  # noqa: F401
@@ -168,6 +169,7 @@ from .endpoint_model_policies import (
     resolve_tts_model_name,
 )
 from .engine.base import EngineBusy, suspend_cancellation
+from .logprobs import TokenLogprob, to_chat_logprobs, to_completion_logprobs
 from .lifecycle import ModelSpec, ResidencyManager
 from .model_registry import (
     ModelLease,
@@ -780,40 +782,31 @@ def _require_logprobs_support(engine: BaseEngine) -> None:
         )
 
 
-def _chat_choice_logprobs(output: Any) -> Any:
-    """Format an engine output's per-token logprobs for a chat choice."""
-    entries = getattr(output, "logprobs", None)
+def _chat_choice_logprobs(
+    entries: list[TokenLogprob] | None,
+) -> ChoiceLogprobs | None:
+    """Format per-token logprobs for a chat choice, if they were requested."""
+    return to_chat_logprobs(entries) if entries is not None else None
+
+
+def _completion_choice_logprobs(
+    entries: list[TokenLogprob] | None, text_offset: int = 0
+) -> CompletionLogprobs | None:
+    """Format per-token logprobs for a completion choice, if requested."""
     if entries is None:
         return None
-    from .logprobs import to_chat_logprobs
-
-    return to_chat_logprobs(entries)
-
-
-def _completion_choice_logprobs(output: Any, text_offset: int = 0) -> Any:
-    """Format an engine output's per-token logprobs for a completion choice."""
-    entries = getattr(output, "logprobs", None)
-    if entries is None:
-        return None
-    from .logprobs import to_completion_logprobs
-
     return to_completion_logprobs(entries, text_offset=text_offset)
 
 
-def _attach_pending_logprobs(
-    chunk: ChatCompletionChunk, pending: list
-) -> ChatCompletionChunk:
-    """Move buffered per-token logprobs onto the next streaming chunk sent.
+def _attach_pending_logprobs(chunk: ChatCompletionChunk, pending: list) -> None:
+    """Move buffered per-token logprobs onto a streaming chunk about to be sent.
 
     Reasoning and tool parsers may consume tokens without emitting a chunk,
     so logprobs are buffered until a chunk with choices actually goes out.
     """
     if pending and chunk.choices:
-        from .logprobs import to_chat_logprobs
-
         chunk.choices[0].logprobs = to_chat_logprobs(pending)
         pending.clear()
-    return chunk
 
 
 def _prepare_chat_completion_invocation(
@@ -5360,7 +5353,9 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     index=i,
                     text=output.text,
                     finish_reason=output.finish_reason,
-                    logprobs=_completion_choice_logprobs(output),
+                    logprobs=_completion_choice_logprobs(
+                        getattr(output, "logprobs", None)
+                    ),
                 )
             )
             total_completion_tokens += output.completion_tokens
@@ -5575,7 +5570,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
                         tool_calls=tool_calls,
                     ),
                     finish_reason=finish_reason,
-                    logprobs=_chat_choice_logprobs(output),
+                    logprobs=_chat_choice_logprobs(getattr(output, "logprobs", None)),
                 )
             ],
             usage=Usage(
@@ -6565,7 +6560,9 @@ async def stream_completion(
                 if hasattr(output, "completion_tokens")
                 else completion_tokens
             )
-            chunk_logprobs = _completion_choice_logprobs(output, text_offset)
+            chunk_logprobs = _completion_choice_logprobs(
+                getattr(output, "new_logprobs", None), text_offset
+            )
             if chunk_logprobs is not None:
                 text_offset += sum(len(token) for token in chunk_logprobs.tokens)
             data = {
@@ -6678,7 +6675,7 @@ async def stream_chat_completion(
     try:
         # Stream content
         async for output in engine.stream_chat(messages=messages, **kwargs):
-            pending_logprobs.extend(getattr(output, "logprobs", None) or [])
+            pending_logprobs.extend(getattr(output, "new_logprobs", None) or [])
             if metrics_tracker is not None:
                 metrics_tracker.observe_ttft()
             delta_text = output.new_text or ""
@@ -6782,7 +6779,8 @@ async def stream_chat_completion(
                                     ],
                                     usage=None,
                                 )
-                                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
+                                _attach_pending_logprobs(chunk, pending_logprobs)
+                                yield f"data: {chunk.model_dump_json()}\n\n"
                             continue
 
                         if "tool_calls" in tool_result:
@@ -6813,7 +6811,8 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
-                            yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
+                            _attach_pending_logprobs(chunk, pending_logprobs)
+                            yield f"data: {chunk.model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
                             )
@@ -6863,7 +6862,8 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
-                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
+                _attach_pending_logprobs(chunk, pending_logprobs)
+                yield f"data: {chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
                 )
@@ -6947,7 +6947,8 @@ async def stream_chat_completion(
                                 ],
                                 usage=get_usage(output) if output.finished else None,
                             )
-                            yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
+                            _attach_pending_logprobs(chunk, pending_logprobs)
+                            yield f"data: {chunk.model_dump_json()}\n\n"
                             finish_reason_emitted = finish_reason_emitted or bool(
                                 chunk.choices[0].finish_reason
                             )
@@ -6996,7 +6997,8 @@ async def stream_chat_completion(
                         else None
                     ),
                 )
-                yield f"data: {_attach_pending_logprobs(chunk, pending_logprobs).model_dump_json()}\n\n"
+                _attach_pending_logprobs(chunk, pending_logprobs)
+                yield f"data: {chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = finish_reason_emitted or bool(
                     chunk.choices[0].finish_reason
                 )
@@ -7042,6 +7044,7 @@ async def stream_chat_completion(
                         )
                     ],
                 )
+                _attach_pending_logprobs(tool_chunk, pending_logprobs)
                 yield f"data: {tool_chunk.model_dump_json()}\n\n"
                 finish_reason_emitted = True
 
@@ -7070,7 +7073,19 @@ async def stream_chat_completion(
                 ],
                 usage=get_usage(last_output),
             )
+            _attach_pending_logprobs(terminal_chunk, pending_logprobs)
             yield f"data: {terminal_chunk.model_dump_json()}\n\n"
+
+        # Tokens a parser consumed after the last chunk still carry logprobs;
+        # send them on a chunk of their own rather than drop them.
+        if pending_logprobs:
+            logprobs_chunk = ChatCompletionChunk(
+                id=response_id,
+                model=_response_model_name(request.model),
+                choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())],
+            )
+            _attach_pending_logprobs(logprobs_chunk, pending_logprobs)
+            yield f"data: {logprobs_chunk.model_dump_json()}\n\n"
 
         # Structured streams are buffered by the endpoint until this independent
         # validation succeeds, so invalid content cannot be returned as a


### PR DESCRIPTION
## Summary

Adds OpenAI-compatible `logprobs` / `top_logprobs` to `/v1/chat/completions` (non-streaming and streaming) and `logprobs` to `/v1/completions`. They are served by the continuous-batching engine on both the LLM scheduler and the MLLM scheduler.

Today these request fields are silently ignored, even though both schedulers already compute a full-vocabulary `log_softmax` every decode step. The values are dropped at the first vllm-mlx output object. This PR carries them through for requests that ask for them.

Closes #786

## What changes

- **`vllm_mlx/logprobs.py` (new).**
  - `extract_token_logprob` reads the sampled token's logprob and the top-k alternatives (`argpartition`) on the engine thread, so no MLX arrays reach the API layer. It decodes token strings and clamps `-inf` from masked logits to `-9999.0`, OpenAI's value for unlikely tokens.
  - `record_step_logprobs` is shared by both schedulers.
  - It also provides formatters for the chat and legacy completions shapes.
- **Engine plumbing.**
  - `SamplingParams.logprobs` and `MLLMBatchRequest.logprobs` carry the request (`None` = off, `k` = top-k).
  - `RequestOutput` gains `new_logprobs` and `output_logprobs`, mirroring `new_token_ids` and `output_token_ids`. `RequestOutputCollector._merge_outputs` merges them.
  - `GenerationOutput` gains `logprobs` and `new_logprobs`, mirroring `text` and `new_text`.
- **Schedulers.** `scheduler.py` (LLM) and `mllm_scheduler.py` (MLLM) record one entry per content token. Stop tokens are excluded.
- **Speculative decoding.** In `mllm_batch_generator.py`, MTP/drafter speculation is bypassed for requests with logprobs, alongside the existing `logits_processors` bypass, because draft-emitted tokens report logprobs from a different distribution. A new `bypass_counts["logprobs"]` counter tracks this. The LLM path's `_install_mtp` hook is already inactive on mlx-lm >= 0.31.3; a comment at the call site notes that it would need the same bypass if it returns.
- **Server.**
  - The request flag is forwarded to the engine.
  - Engines that can't serve logprobs (`BaseEngine.supports_logprobs`, `False` except for `BatchedEngine`) get HTTP 400 up front, before any stream starts.
  - In streaming, reasoning and tool parsers can consume tokens without emitting a chunk. Their entries are buffered and attached to the next chunk sent, including the tool-call fallback and terminal chunks, so none are dropped. Existing `yield` lines are unchanged.
- **API models.** Adds `TopLogprob`, `ChatCompletionTokenLogprob`, `ChoiceLogprobs` and `CompletionLogprobs`. `top_logprobs` without `logprobs: true` is rejected, matching OpenAI.
- **Docs.** A new "Log probabilities" subsection in `docs/guides/server.md`.

## Semantics

- Values come after logits processors (JSON-schema constraints, `logit_bias`, penalties) and before temperature/top-p/top-k/min-p. That is the processed distribution at T=1, which is what mlx-lm's `generate_step` computes.
- Entries cover every generated token except the final stop token. The server post-processes text (reasoning/tool parsing, `response_format` JSON normalization, whitespace trimming), so `message.content` can differ from the concatenated tokens. For example, the model generates pretty-printed JSON and `content` is the compact re-serialization.
- `token` / `bytes` come from decoding each token alone. A partial-UTF-8 token therefore reports U+FFFD, as in vLLM.
- Batched forward passes reduce in a different order from single requests, so values can differ slightly between batched and unbatched runs. At an exact tie this can flip the greedy token. This is pre-existing batching behaviour that logprobs make visible; see Verification.
- **Cost.** Each logprobs request adds one small GPU sync per step (the sampled value plus a top-k over the vocabulary). Requests without logprobs do no extra work, although they share the step with any request that does. Gathering all rows into one `mx.eval` per step is a possible follow-up.

## Out of scope (possible follow-ups)

- **SimpleEngine** returns 400 for logprobs requests. Its generation routes differ (mlx-lm `stream_generate`, the mlx-vlm media path, SpecPrefill), so it is better handled in its own PR.
- `/v1/responses` and the Anthropic endpoint are unchanged.

## Verification

Hardware: Apple M2 Max, 32 GB, macOS.

- **New and updated tests:**
  - `tests/test_logprobs.py`: extraction, sorting, `-inf` clamping, placeholder rows, top-k cap, recording and stop-token exclusion, both output formats, the output-collector merge, and the LLM and MLLM schedulers' `_process_batch_responses`.
  - `tests/test_server_logprobs.py`: chat non-stream and stream, parser-consumed tokens (terminal chunk and end-of-stream flush), the 400 check, and completions non-stream and stream offsets.
  - `tests/test_batched_engine.py`: LLM and MLLM pass-through.
  - `tests/test_api_models.py`: request validation and bounds.
  - `tests/test_mllm_continuous_batching.py`: the MTP logprobs bypass.
- **Full suite:** 3073 passed, 40 skipped, 4 failed, 13 errors. The failures and errors are exactly the ones present on `main` (`ec8e493`) in this environment:
  - 2 in `test_lifecycle_cli`;
  - 2 in `test_prefix_cache_scheduler_parity`, a "no Stream(gpu)" thread error;
  - 13 in `test_streaming_detokenizer`, which needs to download a model.
- **Lint:** `black --check vllm_mlx/ tests/` and the CI ruff command (`ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841`) are clean.
- **Live, `--continuous-batching --max-num-seqs 8`, T=0, JSON-schema `response_format`:**

  | Check | `mlx-community/Qwen3.5-4B-MLX-4bit` (MLLM path) | `mlx-community/Qwen3-0.6B-4bit` (LLM path) |
  |---|---|---|
  | Sampled token's logprob == top-1 logprob at every position | ✓ | ✓ |
  | Streaming vs non-streaming tokens/logprobs | identical (max abs diff 0.0) | identical (max abs diff 0.0) |
  | 8 concurrent requests vs solo | identical | identical except at an exact tie (note below) |
  | `logprobs` omitted → `"logprobs": null` | ✓ | ✓ |
  | `/v1/completions` `logprobs=3` (sampled token in `top_logprobs`) | ✓ | ✓ |

  Default (simple) engine: `logprobs: true` → HTTP 400 with an explanatory message. Requests without logprobs are unaffected.

  **Tie note (Qwen3-0.6B).** At one position the solo run has `'0'` and `'5'` tied at exactly −1.500. Under 8-way batching the order of floating-point reduction breaks the tie either way (for example `'5'` −1.494 vs `'0'` −1.509). As a result, 1–2 of every 8 concurrent requests generate `"confidence": 0.5` instead of `0.0`. Each response's logprobs match its own output, and the same flip happens without logprobs. Otherwise, batched logprob values stay within about 0.06 of the solo run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q1Gph3BbSN6DH4oNBSVen
