### PR TITLE
chore(server): remove dead request/stream helper functions

### DIFF
--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1122,18 +1122,6 @@ async def _acquire_request_model(request_model: str) -> RequestModelContext:
     )
 
 
-async def _stream_with_model_context(
-    context: RequestModelContext,
-    stream: AsyncIterator[str],
-) -> AsyncIterator[str]:
-    """Ensure model leases survive for the full streaming response."""
-    try:
-        async for chunk in stream:
-            yield chunk
-    finally:
-        await context.release()
-
-
 def _build_tool_parser(engine: BaseEngine | None):
     """Create a fresh tool parser instance for a single request/stream."""
     if not _enable_auto_tool_choice or not _tool_call_parser:
@@ -1328,13 +1316,6 @@ def _prepare_openai_stream_reasoning_state(
         and not _thinking_disabled(request, chat_kwargs)
     )
     return parser, is_thinking_model
-
-
-def _request_tool_definitions(request: ChatCompletionRequest) -> list | None:
-    """Return the request tool schema once for streaming argument coercion."""
-    if request and request.tools:
-        return request.model_dump(include={"tools"}).get("tools")
-    return None
 
 
 def _streaming_json_fence_stripper(


### PR DESCRIPTION
## Problem

`vllm_mlx/server.py` has two helper functions with zero call sites anywhere in `vllm_mlx/` or `tests/`:

```
$ git grep -n "_stream_with_model_context\|_request_tool_definitions"
vllm_mlx/server.py:1125:async def _stream_with_model_context(
vllm_mlx/server.py:1333:def _request_tool_definitions(request: ChatCompletionRequest) -> list | None:
```

(only their own definitions — no callers, no imports elsewhere.)

- `_stream_with_model_context` wraps a stream generator to release a model lease in a `finally` block, but every real streaming endpoint calls `context.release()` / `lease.release()` inline instead (`server.py:1084`, `:5114`, `:5159`, `:5171`) — the helper was superseded by the inline pattern actually used everywhere.
- `_request_tool_definitions` reads `request.tools` via `model_dump(include={"tools"})`, but nothing calls it; the request's tool schema is read directly wherever it's needed instead.

Surfaced via a structural repomap-go `find_dead_code` audit (same method as #751 — a `find_dead_code(unexported_only=true, kinds=["function","method","class"])` pass, each candidate manually verified by reading source and grepping the whole repo for the symbol name, including checking that the code the docstring/comment implies should call it, actually doesn't). Full audit write-up: `repomap-deadcode-resweep-2026-09-12.md` (local docs, not part of this repo).

## Changes

- Delete `_stream_with_model_context` and `_request_tool_definitions` from `vllm_mlx/server.py`. No other files reference either, so no other changes are needed.

## Test results

Verified on Apple M5 Max, 128 GB, macOS 27.0, Python 3.12.13, mlx 0.32.2 / mlx-lm 0.31.3 / mlx-vlm 0.7.0, branched from `origin/main` @ `ec8e4932615acbcdd1dcefccbf095ff49b5b7b1e`.

- `pytest tests/` before deletion (baseline): `3064 passed, 25 skipped, 27 deselected in 54.94s`
- `pytest tests/` after deletion: `3064 passed, 25 skipped, 27 deselected in 30.06s`
- Identical pass/skip/deselect counts — no behavior change, as expected for removing unreferenced code.
- `ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841`: clean
- `black --check vllm_mlx/ tests/`: `256 files would be left unchanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmJRN68fp7991pRLXpAJpM