### PR TITLE
fix(vlm): preserve global quantization mode for derived text models

### DIFF
--- a/tests/test_text_model_quantization_mode.py
+++ b/tests/test_text_model_quantization_mode.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level regression for derived text-model quantization plumbing."""
+
+import importlib
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+def _stub_module(name, *, package=False):
+    module = types.ModuleType(name)
+    if package:
+        module.__path__ = []
+    return module
+
+
+@pytest.mark.parametrize(
+    "global_mode, expected_mode", [("mxfp8", "mxfp8"), (None, "affine")]
+)
+def test_build_text_model_forwards_global_mode_without_overriding_layer_dicts(
+    tmp_path, monkeypatch, global_mode, expected_mode
+):
+    """Global mode reaches quantize while explicit layer dicts stay authoritative."""
+
+    mlx = _stub_module("mlx", package=True)
+    mlx_core = _stub_module("mlx.core")
+    mlx_nn = _stub_module("mlx.nn")
+    mlx_utils = _stub_module("mlx.utils")
+    mlx.core = mlx_core
+    mlx.nn = mlx_nn
+    mlx.utils = mlx_utils
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+    monkeypatch.setitem(sys.modules, "mlx.nn", mlx_nn)
+    monkeypatch.setitem(sys.modules, "mlx.utils", mlx_utils)
+
+    mlx_utils.tree_flatten = lambda _parameters: [
+        ("global.scales", object()),
+        ("language_model.override.scales", object()),
+    ]
+
+    class FakeTextModelArgs:
+        @classmethod
+        def from_dict(cls, config):
+            return config
+
+    class FakeTextModel:
+        mtp = None
+
+        def __init__(self, _args):
+            self.loaded = []
+
+        def load_weights(self, weights, strict=False):
+            self.loaded.append((weights, strict))
+
+        def train(self, _mode):
+            return self
+
+    quantize_calls = []
+
+    def record_quantize(model, **kwargs):
+        quantize_calls.append(kwargs)
+        predicate = kwargs["class_predicate"]
+
+        class Quantizable:
+            def to_quantized(self):
+                return None
+
+        assert predicate("global", Quantizable()) is True
+        assert predicate("language_model.override", Quantizable()) == {
+            "group_size": 64,
+            "bits": 8,
+        }
+
+    mlx_nn.quantize = record_quantize
+
+    mlx_lm = _stub_module("mlx_lm", package=True)
+    mlx_lm_models = _stub_module("mlx_lm.models", package=True)
+    mlx_lm_qwen = _stub_module("mlx_lm.models.qwen3_5")
+    mlx_lm_qwen.TextModel = FakeTextModel
+    mlx_lm_qwen.TextModelArgs = FakeTextModelArgs
+    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", mlx_lm_models)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3_5", mlx_lm_qwen)
+
+    model_path = tmp_path / "derived"
+    model_path.mkdir()
+    quantization = {
+        "group_size": 32,
+        "bits": 8,
+        "language_model.override": {"group_size": 64, "bits": 8},
+    }
+    if global_mode is not None:
+        quantization["mode"] = global_mode
+    (model_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen3_5", "quantization": quantization})
+    )
+
+    class FakeLanguageModel:
+        def parameters(self):
+            return []
+
+    class FakeVLM:
+        language_model = FakeLanguageModel()
+
+    source_path = Path(__file__).parents[1] / "vllm_mlx/text_model_from_vlm.py"
+    spec = importlib.util.spec_from_file_location(
+        "text_model_from_vlm_under_test", source_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    module.build_text_model(FakeVLM(), model_path, enable_mtp=False)
+
+    assert len(quantize_calls) == 1
+    assert quantize_calls[0]["group_size"] == 32
+    assert quantize_calls[0]["bits"] == 8
+    assert quantize_calls[0]["mode"] == expected_mode

--- a/tests/test_text_model_quantization_mode_numerical.py
+++ b/tests/test_text_model_quantization_mode_numerical.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiny random-weight numerical check for VLM-to-TextModel mode transfer."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_mxfp8_global_and_affine_override_round_trip(tmp_path, monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    nn = pytest.importorskip("mlx.nn")
+
+    class TextModelArgs:
+        @classmethod
+        def from_dict(cls, _config):
+            return cls()
+
+    class TextModel(nn.Module):
+        mtp = None
+
+        def __init__(self, _args):
+            super().__init__()
+            self.embedding = nn.Embedding(4, 32)
+            self.mxfp8_linear = nn.Linear(64, 64)
+            self.affine_linear = nn.Linear(64, 64)
+
+    mx.random.seed(0)
+    source = TextModel(TextModelArgs())
+    nn.quantize(
+        source,
+        group_size=32,
+        bits=8,
+        mode="mxfp8",
+        class_predicate=lambda path, _module: (
+            {"group_size": 64, "bits": 8} if path == "affine_linear" else True
+        ),
+    )
+    mx.eval(source.parameters())
+
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "gemma4_text",
+                "quantization": {
+                    "group_size": 32,
+                    "bits": 8,
+                    "mode": "mxfp8",
+                    "language_model.affine_linear": {"group_size": 64, "bits": 8},
+                },
+            }
+        )
+    )
+
+    source_path = Path(__file__).parents[1] / "vllm_mlx/text_model_from_vlm.py"
+    spec = importlib.util.spec_from_file_location(
+        "text_model_quantization_numerical", source_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(
+        module, "_import_text_model_classes", lambda _kind: (TextModel, TextModelArgs)
+    )
+
+    class VLM:
+        language_model = source
+
+    derived = module.build_text_model(VLM(), model_path, enable_mtp=False)
+    assert derived is not None
+    assert derived.embedding.mode == "mxfp8"
+    assert derived.mxfp8_linear.mode == "mxfp8"
+    assert derived.affine_linear.mode == "affine"
+
+    indices = mx.array([0])
+    values = mx.random.normal((1, 64))
+    for name, inputs in (
+        ("embedding", indices),
+        ("mxfp8_linear", values),
+        ("affine_linear", values),
+    ):
+        expected = getattr(source, name)(inputs)
+        actual = getattr(derived, name)(inputs)
+        mx.eval(expected, actual)
+        assert bool(mx.allclose(actual, expected, atol=0, rtol=0)), name

--- a/vllm_mlx/text_model_from_vlm.py
+++ b/vllm_mlx/text_model_from_vlm.py
@@ -157,6 +157,7 @@ def build_text_model(
                 text_model,
                 group_size=quantization.get("group_size", 64),
                 bits=quantization.get("bits", 8),
+                mode=quantization.get("mode", "affine"),
                 class_predicate=_class_predicate,
             )
 


### PR DESCRIPTION
Refs #783.

When `build_text_model()` derives a text model from a VLM checkpoint, its quantization setup forwards group size and bit width but drops the global mode. For an MXFP8 checkpoint, that constructs globally quantized layers as affine before loading the MXFP8 weights.

I now forward the checkpoint's global mode, defaulting to affine when it is absent. Explicit per-layer quantization settings remain authoritative.

I added regressions for MXFP8 and the affine default, plus a tiny random-weight model exercising the actual derived-text function. On MLX 0.32.0, all three focused tests pass; the numerical test checks exact embedding and linear outputs, including an explicit affine override.

I have not run the reported Gemma4 checkpoint or reproduced its MLX 0.32.2 result end-to-end. This PR is limited to the mode-plumbing fix and its bounded regression evidence.
