### PR TITLE
chore: remove dead code across model_runner, platform detection, engine init, and memory cache

### DIFF
--- a/vllm_mlx/engine/__init__.py
+++ b/vllm_mlx/engine/__init__.py
@@ -9,7 +9,6 @@ engine_core, or the batched engine stack.
 
 from __future__ import annotations
 
-_ENGINE_CORE_NAMES = frozenset({"EngineCore", "AsyncEngineCore", "EngineConfig"})
 from typing import TYPE_CHECKING
 
 from .base import BaseEngine, GenerationOutput

--- a/vllm_mlx/memory_cache.py
+++ b/vllm_mlx/memory_cache.py
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 _BYTES_PER_MB = 1024 * 1024
 _DEFAULT_MEMORY_PERCENT = 0.20  # 20% of available RAM
 _MIN_MEMORY_BYTES = 100 * _BYTES_PER_MB  # Minimum 100MB
-_MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
 # Bump this when the cache on-disk format or KV semantics change.
 # Loading a cache with a different version is rejected automatically.
 _CACHE_PERSIST_VERSION = 4

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -14,7 +14,7 @@ Includes low-level optimizations:
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
 
@@ -313,53 +313,6 @@ class MLXModelRunner:
             num_tokens_generated=total_tokens,
             generation_time_s=generation_time,
         )
-
-    def _prefill_with_chunking(
-        self,
-        input_ids: mx.array,
-        cache: Optional[Any] = None,
-    ) -> tuple[mx.array, Any]:
-        """
-        Process prompt with optimal chunking for L2 cache efficiency.
-
-        Long prompts are broken into chunks that fit in L2 cache,
-        maximizing memory bandwidth utilization during prefill.
-
-        Args:
-            input_ids: Input token IDs [1, seq_len]
-            cache: Optional existing KV cache
-
-        Returns:
-            Tuple of (logits, updated_cache)
-        """
-        try:
-            from vllm_mlx.optimizations import get_optimal_prefill_size
-        except ImportError:
-            # Fallback if optimizations module not available
-            def get_optimal_prefill_size(seq_len):
-                return min(512, seq_len)
-
-        seq_len = input_ids.shape[-1] if len(input_ids.shape) > 1 else len(input_ids)
-        chunk_size = get_optimal_prefill_size(seq_len)
-
-        # Reshape if needed
-        if len(input_ids.shape) == 1:
-            input_ids = input_ids.reshape(1, -1)
-
-        # Use compiled forward if available, otherwise use model directly
-        forward_fn = self._compiled_forward if self._compiled_forward else self.model
-
-        if seq_len <= chunk_size:
-            # Process entire sequence at once
-            return forward_fn(input_ids, cache=cache)
-
-        # Process in chunks for large prompts
-        for i in range(0, seq_len, chunk_size):
-            chunk = input_ids[:, i : i + chunk_size]
-            logits, cache = forward_fn(chunk, cache=cache)
-            mx.eval(cache)  # Force evaluation to free intermediate memory
-
-        return logits, cache
 
     def _generate_for_request(
         self,

--- a/vllm_mlx/vllm_platform.py
+++ b/vllm_mlx/vllm_platform.py
@@ -8,9 +8,7 @@ GPU acceleration.
 """
 
 import logging
-import platform
 import subprocess
-import sys
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -48,24 +46,6 @@ def _get_unified_memory_size() -> int:
     except Exception:
         # Fallback: return 8GB
         return 8 * 1024 * 1024 * 1024
-
-
-def _is_mlx_available() -> bool:
-    """Check if MLX is available and working."""
-    try:
-        import mlx.core as mx
-
-        # Verify we can actually use MLX
-        _ = mx.array([1.0, 2.0, 3.0])
-        return True
-    except Exception as e:
-        logger.debug("MLX not available: %s", e)
-        return False
-
-
-def _is_apple_silicon() -> bool:
-    """Check if running on Apple Silicon."""
-    return sys.platform == "darwin" and platform.machine() == "arm64"
 
 
 class MLXPlatform:


### PR DESCRIPTION
## Problem

Four independent leftovers, each with zero call sites anywhere in `vllm_mlx/` or `tests/`:

```
$ git grep -n "_prefill_with_chunking\|_is_mlx_available\|_is_apple_silicon\|_ENGINE_CORE_NAMES\|_MAX_ENTRIES_FALLBACK"
vllm_mlx/engine/__init__.py:12:_ENGINE_CORE_NAMES = frozenset({"EngineCore", "AsyncEngineCore", "EngineConfig"})
vllm_mlx/memory_cache.py:42:_MAX_ENTRIES_FALLBACK = 50  # Fallback if memory detection fails
vllm_mlx/model_runner.py:317:    def _prefill_with_chunking(
vllm_mlx/vllm_platform.py:53:def _is_mlx_available() -> bool:
vllm_mlx/vllm_platform.py:66:def _is_apple_silicon() -> bool:
tests/test_platform.py:10:def test_is_apple_silicon():
```

(only their own definitions -- no real callers. `test_is_apple_silicon`'s name is a coincidence: its body imports and calls `vllm_mlx.plugin.is_mlx_available`, a different function, confirmed by reading the test.)

- **`MLXModelRunner._prefill_with_chunking`** (`model_runner.py`): a complete L2-cache-aware chunked-prefill implementation. `_generate_for_request`'s own docstring lists "Prefill chunking for long prompts" as an optimization it uses, but its body never calls this method.
- **`_is_mlx_available` / `_is_apple_silicon`** (`vllm_platform.py`): duplicate MLX/Apple-Silicon detection. The real vLLM platform-plugin entry point (`plugin.py:mlx_platform_plugin`, registered via `pyproject.toml`'s `[project.entry-points."vllm.platform_plugins"]`) reimplements the same checks inline, and exposes the availability check publicly as `plugin.py:is_mlx_available()`.
- **`_ENGINE_CORE_NAMES`** (`engine/__init__.py`): an orphaned `frozenset`. The `__getattr__` lazy-import dispatcher two lines below it checks membership against an inline literal `{"EngineCore", "AsyncEngineCore", "EngineConfig"}` -- the same three names -- instead of reading this constant.
- **`_MAX_ENTRIES_FALLBACK`** (`memory_cache.py`): a stale entry-count fallback constant. `MemoryCacheConfig`'s memory-limit resolution actually falls back to the byte-based `_MIN_MEMORY_BYTES` when memory detection fails, never this one.

Surfaced via a structural repomap-go `find_dead_code` audit (same method as #751 and #789 -- `find_dead_code(unexported_only=true, kinds=["function","method","class"])`, each candidate manually verified by reading source and grepping the whole repo for the symbol name). Full audit write-up: `repomap-deadcode-resweep-2026-09-12.md` (local docs, not part of this repo).

## Changes

- Delete `_prefill_with_chunking` from `vllm_mlx/model_runner.py`.
- Delete `_is_mlx_available` and `_is_apple_silicon` from `vllm_mlx/vllm_platform.py`.
- Delete `_ENGINE_CORE_NAMES` from `vllm_mlx/engine/__init__.py`.
- Delete `_MAX_ENTRIES_FALLBACK` from `vllm_mlx/memory_cache.py`.
- Remove now-unused imports left dangling by the above: `Optional` in `model_runner.py`; `platform` and `sys` in `vllm_platform.py`.

## Test results

Verified on Apple M5 Max, 128 GB, macOS 27.0, Python 3.12.13, mlx 0.32.2 / mlx-lm 0.31.3 / mlx-vlm 0.7.0, branched from `origin/main` @ `ec8e4932615acbcdd1dcefccbf095ff49b5b7b1e`.

- `pytest tests/` before deletion (baseline): `3064 passed, 25 skipped, 27 deselected in 54.94s`
- `pytest tests/` after deletion: `3064 passed, 25 skipped, 27 deselected in 29.54s`
- Identical pass/skip/deselect counts -- no behavior change, as expected for removing unreferenced code.
- `ruff check vllm_mlx/ tests/ --select E,F,W --ignore E402,E501,E731,F811,F841`: clean (after also dropping the imports left unused by the deletions above)
- `black --check vllm_mlx/ tests/`: `256 files would be left unchanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmJRN68fp7991pRLXpAJpM