### PR TITLE
fix(mcp): support SDK2 fields and clean up failed connections

### DIFF
--- a/tests/test_mcp_client_compat.py
+++ b/tests/test_mcp_client_compat.py
@@ -2,6 +2,7 @@
 """Focused MCP SDK compatibility and failed-connect cleanup tests."""
 
 from types import SimpleNamespace
+import asyncio
 
 import pytest
 
@@ -39,12 +40,11 @@ def _client() -> MCPClient:
 async def test_initialize_session_accepts_both_sdk_field_styles(result, caplog):
     client = _client()
     caplog.set_level("DEBUG")
-    client._session = SimpleNamespace(initialize=lambda: result)
 
     async def initialize():
         return result
 
-    client._session.initialize = initialize
+    client._session = SimpleNamespace(initialize=initialize)
     await client._initialize_session()
     assert "initialized" in caplog.text
 
@@ -56,7 +56,7 @@ async def test_initialize_session_accepts_both_sdk_field_styles(result, caplog):
         SimpleNamespace(
             name="snake",
             description="snake schema",
-            input_schema={"type": "object"},
+            input_schema={},
         ),
         SimpleNamespace(
             name="camel",
@@ -74,37 +74,44 @@ async def test_discover_tools_accepts_both_sdk_field_styles(tool):
 
     client._session.list_tools = list_tools
     await client._discover_tools()
-    assert client.tools[0].input_schema == {"type": "object"}
+    expected = getattr(tool, "input_schema", getattr(tool, "inputSchema", {}))
+    assert client.tools[0].input_schema == expected
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("field", ["is_error", "isError"])
-async def test_call_tool_accepts_both_sdk_field_styles(field):
+@pytest.mark.parametrize(
+    "field,value", [("is_error", True), ("isError", True), ("is_error", False)]
+)
+async def test_call_tool_accepts_both_sdk_field_styles(field, value):
     client = _client()
     client._state = MCPServerState.CONNECTED
-    result = SimpleNamespace(content=[], **{field: True})
+    result = SimpleNamespace(content=[], **{field: value})
 
     async def call_tool(_name, _arguments):
         return result
 
     client._session = SimpleNamespace(call_tool=call_tool)
     outcome = await client.call_tool("tool", {})
-    assert outcome.is_error is True
+    assert outcome.is_error is value
 
 
 @pytest.mark.anyio
 async def test_connect_closes_partial_contexts_and_returns_promptly(monkeypatch):
     client = _client()
+    client._tools = [SimpleNamespace(name="stale")]
 
     class Context:
-        def __init__(self):
+        def __init__(self, raises=False):
             self.exited = 0
+            self.raises = raises
 
         async def __aexit__(self, *_args):
             self.exited += 1
+            if self.raises:
+                raise RuntimeError("close failed")
 
     session_context = Context()
-    stdio_context = Context()
+    stdio_context = Context(raises=True)
 
     async def connect_stdio():
         client._stdio_client = stdio_context
@@ -116,9 +123,10 @@ async def test_connect_closes_partial_contexts_and_returns_promptly(monkeypatch)
     monkeypatch.setattr(client, "_connect_stdio", connect_stdio)
     monkeypatch.setattr(client, "_initialize_session", initialize_session)
 
-    assert await client.connect() is False
+    assert await asyncio.wait_for(client.connect(), timeout=1) is False
     assert client.state is MCPServerState.ERROR
     assert client._session is None
     assert client._stdio_client is None
+    assert client._tools == []
     assert session_context.exited == 1
     assert stdio_context.exited == 1

--- a/tests/test_mcp_client_compat.py
+++ b/tests/test_mcp_client_compat.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused MCP SDK compatibility and failed-connect cleanup tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.mcp.client import MCPClient
+from vllm_mlx.mcp.types import MCPServerState, MCPTransport
+
+
+def _client() -> MCPClient:
+    config = SimpleNamespace(
+        name="test",
+        transport=MCPTransport.STDIO,
+        enabled=True,
+        command="python",
+        args=[],
+        env=None,
+        timeout=1.0,
+    )
+    return MCPClient(config)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "result",
+    [
+        SimpleNamespace(
+            protocol_version="2025-11-25",
+            server_info=SimpleNamespace(name="sdk2"),
+        ),
+        SimpleNamespace(
+            protocolVersion="2024-11-05",
+            serverInfo=SimpleNamespace(name="sdk1"),
+        ),
+    ],
+)
+async def test_initialize_session_accepts_both_sdk_field_styles(result, caplog):
+    client = _client()
+    caplog.set_level("DEBUG")
+    client._session = SimpleNamespace(initialize=lambda: result)
+
+    async def initialize():
+        return result
+
+    client._session.initialize = initialize
+    await client._initialize_session()
+    assert "initialized" in caplog.text
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "tool",
+    [
+        SimpleNamespace(
+            name="snake",
+            description="snake schema",
+            input_schema={"type": "object"},
+        ),
+        SimpleNamespace(
+            name="camel",
+            description="camel schema",
+            inputSchema={"type": "object"},
+        ),
+    ],
+)
+async def test_discover_tools_accepts_both_sdk_field_styles(tool):
+    client = _client()
+    client._session = SimpleNamespace(list_tools=lambda: SimpleNamespace(tools=[tool]))
+
+    async def list_tools():
+        return SimpleNamespace(tools=[tool])
+
+    client._session.list_tools = list_tools
+    await client._discover_tools()
+    assert client.tools[0].input_schema == {"type": "object"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("field", ["is_error", "isError"])
+async def test_call_tool_accepts_both_sdk_field_styles(field):
+    client = _client()
+    client._state = MCPServerState.CONNECTED
+    result = SimpleNamespace(content=[], **{field: True})
+
+    async def call_tool(_name, _arguments):
+        return result
+
+    client._session = SimpleNamespace(call_tool=call_tool)
+    outcome = await client.call_tool("tool", {})
+    assert outcome.is_error is True
+
+
+@pytest.mark.anyio
+async def test_connect_closes_partial_contexts_and_returns_promptly(monkeypatch):
+    client = _client()
+
+    class Context:
+        def __init__(self):
+            self.exited = 0
+
+        async def __aexit__(self, *_args):
+            self.exited += 1
+
+    session_context = Context()
+    stdio_context = Context()
+
+    async def connect_stdio():
+        client._stdio_client = stdio_context
+        client._session = session_context
+
+    async def initialize_session():
+        raise AttributeError("protocolVersion")
+
+    monkeypatch.setattr(client, "_connect_stdio", connect_stdio)
+    monkeypatch.setattr(client, "_initialize_session", initialize_session)
+
+    assert await client.connect() is False
+    assert client.state is MCPServerState.ERROR
+    assert client._session is None
+    assert client._stdio_client is None
+    assert session_context.exited == 1
+    assert stdio_context.exited == 1

--- a/tests/test_mcp_client_compat.py
+++ b/tests/test_mcp_client_compat.py
@@ -110,8 +110,8 @@ async def test_connect_closes_partial_contexts_and_returns_promptly(monkeypatch)
             if self.raises:
                 raise RuntimeError("close failed")
 
-    session_context = Context()
-    stdio_context = Context(raises=True)
+    session_context = Context(raises=True)
+    stdio_context = Context()
 
     async def connect_stdio():
         client._stdio_client = stdio_context

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -19,6 +19,21 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+_MISSING = object()
+
+
+def _field(obj: Any, snake_name: str, camel_name: str, default: Any = _MISSING):
+    """Read an MCP SDK field across v1 camelCase and v2 snake_case models."""
+    value = getattr(obj, snake_name, _MISSING)
+    if value is not _MISSING:
+        return value
+    value = getattr(obj, camel_name, _MISSING)
+    if value is not _MISSING:
+        return value
+    if default is not _MISSING:
+        return default
+    raise AttributeError(f"MCP result has neither {snake_name!r} nor {camel_name!r}")
+
 
 class MCPClient:
     """
@@ -116,6 +131,7 @@ class MCPClient:
                 return True
 
             except Exception as e:
+                await self._close_connection()
                 self._state = MCPServerState.ERROR
                 self._error = str(e)
                 logger.error(f"Failed to connect to MCP server '{self.name}': {e}")
@@ -176,10 +192,12 @@ class MCPClient:
 
         # Initialize with capabilities
         result = await self._session.initialize()
+        protocol_version = _field(result, "protocol_version", "protocolVersion")
+        server_info = _field(result, "server_info", "serverInfo", None)
         logger.debug(
             f"MCP server '{self.name}' initialized: "
-            f"protocol={result.protocolVersion}, "
-            f"server={result.serverInfo.name if result.serverInfo else 'unknown'}"
+            f"protocol={protocol_version}, "
+            f"server={server_info.name if server_info else 'unknown'}"
         )
 
     async def _discover_tools(self):
@@ -196,9 +214,7 @@ class MCPClient:
                     server_name=self.name,
                     name=tool.name,
                     description=tool.description or "",
-                    input_schema=(
-                        tool.inputSchema if hasattr(tool, "inputSchema") else {}
-                    ),
+                    input_schema=_field(tool, "input_schema", "inputSchema", {}),
                 )
                 self._tools.append(mcp_tool)
                 logger.debug(f"Discovered tool: {mcp_tool.full_name}")
@@ -213,26 +229,24 @@ class MCPClient:
             if self._state == MCPServerState.DISCONNECTED:
                 return
 
+            await self._close_connection()
+            self._state = MCPServerState.DISCONNECTED
+            self._tools = []
+            logger.info(f"Disconnected from MCP server '{self.name}'")
+
+    async def _close_connection(self):
+        """Close opened SDK contexts without acquiring the client lock."""
+        for attr in ("_session", "_stdio_client", "_sse_client"):
+            context = getattr(self, attr, None)
+            setattr(self, attr, None)
+            if context is None:
+                continue
             try:
-                if self._session:
-                    await self._session.__aexit__(None, None, None)
-                    self._session = None
-
-                if hasattr(self, "_stdio_client") and self._stdio_client:
-                    await self._stdio_client.__aexit__(None, None, None)
-                    self._stdio_client = None
-
-                if hasattr(self, "_sse_client") and self._sse_client:
-                    await self._sse_client.__aexit__(None, None, None)
-                    self._sse_client = None
-
+                await context.__aexit__(None, None, None)
             except Exception as e:
-                logger.warning(f"Error disconnecting from '{self.name}': {e}")
-
-            finally:
-                self._state = MCPServerState.DISCONNECTED
-                self._tools = []
-                logger.info(f"Disconnected from MCP server '{self.name}'")
+                logger.warning(
+                    f"Error closing MCP connection context for '{self.name}': {e}"
+                )
 
     async def call_tool(
         self,
@@ -282,7 +296,7 @@ class MCPClient:
             return MCPToolResult(
                 tool_name=tool_name,
                 content=content,
-                is_error=result.isError if hasattr(result, "isError") else False,
+                is_error=_field(result, "is_error", "isError", False),
             )
 
         except asyncio.TimeoutError:

--- a/vllm_mlx/mcp/client.py
+++ b/vllm_mlx/mcp/client.py
@@ -132,6 +132,7 @@ class MCPClient:
 
             except Exception as e:
                 await self._close_connection()
+                self._tools = []
                 self._state = MCPServerState.ERROR
                 self._error = str(e)
                 logger.error(f"Failed to connect to MCP server '{self.name}': {e}")


### PR DESCRIPTION
## Summary

- Read SDK2 snake_case fields with SDK1 camelCase fallback, preserving empty schemas and false error flags.
- Close partially opened session/transport contexts after connection failure without reacquiring the held client lock, and clear stale tools.

Refs #785.

## Verification

- Eight focused compatibility/cleanup tests pass; Black, Ruff, Python compilation and diff checks pass.
- Bounded model-free stdio echo checks passed against `mcp==1.27.1` and separately pinned `mcp==2.2.0`/`mcp-types==2.2.0`: connect, list, call and disconnect.
- Injected initialization failure returned `False`/ERROR, cleared session/transport references, and the child exited in the bounded check.

## Scope

No model inference or serving-environment change. Real transport checks cover stdio; SSE behavior was not integration-tested. The tests do not certify every MCP server or dependency version.
